### PR TITLE
CLI DX: page-money template, init --dir/--name, validate warnings, harness next-steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 | --- | --- |
 | `civitai login [--token <t>]` | Store your API token (`~/.config/civitai/config.yaml`, 0600). Also reads `CIVITAI_TOKEN`. |
 | `civitai whoami` | Verify the stored token; print the authenticated user. |
-| `civitai app init [name] [--template static\|page-vite]` | Scaffold a correct, ready-to-build App Block project. |
-| `civitai app validate [dir]` | Best-effort local pre-check of `block.manifest.json` (see [Validate fidelity](#validate-fidelity)). |
+| `civitai app init [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | Scaffold a correct, ready-to-build App Block project (default dir `./<slug>`). |
+| `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + submit (or write the bundle + print manual next steps). |
 | `civitai version` | Print version / commit / build date. |
 | `civitai completion [shell]` | Generate a shell-completion script. |
@@ -87,6 +87,13 @@ full details and examples.
   `block.manifest.json` with `page:{}`, no build step).
 - **`page-vite`** — a Vite + React page block with config-as-code build fields
   (`buildCommand: "npm run build"` + `outputDir: "dist"`).
+- **`page-money`** — a Vite + React + TypeScript full-page (W10) **money-path**
+  block wired to the published App SDK (`@civitai/blocks-react` +
+  `@civitai/app-sdk`): prompt → estimate → lazy consent → submit → poll → real
+  Buzz spend, via `useBuzzWorkflow` / `useRequestConsent` / `useBlockResize`
+  (never raw `postMessage`). Ships a `dev:harness` mock host, `.env.*` allowed
+  parent-origin config, and a unit-test stub. Run `npm run dev:harness` (plain
+  `npm run dev` renders blank without a host).
 
 ### Examples
 

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -12,25 +12,38 @@ import (
 func newAppInitCmd() *cobra.Command {
 	var templateFlag string
 	var fromSlug string
+	var dirFlag string
+	var nameFlag string
 
 	cmd := &cobra.Command{
-		Use:   "init [name]",
+		Use:   "init [name] [dir]",
 		Short: "Scaffold a ready-to-build App Block project",
-		Long: `Scaffold a correct, ready-to-build App Block project in a new directory
-named after the slug.
+		Long: `Scaffold a correct, ready-to-build App Block project.
 
 Templates:
-  static     a no-build page block (index.html + a tiny JS, no build step)
-  page-vite  a vite + React page block (config-as-code build: buildCommand + outputDir)
+  static      a no-build page block (index.html + a tiny JS, no build step)
+  page-vite   a vite + React page block (config-as-code build: buildCommand + outputDir)
+  page-money  a vite + React + TS full-page (W10) money-path block wired to the
+              published App SDK (estimate -> consent -> submit -> poll -> Buzz spend)
 
 The display name can be free-form ("My Cool Block"); it is slugified for the
-blockId and directory. A slug-shaped name is used verbatim.`,
-		Example: `  # A no-build static block.
+blockId. A slug-shaped name is used verbatim.
+
+By default the project is created in ./<slug>. Override the output directory with
+a positional [dir] or --dir <path>; override the display name independently with
+--name (so name, slug, and directory can all differ).`,
+		Example: `  # A no-build static block in ./my-block.
   civitai app init my-block
 
-  # A Vite + React block; "My Cool Block" -> slug my-cool-block.
-  civitai app init "My Cool Block" --template page-vite`,
-		Args: cobra.MaximumNArgs(1),
+  # A page-money block; "My Cool Block" -> slug my-cool-block, dir ./my-cool-block.
+  civitai app init "My Cool Block" --template page-money
+
+  # Custom output directory (slug stays my-block; created in ./apps/foo).
+  civitai app init my-block --dir ./apps/foo
+
+  # Name, slug, and dir all independent.
+  civitai app init my-block ./apps/foo --name "My Block"`,
+		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 
@@ -51,11 +64,25 @@ init and copy the upstream files in manually.`)
 			}
 
 			name := ""
-			if len(args) == 1 {
+			if len(args) >= 1 {
 				name = args[0]
 			}
 			if name == "" {
 				return fmt.Errorf("provide a project name: civitai app init <name>")
+			}
+
+			// Positional [dir] (args[1]) and --dir both set the output directory;
+			// they must not conflict.
+			posDir := ""
+			if len(args) == 2 {
+				posDir = args[1]
+			}
+			if posDir != "" && dirFlag != "" && posDir != dirFlag {
+				return fmt.Errorf("conflicting output directory: positional %q and --dir %q", posDir, dirFlag)
+			}
+			targetDir := dirFlag
+			if targetDir == "" {
+				targetDir = posDir
 			}
 
 			// Derive slug + display name. If the name is already a valid slug
@@ -72,7 +99,18 @@ init and copy the upstream files in manually.`)
 				display = name
 			}
 
+			// --name overrides the display name independently of the slug/dir,
+			// so name, slug, and directory can all differ.
+			if nameFlag != "" {
+				display = nameFlag
+			}
+
+			// Output directory: --dir / positional [dir] if given, else ./<slug>
+			// (back-compat: no flag -> current behaviour).
 			destDir := slug
+			if targetDir != "" {
+				destDir = targetDir
+			}
 			abs, err := filepath.Abs(destDir)
 			if err != nil {
 				return err
@@ -108,10 +146,15 @@ init and copy the upstream files in manually.`)
 				fmt.Fprintf(out, "    %s\n", rel)
 			}
 			fmt.Fprintln(out, "\nNext steps:")
-			if tmpl == scaffold.PageVite {
-				fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", slug)
-			} else {
-				fmt.Fprintf(out, "  cd %s   # open index.html or serve the directory\n", slug)
+			switch {
+			case tmpl.NeedsHarness():
+				// SDK/page-money apps render blank under plain `dev` (no host) —
+				// the dev loop needs the mock host via `dev:harness`.
+				fmt.Fprintf(out, "  cd %s && npm install && npm run dev:harness\n", destDir)
+			case tmpl == scaffold.PageVite:
+				fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", destDir)
+			default:
+				fmt.Fprintf(out, "  cd %s   # open index.html or serve the directory\n", destDir)
 			}
 			fmt.Fprintln(out, "  civitai app validate")
 			fmt.Fprintln(out, "  civitai app submit")
@@ -119,8 +162,10 @@ init and copy the upstream files in manually.`)
 		},
 	}
 
-	cmd.Flags().StringVarP(&templateFlag, "template", "t", string(scaffold.Static), "project template: static | page-vite")
+	cmd.Flags().StringVarP(&templateFlag, "template", "t", string(scaffold.Static), "project template: static | page-vite | page-money")
 	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published block slug (not yet wired)")
+	cmd.Flags().StringVar(&dirFlag, "dir", "", "output directory (default ./<slug>)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "display name (default derived from the name argument)")
 	return cmd
 }
 

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/civitai/cli/internal/validate"
 	"github.com/spf13/cobra"
 )
 
 func newAppValidateCmd() *cobra.Command {
+	var strict bool
 	cmd := &cobra.Command{
 		Use:   "validate [dir]",
 		Short: "Validate block.manifest.json against the App Block schema",
@@ -31,9 +33,14 @@ plus the ported semantic rules and structural checks:
     only assigns post-submit)
   - targets[].slotId must be a known registered slot
 
+It also emits non-fatal WARNINGS for money-path footguns the schema can't catch
+as hard errors (e.g. a budgeted page with no page.buzzBudgetPerGen). Warnings do
+NOT fail validation (exit 0) unless --strict is passed.
+
 Defaults to the current directory.`,
 		Example: `  civitai app validate            # the current directory
-  civitai app validate ./my-block`,
+  civitai app validate ./my-block
+  civitai app validate --strict   # treat warnings as failures`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := "."
@@ -41,21 +48,48 @@ Defaults to the current directory.`,
 				dir = args[0]
 			}
 			out := cmd.OutOrStdout()
+			errw := cmd.ErrOrStderr()
 
 			res, err := validate.Dir(dir)
 			if err != nil {
 				return err
 			}
-			if res.OK() {
-				fmt.Fprintf(out, "OK — %s is valid\n", dir)
+
+			// Hard errors always fail.
+			if !res.OK() {
+				fmt.Fprintf(errw, "%d validation error(s) in %s:\n", len(res.Errors), dir)
+				for _, e := range res.Errors {
+					fmt.Fprintf(errw, "  - %s\n", e)
+				}
+				// Surface warnings too — they're useful context even on a failure.
+				printWarnings(errw, res)
+				return fmt.Errorf("validation failed")
+			}
+
+			// Warnings: print to stderr, fail only under --strict.
+			if res.HasWarnings() {
+				printWarnings(errw, res)
+				if strict {
+					return fmt.Errorf("validation failed: %d warning(s) with --strict", len(res.Warnings))
+				}
+				fmt.Fprintf(out, "OK (with %d warning(s)) — %s is valid\n", len(res.Warnings), dir)
 				return nil
 			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "%d validation error(s) in %s:\n", len(res.Errors), dir)
-			for _, e := range res.Errors {
-				fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", e)
-			}
-			return fmt.Errorf("validation failed")
+
+			fmt.Fprintf(out, "OK — %s is valid\n", dir)
+			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&strict, "strict", false, "treat warnings as failures (non-zero exit)")
 	return cmd
+}
+
+func printWarnings(w io.Writer, res validate.Result) {
+	if !res.HasWarnings() {
+		return
+	}
+	fmt.Fprintf(w, "%d warning(s):\n", len(res.Warnings))
+	for _, warn := range res.Warnings {
+		fmt.Fprintf(w, "  ! %s\n", warn)
+	}
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -126,6 +126,127 @@ func TestAppInitPageViteTemplate(t *testing.T) {
 	}
 }
 
+func TestAppInitPageMoneyTemplate(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	out, _, err := run(t, "app", "init", "money-app", "--template", "page-money")
+	if err != nil {
+		t.Fatalf("app init page-money: %v\n%s", err, out)
+	}
+	// SDK-wired files present.
+	for _, f := range []string{"package.json", "src/App.tsx", "src/Harness.tsx", "src/generation.ts", ".env.example"} {
+		if _, err := os.Stat(filepath.Join(tmp, "money-app", filepath.FromSlash(f))); err != nil {
+			t.Errorf("page-money should scaffold %s: %v", f, err)
+		}
+	}
+	// Next steps must use dev:harness (plain `dev` renders blank without a host).
+	if !strings.Contains(out, "npm run dev:harness") {
+		t.Errorf("page-money next steps should mention dev:harness: %s", out)
+	}
+	if strings.Contains(out, "npm run dev\n") {
+		t.Errorf("page-money next steps should NOT suggest plain `npm run dev`: %s", out)
+	}
+	// And it must validate clean (the scaffold sets a budget so no warnings).
+	if _, _, err := run(t, "app", "validate", filepath.Join(tmp, "money-app")); err != nil {
+		t.Errorf("scaffolded page-money should validate: %v", err)
+	}
+}
+
+func TestAppInitDirFlag(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	target := filepath.Join("nested", "custom-dir")
+	out, _, err := run(t, "app", "init", "my-block", "--dir", target)
+	if err != nil {
+		t.Fatalf("app init --dir: %v\n%s", err, out)
+	}
+	// Project lands in the custom dir, not ./<slug>.
+	if _, err := os.Stat(filepath.Join(tmp, target, "block.manifest.json")); err != nil {
+		t.Errorf("expected manifest in --dir target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "my-block")); err == nil {
+		t.Error("--dir should NOT create the default ./<slug> dir")
+	}
+	// The slug is still my-block (independent of the dir).
+	manifest := readManifest(t, filepath.Join(tmp, target))
+	if !strings.Contains(manifest, `"blockId": "my-block"`) {
+		t.Errorf("slug should remain my-block: %s", manifest)
+	}
+	// Next steps should cd into the target dir, not the slug.
+	if !strings.Contains(out, filepath.ToSlash(target)) && !strings.Contains(out, target) {
+		t.Errorf("next steps should reference the target dir: %s", out)
+	}
+}
+
+func TestAppInitPositionalDir(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	_, _, err := run(t, "app", "init", "my-block", "out-dir")
+	if err != nil {
+		t.Fatalf("app init <name> <dir>: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "out-dir", "block.manifest.json")); err != nil {
+		t.Errorf("positional dir should be used: %v", err)
+	}
+}
+
+func TestAppInitNameFlagSeparatesNameFromSlug(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	_, _, err := run(t, "app", "init", "my-block", "--name", "My Fancy Block")
+	if err != nil {
+		t.Fatalf("app init --name: %v", err)
+	}
+	manifest := readManifest(t, filepath.Join(tmp, "my-block"))
+	// Display name from --name, slug from the positional arg — they differ.
+	if !strings.Contains(manifest, `"name": "My Fancy Block"`) {
+		t.Errorf("display name should be from --name: %s", manifest)
+	}
+	if !strings.Contains(manifest, `"blockId": "my-block"`) {
+		t.Errorf("slug should remain my-block: %s", manifest)
+	}
+}
+
+func TestAppInitConflictingDir(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	_, _, err := run(t, "app", "init", "my-block", "posdir", "--dir", "flagdir")
+	if err == nil {
+		t.Fatal("expected error for conflicting positional dir and --dir")
+	}
+	if !strings.Contains(err.Error(), "conflicting") {
+		t.Errorf("error should mention the conflict: %v", err)
+	}
+}
+
+func TestAppValidateWarningsExitZero(t *testing.T) {
+	tmp := t.TempDir()
+	// A budgeted page with no budget: warns but is otherwise valid -> exit 0.
+	writeBudgetedNoBudgetManifest(t, tmp)
+	out, errOut, err := run(t, "app", "validate", tmp)
+	if err != nil {
+		t.Fatalf("warning-only validate should exit 0: %v\nstderr: %s", err, errOut)
+	}
+	if !strings.Contains(errOut, "warning(s)") {
+		t.Errorf("stderr should list warnings: %s", errOut)
+	}
+	if !strings.Contains(out, "OK (with") {
+		t.Errorf("stdout should report OK-with-warnings: %s", out)
+	}
+}
+
+func TestAppValidateStrictFailsOnWarnings(t *testing.T) {
+	tmp := t.TempDir()
+	writeBudgetedNoBudgetManifest(t, tmp)
+	_, errOut, err := run(t, "app", "validate", tmp, "--strict")
+	if err == nil {
+		t.Fatal("expected --strict to fail on warnings")
+	}
+	if !strings.Contains(errOut, "warning(s)") {
+		t.Errorf("stderr should list warnings under --strict: %s", errOut)
+	}
+}
+
 func TestAppInitRequiresName(t *testing.T) {
 	tmp := t.TempDir()
 	chdir(t, tmp)
@@ -263,6 +384,35 @@ func TestJoinLines(t *testing.T) {
 	}
 	if got := joinLines(nil); got != "" {
 		t.Errorf("joinLines(nil) = %q", got)
+	}
+}
+
+func readManifest(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "block.manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return string(b)
+}
+
+func writeBudgetedNoBudgetManifest(t *testing.T, dir string) {
+	t.Helper()
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "no-budget",
+  "version": "0.1.0",
+  "name": "No Budget",
+  "type": "block",
+  "scopes": ["ai:write:budgeted"],
+  "page": { "path": "/", "title": "No Budget" },
+  "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
+  "contentRating": "g",
+  "buildCommand": "npm run build",
+  "outputDir": "dist"
+}`
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(m), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -24,10 +24,17 @@ const (
 	Static Template = "static"
 	// PageVite is a vite+React page block with config-as-code build fields.
 	PageVite Template = "page-vite"
+	// PageMoney is a vite+React+TS page block wired to the published App SDK
+	// for the money path (estimate → consent → submit → poll → Buzz spend).
+	PageMoney Template = "page-money"
 )
 
 // AllTemplates lists the templates available to `civitai app init`.
-func AllTemplates() []Template { return []Template{Static, PageVite} }
+func AllTemplates() []Template { return []Template{Static, PageVite, PageMoney} }
+
+// SDKTemplates are templates whose dev loop needs a mock host (`dev:harness`)
+// rather than a plain `dev` (which renders blank without a host).
+func (t Template) NeedsHarness() bool { return t == PageMoney }
 
 // ParseTemplate validates a template name.
 func ParseTemplate(s string) (Template, error) {
@@ -36,6 +43,8 @@ func ParseTemplate(s string) (Template, error) {
 		return Static, nil
 	case PageVite:
 		return PageVite, nil
+	case PageMoney:
+		return PageMoney, nil
 	default:
 		names := make([]string, 0, len(AllTemplates()))
 		for _, t := range AllTemplates() {
@@ -54,12 +63,20 @@ type Data struct {
 }
 
 // outputName maps an embedded template filename to its on-disk name.
-// `.tmpl` is stripped, and `gitignore` is written as `.gitignore` (go:embed
-// cannot embed files whose names begin with a dot).
+// `.tmpl` is stripped; some names are rewritten because go:embed cannot embed
+// files whose names begin with a dot:
+//   - `gitignore`        -> `.gitignore`
+//   - `env.development`  -> `.env.development`
+//   - `env.production`   -> `.env.production`
+//   - `env.example`      -> `.env.example`
 func outputName(rel string) string {
 	rel = strings.TrimSuffix(rel, ".tmpl")
-	if filepath.Base(rel) == "gitignore" {
+	base := filepath.Base(rel)
+	switch {
+	case base == "gitignore":
 		rel = filepath.Join(filepath.Dir(rel), ".gitignore")
+	case base == "env.development" || base == "env.production" || base == "env.example":
+		rel = filepath.Join(filepath.Dir(rel), "."+base)
 	}
 	return rel
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -60,6 +60,84 @@ func TestRenderPageVite(t *testing.T) {
 	mustContain(t, pkg, `"name": "vite-block"`)
 }
 
+func TestRenderPageMoney(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "money-block")
+	written, err := Render(PageMoney, dest, Data{Slug: "money-block", Name: "Money Block"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := relNames(t, dest, written)
+	for _, expect := range []string{
+		"block.manifest.json", "package.json", "vite.config.ts", "tsconfig.json", "index.html",
+		"src/main.tsx", "src/App.tsx", "src/Harness.tsx", "src/generation.ts",
+		"src/generation.test.ts", "src/index.css",
+		"README.md", ".gitignore", ".env.development", ".env.production", ".env.example",
+	} {
+		if !containsStr(got, expect) {
+			t.Errorf("page-money missing expected file %q (got %v)", expect, got)
+		}
+	}
+
+	// Money-path manifest: budgeted scope + per-gen budget + build fields.
+	manifest := readFile(t, filepath.Join(dest, "block.manifest.json"))
+	mustContain(t, manifest, `"ai:write:budgeted"`)
+	mustContain(t, manifest, `"buzzBudgetPerGen": 10`)
+	mustContain(t, manifest, `"buildCommand": "npm run build"`)
+	mustContain(t, manifest, `"outputDir": "dist"`)
+	// Server-owned fields must NOT be set.
+	if contains(manifest, "iframe.src") || contains(manifest, `"src"`) {
+		t.Error("page-money manifest must not declare iframe.src")
+	}
+	if contains(manifest, "trustTier") {
+		t.Error("page-money manifest must not declare trustTier")
+	}
+
+	// package.json: SDK deps + the dev:harness script + slug name.
+	pkg := readFile(t, filepath.Join(dest, "package.json"))
+	mustContain(t, pkg, `"@civitai/blocks-react"`)
+	mustContain(t, pkg, `"@civitai/app-sdk"`)
+	mustContain(t, pkg, `"dev:harness"`)
+	mustContain(t, pkg, `"build"`)
+	mustContain(t, pkg, `"test"`)
+	mustContain(t, pkg, `"name": "money-block"`)
+
+	// App.tsx must use the SDK, never raw postMessage('*').
+	app := readFile(t, filepath.Join(dest, "src", "App.tsx"))
+	mustContain(t, app, "useRequestConsent")
+	mustContain(t, app, "useBuzzWorkflow")
+	mustContain(t, app, "useBlockResize")
+	if contains(app, "window.parent.postMessage") {
+		t.Error("page-money App.tsx should not use raw window.parent.postMessage")
+	}
+
+	// The display name should land in the manifest + App heading.
+	mustContain(t, manifest, `"name": "Money Block"`)
+	mustContain(t, app, "Money Block")
+}
+
+func TestPageMoneyNeedsHarness(t *testing.T) {
+	if !PageMoney.NeedsHarness() {
+		t.Error("page-money should need the dev harness")
+	}
+	if Static.NeedsHarness() || PageVite.NeedsHarness() {
+		t.Error("static/page-vite should not need the dev harness")
+	}
+}
+
+func TestOutputNameMapsEnvFiles(t *testing.T) {
+	cases := map[string]string{
+		"env.development.tmpl": ".env.development",
+		"env.production.tmpl":  ".env.production",
+		"env.example.tmpl":     ".env.example",
+	}
+	for in, want := range cases {
+		if got := outputName(in); got != want {
+			t.Errorf("outputName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestRenderRefusesNonEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "existing"), []byte("x"), 0o644); err != nil {
@@ -76,6 +154,9 @@ func TestParseTemplate(t *testing.T) {
 	}
 	if _, err := ParseTemplate("page-vite"); err != nil {
 		t.Errorf("page-vite should parse: %v", err)
+	}
+	if _, err := ParseTemplate("page-money"); err != nil {
+		t.Errorf("page-money should parse: %v", err)
 	}
 	if _, err := ParseTemplate("nope"); err == nil {
 		t.Error("unknown template should error")

--- a/internal/scaffold/slug_test.go
+++ b/internal/scaffold/slug_test.go
@@ -37,7 +37,7 @@ func TestSlugifyAllPunctuationFails(t *testing.T) {
 
 func TestSlugifyAllTemplates(t *testing.T) {
 	ts := AllTemplates()
-	if len(ts) != 2 {
-		t.Errorf("AllTemplates = %v, want 2", ts)
+	if len(ts) != 3 {
+		t.Errorf("AllTemplates = %v, want 3", ts)
 	}
 }

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -1,0 +1,60 @@
+# {{ .Name }}
+
+A Civitai **page money-path** App Block (Vite + React + TypeScript), wired to
+the published App SDK (`@civitai/blocks-react` + `@civitai/app-sdk`). It mounts
+as a full-page (W10) app at `/apps/run/{{ .Slug }}` and spends Buzz to generate
+an image: estimate → (lazy consent) → submit → poll → result.
+
+## What this is
+
+A sandboxed static web app served in an iframe by the Civitai host. The platform
+owns the build: it runs `npm ci` then the `buildCommand` from
+`block.manifest.json` (`npm run build`), serving the static output from
+`outputDir` (`dist/`). You do NOT commit `dist/` — the platform builds it.
+
+The money path uses the SDK hooks — never raw `window.parent.postMessage`:
+
+- `useBuzzWorkflow()` — `estimate` / `submit` / `poll` (the spend).
+- `useRequestConsent()` — lazy, on first Generate: `ai:write:budgeted` is
+  consent-gated, so the token mints WITHOUT it; the grant arrives as a
+  `TOKEN_REFRESH` and the app auto-resumes the click.
+- `useBlockResize()` — the SDK reports height to the host safely.
+
+Page constraints: a page is `entity=none` (no model context, no model-picker), so
+the model is hardcoded (`GEN_MODEL` in `src/generation.ts`). A page hard-forbids
+`buzz:read:self`, so insufficient Buzz is detected from a failed snapshot, not
+read proactively. The budget comes from `page.buzzBudgetPerGen` in the manifest.
+
+## Develop
+
+```bash
+npm install
+npm run dev:harness   # http://localhost:5186 — mounts a MOCK host so you see something
+```
+
+`npm run dev` alone shows a blank screen — there's no host to send `BLOCK_INIT`.
+Use `dev:harness`. Query toggles: `?viewer=anon`, `?consent=granted`,
+`?fail=insufficient`, `?theme=light`.
+
+```bash
+npm test              # the pure-logic unit tests in src/*.test.ts
+npm run build         # what the platform produces (tsc typecheck + vite build)
+```
+
+## Allowed parent origins
+
+The SDK drops any inbound message whose origin isn't allowlisted and refuses to
+mount with an empty list. Set `VITE_BLOCK_ALLOWED_PARENT_ORIGINS` per environment
+(`.env.development` for the harness, `.env.production` for the civitai.com host).
+See `.env.example`.
+
+## Validate & submit
+
+```bash
+civitai app validate
+civitai login        # once, to store your API token
+civitai app submit
+```
+
+`submit` packages the SOURCE tree (manifest + src + build config), excluding
+`.git`, `node_modules`, and `dist` — the platform rebuilds from source.

--- a/internal/scaffold/templates/page-money/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/page-money/block.manifest.json.tmpl
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "{{ .Slug }}",
+  "version": "0.1.0",
+  "name": "{{ .Name }}",
+  "type": "block",
+  "scopes": ["ai:write:budgeted"],
+  "page": {
+    "path": "/",
+    "title": "{{ .Name }}",
+    "icon": "bolt",
+    "buzzBudgetPerGen": 10
+  },
+  "iframe": {
+    "minHeight": 600,
+    "maxHeight": 4000,
+    "resizable": true,
+    "sandbox": "allow-scripts allow-forms"
+  },
+  "contentRating": "g",
+  "minApiVersion": "1.0",
+  "buildCommand": "npm run build",
+  "outputDir": "dist"
+}

--- a/internal/scaffold/templates/page-money/env.development.tmpl
+++ b/internal/scaffold/templates/page-money/env.development.tmpl
@@ -1,0 +1,4 @@
+# Loaded by `vite dev` / `npm run dev:harness`. The harness fires BLOCK_INIT
+# from window.location.origin, which is the dev server origin pinned in
+# vite.config.ts (localhost:5186).
+VITE_BLOCK_ALLOWED_PARENT_ORIGINS=http://localhost:5186

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -1,0 +1,18 @@
+# Comma-separated list of allowed parent-frame origins. The published SDK's
+# IframeTransport drops every inbound postMessage whose `event.origin` isn't in
+# this list AND refuses to mount (throws -> blank screen) if the list is empty.
+# The value is BAKED IN AT BUILD TIME (import.meta.env), so it must be correct
+# for the environment the bundle is served in.
+#
+# Production (what the committed dist/ is built with, via .env.production): the
+# host page origin(s) that iframe the full-page app. For a W10 page app the host
+# is civitai.com.
+#   VITE_BLOCK_ALLOWED_PARENT_ORIGINS=https://civitai.com,https://www.civitai.com
+#
+# Local harness (.env.development): the dev-server origin. `npm run dev:harness`
+# serves on localhost:5186 and fires BLOCK_INIT from window.location.origin.
+#   VITE_BLOCK_ALLOWED_PARENT_ORIGINS=http://localhost:5186
+
+# Set to "true" to mount the dev Harness (mock host). `npm run dev:harness`
+# flips this on. NEVER set it in a production build.
+VITE_DEV_HARNESS=

--- a/internal/scaffold/templates/page-money/env.production.tmpl
+++ b/internal/scaffold/templates/page-money/env.production.tmpl
@@ -1,0 +1,8 @@
+# Baked into the committed dist/ (vite build, mode=production). The W10 page host
+# is civitai.com — it iframes the app bundle at /apps/run/{{ .Slug }}, so
+# civitai.com must be an allowed parent origin.
+#
+# To render inside a W10 PREVIEW page host for pre-merge verification, add that
+# preview origin too, e.g. https://pr-<N>.civitaic.com (harmless on prod
+# post-merge — just an extra allowed parent).
+VITE_BLOCK_ALLOWED_PARENT_ORIGINS=https://civitai.com,https://www.civitai.com

--- a/internal/scaffold/templates/page-money/gitignore.tmpl
+++ b/internal/scaffold/templates/page-money/gitignore.tmpl
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+.vite/

--- a/internal/scaffold/templates/page-money/index.html.tmpl
+++ b/internal/scaffold/templates/page-money/index.html.tmpl
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>{{ .Name }} — Civitai App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -1,0 +1,32 @@
+{
+  "name": "{{ .Slug }}",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Civitai App Block (page money path) — estimate -> consent -> submit -> poll -> real Buzz spend, wired to the published App SDK.",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite",
+    "dev:harness": "VITE_DEV_HARNESS=true vite --host localhost --port 5186",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@civitai/app-sdk": "^0.9.0",
+    "@civitai/blocks-react": "^0.6.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.0",
+    "jsdom": "^25.0.0",
+    "typescript": "^5.9.0",
+    "vite": "^8.0.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -1,0 +1,470 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  useBlockContext,
+  useBlockResize,
+  useBlockToken,
+  useBuzzWorkflow,
+  useRequestConsent,
+  useRequestSignIn,
+} from '@civitai/blocks-react';
+import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
+
+import {
+  GEN_MODEL,
+  PAGE_BUZZ_BUDGET,
+  PROMPT_MAX,
+  buildWorkflowBody,
+  firstImageUrl,
+  formatCost,
+  hasBudgetedScope,
+  isBusyPhase,
+  isInsufficientBuzz,
+  isTerminalStatus,
+  phaseForSnapshot,
+  type GenPhase,
+} from './generation.js';
+
+/**
+ * {{ .Name }} — a full-page (W10) money-path App Block. It exercises the page
+ * money path end-to-end: estimate -> (lazy consent) -> submit -> poll -> real
+ * Buzz spend, using the published SDK hooks (NEVER raw postMessage to the parent
+ * with a wildcard origin — the SDK does the origin-checked messaging safely).
+ *
+ * Page-native constraints:
+ *  - slot = app.page (entity=none) via the top-level `page:{}` manifest object.
+ *  - scopes = ['ai:write:budgeted'] ONLY. A page HARD-FORBIDS `buzz:read:self`,
+ *    so we CANNOT read the viewer's balance — insufficient Buzz is detected from
+ *    the `failed` snapshot, never proactively.
+ *  - budget comes from manifest `page.buzzBudgetPerGen`; a page is stateless.
+ *  - the model is hardcoded (a page has no slot model) — see GEN_MODEL.
+ *  - `ai:write:budgeted` is consent-gated -> withheld at mint, requested lazily
+ *    on first Generate via useRequestConsent; the grant arrives as a
+ *    TOKEN_REFRESH carrying the scope, which we observe + retry.
+ */
+export function App() {
+  const { ready, viewer, theme } = useBlockContext();
+  const token = useBlockToken();
+  const { estimate, submit, poll } = useBuzzWorkflow();
+  const { requestConsent } = useRequestConsent();
+  const { requestSignIn } = useRequestSignIn();
+
+  const isDark = theme === 'dark';
+  const c = palette(isDark);
+  const anon = ready && !viewer;
+  const granted = hasBudgetedScope(token.scopes);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  useBlockResize(rootRef);
+
+  const [prompt, setPrompt] = useState('');
+  const [phase, setPhase] = useState<GenPhase>('idle');
+  const [estimatedCost, setEstimatedCost] = useState<number | null>(null);
+  const [actualCost, setActualCost] = useState<number | null>(null);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // True once the user clicked Generate while the scope was missing — so when
+  // the consent grant lands (granted flips true) we auto-resume the submit.
+  const consentPendingRef = useRef(false);
+  // Cancellation token for the in-flight poll loop.
+  const pollCancelRef = useRef<{ cancelled: boolean } | null>(null);
+
+  // Latest poll fn in a ref so the poll loop always calls the current hook
+  // instance without re-subscribing.
+  const pollRef = useRef(poll);
+  pollRef.current = poll;
+
+  useEffect(() => {
+    return () => {
+      if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+    };
+  }, []);
+
+  // Apply a (submit- or poll-returned) snapshot to UI state.
+  const applySnapshot = useCallback((snap: BlockWorkflowSnapshot) => {
+    setActualCost(snap.cost?.total ?? null);
+    const url = firstImageUrl(snap);
+    if (url) setImageUrl(url);
+    const next = phaseForSnapshot(snap);
+    setPhase(next);
+    if (next === 'failed' || next === 'insufficient') {
+      setError(snap.error ?? 'Generation failed.');
+    }
+  }, []);
+
+  /**
+   * Drive a single workflow to terminal with an adaptive-backoff poll loop.
+   * `submit()` does NOT auto-poll (SDK contract) — the caller owns the loop.
+   */
+  const runPollLoop = useCallback(
+    (workflowId: string) => {
+      if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+      const tok = { cancelled: false };
+      pollCancelRef.current = tok;
+
+      const SCHEDULE_MS = [2000, 2000, 3000, 5000, 8000];
+      let attempt = 0;
+
+      const tick = async () => {
+        if (tok.cancelled) return;
+        let snap: BlockWorkflowSnapshot;
+        try {
+          snap = await pollRef.current(workflowId);
+        } catch {
+          // Transient hiccup — keep polling. A real terminal failure surfaces
+          // as a 'failed'/'expired' snapshot, not a throw.
+          if (tok.cancelled) return;
+          const delay = SCHEDULE_MS[Math.min(attempt, SCHEDULE_MS.length - 1)];
+          attempt += 1;
+          setTimeout(tick, delay);
+          return;
+        }
+        if (tok.cancelled) return;
+        applySnapshot(snap);
+        if (isTerminalStatus(snap.status)) return;
+        const delay = SCHEDULE_MS[Math.min(attempt, SCHEDULE_MS.length - 1)];
+        attempt += 1;
+        setTimeout(tick, delay);
+      };
+
+      setTimeout(tick, 0);
+    },
+    [applySnapshot],
+  );
+
+  // The estimate->submit->poll sequence, factored out so both the direct click
+  // and the post-consent auto-resume can call it.
+  const runGeneration = useCallback(async () => {
+    setError(null);
+    setImageUrl(null);
+    setActualCost(null);
+    const body = buildWorkflowBody(prompt);
+
+    // 1) Estimate (best-effort — a failed estimate doesn't block submit; the
+    //    host re-prices at submit anyway).
+    setPhase('estimating');
+    try {
+      const est = await estimate(body);
+      if (est.status === 'failed' || est.error) {
+        if (isInsufficientBuzz(est.error)) {
+          setPhase('insufficient');
+          setError(est.error ?? 'Not enough Buzz.');
+          return;
+        }
+        setEstimatedCost(null);
+      } else {
+        setEstimatedCost(est.cost?.total ?? null);
+      }
+    } catch {
+      setEstimatedCost(null);
+    }
+
+    // 2) Submit (the real spend).
+    setPhase('submitting');
+    let snap: BlockWorkflowSnapshot;
+    try {
+      snap = await submit(body);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'submit failed';
+      setPhase(isInsufficientBuzz(msg) ? 'insufficient' : 'failed');
+      setError(msg);
+      return;
+    }
+
+    // A host can return an instant terminal snapshot (cached / instant-fail).
+    applySnapshot(snap);
+    if (isTerminalStatus(snap.status)) return;
+
+    // 3) Poll to terminal.
+    setPhase('polling');
+    if (snap.workflowId) runPollLoop(snap.workflowId);
+  }, [prompt, estimate, submit, applySnapshot, runPollLoop]);
+
+  const handleGenerate = useCallback(() => {
+    // Anon: convert the click into a host login prompt. Generate is server-gated
+    // anyway (an anon token carries no budgeted scope).
+    if (!viewer) {
+      requestSignIn();
+      return;
+    }
+    // Lazy consent: if the budgeted scope isn't granted yet, ask the host to
+    // open its consent UI and remember the intent. The grant arrives as a
+    // TOKEN_REFRESH (granted flips true) -> the effect below auto-resumes.
+    if (!granted) {
+      consentPendingRef.current = true;
+      setPhase('needs-consent');
+      requestConsent({ scopes: ['ai:write:budgeted'] });
+      return;
+    }
+    void runGeneration();
+  }, [viewer, granted, requestSignIn, requestConsent, runGeneration]);
+
+  // Auto-resume after a consent grant.
+  useEffect(() => {
+    if (granted && consentPendingRef.current) {
+      consentPendingRef.current = false;
+      void runGeneration();
+    }
+  }, [granted, runGeneration]);
+
+  // ---- Render ----
+
+  if (!ready) {
+    return (
+      <div ref={rootRef} data-theme={isDark ? 'dark' : 'light'} style={pageStyle(c)}>
+        <div style={loadingStyle}>Loading…</div>
+      </div>
+    );
+  }
+
+  const busy = isBusyPhase(phase);
+  const showTopUp = phase === 'insufficient';
+
+  return (
+    <div ref={rootRef} data-theme={isDark ? 'dark' : 'light'} style={pageStyle(c)}>
+      <div style={contentStyle}>
+        <header style={headerStyle}>
+          <h1 style={titleStyle}>{{ .Name }}</h1>
+          <p style={subtitleStyle(c)}>
+            Type a prompt and generate one image with <strong>{GEN_MODEL.label}</strong>. Each
+            generation spends a small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).
+          </p>
+        </header>
+
+        <div style={fieldStyle}>
+          <label htmlFor="pm-prompt" style={labelStyle}>
+            Prompt
+          </label>
+          <textarea
+            id="pm-prompt"
+            value={prompt}
+            maxLength={PROMPT_MAX}
+            placeholder="a serene mountain lake at golden hour, highly detailed"
+            onChange={(e) => setPrompt(e.target.value)}
+            aria-label="Generation prompt"
+            rows={4}
+            style={textareaStyle(c)}
+          />
+        </div>
+
+        {anon ? (
+          <button type="button" onClick={handleGenerate} style={primaryBtn(c)} data-testid="pm-signin">
+            Sign in to generate
+          </button>
+        ) : showTopUp ? (
+          <p style={noteStyle(c)} role="status" data-testid="pm-insufficient">
+            Not enough Buzz for this generation. Top up your Buzz balance and try again.
+          </p>
+        ) : (
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={busy || prompt.trim().length === 0}
+            style={primaryBtn(c, busy || prompt.trim().length === 0)}
+            data-testid="pm-generate"
+          >
+            <GenerateLabel phase={phase} estimatedCost={estimatedCost} />
+          </button>
+        )}
+
+        {phase === 'needs-consent' && (
+          <p role="status" style={noteStyle(c)}>
+            Grant access to generate — confirm in the Civitai dialog. If you dismissed it,{' '}
+            <button type="button" onClick={handleGenerate} style={linkBtn(c)}>
+              try again
+            </button>
+            .
+          </p>
+        )}
+        {busy && (
+          <p role="status" style={noteStyle(c)}>
+            {phase === 'estimating'
+              ? 'Estimating cost…'
+              : phase === 'submitting'
+                ? 'Submitting generation…'
+                : 'Generating… this can take 10–60s.'}
+          </p>
+        )}
+
+        {phase === 'failed' && error && (
+          <div role="alert" style={errorBox(c)}>
+            {error}
+          </div>
+        )}
+
+        {phase === 'succeeded' && imageUrl && (
+          <figure style={figureStyle}>
+            <img src={imageUrl} alt="Generated result" style={imgStyle(c)} />
+            <figcaption style={captionStyle(c)}>
+              Done. Spent <strong style={strongFg(c)}>{formatCost(actualCost)}</strong> Buzz.
+            </figcaption>
+          </figure>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GenerateLabel({
+  phase,
+  estimatedCost,
+}: {
+  phase: GenPhase;
+  estimatedCost: number | null;
+}) {
+  if (phase === 'estimating') return <>Estimating…</>;
+  if (phase === 'submitting') return <>Submitting…</>;
+  if (phase === 'polling') return <>Generating…</>;
+  if (estimatedCost != null) return <>Generate · {formatCost(estimatedCost)} Buzz</>;
+  return <>Generate</>;
+}
+
+// ------------------------------------------------------------------
+// Theme — the host can't inject CSS into the iframe, so colors come from
+// useBlockContext().theme via inline styles.
+// ------------------------------------------------------------------
+interface Palette {
+  bg: string;
+  fg: string;
+  border: string;
+  inputBg: string;
+  accent: string;
+  accentFg: string;
+  danger: string;
+  dangerBg: string;
+  muted: string;
+}
+
+function palette(dark: boolean): Palette {
+  return dark
+    ? {
+        bg: '#1a1b1e',
+        fg: '#e9ecef',
+        border: '#373a40',
+        inputBg: '#2c2e33',
+        accent: '#fab005',
+        accentFg: '#1a1b1e',
+        danger: '#ff8787',
+        dangerBg: '#2c1f1f',
+        muted: '#909296',
+      }
+    : {
+        bg: '#ffffff',
+        fg: '#1a1b1e',
+        border: '#dee2e6',
+        inputBg: '#ffffff',
+        accent: '#f08c00',
+        accentFg: '#ffffff',
+        danger: '#e03131',
+        dangerBg: '#fff5f5',
+        muted: '#868e96',
+      };
+}
+
+const loadingStyle: React.CSSProperties = { margin: 'auto', opacity: 0.7 };
+const headerStyle: React.CSSProperties = { display: 'grid', gap: 4 };
+const titleStyle: React.CSSProperties = { fontSize: 24, margin: 0 };
+const fieldStyle: React.CSSProperties = { display: 'grid', gap: 6 };
+const labelStyle: React.CSSProperties = { fontSize: 13, fontWeight: 600 };
+const figureStyle: React.CSSProperties = { margin: 0, display: 'grid', gap: 8 };
+
+function pageStyle(c: Palette): React.CSSProperties {
+  return {
+    fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    background: c.bg,
+    color: c.fg,
+    width: '100%',
+    minHeight: '100dvh',
+    display: 'flex',
+    boxSizing: 'border-box',
+  };
+}
+
+const contentStyle: React.CSSProperties = {
+  margin: '0 auto',
+  width: '100%',
+  maxWidth: 640,
+  padding: 24,
+  display: 'grid',
+  gap: 16,
+  alignContent: 'start',
+  boxSizing: 'border-box',
+};
+
+function subtitleStyle(c: Palette): React.CSSProperties {
+  return { fontSize: 14, color: c.muted, margin: 0, lineHeight: 1.5 };
+}
+
+function textareaStyle(c: Palette): React.CSSProperties {
+  return {
+    resize: 'vertical',
+    padding: 12,
+    borderRadius: 8,
+    border: '1px solid ' + c.border,
+    background: c.inputBg,
+    color: c.fg,
+    fontSize: 15,
+    lineHeight: 1.5,
+    fontFamily: 'inherit',
+    boxSizing: 'border-box',
+    width: '100%',
+    minHeight: 96,
+  };
+}
+
+function primaryBtn(c: Palette, disabled = false): React.CSSProperties {
+  return {
+    padding: '12px 18px',
+    border: 'none',
+    borderRadius: 8,
+    background: disabled ? c.border : c.accent,
+    color: disabled ? c.muted : c.accentFg,
+    fontWeight: 700,
+    fontSize: 15,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  };
+}
+
+function linkBtn(c: Palette): React.CSSProperties {
+  return {
+    background: 'none',
+    border: 'none',
+    color: c.accent,
+    cursor: 'pointer',
+    padding: 0,
+    font: 'inherit',
+    textDecoration: 'underline',
+  };
+}
+
+function noteStyle(c: Palette): React.CSSProperties {
+  return { fontSize: 13, color: c.muted, margin: 0, lineHeight: 1.5 };
+}
+
+function errorBox(c: Palette): React.CSSProperties {
+  return {
+    background: c.dangerBg,
+    color: c.danger,
+    border: '1px solid ' + c.danger,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 13,
+  };
+}
+
+function imgStyle(c: Palette): React.CSSProperties {
+  return { width: '100%', borderRadius: 10, border: '1px solid ' + c.border };
+}
+
+function captionStyle(c: Palette): React.CSSProperties {
+  return { fontSize: 13, color: c.muted };
+}
+
+function strongFg(c: Palette): React.CSSProperties {
+  return { color: c.fg };
+}

--- a/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
@@ -1,0 +1,252 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+import type { BlockContext } from '@civitai/app-sdk/blocks';
+
+const DEV_TOKEN = 'dev.harness.mock.jwt.NOT.A.REAL.RS256';
+const DEV_INSTANCE_ID = 'page_{{ .Slug }}';
+const DEV_BLOCK_ID = '{{ .Slug }}';
+const DEV_APP_ID = 'app_dev';
+
+const BUDGETED_SCOPE = 'ai:write:budgeted';
+
+interface OutboundLog {
+  type: string;
+  payload?: unknown;
+}
+
+/**
+ * Local dev mock host for the {{ .Name }} PAGE app. The real W10 page surface
+ * mounts the block in a full-bleed iframe at /apps/run/{{ .Slug }} and routes the
+ * money messages (ESTIMATE/SUBMIT/POLL) to the generation orchestrator. Locally
+ * there's no host, so this component plays one:
+ *
+ *  1. Intercepts `window.parent.postMessage` so the block's outbound messages
+ *     are answered / logged.
+ *  2. Mints a token WITHOUT the budgeted scope first (mirrors the real mint:
+ *     `ai:write:budgeted` is consent-gated -> withheld until granted). On
+ *     REQUEST_CONSENT it "grants" the scope and pushes a TOKEN_REFRESH carrying
+ *     it — the round-trip the App's auto-resume depends on.
+ *  3. Simulates the orchestrator money path: ESTIMATE -> snapshot{cost},
+ *     SUBMIT -> pending snapshot, then POLL -> processing -> succeeded with a
+ *     placeholder image + a cost.
+ *  4. Dispatches a fake BLOCK_INIT with a PAGE context (slotId 'app.page',
+ *     entity=none — NO model fields).
+ *
+ * URL query toggles:
+ *   ?viewer=anon       -> BLOCK_INIT.viewer = null (anon -> sign-in CTA)
+ *   ?consent=granted   -> start WITH the budgeted scope already granted
+ *   ?fail=insufficient -> SUBMIT returns a failed snapshot with insufficient-Buzz text
+ *   ?theme=light       -> light theme (default dark)
+ *
+ * The mock token is NOT a real RS256 JWT — only the bridge round-trips are
+ * exercised. No real Buzz is spent (there is no orchestrator).
+ */
+export function Harness({ children }: { children: ReactNode }) {
+  const [outbound, setOutbound] = useState<OutboundLog[]>([]);
+  const [parentOrigin] = useState(() => window.location.origin);
+  const tokenSerialRef = useRef(0);
+
+  const params = new URLSearchParams(window.location.search);
+  const anon = params.get('viewer') === 'anon';
+  const startGranted = params.get('consent') === 'granted';
+  const failMode = params.get('fail'); // 'insufficient' | null
+  const theme: 'light' | 'dark' = params.get('theme') === 'light' ? 'light' : 'dark';
+
+  useEffect(() => {
+    const originalParent = window.parent;
+    let consentGranted = startGranted;
+    const workflows = new Map<string, { polls: number }>();
+
+    const dispatchToBlock = (data: unknown) => {
+      window.dispatchEvent(new MessageEvent('message', { data, origin: parentOrigin }));
+    };
+
+    const nextToken = () => {
+      tokenSerialRef.current += 1;
+      return {
+        raw: DEV_TOKEN + '.' + tokenSerialRef.current,
+        scopes: consentGranted ? [BUDGETED_SCOPE] : ([] as string[]),
+        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+        ...(consentGranted ? { buzzBudget: 10 } : {}),
+      };
+    };
+
+    const succeededSnapshot = (workflowId: string) => ({
+      workflowId,
+      status: 'succeeded' as const,
+      cost: { total: 8 },
+      imageUrls: ['https://placehold.co/512x512/1971c2/ffffff/png?text=Generated'],
+    });
+
+    const parentMock = {
+      postMessage: (msg: unknown) => {
+        if (
+          typeof msg !== 'object' ||
+          msg === null ||
+          typeof (msg as { type?: unknown }).type !== 'string'
+        ) {
+          return;
+        }
+        const typed = msg as {
+          type: string;
+          payload?: { requestId?: string; workflowId?: string; body?: unknown };
+        };
+        if (typed.type !== 'RESIZE_IFRAME') {
+          queueMicrotask(() =>
+            setOutbound((prev) => [...prev, { type: typed.type, payload: typed.payload }]),
+          );
+        }
+        const requestId = typed.payload?.requestId;
+
+        if (typed.type === 'REQUEST_TOKEN') {
+          dispatchToBlock({
+            type: 'TOKEN_REFRESH_RESPONSE',
+            payload: { ...(requestId ? { requestId } : {}), token: nextToken() },
+          });
+          return;
+        }
+
+        // Lazy consent: "grant" the budgeted scope, then push a host-initiated
+        // TOKEN_REFRESH (no requestId) carrying the now-granted scope.
+        if (typed.type === 'REQUEST_CONSENT') {
+          consentGranted = true;
+          window.setTimeout(() => {
+            dispatchToBlock({ type: 'TOKEN_REFRESH', payload: { token: nextToken() } });
+          }, 600);
+          return;
+        }
+
+        if (typed.type === 'REQUEST_SIGN_IN') {
+          return;
+        }
+
+        if (typed.type === 'ESTIMATE_WORKFLOW') {
+          dispatchToBlock({
+            type: 'ESTIMATE_RESULT',
+            payload: {
+              requestId,
+              snapshot: { workflowId: 'wf_estimate', status: 'pending', cost: { total: 8 } },
+            },
+          });
+          return;
+        }
+
+        if (typed.type === 'SUBMIT_WORKFLOW') {
+          if (failMode === 'insufficient') {
+            dispatchToBlock({
+              type: 'WORKFLOW_SUBMITTED',
+              payload: {
+                requestId,
+                snapshot: {
+                  workflowId: 'wf_fail',
+                  status: 'failed',
+                  error: 'Insufficient Buzz to run this generation.',
+                },
+              },
+            });
+            return;
+          }
+          const workflowId = 'wf_' + Date.now();
+          workflows.set(workflowId, { polls: 0 });
+          dispatchToBlock({
+            type: 'WORKFLOW_SUBMITTED',
+            payload: { requestId, snapshot: { workflowId, status: 'pending' } },
+          });
+          return;
+        }
+
+        if (typed.type === 'POLL_WORKFLOW') {
+          const workflowId = typed.payload?.workflowId ?? '';
+          const wf = workflows.get(workflowId);
+          const polls = (wf?.polls ?? 0) + 1;
+          if (wf) wf.polls = polls;
+          const snapshot =
+            polls >= 2
+              ? succeededSnapshot(workflowId)
+              : { workflowId, status: 'processing' as const };
+          dispatchToBlock({ type: 'WORKFLOW_STATUS', payload: { requestId, snapshot } });
+          return;
+        }
+      },
+    };
+    Object.defineProperty(window, 'parent', {
+      value: parentMock,
+      configurable: true,
+      writable: true,
+    });
+
+    // PAGE context — entity=none, slotId 'app.page'. No model fields.
+    const context: BlockContext = { slotId: 'app.page', theme };
+    const payload = {
+      blockInstanceId: DEV_INSTANCE_ID,
+      blockId: DEV_BLOCK_ID,
+      appId: DEV_APP_ID,
+      token: nextToken(),
+      context,
+      settings: { publisherSettings: {}, userSettings: {} },
+      viewer: anon ? null : { id: 2, username: 'dev-viewer', status: 'active' as const },
+      theme,
+      renderMode: 'iframe' as const,
+    };
+    const timer = window.setTimeout(() => dispatchToBlock({ type: 'BLOCK_INIT', payload }), 0);
+
+    return () => {
+      window.clearTimeout(timer);
+      Object.defineProperty(window, 'parent', {
+        value: originalParent,
+        configurable: true,
+        writable: true,
+      });
+    };
+  }, [parentOrigin, anon, startGranted, failMode, theme]);
+
+  const summary =
+    'DEV HARNESS · viewer=' +
+    (anon ? 'anon' : 'dev-viewer') +
+    ' · consent=' +
+    (startGranted ? 'granted' : 'withheld') +
+    ' · theme=' +
+    theme +
+    ' · outbound:' +
+    outbound.length;
+
+  return (
+    <div data-harness="true" style={harnessRootStyle}>
+      <main data-harness-frame="true" style={harnessFrameStyle}>
+        {children}
+      </main>
+      <details style={harnessLogStyle}>
+        <summary style={harnessSummaryStyle}>{summary}</summary>
+        <pre style={harnessPreStyle}>
+          {outbound.length === 0
+            ? '// no outbound messages yet'
+            : outbound
+                .map((m, i) => i + 1 + '. ' + m.type + ' ' + JSON.stringify(m.payload ?? {}))
+                .join('\n')}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+const harnessRootStyle: React.CSSProperties = {
+  position: 'relative',
+  width: '100vw',
+  minHeight: '100dvh',
+};
+const harnessFrameStyle: React.CSSProperties = { width: '100%', minHeight: '100%' };
+const harnessSummaryStyle: React.CSSProperties = { cursor: 'pointer' };
+const harnessPreStyle: React.CSSProperties = { margin: 0, maxHeight: 200, overflow: 'auto' };
+const harnessLogStyle: React.CSSProperties = {
+  position: 'fixed',
+  bottom: 8,
+  right: 8,
+  zIndex: 9999,
+  maxWidth: 520,
+  background: 'rgba(17,17,17,0.92)',
+  color: '#7fc',
+  fontSize: 11,
+  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+  padding: '6px 10px',
+  borderRadius: 6,
+};

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
+
+import {
+  GEN_MODEL,
+  PROMPT_MAX,
+  buildWorkflowBody,
+  clampPrompt,
+  formatCost,
+  hasBudgetedScope,
+  isInsufficientBuzz,
+  isTerminalStatus,
+  phaseForSnapshot,
+} from './generation.js';
+
+// A couple of pure-logic tests so authors inherit a working test setup. Run with
+// `npm test`. Add cases here as you grow the app's logic.
+
+describe('formatCost', () => {
+  it('renders an integer with separators', () => {
+    expect(formatCost(1234)).toBe('1,234');
+  });
+  it('renders a dash for null / non-finite', () => {
+    expect(formatCost(null)).toBe('—');
+    expect(formatCost(NaN)).toBe('—');
+  });
+});
+
+describe('hasBudgetedScope', () => {
+  it('true only when ai:write:budgeted is present', () => {
+    expect(hasBudgetedScope(['ai:write:budgeted'])).toBe(true);
+    expect(hasBudgetedScope([])).toBe(false);
+    expect(hasBudgetedScope(undefined)).toBe(false);
+  });
+});
+
+describe('isInsufficientBuzz', () => {
+  it('catches common phrasings, false for unrelated', () => {
+    expect(isInsufficientBuzz('Insufficient Buzz')).toBe(true);
+    expect(isInsufficientBuzz('prompt rejected by audit')).toBe(false);
+    expect(isInsufficientBuzz(null)).toBe(false);
+  });
+});
+
+describe('clampPrompt', () => {
+  it('trims to the server cap', () => {
+    expect(clampPrompt('x'.repeat(PROMPT_MAX + 100)).length).toBe(PROMPT_MAX);
+  });
+});
+
+describe('buildWorkflowBody', () => {
+  it('builds a textToImage body with the hardcoded model + trimmed prompt', () => {
+    expect(buildWorkflowBody('  a cat  ')).toEqual({
+      kind: 'textToImage',
+      modelId: GEN_MODEL.modelId,
+      modelVersionId: GEN_MODEL.modelVersionId,
+      params: { prompt: 'a cat' },
+    });
+  });
+});
+
+describe('isTerminalStatus', () => {
+  it('terminal for end states, not for in-flight', () => {
+    expect(isTerminalStatus('succeeded')).toBe(true);
+    expect(isTerminalStatus('processing')).toBe(false);
+  });
+});
+
+describe('phaseForSnapshot', () => {
+  const snap = (over: Partial<BlockWorkflowSnapshot>): BlockWorkflowSnapshot => ({
+    workflowId: 'wf',
+    status: 'pending',
+    ...over,
+  });
+  it('maps in-flight to polling and success to succeeded', () => {
+    expect(phaseForSnapshot(snap({ status: 'processing' }))).toBe('polling');
+    expect(phaseForSnapshot(snap({ status: 'succeeded' }))).toBe('succeeded');
+  });
+  it('maps an insufficient-Buzz failure to insufficient', () => {
+    expect(phaseForSnapshot(snap({ status: 'failed', error: 'Insufficient Buzz' }))).toBe(
+      'insufficient',
+    );
+  });
+});

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -1,0 +1,144 @@
+// Pure logic for the {{ .Name }} page money app. No React, no DOM — unit-tested
+// in node (see generation.test.ts). The App glue imports these so the
+// load-bearing decisions (cost format, insufficient-Buzz sniff, terminal-status
+// reduction, scope check) live in one tested place.
+
+import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
+
+/**
+ * The hardcoded model this app generates with.
+ *
+ * A W10 page slot is entity=none: it carries NO model/entity context (unlike a
+ * model slot), and the SDK exposes NO model-picker to a page app. The trust
+ * model for page generation is "any public, generatable model, server-validated"
+ * — so we hardcode a single known-good base. The canonical Stability AI "SD XL"
+ * base is public + generation-covered + SFW. Swap to your preferred public,
+ * generation-covered model if you like.
+ */
+export const GEN_MODEL = {
+  modelId: 101055,
+  modelVersionId: 128078,
+  label: 'SD XL 1.0',
+} as const;
+
+/** Server cap mirror — prompts over this are rejected by the workflow schema. */
+export const PROMPT_MAX = 1500;
+
+/**
+ * Manifest budget (page.buzzBudgetPerGen). Keep in sync with block.manifest.json
+ * — the SERVER reads the manifest value at mint and clamps to the per-gen cap;
+ * this constant only drives the client-side "Top up · N" CTA amount and budget
+ * copy. The real ceiling is enforced server-side.
+ */
+export const PAGE_BUZZ_BUDGET = 10;
+
+/** The scope the page token must carry before a generation can be submitted. */
+export const BUDGETED_SCOPE = 'ai:write:budgeted';
+
+/** Snapshot statuses that mean "stop polling". Mirrors the SDK's TERMINAL set. */
+const TERMINAL: ReadonlySet<BlockWorkflowSnapshot['status']> = new Set([
+  'succeeded',
+  'failed',
+  'expired',
+  'canceled',
+]);
+
+export function isTerminalStatus(status: BlockWorkflowSnapshot['status']): boolean {
+  return TERMINAL.has(status);
+}
+
+/**
+ * Does the token carry the budgeted-spend scope? Drives whether a Generate
+ * click submits directly or first asks the host to open the consent UI.
+ * `ai:write:budgeted` is consent-gated, so a fresh viewer's mint WITHHOLDS it
+ * until they grant it; after grant the host pushes TOKEN_REFRESH with the scope
+ * and this flips true -> retry.
+ */
+export function hasBudgetedScope(scopes: readonly string[] | undefined): boolean {
+  return Array.isArray(scopes) && scopes.includes(BUDGETED_SCOPE);
+}
+
+/**
+ * Sniff a workflow failure / error string for insufficient-Buzz language so the
+ * UI can swap to a Top-Up CTA. There is NO structured error.code on the
+ * BlockWorkflowSnapshot today (only a free-text `error`), so this is a substring
+ * heuristic. A page CANNOT request `buzz:read:self`, so we cannot read the
+ * balance proactively; detecting it from the `failed` snapshot is the only
+ * signal available on a page.
+ */
+export function isInsufficientBuzz(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes('insufficient') ||
+    m.includes('not enough') ||
+    m.includes('budget') ||
+    m.includes('balance') ||
+    m.includes('buzz')
+  );
+}
+
+/** Format a Buzz cost for display, with thousands separators. `null` -> '—'. */
+export function formatCost(cost: number | null | undefined): string {
+  if (cost == null || !Number.isFinite(cost)) return '—';
+  return Math.round(cost).toLocaleString();
+}
+
+/** Trim + clamp a prompt to the server cap so submit can't be rejected on length. */
+export function clampPrompt(raw: string): string {
+  return raw.slice(0, PROMPT_MAX);
+}
+
+/**
+ * Build the textToImage submit/estimate body. Page apps keep the param surface
+ * minimal: just the prompt — the host fills sensible defaults for
+ * dimensions/sampler/steps from the base-model family.
+ */
+export function buildWorkflowBody(prompt: string) {
+  return {
+    kind: 'textToImage' as const,
+    modelId: GEN_MODEL.modelId,
+    modelVersionId: GEN_MODEL.modelVersionId,
+    params: { prompt: clampPrompt(prompt.trim()) },
+  };
+}
+
+/** Pull the single displayable image url from a succeeded snapshot, if any. */
+export function firstImageUrl(snapshot: BlockWorkflowSnapshot | null): string | null {
+  if (!snapshot || !snapshot.imageUrls || snapshot.imageUrls.length === 0) return null;
+  return snapshot.imageUrls[0] ?? null;
+}
+
+/** The single-in-flight generation phase the page tracks. */
+export type GenPhase =
+  | 'idle'
+  | 'needs-consent'
+  | 'estimating'
+  | 'submitting'
+  | 'polling'
+  | 'succeeded'
+  | 'failed'
+  | 'insufficient';
+
+/** Is a generation in flight (Generate should be disabled / show progress)? */
+export function isBusyPhase(phase: GenPhase): boolean {
+  return phase === 'estimating' || phase === 'submitting' || phase === 'polling';
+}
+
+/**
+ * Reduce a polled snapshot to the next page phase. Keeps the status->phase
+ * mapping in one tested place so the poll loop stays a thin driver.
+ */
+export function phaseForSnapshot(snapshot: BlockWorkflowSnapshot): GenPhase {
+  switch (snapshot.status) {
+    case 'succeeded':
+      return 'succeeded';
+    case 'failed':
+    case 'expired':
+    case 'canceled':
+      return isInsufficientBuzz(snapshot.error) ? 'insufficient' : 'failed';
+    case 'pending':
+    case 'processing':
+      return 'polling';
+  }
+}

--- a/internal/scaffold/templates/page-money/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-money/src/index.css.tmpl
@@ -1,0 +1,33 @@
+:root {
+  color-scheme: light dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  min-height: 100%;
+}
+
+body {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* Focus affordances key off the root data-theme (the host can't inject CSS). */
+[data-theme='dark'] textarea:focus-visible,
+[data-theme='dark'] button:focus-visible {
+  outline: 2px solid #fab005;
+  outline-offset: 2px;
+}
+
+[data-theme='light'] textarea:focus-visible,
+[data-theme='light'] button:focus-visible {
+  outline: 2px solid #f08c00;
+  outline-offset: 2px;
+}

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -1,0 +1,27 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App.js';
+import { Harness } from './Harness.js';
+import './index.css';
+
+// `npm run dev:harness` sets VITE_DEV_HARNESS=true to mount the local mock host
+// that posts a fake BLOCK_INIT (page context, entity=none), answers the consent
+// + token-refresh round-trip, and simulates the orchestrator money path
+// (estimate / submit / poll). Never set in prod.
+const useHarness = import.meta.env.VITE_DEV_HARNESS === 'true';
+
+const container = document.getElementById('root');
+if (!container) throw new Error('#root missing from index.html');
+
+createRoot(container).render(
+  <StrictMode>
+    {useHarness ? (
+      <Harness>
+        <App />
+      </Harness>
+    ) : (
+      <App />
+    )}
+  </StrictMode>,
+);

--- a/internal/scaffold/templates/page-money/tsconfig.json.tmpl
+++ b/internal/scaffold/templates/page-money/tsconfig.json.tmpl
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client", "node"],
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/internal/scaffold/templates/page-money/vite.config.ts.tmpl
+++ b/internal/scaffold/templates/page-money/vite.config.ts.tmpl
@@ -1,0 +1,29 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// base MUST be '/' — the platform serves the build output at the root of the
+// app's own subdomain and server-owns the manifest iframe.src (the W10 page
+// surface iframes the bundle at /apps/run/{{ .Slug }}). No path prefix.
+export default defineConfig({
+  base: '/',
+  plugins: [react()],
+  server: {
+    // The dev harness fires a fake BLOCK_INIT from window.location.origin and
+    // the SDK IframeTransport drops any postMessage whose origin isn't its
+    // allowed parent origin. Pin host+port so that origin is stable.
+    host: 'localhost',
+    port: 5186,
+    strictPort: true,
+  },
+  build: {
+    target: 'es2022',
+    rollupOptions: { output: { manualChunks: undefined } },
+  },
+  test: {
+    // Pure-logic unit tests run in node; the cost-format / insufficient-Buzz
+    // sniff / poll-state helpers don't touch the DOM.
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -22,11 +22,20 @@ var printer = message.NewPrinter(language.English)
 
 // Result is the outcome of validating a project directory.
 type Result struct {
+	// Errors are hard failures: the server will reject the manifest. Non-empty
+	// Errors means validation failed.
 	Errors []string
+	// Warnings are non-fatal money-path / footgun advisories the schema can't
+	// express as hard errors (e.g. a budgeted page with no per-gen budget).
+	// They do not fail validation unless --strict is requested.
+	Warnings []string
 }
 
-// OK reports whether validation passed.
+// OK reports whether validation passed (no hard errors).
 func (r Result) OK() bool { return len(r.Errors) == 0 }
+
+// HasWarnings reports whether any non-fatal advisories were emitted.
+func (r Result) HasWarnings() bool { return len(r.Warnings) > 0 }
 
 var compiled *jsonschema.Schema
 
@@ -98,8 +107,15 @@ func Dir(dir string) (Result, error) {
 	// set"; here we also check the directory is declared/exists sanely).
 	res.Errors = append(res.Errors, buildCoherence(dir, m)...)
 
+	// Non-fatal advisories: real money-path footguns the schema can't catch as
+	// hard errors (see warnings.go). These never fail validation unless the
+	// caller opts into --strict.
+	res.Warnings = append(res.Warnings, warningChecks(generic)...)
+
 	sort.Strings(res.Errors)
 	res.Errors = dedupe(res.Errors)
+	sort.Strings(res.Warnings)
+	res.Warnings = dedupe(res.Warnings)
 	return res, nil
 }
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -38,6 +38,21 @@ func TestValidateAcceptsPageViteTemplate(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsPageMoneyTemplate(t *testing.T) {
+	res, err := Dir(scaffoldGood(t, scaffold.PageMoney))
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("page-money template should be valid, got: %v", res.Errors)
+	}
+	// The scaffolded page-money manifest declares a budget, so it must be
+	// warning-free (no budgeted-without-budget advisory).
+	if res.HasWarnings() {
+		t.Errorf("page-money scaffold should be warning-free, got: %v", res.Warnings)
+	}
+}
+
 // writeManifest writes a manifest-only project dir and validates it.
 func validateManifest(t *testing.T, json string) Result {
 	t.Helper()

--- a/internal/validate/warnings.go
+++ b/internal/validate/warnings.go
@@ -1,0 +1,82 @@
+package validate
+
+// warnings.go holds the NON-FATAL advisory tier of `civitai app validate`.
+//
+// These are real money-path / page footguns the JSON Schema and the ported
+// semantic rules can't express as HARD errors (the manifest is technically
+// well-formed and the server won't necessarily reject it), but which are almost
+// always a mistake an author wants flagged before submit. They never fail
+// validation unless the caller passes --strict.
+//
+// The budgeted-page-without-budget case is the headline one the page-money
+// dogfood surfaced: a page declaring `ai:write:budgeted` but no
+// `page.buzzBudgetPerGen` mints budget-less tokens, so every generation fails
+// insufficient-budget at the orchestrator — a silent, confusing dead end.
+
+const budgetedScope = "ai:write:budgeted"
+
+// warningChecks runs the advisory rules over the decoded manifest map.
+func warningChecks(generic any) []string {
+	m, ok := generic.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var warns []string
+
+	page, hasPage := m["page"].(map[string]any)
+	scopes := stringSet(m["scopes"])
+	_, hasBudgeted := scopes[budgetedScope]
+	_, hasTargets := m["targets"].([]any)
+
+	// (1) Budgeted scope but no per-gen budget on the page. A page mints
+	//     budget-less ai:write:budgeted tokens → every spend fails at the
+	//     orchestrator. The headline footgun the dogfood found.
+	if hasBudgeted && hasPage {
+		if _, hasBudget := page["buzzBudgetPerGen"]; !hasBudget {
+			warns = append(warns,
+				"scopes include \"ai:write:budgeted\" but page.buzzBudgetPerGen is not set — "+
+					"a page mints budget-less tokens, so every generation will fail with "+
+					"insufficient budget; set page.buzzBudgetPerGen (server-clamped to the per-gen cap)")
+		}
+	}
+
+	// (2) The budgeted (money) scope on a NON-page app. Budgeted spend is a page
+	//     affordance; a model-slot/static app requesting it almost certainly
+	//     meant to be a page (declare a `page` field). Not a hard error (the
+	//     server gates the spend), but worth surfacing.
+	if hasBudgeted && !hasPage {
+		warns = append(warns,
+			"scopes include \"ai:write:budgeted\" but no \"page\" block is declared — "+
+				"budgeted Buzz spend is a full-page (W10) affordance; declare a \"page\" field, "+
+				"or drop the scope if this isn't a money-path page app")
+	}
+
+	// (3) A page app that declares neither model targets nor a money scope and no
+	//     budget — likely an incomplete page. Purely informational: a page with
+	//     a generation budget but no budgeted scope can never spend.
+	if hasPage && !hasBudgeted {
+		if _, hasBudget := page["buzzBudgetPerGen"]; hasBudget {
+			warns = append(warns,
+				"page.buzzBudgetPerGen is set but scopes do not include \"ai:write:budgeted\" — "+
+					"the budget is inert; add the scope to enable budgeted generation, or remove the budget")
+		}
+	}
+
+	_ = hasTargets // reserved for future target-related advisories.
+	return warns
+}
+
+// stringSet decodes a JSON array of strings into a set, ignoring non-strings.
+func stringSet(v any) map[string]struct{} {
+	out := map[string]struct{}{}
+	arr, ok := v.([]any)
+	if !ok {
+		return out
+	}
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out[s] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/validate/warnings_test.go
+++ b/internal/validate/warnings_test.go
@@ -1,0 +1,127 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasWarningContaining(res Result, substr string) bool {
+	for _, w := range res.Warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// A valid, well-formed budgeted page WITHOUT a per-gen budget — the headline
+// footgun. Must warn, must NOT error, must exit OK (no --strict).
+func TestWarnBudgetedPageWithoutBudget(t *testing.T) {
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "no-budget",
+  "version": "0.1.0",
+  "name": "No Budget",
+  "type": "block",
+  "scopes": ["ai:write:budgeted"],
+  "page": { "path": "/", "title": "No Budget" },
+  "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
+  "contentRating": "g",
+  "buildCommand": "npm run build",
+  "outputDir": "dist"
+}`
+	res := validateManifest(t, m)
+	if !res.OK() {
+		t.Fatalf("budgeted-page-without-budget should NOT be a hard error: %v", res.Errors)
+	}
+	if !hasWarningContaining(res, "page.buzzBudgetPerGen is not set") {
+		t.Errorf("expected budgeted-without-budget warning, got: %v", res.Warnings)
+	}
+}
+
+// A budgeted manifest with NO page block — money scope on a non-page app.
+func TestWarnBudgetedScopeWithoutPage(t *testing.T) {
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "money-static",
+  "version": "0.1.0",
+  "name": "Money Static",
+  "type": "block",
+  "scopes": ["ai:write:budgeted"],
+  "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
+  "contentRating": "g"
+}`
+	res := validateManifest(t, m)
+	if !res.OK() {
+		t.Fatalf("budgeted-without-page should NOT be a hard error: %v", res.Errors)
+	}
+	if !hasWarningContaining(res, "no \"page\" block is declared") {
+		t.Errorf("expected budgeted-without-page warning, got: %v", res.Warnings)
+	}
+}
+
+// A page with a budget but NO budgeted scope — the budget is inert.
+func TestWarnBudgetWithoutScope(t *testing.T) {
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "inert-budget",
+  "version": "0.1.0",
+  "name": "Inert Budget",
+  "type": "block",
+  "scopes": [],
+  "page": { "path": "/", "title": "Inert Budget", "buzzBudgetPerGen": 10 },
+  "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
+  "contentRating": "g",
+  "buildCommand": "npm run build",
+  "outputDir": "dist"
+}`
+	res := validateManifest(t, m)
+	if !res.OK() {
+		t.Fatalf("budget-without-scope should NOT be a hard error: %v", res.Errors)
+	}
+	if !hasWarningContaining(res, "the budget is inert") {
+		t.Errorf("expected inert-budget warning, got: %v", res.Warnings)
+	}
+}
+
+// A correctly-configured budgeted page (budget + scope) emits NO warnings.
+func TestNoWarningsForBudgetedPageWithBudget(t *testing.T) {
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "good-money",
+  "version": "0.1.0",
+  "name": "Good Money",
+  "type": "block",
+  "scopes": ["ai:write:budgeted"],
+  "page": { "path": "/", "title": "Good Money", "buzzBudgetPerGen": 10 },
+  "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
+  "contentRating": "g",
+  "buildCommand": "npm run build",
+  "outputDir": "dist"
+}`
+	res := validateManifest(t, m)
+	if !res.OK() {
+		t.Fatalf("good money page should be valid: %v", res.Errors)
+	}
+	if res.HasWarnings() {
+		t.Errorf("good money page should be warning-free, got: %v", res.Warnings)
+	}
+}
+
+// A plain static app (no money scope, no page) emits no warnings.
+func TestNoWarningsForStaticApp(t *testing.T) {
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "plain-static",
+  "version": "0.1.0",
+  "name": "Plain Static",
+  "type": "block",
+  "scopes": ["models:read:self"],
+  "iframe": { "minHeight": 200, "resizable": true, "sandbox": "allow-scripts" },
+  "contentRating": "g"
+}`
+	res := validateManifest(t, m)
+	if res.HasWarnings() {
+		t.Errorf("plain static app should be warning-free, got: %v", res.Warnings)
+	}
+}


### PR DESCRIPTION
Four CLI improvements surfaced by the Gen Matrix page-app dogfood. All four are deterministic/structural (no behavior is prose-gated).

## 1. `page-money` SDK template (the big one)
The existing `page-vite` template is plain JS + raw `postMessage` — useless for a money-path page app. This adds `internal/scaffold/templates/page-money` (wired into `init --template page-money`): a real full-page (W10) money-path App Block, modeled on the working `civitai-block-buzz-generator` reference but a simpler single-generation skeleton.

- `package.json`: `@civitai/blocks-react@^0.6.0` + `@civitai/app-sdk@^0.9.0` + React 19 + Vite/TS; scripts `dev` / **`dev:harness`** / `build` / `test` / `typecheck` / `preview`.
- `src/App.tsx`: prompt → estimate (cost on the button) → first-Generate **lazy consent via `useRequestConsent`** → submit → poll → image, using `useBuzzWorkflow` + `useBlockResize`. **No raw `window.parent.postMessage`** — the SDK does origin-checked messaging.
- `src/Harness.tsx`: a mock host (page `BLOCK_INIT` + consent round-trip + mocked orchestrator estimate/submit/poll) so `dev:harness` renders.
- `src/generation.ts` + `src/generation.test.ts`: pure logic + a unit-test stub so authors inherit a test setup.
- `.env.development` / `.env.production` / `.env.example`: allowed parent origins (`go:embed` can't carry dotfiles, so they're embedded as `env.*.tmpl` and mapped on render).
- `block.manifest.json`: page app, `scopes:["ai:write:budgeted"]`, `page.buzzBudgetPerGen`, `buildCommand`/`outputDir`; server-owned `iframe.src`/`trustTier` omitted.

`page-vite` + `static` are unchanged. The scaffold passes `civitai app validate` (asserted in tests), and was independently verified to **npm-install → typecheck → vitest (9 pass) → vite build** with the published SDK packages.

## 2. `init` dir control
`--dir <path>` and/or a positional `[dir]` set the output directory; `--name` overrides the display name independently. So name, slug, and directory can all differ. No flag → `./<slug>` (back-compat). Conflicting positional+`--dir` is a clear error.

## 3. `validate` warning tier
Non-fatal WARNINGS distinct from errors — exit 0 with warnings, or `--strict` to fail. Warnings:
- **`ai:write:budgeted` in scopes but `page.buzzBudgetPerGen` missing** (the headline footgun: budget-less tokens → every spend fails).
- money scope on a non-page app (budgeted spend is a page affordance).
- a budget set with no budgeted scope (inert budget).

## 4. `init` next-steps fix
Next-steps are template-aware: `page-money` → `npm run dev:harness` (plain `dev` renders blank without a host); the `cd` target is the actual output dir.

## Quality
`go build` / `go test` / `go vet` / `gofmt -s -l` clean; `goreleaser check` passes. New-logic coverage: scaffold 83.3%, validate 91.5%, cmd 92.4% (warningChecks 94.4%; NeedsHarness/outputName/printWarnings 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)