### PR TITLE
feat(login): OAuth device-flow login + token refresh; submit via token route

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ civitai version
 ## Quickstart
 
 ```bash
-# 1. Authenticate once (create a token at https://civitai.com/user/account).
+# 1. Authenticate once (browser device login; or `civitai login --token <t>`).
 civitai login
 
 # 2. Scaffold a ready-to-build App Block.
@@ -56,7 +56,7 @@ cd my-app
 # 3. Edit your app, then check the manifest before submitting.
 civitai app validate
 
-# 4. Package + submit for review (or write the bundle + print next steps).
+# 4. Package + submit for review (uploads with your stored token by default).
 civitai app submit
 ```
 
@@ -70,11 +70,11 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 
 | Command | What it does |
 | --- | --- |
-| `civitai login [--token <t>]` | Store your API token (`~/.config/civitai/config.yaml`, 0600). Also reads `CIVITAI_TOKEN`. |
+| `civitai login [--token <t>] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens); `--token` stores a personal API key instead. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
 | `civitai whoami` | Verify the stored token; print the authenticated user. |
 | `civitai app init [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | Scaffold a correct, ready-to-build App Block project (default dir `./<slug>`). |
 | `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
-| `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + submit (or write the bundle + print manual next steps). |
+| `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai version` | Print version / commit / build date. |
 | `civitai completion [shell]` | Generate a shell-completion script. |
 
@@ -126,18 +126,24 @@ the real `BlockManifestValidator` (the faithful contract), with this schema
 published as the syntactic half. See [`CLAUDE.md`](CLAUDE.md) for the full
 caveat and how the vendored schema + Go checks are kept in sync.
 
-## Submit & auth (current state)
+## Submit & auth
 
-The live upload route (`POST /api/blocks/submit-version`) is **session-cookie +
-moderator** authenticated today — it does not accept an API token — so a fully
-programmatic `civitai app submit` needs a companion token-accepting server
-endpoint. Until that ships:
+`civitai login` (no flags) runs the **OAuth device-authorization grant**: it
+prints a URL + a short code, you approve in your browser, and the CLI stores a
+short-lived access token (1h) plus a refresh token (30d) that it rotates
+automatically before requests and once on a `401`. `civitai login --token <key>`
+stores a personal API key instead (no refresh). `CIVITAI_TOKEN` overrides the
+stored credential (treated as a personal key).
 
-- `civitai app submit` always **validates + packages** the canonical source ZIP.
-- If a token *and* a token-accepting endpoint are configured (set
-  `CIVITAI_SUBMIT_PATH`), it uploads directly with `Authorization: Bearer`.
-- Otherwise it **writes the `.zip` and prints the exact manual next steps**
-  (web upload at `/apps/submit`, or the git-push path for updates).
+`civitai app submit`:
+
+- always **validates + packages** the canonical source ZIP, then
+- **uploads it with your stored token** to the token-authenticated route
+  `POST /api/v1/blocks/submit-version` (`Authorization: Bearer`). OAuth tokens
+  refresh transparently. Set `CIVITAI_SUBMIT_PATH` to override the route.
+- With **no token configured** (and not `--package-only`), it instead writes the
+  `.zip` and prints the next steps (`civitai login`, or web upload at
+  `/apps/submit`).
 
 `--package-only` always just writes the `.zip` and stops.
 
@@ -145,9 +151,10 @@ endpoint. Until that ships:
 
 | Setting | Config key | Env var | Default |
 | --- | --- | --- | --- |
-| API token | `token` | `CIVITAI_TOKEN` | — |
+| Personal API key | `token` | `CIVITAI_TOKEN` | — |
+| OAuth tokens (device login) | `auth_kind`, `access_token`, `refresh_token`, `token_expiry`, `scope` | — | — |
 | API base URL | `base_url` | `CIVITAI_BASE_URL` | `https://civitai.com` |
-| Submit endpoint | — | `CIVITAI_SUBMIT_PATH` | `/api/blocks/submit-version` |
+| Submit endpoint | — | `CIVITAI_SUBMIT_PATH` | `/api/v1/blocks/submit-version` |
 
 Config lives at `~/.config/civitai/config.yaml` (honours `XDG_CONFIG_HOME`),
 written owner-readable only.
@@ -155,8 +162,10 @@ written owner-readable only.
 ## Troubleshooting
 
 - **`no token configured`** — run `civitai login` (or set `CIVITAI_TOKEN`).
-- **`unauthorized (401)`** — your token is invalid/expired; create a new one at
-  `https://civitai.com/user/account` and `civitai login` again.
+- **`unauthorized (401)`** — your token is invalid/expired. OAuth tokens refresh
+  automatically; if the refresh token has also expired, run `civitai login`
+  again. For a personal key, create a new one at
+  `https://civitai.com/user/account` and `civitai login --token <key>`.
 - **`forbidden (403)` / `service unavailable (503)`** — your account may lack
   App Blocks access while the feature is gated.
 - **`validation failed`** — read each `- ...` line; fix the manifest, or pass

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,22 +1,17 @@
 // Package api is the (thin) HTTP client for the Civitai App Blocks surface.
 //
-// Auth/submit contract (investigated against civitai/civitai @ main, 2026-06):
+// Auth/submit contract (civitai/civitai PR #2644):
 //
-//   - The live bundle-upload route is POST /api/blocks/submit-version. It is
-//     wrapped in ModEndpoint = SESSION-COOKIE auth + isModerator + appBlocks
-//     flag. It does NOT accept an API key / bearer token today, so a clean
-//     programmatic "civitai app submit" is blocked on a server change.
-//   - The git-push flow (blocks.getMyAppRepo, #2587) provisions a scoped
-//     Forgejo repo but only AFTER the first version has been ZIP-approved, and
-//     is itself session-auth tRPC.
+//   - The token-authenticated bundle-upload route is
+//     POST /api/v1/blocks/submit-version (Bearer access token). This is the
+//     default the CLI targets; CIVITAI_SUBMIT_PATH overrides it.
+//   - The legacy /api/blocks/submit-version route is session-cookie + moderator
+//     authenticated and not used by the CLI.
 //
-// So: this client speaks the submit-version payload shape and sends the token
-// as a Bearer header against a configurable path (CIVITAI_SUBMIT_PATH), which
-// is exactly what the companion server endpoint needs to accept. Until that
-// endpoint exists, `civitai app submit` falls back to writing the canonical
-// ZIP + printing next steps (see internal/cmd/app_submit.go). Keeping the
-// network call behind the Submitter interface makes the whole thing testable
-// without a live server.
+// Auth is supplied via a TokenSource so OAuth (device-flow) access tokens are
+// refreshed transparently before a request and once on a 401; a personal API
+// key is a static source with no refresh. Keeping the network call behind the
+// Submitter interface makes the whole thing testable without a live server.
 package api
 
 import (
@@ -30,6 +25,31 @@ import (
 	"strings"
 	"time"
 )
+
+// TokenSource yields the Bearer token to send. Refresh, if supported, refreshes
+// the token (e.g. after a 401) and returns the new one; a static personal-key
+// source returns ErrNoRefresh.
+type TokenSource interface {
+	// Token returns the current bearer token, refreshing first if it is known
+	// to be expired. An empty token means "unauthenticated".
+	Token(ctx context.Context) (string, error)
+	// Refresh forces a refresh (used on a 401) and returns the new token.
+	// Sources that cannot refresh return ("", ErrNoRefresh).
+	Refresh(ctx context.Context) (string, error)
+}
+
+// ErrNoRefresh is returned by a non-refreshable (personal-key) TokenSource.
+var ErrNoRefresh = fmt.Errorf("token source cannot refresh")
+
+// StaticToken is a TokenSource for a fixed token (personal API key). It never
+// refreshes.
+type StaticToken string
+
+// Token returns the static token.
+func (s StaticToken) Token(context.Context) (string, error) { return string(s), nil }
+
+// Refresh always fails: a personal key has no refresh path.
+func (s StaticToken) Refresh(context.Context) (string, error) { return "", ErrNoRefresh }
 
 // Submitter submits a packaged bundle and returns the server's response.
 type Submitter interface {
@@ -55,25 +75,76 @@ type SubmitResult struct {
 	Status           string `json:"status"`
 }
 
+// DefaultSubmitPath is the token-authenticated submit-version route.
+const DefaultSubmitPath = "/api/v1/blocks/submit-version"
+
 // Client is the default HTTP implementation.
 type Client struct {
 	BaseURL    string
-	Token      string
-	SubmitPath string // route for submit-version; companion endpoint, configurable
+	Tokens     TokenSource
+	SubmitPath string // route for submit-version; CIVITAI_SUBMIT_PATH overrides
 	HTTP       *http.Client
 }
 
-// New builds a Client with sane defaults.
+// New builds a Client with sane defaults from a static token (personal API key
+// or a one-shot access token). For refreshable OAuth credentials use
+// NewWithSource.
 func New(baseURL, token, submitPath string) *Client {
+	return NewWithSource(baseURL, StaticToken(token), submitPath)
+}
+
+// NewWithSource builds a Client backed by a TokenSource (which may refresh).
+func NewWithSource(baseURL string, src TokenSource, submitPath string) *Client {
 	if submitPath == "" {
-		submitPath = "/api/blocks/submit-version"
+		submitPath = DefaultSubmitPath
 	}
 	return &Client{
 		BaseURL:    strings.TrimRight(baseURL, "/"),
-		Token:      token,
+		Tokens:     src,
 		SubmitPath: submitPath,
 		HTTP:       &http.Client{Timeout: 120 * time.Second},
 	}
+}
+
+// authedDo runs build() (which builds a fresh *http.Request each call, since a
+// retried request needs a fresh body) with a Bearer token from the source,
+// refreshing once on a 401 and retrying. The returned response body is fully
+// read into raw and the response is closed.
+func (c *Client) authedDo(ctx context.Context, build func() (*http.Request, error)) (int, []byte, error) {
+	token, err := c.Tokens.Token(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	status, raw, err := c.doOnce(ctx, build, token)
+	if err != nil {
+		return 0, nil, err
+	}
+	if status == http.StatusUnauthorized {
+		// Try a single refresh + retry. A non-refreshable source returns
+		// ErrNoRefresh and we keep the original 401.
+		newTok, rerr := c.Tokens.Refresh(ctx)
+		if rerr == nil && newTok != "" {
+			return c.doOnce(ctx, build, newTok)
+		}
+	}
+	return status, raw, nil
+}
+
+func (c *Client) doOnce(ctx context.Context, build func() (*http.Request, error), token string) (int, []byte, error) {
+	req, err := build()
+	if err != nil {
+		return 0, nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, raw, nil
 }
 
 // submitBody mirrors submitVersionSchema: a base64-encoded ZIP.
@@ -81,8 +152,8 @@ type submitBody struct {
 	BundleBase64 string `json:"bundleBase64"`
 }
 
-// SubmitVersion uploads the bundle. The server route this targets must accept
-// a Bearer token (the companion change); see package doc.
+// SubmitVersion uploads the bundle to the token-authenticated submit route,
+// refreshing the OAuth access token transparently if needed.
 func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitResult, error) {
 	body, err := json.Marshal(submitBody{
 		BundleBase64: base64.StdEncoding.EncodeToString(zipBytes),
@@ -90,51 +161,47 @@ func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitRes
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+c.SubmitPath, bytes.NewReader(body))
+	build := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+c.SubmitPath, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}
+	status, raw, err := c.authedDo(ctx, build)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if c.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.Token)
-	}
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, serverError(resp.StatusCode, raw)
+	if status != http.StatusOK {
+		return nil, serverError(status, raw)
 	}
 	var out SubmitResult
 	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("unexpected response (status %d): %s", resp.StatusCode, string(raw))
+		return nil, fmt.Errorf("unexpected response (status %d): %s", status, string(raw))
 	}
 	return &out, nil
 }
 
-// WhoAmI verifies the token. The public Civitai REST surface exposes
-// authenticated user details; we hit a configurable path and tolerate either
-// {username,id} directly or wrapped. Minimal by design.
+// WhoAmI verifies the token against /api/v1/me, refreshing the OAuth access
+// token transparently if needed.
 func (c *Client) WhoAmI(ctx context.Context) (*Identity, error) {
-	if c.Token == "" {
+	tok, err := c.Tokens.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if tok == "" {
 		return nil, fmt.Errorf("no token configured — run `civitai login` first")
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v1/me", nil)
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v1/me", nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.Token)
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if resp.StatusCode != http.StatusOK {
-		return nil, serverError(resp.StatusCode, raw)
+	if status != http.StatusOK {
+		return nil, serverError(status, raw)
 	}
 	var id Identity
 	if err := json.Unmarshal(raw, &id); err != nil {

--- a/internal/api/api_extra_test.go
+++ b/internal/api/api_extra_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestNewDefaultsSubmitPath(t *testing.T) {
 	c := New("https://civitai.com/", "tok", "")
-	if c.SubmitPath != "/api/blocks/submit-version" {
-		t.Errorf("default SubmitPath = %q", c.SubmitPath)
+	if c.SubmitPath != DefaultSubmitPath {
+		t.Errorf("default SubmitPath = %q, want %q", c.SubmitPath, DefaultSubmitPath)
 	}
 	if c.BaseURL != "https://civitai.com" {
 		t.Errorf("BaseURL should be trimmed of trailing slash: %q", c.BaseURL)

--- a/internal/api/client_refresh_test.go
+++ b/internal/api/client_refresh_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// stubSource is a refreshable TokenSource: it serves "stale" until Refresh is
+// called once, after which it serves "fresh".
+type stubSource struct {
+	current      atomic.Value // string
+	refreshes    int32
+	refreshErr   error
+	refreshedTok string
+}
+
+func newStubSource(initial, refreshed string) *stubSource {
+	s := &stubSource{refreshedTok: refreshed}
+	s.current.Store(initial)
+	return s
+}
+
+func (s *stubSource) Token(context.Context) (string, error) { return s.current.Load().(string), nil }
+
+func (s *stubSource) Refresh(context.Context) (string, error) {
+	atomic.AddInt32(&s.refreshes, 1)
+	if s.refreshErr != nil {
+		return "", s.refreshErr
+	}
+	s.current.Store(s.refreshedTok)
+	return s.refreshedTok, nil
+}
+
+func TestClient401TriggersRefreshAndRetry(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		seen = append(seen, auth)
+		if auth != "Bearer fresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"expired"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"username":"zach","id":1}`))
+	}))
+	defer srv.Close()
+
+	src := newStubSource("stale", "fresh")
+	c := NewWithSource(srv.URL, src, "")
+	id, err := c.WhoAmI(context.Background())
+	if err != nil {
+		t.Fatalf("WhoAmI after refresh: %v", err)
+	}
+	if id.Username != "zach" {
+		t.Errorf("identity = %+v", id)
+	}
+	if src.refreshes != 1 {
+		t.Errorf("expected exactly one refresh, got %d", src.refreshes)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer stale" || seen[1] != "Bearer fresh" {
+		t.Errorf("auth sequence = %v, want [stale fresh]", seen)
+	}
+}
+
+func TestClientStaticTokenDoesNotRetryOn401(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"nope"}`))
+	}))
+	defer srv.Close()
+
+	// StaticToken (personal key) cannot refresh: a 401 must not retry.
+	c := New(srv.URL, "personal-key", "")
+	if _, err := c.WhoAmI(context.Background()); err == nil {
+		t.Fatal("expected a 401 error")
+	}
+	if hits != 1 {
+		t.Errorf("static token should hit the server once (no retry), got %d", hits)
+	}
+}
+
+func TestSubmitVersionUsesV1RouteAndRefreshes(t *testing.T) {
+	var path, auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		auth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"publishRequestId":"pr_1","slug":"x","version":"0.1.0","status":"pending"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP")); err != nil {
+		t.Fatalf("SubmitVersion: %v", err)
+	}
+	if path != DefaultSubmitPath {
+		t.Errorf("submit path = %q, want %q", path, DefaultSubmitPath)
+	}
+	if auth != "Bearer tok" {
+		t.Errorf("auth = %q", auth)
+	}
+}

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -1,0 +1,276 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// OAuth device-authorization-grant client for the civitai-cli public client.
+//
+// Contract (civitai/civitai PR #2644):
+//   - device init:  POST {BaseURL}/api/auth/oauth/device
+//   - device poll:  POST {BaseURL}/api/auth/oauth/device-token
+//   - token refresh: POST {BaseURL}/api/auth/oauth/token
+//
+// civitai-cli is a PUBLIC client (PKCE/device): no client secret.
+const (
+	// ClientID is the public OAuth client id for the CLI.
+	ClientID = "civitai-cli"
+
+	// DeviceScope is UserRead|AppBlocksSubmit (bit flags), the fixed scope the
+	// CLI requests. 33554433 == (1<<0)|(1<<25) in the server's scope bitset.
+	DeviceScope = "33554433"
+
+	grantTypeDeviceCode   = "urn:ietf:params:oauth:grant-type:device_code"
+	grantTypeRefreshToken = "refresh_token"
+
+	pathDeviceInit  = "/api/auth/oauth/device"
+	pathDeviceToken = "/api/auth/oauth/device-token"
+	pathToken       = "/api/auth/oauth/token"
+)
+
+// OAuthClient talks the device-flow + refresh endpoints.
+type OAuthClient struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// NewOAuthClient builds an OAuthClient with sane defaults.
+func NewOAuthClient(baseURL string) *OAuthClient {
+	return &OAuthClient{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// DeviceAuth is the device-init response.
+type DeviceAuth struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// TokenResponse is the successful device-token / refresh response. RefreshToken
+// may be empty on a refresh that doesn't rotate.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// oauthErr is the OAuth error body ({"error": "..."}).
+type oauthErr struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// DeviceFlowError is a terminal OAuth error (expired_token, access_denied, …)
+// surfaced to the caller. authorization_pending / slow_down are handled inline
+// by PollToken and never returned as this.
+type DeviceFlowError struct {
+	Code        string
+	Description string
+}
+
+func (e *DeviceFlowError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("device login failed: %s (%s)", e.Description, e.Code)
+	}
+	switch e.Code {
+	case "expired_token":
+		return "device login expired before it was approved — run `civitai login` again"
+	case "access_denied":
+		return "device login was denied in the browser"
+	default:
+		return "device login failed: " + e.Code
+	}
+}
+
+// StartDevice initiates the device-authorization grant.
+func (c *OAuthClient) StartDevice(ctx context.Context) (*DeviceAuth, error) {
+	body, _ := json.Marshal(map[string]string{
+		"client_id": ClientID,
+		"scope":     DeviceScope,
+	})
+	resp, raw, err := c.post(ctx, pathDeviceInit, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp != http.StatusOK {
+		return nil, fmt.Errorf("device init failed (status %d): %s", resp, oauthMsg(raw))
+	}
+	var d DeviceAuth
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("unexpected device-init response: %s", string(raw))
+	}
+	if d.DeviceCode == "" || d.UserCode == "" {
+		return nil, fmt.Errorf("device-init response missing device_code/user_code")
+	}
+	if d.Interval <= 0 {
+		d.Interval = 5
+	}
+	if d.ExpiresIn <= 0 {
+		d.ExpiresIn = 900
+	}
+	return &d, nil
+}
+
+// pollOutcome is the internal result of a single device-token poll.
+type pollOutcome int
+
+const (
+	pollPending  pollOutcome = iota // authorization_pending — keep polling
+	pollSlowDown                    // slow_down — increase the interval, keep polling
+	pollDone                        // success
+)
+
+// pollOnce performs a single device-token POST.
+func (c *OAuthClient) pollOnce(ctx context.Context, deviceCode string) (pollOutcome, *TokenResponse, error) {
+	body, _ := json.Marshal(map[string]string{
+		"grant_type":  grantTypeDeviceCode,
+		"device_code": deviceCode,
+		"client_id":   ClientID,
+	})
+	status, raw, err := c.post(ctx, pathDeviceToken, body)
+	if err != nil {
+		return pollPending, nil, err
+	}
+	if status == http.StatusOK {
+		var tr TokenResponse
+		if err := json.Unmarshal(raw, &tr); err != nil {
+			return pollPending, nil, fmt.Errorf("unexpected device-token response: %s", string(raw))
+		}
+		if tr.AccessToken == "" {
+			return pollPending, nil, fmt.Errorf("device-token success response had no access_token")
+		}
+		return pollDone, &tr, nil
+	}
+	// Non-200: an OAuth error code drives the polling state machine.
+	var oe oauthErr
+	_ = json.Unmarshal(raw, &oe)
+	switch oe.Error {
+	case "authorization_pending":
+		return pollPending, nil, nil
+	case "slow_down":
+		return pollSlowDown, nil, nil
+	case "expired_token", "access_denied", "invalid_grant", "invalid_client", "unauthorized_client":
+		return pollPending, nil, &DeviceFlowError{Code: oe.Error, Description: oe.ErrorDescription}
+	default:
+		if oe.Error != "" {
+			return pollPending, nil, &DeviceFlowError{Code: oe.Error, Description: oe.ErrorDescription}
+		}
+		return pollPending, nil, fmt.Errorf("device-token poll failed (status %d): %s", status, oauthMsg(raw))
+	}
+}
+
+// PollToken polls device-token until approval, a terminal error, or the
+// device-flow deadline (auth.ExpiresIn). It blocks for `interval` seconds
+// between polls and increases the interval by 5s on slow_down. sleep is
+// injectable for tests; pass nil for the real time.Sleep.
+func (c *OAuthClient) PollToken(ctx context.Context, auth *DeviceAuth, sleep func(time.Duration)) (*TokenResponse, error) {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	interval := time.Duration(auth.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(auth.ExpiresIn) * time.Second)
+
+	for {
+		if time.Now().After(deadline) {
+			return nil, &DeviceFlowError{Code: "expired_token"}
+		}
+		outcome, tr, err := c.pollOnce(ctx, auth.DeviceCode)
+		if err != nil {
+			return nil, err
+		}
+		switch outcome {
+		case pollDone:
+			return tr, nil
+		case pollSlowDown:
+			interval += 5 * time.Second
+		}
+		// Don't sleep past the deadline.
+		if time.Now().Add(interval).After(deadline) {
+			// One more short wait then a final loop check will expire it.
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return nil, &DeviceFlowError{Code: "expired_token"}
+			}
+			sleep(remaining)
+			return nil, &DeviceFlowError{Code: "expired_token"}
+		}
+		sleep(interval)
+	}
+}
+
+// Refresh exchanges a refresh token for a new access token. The server may
+// rotate the refresh token; callers must persist tr.RefreshToken if non-empty.
+func (c *OAuthClient) Refresh(ctx context.Context, refreshToken string) (*TokenResponse, error) {
+	body, _ := json.Marshal(map[string]string{
+		"grant_type":    grantTypeRefreshToken,
+		"refresh_token": refreshToken,
+		"client_id":     ClientID,
+	})
+	status, raw, err := c.post(ctx, pathToken, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		var oe oauthErr
+		_ = json.Unmarshal(raw, &oe)
+		if oe.Error != "" {
+			return nil, &DeviceFlowError{Code: oe.Error, Description: oe.ErrorDescription}
+		}
+		return nil, fmt.Errorf("token refresh failed (status %d): %s", status, oauthMsg(raw))
+	}
+	var tr TokenResponse
+	if err := json.Unmarshal(raw, &tr); err != nil {
+		return nil, fmt.Errorf("unexpected refresh response: %s", string(raw))
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("refresh response had no access_token")
+	}
+	return &tr, nil
+}
+
+// post sends a JSON POST and returns the status + body.
+func (c *OAuthClient) post(ctx context.Context, path string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, raw, nil
+}
+
+// oauthMsg extracts a human message from an OAuth error body.
+func oauthMsg(raw []byte) string {
+	var oe oauthErr
+	if json.Unmarshal(raw, &oe) == nil && oe.Error != "" {
+		if oe.ErrorDescription != "" {
+			return oe.Error + ": " + oe.ErrorDescription
+		}
+		return oe.Error
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -33,6 +33,10 @@ const (
 	pathDeviceInit  = "/api/auth/oauth/device"
 	pathDeviceToken = "/api/auth/oauth/device-token"
 	pathToken       = "/api/auth/oauth/token"
+
+	// maxPollInterval caps the RFC 8628 +5s-per-slow_down backoff so a
+	// misbehaving (or repeated) slow_down can't stretch the poll unboundedly.
+	maxPollInterval = 60 * time.Second
 )
 
 // OAuthClient talks the device-flow + refresh endpoints.
@@ -59,6 +63,44 @@ type DeviceAuth struct {
 	Interval                int    `json:"interval"`
 }
 
+// Scope is a token scope that tolerates BOTH JSON shapes the server emits:
+// the device-token (login) route returns a plain string (`scope.toString()`),
+// while the token/refresh route returns the @node-oauth/oauth2-server shape
+// where scope is an ARRAY of strings (e.g. ["33554433"]). Declaring scope as a
+// plain `string` made json.Unmarshal of the refresh response fail the whole
+// struct, killing Refresh() after the 1h access-token TTL. UnmarshalJSON
+// normalizes either shape to a single space-joined string (OAuth convention).
+// The CLI only stores/displays scope, it never enforces it, so this is safe.
+type Scope string
+
+// UnmarshalJSON accepts a JSON string OR a JSON array of strings.
+func (s *Scope) UnmarshalJSON(b []byte) error {
+	// Null/absent -> empty.
+	if len(b) == 0 || string(b) == "null" {
+		*s = ""
+		return nil
+	}
+	// Array shape (refresh route): ["33554433"] -> "33554433".
+	if b[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return err
+		}
+		*s = Scope(strings.Join(arr, " "))
+		return nil
+	}
+	// String shape (device-token route).
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	*s = Scope(str)
+	return nil
+}
+
+// String returns the scope as a plain string for storage/display.
+func (s Scope) String() string { return string(s) }
+
 // TokenResponse is the successful device-token / refresh response. RefreshToken
 // may be empty on a refresh that doesn't rotate.
 type TokenResponse struct {
@@ -66,7 +108,7 @@ type TokenResponse struct {
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
 	RefreshToken string `json:"refresh_token"`
-	Scope        string `json:"scope"`
+	Scope        Scope  `json:"scope"`
 }
 
 // oauthErr is the OAuth error body ({"error": "..."}).
@@ -201,6 +243,9 @@ func (c *OAuthClient) PollToken(ctx context.Context, auth *DeviceAuth, sleep fun
 			return tr, nil
 		case pollSlowDown:
 			interval += 5 * time.Second
+			if interval > maxPollInterval {
+				interval = maxPollInterval
+			}
 		}
 		// Don't sleep past the deadline.
 		if time.Now().Add(interval).After(deadline) {

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -170,6 +170,113 @@ func TestRefreshRotatesToken(t *testing.T) {
 	if tr.AccessToken != "new-at" || tr.RefreshToken != "new-rt" {
 		t.Errorf("refresh result = %+v", tr)
 	}
+	if tr.Scope.String() != DeviceScope {
+		t.Errorf("scope = %q, want %q", tr.Scope, DeviceScope)
+	}
+}
+
+// TestRefreshArrayScopeContract replays the ACTUAL server refresh body, where
+// the @node-oauth/oauth2-server token route serializes scope as an ARRAY of
+// strings (e.g. ["33554433"]) — unlike the device-token route, which sends a
+// plain string. Before the C1 fix (Scope was a plain `string`), json.Unmarshal
+// of this body failed the whole struct and Refresh() returned "unexpected
+// refresh response", silently killing refresh after the 1h access-token TTL.
+// This test is the regression guard: it FAILS without the custom Scope
+// UnmarshalJSON and PASSES with it.
+func TestRefreshArrayScopeContract(t *testing.T) {
+	// Raw body byte-for-byte as the real /api/auth/oauth/token route emits it.
+	const body = `{"access_token":"new-at","token_type":"Bearer","expires_in":3600,"refresh_token":"new-rt","scope":["33554433"]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	tr, err := NewOAuthClient(srv.URL).Refresh(context.Background(), "old-rt")
+	if err != nil {
+		t.Fatalf("Refresh with array scope: %v", err)
+	}
+	if tr.AccessToken != "new-at" || tr.RefreshToken != "new-rt" {
+		t.Errorf("refresh result = %+v", tr)
+	}
+	// Array ["33554433"] must normalize to the space-joined string "33554433".
+	if tr.Scope.String() != "33554433" {
+		t.Errorf("array scope normalized to %q, want %q", tr.Scope, "33554433")
+	}
+}
+
+// TestRefreshMultiElementArrayScope confirms a multi-element scope array is
+// normalized to a space-joined string per OAuth convention.
+func TestRefreshMultiElementArrayScope(t *testing.T) {
+	const body = `{"access_token":"a","expires_in":3600,"refresh_token":"r","scope":["1","33554432"]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	tr, err := NewOAuthClient(srv.URL).Refresh(context.Background(), "rt")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if tr.Scope.String() != "1 33554432" {
+		t.Errorf("multi-element scope = %q, want %q", tr.Scope, "1 33554432")
+	}
+}
+
+// TestDeviceTokenStringScopeContract replays the device-token (login) route's
+// string-shaped scope and asserts it parses to the same plain string. Together
+// with TestRefreshArrayScopeContract this covers BOTH server scope shapes.
+func TestDeviceTokenStringScopeContract(t *testing.T) {
+	const body = `{"access_token":"at","token_type":"Bearer","expires_in":3600,"refresh_token":"rt","scope":"33554433"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewOAuthClient(srv.URL)
+	tr, err := c.PollToken(context.Background(),
+		&DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 900}, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("PollToken: %v", err)
+	}
+	if tr.Scope.String() != "33554433" {
+		t.Errorf("string scope = %q, want %q", tr.Scope, "33554433")
+	}
+}
+
+// TestPollSlowDownIntervalCapped verifies the +5s-per-slow_down backoff is
+// bounded by maxPollInterval (M2): many consecutive slow_downs must not push
+// the sleep interval past the cap.
+func TestPollSlowDownIntervalCapped(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		// 20 slow_downs (would push interval to 5+20*5=105s uncapped), then succeed.
+		if n <= 20 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "slow_down"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "at", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	var durs []time.Duration
+	sleep := func(d time.Duration) { durs = append(durs, d) }
+	_, err := NewOAuthClient(srv.URL).PollToken(context.Background(),
+		&DeviceAuth{DeviceCode: "dc", Interval: 5, ExpiresIn: 100000}, sleep)
+	if err != nil {
+		t.Fatalf("PollToken: %v", err)
+	}
+	for i, d := range durs {
+		if d > maxPollInterval {
+			t.Errorf("sleep[%d] = %v exceeds cap %v", i, d, maxPollInterval)
+		}
+	}
+	// The last few sleeps should be clamped at the cap, not growing past it.
+	if len(durs) == 0 || durs[len(durs)-1] != maxPollInterval {
+		t.Errorf("final interval = %v, want clamped to %v", durs, maxPollInterval)
+	}
 }
 
 func TestRefreshTerminalError(t *testing.T) {

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStartDeviceParsesResponse(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathDeviceInit {
+			t.Errorf("init hit wrong path %q", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(DeviceAuth{
+			DeviceCode:              "dev-secret",
+			UserCode:                "WXYZ-1234",
+			VerificationURI:         "https://civitai.com/oauth/device",
+			VerificationURIComplete: "https://civitai.com/oauth/device?user_code=WXYZ-1234",
+			ExpiresIn:               900,
+			Interval:                5,
+		})
+	}))
+	defer srv.Close()
+
+	d, err := NewOAuthClient(srv.URL).StartDevice(context.Background())
+	if err != nil {
+		t.Fatalf("StartDevice: %v", err)
+	}
+	if gotBody["client_id"] != ClientID || gotBody["scope"] != DeviceScope {
+		t.Errorf("init body = %v, want client_id=%s scope=%s", gotBody, ClientID, DeviceScope)
+	}
+	if d.UserCode != "WXYZ-1234" || d.DeviceCode != "dev-secret" {
+		t.Errorf("device auth = %+v", d)
+	}
+}
+
+func TestPollTokenHappyPathAfterPending(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathDeviceToken {
+			t.Errorf("poll hit wrong path %q", r.URL.Path)
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["grant_type"] != grantTypeDeviceCode || body["device_code"] != "dc" || body["client_id"] != ClientID {
+			t.Errorf("poll body = %v", body)
+		}
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "at-1", TokenType: "Bearer", ExpiresIn: 3600,
+			RefreshToken: "rt-1", Scope: DeviceScope,
+		})
+	}))
+	defer srv.Close()
+
+	var slept int
+	sleep := func(time.Duration) { slept++ }
+	c := NewOAuthClient(srv.URL)
+	tr, err := c.PollToken(context.Background(), &DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 900}, sleep)
+	if err != nil {
+		t.Fatalf("PollToken: %v", err)
+	}
+	if tr.AccessToken != "at-1" || tr.RefreshToken != "rt-1" {
+		t.Errorf("token response = %+v", tr)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 polls, got %d", calls)
+	}
+	if slept != 2 {
+		t.Errorf("expected 2 sleeps (between the 3 polls), got %d", slept)
+	}
+}
+
+func TestPollTokenSlowDownIncreasesInterval(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "slow_down"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "at", TokenType: "Bearer", ExpiresIn: 3600})
+	}))
+	defer srv.Close()
+
+	var durs []time.Duration
+	sleep := func(d time.Duration) { durs = append(durs, d) }
+	_, err := NewOAuthClient(srv.URL).PollToken(context.Background(),
+		&DeviceAuth{DeviceCode: "dc", Interval: 5, ExpiresIn: 900}, sleep)
+	if err != nil {
+		t.Fatalf("PollToken: %v", err)
+	}
+	// After a slow_down the interval should grow from 5s to 10s.
+	if len(durs) != 1 || durs[0] != 10*time.Second {
+		t.Errorf("after slow_down expected one 10s sleep, got %v", durs)
+	}
+}
+
+func TestPollTokenTerminalErrors(t *testing.T) {
+	for _, code := range []string{"expired_token", "access_denied"} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+		}))
+		_, err := NewOAuthClient(srv.URL).PollToken(context.Background(),
+			&DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 900}, func(time.Duration) {})
+		srv.Close()
+		if err == nil {
+			t.Fatalf("%s: expected terminal error", code)
+		}
+		var dfe *DeviceFlowError
+		if !errorsAs(err, &dfe) || dfe.Code != code {
+			t.Errorf("%s: error = %v, want DeviceFlowError{%s}", code, err, code)
+		}
+	}
+}
+
+func TestPollTokenOverallTimeout(t *testing.T) {
+	// Always pending: the flow must give up at the deadline.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+	}))
+	defer srv.Close()
+
+	// ExpiresIn 0 => deadline already past on the first loop check.
+	_, err := NewOAuthClient(srv.URL).PollToken(context.Background(),
+		&DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 0}, func(time.Duration) {})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("timeout error should mention expiry: %v", err)
+	}
+}
+
+func TestRefreshRotatesToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != pathToken {
+			t.Errorf("refresh hit wrong path %q", r.URL.Path)
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["grant_type"] != grantTypeRefreshToken || body["refresh_token"] != "old-rt" {
+			t.Errorf("refresh body = %v", body)
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "new-at", ExpiresIn: 3600, RefreshToken: "new-rt", Scope: DeviceScope,
+		})
+	}))
+	defer srv.Close()
+
+	tr, err := NewOAuthClient(srv.URL).Refresh(context.Background(), "old-rt")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if tr.AccessToken != "new-at" || tr.RefreshToken != "new-rt" {
+		t.Errorf("refresh result = %+v", tr)
+	}
+}
+
+func TestRefreshTerminalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+	}))
+	defer srv.Close()
+	if _, err := NewOAuthClient(srv.URL).Refresh(context.Background(), "rt"); err == nil {
+		t.Fatal("expected error for invalid_grant")
+	}
+}
+
+// errorsAs is a tiny local errors.As shim to avoid importing errors in just one
+// spot; keeps the test file self-contained.
+func errorsAs(err error, target **DeviceFlowError) bool {
+	for err != nil {
+		if dfe, ok := err.(*DeviceFlowError); ok {
+			*target = dfe
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -1,0 +1,102 @@
+// Package auth bridges the persisted config and the api.TokenSource contract:
+// it yields a Bearer token for the api client, refreshing device-flow OAuth
+// tokens (and persisting the rotated refresh token) when they expire or after a
+// 401. A personal API key is served as-is and never refreshes.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/config"
+)
+
+// expirySkew refreshes the access token slightly before its real expiry so an
+// in-flight request doesn't race the boundary.
+const expirySkew = 30 * time.Second
+
+// refresher is the subset of api.OAuthClient the source needs (injectable in
+// tests).
+type refresher interface {
+	Refresh(ctx context.Context, refreshToken string) (*api.TokenResponse, error)
+}
+
+// Source is an api.TokenSource backed by the on-disk config. For a personal-key
+// config it returns the key and never refreshes; for an OAuth config it
+// refreshes via the refresher and persists rotated tokens.
+type Source struct {
+	cfg *config.Config
+	oc  refresher
+	mu  sync.Mutex
+}
+
+// New builds a Source for cfg. The refresher defaults to an api.OAuthClient
+// against the config's base URL.
+func New(cfg *config.Config) *Source {
+	return &Source{cfg: cfg, oc: api.NewOAuthClient(cfg.BaseURL())}
+}
+
+// newWithRefresher is the test seam.
+func newWithRefresher(cfg *config.Config, oc refresher) *Source {
+	return &Source{cfg: cfg, oc: oc}
+}
+
+// Token returns the current bearer token, refreshing an expired OAuth access
+// token first.
+func (s *Source) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cfg.AuthKind() != config.AuthKindOAuth {
+		return s.cfg.Token(), nil
+	}
+	// OAuth: refresh if the access token is expired (or about to be).
+	if exp := s.cfg.TokenExpiry(); !exp.IsZero() && time.Now().Add(expirySkew).After(exp) {
+		if _, err := s.refreshLocked(ctx); err != nil {
+			return "", err
+		}
+	}
+	return s.cfg.AccessToken(), nil
+}
+
+// Refresh forces a refresh (used by the api client on a 401). A personal-key
+// config returns api.ErrNoRefresh.
+func (s *Source) Refresh(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cfg.AuthKind() != config.AuthKindOAuth {
+		return "", api.ErrNoRefresh
+	}
+	return s.refreshLocked(ctx)
+}
+
+// refreshLocked performs the refresh grant and persists the result. Caller
+// holds s.mu.
+func (s *Source) refreshLocked(ctx context.Context) (string, error) {
+	rt := s.cfg.RefreshToken()
+	if rt == "" {
+		return "", fmt.Errorf("no refresh token stored — run `civitai login` again")
+	}
+	tr, err := s.oc.Refresh(ctx, rt)
+	if err != nil {
+		return "", err
+	}
+	// The server may rotate the refresh token; keep the old one if it didn't.
+	newRefresh := tr.RefreshToken
+	if newRefresh == "" {
+		newRefresh = rt
+	}
+	scope := tr.Scope
+	if scope == "" {
+		scope = s.cfg.Scope()
+	}
+	expiry := time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	if err := s.cfg.SetOAuthTokens(tr.AccessToken, newRefresh, expiry, scope); err != nil {
+		return "", fmt.Errorf("persist refreshed tokens: %w", err)
+	}
+	return tr.AccessToken, nil
+}

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -76,6 +76,13 @@ func (s *Source) Refresh(ctx context.Context) (string, error) {
 
 // refreshLocked performs the refresh grant and persists the result. Caller
 // holds s.mu.
+//
+// FOLLOW-UP (M3, not fixed here): this refresh is not coordinated across
+// concurrent CLI processes. The server rotates (and revokes the old) refresh
+// token on each refresh, so two processes refreshing at once can race: the
+// second sees its now-revoked token rejected and forces the user to re-login.
+// The fix is a cross-process file lock around read-refresh-persist; left as a
+// documented follow-up since the common single-process case is unaffected.
 func (s *Source) refreshLocked(ctx context.Context) (string, error) {
 	rt := s.cfg.RefreshToken()
 	if rt == "" {
@@ -90,9 +97,17 @@ func (s *Source) refreshLocked(ctx context.Context) (string, error) {
 	if newRefresh == "" {
 		newRefresh = rt
 	}
-	scope := tr.Scope
+	scope := tr.Scope.String()
 	if scope == "" {
 		scope = s.cfg.Scope()
+	}
+	// Floor-guard expires_in: a non-positive value would set the expiry to ~now
+	// and trigger a refresh on every subsequent call (or, with skew, never serve
+	// the token). The server always sends a positive lifetime, so treat a
+	// non-positive one as a malformed response rather than silently persisting a
+	// dead token.
+	if tr.ExpiresIn <= 0 {
+		return "", fmt.Errorf("refresh response had a non-positive expires_in (%d)", tr.ExpiresIn)
 	}
 	expiry := time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
 	if err := s.cfg.SetOAuthTokens(tr.AccessToken, newRefresh, expiry, scope); err != nil {

--- a/internal/auth/source_test.go
+++ b/internal/auth/source_test.go
@@ -118,6 +118,55 @@ func TestSourceRefreshKeepsOldRefreshTokenWhenNotRotated(t *testing.T) {
 	}
 }
 
+func TestSourceRefreshRejectsNonPositiveExpiresIn(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	if err := cfg.SetOAuthTokens("old-at", "old-rt", time.Now().Add(-time.Minute), "s"); err != nil {
+		t.Fatal(err)
+	}
+	// A refresh that returns expires_in<=0 must be treated as an error, not
+	// persisted with an ~now expiry (which would refresh on every call).
+	ref := &stubRefresher{resp: &api.TokenResponse{AccessToken: "new-at", ExpiresIn: 0, RefreshToken: "new-rt"}}
+	src := newWithRefresher(cfg, ref)
+
+	if _, err := src.Token(context.Background()); err == nil {
+		t.Fatal("expected an error for non-positive expires_in")
+	}
+	// The dead token must NOT have been persisted.
+	reloaded := loadCfg(t)
+	if reloaded.AccessToken() == "new-at" {
+		t.Errorf("dead token should not have been persisted")
+	}
+}
+
+func TestSourceRefreshPersistsArrayScope(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	if err := cfg.SetOAuthTokens("old-at", "old-rt", time.Now().Add(-time.Minute), "s"); err != nil {
+		t.Fatal(err)
+	}
+	// Scope arriving as the array-normalized string (what the refresh route
+	// yields via the custom Scope unmarshaler) must round-trip into config.
+	ref := &stubRefresher{resp: &api.TokenResponse{
+		AccessToken: "new-at", ExpiresIn: 3600, RefreshToken: "new-rt", Scope: "33554433",
+	}}
+	src := newWithRefresher(cfg, ref)
+
+	if _, err := src.Token(context.Background()); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	reloaded := loadCfg(t)
+	if reloaded.Scope() != "33554433" {
+		t.Errorf("persisted scope = %q, want 33554433", reloaded.Scope())
+	}
+}
+
 func TestSourcePersonalKeyNeverRefreshes(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/internal/auth/source_test.go
+++ b/internal/auth/source_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/config"
+)
+
+// stubRefresher returns a fixed response and records the refresh token it saw.
+type stubRefresher struct {
+	calls int
+	sawRT string
+	resp  *api.TokenResponse
+	rerr  error
+}
+
+func (s *stubRefresher) Refresh(_ context.Context, rt string) (*api.TokenResponse, error) {
+	s.calls++
+	s.sawRT = rt
+	if s.rerr != nil {
+		return nil, s.rerr
+	}
+	return s.resp, nil
+}
+
+func loadCfg(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	return cfg
+}
+
+func TestSourceExpiredAccessTokenTriggersRefresh(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	// Already-expired access token + a refresh token.
+	if err := cfg.SetOAuthTokens("old-at", "old-rt", time.Now().Add(-time.Minute), "s"); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := &stubRefresher{resp: &api.TokenResponse{
+		AccessToken: "new-at", ExpiresIn: 3600, RefreshToken: "rotated-rt", Scope: "s",
+	}}
+	src := newWithRefresher(cfg, ref)
+
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "new-at" {
+		t.Errorf("Token() = %q, want new-at", tok)
+	}
+	if ref.calls != 1 || ref.sawRT != "old-rt" {
+		t.Errorf("refresh calls=%d sawRT=%q", ref.calls, ref.sawRT)
+	}
+	// The rotated refresh token must be persisted.
+	reloaded := loadCfg(t)
+	if reloaded.RefreshToken() != "rotated-rt" {
+		t.Errorf("persisted refresh token = %q, want rotated-rt", reloaded.RefreshToken())
+	}
+	if reloaded.AccessToken() != "new-at" {
+		t.Errorf("persisted access token = %q, want new-at", reloaded.AccessToken())
+	}
+}
+
+func TestSourceValidTokenSkipsRefresh(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	if err := cfg.SetOAuthTokens("good-at", "rt", time.Now().Add(time.Hour), "s"); err != nil {
+		t.Fatal(err)
+	}
+	ref := &stubRefresher{resp: &api.TokenResponse{AccessToken: "nope"}}
+	src := newWithRefresher(cfg, ref)
+
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "good-at" {
+		t.Errorf("Token() = %q, want the non-expired good-at", tok)
+	}
+	if ref.calls != 0 {
+		t.Errorf("a valid token should not refresh, got %d calls", ref.calls)
+	}
+}
+
+func TestSourceRefreshKeepsOldRefreshTokenWhenNotRotated(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	if err := cfg.SetOAuthTokens("old-at", "keep-rt", time.Now().Add(-time.Minute), "s"); err != nil {
+		t.Fatal(err)
+	}
+	// Server returns no refresh_token (no rotation).
+	ref := &stubRefresher{resp: &api.TokenResponse{AccessToken: "new-at", ExpiresIn: 3600}}
+	src := newWithRefresher(cfg, ref)
+
+	if _, err := src.Token(context.Background()); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	reloaded := loadCfg(t)
+	if reloaded.RefreshToken() != "keep-rt" {
+		t.Errorf("refresh token should be retained when not rotated, got %q", reloaded.RefreshToken())
+	}
+}
+
+func TestSourcePersonalKeyNeverRefreshes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg := loadCfg(t)
+	if err := cfg.SetToken("personal-key"); err != nil {
+		t.Fatal(err)
+	}
+	ref := &stubRefresher{resp: &api.TokenResponse{AccessToken: "should-not-be-used"}}
+	src := newWithRefresher(cfg, ref)
+
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "personal-key" {
+		t.Errorf("Token() = %q, want personal-key", tok)
+	}
+	if _, err := src.Refresh(context.Background()); err != api.ErrNoRefresh {
+		t.Errorf("personal-key Refresh err = %v, want ErrNoRefresh", err)
+	}
+	if ref.calls != 0 {
+		t.Errorf("personal key must not call the refresher, got %d", ref.calls)
+	}
+}

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/internal/manifest"
 	"github.com/civitai/cli/internal/pkgzip"
@@ -30,12 +31,12 @@ prebuilt dist. The platform rebuilds from source. These are excluded:
   ` + pkgzip.JoinExcluded() + `
 
 Submission path:
-  The live server upload route (POST /api/blocks/submit-version) is SESSION-
-  COOKIE + moderator authenticated today — it does NOT accept an API token, so
-  a fully programmatic token submit needs a companion server endpoint (see the
-  repo README / PR). When CIVITAI_SUBMIT_PATH points at such a token-accepting
-  endpoint, this command uploads directly. Otherwise it writes the canonical
-  .zip and prints the exact manual next steps.
+  By default this uploads the bundle directly using your stored token to the
+  token-authenticated submit route (POST /api/v1/blocks/submit-version). OAuth
+  device-login tokens (` + "`civitai login`" + `) and personal API keys both work;
+  OAuth tokens refresh automatically. Set CIVITAI_SUBMIT_PATH to override the
+  route. With no token configured (and no --package-only), it writes the
+  canonical .zip and prints the manual next steps.
 
   --package-only always just writes the .zip and stops.
 
@@ -84,14 +85,13 @@ Defaults to the current directory.`,
 				return err
 			}
 
-			// Resolve the (optional) token-accepting submit endpoint.
+			// The submit route defaults to the v1 token route; env overrides it.
 			submitPath := os.Getenv("CIVITAI_SUBMIT_PATH")
 
-			// 3a. Programmatic submit if we have both a token and a configured
-			// token-accepting endpoint.
-			canUpload := !packageOnly && cfg.Token() != "" && submitPath != ""
+			// 3a. Programmatic submit if we have a token (OAuth or personal key).
+			canUpload := !packageOnly && cfg.Token() != ""
 			if canUpload {
-				client := api.New(cfg.BaseURL(), cfg.Token(), submitPath)
+				client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), submitPath)
 				return doUpload(cmd, client, pkg.Zip, m)
 			}
 
@@ -134,13 +134,11 @@ func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *mani
 
 func printManualNextSteps(cmd *cobra.Command, cfg *config.Config, m *manifest.Manifest, zipPath string) {
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "\nSubmission is not yet automated for API tokens. Submit the bundle one of these ways:")
-	fmt.Fprintf(out, "\n  1) Web (works today): upload %s at\n", filepath.Base(zipPath))
+	fmt.Fprintln(out, "\nNo token configured, so the bundle was written but not uploaded.")
+	fmt.Fprintln(out, "\n  1) Authenticate, then re-run to upload directly:")
+	fmt.Fprintln(out, "     civitai login          # browser device login")
+	fmt.Fprintln(out, "     civitai app submit")
+	fmt.Fprintf(out, "\n  2) Or upload %s via the web UI:\n", filepath.Base(zipPath))
 	fmt.Fprintf(out, "     %s/apps/submit\n", cfg.BaseURL())
 	fmt.Fprintln(out, "     (requires a moderator account while App Blocks is mod-gated).")
-	fmt.Fprintln(out, "\n  2) Git push (for updates after your first version is approved):")
-	fmt.Fprintln(out, "     after approval, `blocks.getMyAppRepo` provisions a Forgejo repo —")
-	fmt.Fprintln(out, "     clone it and `git push` to park a pending review.")
-	fmt.Fprintln(out, "\n  To enable `civitai app submit` to upload directly, the server needs a")
-	fmt.Fprintln(out, "  token-authenticated submit endpoint; set CIVITAI_SUBMIT_PATH to it once it exists.")
 }

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -54,7 +54,7 @@ func TestAppSubmitFallbackPrintsManualSteps(t *testing.T) {
 	tmp := t.TempDir()
 	writeStaticManifest(t, tmp)
 
-	// No token + no submit path => fallback to writing zip + manual steps.
+	// No token => fallback to writing zip + manual steps.
 	cfgdir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", cfgdir)
 	t.Setenv("CIVITAI_TOKEN", "")
@@ -65,8 +65,11 @@ func TestAppSubmitFallbackPrintsManualSteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("submit fallback: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "not yet automated") || !strings.Contains(stdout, "/apps/submit") {
+	if !strings.Contains(stdout, "No token configured") || !strings.Contains(stdout, "/apps/submit") {
 		t.Errorf("fallback should print manual next steps: %s", stdout)
+	}
+	if !strings.Contains(stdout, "civitai login") {
+		t.Errorf("fallback should point at `civitai login`: %s", stdout)
 	}
 }
 
@@ -115,6 +118,51 @@ func TestAppSubmitUploadsWhenTokenAndPathConfigured(t *testing.T) {
 		t.Errorf("server saw auth %q, want Bearer tok-xyz", gotAuth)
 	}
 	if !strings.Contains(stdout, "pr_42") || !strings.Contains(stdout, "pending") {
+		t.Errorf("output should report the publish request: %s", stdout)
+	}
+}
+
+func TestAppSubmitUploadsToV1RouteByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+
+	var gotPath, gotAuth, gotBundle string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var body struct {
+			BundleBase64 string `json:"bundleBase64"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotBundle = body.BundleBase64
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"publishRequestId": "pr_77", "slug": "demo-block", "version": "0.1.0", "status": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	cfgdir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgdir)
+	t.Setenv("CIVITAI_TOKEN", "tok-default")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	// No CIVITAI_SUBMIT_PATH => must default to the v1 token route.
+	t.Setenv("CIVITAI_SUBMIT_PATH", "")
+
+	stdout, _, err := run(t, "app", "submit", tmp)
+	if err != nil {
+		t.Fatalf("submit default upload: %v\n%s", err, stdout)
+	}
+	if gotPath != "/api/v1/blocks/submit-version" {
+		t.Errorf("submit path = %q, want /api/v1/blocks/submit-version", gotPath)
+	}
+	if gotAuth != "Bearer tok-default" {
+		t.Errorf("auth = %q, want Bearer tok-default", gotAuth)
+	}
+	if gotBundle == "" {
+		t.Error("server should have received a bundleBase64 body")
+	}
+	if !strings.Contains(stdout, "pr_77") {
 		t.Errorf("output should report the publish request: %s", stdout)
 	}
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -2,50 +2,143 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
+	"os/exec"
+	"runtime"
 	"strings"
+	"time"
 
+	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
 func newLoginCmd() *cobra.Command {
 	var tokenFlag string
+	var noBrowser bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Store your Civitai API token",
-		Long: `Store a Civitai API token for authenticated commands (e.g. app submit).
+		Short: "Authenticate with Civitai",
+		Long: `Authenticate the CLI with Civitai for authenticated commands (whoami,
+app submit).
 
-Create a token at https://civitai.com/user/account (API Keys). The token is
-saved to your config file (~/.config/civitai/config.yaml, owner-readable only)
-and can also be supplied via the CIVITAI_TOKEN environment variable.`,
-		Example: `  civitai login --token <token>
-  civitai login                 # prompts for the token`,
+By default ` + "`civitai login`" + ` runs a browser-based device login: it prints a
+URL and a code, you approve in your browser, and the CLI stores short-lived
+OAuth tokens that refresh automatically.
+
+Alternatively, pass --token to store a personal API key created at
+https://civitai.com/user/account (API Keys). Either way the credential is saved
+to your config file (~/.config/civitai/config.yaml, owner-readable only). The
+CIVITAI_TOKEN environment variable still overrides the stored credential.`,
+		Example: `  civitai login                 # browser device login (recommended)
+  civitai login --no-browser    # device login without auto-opening a browser
+  civitai login --token <token> # store a personal API key instead`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return err
 			}
-			token := strings.TrimSpace(tokenFlag)
-			if token == "" {
-				fmt.Fprint(cmd.OutOrStdout(), "Civitai API token: ")
-				r := bufio.NewReader(cmd.InOrStdin())
-				line, _ := r.ReadString('\n')
-				token = strings.TrimSpace(line)
+
+			// --token (or piped stdin to the prompt) keeps the personal-key path.
+			if strings.TrimSpace(tokenFlag) != "" {
+				return loginWithToken(cmd, cfg, tokenFlag)
 			}
-			if token == "" {
-				return fmt.Errorf("no token provided")
-			}
-			if err := cfg.SetToken(token); err != nil {
-				return err
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Token saved to %s\n", cfg.Path())
-			fmt.Fprintln(cmd.OutOrStdout(), "Verify with: civitai whoami")
-			return nil
+			return loginWithDevice(cmd, cfg, noBrowser)
 		},
 	}
-	cmd.Flags().StringVar(&tokenFlag, "token", "", "API token (omit to be prompted)")
+	cmd.Flags().StringVar(&tokenFlag, "token", "", "store a personal API key instead of the browser device login")
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "do not attempt to open a browser for device login")
 	return cmd
+}
+
+// loginWithToken stores a personal API key (manual, no refresh).
+func loginWithToken(cmd *cobra.Command, cfg *config.Config, tokenFlag string) error {
+	token := strings.TrimSpace(tokenFlag)
+	if token == "" {
+		fmt.Fprint(cmd.OutOrStdout(), "Civitai API token: ")
+		r := bufio.NewReader(cmd.InOrStdin())
+		line, _ := r.ReadString('\n')
+		token = strings.TrimSpace(line)
+	}
+	if token == "" {
+		return fmt.Errorf("no token provided")
+	}
+	if err := cfg.SetToken(token); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Token saved to %s\n", cfg.Path())
+	fmt.Fprintln(cmd.OutOrStdout(), "Verify with: civitai whoami")
+	return nil
+}
+
+// loginWithDevice runs the OAuth device-authorization grant.
+func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) error {
+	out := cmd.OutOrStdout()
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	oc := api.NewOAuthClient(cfg.BaseURL())
+	da, err := oc.StartDevice(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Tell the user what to do. Never print the device_code (secret).
+	uri := da.VerificationURI
+	if uri == "" {
+		uri = cfg.BaseURL() + "/oauth/device"
+	}
+	fmt.Fprintln(out, "To authenticate, open this URL in your browser and enter the code:")
+	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", uri, da.UserCode)
+
+	if !noBrowser && da.VerificationURIComplete != "" {
+		if err := openBrowser(da.VerificationURIComplete); err == nil {
+			fmt.Fprintln(out, "Opened your browser. Waiting for approval...")
+		} else {
+			fmt.Fprintln(out, "Waiting for approval...")
+		}
+	} else {
+		fmt.Fprintln(out, "Waiting for approval...")
+	}
+
+	tr, err := oc.PollToken(ctx, da, nil)
+	if err != nil {
+		return err
+	}
+
+	expiry := time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	if err := cfg.SetOAuthTokens(tr.AccessToken, tr.RefreshToken, expiry, tr.Scope); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "\nLogged in. Tokens saved to %s\n", cfg.Path())
+	fmt.Fprintln(out, "Verify with: civitai whoami")
+	return nil
+}
+
+// openBrowser best-effort opens url in the default browser. A failure is
+// non-fatal (the user can use the printed URL).
+func openBrowser(url string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name = "open"
+		args = []string{url}
+	case "windows":
+		name = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", url}
+	default:
+		name = "xdg-open"
+		args = []string{url}
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return err
+	}
+	return exec.Command(path, args...).Start()
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -91,7 +91,7 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 	// Tell the user what to do. Never print the device_code (secret).
 	uri := da.VerificationURI
 	if uri == "" {
-		uri = cfg.BaseURL() + "/oauth/device"
+		uri = cfg.BaseURL() + "/login/oauth/device"
 	}
 	fmt.Fprintln(out, "To authenticate, open this URL in your browser and enter the code:")
 	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", uri, da.UserCode)
@@ -112,7 +112,7 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 	}
 
 	expiry := time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
-	if err := cfg.SetOAuthTokens(tr.AccessToken, tr.RefreshToken, expiry, tr.Scope); err != nil {
+	if err := cfg.SetOAuthTokens(tr.AccessToken, tr.RefreshToken, expiry, tr.Scope.String()); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "\nLogged in. Tokens saved to %s\n", cfg.Path())

--- a/internal/cmd/login_device_test.go
+++ b/internal/cmd/login_device_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestLoginDeviceFlowHappyPath drives `civitai login` (no --token) end to end
+// against an httptest server: init -> two authorization_pending polls -> 200
+// success -> tokens persisted at 0600.
+func TestLoginDeviceFlowHappyPath(t *testing.T) {
+	var polls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/oauth/device":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dev-secret-code",
+				"user_code":                 "ABCD-1234",
+				"verification_uri":          "https://civitai.com/oauth/device",
+				"verification_uri_complete": "https://civitai.com/oauth/device?user_code=ABCD-1234",
+				"expires_in":                900,
+				"interval":                  1,
+			})
+		case "/api/auth/oauth/device-token":
+			n := atomic.AddInt32(&polls, 1)
+			if n < 3 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "authorization_pending"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "access-123",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "refresh-456",
+				"scope":         "33554433",
+			})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	// --no-browser to avoid spawning anything; the device flow still runs.
+	out, _, err := run(t, "login", "--no-browser")
+	if err != nil {
+		t.Fatalf("login device flow: %v\n%s", err, out)
+	}
+
+	// User-facing output shows the URL + code but never the device_code secret.
+	if !strings.Contains(out, "ABCD-1234") {
+		t.Errorf("login output should show the user_code: %s", out)
+	}
+	if strings.Contains(out, "dev-secret-code") {
+		t.Errorf("login output must NOT leak the device_code: %s", out)
+	}
+	if !strings.Contains(out, "Logged in") {
+		t.Errorf("login should confirm success: %s", out)
+	}
+	if polls != 3 {
+		t.Errorf("expected 3 device-token polls, got %d", polls)
+	}
+
+	// Tokens persisted at 0600.
+	cfgPath := filepath.Join(dir, "civitai", "config.yaml")
+	info, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config perms = %o, want 600", perm)
+	}
+	raw, _ := os.ReadFile(cfgPath)
+	var onDisk map[string]any
+	if err := yaml.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("config yaml: %v", err)
+	}
+	if onDisk["access_token"] != "access-123" || onDisk["refresh_token"] != "refresh-456" {
+		t.Errorf("persisted tokens = %v", onDisk)
+	}
+	if onDisk["auth_kind"] != "oauth" {
+		t.Errorf("auth_kind = %v, want oauth", onDisk["auth_kind"])
+	}
+	if onDisk["scope"] != "33554433" {
+		t.Errorf("scope = %v", onDisk["scope"])
+	}
+}
+
+// TestLoginDeviceFlowDenied surfaces a terminal access_denied error.
+func TestLoginDeviceFlowDenied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/auth/oauth/device":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code": "dc", "user_code": "X", "verification_uri": "https://e/x",
+				"expires_in": 900, "interval": 1,
+			})
+		case "/api/auth/oauth/device-token":
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "access_denied"})
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "login", "--no-browser")
+	if err == nil {
+		t.Fatal("expected a terminal error on access_denied")
+	}
+	if !strings.Contains(err.Error(), "denied") {
+		t.Errorf("error should mention denial: %v", err)
+	}
+	// Nothing should be persisted on failure.
+	if _, statErr := os.Stat(filepath.Join(dir, "civitai", "config.yaml")); statErr == nil {
+		t.Error("no config should be written on a failed login")
+	}
+}
+
+// TestLoginTokenFlagStillWorks confirms the personal-key path is unchanged and
+// does not invoke the device flow.
+func TestLoginTokenFlagStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+
+	out, _, err := run(t, "login", "--token", "pk-123")
+	if err != nil {
+		t.Fatalf("login --token: %v", err)
+	}
+	if !strings.Contains(out, "Token saved") {
+		t.Errorf("token login should confirm save: %s", out)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "civitai", "config.yaml"))
+	var onDisk map[string]any
+	_ = yaml.Unmarshal(raw, &onDisk)
+	if onDisk["token"] != "pk-123" {
+		t.Errorf("personal key not stored under token: %v", onDisk)
+	}
+	if onDisk["auth_kind"] != "token" {
+		t.Errorf("auth_kind = %v, want token", onDisk["auth_kind"])
+	}
+}

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,7 @@ authenticated username. Reads the token from config or CIVITAI_TOKEN.`,
 			if cfg.Token() == "" {
 				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
 			}
-			client := api.New(cfg.BaseURL(), cfg.Token(), "")
+			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
 			id, err := client.WhoAmI(context.Background())
 			if err != nil {
 				return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -18,6 +19,18 @@ const (
 
 	keyToken   = "token"
 	keyBaseURL = "base_url"
+
+	// OAuth (device-flow) keys.
+	keyAuthKind     = "auth_kind"
+	keyAccessToken  = "access_token"
+	keyRefreshToken = "refresh_token"
+	keyTokenExpiry  = "token_expiry" // RFC3339 absolute expiry of the access token
+	keyScope        = "scope"
+
+	// AuthKindOAuth marks a config holding device-flow OAuth tokens.
+	AuthKindOAuth = "oauth"
+	// AuthKindToken marks a config holding a personal API key (no refresh).
+	AuthKindToken = "token"
 
 	// EnvPrefix maps CIVITAI_TOKEN / CIVITAI_BASE_URL onto config keys.
 	EnvPrefix = "CIVITAI"
@@ -69,8 +82,15 @@ func Load() (*Config, error) {
 	return &Config{v: v, path: filepath.Join(dir, "config.yaml")}, nil
 }
 
-// Token returns the configured API token (env overrides file).
-func (c *Config) Token() string { return c.v.GetString(keyToken) }
+// Token returns the credential to send as a Bearer token. For an OAuth config
+// it is the stored access token; for a personal-key config it is the API key.
+// Env (CIVITAI_TOKEN) overrides the file in both cases.
+func (c *Config) Token() string {
+	if t := c.v.GetString(keyToken); t != "" {
+		return t
+	}
+	return c.v.GetString(keyAccessToken)
+}
 
 // BaseURL returns the configured API base URL.
 func (c *Config) BaseURL() string { return c.v.GetString(keyBaseURL) }
@@ -78,10 +98,73 @@ func (c *Config) BaseURL() string { return c.v.GetString(keyBaseURL) }
 // Path returns the on-disk config file path.
 func (c *Config) Path() string { return c.path }
 
-// SetToken stores the API token and persists the config file.
+// AuthKind reports how the stored credential was obtained: AuthKindOAuth (a
+// device-flow login that can refresh) or AuthKindToken (a personal key with no
+// refresh). A CIVITAI_TOKEN env override is always treated as a personal key.
+func (c *Config) AuthKind() string {
+	// An env-supplied token is a personal key — never refreshable.
+	if c.v.GetString(keyToken) != "" {
+		return AuthKindToken
+	}
+	if k := c.v.GetString(keyAuthKind); k != "" {
+		return k
+	}
+	if c.v.GetString(keyAccessToken) != "" {
+		return AuthKindOAuth
+	}
+	return AuthKindToken
+}
+
+// AccessToken returns the stored OAuth access token (empty for a personal key).
+func (c *Config) AccessToken() string { return c.v.GetString(keyAccessToken) }
+
+// RefreshToken returns the stored OAuth refresh token (empty for a personal key).
+func (c *Config) RefreshToken() string { return c.v.GetString(keyRefreshToken) }
+
+// Scope returns the stored OAuth scope string.
+func (c *Config) Scope() string { return c.v.GetString(keyScope) }
+
+// TokenExpiry returns the absolute access-token expiry, or the zero time if
+// none is stored.
+func (c *Config) TokenExpiry() time.Time {
+	s := c.v.GetString(keyTokenExpiry)
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// SetToken stores a personal API key and persists the config file. It clears
+// any OAuth state so the two auth kinds never coexist on disk.
 func (c *Config) SetToken(token string) error {
 	c.v.Set(keyToken, token)
+	c.v.Set(keyAuthKind, AuthKindToken)
+	c.clearOAuth()
 	return c.save()
+}
+
+// SetOAuthTokens stores device-flow tokens (access + refresh + expiry + scope)
+// and persists the config file. It clears any personal-key token so the two
+// auth kinds never coexist on disk.
+func (c *Config) SetOAuthTokens(accessToken, refreshToken string, expiry time.Time, scope string) error {
+	c.v.Set(keyAuthKind, AuthKindOAuth)
+	c.v.Set(keyAccessToken, accessToken)
+	c.v.Set(keyRefreshToken, refreshToken)
+	c.v.Set(keyTokenExpiry, expiry.UTC().Format(time.RFC3339))
+	c.v.Set(keyScope, scope)
+	c.v.Set(keyToken, "")
+	return c.save()
+}
+
+func (c *Config) clearOAuth() {
+	c.v.Set(keyAccessToken, "")
+	c.v.Set(keyRefreshToken, "")
+	c.v.Set(keyTokenExpiry, "")
+	c.v.Set(keyScope, "")
 }
 
 // SetBaseURL stores a custom base URL and persists the config file.

--- a/internal/config/oauth_test.go
+++ b/internal/config/oauth_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSetOAuthTokensPersists(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	exp := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	if err := cfg.SetOAuthTokens("at-1", "rt-1", exp, "33554433"); err != nil {
+		t.Fatalf("SetOAuthTokens: %v", err)
+	}
+
+	cfg2, err := Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if cfg2.AuthKind() != AuthKindOAuth {
+		t.Errorf("AuthKind = %q, want oauth", cfg2.AuthKind())
+	}
+	if cfg2.AccessToken() != "at-1" || cfg2.RefreshToken() != "rt-1" {
+		t.Errorf("tokens = %q/%q", cfg2.AccessToken(), cfg2.RefreshToken())
+	}
+	if cfg2.Scope() != "33554433" {
+		t.Errorf("scope = %q", cfg2.Scope())
+	}
+	if !cfg2.TokenExpiry().Equal(exp) {
+		t.Errorf("expiry = %v, want %v", cfg2.TokenExpiry(), exp)
+	}
+	// Token() should serve the access token for OAuth configs.
+	if cfg2.Token() != "at-1" {
+		t.Errorf("Token() = %q, want the access token", cfg2.Token())
+	}
+	// File must be owner-only.
+	info, err := os.Stat(cfg2.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config perms = %o, want 600", perm)
+	}
+}
+
+func TestSetTokenClearsOAuthState(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("CIVITAI_TOKEN")
+
+	cfg, _ := Load()
+	if err := cfg.SetOAuthTokens("at", "rt", time.Now().Add(time.Hour), "s"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetToken("personal-key"); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, _ := Load()
+	if cfg2.AuthKind() != AuthKindToken {
+		t.Errorf("AuthKind = %q, want token", cfg2.AuthKind())
+	}
+	if cfg2.RefreshToken() != "" || cfg2.AccessToken() != "" {
+		t.Errorf("OAuth state should be cleared: at=%q rt=%q", cfg2.AccessToken(), cfg2.RefreshToken())
+	}
+	if cfg2.Token() != "personal-key" {
+		t.Errorf("Token() = %q", cfg2.Token())
+	}
+}
+
+func TestEnvTokenIsAlwaysPersonalKind(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "env-key")
+
+	cfg, _ := Load()
+	if cfg.AuthKind() != AuthKindToken {
+		t.Errorf("env CIVITAI_TOKEN should be a personal key, got %q", cfg.AuthKind())
+	}
+	if cfg.Token() != "env-key" {
+		t.Errorf("Token() = %q", cfg.Token())
+	}
+}


### PR DESCRIPTION
Adds a browser-based **OAuth device-authorization grant** to the CLI so `civitai login` (no flags) authenticates via the browser and stores auto-refreshing tokens that work for `app submit` and `whoami`. Implements the server contract from civitai/civitai **PR #2644**.

## What changed
- **`civitai login`** (no `--token`): device init (`POST /api/auth/oauth/device`) → print the verification URL + user code (best-effort browser-open of `verification_uri_complete`; `--no-browser` to skip) → poll `POST /api/auth/oauth/device-token` every `interval`s, respecting `slow_down` (interval bump) and stopping at `expires_in` → store tokens. `expired_token`/`access_denied` surface a clear terminal error. **`civitai login --token <key>` stays unchanged** (personal API key, no refresh).
- **Token storage** (`internal/config`): stores `access_token`, `refresh_token`, absolute `token_expiry`, `scope`, and an `auth_kind` marker (`oauth` vs `token`), alongside the legacy single-`token` personal key. Backward compatible, written `0600`. `CIVITAI_TOKEN` env is always treated as a personal key.
- **Refresh** (`internal/auth.Source`, an `api.TokenSource`): before a request it refreshes an expired OAuth access token (`POST /api/auth/oauth/token`), persists the **rotated** refresh token if the server returns one, and retries **once on a 401**. A personal key is served as-is with no refresh. `whoami` + `app submit` both use it, so they refresh transparently.
- **`app submit` uploads by default** to the v1 token route **`/api/v1/blocks/submit-version`** (`CIVITAI_SUBMIT_PATH` still overrides). Stale "not yet automated" copy + README updated.

Client id `civitai-cli` is a **public** (PKCE/device) client — no secret. Scope `33554433` = `UserRead|AppBlocksSubmit`, hardcoded as CLI constants.

## Tests (`go build ./... && go test ./...` green)
- Device happy path against `httptest`: init → two `authorization_pending` polls → 200 success → tokens persisted (config contents + `0600` asserted).
- `slow_down` increases the interval; `expired_token`/`access_denied` terminal errors; overall timeout at `expires_in`.
- Refresh: expired access token triggers a refresh, persists the rotated refresh token, retried request succeeds; a 401 mid-request triggers one refresh+retry; personal key never refreshes.
- `app submit` posts to `/api/v1/blocks/submit-version` with the stored `Bearer` + `bundleBase64` body.
- Personal-key (`--token`) path still works and does not refresh.

## Self-audit
Tokens persisted `0600`, never logged/printed (the test asserts the `device_code` secret doesn't leak); refresh rotation handled (old refresh token retained when not rotated); the personal-key path is unchanged; submit defaults to the v1 token route.

## Not verified
Real end-to-end against prod — needs **PR #2644 merged** and the `civitai-cli` OAuth client row provisioned server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)