### PR TITLE
feat(app): add 'app create' command (page-money default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ civitai version
 # 1. Authenticate once (browser device login; or `civitai login --token <t>`).
 civitai login
 
-# 2. Scaffold a ready-to-build App Block.
-civitai app init my-app --template page-vite
+# 2. Scaffold a ready-to-build App Block (batteries-included page-money default).
+civitai app create my-app
 cd my-app
 
 # 3. Edit your app, then check the manifest before submitting.
@@ -72,7 +72,8 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 | --- | --- |
 | `civitai login [--token <t>] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens); `--token` stores a personal API key instead. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
 | `civitai whoami` | Verify the stored token; print the authenticated user. |
-| `civitai app init [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | Scaffold a correct, ready-to-build App Block project (default dir `./<slug>`). |
+| `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App Block, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
+| `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
 | `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai version` | Print version / commit / build date. |

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -11,11 +11,16 @@ func newAppCmd() *cobra.Command {
 
 An App Block is a sandboxed static web app served in an iframe. The platform
 owns the build and the runtime; the only mandatory file is block.manifest.json.
-The typical lifecycle is init -> validate -> submit.`,
-		Example: `  civitai app init my-block --template page-vite
+The typical lifecycle is create -> validate -> submit.
+
+"civitai app create" is the friendly, batteries-included scaffolder (defaults to
+the rich page-money SDK template); "civitai app init" is the same scaffolder
+with a no-build static default (back-compat alias).`,
+		Example: `  civitai app create my-block
   civitai app validate ./my-block
   civitai app submit ./my-block`,
 	}
+	cmd.AddCommand(newAppCreateCmd())
 	cmd.AddCommand(newAppInitCmd())
 	cmd.AddCommand(newAppValidateCmd())
 	cmd.AddCommand(newAppSubmitCmd())

--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"github.com/civitai/cli/internal/scaffold"
+	"github.com/spf13/cobra"
+)
+
+// newAppCreateCmd is the batteries-included, friendly scaffolder. It is a thin
+// superset of `app init` — same flags, same slug/display derivation, same
+// self-validation and next-steps output — that defaults --template to the rich
+// `page-money` SDK template (vs init's no-build `static` default).
+func newAppCreateCmd() *cobra.Command {
+	var templateFlag string
+	var fromSlug string
+	var dirFlag string
+	var nameFlag string
+
+	cmd := &cobra.Command{
+		Use:   "create [name] [dir]",
+		Short: "Create a ready-to-build App Block (batteries-included, SDK money-path)",
+		Long: `Create a ready-to-build App Block, batteries included.
+
+This is the friendly happy path: a thin superset of "civitai app init" that
+defaults to the rich page-money template — a Vite + React + TypeScript full-page
+block wired to the published App SDK (estimate -> consent -> submit -> poll ->
+Buzz spend), with a mock-host dev harness and a unit test. The scaffold is
+immediately runnable (npm install && npm run dev:harness), test-green, and
+validates clean.
+
+Templates (override with --template):
+  static      a no-build page block (index.html + a tiny JS, no build step)
+  page-vite   a vite + React page block (config-as-code build: buildCommand + outputDir)
+  page-money  a vite + React + TS full-page (W10) money-path block wired to the
+              published App SDK (estimate -> consent -> submit -> poll -> Buzz spend)
+              [default for create]
+
+The display name can be free-form ("My Cool Block"); it is slugified for the
+blockId. A slug-shaped name is used verbatim.
+
+By default the project is created in ./<slug>. Override the output directory with
+a positional [dir] or --dir <path>; override the display name independently with
+--name (so name, slug, and directory can all differ).`,
+		Example: `  # A page-money block in ./my-block (the batteries-included default).
+  civitai app create my-block
+
+  # "My Cool Block" -> slug my-cool-block, dir ./my-cool-block.
+  civitai app create "My Cool Block"
+
+  # Same as init: a no-build static block.
+  civitai app create my-block --template static
+
+  # Custom output directory (slug stays my-block; created in ./apps/foo).
+  civitai app create my-block --dir ./apps/foo`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAppScaffold(cmd, args, templateFlag, fromSlug, dirFlag, nameFlag)
+		},
+	}
+
+	// create defaults to the batteries-included page-money template; every
+	// other flag matches init exactly.
+	cmd.Flags().StringVarP(&templateFlag, "template", "t", string(scaffold.PageMoney), "project template: static | page-vite | page-money")
+	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published block slug (not yet wired)")
+	cmd.Flags().StringVar(&dirFlag, "dir", "", "output directory (default ./<slug>)")
+	cmd.Flags().StringVar(&nameFlag, "name", "", "display name (default derived from the name argument)")
+	return cmd
+}

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/validate"
+)
+
+// assertScaffoldValid asserts the scaffolded dir is non-empty and passes the
+// same self-validation the scaffold commands run.
+func assertScaffoldValid(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read scaffold dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("scaffold dir is empty")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "block.manifest.json")); err != nil {
+		t.Errorf("block.manifest.json missing: %v", err)
+	}
+	res, err := validate.Dir(dir)
+	if err != nil {
+		t.Fatalf("validate.Dir: %v", err)
+	}
+	if !res.OK() {
+		t.Errorf("scaffold failed self-validation: %v", res.Errors)
+	}
+}
+
+func TestAppCreateDefaultsToPageMoney(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "my-block")
+
+	stdout, _, err := run(t, "app", "create", "my-block", dest)
+	if err != nil {
+		t.Fatalf("app create: %v\n%s", err, stdout)
+	}
+
+	// Defaulted to the batteries-included page-money template.
+	if !strings.Contains(stdout, "template: page-money") {
+		t.Errorf("create should default to page-money:\n%s", stdout)
+	}
+	// Harness-aware next steps (page-money needs the mock host).
+	if !strings.Contains(stdout, "dev:harness") {
+		t.Errorf("create should print dev:harness next step:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "civitai app validate") {
+		t.Errorf("create should print the validate next step:\n%s", stdout)
+	}
+
+	assertScaffoldValid(t, dest)
+
+	// page-money signature files exist.
+	for _, f := range []string{"package.json", "vite.config.ts", "tsconfig.json", "src/App.tsx"} {
+		if _, err := os.Stat(filepath.Join(dest, filepath.FromSlash(f))); err != nil {
+			t.Errorf("page-money file %q missing: %v", f, err)
+		}
+	}
+	// The page-money manifest carries the money-path scope + build fields.
+	manifest, err := os.ReadFile(filepath.Join(dest, "block.manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(manifest), "ai:write:budgeted") {
+		t.Errorf("page-money manifest missing the budgeted scope:\n%s", manifest)
+	}
+}
+
+func TestAppCreateRespectsTemplateOverride(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "static-block")
+
+	stdout, _, err := run(t, "app", "create", "static-block", dest, "--template", "static")
+	if err != nil {
+		t.Fatalf("app create --template static: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "template: static") {
+		t.Errorf("--template static should override the page-money default:\n%s", stdout)
+	}
+	assertScaffoldValid(t, dest)
+	// Static is no-build: no package.json.
+	if _, err := os.Stat(filepath.Join(dest, "package.json")); err == nil {
+		t.Error("static template should not produce a package.json")
+	}
+}
+
+func TestAppCreateDerivesSlugFromDisplayName(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "out")
+
+	stdout, _, err := run(t, "app", "create", "My Cool Block", dest)
+	if err != nil {
+		t.Fatalf("app create with display name: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "slug: my-cool-block") {
+		t.Errorf("display name should slugify to my-cool-block:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"My Cool Block"`) {
+		t.Errorf("output should report the display name:\n%s", stdout)
+	}
+}
+
+func TestAppCreateRefusesNonEmptyDir(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "existing"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "app", "create", "my-block", tmp); err == nil {
+		t.Fatal("expected create to refuse a non-empty dir")
+	}
+}
+
+func TestAppCreateFromIsNotWired(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "out")
+	_, errOut, err := run(t, "app", "create", "my-block", dest, "--from", "some-slug")
+	if err == nil {
+		t.Fatal("expected --from to error (not yet wired)")
+	}
+	if !strings.Contains(err.Error()+errOut, "not yet wired") {
+		t.Errorf("--from should report it is not wired: err=%v stderr=%s", err, errOut)
+	}
+}
+
+// TestAppInitStillDefaultsToStatic guards the back-compat alias: the refactor to
+// the shared helper must not change init's default template.
+func TestAppInitStillDefaultsToStatic(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "init-block")
+
+	stdout, _, err := run(t, "app", "init", "init-block", dest)
+	if err != nil {
+		t.Fatalf("app init: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "template: static") {
+		t.Errorf("init should still default to static:\n%s", stdout)
+	}
+	assertScaffoldValid(t, dest)
+	if _, err := os.Stat(filepath.Join(dest, "package.json")); err == nil {
+		t.Error("init's static default should not produce a package.json")
+	}
+}
+
+func TestAppInitPageMoneyViaFlag(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "init-money")
+
+	stdout, _, err := run(t, "app", "init", "init-money", dest, "--template", "page-money")
+	if err != nil {
+		t.Fatalf("app init --template page-money: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(stdout, "template: page-money") {
+		t.Errorf("init --template page-money should scaffold page-money:\n%s", stdout)
+	}
+	assertScaffoldValid(t, dest)
+}

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/civitai/cli/internal/scaffold"
@@ -45,120 +46,7 @@ a positional [dir] or --dir <path>; override the display name independently with
   civitai app init my-block ./apps/foo --name "My Block"`,
 		Args: cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out := cmd.OutOrStdout()
-
-			if fromSlug != "" {
-				return fmt.Errorf(`--from is not yet wired up.
-
-Forking an existing published block requires fetching its source from the
-server, which this CLI cannot do yet (no programmatic block-source endpoint).
-
-TODO(server): expose a read endpoint that returns a published block's canonical
-source tree by slug, then --from can scaffold from it. For now, run a plain
-init and copy the upstream files in manually.`)
-			}
-
-			tmpl, err := scaffold.ParseTemplate(templateFlag)
-			if err != nil {
-				return err
-			}
-
-			name := ""
-			if len(args) >= 1 {
-				name = args[0]
-			}
-			if name == "" {
-				return fmt.Errorf("provide a project name: civitai app init <name>")
-			}
-
-			// Positional [dir] (args[1]) and --dir both set the output directory;
-			// they must not conflict.
-			posDir := ""
-			if len(args) == 2 {
-				posDir = args[1]
-			}
-			if posDir != "" && dirFlag != "" && posDir != dirFlag {
-				return fmt.Errorf("conflicting output directory: positional %q and --dir %q", posDir, dirFlag)
-			}
-			targetDir := dirFlag
-			if targetDir == "" {
-				targetDir = posDir
-			}
-
-			// Derive slug + display name. If the name is already a valid slug
-			// use it verbatim; otherwise slugify and title-case for display.
-			var slug, display string
-			if err := scaffold.ValidateSlug(name); err == nil {
-				slug = name
-				display = scaffold.TitleFromSlug(name)
-			} else {
-				slug, err = scaffold.Slugify(name)
-				if err != nil {
-					return err
-				}
-				display = name
-			}
-
-			// --name overrides the display name independently of the slug/dir,
-			// so name, slug, and directory can all differ.
-			if nameFlag != "" {
-				display = nameFlag
-			}
-
-			// Output directory: --dir / positional [dir] if given, else ./<slug>
-			// (back-compat: no flag -> current behaviour).
-			destDir := slug
-			if targetDir != "" {
-				destDir = targetDir
-			}
-			abs, err := filepath.Abs(destDir)
-			if err != nil {
-				return err
-			}
-
-			written, err := scaffold.Render(tmpl, destDir, scaffold.Data{
-				Slug: slug,
-				Name: display,
-			})
-			if err != nil {
-				return err
-			}
-
-			// Sanity-check the scaffold we just produced is schema-valid. If it
-			// isn't, that's a bug in our own templates — fail loudly.
-			res, verr := validate.Dir(destDir)
-			if verr != nil {
-				return verr
-			}
-			if !res.OK() {
-				return fmt.Errorf("internal error: scaffolded manifest failed validation:\n  %s", joinLines(res.Errors))
-			}
-
-			fmt.Fprintf(out, "Created App Block %q (slug: %s, template: %s)\n", display, slug, tmpl)
-			fmt.Fprintf(out, "  %s\n", abs)
-			for _, w := range written {
-				// `written` paths are relative to destDir's parent; show them
-				// relative to the project dir for a clean tree.
-				rel, err := filepath.Rel(destDir, w)
-				if err != nil {
-					rel = w
-				}
-				fmt.Fprintf(out, "    %s\n", rel)
-			}
-			fmt.Fprintln(out, "\nNext steps:")
-			switch {
-			case tmpl.NeedsHarness():
-				// SDK/page-money apps render blank under plain `dev` (no host) —
-				// the dev loop needs the mock host via `dev:harness`.
-				fmt.Fprintf(out, "  cd %s && npm install && npm run dev:harness\n", destDir)
-			case tmpl == scaffold.PageVite:
-				fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", destDir)
-			default:
-				fmt.Fprintf(out, "  cd %s   # open index.html or serve the directory\n", destDir)
-			}
-			fmt.Fprintln(out, "  civitai app validate")
-			fmt.Fprintln(out, "  civitai app submit")
-			return nil
+			return runAppScaffold(cmd, args, templateFlag, fromSlug, dirFlag, nameFlag)
 		},
 	}
 
@@ -167,6 +55,132 @@ init and copy the upstream files in manually.`)
 	cmd.Flags().StringVar(&dirFlag, "dir", "", "output directory (default ./<slug>)")
 	cmd.Flags().StringVar(&nameFlag, "name", "", "display name (default derived from the name argument)")
 	return cmd
+}
+
+// runAppScaffold is the shared scaffold body behind both `app init` and
+// `app create`. The two commands differ only in the default template; all of
+// the slug/display derivation, dir resolution, rendering, self-validation, and
+// next-steps output lives here so there is a single code path.
+func runAppScaffold(cmd *cobra.Command, args []string, templateFlag, fromSlug, dirFlag, nameFlag string) error {
+	out := cmd.OutOrStdout()
+
+	if fromSlug != "" {
+		return fmt.Errorf(`--from is not yet wired up.
+
+Forking an existing published block requires fetching its source from the
+server, which this CLI cannot do yet (no programmatic block-source endpoint).
+
+TODO(server): expose a read endpoint that returns a published block's canonical
+source tree by slug, then --from can scaffold from it. For now, run a plain
+init and copy the upstream files in manually.`)
+	}
+
+	tmpl, err := scaffold.ParseTemplate(templateFlag)
+	if err != nil {
+		return err
+	}
+
+	name := ""
+	if len(args) >= 1 {
+		name = args[0]
+	}
+	if name == "" {
+		return fmt.Errorf("provide a project name: %s <name>", cmd.CommandPath())
+	}
+
+	// Positional [dir] (args[1]) and --dir both set the output directory;
+	// they must not conflict.
+	posDir := ""
+	if len(args) == 2 {
+		posDir = args[1]
+	}
+	if posDir != "" && dirFlag != "" && posDir != dirFlag {
+		return fmt.Errorf("conflicting output directory: positional %q and --dir %q", posDir, dirFlag)
+	}
+	targetDir := dirFlag
+	if targetDir == "" {
+		targetDir = posDir
+	}
+
+	// Derive slug + display name. If the name is already a valid slug
+	// use it verbatim; otherwise slugify and title-case for display.
+	var slug, display string
+	if err := scaffold.ValidateSlug(name); err == nil {
+		slug = name
+		display = scaffold.TitleFromSlug(name)
+	} else {
+		slug, err = scaffold.Slugify(name)
+		if err != nil {
+			return err
+		}
+		display = name
+	}
+
+	// --name overrides the display name independently of the slug/dir,
+	// so name, slug, and directory can all differ.
+	if nameFlag != "" {
+		display = nameFlag
+	}
+
+	// Output directory: --dir / positional [dir] if given, else ./<slug>
+	// (back-compat: no flag -> current behaviour).
+	destDir := slug
+	if targetDir != "" {
+		destDir = targetDir
+	}
+	abs, err := filepath.Abs(destDir)
+	if err != nil {
+		return err
+	}
+
+	written, err := scaffold.Render(tmpl, destDir, scaffold.Data{
+		Slug: slug,
+		Name: display,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Sanity-check the scaffold we just produced is schema-valid. If it
+	// isn't, that's a bug in our own templates — fail loudly.
+	res, verr := validate.Dir(destDir)
+	if verr != nil {
+		return verr
+	}
+	if !res.OK() {
+		return fmt.Errorf("internal error: scaffolded manifest failed validation:\n  %s", joinLines(res.Errors))
+	}
+
+	printScaffoldResult(out, display, slug, tmpl, destDir, abs, written)
+	return nil
+}
+
+// printScaffoldResult prints the created-files tree + harness-aware next steps.
+func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Template, destDir, abs string, written []string) {
+	fmt.Fprintf(out, "Created App Block %q (slug: %s, template: %s)\n", display, slug, tmpl)
+	fmt.Fprintf(out, "  %s\n", abs)
+	for _, w := range written {
+		// `written` paths are relative to destDir's parent; show them
+		// relative to the project dir for a clean tree.
+		rel, err := filepath.Rel(destDir, w)
+		if err != nil {
+			rel = w
+		}
+		fmt.Fprintf(out, "    %s\n", rel)
+	}
+	fmt.Fprintln(out, "\nNext steps:")
+	switch {
+	case tmpl.NeedsHarness():
+		// SDK/page-money apps render blank under plain `dev` (no host) —
+		// the dev loop needs the mock host via `dev:harness`.
+		fmt.Fprintf(out, "  cd %s && npm install && npm run dev:harness\n", destDir)
+	case tmpl == scaffold.PageVite:
+		fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", destDir)
+	default:
+		fmt.Fprintf(out, "  cd %s   # open index.html or serve the directory\n", destDir)
+	}
+	fmt.Fprintln(out, "  civitai app validate")
+	fmt.Fprintln(out, "  civitai app submit")
 }
 
 func joinLines(lines []string) string {


### PR DESCRIPTION
## What

Adds `civitai app create [name] [dir]` — a friendly, batteries-included scaffolder that is a **thin superset of `app init`**, defaulting to the rich `page-money` SDK template instead of init's no-build `static` default.

`page-money` is a Vite + React + TypeScript full-page (W10) money-path block wired to the published App SDK (estimate → consent → submit → poll → Buzz spend), with a mock-host dev harness and a unit test. `create <name>` gives you a project that is immediately `npm install && npm run dev:harness`-runnable, test-green, and `civitai app validate`-clean out of the box.

## How

- **Shared helper, no logic fork.** Factored the scaffold body out of `app_init.go` into `runAppScaffold(...)` (plus a `printScaffoldResult` output helper). Both `init` and `create` call it — slug/display derivation, positional/`--dir` resolution + conflict check, render, self-validation via `validate.Dir`, refuse-non-empty-dir, and harness-aware next-steps all live in one place.
- `create` defaults `--template` to `page-money`; `init` keeps its `static` default. Every other flag (`--dir`, `--name`, `-t/--template`, `--from`) behaves identically; `--from`'s "not yet wired" error is preserved on both.
- `init` stays registered and **behaviorally unchanged** (back-compat alias). `create` is the documented happy path: `app` group examples + README updated (quickstart + command-reference table).

## Tests

- New `internal/cmd/app_create_cmd_test.go`: `create` defaults to page-money (correct files + budgeted-scope manifest + `dev:harness` next-step), `--template` override works, slug derivation from a free-form display name, refuse-non-empty-dir, `--from` errors.
- Regression guards: `init` still defaults to `static`, and `init --template page-money` still works (proves the shared-helper refactor didn't change init).
- `go build ./...`, `go vet ./...`, `go test ./...` all green (43 cmd tests, 16 scaffold tests pass).

## Out of scope (Phase 2)

Per the task, this does **not** modify the template's test files or wire in the SDK `createMockHost` — that's a deliberate follow-up gated on the SDK publish (`@civitai/blocks-react` PR #50). This PR is just the `create` command + the shared-helper refactor; templates were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)