### PR TITLE
feat(templates): page-money uses SDK Harness + unit/e2e test boilerplate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,44 @@ jobs:
 
       - name: build
         run: go build ./...
+
+  # Rot-guard: scaffold the page-money template and run its JS toolchain against
+  # the PUBLISHED SDK (@civitai/blocks-react). Catches a template that renders
+  # but no longer installs / typechecks / tests / builds after an SDK bump — the
+  # out-of-the-box contract the template promises.
+  template-page-money:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: scaffold page-money
+        run: go run ./cmd/civitai app init "CI Money Block" --dir ./_ci-page-money --template page-money
+
+      - name: install
+        working-directory: ./_ci-page-money
+        run: npm install --no-audit --no-fund
+
+      - name: typecheck
+        working-directory: ./_ci-page-money
+        run: npm run typecheck
+
+      - name: test (node + dom suites)
+        working-directory: ./_ci-page-money
+        run: npm test
+
+      - name: build
+        working-directory: ./_ci-page-money
+        run: npm run build
+
+      - name: validate
+        working-directory: ./_ci-page-money
+        run: go run ../cmd/civitai app validate

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -36,10 +36,27 @@ npm run dev:harness   # http://localhost:5186 — mounts a MOCK host so you see 
 Use `dev:harness`. Query toggles: `?viewer=anon`, `?consent=granted`,
 `?fail=insufficient`, `?theme=light`.
 
+`npm run dev:harness` mounts the published SDK mock host
+(`@civitai/blocks-react/testing`) — no hand-rolled simulator to maintain.
+
 ```bash
-npm test              # the pure-logic unit tests in src/*.test.ts
+npm test              # all tests (vitest run), two suites:
+                      #   node : pure-logic units    (src/*.test.ts)
+                      #   dom  : component + e2e      (src/*.test.tsx, jsdom)
 npm run build         # what the platform produces (tsc typecheck + vite build)
 ```
+
+### Tests
+
+`npm test` runs both vitest projects in one go (split in `vite.config.ts`):
+
+- **`src/generation.test.ts`** — pure-logic units (node env).
+- **`src/App.test.tsx`** — component tests: render `<App/>` against
+  `createMockHost()` and assert the UI (anon → sign-in, signed-in → prompt).
+- **`src/e2e.test.tsx`** — the money-path proof: drives the FULL
+  estimate → consent → submit → poll → succeeded flow through the REAL SDK
+  transport against the mock host (no hook mocking). This is what tells you the
+  spend wiring still works after you edit the app.
 
 ## Allowed parent origins
 

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -14,12 +14,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.9.0",
-    "@civitai/blocks-react": "^0.6.0",
+    "@civitai/app-sdk": "^0.12.0",
+    "@civitai/blocks-react": "^0.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.0",
     "@types/node": "^25.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMockHost } from '@civitai/blocks-react/testing';
+
+import { App } from './App.js';
+
+// Component tests: render <App/> against the SDK mock host under a scenario and
+// assert the rendered UI. We install the mock host directly (not the React
+// <Harness>) so each test controls its own scenario + teardown. The transport
+// is reset before each test by src/test-setup.ts.
+
+describe('App (component)', () => {
+  let uninstall: (() => void) | undefined;
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+  });
+
+  it('shows a loading state before BLOCK_INIT lands', () => {
+    // Install the host but render before its setTimeout(0) BLOCK_INIT fires.
+    uninstall = createMockHost({ viewer: null }).install();
+    render(<App />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('anon viewer -> renders the sign-in affordance (no Generate button)', async () => {
+    uninstall = createMockHost({ viewer: null }).install();
+    render(<App />);
+
+    // Once BLOCK_INIT arrives with viewer=null, the App swaps the loading state
+    // for the sign-in CTA.
+    const signIn = await screen.findByTestId('pm-signin');
+    expect(signIn).toHaveTextContent(/sign in to generate/i);
+    expect(screen.queryByTestId('pm-generate')).not.toBeInTheDocument();
+  });
+
+  it('signed-in viewer -> renders the prompt field + Generate button', async () => {
+    uninstall = createMockHost({ viewer: { id: 2, username: 'dev', status: 'active' } }).install();
+    render(<App />);
+
+    expect(await screen.findByTestId('pm-generate')).toBeInTheDocument();
+    expect(screen.getByLabelText(/generation prompt/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('pm-signin')).not.toBeInTheDocument();
+  });
+});

--- a/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
@@ -1,252 +1,28 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
-import type { BlockContext } from '@civitai/app-sdk/blocks';
-
-const DEV_TOKEN = 'dev.harness.mock.jwt.NOT.A.REAL.RS256';
-const DEV_INSTANCE_ID = 'page_{{ .Slug }}';
-const DEV_BLOCK_ID = '{{ .Slug }}';
-const DEV_APP_ID = 'app_dev';
-
-const BUDGETED_SCOPE = 'ai:write:budgeted';
-
-interface OutboundLog {
-  type: string;
-  payload?: unknown;
-}
+import { Harness as SdkHarness } from '@civitai/blocks-react/testing';
 
 /**
- * Local dev mock host for the {{ .Name }} PAGE app. The real W10 page surface
- * mounts the block in a full-bleed iframe at /apps/run/{{ .Slug }} and routes the
- * money messages (ESTIMATE/SUBMIT/POLL) to the generation orchestrator. Locally
- * there's no host, so this component plays one:
+ * Local dev mock host for the {{ .Name }} PAGE app.
  *
- *  1. Intercepts `window.parent.postMessage` so the block's outbound messages
- *     are answered / logged.
- *  2. Mints a token WITHOUT the budgeted scope first (mirrors the real mint:
- *     `ai:write:budgeted` is consent-gated -> withheld until granted). On
- *     REQUEST_CONSENT it "grants" the scope and pushes a TOKEN_REFRESH carrying
- *     it — the round-trip the App's auto-resume depends on.
- *  3. Simulates the orchestrator money path: ESTIMATE -> snapshot{cost},
- *     SUBMIT -> pending snapshot, then POLL -> processing -> succeeded with a
- *     placeholder image + a cost.
- *  4. Dispatches a fake BLOCK_INIT with a PAGE context (slotId 'app.page',
- *     entity=none — NO model fields).
+ * The real W10 page surface mounts the block in a full-bleed iframe at
+ * /apps/run/{{ .Slug }} and routes the money messages (ESTIMATE/SUBMIT/POLL) to
+ * the generation orchestrator. Locally there's no host, so this plays one — but
+ * we no longer hand-roll it: the published SDK ships the mock host
+ * (`@civitai/blocks-react/testing`). This wrapper just mounts it.
  *
- * URL query toggles:
- *   ?viewer=anon       -> BLOCK_INIT.viewer = null (anon -> sign-in CTA)
+ * `applyUrlToggles` (default true) reads the URL query knobs so the dev loop
+ * stays interactive:
+ *   ?viewer=anon       -> anonymous viewer (sign-in CTA)
  *   ?consent=granted   -> start WITH the budgeted scope already granted
- *   ?fail=insufficient -> SUBMIT returns a failed snapshot with insufficient-Buzz text
+ *   ?fail=insufficient -> SUBMIT returns an insufficient-Buzz failed snapshot
  *   ?theme=light       -> light theme (default dark)
  *
- * The mock token is NOT a real RS256 JWT — only the bridge round-trips are
- * exercised. No real Buzz is spent (there is no orchestrator).
+ * IMPORTANT: the SDK transport DROPS inbound messages whose origin isn't in its
+ * allowlist, and the mock host fires from `window.location.origin`. The harness
+ * entry (main.tsx) pre-initializes the transport with that origin allowlisted —
+ * see `installHarnessTransport`. No real Buzz is spent (there is no orchestrator).
  */
 export function Harness({ children }: { children: ReactNode }) {
-  const [outbound, setOutbound] = useState<OutboundLog[]>([]);
-  const [parentOrigin] = useState(() => window.location.origin);
-  const tokenSerialRef = useRef(0);
-
-  const params = new URLSearchParams(window.location.search);
-  const anon = params.get('viewer') === 'anon';
-  const startGranted = params.get('consent') === 'granted';
-  const failMode = params.get('fail'); // 'insufficient' | null
-  const theme: 'light' | 'dark' = params.get('theme') === 'light' ? 'light' : 'dark';
-
-  useEffect(() => {
-    const originalParent = window.parent;
-    let consentGranted = startGranted;
-    const workflows = new Map<string, { polls: number }>();
-
-    const dispatchToBlock = (data: unknown) => {
-      window.dispatchEvent(new MessageEvent('message', { data, origin: parentOrigin }));
-    };
-
-    const nextToken = () => {
-      tokenSerialRef.current += 1;
-      return {
-        raw: DEV_TOKEN + '.' + tokenSerialRef.current,
-        scopes: consentGranted ? [BUDGETED_SCOPE] : ([] as string[]),
-        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
-        ...(consentGranted ? { buzzBudget: 10 } : {}),
-      };
-    };
-
-    const succeededSnapshot = (workflowId: string) => ({
-      workflowId,
-      status: 'succeeded' as const,
-      cost: { total: 8 },
-      imageUrls: ['https://placehold.co/512x512/1971c2/ffffff/png?text=Generated'],
-    });
-
-    const parentMock = {
-      postMessage: (msg: unknown) => {
-        if (
-          typeof msg !== 'object' ||
-          msg === null ||
-          typeof (msg as { type?: unknown }).type !== 'string'
-        ) {
-          return;
-        }
-        const typed = msg as {
-          type: string;
-          payload?: { requestId?: string; workflowId?: string; body?: unknown };
-        };
-        if (typed.type !== 'RESIZE_IFRAME') {
-          queueMicrotask(() =>
-            setOutbound((prev) => [...prev, { type: typed.type, payload: typed.payload }]),
-          );
-        }
-        const requestId = typed.payload?.requestId;
-
-        if (typed.type === 'REQUEST_TOKEN') {
-          dispatchToBlock({
-            type: 'TOKEN_REFRESH_RESPONSE',
-            payload: { ...(requestId ? { requestId } : {}), token: nextToken() },
-          });
-          return;
-        }
-
-        // Lazy consent: "grant" the budgeted scope, then push a host-initiated
-        // TOKEN_REFRESH (no requestId) carrying the now-granted scope.
-        if (typed.type === 'REQUEST_CONSENT') {
-          consentGranted = true;
-          window.setTimeout(() => {
-            dispatchToBlock({ type: 'TOKEN_REFRESH', payload: { token: nextToken() } });
-          }, 600);
-          return;
-        }
-
-        if (typed.type === 'REQUEST_SIGN_IN') {
-          return;
-        }
-
-        if (typed.type === 'ESTIMATE_WORKFLOW') {
-          dispatchToBlock({
-            type: 'ESTIMATE_RESULT',
-            payload: {
-              requestId,
-              snapshot: { workflowId: 'wf_estimate', status: 'pending', cost: { total: 8 } },
-            },
-          });
-          return;
-        }
-
-        if (typed.type === 'SUBMIT_WORKFLOW') {
-          if (failMode === 'insufficient') {
-            dispatchToBlock({
-              type: 'WORKFLOW_SUBMITTED',
-              payload: {
-                requestId,
-                snapshot: {
-                  workflowId: 'wf_fail',
-                  status: 'failed',
-                  error: 'Insufficient Buzz to run this generation.',
-                },
-              },
-            });
-            return;
-          }
-          const workflowId = 'wf_' + Date.now();
-          workflows.set(workflowId, { polls: 0 });
-          dispatchToBlock({
-            type: 'WORKFLOW_SUBMITTED',
-            payload: { requestId, snapshot: { workflowId, status: 'pending' } },
-          });
-          return;
-        }
-
-        if (typed.type === 'POLL_WORKFLOW') {
-          const workflowId = typed.payload?.workflowId ?? '';
-          const wf = workflows.get(workflowId);
-          const polls = (wf?.polls ?? 0) + 1;
-          if (wf) wf.polls = polls;
-          const snapshot =
-            polls >= 2
-              ? succeededSnapshot(workflowId)
-              : { workflowId, status: 'processing' as const };
-          dispatchToBlock({ type: 'WORKFLOW_STATUS', payload: { requestId, snapshot } });
-          return;
-        }
-      },
-    };
-    Object.defineProperty(window, 'parent', {
-      value: parentMock,
-      configurable: true,
-      writable: true,
-    });
-
-    // PAGE context — entity=none, slotId 'app.page'. No model fields.
-    const context: BlockContext = { slotId: 'app.page', theme };
-    const payload = {
-      blockInstanceId: DEV_INSTANCE_ID,
-      blockId: DEV_BLOCK_ID,
-      appId: DEV_APP_ID,
-      token: nextToken(),
-      context,
-      settings: { publisherSettings: {}, userSettings: {} },
-      viewer: anon ? null : { id: 2, username: 'dev-viewer', status: 'active' as const },
-      theme,
-      renderMode: 'iframe' as const,
-    };
-    const timer = window.setTimeout(() => dispatchToBlock({ type: 'BLOCK_INIT', payload }), 0);
-
-    return () => {
-      window.clearTimeout(timer);
-      Object.defineProperty(window, 'parent', {
-        value: originalParent,
-        configurable: true,
-        writable: true,
-      });
-    };
-  }, [parentOrigin, anon, startGranted, failMode, theme]);
-
-  const summary =
-    'DEV HARNESS · viewer=' +
-    (anon ? 'anon' : 'dev-viewer') +
-    ' · consent=' +
-    (startGranted ? 'granted' : 'withheld') +
-    ' · theme=' +
-    theme +
-    ' · outbound:' +
-    outbound.length;
-
-  return (
-    <div data-harness="true" style={harnessRootStyle}>
-      <main data-harness-frame="true" style={harnessFrameStyle}>
-        {children}
-      </main>
-      <details style={harnessLogStyle}>
-        <summary style={harnessSummaryStyle}>{summary}</summary>
-        <pre style={harnessPreStyle}>
-          {outbound.length === 0
-            ? '// no outbound messages yet'
-            : outbound
-                .map((m, i) => i + 1 + '. ' + m.type + ' ' + JSON.stringify(m.payload ?? {}))
-                .join('\n')}
-        </pre>
-      </details>
-    </div>
-  );
+  return <SdkHarness>{children}</SdkHarness>;
 }
-
-const harnessRootStyle: React.CSSProperties = {
-  position: 'relative',
-  width: '100vw',
-  minHeight: '100dvh',
-};
-const harnessFrameStyle: React.CSSProperties = { width: '100%', minHeight: '100%' };
-const harnessSummaryStyle: React.CSSProperties = { cursor: 'pointer' };
-const harnessPreStyle: React.CSSProperties = { margin: 0, maxHeight: 200, overflow: 'auto' };
-const harnessLogStyle: React.CSSProperties = {
-  position: 'fixed',
-  bottom: 8,
-  right: 8,
-  zIndex: 9999,
-  maxWidth: 520,
-  background: 'rgba(17,17,17,0.92)',
-  color: '#7fc',
-  fontSize: 11,
-  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
-  padding: '6px 10px',
-  borderRadius: 6,
-};

--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -1,0 +1,34 @@
+// Test/dev-only transport wiring. NOT imported by production code (App.tsx uses
+// the SDK hooks, which read the build-time env allowlist via getTransport()).
+//
+// The SDK's IframeTransport is a process-wide singleton: the FIRST getTransport()
+// call decides its origin allowlist. In production that allowlist comes from
+// VITE_BLOCK_ALLOWED_PARENT_ORIGINS (baked in at build). But the mock host (dev
+// harness AND vitest) replies from `window.location.origin`, and the transport
+// DROPS any inbound message whose origin isn't allowlisted — so in harness/test
+// mode we MUST initialize the transport with `window.location.origin` allowed
+// BEFORE any hook (or the mock host) runs. That's what this does.
+
+import { getTransport } from '@civitai/blocks-react';
+import { resetTransport } from '@civitai/blocks-react/testing';
+
+/**
+ * Initialize the SDK transport with the current page origin allowlisted, so the
+ * mock host's `window.location.origin` replies are accepted. Call this once,
+ * before rendering, in the dev harness entry. Idempotent at the singleton level
+ * (the first call wins).
+ */
+export function installHarnessTransport() {
+  getTransport({ allowedParentOrigins: [window.location.origin] });
+}
+
+/**
+ * Reset + re-initialize the transport for a single test. Call in `beforeEach`
+ * so each test gets a fresh singleton whose allowlist contains the jsdom origin
+ * (`window.location.origin`). Without the reset, the first test's singleton
+ * leaks into the next.
+ */
+export function resetHarnessTransport() {
+  resetTransport();
+  getTransport({ allowedParentOrigins: [window.location.origin] });
+}

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMockHost } from '@civitai/blocks-react/testing';
+
+import { App } from './App.js';
+
+// End-to-end proof of the money wiring: this drives the FULL page money path
+// through the REAL SDK transport (NO hook mocking) against the published mock
+// host. It is the regression guard that estimate -> consent -> submit -> poll
+// stays wired:
+//
+//   render <App/> (consent WITHHELD)
+//     -> type a prompt
+//     -> click Generate
+//     -> App asks the host for consent (REQUEST_CONSENT)
+//     -> host grants + pushes a TOKEN_REFRESH carrying ai:write:budgeted
+//     -> App auto-resumes: estimate -> submit -> poll
+//     -> succeeded snapshot -> result image + spent-cost caption
+//
+// The mock host's internal timers all fire on setTimeout(0), so real timers +
+// findBy/waitFor resolve promptly — no fake-timer juggling required.
+
+describe('App money path (e2e)', () => {
+  let uninstall: (() => void) | undefined;
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+  });
+
+  it('estimate -> consent -> submit -> poll -> succeeded (+cost)', async () => {
+    const user = userEvent.setup();
+    // consentGranted:false -> the first token has NO budgeted scope, so the
+    // first Generate must go through the lazy-consent round-trip. cost:8 is the
+    // succeeded snapshot's reported cost.
+    uninstall = createMockHost({
+      viewer: { id: 2, username: 'dev', status: 'active' },
+      consentGranted: false,
+      cost: 8,
+      pollsUntilDone: 2,
+    }).install();
+
+    render(<App />);
+
+    // Wait for BLOCK_INIT -> the Generate button appears.
+    const generate = await screen.findByTestId('pm-generate');
+
+    // Enter a prompt (Generate is disabled while empty).
+    await user.type(screen.getByLabelText(/generation prompt/i), 'a serene mountain lake');
+    expect(generate).toBeEnabled();
+
+    // Click Generate. Scope is withheld -> App requests consent first.
+    await user.click(generate);
+
+    // The host grants consent + token-refreshes; the App auto-resumes through
+    // estimate -> submit -> poll -> succeeded. Assert the terminal success UI.
+    const result = await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
+    expect(result).toBeInTheDocument();
+
+    // The succeeded snapshot's cost is rendered in the caption.
+    await waitFor(() => {
+      expect(screen.getByText(/spent/i)).toHaveTextContent('8');
+    });
+
+    // No error surfaced anywhere in the happy path.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('insufficient Buzz on submit -> Top-Up CTA, no result image', async () => {
+    const user = userEvent.setup();
+    uninstall = createMockHost({
+      viewer: { id: 2, username: 'dev', status: 'active' },
+      consentGranted: true, // skip the consent round-trip; go straight to submit
+      failMode: 'insufficient',
+    }).install();
+
+    render(<App />);
+
+    const generate = await screen.findByTestId('pm-generate');
+    await user.type(screen.getByLabelText(/generation prompt/i), 'a cat');
+    await user.click(generate);
+
+    // The failed snapshot carries insufficient-Buzz text -> the App swaps to
+    // the Top-Up CTA and renders no image.
+    expect(await screen.findByTestId('pm-insufficient')).toBeInTheDocument();
+    expect(screen.queryByAltText(/generated result/i)).not.toBeInTheDocument();
+  });
+});

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -3,13 +3,20 @@ import { createRoot } from 'react-dom/client';
 
 import { App } from './App.js';
 import { Harness } from './Harness.js';
+import { installHarnessTransport } from './dev-transport.js';
 import './index.css';
 
 // `npm run dev:harness` sets VITE_DEV_HARNESS=true to mount the local mock host
-// that posts a fake BLOCK_INIT (page context, entity=none), answers the consent
-// + token-refresh round-trip, and simulates the orchestrator money path
-// (estimate / submit / poll). Never set in prod.
+// (the published `@civitai/blocks-react/testing` Harness) that posts a fake
+// BLOCK_INIT (page context, entity=none), answers the consent + token-refresh
+// round-trip, and simulates the orchestrator money path (estimate / submit /
+// poll). Never set in prod.
 const useHarness = import.meta.env.VITE_DEV_HARNESS === 'true';
+
+// The mock host replies from window.location.origin; the SDK transport drops
+// mismatched-origin messages. Allowlist this origin BEFORE any hook runs so
+// BLOCK_INIT lands. (Prod uses VITE_BLOCK_ALLOWED_PARENT_ORIGINS instead.)
+if (useHarness) installHarnessTransport();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('#root missing from index.html');

--- a/internal/scaffold/templates/page-money/src/test-setup.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/test-setup.ts.tmpl
@@ -1,0 +1,20 @@
+// Setup for the jsdom (component + e2e) test project. Loaded via setupFiles in
+// vite.config.ts's `dom` project.
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeEach } from 'vitest';
+
+import { resetHarnessTransport } from './dev-transport.js';
+
+// The SDK transport is a process-wide singleton — reset it before each test so
+// each gets a fresh instance whose allowlist contains the jsdom origin, and so
+// no BLOCK_INIT / token state leaks between tests.
+beforeEach(() => {
+  resetHarnessTransport();
+});
+
+// Unmount React trees + clear jsdom between tests.
+afterEach(() => {
+  cleanup();
+});

--- a/internal/scaffold/templates/page-money/vite.config.ts.tmpl
+++ b/internal/scaffold/templates/page-money/vite.config.ts.tmpl
@@ -21,9 +21,28 @@ export default defineConfig({
     rollupOptions: { output: { manualChunks: undefined } },
   },
   test: {
-    // Pure-logic unit tests run in node; the cost-format / insufficient-Buzz
-    // sniff / poll-state helpers don't touch the DOM.
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
+    // Two suites in one `vitest run`:
+    //  - `node`: pure-logic unit tests (*.test.ts) — no DOM, fast.
+    //  - `dom` : component + e2e tests (*.test.tsx) — jsdom + testing-library,
+    //            driving <App/> against the SDK's createMockHost.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'node',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'dom',
+          environment: 'jsdom',
+          include: ['src/**/*.test.tsx'],
+          setupFiles: ['./src/test-setup.ts'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## What

Phase 2 of the App Blocks DX work: the `page-money` scaffold now adopts the **published SDK mock host** shipped in `@civitai/blocks-react@0.8.0` (the `/testing` export) and ships **unit + component + e2e test boilerplate**, so a freshly-created app runs locally and is tested out of the box.

Templates-only change (plus a CI job). No CLI command code touched (that's #6 / the `app create` PR #5/#6 — no overlap).

## Changes

- **Slim the Harness**: replace the ~250-line hand-rolled `src/Harness.tsx` simulator with a ~15-line wrapper around the SDK's `<Harness>` (`createMockHost` under the hood). Net **-232 lines** of per-block boilerplate.
- **Transport-origin wiring**: add `src/dev-transport.ts` that allowlists `window.location.origin` for the dev harness AND tests — the mock host replies from that origin and the SDK `IframeTransport` drops mismatched-origin messages. `main.tsx` calls `installHarnessTransport()` before render in harness mode (prod still uses the baked-in `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`).
- **Dep bumps**: `@civitai/blocks-react ^0.8.0` + `@civitai/app-sdk ^0.12.0` (the 0.8.0 peer requires `>=0.10.0`). Add `@testing-library/react` + `@testing-library/jest-dom` + `@testing-library/user-event` devDeps.
- **vitest split**: two projects in one `vitest run` — `node` (`*.test.ts`, pure logic) + `dom` (`*.test.tsx`, jsdom) via `test.projects`. Add `src/test-setup.ts` (jest-dom matchers + per-test transport reset + cleanup). Existing `generation.test.ts` kept.
- **New tests**:
  - `src/App.test.tsx` — component: anon → sign-in affordance, signed-in → prompt + Generate, loading state.
  - `src/e2e.test.tsx` — the money-path proof, driving the FULL flow through the **real SDK transport** (no hook mocking): estimate → consent → submit → poll → succeeded (+cost), plus the insufficient-Buzz Top-Up path.
- **README** updated for the new harness + test split.
- **CI rot-guard**: a new `template-page-money` job scaffolds the template and runs `npm install` / `typecheck` / `test` / `build` / `app validate` against the published SDK, so the template can't silently rot after an SDK bump.

## Verification (real scaffolded project)

Scaffolded `page-money` via the built CLI, then on the rendered project:

- `npm install` → resolved `@civitai/blocks-react@0.8.0` + `@civitai/app-sdk@0.12.0`, 0 vulnerabilities.
- `npm run typecheck` → clean.
- `npm test` → **14 passed (3 files)**: 9 `node` + 5 `dom` (3 component + 2 e2e). The full money-path e2e exercises the real transport round-trips (~2.1s).
- `npm run build` → tsc + vite build OK (208 kB / 66 kB gzip).
- `civitai app validate` → `OK — . is valid`.
- `go test ./...` → green (scaffold render tests unaffected; subset checks tolerate the new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)