### PR TITLE
fix(pkgzip): exclude .venv & build/tooling caches from the App Block source bundle

### DIFF
--- a/internal/pkgzip/pkgzip.go
+++ b/internal/pkgzip/pkgzip.go
@@ -25,11 +25,33 @@ const (
 )
 
 // excludedDirs are directory names skipped anywhere in the tree. The platform
-// rebuilds from source, so build output and dependencies must not be shipped.
+// rebuilds from source, so VCS metadata, dependency installs, build output, and
+// tooling caches must not be shipped — they bloat the bundle (a stray Python
+// .venv alone added ~860 files / ~11 MiB to a Vite/TS block) and slow the
+// review-repo push without ever being used by the server build recipe.
 var excludedDirs = map[string]struct{}{
-	".git":         {},
+	// VCS metadata
+	".git": {},
+	".hg":  {},
+	".svn": {},
+	// dependency installs
 	"node_modules": {},
-	"dist":         {},
+	".venv":        {},
+	"venv":         {},
+	".pnpm-store":  {},
+	// build output
+	"dist":  {},
+	"build": {},
+	"out":   {},
+	".next": {},
+	// tooling / test caches
+	".vite":         {},
+	".cache":        {},
+	"coverage":      {},
+	".pytest_cache": {},
+	".mypy_cache":   {},
+	".ruff_cache":   {},
+	".turbo":        {},
 }
 
 // Result describes a produced package.

--- a/internal/pkgzip/pkgzip_extra_test.go
+++ b/internal/pkgzip/pkgzip_extra_test.go
@@ -8,13 +8,23 @@ import (
 
 func TestExcludedNamesAndJoin(t *testing.T) {
 	names := ExcludedNames()
-	if len(names) != 3 {
-		t.Fatalf("ExcludedNames = %v, want 3 entries", names)
+	if len(names) < 3 {
+		t.Fatalf("ExcludedNames = %v, want at least the core entries", names)
 	}
 	// Sorted.
 	for i := 1; i < len(names); i++ {
 		if names[i-1] > names[i] {
 			t.Errorf("ExcludedNames not sorted: %v", names)
+		}
+	}
+	// Must include the original core dirs.
+	have := map[string]bool{}
+	for _, n := range names {
+		have[n] = true
+	}
+	for _, core := range []string{".git", "node_modules", "dist"} {
+		if !have[core] {
+			t.Errorf("ExcludedNames missing core entry %q: %v", core, names)
 		}
 	}
 	if JoinExcluded() == "" {

--- a/internal/pkgzip/pkgzip_test.go
+++ b/internal/pkgzip/pkgzip_test.go
@@ -99,13 +99,55 @@ func TestBuildDeterministicOrder(t *testing.T) {
 }
 
 func TestExcludedNames(t *testing.T) {
-	for _, n := range []string{".git", "node_modules", "dist"} {
+	for _, n := range []string{
+		".git", ".hg", ".svn",
+		"node_modules", ".venv", "venv", ".pnpm-store",
+		"dist", "build", "out", ".next",
+		".vite", ".cache", "coverage", ".pytest_cache", ".mypy_cache", ".ruff_cache", ".turbo",
+	} {
 		if !IsExcluded(n) {
 			t.Errorf("%q should be excluded", n)
 		}
 	}
-	if IsExcluded("src") {
-		t.Error("src should not be excluded")
+	for _, n := range []string{"src", "public", "assets", "lib"} {
+		if IsExcluded(n) {
+			t.Errorf("%q should NOT be excluded", n)
+		}
+	}
+}
+
+// TestBuildExcludesVenvAndCaches guards the regression that bloated the
+// gen-matrix bundle to 888 files: a stray Python .venv plus build/test caches
+// leaking into the SOURCE bundle. Only real source must survive.
+func TestBuildExcludesVenvAndCaches(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, dir, "package.json", "{}")
+	writeFile(t, dir, "src/main.tsx", "export default 1")
+	// Junk that must all be excluded:
+	writeFile(t, dir, ".venv/lib/python3.12/site-packages/foo/__init__.py", "x")
+	writeFile(t, dir, "venv/bin/activate", "x")
+	writeFile(t, dir, "build/index.js", "x")
+	writeFile(t, dir, "out/page.html", "x")
+	writeFile(t, dir, ".next/server/app.js", "x")
+	writeFile(t, dir, ".vite/deps/chunk.js", "x")
+	writeFile(t, dir, "coverage/lcov.info", "x")
+	writeFile(t, dir, ".pytest_cache/v/cache/lastfailed", "x")
+
+	res, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	got := namesInZip(t, res.Zip)
+	sort.Strings(got)
+	want := []string{"block.manifest.json", "package.json", "src/main.tsx"}
+	if len(got) != len(want) {
+		t.Fatalf("zip contents = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("zip[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`app submit` packages the **source tree** for the platform to rebuild, but the packager only skipped `.git` / `node_modules` / `dist`. Anything else in the project dir shipped — including a stray Python **`.venv`** in the gen-matrix block dir.

That one `.venv` added **859 files / ~11 MiB**, bloating the gen-matrix submit bundle to **888 files / 4.5 MiB**. The server never uses it (it rebuilds from `src` + configs), and the extra files slow the Forgejo review-repo push.

## Fix

Extend the default `excludedDirs` set to the obvious VCS / dependency-install / build-output / tooling-cache dirs that should never ship:

- VCS: `.git`, `.hg`, `.svn`
- deps: `node_modules`, `.venv`, `venv`, `.pnpm-store`
- build output: `dist`, `build`, `out`, `.next`
- caches: `.vite`, `.cache`, `coverage`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.turbo`

The `app submit --help` excludes list renders from `pkgzip.JoinExcluded()`, so it updates automatically.

## Result (gen-matrix)

| | files | compressed |
|---|---|---|
| before | 888 | 4.5 MiB |
| after | 29 | 126 KiB |

Only real source remains: `block.manifest.json`, `package.json`, `pnpm-lock.yaml`, configs, 14 `src/` files, docs.

## Tests

- New `TestBuildExcludesVenvAndCaches` asserts a tree with `.venv`/`venv`/`build`/`out`/`.next`/`.vite`/`coverage`/`.pytest_cache` packages down to just real source.
- `TestExcludedNames` extended to cover every new entry (and assert `src`/`public`/`assets`/`lib` are NOT excluded).
- The count-pinned `TestExcludedNamesAndJoin` assertion relaxed from `== 3` to a core-membership check so it won't break on future additions.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)