### PR TITLE
feat(page-money): mock/live harness toggle + scenario controls + loud banner

### DIFF
--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -33,11 +33,58 @@ npm run dev:harness   # http://localhost:5186 — mounts a MOCK host so you see 
 ```
 
 `npm run dev` alone shows a blank screen — there's no host to send `BLOCK_INIT`.
-Use `dev:harness`. Query toggles: `?viewer=anon`, `?consent=granted`,
-`?fail=insufficient`, `?theme=light`.
+Use `dev:harness`.
 
 `npm run dev:harness` mounts the published SDK mock host
-(`@civitai/blocks-react/testing`) — no hand-rolled simulator to maintain.
+(`@civitai/blocks-react/testing`) — no hand-rolled simulator to maintain. A loud
+**🧪 MOCK HOST · no real Buzz spent** banner is always on screen so you never
+mistake it for the real thing.
+
+### Mock vs live
+
+There are two harness modes, selected by `VITE_HARNESS_MODE` (the npm scripts
+set it for you):
+
+| Script | Mode | What it does |
+|---|---|---|
+| `npm run dev:harness` | **mock** (default) | The SDK mock host. Synthetic — **no real Buzz, no compute, no network.** Safe to spam. |
+| `npm run dev:live` | **live** | Talk to a REAL host with a REAL block token — **spends REAL Buzz / real compute.** |
+
+> ⚠️ **Live mode is a wired stub.** A true live proxy-host needs a server
+> dev-token endpoint to mint a scoped block token — that's **Layer 2, not built
+> yet.** Until it lands, `dev:live` **fails safe**: it reads `VITE_LIVE_BLOCK_TOKEN`
+> + `VITE_LIVE_PROXY_READY` and, finding the plumbing absent, renders a clear
+> notice instead of silently spending or breaking. The env + mode switch are
+> already wired, so live lights up the moment Layer 2 ships. Do **not** fake
+> "live" as mock.
+
+### Scenarios (exercise the money / error / storage UX for free)
+
+The mock host is configurable, so you can test the full spend / failure /
+insufficient-Buzz UX without spending anything. Drive it two ways:
+
+- **On-screen scenario panel** (top-left, collapsed): buttons + inputs to flip
+  *force insufficient Buzz*, *fail next generation*, *50% failure rate*, a
+  simulated *balance*, and *latency* live — no reload.
+- **URL query params** (read once on load):
+
+  | Param | Effect |
+  |---|---|
+  | `?viewer=anon` | anonymous viewer (sign-in CTA) |
+  | `?consent=granted` | start with the budgeted scope granted |
+  | `?theme=light` | light theme (default dark) |
+  | `?balance=0` | simulate a Buzz balance — a gen over it returns insufficient-Buzz |
+  | `?fail=insufficient` | force every submit down the insufficient path |
+  | `?latency=2000` | 2s synthetic gen latency (`?latency=500-2000` for a range) |
+  | `?costPerGen=12` | cost reported per generation |
+  | `?failNext=1` | fail the next N submits (generic gen error) |
+  | `?failRate=0.5` | probabilistic submit failures |
+
+  e.g. `http://localhost:5186/?balance=0&fail=insufficient` to land straight in
+  the insufficient-Buzz / top-up flow.
+
+These map to the `createMockHost` scenario options
+(`generation` / `buzz` / `storage`) from `@civitai/blocks-react`.
 
 ```bash
 npm test              # all tests (vitest run), two suites:

--- a/internal/scaffold/templates/page-money/env.development.tmpl
+++ b/internal/scaffold/templates/page-money/env.development.tmpl
@@ -2,3 +2,7 @@
 # from window.location.origin, which is the dev server origin pinned in
 # vite.config.ts (localhost:5186).
 VITE_BLOCK_ALLOWED_PARENT_ORIGINS=http://localhost:5186
+
+# Default harness mode for local dev: the MOCK host (no real Buzz). The
+# `dev:live` script overrides this to "live" (which fails safe until Layer 2).
+VITE_HARNESS_MODE=mock

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -13,6 +13,29 @@
 # serves on localhost:5186 and fires BLOCK_INIT from window.location.origin.
 #   VITE_BLOCK_ALLOWED_PARENT_ORIGINS=http://localhost:5186
 
-# Set to "true" to mount the dev Harness (mock host). `npm run dev:harness`
-# flips this on. NEVER set it in a production build.
+# Set to "true" to mount the dev Harness. `npm run dev:harness` / `dev:live`
+# flip this on. NEVER set it in a production build.
 VITE_DEV_HARNESS=
+
+# Which harness to mount: "mock" (default) or "live".
+#   mock  -> the SDK MOCK host: synthetic, no real Buzz, no compute, no network.
+#            `npm run dev:harness` sets this.
+#   live  -> talk to a REAL host with a REAL block token (spends REAL Buzz / real
+#            compute). `npm run dev:live` sets this. LIVE IS A WIRED STUB: a true
+#            live proxy-host needs a server dev-token endpoint (Layer 2), not
+#            built yet, so live FAILS SAFE (renders a notice) until that lands.
+VITE_HARNESS_MODE=
+
+# LIVE mode only. A real, scoped block token minted for local dev. Until the
+# Layer-2 dev-token endpoint exists you cannot get one — leave blank. ⚠️ A real
+# token here spends REAL Buzz; never commit one.
+VITE_LIVE_BLOCK_TOKEN=
+
+# LIVE mode only. The real host origin the block token targets. Defaults to
+# https://civitai.com.
+VITE_LIVE_HOST_ORIGIN=
+
+# LIVE mode only. Layer-2 enablement gate. Until the live proxy-host + dev-token
+# endpoint are built, leave this UNSET — live mode fail-safes regardless of the
+# token so it can never silently spend. Set to "true" only once Layer 2 lands.
+VITE_LIVE_PROXY_READY=

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -7,15 +7,16 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "dev:harness": "VITE_DEV_HARNESS=true vite --host localhost --port 5186",
+    "dev:harness": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=mock vite --host localhost --port 5186",
+    "dev:live": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=live vite --host localhost --port 5186",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.12.0",
-    "@civitai/blocks-react": "^0.8.0",
+    "@civitai/app-sdk": "^0.13.0",
+    "@civitai/blocks-react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
@@ -1,6 +1,10 @@
-import type { ReactNode } from 'react';
+import { useRef, useState, type CSSProperties, type ReactNode } from 'react';
 
-import { Harness as SdkHarness } from '@civitai/blocks-react/testing';
+import {
+  Harness as SdkHarness,
+  readMockHostUrlOptions,
+  type MockHostOptions,
+} from '@civitai/blocks-react/testing';
 
 /**
  * Local dev mock host for the {{ .Name }} PAGE app.
@@ -9,14 +13,24 @@ import { Harness as SdkHarness } from '@civitai/blocks-react/testing';
  * /apps/run/{{ .Slug }} and routes the money messages (ESTIMATE/SUBMIT/POLL) to
  * the generation orchestrator. Locally there's no host, so this plays one — but
  * we no longer hand-roll it: the published SDK ships the mock host
- * (`@civitai/blocks-react/testing`). This wrapper just mounts it.
+ * (`@civitai/blocks-react/testing`). This wrapper mounts it AND renders a loud
+ * "MOCK HOST" banner + a tiny scenario panel so it's always obvious that
+ * **no real Buzz is being spent**.
  *
- * `applyUrlToggles` (default true) reads the URL query knobs so the dev loop
- * stays interactive:
- *   ?viewer=anon       -> anonymous viewer (sign-in CTA)
- *   ?consent=granted   -> start WITH the budgeted scope already granted
- *   ?fail=insufficient -> SUBMIT returns an insufficient-Buzz failed snapshot
- *   ?theme=light       -> light theme (default dark)
+ * URL query knobs (read once on mount) drive the initial scenario — both the
+ * original toggles and the new Layer-1 scenario knobs:
+ *   ?viewer=anon        -> anonymous viewer (sign-in CTA)
+ *   ?consent=granted    -> start WITH the budgeted scope already granted
+ *   ?fail=insufficient  -> SUBMIT returns an insufficient-Buzz failed snapshot
+ *   ?theme=light        -> light theme (default dark)
+ *   ?balance=0          -> simulate a Buzz balance (a gen over it -> insufficient)
+ *   ?latency=2000       -> 2s synthetic gen latency (or ?latency=500-2000 range)
+ *   ?costPerGen=12      -> cost reported per generation
+ *   ?failNext=1         -> fail the next N submits (generic gen error)
+ *   ?failRate=0.5       -> probabilistic submit failures
+ *
+ * The on-screen scenario panel maps the same controls onto buttons so a dev can
+ * flip them live (it re-mounts the mock host with the new options).
  *
  * IMPORTANT: the SDK transport DROPS inbound messages whose origin isn't in its
  * allowlist, and the mock host fires from `window.location.origin`. The harness
@@ -24,5 +38,148 @@ import { Harness as SdkHarness } from '@civitai/blocks-react/testing';
  * see `installHarnessTransport`. No real Buzz is spent (there is no orchestrator).
  */
 export function Harness({ children }: { children: ReactNode }) {
-  return <SdkHarness>{children}</SdkHarness>;
+  // Read the URL toggles ONCE; the scenario panel then owns the live options
+  // (so a panel choice isn't wiped by a re-mount re-reading the URL).
+  const initial = useRef<MockHostOptions | null>(null);
+  if (initial.current === null) initial.current = readMockHostUrlOptions();
+
+  const [scenario, setScenario] = useState<MockHostOptions>(initial.current);
+  const [scenarioKey, setScenarioKey] = useState(0);
+  const apply = (patch: MockHostOptions) => {
+    setScenario((prev) => ({ ...prev, ...patch }));
+    setScenarioKey((k) => k + 1);
+  };
+
+  return (
+    <div style={rootStyle}>
+      <MockBanner />
+      <ScenarioPanel onApply={apply} />
+      {/* applyUrlToggles=false: the panel is authoritative once mounted. */}
+      <SdkHarness key={scenarioKey} applyUrlToggles={false} {...scenario}>
+        {children}
+      </SdkHarness>
+    </div>
+  );
 }
+
+/** Loud, always-visible banner so a dev never mistakes mock for live. */
+function MockBanner() {
+  return (
+    <div data-harness-banner="mock" style={bannerStyle}>
+      🧪 MOCK HOST · no real Buzz spent · no real compute
+    </div>
+  );
+}
+
+/**
+ * Dev-only scenario control panel. Maps buttons onto the new `createMockHost`
+ * options so a dev can flip insufficient-buzz / failures / latency WITHOUT
+ * editing code or reloading with URL params. Collapsed by default.
+ */
+function ScenarioPanel({ onApply }: { onApply: (patch: MockHostOptions) => void }) {
+  const [balance, setBalance] = useState('');
+  const [latency, setLatency] = useState('');
+
+  return (
+    <details data-harness-scenario-panel="true" style={panelStyle}>
+      <summary style={summaryStyle}>scenarios</summary>
+      <div style={panelBodyStyle}>
+        <button type="button" onClick={() => onApply({ failMode: 'none', buzz: undefined })}>
+          reset (all succeed)
+        </button>
+        <button type="button" onClick={() => onApply({ failMode: 'insufficient' })}>
+          force insufficient Buzz
+        </button>
+        <button type="button" onClick={() => onApply({ generation: { failNext: 1 } })}>
+          fail next generation
+        </button>
+        <button type="button" onClick={() => onApply({ generation: { failRate: 0.5 } })}>
+          50% failure rate
+        </button>
+        <label style={rowStyle}>
+          balance
+          <input
+            value={balance}
+            placeholder="e.g. 5"
+            onChange={(e) => setBalance(e.target.value)}
+            style={inputStyle}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const n = Number(balance);
+              if (Number.isFinite(n)) onApply({ buzz: { balance: n } });
+            }}
+          >
+            set
+          </button>
+        </label>
+        <label style={rowStyle}>
+          latency ms
+          <input
+            value={latency}
+            placeholder="e.g. 2000"
+            onChange={(e) => setLatency(e.target.value)}
+            style={inputStyle}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              const n = Number(latency);
+              if (Number.isFinite(n)) onApply({ generation: { latencyMs: n } });
+            }}
+          >
+            set
+          </button>
+        </label>
+      </div>
+    </details>
+  );
+}
+
+const MONO = 'ui-monospace, SFMono-Regular, monospace';
+
+const rootStyle: CSSProperties = { position: 'relative', minHeight: '100dvh' };
+
+const bannerStyle: CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  zIndex: 10000,
+  background: '#1971c2',
+  color: '#fff',
+  fontFamily: MONO,
+  fontSize: 12,
+  fontWeight: 700,
+  textAlign: 'center',
+  padding: '4px 8px',
+  letterSpacing: 0.3,
+};
+
+const panelStyle: CSSProperties = {
+  position: 'fixed',
+  top: 28,
+  left: 8,
+  zIndex: 10000,
+  background: 'rgba(17,17,17,0.92)',
+  color: '#7fc',
+  fontFamily: MONO,
+  fontSize: 11,
+  padding: '6px 10px',
+  borderRadius: 6,
+  maxWidth: 300,
+};
+
+const summaryStyle: CSSProperties = { cursor: 'pointer' };
+
+const panelBodyStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  marginTop: 6,
+};
+
+const rowStyle: CSSProperties = { display: 'flex', gap: 4, alignItems: 'center' };
+
+const inputStyle: CSSProperties = { width: 60 };

--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -13,6 +13,25 @@ import { getTransport } from '@civitai/blocks-react';
 import { resetTransport } from '@civitai/blocks-react/testing';
 
 /**
+ * Dev harness modes. Selected by `VITE_HARNESS_MODE` (the `dev:harness` and
+ * `dev:live` npm scripts set it):
+ *
+ *  - `'mock'`  (default) — the SDK mock host. Synthetic, no real Buzz, no
+ *    network. Safe to spam.
+ *  - `'live'`  — talk to a REAL host with a REAL block token (spends REAL Buzz
+ *    and real compute). **Layer 2 — not built yet.** A true live proxy-host
+ *    needs a server dev-token endpoint to mint a scoped block token; until that
+ *    lands, live mode FAILS SAFE (see {@link resolveLiveConfig}): it never
+ *    silently spends.
+ */
+export type HarnessMode = 'mock' | 'live';
+
+/** Read the configured harness mode (defaults to `'mock'`). */
+export function getHarnessMode(): HarnessMode {
+  return import.meta.env.VITE_HARNESS_MODE === 'live' ? 'live' : 'mock';
+}
+
+/**
  * Initialize the SDK transport with the current page origin allowlisted, so the
  * mock host's `window.location.origin` replies are accepted. Call this once,
  * before rendering, in the dev harness entry. Idempotent at the singleton level
@@ -31,4 +50,48 @@ export function installHarnessTransport() {
 export function resetHarnessTransport() {
   resetTransport();
   getTransport({ allowedParentOrigins: [window.location.origin] });
+}
+
+/**
+ * The result of trying to wire LIVE mode. `ready: false` means Layer-2 plumbing
+ * (a server dev-token endpoint) isn't available yet OR no token was provided —
+ * in either case the harness must show {@link reason} and NOT mount a real
+ * money path. `ready: true` carries the token + target origin to wire a real
+ * host with (the actual live proxy-host is Layer 2 / not built — see README).
+ */
+export type LiveConfig =
+  | { ready: false; reason: string }
+  | { ready: true; token: string; targetOrigin: string };
+
+/**
+ * Resolve live-mode config from env. FAIL-SAFE by design: a true live
+ * proxy-host needs a server dev-token endpoint (Layer 2) that doesn't exist
+ * yet, so this returns `{ ready: false }` with a clear reason unless BOTH a
+ * block token (`VITE_LIVE_BLOCK_TOKEN`) and the Layer-2 enablement flag
+ * (`VITE_LIVE_PROXY_READY=true`) are present. We read the env + the mode switch
+ * now so this lights up the moment Layer 2 lands — without faking "live" as
+ * mock.
+ */
+export function resolveLiveConfig(): LiveConfig {
+  const token = import.meta.env.VITE_LIVE_BLOCK_TOKEN as string | undefined;
+  const targetOrigin =
+    (import.meta.env.VITE_LIVE_HOST_ORIGIN as string | undefined) ?? 'https://civitai.com';
+  // Layer-2 plumbing (the dev-token endpoint + live proxy-host) is not built.
+  const layer2Ready = import.meta.env.VITE_LIVE_PROXY_READY === 'true';
+
+  if (!token) {
+    return {
+      ready: false,
+      reason:
+        'Live mode needs a dev block token (VITE_LIVE_BLOCK_TOKEN). See the dev-token endpoint — not yet available (Layer 2).',
+    };
+  }
+  if (!layer2Ready) {
+    return {
+      ready: false,
+      reason:
+        'Live mode plumbing (the server dev-token endpoint / live proxy-host) is Layer 2 and not built yet. A token is set, but there is no real host to spend against — refusing to mount to avoid silently breaking.',
+    };
+  }
+  return { ready: true, token, targetOrigin };
 }

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -1,34 +1,98 @@
-import { StrictMode } from 'react';
+import { StrictMode, type CSSProperties } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App.js';
 import { Harness } from './Harness.js';
-import { installHarnessTransport } from './dev-transport.js';
+import {
+  getHarnessMode,
+  installHarnessTransport,
+  resolveLiveConfig,
+} from './dev-transport.js';
 import './index.css';
 
-// `npm run dev:harness` sets VITE_DEV_HARNESS=true to mount the local mock host
-// (the published `@civitai/blocks-react/testing` Harness) that posts a fake
-// BLOCK_INIT (page context, entity=none), answers the consent + token-refresh
-// round-trip, and simulates the orchestrator money path (estimate / submit /
-// poll). Never set in prod.
+// Dev harness entry. Two mounts decide the surface:
+//
+//   VITE_DEV_HARNESS=true   -> mount a harness at all (never in prod).
+//   VITE_HARNESS_MODE=mock  -> (default) the SDK MOCK host. Synthetic, no real
+//                              Buzz, no compute, no network. `npm run dev:harness`.
+//   VITE_HARNESS_MODE=live  -> talk to a REAL host with a REAL block token —
+//                              spends REAL Buzz / real compute. `npm run dev:live`.
+//                              LIVE IS A WIRED STUB: a true live proxy-host needs
+//                              a server dev-token endpoint (Layer 2), not built
+//                              yet. Until then live FAILS SAFE — it renders a
+//                              clear message instead of silently spending.
+//
+// Prod builds set neither and render <App/> bare (the platform is the host).
 const useHarness = import.meta.env.VITE_DEV_HARNESS === 'true';
+const mode = getHarnessMode();
 
 // The mock host replies from window.location.origin; the SDK transport drops
 // mismatched-origin messages. Allowlist this origin BEFORE any hook runs so
 // BLOCK_INIT lands. (Prod uses VITE_BLOCK_ALLOWED_PARENT_ORIGINS instead.)
-if (useHarness) installHarnessTransport();
+if (useHarness && mode === 'mock') installHarnessTransport();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('#root missing from index.html');
 
+/** Render decision for the harness. */
+function Root() {
+  if (!useHarness) return <App />;
+
+  if (mode === 'live') {
+    const live = resolveLiveConfig();
+    if (!live.ready) return <LiveUnavailable reason={live.reason} />;
+    // Layer 2 (the real live proxy-host) is not built. When it lands, wire the
+    // real transport here using `live.token` + `live.targetOrigin`, then render
+    // <App/>. Until then resolveLiveConfig() returns ready:false above, so this
+    // branch is unreachable — we never silently spend.
+    return <LiveUnavailable reason="Live proxy-host wiring is Layer 2 — not implemented yet." />;
+  }
+
+  // mode === 'mock'
+  return (
+    <Harness>
+      <App />
+    </Harness>
+  );
+}
+
+/**
+ * Fail-safe LIVE screen. Shown when `dev:live` is requested but the Layer-2
+ * plumbing (server dev-token endpoint / live proxy-host) isn't available — so a
+ * dev sees WHY nothing is spending instead of a silent mock or a blank screen.
+ */
+function LiveUnavailable({ reason }: { reason: string }) {
+  return (
+    <div data-harness-banner="live-unavailable" style={liveWrapStyle}>
+      <div style={liveInnerStyle}>
+        <div style={liveTitleStyle}>⚠️ LIVE MODE — spends REAL Buzz / real compute</div>
+        <p style={liveReasonStyle}>{reason}</p>
+        <p style={liveHintStyle}>
+          Use <code>npm run dev:harness</code> (mock host) for free local
+          development. See README → “Mock vs live”.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const liveWrapStyle: CSSProperties = {
+  minHeight: '100dvh',
+  display: 'grid',
+  placeItems: 'center',
+  background: '#1a1207',
+  color: '#ffd8a8',
+  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+  padding: 24,
+  textAlign: 'center',
+};
+const liveInnerStyle: CSSProperties = { maxWidth: 560 };
+const liveTitleStyle: CSSProperties = { fontSize: 20, fontWeight: 800, color: '#ffa94d' };
+const liveReasonStyle: CSSProperties = { marginTop: 12, lineHeight: 1.5 };
+const liveHintStyle: CSSProperties = { marginTop: 12, opacity: 0.8 };
+
 createRoot(container).render(
   <StrictMode>
-    {useHarness ? (
-      <Harness>
-        <App />
-      </Harness>
-    ) : (
-      <App />
-    )}
+    <Root />
   </StrictMode>,
 );


### PR DESCRIPTION
## What

**Layer 1** of the App Blocks local-dev DX, template half. Makes the page-money template's mock host the **obvious, safe-by-default** mode, exposes the new `createMockHost` scenario controls in the harness, and wires (but does **not** fake) an opt-in **live** mode. Companion to the SDK PR that adds the scenarios: **civitai/civitai-app-starters#54**.

## Changes

- **Mock is the default + LOUD.** `dev:harness` stays mock; a fixed `🧪 MOCK HOST · no real Buzz spent · no real compute` banner is always on screen.
- **Opt-in `live` mode** (`npm run dev:live` / `VITE_HARNESS_MODE=live`), loudly warned (`⚠️ LIVE — spends REAL Buzz / real compute`). Live reads a real block token (`VITE_LIVE_BLOCK_TOKEN`) + target origin (`VITE_LIVE_HOST_ORIGIN`).
  - **Live is a wired STUB.** A true live proxy-host needs a server **dev-token endpoint** — that's **Layer 2, not built yet.** So live **fails safe**: `resolveLiveConfig()` returns `ready:false` (with a clear reason) unless BOTH a token AND `VITE_LIVE_PROXY_READY=true` are set, and `main.tsx` renders a clear "not yet available" notice instead of silently spending or breaking. The env reads + mode switch are wired so it lights up the moment Layer 2 lands. It does **not** fake "live" as mock.
- **Scenario controls, two ways:**
  - an on-screen **dev-only scenario panel** (top-left): *force insufficient Buzz*, *fail next generation*, *50% failure rate*, simulated *balance*, *latency* — flip live, no reload;
  - **URL params**: `?balance` / `?fail` / `?latency` (`2000` or `500-2000`) / `?costPerGen` / `?failNext` / `?failRate` — mapping to the new `generation` / `buzz` SDK options.
- **Dep bumps:** `@civitai/blocks-react` `^0.8.0` → `^0.10.0`, `@civitai/app-sdk` `^0.12.0` → `^0.13.0`.
- **README:** "Mock vs live" section + scenario tables + the publish-sequencing note.

## ⚠️ Sequencing — merge AFTER the SDK publishes

`ci.yml`'s rot-guard scaffolds the template and runs `npm install` against the **published** `@civitai/blocks-react`. This PR pins `^0.10.0`, which doesn't exist on npm until **civitai-app-starters#54** is merged + its Version Packages PR publishes `0.10.0`. So **Part B's CI is green only after Part A publishes** — merge this PR **after** that publish (the pinned `^0.10.0` is exact-targeted to the minor bump from #54).

## Verification

The new SDK version isn't on npm yet, so I verified locally by `npm pack`-ing the Part A build and installing the tarballs into a freshly-scaffolded project:

- `civitai app init … --template page-money` — scaffolds clean (Go templating valid; all inline styles moved to named `CSSProperties` consts to avoid the `{{ }}` collision).
- `tsc -p tsconfig.json --noEmit` — green.
- `vitest run` — **14 passed** (incl. the e2e estimate→consent→submit→poll money-path proof) against the new SDK.
- `vite build` — green.
- `go test ./...` — all packages pass (scaffold + cmd).

**Real vs stub:** mock mode + scenarios are fully real and exercised. `live` mode is a **wired stub** that fail-safes pending Layer 2 (the server dev-token endpoint / live proxy-host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)