### PR TITLE
fix(cli): make login tests hermetic (kill the 10-min network-flake)

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // run executes the root command with args, capturing stdout+stderr.
@@ -363,18 +365,62 @@ func TestLoginStoresToken(t *testing.T) {
 	}
 }
 
-func TestLoginEmptyTokenViaStdinFails(t *testing.T) {
+// TestLoginDeviceStartFailureReturnsError drives the DEFAULT `civitai login`
+// (no --token => OAuth device flow) against an httptest server whose device-init
+// endpoint fails, and asserts login returns an error FAST.
+//
+// This replaces the old TestLoginEmptyTokenViaStdinFails, which assumed the
+// default path read a token from stdin ("no token provided"). It no longer
+// does: with no --token, login runs the device flow and makes a real network
+// call to base_url. With no CIVITAI_BASE_URL override that call hit the REAL
+// https://civitai.com — when egress was open, device-init succeeded and the
+// poll looped until the device-code expired (~10 min), tripping Go's 10-min
+// test timeout (network-dependent flake). Here we point the CLI at a local
+// server (t.Setenv CIVITAI_BASE_URL = srv.URL) that returns 4xx on device-init,
+// so StartDevice errors immediately, no polling, no real network, sub-second.
+func TestLoginDeviceStartFailureReturnsError(t *testing.T) {
+	var gotDeviceInit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Device-init is the first (and here, only) request the device flow makes.
+		if r.URL.Path == "/api/auth/oauth/device" {
+			gotDeviceInit = true
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_client"})
+			return
+		}
+		// Reaching the poll endpoint would mean StartDevice wrongly succeeded.
+		t.Errorf("unexpected path %q — login should fail at device-init, never poll", r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("CIVITAI_TOKEN", "")
-	root := NewRootCmd()
-	var out, errb bytes.Buffer
-	root.SetOut(&out)
-	root.SetErr(&errb)
-	root.SetIn(strings.NewReader("\n")) // empty line at the prompt
-	root.SetArgs([]string{"login"})
-	if err := root.Execute(); err == nil {
-		t.Fatal("expected error for empty token")
+	// Hermetic: pin the CLI at the local server so it NEVER touches civitai.com.
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	start := time.Now()
+	// --no-browser so a failure can't spawn anything; the device flow still runs.
+	_, _, err := run(t, "login", "--no-browser")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when device-init fails")
+	}
+	if !strings.Contains(err.Error(), "device init failed") {
+		t.Errorf("error should report the device-init failure, got: %v", err)
+	}
+	if !gotDeviceInit {
+		t.Error("login should have hit the local device-init endpoint")
+	}
+	// Deterministic + fast: a clean device-init failure must not poll/wait.
+	if elapsed > 5*time.Second {
+		t.Errorf("login took %v — should fail fast without polling", elapsed)
+	}
+	// Nothing persisted on a failed login.
+	if _, statErr := os.Stat(filepath.Join(dir, "civitai", "config.yaml")); statErr == nil {
+		t.Error("no config should be written on a failed login")
 	}
 }
 


### PR DESCRIPTION
## Root cause

`TestLoginEmptyTokenViaStdinFails` (in `internal/cmd/cmd_test.go`) was flaky and could time out at Go's 10-min test ceiling in CI.

`civitai login` now **defaults to the OAuth device flow**: with no `--token`, `RunE` calls `loginWithDevice` → `oc.StartDevice(ctx)`, a **real network call to `base_url`**. The old test set stdin to `"\n"` expecting the *old* personal-key token-prompt error (`"no token provided"`), but the default path no longer reads stdin. The test only set `XDG_CONFIG_HOME` (not `CIVITAI_BASE_URL`), so `base_url` defaulted to the **real `https://civitai.com`** — the test made an actual production device-login attempt.

- **Egress open** → `StartDevice` succeeds → `PollToken` loops until the device-code expiry (~10 min) waiting for an approval that never comes → **Go's 10-min timeout fires**.
- **Egress blocked** → `StartDevice` fails in ~30s → test passes.

Hence flaky (network-dependent), and a real production device-login attempt from CI.

## The fix

Replaced the obsolete test with `TestLoginDeviceStartFailureReturnsError` (hermetic, deterministic):

- Stands up an `httptest.NewServer` whose device-init endpoint (`/api/auth/oauth/device`) returns `403 {"error":"invalid_client"}`.
- Pins the CLI at it via `t.Setenv("CIVITAI_BASE_URL", srv.URL)` so it **never touches civitai.com**.
- Runs `login --no-browser` and asserts: an error is returned, it reports the device-init failure, the **poll endpoint is never reached** (proves it fails at init, no `~10-min` poll), nothing is persisted, and it completes **sub-second** (asserts `< 5s`).

The old test's intent ("empty token via stdin fails") is **obsolete**: `loginWithToken`'s empty-prompt branch is only reachable when `--token` is passed, and `RunE` only calls `loginWithToken` when the trimmed `--token` is non-empty — so that branch is unreachable from the CLI. No point asserting a path that can't be triggered; the new test asserts the real, reachable default behavior (device login fails cleanly).

## Other network-touching tests

Audited all of `internal/cmd/*_test.go` and `internal/api/*_test.go`. Every other HTTP-exercising test already stands up an `httptest` server and overrides `CIVITAI_BASE_URL` (whoami, app submit upload paths, all oauth/api tests). The no-token `app submit` path falls back to writing a local zip — no network. **This was the only test that could reach the real network.** `go test ./...` no longer depends on outbound network.

## Proof — fast & deterministic, no real network

- `go build ./...` green; `go vet ./internal/cmd/...` green.
- `go test ./internal/cmd/... ./internal/api/...` passes in **~2s** (was a 10-min timeout when the flake tripped). The new test itself runs in **0.00s**. The residual ~2s is `TestLoginDeviceFlowHappyPath`'s two 1s device-flow `interval` sleeps **against its local httptest server** — not the network.
- Hermeticity proven by re-running both packages inside an `unshare -rn` network namespace with an **empty route table** (external TCP to a public IP returns `connect: network is unreachable`). Tests still pass in ~2s, proving no real egress is required.

## Product code

**None changed** — test-only. (The HTTP client already has a 30s timeout and `PollToken` is deadline-bounded by `ExpiresIn`; the perceived "hang" was the device-code lifetime, which the user Ctrl-Cs. Not over-engineered here — test hermeticity is the actual fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)