### PR TITLE
release: binaries-only v0.1.0 (disable Homebrew until tap is public)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,30 +61,32 @@ changelog:
       - "^chore:"
 
 # Homebrew tap (cask). goreleaser v2 replaced `brews:` with `homebrew_casks:`.
-# NOTE: the `civitai/homebrew-tap` repo must exist and the release workflow must
-# expose a HOMEBREW_TAP_GITHUB_TOKEN with write access to it. If you don't want
-# a tap yet, comment out this whole block (and the brew install line in README).
-homebrew_casks:
-  - name: civitai
-    binaries:
-      - civitai
-    repository:
-      owner: civitai
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: "https://github.com/civitai/cli"
-    description: "Civitai CLI — author and ship App Blocks"
-    commit_author:
-      name: civitai-bot
-      email: bot@civitai.com
-    # Strip the macOS quarantine attribute so `civitai` runs without a Gatekeeper
-    # prompt (the binaries are not notarized).
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/civitai"]
-          end
+# DISABLED for the binaries-only v0.1.0 release: the `civitai/homebrew-tap` repo
+# is still private and no HOMEBREW_TAP_GITHUB_TOKEN secret is set, so a release
+# with this block enabled would fail at the formula-push step. To re-enable:
+#   1. make `civitai/homebrew-tap` public (after its own secret audit),
+#   2. set the HOMEBREW_TAP_GITHUB_TOKEN repo secret (PAT w/ write to the tap),
+#   3. uncomment this block + restore the `brew install` line in README.md,
+#   4. cut the next tag.
+# homebrew_casks:
+#   - name: civitai
+#     binaries:
+#       - civitai
+#     repository:
+#       owner: civitai
+#       name: homebrew-tap
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     homepage: "https://github.com/civitai/cli"
+#     description: "Civitai CLI — author and ship App Blocks"
+#     commit_author:
+#       name: civitai-bot
+#       email: bot@civitai.com
+#     hooks:
+#       post:
+#         install: |
+#           if OS.mac?
+#             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/civitai"]
+#           end
 
 release:
   draft: true

--- a/README.md
+++ b/README.md
@@ -14,15 +14,6 @@ contract, and **packages/submits** it for review.
 
 ## Install
 
-### Homebrew
-
-```bash
-brew install civitai/tap/civitai
-```
-
-> The tap (`civitai/homebrew-tap`) is published from this repo's release flow.
-> Until the first tagged release lands, use one of the methods below.
-
 ### Go install (Go 1.25+)
 
 ```bash
@@ -42,6 +33,15 @@ tar xzf civitai_*_linux_amd64.tar.gz
 sudo mv civitai /usr/local/bin/
 civitai version
 ```
+
+### Homebrew
+
+> ⚠️ Not available yet — the Homebrew tap is still being set up. Use **Go install**
+> or a **prebuilt binary** (above) for now. Once the tap is live:
+>
+> ```bash
+> brew install civitai/tap/civitai
+> ```
 
 ## Quickstart
 


### PR DESCRIPTION
Prep for the **first public release** of the Go `civitai` CLI now that the repo is public.

## Why
`civitai/homebrew-tap` is still private and no `HOMEBREW_TAP_GITHUB_TOKEN` secret is set, so a release with the `homebrew_casks` block enabled would **fail at the formula-push step**. This ships a **binaries-only v0.1.0** (linux/macOS/windows × amd64/arm64 + checksums); Homebrew follows once the tap is public + the secret is set (re-enable steps documented inline in `.goreleaser.yaml`).

## Changes
- `.goreleaser.yaml`: comment out `homebrew_casks:` (binaries-only); everything else (builds/archives/checksums/draft release) unchanged.
- `README.md`: lead the install section with `go install` + prebuilt binary; mark Homebrew "not available yet."

## Verified
- `goreleaser check` ✅
- `goreleaser release --snapshot --clean` ✅ — all 5 targets build + archive + checksum, Homebrew step cleanly skipped.

After merge: tag `v0.1.0` → `release.yml` runs goreleaser → draft GitHub Release with the binaries → publish manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)