### PR TITLE
fix(pkgzip): exclude .env* (token leak) and *.zip (recursive re-bundle)

### DIFF
--- a/internal/pkgzip/pkgzip.go
+++ b/internal/pkgzip/pkgzip.go
@@ -1,6 +1,21 @@
 // Package pkgzip packages an App Block project directory into the canonical
 // ZIP the platform build recipe expects: the SOURCE tree (manifest + src +
 // build config), with build artifacts and VCS/dependency dirs excluded.
+//
+// Two kinds of exclusion are applied:
+//
+//   - Directory names (excludedDirs): VCS metadata, dependency installs, build
+//     output, tooling caches — see that var.
+//   - File names (isExcludedFile): build artifacts (*.zip) and dev-local /
+//     secret-bearing dotenv files (.env, .env.local, .env.development,
+//     .env.*.local). The scaffolded page-money template documents pasting a
+//     real, Buzz-spending block token into .env.development
+//     (VITE_LIVE_BLOCK_TOKEN) for `dev:live`; bundling that file would leak the
+//     token to the server, the moderator reviewer, and the built image. We KEEP
+//     .env.example / .env.sample (templates, no secrets — useful to the
+//     reviewer) and .env.production (the server build's `vite build` runs in
+//     mode=production and reads it; it carries only public VITE_ origins, never
+//     a secret). See isExcludedFile for the full rule + rationale.
 package pkgzip
 
 import (
@@ -54,6 +69,60 @@ var excludedDirs = map[string]struct{}{
 	".turbo":        {},
 }
 
+// excludedFilePatterns is the human-readable list of file-level exclusions, for
+// CLI messaging. The authoritative matcher is isExcludedFile — keep the two in
+// sync. These are matched on the file's BASE NAME anywhere in the tree.
+var excludedFilePatterns = []string{
+	// Build artifacts. A `--package-only` run drops a *.zip in the project dir;
+	// without this, the next package recursively sweeps that zip back in (a real
+	// dogfood regression: 22 files/93 KB vs the correct 21 files/47 KB).
+	"*.zip",
+	// Dev-local / secret-bearing dotenv files. The page-money template tells devs
+	// to paste a real VITE_LIVE_BLOCK_TOKEN into .env.development for `dev:live`;
+	// these must never reach the server / reviewer / built image.
+	".env",
+	".env.local",
+	".env.*.local", // e.g. .env.development.local, .env.production.local
+	".env.development",
+	".env.test",
+}
+
+// keptEnvFiles are .env* files we deliberately INCLUDE despite the broad dotenv
+// exclusion below. They carry no secret and are useful server- or reviewer-side:
+//   - .env.example / .env.sample: templates (documented placeholders, no token).
+//   - .env.production: the server build runs `vite build` (mode=production),
+//     which reads .env.production; it holds only the PUBLIC
+//     VITE_BLOCK_ALLOWED_PARENT_ORIGINS (Vite inlines every VITE_ var into the
+//     client bundle by design, so by construction it cannot hold a secret).
+//   - .env.production.local is NOT kept — `.local` is the dev-local override
+//     convention and is caught by the `.env.*.local` rule above.
+var keptEnvFiles = map[string]struct{}{
+	".env.example":    {},
+	".env.sample":     {},
+	".env.production": {},
+}
+
+// isExcludedFile reports whether a regular file (by base name) must be left out
+// of the package. The rule is deliberately CONSERVATIVE toward "never upload a
+// secret": every .env* is dropped UNLESS it is explicitly an allow-listed,
+// secret-free file (keptEnvFiles). Build-time config for the server must come
+// from the manifest / build recipe, not an uploaded dotenv.
+func isExcludedFile(name string) bool {
+	// Build artifacts.
+	if strings.HasSuffix(name, ".zip") {
+		return true
+	}
+	// Dotenv handling: allow-list the known-safe template / production files,
+	// drop everything else that starts with ".env".
+	if name == ".env" || strings.HasPrefix(name, ".env.") {
+		if _, keep := keptEnvFiles[name]; keep {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
 // Result describes a produced package.
 type Result struct {
 	Files []string // archive-relative paths included, sorted
@@ -98,6 +167,10 @@ func Build(dir string) (*Result, error) {
 		}
 		// Skip non-regular files (symlinks, sockets, devices).
 		if !d.Type().IsRegular() {
+			return nil
+		}
+		// Skip excluded files (build artifacts, secret-bearing dotenv files).
+		if isExcludedFile(d.Name()) {
 			return nil
 		}
 		rel, err := filepath.Rel(dir, p)
@@ -192,6 +265,18 @@ func ExcludedNames() []string {
 	return out
 }
 
+// IsExcludedFile reports whether a file would be excluded by base name
+// (exported for tests + messaging). See isExcludedFile for the rule.
+func IsExcludedFile(name string) bool { return isExcludedFile(name) }
+
+// ExcludedFilePatterns returns the human-readable file-exclusion patterns, in
+// declaration order (build artifacts first, then dotenv).
+func ExcludedFilePatterns() []string {
+	out := make([]string, len(excludedFilePatterns))
+	copy(out, excludedFilePatterns)
+	return out
+}
+
 // zipBuffer is a tiny io.Writer collecting bytes (avoids bytes.Buffer's extra
 // API surface; keeps the produced []byte addressable).
 type zipBuffer struct{ b []byte }
@@ -201,5 +286,8 @@ func (z *zipBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// JoinExcluded is a small helper for messages.
-func JoinExcluded() string { return strings.Join(ExcludedNames(), ", ") }
+// JoinExcluded is a small helper for messages: the excluded directory names
+// followed by the file-level patterns (dotenv secrets + *.zip artifacts).
+func JoinExcluded() string {
+	return strings.Join(append(ExcludedNames(), ExcludedFilePatterns()...), ", ")
+}

--- a/internal/pkgzip/pkgzip_files_test.go
+++ b/internal/pkgzip/pkgzip_files_test.go
@@ -1,0 +1,182 @@
+package pkgzip
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fakeToken is a sentinel a secret-bearing dotenv would carry. We assert it
+// never appears in the produced file list (and the file that holds it is gone).
+const fakeToken = "VITE_LIVE_BLOCK_TOKEN=secret-do-not-leak"
+
+// TestBuildExcludesEnvAndZip is the headline security + data-integrity guard:
+// a project tree with secret-bearing dotenv files and a stray output zip must
+// produce a package that includes the source + .env.example and excludes the
+// dev-local/secret dotenv files and the .zip.
+func TestBuildExcludesEnvAndZip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, dir, "package.json", "{}")
+	writeFile(t, dir, "src/App.tsx", "export default 1")
+
+	// SECRET-bearing / dev-local — must be excluded.
+	writeFile(t, dir, ".env.development", fakeToken+"\n")
+	writeFile(t, dir, ".env.local", "VITE_HARNESS_MODE=live\n")
+	writeFile(t, dir, ".env", "VITE_LIVE_BLOCK_TOKEN=root-secret\n")
+	writeFile(t, dir, ".env.development.local", "VITE_LIVE_BLOCK_TOKEN=local-override\n")
+
+	// Template — must be KEPT (no secret, useful to the reviewer).
+	writeFile(t, dir, ".env.example", "VITE_LIVE_BLOCK_TOKEN=\n")
+
+	// Stray build artifact from a prior --package-only run — must be excluded.
+	writeFile(t, dir, "prev-package.zip", "PK\x03\x04junk")
+
+	res, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	got := namesInZip(t, res.Zip)
+	sort.Strings(got)
+	want := []string{".env.example", "block.manifest.json", "package.json", "src/App.tsx"}
+	if len(got) != len(want) {
+		t.Fatalf("zip contents = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("zip[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Explicit per-file assertions.
+	excluded := []string{".env", ".env.local", ".env.development", ".env.development.local", "prev-package.zip"}
+	for _, bad := range got {
+		for _, e := range excluded {
+			if bad == e {
+				t.Errorf("%q should have been excluded", bad)
+			}
+		}
+	}
+	included := map[string]bool{}
+	for _, g := range got {
+		included[g] = true
+	}
+	if !included[".env.example"] {
+		t.Error(".env.example (template, no secret) should be INCLUDED")
+	}
+	if !included["src/App.tsx"] {
+		t.Error("source file should be INCLUDED")
+	}
+}
+
+// TestResultFilesHaveNoSecretEnv asserts no secret-bearing .env* path appears in
+// the exported Result.Files list (what the CLI prints / uploads).
+func TestResultFilesHaveNoSecretEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, dir, ".env.development", fakeToken+"\n")
+	writeFile(t, dir, ".env.local", "x")
+	writeFile(t, dir, ".env", "x")
+	writeFile(t, dir, "src/main.tsx", "export default 1")
+
+	res, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, f := range res.Files {
+		switch f {
+		case ".env", ".env.local", ".env.development":
+			t.Errorf("secret-bearing dotenv %q leaked into Result.Files: %v", f, res.Files)
+		}
+		if strings.Contains(f, fakeToken) {
+			t.Errorf("token sentinel leaked into a file path: %q", f)
+		}
+	}
+}
+
+// TestBuildRecursiveZipReproduce reproduces the dogfound recursive re-bundle:
+// build once, leave the output zip in the dir, build again — the second package
+// must NOT contain the first zip, and the file count must be stable.
+func TestBuildRecursiveZipReproduce(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, dir, "package.json", "{}")
+	writeFile(t, dir, "src/main.tsx", "export default 1")
+
+	first, err := Build(dir)
+	if err != nil {
+		t.Fatalf("first Build: %v", err)
+	}
+	firstCount := len(first.Files)
+
+	// Simulate `--package-only`: drop the produced zip into the project dir.
+	writeFile(t, dir, "my-block.zip", string(first.Zip))
+
+	second, err := Build(dir)
+	if err != nil {
+		t.Fatalf("second Build: %v", err)
+	}
+
+	for _, f := range second.Files {
+		if strings.HasSuffix(f, ".zip") {
+			t.Errorf("second package recursively re-bundled a zip: %q (all: %v)", f, second.Files)
+		}
+	}
+	if len(second.Files) != firstCount {
+		t.Errorf("file count not stable across re-package: first=%d second=%d (%v)", firstCount, len(second.Files), second.Files)
+	}
+}
+
+// TestIsExcludedFileRule pins the exact dotenv keep/drop decision so the
+// build-safety judgment is regression-tested.
+func TestIsExcludedFileRule(t *testing.T) {
+	drop := []string{
+		"prev-package.zip", "a/b.zip",
+		".env", ".env.local", ".env.development", ".env.test",
+		".env.development.local", ".env.production.local", ".env.staging",
+	}
+	for _, n := range drop {
+		// IsExcludedFile matches on base name; strip dir for the path-y cases.
+		base := n
+		if i := strings.LastIndex(n, "/"); i >= 0 {
+			base = n[i+1:]
+		}
+		if !IsExcludedFile(base) {
+			t.Errorf("%q should be excluded", base)
+		}
+	}
+	keep := []string{
+		".env.example", ".env.sample", ".env.production",
+		"src/App.tsx", "package.json", "block.manifest.json", "vite.config.ts",
+		"zipper.ts", // contains "zip" but is not a .zip
+	}
+	for _, n := range keep {
+		base := n
+		if i := strings.LastIndex(n, "/"); i >= 0 {
+			base = n[i+1:]
+		}
+		if IsExcludedFile(base) {
+			t.Errorf("%q should NOT be excluded", base)
+		}
+	}
+}
+
+// TestExcludedFilePatternsInJoin makes sure the CLI's printed exclusion list
+// surfaces the new file patterns (so users know .env*/*.zip are dropped).
+func TestExcludedFilePatternsInJoin(t *testing.T) {
+	pats := ExcludedFilePatterns()
+	if len(pats) == 0 {
+		t.Fatal("ExcludedFilePatterns is empty")
+	}
+	joined := JoinExcluded()
+	for _, p := range []string{"*.zip", ".env"} {
+		if !strings.Contains(joined, p) {
+			t.Errorf("JoinExcluded() = %q, missing file pattern %q", joined, p)
+		}
+	}
+	// Dir names must still be present too.
+	if !strings.Contains(joined, "node_modules") {
+		t.Errorf("JoinExcluded() lost the dir names: %q", joined)
+	}
+}

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -121,4 +121,9 @@ civitai app submit
 ```
 
 `submit` packages the SOURCE tree (manifest + src + build config), excluding
-`.git`, `node_modules`, and `dist` — the platform rebuilds from source.
+`.git`, `node_modules`, and `dist` — the platform rebuilds from source. It also
+excludes build artifacts (`*.zip`) and dev-local / secret-bearing dotenv files
+(`.env`, `.env.local`, `.env.development`, `.env.*.local`) so a pasted
+`VITE_LIVE_BLOCK_TOKEN` can never leak into the upload. `.env.example` and
+`.env.production` (public `VITE_` origins only) ARE included — the production
+build reads `.env.production`.


### PR DESCRIPTION
## The two bugs (dogfood-verified)

`civitai app submit` packages the project dir via `internal/pkgzip`. The packager only excluded **directory names** (`.git`, `node_modules`, `dist`, …) — never **files**, so:

1. 🔴 **SECURITY — `.env*` files were bundled.** The page-money template tells devs to paste a real, Buzz-spending block token into `.env.development` (`VITE_LIVE_BLOCK_TOKEN`) for `dev:live`. `submit` then uploaded that file inside the package → the live token (and any other local secret in `.env`/`.env.local`) leaked to the server, the moderator reviewer, and the built/deployed image.
2. 🟠 **DATA-INTEGRITY — stray `*.zip` artifacts got recursively re-bundled.** A `--package-only` output zip left in the dir was swept into the next package.

## The exclusion rule chosen (+ why)

Added file-level exclusion (`isExcludedFile`) alongside the existing dir exclusion:

- **`*.zip`** — always excluded (build artifact; stops the recursive re-bundle).
- **dotenv** — every `.env*` is excluded **EXCEPT** an explicit secret-free allow-list:
  - **KEEP `.env.example` / `.env.sample`** — documented templates, no real token, useful to the reviewer.
  - **KEEP `.env.production`** — the server build runs `npm run build` → `vite build` (**mode=production**), which reads `.env.production`. It carries only `VITE_BLOCK_ALLOWED_PARENT_ORIGINS` (the public civitai.com origins). Vite inlines **every** `VITE_`-prefixed var into the client bundle by design, so by construction a `VITE_`-only `.env.production` cannot hold a secret.
  - **DROP everything else:** `.env`, `.env.local`, `.env.development`, `.env.test`, and `.env.*.local` (incl. `.env.production.local` — `.local` is the dev-local override convention).

Rule is deliberately **conservative toward "never upload a secret"**: dotenv is deny-by-default with a tiny known-safe allow-list, not allow-by-default. Build-time config the server needs must come from the manifest / build recipe, not an uploaded dotenv.

Evidence base: `internal/scaffold/templates/page-money/{env.*.tmpl, package.json.tmpl, vite.config.ts.tmpl, block.manifest.json.tmpl, README.md.tmpl}` — the build recipe is `npm ci && npm run build` (manifest `buildCommand`), `vite build` defaults to mode=production, and the env templates document the live token going into `.env.development`.

## Implementation

- `isExcludedFile(name)` matcher + exported `IsExcludedFile` / `ExcludedFilePatterns`, mirroring the existing `IsExcluded` / `ExcludedNames` dir API.
- `JoinExcluded()` now appends the file patterns, so `civitai app submit --help` lists them.
- Package doc comment + the scaffolded page-money `README.md` updated to enumerate the new exclusions.

## Tests added (`internal/pkgzip/pkgzip_files_test.go`)

- `TestBuildExcludesEnvAndZip` — tree with `.env.development` (fake `VITE_LIVE_BLOCK_TOKEN`), `.env.local`, `.env`, `.env.development.local`, `.env.example`, a source file, and `prev-package.zip` → includes source + `.env.example`, excludes the secret dotenvs + the zip.
- `TestBuildRecursiveZipReproduce` — build once, drop the output zip in the dir, build again → second package contains no `.zip` and the file count is stable.
- `TestResultFilesHaveNoSecretEnv` — no secret `.env*` path appears in `Result.Files`.
- `TestIsExcludedFileRule` / `TestExcludedFilePatternsInJoin` — pin the keep/drop decision and the CLI messaging.

## Verification

`make ci` (= `go mod tidy && go vet ./... && go test ./... && build`) — **green**, all existing pkgzip / scaffold / examples tests still pass.

Before/after on a sample tree (stray zip + secret `.env.development`):
- **before (`origin/main`):** 23 files / 43647 B — `prev-package.zip` re-bundled **and** `.env.development` leaked.
- **after:** 21 files / 3296 B — no zip, no secret env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)