### PR TITLE
docs: warn App Blocks is a gated preview + set the post-submit review/deploy expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ contract, and **packages/submits** it for review.
 > Learn more about App Blocks in the [Civitai App Blocks docs](https://civitai.com/articles)
 > (search "App Blocks").
 
+> ⚠️ **App Blocks is in a limited, moderator-gated preview (pre-GA).** You can
+> install this CLI, `login`, scaffold, validate, and run a block locally right
+> now — but **`civitai app submit` requires App Blocks access**. While the
+> feature is dark, submission is restricted to enrolled/approved accounts: an
+> un-enrolled account can't submit (or its block won't be reviewed/approved, so
+> it won't go live) until App Blocks opens up. There is no public self-serve
+> "request access" form yet — watch [civitai.com](https://civitai.com) and the
+> [issues on this repo](https://github.com/civitai/cli/issues) for the
+> general-availability announcement.
+
 ## Install
 
 ### Go install (Go 1.25+)
@@ -59,6 +69,15 @@ civitai app validate
 # 4. Package + submit for review (uploads with your stored token by default).
 civitai app submit
 ```
+
+> **Submit ≠ live.** `civitai app submit` enters your block into **moderator
+> review** — it is **not** published immediately. The lifecycle is
+> **submit → review → approve → build + deploy → `https://<blockId>.civit.ai/`**:
+> that URL **404s until a moderator approves your submission and the platform
+> builds + deploys it** (a few minutes after approval). Until then, track status
+> on **`/apps/my-submissions`** (a fresh submission sits at `pending`). See
+> [Submit & auth](#submit--auth) for the full flow. (And note App Blocks is a
+> gated preview — see the warning above.)
 
 Enable shell completion (optional):
 
@@ -148,6 +167,26 @@ stored credential (treated as a personal key).
 
 `--package-only` always just writes the `.zip` and stops.
 
+### After you submit: review → approve → deploy
+
+A successful `submit` does **not** publish your block — it queues it for
+moderator review. The lifecycle is:
+
+1. **submit** → your submission lands at `/apps/my-submissions` with status
+   `pending`.
+2. **review** → a moderator reviews the manifest + files. They either **approve**
+   or **reject** (with a reason you can read inline, then fix and resubmit).
+3. **deploy** → on **approval**, the platform builds and deploys your block
+   (injects its build recipe → builds the image → deploys → programs the
+   `<blockId>.civit.ai` DNS record). A few minutes after approval it serves live
+   at **`https://<blockId>.civit.ai/`**.
+
+Before approval, **`https://<blockId>.civit.ai/` 404s** — submitting does not
+make the subdomain serve. For the full end-to-end walkthrough (build → submit →
+review → deploy), see the
+[Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
+guide.
+
 ## Configuration
 
 | Setting | Config key | Env var | Default |
@@ -168,7 +207,9 @@ written owner-readable only.
   again. For a personal key, create a new one at
   `https://civitai.com/user/account` and `civitai login --token <key>`.
 - **`forbidden (403)` / `service unavailable (503)`** — your account may lack
-  App Blocks access while the feature is gated.
+  App Blocks access while the feature is in its gated preview (see the warning at
+  the top of this README). Submission is limited to enrolled/approved accounts
+  until App Blocks reaches general availability.
 - **`validation failed`** — read each `- ...` line; fix the manifest, or pass
   `--skip-validate` to package anyway (the server will still re-validate).
 - **`<dir> is not empty — refusing to overwrite`** — `app init` won't clobber an

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ contract, and **packages/submits** it for review.
 > ⚠️ **App Blocks is in a limited, moderator-gated preview (pre-GA).** You can
 > install this CLI, `login`, scaffold, validate, and run a block locally right
 > now — but **`civitai app submit` requires App Blocks access**. While the
-> feature is dark, submission is restricted to enrolled/approved accounts: an
-> un-enrolled account can't submit (or its block won't be reviewed/approved, so
-> it won't go live) until App Blocks opens up. There is no public self-serve
-> "request access" form yet — watch [civitai.com](https://civitai.com) and the
+> feature is dark, submission is restricted to **Civitai moderators / the team**:
+> a non-moderator account can't submit (or its block won't be reviewed/approved,
+> so it won't go live) until App Blocks opens to the public. There is no public
+> self-serve "request access" form yet — watch [civitai.com](https://civitai.com) and the
 > [issues on this repo](https://github.com/civitai/cli/issues) for the
 > general-availability announcement.
 
@@ -208,7 +208,7 @@ written owner-readable only.
   `https://civitai.com/user/account` and `civitai login --token <key>`.
 - **`forbidden (403)` / `service unavailable (503)`** — your account may lack
   App Blocks access while the feature is in its gated preview (see the warning at
-  the top of this README). Submission is limited to enrolled/approved accounts
+  the top of this README). Submission is limited to Civitai moderators / the team
   until App Blocks reaches general availability.
 - **`validation failed`** — read each `- ...` line; fix the manifest, or pass
   `--skip-validate` to package anyway (the server will still re-validate).


### PR DESCRIPTION
Doc-only fixes surfaced by an external-developer dogfood of the public App Blocks toolchain.

## Why
An external dev installs the CLI, runs `civitai login` / `civitai app submit`, and gets gated at submit/review with **no prior warning** — and nothing tells them that submit ≠ live.

## Changes (README.md only)
1. **Gated-preview warning** near the top + a pointer in the quickstart: App Blocks is in a limited, moderator-gated preview (pre-GA); `civitai app submit` requires App Blocks access; an un-enrolled account can't submit / get a block reviewed until the feature opens up.
   - No invented "request access" URL — points only at civitai.com and this repo's issues for the GA announcement.
2. **Post-submit lifecycle made explicit** in the quickstart and a new "After you submit: review → approve → deploy" subsection: `submit → review → approve → build + deploy → https://<blockId>.civit.ai/`, and that the subdomain **404s until a moderator approves and the platform builds + deploys** the block.
3. Tied the existing `403`/`503` troubleshooting line back to the preview-gate note.

Consistent with the just-merged Go-CLI canonicalization — introduces no `dev`/`deploy` commands.

## Please verify (claims I can't confirm from the repo alone)
- That App Blocks submission is currently restricted to enrolled/approved accounts (the "gated preview" framing). The README already hinted at this (`403`/`503` → "App Blocks access while the feature is gated"); I made it prominent.
- That `https://<blockId>.civit.ai/` 404s before approval and serves only after approve + deploy. This mirrors the app-starters guide's §8 ("Review + deploy"), but I haven't reproduced the 404 myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)