### PR TITLE
feat(cli): version build-info fallback, wire dev:live to createLiveHost, surface dev docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ manifest against the platform contract, and packages/submits it for review.
 ```
 cmd/civitai/main.go        binary entrypoint; injects build version/commit/date
 internal/cmd/              the Cobra command tree (one file per command)
-  root.go                  root command + SetBuildInfo + subcommand wiring
+  root.go                  root command + SetBuildInfo (ldflags authoritative; falls back to runtime/debug.ReadBuildInfo for `go install` builds) + subcommand wiring
   app.go                   `civitai app` group
   app_init.go              `civitai app init`   -> internal/scaffold
   app_validate.go          `civitai app validate` -> internal/validate

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ full details and examples.
   parent-origin config, and a unit-test stub. Run `npm run dev:harness` (plain
   `npm run dev` renders blank without a host).
 
+### Local dev loop (harness: mock vs live)
+
+A scaffolded App Block is a sandboxed iframe — `npm run dev` alone shows a blank
+screen because there's no host to send `BLOCK_INIT`. The `page-money` /
+`page-vite` templates ship a dev **harness** (the SDK's
+[`@civitai/blocks-react/testing`](https://www.npmjs.com/package/@civitai/blocks-react)
+hosts) with two modes:
+
+| Command | Mode | What it does |
+|---|---|---|
+| `npm run dev:harness` | **mock** (default) | Mounts the SDK **mock host** — synthetic replies, **no real Buzz, no compute, no network.** Safe to spam; drive money/error/insufficient-Buzz UX via on-screen scenarios or `?` URL params. Start here. |
+| `npm run dev:live` | **live** | Mounts the SDK **live host** (`createLiveHost`) — forwards the App-Block protocol to the **real Civitai backend** with a pasted dev token (Bearer). **Spends REAL Buzz / real compute.** |
+
+**Live mode** needs a short-lived dev block token (mint via the moderator-gated
+`POST /api/v1/blocks/dev-token`), pasted into `.env.development` as
+`VITE_LIVE_BLOCK_TOKEN=` (never committed — `submit` excludes `.env.development`).
+With no token it **fails safe** (renders a notice, never spends). Live v1 covers
+the money path (`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set,
+App-Storage KV, and in-band Buzz purchase are mock-only.
+
+Env vars (`VITE_BLOCK_ALLOWED_PARENT_ORIGINS`, `VITE_HARNESS_MODE`,
+`VITE_LIVE_BLOCK_TOKEN`, …) and the scenario knobs are documented in depth in the
+scaffolded project's own `README.md` and `.env.example` — see
+[`internal/scaffold/templates/page-money/README.md.tmpl`](internal/scaffold/templates/page-money/README.md.tmpl).
+
 ### Examples
 
 Two real example manifests live under [`examples/`](examples/) (copied from the

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"runtime/debug"
+
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +15,16 @@ var (
 	date    = "unknown"
 )
 
-// SetBuildInfo lets main inject the build version, commit, and date.
+// readBuildInfo is a seam so tests can stub runtime/debug.ReadBuildInfo.
+var readBuildInfo = debug.ReadBuildInfo
+
+// SetBuildInfo lets main inject the build version, commit, and date. Goreleaser
+// release binaries pass real ldflag values, which are authoritative. For a plain
+// `go install github.com/civitai/cli/cmd/civitai@latest` (or any source build),
+// the ldflags are absent and the injected values are still the "dev" defaults —
+// in that case we fall back to runtime/debug.ReadBuildInfo so `civitai version`
+// reports the module version (e.g. v0.1.1 or a pseudo-version) and the embedded
+// VCS revision/time instead of dev/none/unknown.
 func SetBuildInfo(v, c, d string) {
 	if v != "" {
 		version = v
@@ -24,6 +35,40 @@ func SetBuildInfo(v, c, d string) {
 	if d != "" {
 		date = d
 	}
+	applyBuildInfoFallback()
+}
+
+// applyBuildInfoFallback fills version/commit/date from the embedded Go build
+// info when (and only when) the corresponding value is still its dev default —
+// i.e. no goreleaser ldflag overrode it. Each field falls back independently.
+func applyBuildInfoFallback() {
+	info, ok := readBuildInfo()
+	if !ok || info == nil {
+		return
+	}
+	if isDevDefault(version) {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			version = v
+		}
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if commit == "none" && s.Value != "" {
+				commit = s.Value
+			}
+		case "vcs.time":
+			if date == "unknown" && s.Value != "" {
+				date = s.Value
+			}
+		}
+	}
+}
+
+// isDevDefault reports whether v is one of the placeholder values that mean
+// "no real version was stamped in" (so a build-info fallback should apply).
+func isDevDefault(v string) bool {
+	return v == "" || v == "dev"
 }
 
 // NewRootCmd builds the root command with all subcommands attached.

--- a/internal/cmd/version_fallback_test.go
+++ b/internal/cmd/version_fallback_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// stubBuildInfo swaps readBuildInfo for the duration of a test.
+func stubBuildInfo(t *testing.T, info *debug.BuildInfo, ok bool) {
+	t.Helper()
+	orig := readBuildInfo
+	readBuildInfo = func() (*debug.BuildInfo, bool) { return info, ok }
+	t.Cleanup(func() { readBuildInfo = orig })
+}
+
+// resetBuildVars restores the package build vars after a test.
+func resetBuildVars(t *testing.T) {
+	t.Helper()
+	origV, origC, origD := version, commit, date
+	t.Cleanup(func() { version, commit, date = origV, origC, origD })
+}
+
+func TestSetBuildInfoFallsBackToBuildInfo(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "dev", "none", "unknown"
+
+	stubBuildInfo(t, &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.1.1"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "deadbeefcafe"},
+			{Key: "vcs.time", Value: "2026-06-23T00:00:00Z"},
+		},
+	}, true)
+
+	// Empty ldflag values => still dev defaults => fallback applies.
+	SetBuildInfo("", "", "")
+
+	if version != "v0.1.1" {
+		t.Errorf("version: got %q want v0.1.1", version)
+	}
+	if commit != "deadbeefcafe" {
+		t.Errorf("commit: got %q want deadbeefcafe", commit)
+	}
+	if date != "2026-06-23T00:00:00Z" {
+		t.Errorf("date: got %q want 2026-06-23T00:00:00Z", date)
+	}
+}
+
+func TestSetBuildInfoLdflagsAreAuthoritative(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "dev", "none", "unknown"
+
+	stubBuildInfo(t, &debug.BuildInfo{
+		Main: debug.Module{Version: "v9.9.9"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "frombuildinfo"},
+			{Key: "vcs.time", Value: "2000-01-01T00:00:00Z"},
+		},
+	}, true)
+
+	// Real release ldflag values must win over build info.
+	SetBuildInfo("1.2.3", "abc123", "2026-01-01")
+
+	if version != "1.2.3" {
+		t.Errorf("version: got %q want 1.2.3 (ldflag authoritative)", version)
+	}
+	if commit != "abc123" {
+		t.Errorf("commit: got %q want abc123 (ldflag authoritative)", commit)
+	}
+	if date != "2026-01-01" {
+		t.Errorf("date: got %q want 2026-01-01 (ldflag authoritative)", date)
+	}
+}
+
+func TestApplyBuildInfoFallbackPartial(t *testing.T) {
+	resetBuildVars(t)
+	// version stamped by ldflag, commit/date still defaults.
+	version, commit, date = "1.0.0", "none", "unknown"
+
+	stubBuildInfo(t, &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.1.1"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "rev123"},
+			{Key: "vcs.time", Value: "2026-06-23T00:00:00Z"},
+		},
+	}, true)
+
+	applyBuildInfoFallback()
+
+	if version != "1.0.0" {
+		t.Errorf("version: got %q want 1.0.0 (already stamped, not overridden)", version)
+	}
+	if commit != "rev123" {
+		t.Errorf("commit: got %q want rev123 (filled from build info)", commit)
+	}
+	if date != "2026-06-23T00:00:00Z" {
+		t.Errorf("date: got %q want build-info time", date)
+	}
+}
+
+func TestApplyBuildInfoFallbackDevelVersionIgnored(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "dev", "none", "unknown"
+
+	// `go build` (no module path version) yields "(devel)" — not useful, keep "dev".
+	stubBuildInfo(t, &debug.BuildInfo{
+		Main:     debug.Module{Version: "(devel)"},
+		Settings: nil,
+	}, true)
+
+	applyBuildInfoFallback()
+
+	if version != "dev" {
+		t.Errorf("version: got %q want dev ((devel) should be ignored)", version)
+	}
+}
+
+func TestApplyBuildInfoFallbackNoBuildInfo(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "dev", "none", "unknown"
+
+	stubBuildInfo(t, nil, false)
+	applyBuildInfoFallback()
+
+	if version != "dev" || commit != "none" || date != "unknown" {
+		t.Errorf("expected dev defaults preserved when build info unavailable: %s %s %s", version, commit, date)
+	}
+}

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -48,15 +48,27 @@ set it for you):
 | Script | Mode | What it does |
 |---|---|---|
 | `npm run dev:harness` | **mock** (default) | The SDK mock host. Synthetic — **no real Buzz, no compute, no network.** Safe to spam. |
-| `npm run dev:live` | **live** | Talk to a REAL host with a REAL block token — **spends REAL Buzz / real compute.** |
+| `npm run dev:live` | **live** | The SDK **live host** (`createLiveHost`) — forwards the protocol to the **real Civitai backend** with a real dev token. **Spends REAL Buzz / real compute.** |
 
-> ⚠️ **Live mode is a wired stub.** A true live proxy-host needs a server
-> dev-token endpoint to mint a scoped block token — that's **Layer 2, not built
-> yet.** Until it lands, `dev:live` **fails safe**: it reads `VITE_LIVE_BLOCK_TOKEN`
-> + `VITE_LIVE_PROXY_READY` and, finding the plumbing absent, renders a clear
-> notice instead of silently spending or breaking. The env + mode switch are
-> already wired, so live lights up the moment Layer 2 ships. Do **not** fake
-> "live" as mock.
+**Live mode setup.** `dev:live` mounts `createLiveHost` from
+`@civitai/blocks-react/testing`, which forwards the App-Block postMessage
+protocol to the real backend using a pasted dev token (Bearer). To use it:
+
+1. Mint a short-lived dev block token via the moderator-gated endpoint
+   `POST /api/v1/blocks/dev-token` (the token is a ~15-minute RS256 JWT; re-mint
+   + restart when it expires).
+2. Paste it into `.env.development` as `VITE_LIVE_BLOCK_TOKEN=` (never commit it;
+   `submit` excludes `.env.development`).
+3. `npm run dev:live` — a persistent **⚠️ LIVE HOST** banner stays on screen; a
+   successful Generate spends your own real Buzz.
+
+> ⚠️ With no `VITE_LIVE_BLOCK_TOKEN`, `dev:live` **fails safe**: it renders a
+> notice telling you to mint a token, and never silently spends.
+>
+> **Live v1 scope:** `createLiveHost` supports the money path
+> (`estimate`/`submit`/`poll`/`cancel`). It does **not** support pickers,
+> `SET_USER_CHECKPOINT`, the App-Storage KV protocol, or in-band Buzz purchase —
+> those reply "not supported in live v1" (use mock mode for them).
 
 ### Scenarios (exercise the money / error / storage UX for free)
 

--- a/internal/scaffold/templates/page-money/env.development.tmpl
+++ b/internal/scaffold/templates/page-money/env.development.tmpl
@@ -4,5 +4,6 @@
 VITE_BLOCK_ALLOWED_PARENT_ORIGINS=http://localhost:5186
 
 # Default harness mode for local dev: the MOCK host (no real Buzz). The
-# `dev:live` script overrides this to "live" (which fails safe until Layer 2).
+# `dev:live` script overrides this to "live" — which forwards to the real
+# backend and SPENDS REAL BUZZ (and fails safe with no VITE_LIVE_BLOCK_TOKEN).
 VITE_HARNESS_MODE=mock

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -20,22 +20,18 @@ VITE_DEV_HARNESS=
 # Which harness to mount: "mock" (default) or "live".
 #   mock  -> the SDK MOCK host: synthetic, no real Buzz, no compute, no network.
 #            `npm run dev:harness` sets this.
-#   live  -> talk to a REAL host with a REAL block token (spends REAL Buzz / real
-#            compute). `npm run dev:live` sets this. LIVE IS A WIRED STUB: a true
-#            live proxy-host needs a server dev-token endpoint (Layer 2), not
-#            built yet, so live FAILS SAFE (renders a notice) until that lands.
+#   live  -> the SDK LIVE host (`createLiveHost`): forwards the protocol to the
+#            REAL Civitai backend with a REAL block token (spends REAL Buzz /
+#            real compute). `npm run dev:live` sets this. With no
+#            VITE_LIVE_BLOCK_TOKEN it FAILS SAFE (renders a notice, never spends).
 VITE_HARNESS_MODE=
 
-# LIVE mode only. A real, scoped block token minted for local dev. Until the
-# Layer-2 dev-token endpoint exists you cannot get one — leave blank. ⚠️ A real
-# token here spends REAL Buzz; never commit one.
+# LIVE mode only. A short-lived, scoped dev block token minted for local dev via
+# the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token). Paste
+# it here to run `dev:live` against the real backend. ⚠️ A real token here spends
+# REAL Buzz; it's short-lived (~15min) — never commit one.
 VITE_LIVE_BLOCK_TOKEN=
 
-# LIVE mode only. The real host origin the block token targets. Defaults to
+# LIVE mode only. The backend base URL the live host forwards to. Defaults to
 # https://civitai.com.
 VITE_LIVE_HOST_ORIGIN=
-
-# LIVE mode only. Layer-2 enablement gate. Until the live proxy-host + dev-token
-# endpoint are built, leave this UNSET — live mode fail-safes regardless of the
-# token so it can never silently spend. Set to "true" only once Layer 2 lands.
-VITE_LIVE_PROXY_READY=

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.13.0",
-    "@civitai/blocks-react": "^0.10.0",
+    "@civitai/blocks-react": "^0.11.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -10,7 +10,7 @@
 // BEFORE any hook (or the mock host) runs. That's what this does.
 
 import { getTransport } from '@civitai/blocks-react';
-import { resetTransport } from '@civitai/blocks-react/testing';
+import { createLiveHost, resetTransport } from '@civitai/blocks-react/testing';
 
 /**
  * Dev harness modes. Selected by `VITE_HARNESS_MODE` (the `dev:harness` and
@@ -19,10 +19,11 @@ import { resetTransport } from '@civitai/blocks-react/testing';
  *  - `'mock'`  (default) — the SDK mock host. Synthetic, no real Buzz, no
  *    network. Safe to spam.
  *  - `'live'`  — talk to a REAL host with a REAL block token (spends REAL Buzz
- *    and real compute). **Layer 2 — not built yet.** A true live proxy-host
- *    needs a server dev-token endpoint to mint a scoped block token; until that
- *    lands, live mode FAILS SAFE (see {@link resolveLiveConfig}): it never
- *    silently spends.
+ *    and real compute) via the SDK's `createLiveHost`, which forwards the
+ *    App-Block postMessage protocol to the real Civitai backend (Bearer = the
+ *    pasted dev token). Needs a `VITE_LIVE_BLOCK_TOKEN`; until you paste one,
+ *    live mode FAILS SAFE (see {@link resolveLiveConfig}) — it never silently
+ *    spends.
  */
 export type HarnessMode = 'mock' | 'live';
 
@@ -53,45 +54,56 @@ export function resetHarnessTransport() {
 }
 
 /**
- * The result of trying to wire LIVE mode. `ready: false` means Layer-2 plumbing
- * (a server dev-token endpoint) isn't available yet OR no token was provided —
- * in either case the harness must show {@link reason} and NOT mount a real
- * money path. `ready: true` carries the token + target origin to wire a real
- * host with (the actual live proxy-host is Layer 2 / not built — see README).
+ * The result of trying to wire LIVE mode. `ready: false` means no dev block
+ * token was provided — the harness must show {@link reason} and NOT mount a
+ * real money path. `ready: true` carries the token + backend base URL used to
+ * build the real {@link createLiveHost} (see {@link installLiveHost}).
  */
 export type LiveConfig =
   | { ready: false; reason: string }
-  | { ready: true; token: string; targetOrigin: string };
+  | { ready: true; token: string; backendBaseUrl: string };
 
 /**
- * Resolve live-mode config from env. FAIL-SAFE by design: a true live
- * proxy-host needs a server dev-token endpoint (Layer 2) that doesn't exist
- * yet, so this returns `{ ready: false }` with a clear reason unless BOTH a
- * block token (`VITE_LIVE_BLOCK_TOKEN`) and the Layer-2 enablement flag
- * (`VITE_LIVE_PROXY_READY=true`) are present. We read the env + the mode switch
- * now so this lights up the moment Layer 2 lands — without faking "live" as
- * mock.
+ * Resolve live-mode config from env. FAIL-SAFE by design: live mode forwards
+ * the protocol to the REAL backend and SPENDS REAL BUZZ, so it refuses to mount
+ * unless a dev block token (`VITE_LIVE_BLOCK_TOKEN`) is present — returning
+ * `{ ready: false }` with a clear reason otherwise. The token is a short-lived
+ * RS256 JWT minted by the server dev-token endpoint (`POST /api/v1/blocks/dev-token`,
+ * moderator-gated); paste it into `VITE_LIVE_BLOCK_TOKEN` (never commit it).
  */
 export function resolveLiveConfig(): LiveConfig {
   const token = import.meta.env.VITE_LIVE_BLOCK_TOKEN as string | undefined;
-  const targetOrigin =
+  const backendBaseUrl =
     (import.meta.env.VITE_LIVE_HOST_ORIGIN as string | undefined) ?? 'https://civitai.com';
-  // Layer-2 plumbing (the dev-token endpoint + live proxy-host) is not built.
-  const layer2Ready = import.meta.env.VITE_LIVE_PROXY_READY === 'true';
 
   if (!token) {
     return {
       ready: false,
       reason:
-        'Live mode needs a dev block token (VITE_LIVE_BLOCK_TOKEN). See the dev-token endpoint — not yet available (Layer 2).',
+        'Live mode needs a dev block token (VITE_LIVE_BLOCK_TOKEN). Mint a short-lived token via the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token) and paste it into .env.development — never commit it.',
     };
   }
-  if (!layer2Ready) {
-    return {
-      ready: false,
-      reason:
-        'Live mode plumbing (the server dev-token endpoint / live proxy-host) is Layer 2 and not built yet. A token is set, but there is no real host to spend against — refusing to mount to avoid silently breaking.',
-    };
-  }
-  return { ready: true, token, targetOrigin };
+  return { ready: true, token, backendBaseUrl };
+}
+
+/**
+ * Mount the SDK's real LIVE host (`createLiveHost`) for `dev:live`. It forwards
+ * the App-Block postMessage protocol to the real Civitai backend using the
+ * pasted dev token (Bearer), so a successful submit SPENDS REAL BUZZ against
+ * real compute. Like the mock host, it replies from `window.location.origin`,
+ * so the SDK transport must allow this origin first ({@link installHarnessTransport}).
+ *
+ * Returns the `uninstall()` teardown. v1 live mode does NOT support pickers,
+ * SET_USER_CHECKPOINT, the App-Storage KV protocol, or in-band Buzz purchase —
+ * those reply "not supported in live v1" (use mock mode for them).
+ */
+export function installLiveHost(config: { token: string; backendBaseUrl: string }): () => void {
+  // Same origin requirement as the mock host: createLiveHost fires its replies
+  // from window.location.origin, which the SDK transport drops unless allowed.
+  installHarnessTransport();
+  const host = createLiveHost({
+    blockToken: config.token,
+    backendBaseUrl: config.backendBaseUrl,
+  });
+  return host.install();
 }

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -1,4 +1,4 @@
-import { StrictMode, type CSSProperties } from 'react';
+import { StrictMode, useEffect, useState, type CSSProperties } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App.js';
@@ -6,21 +6,21 @@ import { Harness } from './Harness.js';
 import {
   getHarnessMode,
   installHarnessTransport,
+  installLiveHost,
   resolveLiveConfig,
 } from './dev-transport.js';
 import './index.css';
 
-// Dev harness entry. Two mounts decide the surface:
+// Dev harness entry. The mode decides the surface:
 //
 //   VITE_DEV_HARNESS=true   -> mount a harness at all (never in prod).
 //   VITE_HARNESS_MODE=mock  -> (default) the SDK MOCK host. Synthetic, no real
 //                              Buzz, no compute, no network. `npm run dev:harness`.
-//   VITE_HARNESS_MODE=live  -> talk to a REAL host with a REAL block token —
-//                              spends REAL Buzz / real compute. `npm run dev:live`.
-//                              LIVE IS A WIRED STUB: a true live proxy-host needs
-//                              a server dev-token endpoint (Layer 2), not built
-//                              yet. Until then live FAILS SAFE — it renders a
-//                              clear message instead of silently spending.
+//   VITE_HARNESS_MODE=live  -> the SDK LIVE host (`createLiveHost`): forwards the
+//                              protocol to the REAL Civitai backend with a REAL
+//                              block token — spends REAL Buzz / real compute.
+//                              `npm run dev:live`. With no VITE_LIVE_BLOCK_TOKEN
+//                              it FAILS SAFE (renders a notice, never spends).
 //
 // Prod builds set neither and render <App/> bare (the platform is the host).
 const useHarness = import.meta.env.VITE_DEV_HARNESS === 'true';
@@ -29,6 +29,7 @@ const mode = getHarnessMode();
 // The mock host replies from window.location.origin; the SDK transport drops
 // mismatched-origin messages. Allowlist this origin BEFORE any hook runs so
 // BLOCK_INIT lands. (Prod uses VITE_BLOCK_ALLOWED_PARENT_ORIGINS instead.)
+// Live mode does the same inside installLiveHost (deferred to mount).
 if (useHarness && mode === 'mock') installHarnessTransport();
 
 const container = document.getElementById('root');
@@ -41,11 +42,7 @@ function Root() {
   if (mode === 'live') {
     const live = resolveLiveConfig();
     if (!live.ready) return <LiveUnavailable reason={live.reason} />;
-    // Layer 2 (the real live proxy-host) is not built. When it lands, wire the
-    // real transport here using `live.token` + `live.targetOrigin`, then render
-    // <App/>. Until then resolveLiveConfig() returns ready:false above, so this
-    // branch is unreachable — we never silently spend.
-    return <LiveUnavailable reason="Live proxy-host wiring is Layer 2 — not implemented yet." />;
+    return <LiveApp token={live.token} backendBaseUrl={live.backendBaseUrl} />;
   }
 
   // mode === 'mock'
@@ -57,9 +54,33 @@ function Root() {
 }
 
 /**
- * Fail-safe LIVE screen. Shown when `dev:live` is requested but the Layer-2
- * plumbing (server dev-token endpoint / live proxy-host) isn't available — so a
- * dev sees WHY nothing is spending instead of a silent mock or a blank screen.
+ * LIVE harness mount. Installs the SDK's real `createLiveHost` (which forwards
+ * the protocol to the real backend, Bearer = the dev token) on mount and tears
+ * it down on unmount, then renders <App/> against it. A successful submit here
+ * SPENDS REAL BUZZ. A persistent ⚠️ banner keeps that unmistakable on screen.
+ */
+function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: string }) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const uninstall = installLiveHost({ token, backendBaseUrl });
+    setReady(true);
+    return uninstall;
+  }, [token, backendBaseUrl]);
+
+  return (
+    <>
+      <div data-harness-banner="live" style={liveBannerStyle}>
+        ⚠️ LIVE HOST · spends REAL Buzz / real compute · {backendBaseUrl}
+      </div>
+      {ready ? <App /> : null}
+    </>
+  );
+}
+
+/**
+ * Fail-safe LIVE screen. Shown when `dev:live` is requested but no dev block
+ * token is set — so a dev sees WHY nothing is spending instead of a silent mock
+ * or a blank screen.
  */
 function LiveUnavailable({ reason }: { reason: string }) {
   return (
@@ -75,6 +96,19 @@ function LiveUnavailable({ reason }: { reason: string }) {
     </div>
   );
 }
+
+const liveBannerStyle: CSSProperties = {
+  position: 'sticky',
+  top: 0,
+  zIndex: 9999,
+  background: '#7a1f1f',
+  color: '#ffd8a8',
+  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+  fontSize: 13,
+  fontWeight: 700,
+  padding: '6px 12px',
+  textAlign: 'center',
+};
 
 const liveWrapStyle: CSSProperties = {
   minHeight: '100dvh',


### PR DESCRIPTION
Addresses three external-dev dogfood DX findings (C/B/D) and assesses a fourth (A).

## (C) `civitai version` build-info fallback — FIXED
`go install github.com/civitai/cli/cmd/civitai@latest` doesn't run goreleaser's ldflags, so `civitai version` printed `dev`/`none`/`unknown`. `SetBuildInfo` now calls `applyBuildInfoFallback()`, which fills each field from `runtime/debug.ReadBuildInfo()` **only when it's still its dev default**:
- `version` ← `info.Main.Version` (e.g. `v0.1.1` or a pseudo-version), ignoring `(devel)`
- `commit` ← the `vcs.revision` build setting
- `built` ← the `vcs.time` build setting

Release-binary ldflag values stay authoritative (per-field: a field is only overridden when it's a dev default). Added `internal/cmd/version_fallback_test.go` covering fallback / ldflags-authoritative / partial / `(devel)`-ignored / no-build-info. `readBuildInfo` is a stubbable seam.

## (B) Wire `dev:live` to the published `createLiveHost` — WIRED (UNVERIFIED against a real token)
`@civitai/blocks-react@0.11.1` (latest; verified via `npm view`) now exports `createLiveHost` from `/testing`. The `page-money` template's live mode previously rendered a "Layer 2 not ready" fail-safe stub; it now mounts the real live host.

**`createLiveHost` signature I used** (from the published `liveHost.d.ts`):
```ts
createLiveHost({
  blockToken: string,        // pasted short-lived RS256 dev JWT (Bearer)
  backendBaseUrl?: string,   // default 'https://civitai.com'
}): MockHost                 // host.install() -> uninstall()
```
(Other `LiveHostOptions` — `viewer`/`theme`/`context`/`onOutbound`/`window`/`fetchImpl` — left at defaults.) I call `host.install()` in a `useEffect` and render `<App/>` against it, mirroring how mock mode uses `<Harness>`. Same origin requirement as the mock host (replies fire from `window.location.origin`), so `installLiveHost` calls `installHarnessTransport()` first.

Changes:
- `package.json.tmpl`: `@civitai/blocks-react` `^0.10.0` → `^0.11.1`
- `dev-transport.ts.tmpl`: `resolveLiveConfig` now returns `ready:true` when `VITE_LIVE_BLOCK_TOKEN` is set (dropped the obsolete `VITE_LIVE_PROXY_READY` Layer-2 gate); added `installLiveHost`
- `main.tsx.tmpl`: live branch mounts `createLiveHost` via a new `LiveApp` (persistent ⚠️ LIVE HOST banner); graceful `LiveUnavailable` when no token
- `.env.example.tmpl` / `.env.development.tmpl` / template `README.md.tmpl`: updated copy, removed `VITE_LIVE_PROXY_READY`, documented minting a token via `POST /api/v1/blocks/dev-token`

⚠️ **`dev:live` is wired but UNVERIFIED against a real backend/token.** The real flow needs a moderator dev-token (not available in this env), so I could not end-to-end exercise a real spend. The tRPC contract `createLiveHost` assumes (auth via the `blockToken` field, the `/blocks/me` + `estimate/submit/poll/cancel` calls) is itself unverified-in-prod here. Verified only: template typechecks + builds with the live path wired, mock mode still works (see below).

## (D) Surface dev docs in the repo README — DONE
Added a concise **"Local dev loop (harness: mock vs live)"** section to `README.md` (mock vs live table, the live-token setup, live-v1 scope), linking the scaffolded template README for depth instead of duplicating.

## (A) `civitai app status` — ASSESSED: blocked-on-backend
A list endpoint **does** exist: `blocks.router.ts` `listMyPublishRequests` returns exactly what a status command wants (`status`, `deployState`, `rejectionReason`, `submittedAt`, …) and backs the web `/apps/my-submissions` page. **But it's a `moderatorProcedure`** (`protectedProcedure.use(isMod)`) — not reachable by a normal dev's CLI token. The submit REST route (`POST /api/v1/blocks/submit-version`) is the only token-auth blocks endpoint, and it returns only the *initial* status. **There is no public, token-authenticated submission-status endpoint**, so I did NOT build `civitai app status`. To unblock: a server REST/tRPC route (token-auth, scoped to the caller's own `submittedByUserId`) mirroring `listMyPublishRequests` for non-mod authors — then a thin `civitai app status` over it.

## Verification
- `make ci` (tidy + vet + test + build): **PASS** — all Go packages green.
- Scaffolded the `page-money` template via the built CLI into a temp dir, `npm install` (resolved `@civitai/blocks-react@0.11.1`, `createLiveHost` present in `testing.d.ts`), `npm run build` (**tsc --noEmit + vite build PASS**), `npm test` (**14/14 pass** — mock host + e2e money path intact). npm/network were available in this env.

Per repo rules: not merging.