### PR TITLE
feat(cli): civitai app status — check your submission review/deploy status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ internal/cmd/              the Cobra command tree (one file per command)
   app_init.go              `civitai app init`   -> internal/scaffold
   app_validate.go          `civitai app validate` -> internal/validate
   app_submit.go            `civitai app submit` -> internal/{pkgzip,api}
+  app_status.go            `civitai app status` -> internal/api (GET /api/v1/blocks/submissions, self-scoped)
   login.go / whoami.go     auth -> internal/{config,api}
   version.go               `civitai version`
   completion.go            `civitai completion` (Cobra built-in generators)
@@ -27,7 +28,7 @@ internal/scaffold/         embedded project templates (go:embed) + slug logic
 internal/validate/         JSON-Schema + ported semantic checks (see fidelity caveat)
 internal/pkgzip/           canonical source-tree ZIP packaging + server caps
 internal/manifest/         the manifest filename + a thin reader
-internal/api/              HTTP client (submit + whoami) behind interfaces
+internal/api/              HTTP client (submit + whoami + submission status) behind interfaces
 internal/config/           Viper-backed config (~/.config/civitai/config.yaml)
 schema/                    vendored App Block manifest JSON Schema (embedded)
 examples/                  real example manifests (validated by examples_test.go)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ civitai app validate
 
 # 4. Package + submit for review (uploads with your stored token by default).
 civitai app submit
+
+# 5. Check where your submission is in review / deploy.
+civitai app status
 ```
 
 > **Submit ≠ live.** `civitai app submit` enters your block into **moderator
@@ -95,6 +98,7 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
 | `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
+| `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai version` | Print version / commit / build date. |
 | `civitai completion [shell]` | Generate a shell-completion script. |
 
@@ -211,6 +215,47 @@ make the subdomain serve. For the full end-to-end walkthrough (build → submit 
 review → deploy), see the
 [Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 guide.
+
+## Submission status
+
+`civitai app status` checks where **your own** submissions are in that lifecycle
+without leaving the terminal. It calls the token-authenticated, self-scoped route
+`GET /api/v1/blocks/submissions` with your stored credential — you only ever see
+your own submissions (the same token that submitted can read its status; OAuth
+tokens need the App Blocks submit scope).
+
+With no argument it lists every submission, newest first:
+
+```text
+$ civitai app status
+BLOCK_ID    VERSION  STATUS    DEPLOY    SUBMITTED   URL
+gen-matrix  0.6.0    approved  live      2026-06-22  https://gen-matrix.civit.ai/
+my-block    0.2.0    pending   -         2026-06-21  -
+old-app     0.1.0    approved  building  2026-06-19  -
+```
+
+Pass a `blockId` (app slug) or `--id <pubreq_id>` to see one in detail — including
+the **rejection reason** if it was rejected (so you can fix + resubmit) and the
+**live URL** once it is approved and deployed:
+
+```text
+$ civitai app status gen-matrix
+Block ID:         gen-matrix
+Version:          0.6.0
+Publish request:  pubreq_01HZX
+Status:           rejected
+Deploy state:     -
+Submitted:        2026-06-22 09:05 CDT
+Reviewed:         2026-06-22 11:40 CDT
+
+Rejection reason:
+  the budgeted scope needs the per-app Sybil cap signed off first
+
+Not live yet — gen-matrix.civit.ai only serves after the app is approved and deployed (deployState 'live').
+```
+
+`--json` emits the raw response for scripting. An empty list prints a friendly
+"run `civitai app submit`" hint; with no token it points you at `civitai login`.
 
 ## Configuration
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -61,6 +62,37 @@ type Verifier interface {
 	WhoAmI(ctx context.Context) (*Identity, error)
 }
 
+// StatusReader reads the caller's own App-Block submission review/deploy state.
+type StatusReader interface {
+	// ListSubmissions returns the caller's submissions, newest first. An empty
+	// blockId lists all of them.
+	ListSubmissions(ctx context.Context, blockID string) ([]Submission, error)
+	// GetSubmission returns a single submission. Exactly one of id (a
+	// pubreq_<ULID>) or blockID (an app slug) must be set.
+	GetSubmission(ctx context.Context, id, blockID string) (*Submission, error)
+}
+
+// Submission mirrors the shaped row from GET /api/v1/blocks/submissions
+// (civitai/civitai src/pages/api/v1/blocks/submissions.ts -> shapeRow). Field
+// names + JSON casing track the server EXACTLY.
+type Submission struct {
+	ID              string  `json:"id"`
+	BlockID         string  `json:"blockId"` // the app slug; builds <blockId>.civit.ai
+	AppBlockID      *string `json:"appBlockId"`
+	Version         string  `json:"version"`
+	Status          string  `json:"status"` // pending | approved | rejected | withdrawn
+	RejectionReason *string `json:"rejectionReason"`
+	ApprovalNotes   *string `json:"approvalNotes"`
+	DeployState     *string `json:"deployState"` // null | building | deploying | live | failed
+	DeployDetail    *string `json:"deployDetail"`
+	DeployUpdatedAt *string `json:"deployUpdatedAt"`
+	SubmittedAt     string  `json:"submittedAt"`
+	ReviewedAt      *string `json:"reviewedAt"`
+	UpdatedAt       string  `json:"updatedAt"`
+	CreatedAt       string  `json:"createdAt"`
+	LiveURL         *string `json:"liveUrl"` // set once serving (approved+live)
+}
+
 // Identity is the minimal authenticated-user view `whoami` reports.
 type Identity struct {
 	Username string `json:"username"`
@@ -77,6 +109,10 @@ type SubmitResult struct {
 
 // DefaultSubmitPath is the token-authenticated submit-version route.
 const DefaultSubmitPath = "/api/v1/blocks/submit-version"
+
+// SubmissionsPath is the token-authenticated, self-scoped submission-status
+// route (GET; civitai/civitai src/pages/api/v1/blocks/submissions.ts).
+const SubmissionsPath = "/api/v1/blocks/submissions"
 
 // Client is the default HTTP implementation.
 type Client struct {
@@ -210,21 +246,119 @@ func (c *Client) WhoAmI(ctx context.Context) (*Identity, error) {
 	return &id, nil
 }
 
-// serverError turns a non-2xx response into a clear, actionable error.
-func serverError(status int, raw []byte) error {
+// submissionsURL builds the GET URL with optional id / blockId query params.
+func (c *Client) submissionsURL(id, blockID string) string {
+	u := c.BaseURL + SubmissionsPath
+	q := url.Values{}
+	if id != "" {
+		q.Set("id", id)
+	}
+	if blockID != "" {
+		q.Set("blockId", blockID)
+	}
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	return u
+}
+
+// ListSubmissions returns the caller's own submissions (newest first). An empty
+// blockID lists all; a non-empty blockID narrows to that app's submissions.
+func (c *Client) ListSubmissions(ctx context.Context, blockID string) ([]Submission, error) {
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, c.submissionsURL("", blockID), nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, submissionsError(status, raw)
+	}
+	var out struct {
+		Submissions []Submission `json:"submissions"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("unexpected /api/v1/blocks/submissions response: %s", string(raw))
+	}
+	return out.Submissions, nil
+}
+
+// GetSubmission returns a single submission. Exactly one of id (a pubreq id) or
+// blockID (an app slug) should be set; id takes precedence if both are given.
+func (c *Client) GetSubmission(ctx context.Context, id, blockID string) (*Submission, error) {
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, c.submissionsURL(id, blockID), nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, submissionsError(status, raw)
+	}
+	// An `?id=` lookup returns {submission: {...}}; an `?blockId=` lookup returns
+	// {submissions: [...]} (narrowed list) — handle both so either selector works.
+	var single struct {
+		Submission *Submission `json:"submission"`
+	}
+	if err := json.Unmarshal(raw, &single); err == nil && single.Submission != nil {
+		return single.Submission, nil
+	}
+	var list struct {
+		Submissions []Submission `json:"submissions"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("unexpected /api/v1/blocks/submissions response: %s", string(raw))
+	}
+	if len(list.Submissions) == 0 {
+		return nil, fmt.Errorf("no such submission")
+	}
+	return &list.Submissions[0], nil
+}
+
+// submissionsError maps a non-2xx submissions response to a clear, actionable
+// error, with App-Blocks-specific guidance for 403/404/429/503.
+func submissionsError(status int, raw []byte) error {
+	msg := serverMessage(raw)
+	switch status {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("not logged in (401): %s — run `civitai login`", msg)
+	case http.StatusForbidden:
+		return fmt.Errorf("App Blocks access required (gated preview) (403): %s", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("no such submission (404): %s", msg)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limited (429): %s — wait a moment and retry", msg)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("App Blocks is not enabled (503): %s", msg)
+	default:
+		return fmt.Errorf("server returned %d: %s", status, msg)
+	}
+}
+
+// serverMessage extracts the {"message"|"error": ...} field, falling back to the
+// trimmed raw body.
+func serverMessage(raw []byte) string {
 	msg := strings.TrimSpace(string(raw))
-	// The server returns {"message": "..."} for these routes.
 	var wrapped struct {
 		Message string `json:"message"`
 		Error   string `json:"error"`
 	}
 	if json.Unmarshal(raw, &wrapped) == nil {
 		if wrapped.Message != "" {
-			msg = wrapped.Message
-		} else if wrapped.Error != "" {
-			msg = wrapped.Error
+			return wrapped.Message
+		}
+		if wrapped.Error != "" {
+			return wrapped.Error
 		}
 	}
+	return msg
+}
+
+// serverError turns a non-2xx response into a clear, actionable error.
+func serverError(status int, raw []byte) error {
+	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("unauthorized (401): %s — check your token with `civitai login`", msg)

--- a/internal/api/submissions_test.go
+++ b/internal/api/submissions_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleSubmission(slug, status string) Submission {
+	live := "https://" + slug + ".civit.ai/"
+	building := "building"
+	return Submission{
+		ID:          "pubreq_01H",
+		BlockID:     slug,
+		Version:     "0.1.0",
+		Status:      status,
+		DeployState: &building,
+		SubmittedAt: "2026-06-20T10:00:00.000Z",
+		UpdatedAt:   "2026-06-20T10:00:00.000Z",
+		CreatedAt:   "2026-06-20T10:00:00.000Z",
+		LiveURL:     &live,
+	}
+}
+
+func TestListSubmissionsSendsBearerAndParses(t *testing.T) {
+	var gotAuth, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"submissions": []Submission{
+				sampleSubmission("alpha", "pending"),
+				sampleSubmission("beta", "approved"),
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	subs, err := c.ListSubmissions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListSubmissions: %v", err)
+	}
+	if gotAuth != "Bearer tok123" {
+		t.Errorf("auth header = %q, want Bearer tok123", gotAuth)
+	}
+	if gotPath != SubmissionsPath {
+		t.Errorf("path = %q, want %q", gotPath, SubmissionsPath)
+	}
+	if gotQuery != "" {
+		t.Errorf("query = %q, want empty for a full list", gotQuery)
+	}
+	if len(subs) != 2 || subs[0].BlockID != "alpha" || subs[1].Status != "approved" {
+		t.Errorf("unexpected submissions: %+v", subs)
+	}
+}
+
+func TestListSubmissionsNarrowsByBlockID(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("blockId")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"submissions": []Submission{sampleSubmission("alpha", "pending")},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	if _, err := c.ListSubmissions(context.Background(), "alpha"); err != nil {
+		t.Fatalf("ListSubmissions: %v", err)
+	}
+	if gotQuery != "alpha" {
+		t.Errorf("blockId query = %q, want alpha", gotQuery)
+	}
+}
+
+func TestGetSubmissionByIDParsesSingle(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("id")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"submission": sampleSubmission("alpha", "rejected"),
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	sub, err := c.GetSubmission(context.Background(), "pubreq_01H", "")
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if gotQuery != "pubreq_01H" {
+		t.Errorf("id query = %q, want pubreq_01H", gotQuery)
+	}
+	if sub.Status != "rejected" || sub.BlockID != "alpha" {
+		t.Errorf("unexpected submission: %+v", sub)
+	}
+}
+
+func TestGetSubmissionByBlockIDFallsBackToList(t *testing.T) {
+	// A `?blockId=` lookup returns {submissions:[...]} — GetSubmission should take
+	// the first element.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"submissions": []Submission{sampleSubmission("alpha", "approved")},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	sub, err := c.GetSubmission(context.Background(), "", "alpha")
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if sub.Status != "approved" {
+		t.Errorf("unexpected submission: %+v", sub)
+	}
+}
+
+func TestGetSubmissionEmptyListIsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"submissions": []Submission{}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	_, err := c.GetSubmission(context.Background(), "", "ghost")
+	if err == nil || !strings.Contains(err.Error(), "no such submission") {
+		t.Errorf("want no-such-submission error, got %v", err)
+	}
+}
+
+func TestSubmissionsErrorMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		body   map[string]string
+		want   string
+	}{
+		{http.StatusUnauthorized, map[string]string{"message": "Invalid API key"}, "civitai login"},
+		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "App Blocks access required (gated preview)"},
+		{http.StatusNotFound, map[string]string{"message": "Submission not found"}, "no such submission"},
+		{http.StatusTooManyRequests, map[string]string{"message": "Rate limit exceeded"}, "rate limited"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "not enabled"},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			_ = json.NewEncoder(w).Encode(tc.body)
+		}))
+		c := New(srv.URL, "tok", "")
+		_, err := c.ListSubmissions(context.Background(), "")
+		if err == nil {
+			srv.Close()
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
+		}
+		srv.Close()
+	}
+}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -18,11 +18,13 @@ the rich page-money SDK template); "civitai app init" is the same scaffolder
 with a no-build static default (back-compat alias).`,
 		Example: `  civitai app create my-block
   civitai app validate ./my-block
-  civitai app submit ./my-block`,
+  civitai app submit ./my-block
+  civitai app status`,
 	}
 	cmd.AddCommand(newAppCreateCmd())
 	cmd.AddCommand(newAppInitCmd())
 	cmd.AddCommand(newAppValidateCmd())
 	cmd.AddCommand(newAppSubmitCmd())
+	cmd.AddCommand(newAppStatusCmd())
 	return cmd
 }

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newAppStatusCmd() *cobra.Command {
+	var idFlag string
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "status [blockId]",
+		Short: "Check the review/deploy status of your App Block submissions",
+		Long: `Check the review and deploy status of your own App Block submissions.
+
+Calls the token-authenticated, self-scoped status route
+(GET /api/v1/blocks/submissions) with your stored credential — you only ever see
+your OWN submissions. Both a personal API key and an OAuth login (civitai login)
+work; the OAuth token must carry the App Blocks submit scope (the same gate the
+submit route uses).
+
+With no argument it lists all your submissions (newest first). Pass a blockId
+(app slug) or --id <pubreq_id> to see a single submission in detail, including the
+rejection reason (if rejected) and the live URL (if approved + deployed).
+
+Note: a submission's <blockId>.civit.ai surface only serves AFTER it is approved
+and deployed (deployState 'live').`,
+		Example: `  civitai app status                 # list all your submissions
+  civitai app status my-block        # detail for the my-block app
+  civitai app status --id pubreq_01H # detail by publish-request id
+  civitai app status --json          # raw JSON (scriptable)`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if cfg.Token() == "" {
+				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+			}
+
+			var blockID string
+			if len(args) == 1 {
+				blockID = args[0]
+			}
+
+			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
+			ctx := context.Background()
+			out := cmd.OutOrStdout()
+
+			// Detail view when a blockId arg OR --id is given.
+			if idFlag != "" || blockID != "" {
+				sub, err := client.GetSubmission(ctx, idFlag, blockID)
+				if err != nil {
+					return err
+				}
+				if jsonOut {
+					return writeJSON(out, sub)
+				}
+				printSubmissionDetail(out, sub)
+				return nil
+			}
+
+			subs, err := client.ListSubmissions(ctx, "")
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return writeJSON(out, map[string]any{"submissions": subs})
+			}
+			if len(subs) == 0 {
+				fmt.Fprintln(out, "No submissions yet — run `civitai app submit` to create one.")
+				return nil
+			}
+			printSubmissionTable(out, subs)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&idFlag, "id", "", "look up a single submission by publish-request id (pubreq_...)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON (scriptable)")
+	return cmd
+}
+
+func writeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func printSubmissionTable(w io.Writer, subs []api.Submission) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "BLOCK_ID\tVERSION\tSTATUS\tDEPLOY\tSUBMITTED\tURL")
+	for _, s := range subs {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.BlockID,
+			s.Version,
+			s.Status,
+			deployLabel(s.DeployState),
+			shortDate(s.SubmittedAt),
+			strOr(s.LiveURL, "-"),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func printSubmissionDetail(w io.Writer, s *api.Submission) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Block ID:\t%s\n", s.BlockID)
+	fmt.Fprintf(tw, "Version:\t%s\n", s.Version)
+	fmt.Fprintf(tw, "Publish request:\t%s\n", s.ID)
+	fmt.Fprintf(tw, "Status:\t%s\n", s.Status)
+	fmt.Fprintf(tw, "Deploy state:\t%s\n", deployLabel(s.DeployState))
+	if s.DeployDetail != nil && *s.DeployDetail != "" {
+		fmt.Fprintf(tw, "Deploy detail:\t%s\n", *s.DeployDetail)
+	}
+	fmt.Fprintf(tw, "Submitted:\t%s\n", fullDate(s.SubmittedAt))
+	if s.ReviewedAt != nil && *s.ReviewedAt != "" {
+		fmt.Fprintf(tw, "Reviewed:\t%s\n", fullDate(*s.ReviewedAt))
+	}
+	if s.DeployUpdatedAt != nil && *s.DeployUpdatedAt != "" {
+		fmt.Fprintf(tw, "Deploy updated:\t%s\n", fullDate(*s.DeployUpdatedAt))
+	}
+	_ = tw.Flush()
+
+	if s.Status == "rejected" && s.RejectionReason != nil && *s.RejectionReason != "" {
+		fmt.Fprintf(w, "\nRejection reason:\n  %s\n", *s.RejectionReason)
+	}
+	if s.ApprovalNotes != nil && *s.ApprovalNotes != "" {
+		fmt.Fprintf(w, "\nApproval notes:\n  %s\n", *s.ApprovalNotes)
+	}
+	if s.LiveURL != nil && *s.LiveURL != "" {
+		fmt.Fprintf(w, "\nLive at: %s\n", *s.LiveURL)
+	} else {
+		fmt.Fprintf(w, "\nNot live yet — %s.civit.ai only serves after the app is approved and deployed (deployState 'live').\n", s.BlockID)
+	}
+}
+
+// deployLabel renders a possibly-null deployState; null means "no Phase-2 deploy
+// pipeline ran" (legacy/approved rows assume live).
+func deployLabel(state *string) string {
+	if state == nil || *state == "" {
+		return "-"
+	}
+	return *state
+}
+
+func strOr(p *string, fallback string) string {
+	if p == nil || *p == "" {
+		return fallback
+	}
+	return *p
+}
+
+// shortDate renders an RFC3339 timestamp as YYYY-MM-DD; the raw string on a parse
+// failure so we never hide data.
+func shortDate(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return t.Format("2006-01-02")
+}
+
+// fullDate renders an RFC3339 timestamp in local time, minute precision.
+func fullDate(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	return t.Local().Format("2006-01-02 15:04 MST")
+}

--- a/internal/cmd/app_status_test.go
+++ b/internal/cmd/app_status_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// statusServer stands up an httptest server emulating GET
+// /api/v1/blocks/submissions, returning the canned body and recording the
+// request. handler may be nil for the default OK list.
+func statusServer(t *testing.T, body any, status int, rec *struct {
+	auth, path, id, blockID string
+}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rec != nil {
+			rec.auth = r.Header.Get("Authorization")
+			rec.path = r.URL.Path
+			rec.id = r.URL.Query().Get("id")
+			rec.blockID = r.URL.Query().Get("blockId")
+		}
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func TestAppStatusListRendersTable(t *testing.T) {
+	var rec struct{ auth, path, id, blockID string }
+	body := map[string]any{
+		"submissions": []map[string]any{
+			{"id": "pubreq_2", "blockId": "beta", "version": "0.2.0", "status": "approved",
+				"deployState": "live", "submittedAt": "2026-06-21T09:00:00.000Z",
+				"liveUrl": "https://beta.civit.ai/"},
+			{"id": "pubreq_1", "blockId": "alpha", "version": "0.1.0", "status": "pending",
+				"deployState": nil, "submittedAt": "2026-06-20T08:00:00.000Z", "liveUrl": nil},
+		},
+	}
+	srv := statusServer(t, body, http.StatusOK, &rec)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "status")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if rec.auth != "Bearer tok-1" {
+		t.Errorf("auth header = %q", rec.auth)
+	}
+	if rec.path != "/api/v1/blocks/submissions" {
+		t.Errorf("path = %q", rec.path)
+	}
+	if rec.id != "" || rec.blockID != "" {
+		t.Errorf("full list should send no id/blockId, got id=%q blockId=%q", rec.id, rec.blockID)
+	}
+	for _, want := range []string{"BLOCK_ID", "VERSION", "STATUS", "DEPLOY", "SUBMITTED", "URL",
+		"alpha", "beta", "approved", "pending", "live", "https://beta.civit.ai/", "2026-06-21"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAppStatusEmptyListFriendly(t *testing.T) {
+	srv := statusServer(t, map[string]any{"submissions": []any{}}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "status")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if !strings.Contains(out, "No submissions yet") || !strings.Contains(out, "civitai app submit") {
+		t.Errorf("empty list should be friendly: %s", out)
+	}
+}
+
+func TestAppStatusDetailByBlockID(t *testing.T) {
+	var rec struct{ auth, path, id, blockID string }
+	body := map[string]any{
+		"submissions": []map[string]any{
+			{"id": "pubreq_9", "blockId": "rejected-app", "version": "0.3.0", "status": "rejected",
+				"rejectionReason": "manifest scope ai:write:budgeted not allowed yet",
+				"deployState":     nil, "submittedAt": "2026-06-22T12:00:00.000Z",
+				"reviewedAt": "2026-06-22T15:30:00.000Z", "liveUrl": nil},
+		},
+	}
+	srv := statusServer(t, body, http.StatusOK, &rec)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "status", "rejected-app")
+	if err != nil {
+		t.Fatalf("app status <blockId>: %v", err)
+	}
+	if rec.blockID != "rejected-app" {
+		t.Errorf("blockId query = %q, want rejected-app", rec.blockID)
+	}
+	for _, want := range []string{"rejected-app", "0.3.0", "rejected",
+		"Rejection reason", "manifest scope ai:write:budgeted not allowed yet",
+		"Not live yet", "rejected-app.civit.ai"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAppStatusDetailByIDFlagLive(t *testing.T) {
+	var rec struct{ auth, path, id, blockID string }
+	body := map[string]any{
+		"submission": map[string]any{
+			"id": "pubreq_live", "blockId": "shipped", "version": "1.0.0", "status": "approved",
+			"deployState": "live", "submittedAt": "2026-06-10T00:00:00.000Z",
+			"reviewedAt": "2026-06-11T00:00:00.000Z", "liveUrl": "https://shipped.civit.ai/",
+		},
+	}
+	srv := statusServer(t, body, http.StatusOK, &rec)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "status", "--id", "pubreq_live")
+	if err != nil {
+		t.Fatalf("app status --id: %v", err)
+	}
+	if rec.id != "pubreq_live" {
+		t.Errorf("id query = %q, want pubreq_live", rec.id)
+	}
+	for _, want := range []string{"shipped", "approved", "live", "Live at: https://shipped.civit.ai/"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("live detail missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Not live yet") {
+		t.Errorf("a live submission should not say 'Not live yet':\n%s", out)
+	}
+}
+
+func TestAppStatusJSONPassthrough(t *testing.T) {
+	body := map[string]any{
+		"submissions": []map[string]any{
+			{"id": "pubreq_1", "blockId": "alpha", "version": "0.1.0", "status": "pending",
+				"deployState": nil, "submittedAt": "2026-06-20T08:00:00.000Z", "liveUrl": nil},
+		},
+	}
+	srv := statusServer(t, body, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "status", "--json")
+	if err != nil {
+		t.Fatalf("app status --json: %v", err)
+	}
+	// Must be valid JSON with the field names preserved (scriptable).
+	var parsed struct {
+		Submissions []map[string]any `json:"submissions"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Submissions) != 1 || parsed.Submissions[0]["blockId"] != "alpha" {
+		t.Errorf("unexpected --json payload: %s", out)
+	}
+}
+
+func TestAppStatusMissingTokenErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	_, _, err := run(t, "app", "status")
+	if err == nil {
+		t.Fatal("expected error with no token")
+	}
+	if !strings.Contains(err.Error(), "no token") || !strings.Contains(err.Error(), "civitai login") {
+		t.Errorf("missing-token error should point to login: %v", err)
+	}
+}
+
+func TestAppStatusErrorMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		msg    string
+		want   string
+	}{
+		{http.StatusUnauthorized, "Invalid API key", "civitai login"},
+		{http.StatusForbidden, "restricted to the civitai team", "gated preview"},
+		{http.StatusNotFound, "Submission not found", "no such submission"},
+		{http.StatusTooManyRequests, "Rate limit exceeded", "rate limited"},
+		{http.StatusServiceUnavailable, "App Blocks is not enabled", "not enabled"},
+	}
+	for _, tc := range cases {
+		srv := statusServer(t, map[string]string{"message": tc.msg}, tc.status, nil)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("CIVITAI_TOKEN", "tok")
+		t.Setenv("CIVITAI_BASE_URL", srv.URL)
+		_, _, err := run(t, "app", "status")
+		srv.Close()
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
+		}
+	}
+}
+
+func TestAppHelpListsStatus(t *testing.T) {
+	out, _, err := run(t, "app", "--help")
+	if err != nil {
+		t.Fatalf("app --help: %v", err)
+	}
+	if !strings.Contains(out, "status") {
+		t.Errorf("app help should list the status subcommand:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What

Adds `civitai app status` — a developer can now check the review + deploy state of **their own** App Block submissions from the terminal, instead of needing the mod-only `/apps/my-submissions` page.

It binds to the just-merged server route (civitai/civitai `main`, `src/pages/api/v1/blocks/submissions.ts`).

## Command UX

**List (no args)** — newest first, `text/tabwriter`-aligned:

```text
$ civitai app status
BLOCK_ID    VERSION  STATUS    DEPLOY    SUBMITTED   URL
gen-matrix  0.6.0    approved  live      2026-06-22  https://gen-matrix.civit.ai/
my-block    0.2.0    pending   -         2026-06-21  -
old-app     0.1.0    approved  building  2026-06-19  -
```

**Detail** (`civitai app status <blockId>` or `--id <pubreq>`) — surfaces the **rejectionReason** if rejected and the **liveUrl** once deployed:

```text
$ civitai app status gen-matrix
Block ID:         gen-matrix
Version:          0.6.0
Publish request:  pubreq_01HZX
Status:           rejected
Deploy state:     -
Submitted:        2026-06-22 09:05 CDT
Reviewed:         2026-06-22 11:40 CDT

Rejection reason:
  the budgeted scope needs the per-app Sybil cap signed off first

Not live yet — gen-matrix.civit.ai only serves after the app is approved and deployed (deployState 'live').
```

- `--json` emits the raw response (scriptable).
- Empty list → friendly `No submissions yet — run \`civitai app submit\` to create one.`
- No token → the same `no token configured — run \`civitai login\`` error `app submit` gives.

## Server contract bound to

`GET /api/v1/blocks/submissions`, `Authorization: Bearer <token>` (personal API key, or an OAuth token carrying `AppBlocksSubmit` scope — same gate as submit-version; mod-only pre-GA). Self-scoped server-side to the caller; the optional params only narrow.

- no params → `{ submissions: [...] }` (newest first, capped 100)
- `?id=<pubreq>` → `{ submission: {...} }`
- `?blockId=<slug>` → narrowed `{ submissions: [...] }`

Response fields bound (exact names/casing from the server `shapeRow`): `id`, `blockId` (the app slug), `appBlockId`, `version`, `status` (`pending|approved|rejected|withdrawn`), `rejectionReason`, `approvalNotes`, `deployState` (`null|building|deploying|live|failed`), `deployDetail`, `deployUpdatedAt`, `submittedAt`, `reviewedAt`, `updatedAt`, `createdAt`, `liveUrl` (set only once approved+serving). Nullable fields are `*string` so a JSON `null` round-trips faithfully.

## Error mapping

| HTTP | CLI message |
|---|---|
| 401 | `not logged in (401): … — run \`civitai login\`` |
| 403 | `App Blocks access required (gated preview) (403): …` |
| 404 | `no such submission (404): …` |
| 429 | `rate limited (429): … — wait a moment and retry` |
| 503 | `App Blocks is not enabled (503): …` |

## Implementation

- `internal/api/api.go`: `StatusReader` interface + `ListSubmissions`/`GetSubmission` on `Client`, the `Submission` type, `SubmissionsPath`, and `submissionsError`. Refactored `serverError` onto a shared `serverMessage` helper (no dup).
- `internal/cmd/app_status.go`: `newAppStatusCmd()`, registered under `newAppCmd` in `app.go`. Reuses the same config/token/`auth.New` path as `whoami`/`submit`.

## Tests

`internal/api/submissions_test.go` + `internal/cmd/app_status_test.go` (httptest): table + detail + `--json` render, request shape (path, `?id=`/`?blockId=`, Bearer header), full error-code mapping (401/403/404/429/503), empty-list friendly message, missing-token error, `?blockId=`→list-fallback, empty-list→not-found.

**`make ci` (tidy / vet / test / build): green.** `gofmt` clean.

## Verification status

The server endpoint is **merged to civitai `main` but not yet deployed to prod**. The command is built + unit-tested against the contract via httptest — it has **not** been exercised against a live prod endpoint (that needs the deploy + a mod token, since App Blocks is mod-gated pre-GA). No live end-to-end run was possible from here.

## Notes / things I was unsure of in the contract

- For a `?blockId=` single-item lookup the server returns a **list** (`{submissions:[...]}`), not `{submission}` — only `?id=` returns the single-object form. `GetSubmission` handles **both** (parses `{submission}` first, falls back to the first list element) so either selector works; an empty narrowed list maps to "no such submission".
- `deployState: null` on an approved row means "no Phase-2 deploy pipeline ran"; the server's `shapeRow` treats that as live (sets `liveUrl`). The CLI renders a null deployState as `-` in the table and trusts the server's `liveUrl` for the live/not-live note, so it stays consistent with that rule without re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
