### PR TITLE
feat(login): request UserRead|AppBlocksSubmit on civitai login (dev:live estimate/read); personal key for real Buzz

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,21 @@ the money path (`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set,
 App-Storage KV, and in-band Buzz purchase are mock-only.
 
 **Auth for the dev-token mint.** The mint needs a credential carrying the **App
-Blocks submit** scope; **real Buzz spend additionally needs AI Services scope**
-(the server applies a uniform AI-Services ceiling — a credential without it mints
-a read/estimate-only token). The simplest credential is a full-scope **personal
-API key** (create at `civitai.com/user/account` — a personal key carries every
-scope). Alternatively `civitai login` works once the `civitai-cli` OAuth client
-is granted those scopes: `civitai login` already **requests** App Blocks submit +
-AI Services on the device flow, and the granted token mints a spend-capable dev
-token (paired with the server change that lets the dev-token endpoint accept an
-App-Blocks-submit-scoped OAuth token). Until that client config is applied, use a
-personal API key.
+Blocks submit** scope. The server applies a uniform **AI Services ceiling** on the
+budgeted-spend scope, so the minted dev token can only **spend real Buzz** if the
+credential ALSO carries AI Services — a credential without it mints a
+**read/estimate-only** token (cost preview / whatif, catalog browsing, app
+storage; no real generation).
+
+- **`civitai login` (OAuth) → `dev:live` estimate/read/storage.** Login requests
+  only `UserRead | AppBlocksSubmit` (the `civitai-cli` client's allowed set — it
+  deliberately does NOT carry AI Services). The granted token mints a dev token,
+  but with AI Services stripped that token is **read/estimate only** — it can
+  preview costs and browse, but **cannot run a real generation**.
+- **Personal API key (full scope) → real generation/spend.** Create one at
+  `civitai.com/user/account`; a personal key carries every scope (including AI
+  Services), so its minted dev token spends real Buzz. Paste it as
+  `VITE_LIVE_BLOCK_TOKEN` for a `dev:live` session that actually generates.
 
 Env vars (`VITE_BLOCK_ALLOWED_PARENT_ORIGINS`, `VITE_HARNESS_MODE`,
 `VITE_LIVE_BLOCK_TOKEN`, …) and the scenario knobs are documented in depth in the
@@ -193,11 +198,15 @@ caveat and how the vendored schema + Go checks are kept in sync.
 prints a URL + a short code, you approve in your browser, and the CLI stores a
 short-lived access token (1h) plus a refresh token (30d) that it rotates
 automatically before requests and once on a `401`. It **requests** the scopes
-`UserRead | AppBlocksSubmit | AIServicesWrite` — identity, App-Blocks submit (for
-`app submit` and the dev-token mint), and AI Services (so the token can mint a
-**spend-capable** dev token for `dev:live`). The effective grant is the
-intersection with the `civitai-cli` OAuth client's `allowedScopes`, so AI
-Services takes effect only once that client is granted it server-side.
+`UserRead | AppBlocksSubmit` (== `33554433`, exactly the `civitai-cli` OAuth
+client's `allowedScopes`) — identity plus App-Blocks submit, which gates both
+`app submit` and the dev-token mint. It deliberately does **not** request
+`AIServicesWrite`: the server's device-flow scope check is all-or-nothing, so
+asking for a scope the client doesn't allow would reject the whole login. A
+login token therefore drives the **read/estimate** `dev:live` paths (estimate /
+cost preview, catalog, app storage) but **cannot spend real Buzz** — for a real
+generation use a full-scope **personal API key** (see "Auth for the dev-token
+mint" above), which carries AI Services.
 `civitai login --token <key>` stores a personal API key instead (no refresh).
 `CIVITAI_TOKEN` overrides the stored credential (treated as a personal key).
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ With no token it **fails safe** (renders a notice, never spends). Live v1 covers
 the money path (`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set,
 App-Storage KV, and in-band Buzz purchase are mock-only.
 
+**Auth for the dev-token mint.** The mint needs a credential carrying the **App
+Blocks submit** scope; **real Buzz spend additionally needs AI Services scope**
+(the server applies a uniform AI-Services ceiling — a credential without it mints
+a read/estimate-only token). The simplest credential is a full-scope **personal
+API key** (create at `civitai.com/user/account` — a personal key carries every
+scope). Alternatively `civitai login` works once the `civitai-cli` OAuth client
+is granted those scopes: `civitai login` already **requests** App Blocks submit +
+AI Services on the device flow, and the granted token mints a spend-capable dev
+token (paired with the server change that lets the dev-token endpoint accept an
+App-Blocks-submit-scoped OAuth token). Until that client config is applied, use a
+personal API key.
+
 Env vars (`VITE_BLOCK_ALLOWED_PARENT_ORIGINS`, `VITE_HARNESS_MODE`,
 `VITE_LIVE_BLOCK_TOKEN`, …) and the scenario knobs are documented in depth in the
 scaffolded project's own `README.md` and `.env.example` — see
@@ -180,9 +192,14 @@ caveat and how the vendored schema + Go checks are kept in sync.
 `civitai login` (no flags) runs the **OAuth device-authorization grant**: it
 prints a URL + a short code, you approve in your browser, and the CLI stores a
 short-lived access token (1h) plus a refresh token (30d) that it rotates
-automatically before requests and once on a `401`. `civitai login --token <key>`
-stores a personal API key instead (no refresh). `CIVITAI_TOKEN` overrides the
-stored credential (treated as a personal key).
+automatically before requests and once on a `401`. It **requests** the scopes
+`UserRead | AppBlocksSubmit | AIServicesWrite` — identity, App-Blocks submit (for
+`app submit` and the dev-token mint), and AI Services (so the token can mint a
+**spend-capable** dev token for `dev:live`). The effective grant is the
+intersection with the `civitai-cli` OAuth client's `allowedScopes`, so AI
+Services takes effect only once that client is granted it server-side.
+`civitai login --token <key>` stores a personal API key instead (no refresh).
+`CIVITAI_TOKEN` overrides the stored credential (treated as a personal key).
 
 `civitai app submit`:
 

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -24,9 +24,20 @@ const (
 	// ClientID is the public OAuth client id for the CLI.
 	ClientID = "civitai-cli"
 
-	// DeviceScope is UserRead|AppBlocksSubmit (bit flags), the fixed scope the
-	// CLI requests. 33554433 == (1<<0)|(1<<25) in the server's scope bitset.
-	DeviceScope = "33554433"
+	// DeviceScope is UserRead|AIServicesWrite|AppBlocksSubmit (bit flags), the
+	// fixed scope the CLI requests on login. 33587201 == (1<<0)|(1<<15)|(1<<25)
+	// in the server's scope bitset:
+	//   - UserRead        (1<<0  = 1)        — whoami / identity.
+	//   - AIServicesWrite (1<<15 = 32768)    — so a granted token can mint a
+	//     SPEND-capable App-Blocks dev token (dev:live real-Buzz path). The
+	//     server's dev-token mint applies a uniform AIServicesWrite ceiling on the
+	//     budgeted-spend scope, so WITHOUT this bit dev:live can only read/estimate.
+	//   - AppBlocksSubmit (1<<25 = 33554432) — `app submit` AND the dev-token mint
+	//     gate (both require this on an OAuth token).
+	// The server only grants the INTERSECTION of this request and the civitai-cli
+	// OauthClient.allowedScopes bitmask, so the effective token is capped server-
+	// side regardless of what is requested here.
+	DeviceScope = "33587201"
 
 	grantTypeDeviceCode   = "urn:ietf:params:oauth:grant-type:device_code"
 	grantTypeRefreshToken = "refresh_token"

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -24,20 +24,25 @@ const (
 	// ClientID is the public OAuth client id for the CLI.
 	ClientID = "civitai-cli"
 
-	// DeviceScope is UserRead|AIServicesWrite|AppBlocksSubmit (bit flags), the
-	// fixed scope the CLI requests on login. 33587201 == (1<<0)|(1<<15)|(1<<25)
-	// in the server's scope bitset:
+	// DeviceScope is UserRead|AppBlocksSubmit (bit flags), the fixed scope the CLI
+	// requests on login. 33554433 == (1<<0)|(1<<25) in the server's scope bitset:
 	//   - UserRead        (1<<0  = 1)        — whoami / identity.
-	//   - AIServicesWrite (1<<15 = 32768)    — so a granted token can mint a
-	//     SPEND-capable App-Blocks dev token (dev:live real-Buzz path). The
-	//     server's dev-token mint applies a uniform AIServicesWrite ceiling on the
-	//     budgeted-spend scope, so WITHOUT this bit dev:live can only read/estimate.
 	//   - AppBlocksSubmit (1<<25 = 33554432) — `app submit` AND the dev-token mint
 	//     gate (both require this on an OAuth token).
-	// The server only grants the INTERSECTION of this request and the civitai-cli
-	// OauthClient.allowedScopes bitmask, so the effective token is capped server-
-	// side regardless of what is requested here.
-	DeviceScope = "33587201"
+	// This is exactly the civitai-cli OauthClient.allowedScopes set (33554433). We
+	// deliberately do NOT request AIServicesWrite: the server's device-flow
+	// validateScope is all-or-nothing — requesting any scope the client doesn't
+	// allow REJECTS the whole login — and we don't want every login token to carry
+	// general Buzz-spend authority.
+	//
+	// What a login token can do: it can MINT an App-Blocks dev token (the mint gate
+	// only needs AppBlocksSubmit) and drive the read/estimate harness paths — cost
+	// preview / whatif, catalog browsing, and app storage. It CANNOT run a real
+	// generation: the dev-token mint applies a uniform AIServicesWrite ceiling on
+	// the budgeted-spend scope, so a login-minted dev token has ai:write:budgeted
+	// STRIPPED (read/estimate only). Real-Buzz dev:live needs a personal API key
+	// with full scope (civitai.com/user/account), which carries AIServicesWrite.
+	DeviceScope = "33554433"
 
 	grantTypeDeviceCode   = "urn:ietf:params:oauth:grant-type:device_code"
 	grantTypeRefreshToken = "refresh_token"

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -38,6 +39,39 @@ func TestStartDeviceParsesResponse(t *testing.T) {
 	}
 	if d.UserCode != "WXYZ-1234" || d.DeviceCode != "dev-secret" {
 		t.Errorf("device auth = %+v", d)
+	}
+}
+
+// TestDeviceScopeCarriesRequiredBits pins the login scope contract: `civitai
+// login` must REQUEST UserRead + AIServicesWrite + AppBlocksSubmit so a granted
+// token can (a) identify the user, (b) mint a SPEND-capable App-Blocks dev token
+// for dev:live, and (c) submit/mint via the AppBlocksSubmit-gated routes. The
+// effective grant is still capped server-side by the civitai-cli client's
+// allowedScopes, but the CLI must ASK for these or dev:live can never spend.
+func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
+	const (
+		userRead        = 1 << 0  // 1
+		aiServicesWrite = 1 << 15 // 32768
+		appBlocksSubmit = 1 << 25 // 33554432
+	)
+	got, err := strconv.Atoi(DeviceScope)
+	if err != nil {
+		t.Fatalf("DeviceScope %q is not a base-10 bitmask: %v", DeviceScope, err)
+	}
+	for _, c := range []struct {
+		name string
+		bit  int
+	}{
+		{"UserRead", userRead},
+		{"AIServicesWrite", aiServicesWrite},
+		{"AppBlocksSubmit", appBlocksSubmit},
+	} {
+		if got&c.bit == 0 {
+			t.Errorf("DeviceScope=%d is missing the %s bit (%d)", got, c.name, c.bit)
+		}
+	}
+	if want := userRead | aiServicesWrite | appBlocksSubmit; got != want {
+		t.Errorf("DeviceScope=%d, want exactly %d (UserRead|AIServicesWrite|AppBlocksSubmit)", got, want)
 	}
 }
 

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -43,11 +43,13 @@ func TestStartDeviceParsesResponse(t *testing.T) {
 }
 
 // TestDeviceScopeCarriesRequiredBits pins the login scope contract: `civitai
-// login` must REQUEST UserRead + AIServicesWrite + AppBlocksSubmit so a granted
-// token can (a) identify the user, (b) mint a SPEND-capable App-Blocks dev token
-// for dev:live, and (c) submit/mint via the AppBlocksSubmit-gated routes. The
-// effective grant is still capped server-side by the civitai-cli client's
-// allowedScopes, but the CLI must ASK for these or dev:live can never spend.
+// login` must REQUEST exactly UserRead + AppBlocksSubmit — the civitai-cli
+// client's allowedScopes set. It must NOT request AIServicesWrite: the server's
+// device-flow validateScope is all-or-nothing, so asking for a scope the client
+// doesn't allow would REJECT the whole login. A granted token can still (a)
+// identify the user, (b) MINT an App-Blocks dev token (read/estimate; the mint
+// strips ai:write:budgeted without AIServicesWrite), and (c) submit via the
+// AppBlocksSubmit-gated routes. Real-Buzz dev:live needs a personal API key.
 func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
 	const (
 		userRead        = 1 << 0  // 1
@@ -63,15 +65,19 @@ func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
 		bit  int
 	}{
 		{"UserRead", userRead},
-		{"AIServicesWrite", aiServicesWrite},
 		{"AppBlocksSubmit", appBlocksSubmit},
 	} {
 		if got&c.bit == 0 {
 			t.Errorf("DeviceScope=%d is missing the %s bit (%d)", got, c.name, c.bit)
 		}
 	}
-	if want := userRead | aiServicesWrite | appBlocksSubmit; got != want {
-		t.Errorf("DeviceScope=%d, want exactly %d (UserRead|AIServicesWrite|AppBlocksSubmit)", got, want)
+	// AIServicesWrite must be ABSENT — requesting it would break `civitai login`
+	// (the civitai-cli client does not allow it, and validateScope is all-or-nothing).
+	if got&aiServicesWrite != 0 {
+		t.Errorf("DeviceScope=%d unexpectedly includes the AIServicesWrite bit (%d) — would break login", got, aiServicesWrite)
+	}
+	if want := userRead | appBlocksSubmit; got != want {
+		t.Errorf("DeviceScope=%d, want exactly %d (UserRead|AppBlocksSubmit)", got, want)
 	}
 }
 

--- a/internal/cmd/login_device_test.go
+++ b/internal/cmd/login_device_test.go
@@ -41,10 +41,10 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 				"token_type":    "Bearer",
 				"expires_in":    3600,
 				"refresh_token": "refresh-456",
-				// Echo the login scope the CLI requests (UserRead|AIServicesWrite|
-				// AppBlocksSubmit = 33587201) so the persisted-scope assertion
-				// below reflects what `civitai login` obtains for dev:live.
-				"scope": "33587201",
+				// Echo the login scope the CLI requests (UserRead|AppBlocksSubmit
+				// = 33554433) so the persisted-scope assertion below reflects what
+				// `civitai login` obtains for the dev:live read/estimate paths.
+				"scope": "33554433",
 			})
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
@@ -97,7 +97,7 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 	if onDisk["auth_kind"] != "oauth" {
 		t.Errorf("auth_kind = %v, want oauth", onDisk["auth_kind"])
 	}
-	if onDisk["scope"] != "33587201" {
+	if onDisk["scope"] != "33554433" {
 		t.Errorf("scope = %v", onDisk["scope"])
 	}
 }

--- a/internal/cmd/login_device_test.go
+++ b/internal/cmd/login_device_test.go
@@ -41,7 +41,10 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 				"token_type":    "Bearer",
 				"expires_in":    3600,
 				"refresh_token": "refresh-456",
-				"scope":         "33554433",
+				// Echo the login scope the CLI requests (UserRead|AIServicesWrite|
+				// AppBlocksSubmit = 33587201) so the persisted-scope assertion
+				// below reflects what `civitai login` obtains for dev:live.
+				"scope": "33587201",
 			})
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
@@ -94,7 +97,7 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 	if onDisk["auth_kind"] != "oauth" {
 		t.Errorf("auth_kind = %v, want oauth", onDisk["auth_kind"])
 	}
-	if onDisk["scope"] != "33554433" {
+	if onDisk["scope"] != "33587201" {
 		t.Errorf("scope = %v", onDisk["scope"])
 	}
 }

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -56,9 +56,28 @@ protocol to the real backend using a pasted dev token (Bearer). To use it:
 
 1. Mint a short-lived dev block token via the moderator-gated endpoint
    `POST /api/v1/blocks/dev-token` (the token is a ~15-minute RS256 JWT; re-mint
-   + restart when it expires).
-2. Paste it into `.env.development` as `VITE_LIVE_BLOCK_TOKEN=` (never commit it;
-   `submit` excludes `.env.development`).
+   + restart when it expires). **Auth — the credential you mint with decides what
+   the dev token can do:**
+   - The mint needs a credential carrying the **App Blocks submit** scope. The
+     simplest is a full-scope **personal API key** (create one at
+     `https://civitai.com/user/account` — a personal key carries every scope):
+     ```bash
+     curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
+       -H "Authorization: Bearer $CIVITAI_TOKEN" \
+       -H 'Content-Type: application/json' \
+       -d '{"slug":"{{ .Slug }}"}'   # → { token, expiresAt, scopes, buzzBudget }
+     ```
+   - Or `civitai login` (the OAuth device flow) — **once the `civitai-cli` OAuth
+     client is granted the App Blocks submit + AI Services scopes** (the CLI
+     requests them on login; the client's `allowedScopes` must allow them). Until
+     that client config lands, use a personal API key.
+   - **Real Buzz spend additionally needs AI Services scope** on that credential.
+     The server applies a uniform AI-Services ceiling: a credential without it
+     mints a read/estimate-only dev token (no spend scope, no budget). A
+     full-scope personal key has it; an OAuth login has it only if the client was
+     granted AI Services and you consented.
+2. Paste the returned `token` into `.env.development` as `VITE_LIVE_BLOCK_TOKEN=`
+   (never commit it; `submit` excludes `.env.development`).
 3. `npm run dev:live` — a persistent **⚠️ LIVE HOST** banner stays on screen; a
    successful Generate spends your own real Buzz.
 

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -58,24 +58,23 @@ protocol to the real backend using a pasted dev token (Bearer). To use it:
    `POST /api/v1/blocks/dev-token` (the token is a ~15-minute RS256 JWT; re-mint
    + restart when it expires). **Auth — the credential you mint with decides what
    the dev token can do:**
-   - The mint needs a credential carrying the **App Blocks submit** scope. The
-     simplest is a full-scope **personal API key** (create one at
-     `https://civitai.com/user/account` — a personal key carries every scope):
+   - The mint needs a credential carrying the **App Blocks submit** scope.
+   - **Real generation (spends real Buzz) needs a full-scope personal API key.**
+     Create one at `https://civitai.com/user/account` (a personal key carries
+     every scope, including AI Services):
      ```bash
      curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
        -H "Authorization: Bearer $CIVITAI_TOKEN" \
        -H 'Content-Type: application/json' \
        -d '{"slug":"{{ .Slug }}"}'   # → { token, expiresAt, scopes, buzzBudget }
      ```
-   - Or `civitai login` (the OAuth device flow) — **once the `civitai-cli` OAuth
-     client is granted the App Blocks submit + AI Services scopes** (the CLI
-     requests them on login; the client's `allowedScopes` must allow them). Until
-     that client config lands, use a personal API key.
-   - **Real Buzz spend additionally needs AI Services scope** on that credential.
-     The server applies a uniform AI-Services ceiling: a credential without it
-     mints a read/estimate-only dev token (no spend scope, no budget). A
-     full-scope personal key has it; an OAuth login has it only if the client was
-     granted AI Services and you consented.
+   - **`civitai login` (the OAuth device flow) mints a read/estimate-only dev
+     token.** The `civitai-cli` client carries App Blocks submit but NOT AI
+     Services (by design — login shouldn't grant general Buzz spend). The server
+     applies a uniform AI-Services ceiling on the spend scope, so a login-minted
+     token can estimate / preview cost, browse the catalog, and use app storage,
+     but **cannot run a real generation**. For that, use the personal API key
+     above.
 2. Paste the returned `token` into `.env.development` as `VITE_LIVE_BLOCK_TOKEN=`
    (never commit it; `submit` excludes `.env.development`).
 3. `npm run dev:live` — a persistent **⚠️ LIVE HOST** banner stays on screen; a

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -31,14 +31,14 @@ VITE_HARNESS_MODE=
 # it here to run `dev:live` against the real backend. ⚠️ A real token here spends
 # REAL Buzz; it's short-lived (~15min) — never commit one.
 #
-# Mint with a credential carrying the App Blocks submit scope — simplest is a
-# full-scope PERSONAL API KEY (create at https://civitai.com/user/account):
+# For REAL generation (spends real Buzz), mint with a full-scope PERSONAL API KEY
+# (create at https://civitai.com/user/account — it carries AI Services):
 #   curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
 #     -H "Authorization: Bearer $CIVITAI_TOKEN" -H 'Content-Type: application/json' \
 #     -d '{"slug":"<your-app-slug>"}'
-# REAL Buzz spend additionally needs AI Services scope on that credential (a
-# full-scope personal key has it). `civitai login` (OAuth) also works once the
-# civitai-cli client is granted App Blocks submit + AI Services. See README.
+# `civitai login` (OAuth) mints a READ/ESTIMATE-ONLY token: the civitai-cli client
+# has App Blocks submit but NOT AI Services, so the server strips the spend scope
+# (estimate / cost preview / storage work; real generation does not). See README.
 VITE_LIVE_BLOCK_TOKEN=
 
 # LIVE mode only. The backend base URL the live host forwards to. Defaults to

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -30,6 +30,15 @@ VITE_HARNESS_MODE=
 # the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token). Paste
 # it here to run `dev:live` against the real backend. ⚠️ A real token here spends
 # REAL Buzz; it's short-lived (~15min) — never commit one.
+#
+# Mint with a credential carrying the App Blocks submit scope — simplest is a
+# full-scope PERSONAL API KEY (create at https://civitai.com/user/account):
+#   curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
+#     -H "Authorization: Bearer $CIVITAI_TOKEN" -H 'Content-Type: application/json' \
+#     -d '{"slug":"<your-app-slug>"}'
+# REAL Buzz spend additionally needs AI Services scope on that credential (a
+# full-scope personal key has it). `civitai login` (OAuth) also works once the
+# civitai-cli client is granted App Blocks submit + AI Services. See README.
 VITE_LIVE_BLOCK_TOKEN=
 
 # LIVE mode only. The backend base URL the live host forwards to. Defaults to


### PR DESCRIPTION
Pairs with civitai #2730 (merged) to unblock App Blocks `dev:live` for the `civitai login` (OAuth) flow — **Option A** (no scope widening).

## What
- `civitai login` requests scope **`33554433` = `UserRead | AppBlocksSubmit`** (the `civitai-cli` client's allowed set). It deliberately does **NOT** request `AIServicesWrite`: the server's device-flow `validateScope` is all-or-nothing, so requesting a scope the client doesn't allow would **break login**.
- A login token can **mint a read/estimate dev token** (estimate / catalog / app storage). **Real-Buzz generation in `dev:live` requires a full-scope personal API key** (which carries `AIServicesWrite`) — the dev-token mint applies a uniform `AIServicesWrite` ceiling on the spend scope. Docs/templates updated to say exactly that.

## Why Option A
Granting `civitai-cli` `AIServicesWrite` (the alternative) would broaden every login token to general Buzz spend across ~30+ generation/training procedures (bypassing the dev-token 250 cap) — too much surface for a local-testing convenience. Real-spend `dev:live` uses a personal key instead.

## Tests
`make ci` green. `TestDeviceScopeCarriesRequiredBits` asserts the scope is exactly `33554433`, includes `UserRead`+`AppBlocksSubmit`, and **explicitly that `AIServicesWrite` is absent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)