### PR TITLE
fix(dev:live): retry transient poll errors instead of failing the workflow

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -71,7 +71,7 @@ func TestRenderPageMoney(t *testing.T) {
 	for _, expect := range []string{
 		"block.manifest.json", "package.json", "vite.config.ts", "tsconfig.json", "index.html",
 		"src/main.tsx", "src/App.tsx", "src/Harness.tsx", "src/generation.ts",
-		"src/generation.test.ts", "src/index.css",
+		"src/generation.test.ts", "src/App.pollretry.test.tsx", "src/index.css",
 		"README.md", ".gitignore", ".env.development", ".env.production", ".env.example",
 	} {
 		if !containsStr(got, expect) {
@@ -110,6 +110,11 @@ func TestRenderPageMoney(t *testing.T) {
 	if contains(app, "window.parent.postMessage") {
 		t.Error("page-money App.tsx should not use raw window.parent.postMessage")
 	}
+	// The poll loop must retry transient transport errors (a throw), not turn
+	// them into a terminal failure — guards the round-5 dogfood regression where
+	// a poll blip marked a server-side SUCCESS as FAILED.
+	mustContain(t, app, "MAX_TRANSIENT_ERRORS")
+	mustContain(t, app, "consecutiveErrors")
 
 	// The display name should land in the manifest + App heading.
 	mustContain(t, manifest, `"name": "Money Block"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -149,6 +149,10 @@ npm run build         # what the platform produces (tsc typecheck + vite build)
   estimate → consent → submit → poll → succeeded flow through the REAL SDK
   transport against the mock host (no hook mocking). This is what tells you the
   spend wiring still works after you edit the app.
+- **`src/App.pollretry.test.tsx`** — poll-loop robustness: a transient poll
+  error (a transport blip, e.g. a not-yet-rolled-out pod) is retried, not turned
+  into a terminal failure, while a genuine `failed` status stays terminal. Keep
+  this if you customize `runPollLoop`.
 
 ## Allowed parent origins
 

--- a/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
+
+// Robustness regression for the poll loop's TRANSIENT-error handling: a poll
+// that THROWS (a transport/infra blip — a network hiccup, a not-yet-rolled-out
+// backend pod 401ing) must be RETRIED, not turned into a terminal `failed`.
+// The round-5 dogfood bug: a single bad poll marked a server-side SUCCESS as
+// FAILED and stopped the loop.
+//
+// We mock `@civitai/blocks-react` with minimal hook stubs so we control exactly
+// what `poll()` does (throw N times, then resolve `succeeded`), and drive the
+// App through estimate -> submit -> poll against those stubs. `submit` returns a
+// non-terminal `processing` snapshot so the App enters the poll loop.
+
+const pollFn = vi.fn<(workflowId: string) => Promise<BlockWorkflowSnapshot>>();
+const submitFn = vi.fn<() => Promise<BlockWorkflowSnapshot>>();
+const estimateFn = vi.fn<() => Promise<BlockWorkflowSnapshot>>();
+
+vi.mock('@civitai/blocks-react', () => ({
+  useBlockContext: () => ({ ready: true, viewer: { id: 2, username: 'dev' }, theme: 'dark' }),
+  useBlockResize: () => {},
+  useBlockToken: () => ({ scopes: ['ai:write:budgeted'], raw: 't', expiresAt: '' }),
+  useBuzzWorkflow: () => ({ estimate: estimateFn, submit: submitFn, poll: pollFn }),
+  useRequestConsent: () => ({ requestConsent: vi.fn() }),
+  useRequestSignIn: () => ({ requestSignIn: vi.fn() }),
+}));
+
+// Imported AFTER the mock is registered.
+const { App } = await import('./App.js');
+
+const snap = (over: Partial<BlockWorkflowSnapshot>): BlockWorkflowSnapshot => ({
+  workflowId: 'wf_1',
+  status: 'processing',
+  ...over,
+});
+
+async function clickGenerate() {
+  const user = userEvent.setup();
+  render(<App />);
+  const generate = await screen.findByTestId('pm-generate');
+  await user.type(screen.getByLabelText(/generation prompt/i), 'a serene mountain lake');
+  await user.click(generate);
+}
+
+describe('App poll loop — transient-error robustness', () => {
+  afterEach(() => {
+    pollFn.mockReset();
+    submitFn.mockReset();
+    estimateFn.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('a transient poll THROW mid-loop → retries and completes on the next success (NOT failed)', async () => {
+    estimateFn.mockResolvedValue(snap({ status: 'processing', cost: { total: 8 } }));
+    submitFn.mockResolvedValue(snap({ status: 'processing' }));
+    // First poll throws (transport blip), second poll succeeds.
+    pollFn
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValueOnce(
+        snap({ status: 'succeeded', cost: { total: 8 }, imageUrls: ['https://img.test/ok.png'] }),
+      );
+
+    await clickGenerate();
+
+    // The loop retries the throw (500ms backoff) and then renders the SUCCESS.
+    const result = await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
+    expect(result).toHaveAttribute('src', 'https://img.test/ok.png');
+    // It retried exactly once before succeeding; never showed an error.
+    expect(pollFn).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('a GENUINE failed STATUS (a snapshot, not a throw) → terminal failure', async () => {
+    estimateFn.mockResolvedValue(snap({ status: 'processing' }));
+    submitFn.mockResolvedValue(snap({ status: 'processing' }));
+    pollFn.mockResolvedValueOnce(
+      snap({ status: 'failed', error: 'NSFW prompt rejected by audit' }),
+    );
+
+    await clickGenerate();
+
+    const alert = await screen.findByRole('alert', {}, { timeout: 5000 });
+    expect(alert).toHaveTextContent(/NSFW prompt rejected/i);
+    expect(pollFn).toHaveBeenCalledTimes(1); // a real failed status is not retried
+    expect(screen.queryByAltText(/generated result/i)).not.toBeInTheDocument();
+  });
+});

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -96,6 +96,17 @@ export function App() {
   /**
    * Drive a single workflow to terminal with an adaptive-backoff poll loop.
    * `submit()` does NOT auto-poll (SDK contract) — the caller owns the loop.
+   *
+   * Robustness contract: a `poll()` THROW is a transport/infra blip (a network
+   * hiccup, a not-yet-rolled-out backend pod 401ing for a few seconds, …) — NOT
+   * a workflow failure. A workflow that the orchestrator actually failed comes
+   * back as a 'failed'/'expired'/'canceled' SNAPSHOT, never a throw. So we retry
+   * a throw with bounded backoff instead of failing the generation (which would
+   * mark a server-side SUCCESS as FAILED — the round-5 dogfood bug). Only after
+   * MAX_TRANSIENT_ERRORS consecutive failures (the backend is genuinely
+   * unreachable, not just blipping) do we give up with a clear transport error.
+   * The error counter resets on any successful poll, so a long generation that
+   * hits the occasional blip never accumulates toward the cap.
    */
   const runPollLoop = useCallback(
     (workflowId: string) => {
@@ -103,8 +114,16 @@ export function App() {
       const tok = { cancelled: false };
       pollCancelRef.current = tok;
 
+      // Backoff between normal (snapshot-returning) polls.
       const SCHEDULE_MS = [2000, 2000, 3000, 5000, 8000];
+      // Shorter backoff between retries of a transient transport error, so a
+      // brief blip recovers fast.
+      const RETRY_MS = [500, 1000, 2000, 4000];
+      // Give up only after this many CONSECUTIVE transport failures (~30s of
+      // retries) — a genuinely-down backend, not a transient blip.
+      const MAX_TRANSIENT_ERRORS = 8;
       let attempt = 0;
+      let consecutiveErrors = 0;
 
       const tick = async () => {
         if (tok.cancelled) return;
@@ -112,15 +131,27 @@ export function App() {
         try {
           snap = await pollRef.current(workflowId);
         } catch {
-          // Transient hiccup — keep polling. A real terminal failure surfaces
-          // as a 'failed'/'expired' snapshot, not a throw.
+          // Transient hiccup — retry with bounded backoff. A real terminal
+          // failure surfaces as a 'failed'/'expired' snapshot, not a throw.
           if (tok.cancelled) return;
-          const delay = SCHEDULE_MS[Math.min(attempt, SCHEDULE_MS.length - 1)];
-          attempt += 1;
+          consecutiveErrors += 1;
+          if (consecutiveErrors > MAX_TRANSIENT_ERRORS) {
+            // Backend unreachable after repeated retries — surface a transport
+            // error (distinct from a workflow failure) and stop.
+            setPhase('failed');
+            setError(
+              "Couldn't reach the generation service after several retries. " +
+                'Your generation may still be running — refresh to check.',
+            );
+            return;
+          }
+          const delay = RETRY_MS[Math.min(consecutiveErrors - 1, RETRY_MS.length - 1)];
           setTimeout(tick, delay);
           return;
         }
         if (tok.cancelled) return;
+        // A successful poll clears the transient-error streak.
+        consecutiveErrors = 0;
         applySnapshot(snap);
         if (isTerminalStatus(snap.status)) return;
         const delay = SCHEDULE_MS[Math.min(attempt, SCHEDULE_MS.length - 1)];


### PR DESCRIPTION
## Problem

The page-money scaffold's `runPollLoop` (`internal/scaffold/templates/page-money/src/App.tsx.tmpl`) is meant to retry a transient poll error and only fail on a real terminal `failed` status. Two gaps:

1. **The deeper bug is one layer down** (fixed in the sibling `civitai/civitai-app-starters` PR #63): the `dev:live` host turned a transport blip into a fabricated terminal `failed` snapshot, so the scaffold loop never even saw a throw to retry — it saw `failed` and stopped. This is the round-5 dogfood bug: a poll blip (a not-yet-rolled-out pod) marked a **server-side SUCCESS as FAILED**.
2. The scaffold's own throw-retry was **unbounded** — a genuinely-down backend would spin forever.

## Fix

`runPollLoop` now retries a transient poll **throw** with bounded backoff (`RETRY_MS = [500, 1000, 2000, 4000]`) and a consecutive-error cap (`MAX_TRANSIENT_ERRORS = 8`, ~30s). Only a genuinely-unreachable backend gives up — with a clear transport-error message distinct from a workflow failure ("Couldn't reach the generation service… your generation may still be running"). The error streak **resets on any successful poll**, so a long generation that hits the occasional blip never accumulates toward the cap. A real terminal `failed`/`expired`/`canceled` **snapshot** still stops the loop immediately; the success and insufficient-Buzz paths are untouched.

## Retry policy

Per-throw backoff 500ms → 1s → 2s → 4s (capped), give up after 8 consecutive failures. Resets to 0 on any snapshot-returning poll.

## Tests

New `src/App.pollretry.test.tsx` (shipped to generated projects) mocks `useBuzzWorkflow` so `poll()` is controllable:

- a transient poll **throw** mid-loop → retries and completes on the next success (**NOT** failed), exactly one retry, no error UI;
- a genuine `failed` STATUS (a snapshot, not a throw) → terminal failure, not retried.

Verified end-to-end by scaffolding a real `page-money` project and running `npm test` (**16 passing**) + `tsc --noEmit` (clean). `TestRenderPageMoney` now asserts the new test file renders and the retry logic (`MAX_TRANSIENT_ERRORS` / `consecutiveErrors`) is present, so the fix is regression-guarded at the Go layer too.

## CI

`make ci` (tidy + vet + `go test ./...` + build): **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)