### PR TITLE
docs(readme): OAuth/CLI can't mint a personal key (apiKey.add 403)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,13 @@ storage; no real generation).
   real generation does NOT work**. (A paired civitai server change grants
   `user:read:self` so the viewer resolves cleanly; until it lands OAuth dev:live
   is limited.) For real generation/spend use a full-scope **personal API key**.
-- **Personal API key (full scope) → real generation/spend.** Create one at
-  `civitai.com/user/account`; a personal key carries every scope (including AI
-  Services), so its minted dev token spends real Buzz. Paste it as
-  `VITE_LIVE_BLOCK_TOKEN` for a `dev:live` session that actually generates.
+- **Personal API key (full scope) → real generation/spend.** Create one **in the
+  web UI** at `civitai.com/user/account` — you can't mint a personal key over
+  OAuth or the CLI (`apiKey.add` returns 403 without a full-scope session), so an
+  OAuth-only dev must visit the web UI for a real-spend `dev:live`. A personal key
+  carries every scope (including AI Services), so its minted dev token spends real
+  Buzz. Paste it as `VITE_LIVE_BLOCK_TOKEN` for a `dev:live` session that actually
+  generates.
 
 Env vars (`VITE_BLOCK_ALLOWED_PARENT_ORIGINS`, `VITE_HARNESS_MODE`,
 `VITE_LIVE_BLOCK_TOKEN`, …) and the scenario knobs are documented in depth in the


### PR DESCRIPTION
Closes the last open README note from the App Blocks CLI `dev:live` arc.

The README already documents that real-spend `dev:live` needs a full-scope **personal API key** created at `civitai.com/user/account`. This adds the one missing footgun: you **can't mint a personal key over OAuth or the CLI** — `apiKey.add` returns 403 without a full-scope session — so an OAuth-only dev must use the web UI. Without this, OAuth devs hit an opaque 403 trying to script key creation.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)