### PR TITLE
fix(scaffold): inline favicon to kill the dev /favicon.ico 404

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,10 +61,10 @@ changelog:
       - "^chore:"
 
 # Homebrew tap (cask). goreleaser v2 replaced `brews:` with `homebrew_casks:`.
-# DISABLED for the binaries-only v0.1.0 release: the `civitai/homebrew-tap` repo
-# is still private and no HOMEBREW_TAP_GITHUB_TOKEN secret is set, so a release
-# with this block enabled would fail at the formula-push step. To re-enable:
-#   1. make `civitai/homebrew-tap` public (after its own secret audit),
+# DISABLED: `civitai/homebrew-tap` is now PUBLIC (audited clean 2026-06-23), but
+# the HOMEBREW_TAP_GITHUB_TOKEN repo secret is still unset, so a release with this
+# block enabled would fail at the formula-push step. ONE step remains to re-enable:
+#   1. (DONE) make `civitai/homebrew-tap` public.
 #   2. set the HOMEBREW_TAP_GITHUB_TOKEN repo secret (PAT w/ write to the tap),
 #   3. uncomment this block + restore the `brew install` line in README.md,
 #   4. cut the next tag.

--- a/internal/scaffold/templates/page-money/index.html.tmpl
+++ b/internal/scaffold/templates/page-money/index.html.tmpl
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <title>{{ .Name }} — Civitai App</title>
   </head>
   <body>

--- a/internal/scaffold/templates/page-vite/index.html.tmpl
+++ b/internal/scaffold/templates/page-vite/index.html.tmpl
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <title>{{ .Name }}</title>
   </head>
   <body>

--- a/internal/scaffold/templates/static/index.html.tmpl
+++ b/internal/scaffold/templates/static/index.html.tmpl
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ .Name }}</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>


### PR DESCRIPTION
Scaffold templates (page-money, page-vite, static) shipped no favicon, so the dev server logged a `/favicon.ico` 404 in the console. Adds an inline data-URI SVG icon to each `<head>` — no extra file, no network request, no 404.

Also updates the goreleaser Homebrew comment to reflect that `civitai/homebrew-tap` is now **public** (audited clean); only the `HOMEBREW_TAP_GITHUB_TOKEN` secret remains before `brew install` can ship.

Build + full `go test ./...` green. Cosmetic scaffold change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)