### PR TITLE
docs/help: warn OAuth can't spend in dev:live (#23) + dev:live needs an approved+deployed app (#22 docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ hosts) with two modes:
 | `npm run dev:harness` | **mock** (default) | Mounts the SDK **mock host** — synthetic replies, **no real Buzz, no compute, no network.** Safe to spam; drive money/error/insufficient-Buzz UX via on-screen scenarios or `?` URL params. Start here. |
 | `npm run dev:live` | **live** | Mounts the SDK **live host** (`createLiveHost`) — forwards the App-Block protocol to the **real Civitai backend** with a pasted dev token (Bearer). **Spends REAL Buzz / real compute.** |
 
+> ⚠️ **`dev:live` needs an approved + deployed app.** It talks to a **deployed
+> block instance**, so the dev-token mint only succeeds once the app is approved
+> and deployed (deployState `live`). A brand-new app — even right after a
+> successful `civitai app submit` (status `pending`) — gets `App not found`. You
+> **can't `dev:live`-test your own first app before its first approval + deploy**;
+> validate with `dev:harness` (mock) until your first version is live.
+
 **Live mode** needs a short-lived dev block token (mint via the moderator-gated
 `POST /api/v1/blocks/dev-token`), pasted into `.env.development` as
 `VITE_LIVE_BLOCK_TOKEN=` (never committed — `submit` excludes `.env.development`).

--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -39,7 +39,11 @@ blockId. A slug-shaped name is used verbatim.
 
 By default the project is created in ./<slug>. Override the output directory with
 a positional [dir] or --dir <path>; override the display name independently with
---name (so name, slug, and directory can all differ).`,
+--name (so name, slug, and directory can all differ).
+
+Note: ` + "`civitai login`" + ` (OAuth) grants submit but NOT Buzz-spend. To run
+` + "`dev:live`" + ` real generations, authenticate with a full-scope personal API key
+(` + "`civitai login --token <key>`" + `, created at https://civitai.com/user/account).`,
 		Example: `  # A page-money block in ./my-block (the batteries-included default).
   civitai app create my-block
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -31,7 +31,11 @@ OAuth tokens that refresh automatically.
 Alternatively, pass --token to store a personal API key created at
 https://civitai.com/user/account (API Keys). Either way the credential is saved
 to your config file (~/.config/civitai/config.yaml, owner-readable only). The
-CIVITAI_TOKEN environment variable still overrides the stored credential.`,
+CIVITAI_TOKEN environment variable still overrides the stored credential.
+
+Note: ` + "`civitai login`" + ` (OAuth) grants submit but NOT Buzz-spend. To run
+` + "`dev:live`" + ` real generations, authenticate with a full-scope personal API key
+(` + "`civitai login --token <key>`" + `, created at https://civitai.com/user/account).`,
 		Example: `  civitai login                 # browser device login (recommended)
   civitai login --no-browser    # device login without auto-opening a browser
   civitai login --token <token> # store a personal API key instead`,

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -63,7 +63,19 @@ and (2) be rejected by civitai's tRPC origin gate ("Please use the public API
 instead"). The same-origin proxy + Origin rewrite fixes both. Override the proxy
 target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 
-**Live mode setup.** To use it:
+**Live mode setup.**
+
+> ⚠️ **Prerequisite — `dev:live` needs an approved + DEPLOYED app.** `dev:live`
+> talks to a **deployed block instance**, so the dev-token mint
+> (`POST /api/v1/blocks/dev-token`) only succeeds once **this app is approved and
+> deployed** (deployState `live`). For a brand-new app — even right after a
+> successful `civitai app submit` (status `pending`) — the mint returns
+> **`App not found`**. That's expected: you **cannot `dev:live`-test your own
+> first app before its first approval + deploy**. Until your first version is
+> live, validate everything with `dev:harness` (the mock host — no real Buzz, no
+> network). Once the app is live, come back here for real-spend testing.
+
+To use it:
 
 1. Mint a short-lived dev block token via the moderator-gated endpoint
    `POST /api/v1/blocks/dev-token` (the token is a ~15-minute RS256 JWT; re-mint


### PR DESCRIPTION
Two documented DX gaps in the App Blocks authoring flow, both surfaced at point-of-use.

## #23 — CLI `--help` doesn't warn OAuth can't spend in `dev:live`
The README already documents that the default `civitai login` (OAuth) flow grants submit but **not** Buzz-spend, so it can't drive real `dev:live` generations — but the CLI's own `--help`, the first surface a newcomer reads, did not. Added a concise note (matching the existing tone) to the `Long` help text of **both** `login` and `app create`, pointing OAuth users at a full-scope personal API key (`civitai login --token <key>`, created at civitai.com/user/account) for real `dev:live` generations.

Verified both render:
```
Note: `civitai login` (OAuth) grants submit but NOT Buzz-spend. To run
`dev:live` real generations, authenticate with a full-scope personal API key
(`civitai login --token <key>`, created at https://civitai.com/user/account).
```

## #22 (docs half) — `dev:live` hard-fails for a brand-new app
`dev:live` talks to a **deployed** block instance, so the dev-token mint (`POST /api/v1/blocks/dev-token`) only succeeds once the app is **approved + deployed** (deployState `live`). A brand-new app — even right after a successful `civitai app submit` (status `pending`) — gets `App not found`. You therefore **cannot** `dev:live`-test your own first app before its first approval + deploy.

Documented this prerequisite where the lifecycle is described so the docs no longer imply otherwise:
- `internal/scaffold/templates/page-money/README.md.tmpl` — a clear PREREQUISITE callout at the top of the **Live mode setup** section (and steers you to `dev:harness` until your first version is live).
- `README.md` — the same one-line caveat in the **Local dev loop (harness: mock vs live)** section.

## Verification
- `go build ./...` — passes
- `go test ./...` — passes (182 tests). No golden/snapshot updates needed; the `--help` tests assert substrings (`Contains`), not exact text.

Closes #23
Addresses #22 (scaffold-README / CLI-README docs half; the server-side error-message fix is a separate civitai PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)