### PR TITLE
fix(submit): scope a longer 120s timeout to the upload, not fast calls

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,10 +19,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -52,9 +55,12 @@ func (s StaticToken) Token(context.Context) (string, error) { return string(s), 
 // Refresh always fails: a personal key has no refresh path.
 func (s StaticToken) Refresh(context.Context) (string, error) { return "", ErrNoRefresh }
 
-// Submitter submits a packaged bundle and returns the server's response.
+// Submitter submits a packaged bundle and returns the server's response. The
+// slug + version identify the submission so that, if the upload's response is
+// lost to a timeout, the submit path can poll for a landed submission and
+// recover rather than reporting a false failure (see SubmitVersion).
 type Submitter interface {
-	SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitResult, error)
+	SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string) (*SubmitResult, error)
 }
 
 // Verifier verifies a token and returns the authenticated identity.
@@ -133,6 +139,14 @@ type Client struct {
 	Tokens     TokenSource
 	SubmitPath string // route for submit-version; CIVITAI_SUBMIT_PATH overrides
 	HTTP       *http.Client
+	// SubmitTimeout overrides the submit-upload timeout when non-zero; it
+	// defaults to submitTimeout. Used by tests to exercise the timeout-recovery
+	// path without a real slow upload.
+	SubmitTimeout time.Duration
+	// SubmitPollDelay overrides the inter-attempt delay of the post-timeout
+	// recovery poll when set (>= 0 with the zero value meaning "use the
+	// default"); tests set it to 0 to avoid sleeping.
+	SubmitPollDelay *time.Duration
 }
 
 // New builds a Client with sane defaults from a static token (personal API key
@@ -218,8 +232,12 @@ func (c *Client) submitClient() *http.Client {
 	if base == nil {
 		base = &http.Client{}
 	}
+	timeout := submitTimeout
+	if c.SubmitTimeout > 0 {
+		timeout = c.SubmitTimeout
+	}
 	return &http.Client{
-		Timeout:       submitTimeout,
+		Timeout:       timeout,
 		Transport:     base.Transport,
 		CheckRedirect: base.CheckRedirect,
 		Jar:           base.Jar,
@@ -228,7 +246,18 @@ func (c *Client) submitClient() *http.Client {
 
 // SubmitVersion uploads the bundle to the token-authenticated submit route,
 // refreshing the OAuth access token transparently if needed.
-func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitResult, error) {
+//
+// The upload can complete server-side while its HTTP response is slow or never
+// arrives within the timeout — observed in the wild as a false "context
+// deadline exceeded" failure on a submit that had actually landed, leaving the
+// user to retry into "you already have a pending submission". So when (and only
+// when) the POST fails with a timeout / deadline-exceeded / no-response error
+// (as opposed to a clean HTTP error status), this polls
+// GET /api/v1/blocks/submissions for a submission matching slug+version and, if
+// one is now present, reports it as a success — surfacing the pubreq id. If no
+// matching submission is found, it returns a clear error telling the user to
+// check `civitai app status` before resubmitting.
+func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string) (*SubmitResult, error) {
 	body, err := json.Marshal(submitBody{
 		BundleBase64: base64.StdEncoding.EncodeToString(zipBytes),
 	})
@@ -245,6 +274,9 @@ func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitRes
 	}
 	status, raw, err := c.authedDoWith(ctx, c.submitClient(), build)
 	if err != nil {
+		if isTimeoutErr(err) {
+			return c.recoverTimedOutSubmit(ctx, slug, version, err)
+		}
 		return nil, err
 	}
 	if status != http.StatusOK {
@@ -255,6 +287,96 @@ func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitRes
 		return nil, fmt.Errorf("unexpected response (status %d): %s", status, string(raw))
 	}
 	return &out, nil
+}
+
+// isTimeoutErr reports whether err is a request timeout / deadline-exceeded /
+// no-response condition (as opposed to a clean HTTP error response). It matches
+// context.DeadlineExceeded, os timeouts, and any net.Error whose Timeout() is
+// true (which is what http.Client.Timeout surfaces when awaiting headers).
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+// submitPollAttempts / submitPollDelay bound the post-timeout recovery poll:
+// the submission may take a moment to become visible after the upload lands, so
+// poll a few times with a short delay rather than just once.
+const (
+	submitPollAttempts = 3
+	submitPollDelay    = 2 * time.Second
+)
+
+// recoverTimedOutSubmit is called only after a submit POST timed out. It polls
+// the submissions list for a row matching slug+version; if found it reports a
+// success (the submit landed), otherwise a clear error citing the original
+// timeout and pointing at `civitai app status`.
+func (c *Client) recoverTimedOutSubmit(ctx context.Context, slug, version string, cause error) (*SubmitResult, error) {
+	delay := submitPollDelay
+	if c.SubmitPollDelay != nil {
+		delay = *c.SubmitPollDelay
+	}
+	for attempt := 0; attempt < submitPollAttempts; attempt++ {
+		if attempt > 0 && delay > 0 {
+			t := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return nil, timedOutSubmitError(slug, cause)
+			case <-t.C:
+			}
+		}
+		subs, err := c.ListSubmissions(ctx, slug)
+		if err != nil {
+			// The poll itself failed; keep trying within the bound.
+			continue
+		}
+		if sub := latestMatchingSubmission(subs, slug, version); sub != nil {
+			return &SubmitResult{
+				PublishRequestID: sub.ID,
+				Slug:             sub.BlockID,
+				Version:          sub.Version,
+				Status:           sub.Status,
+			}, nil
+		}
+	}
+	return nil, timedOutSubmitError(slug, cause)
+}
+
+// latestMatchingSubmission returns the first submission matching slug+version in
+// a non-terminal (pending/submitted) state, falling back to any slug+version
+// match. Submissions are returned newest-first, so the first match is latest.
+func latestMatchingSubmission(subs []Submission, slug, version string) *Submission {
+	var anyMatch *Submission
+	for i := range subs {
+		s := &subs[i]
+		if s.BlockID != slug || s.Version != version {
+			continue
+		}
+		switch strings.ToLower(s.Status) {
+		case "pending", "submitted":
+			return s
+		}
+		if anyMatch == nil {
+			anyMatch = s
+		}
+	}
+	return anyMatch
+}
+
+// timedOutSubmitError builds the actionable error returned when a submit timed
+// out and no matching submission could be confirmed afterwards.
+func timedOutSubmitError(slug string, cause error) error {
+	return fmt.Errorf("submit timed out and the upload may not have completed (%v) — "+
+		"run `civitai app status %s` to check whether it landed before resubmitting", cause, slug)
 }
 
 // WhoAmI verifies the token against /api/v1/me, refreshing the OAuth access

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -110,6 +110,19 @@ type SubmitResult struct {
 // DefaultSubmitPath is the token-authenticated submit-version route.
 const DefaultSubmitPath = "/api/v1/blocks/submit-version"
 
+// defaultTimeout governs the fast, interactive calls (whoami, submissions).
+// Kept short so a hung connection surfaces quickly.
+const defaultTimeout = 30 * time.Second
+
+// submitTimeout governs the submit-version upload specifically. A submit
+// uploads a multi-file base64 ZIP and then waits for server-side processing
+// (publish-request creation), which can take well over the fast-call timeout.
+// A short timeout here produced a FALSE failure ("context deadline exceeded")
+// on submits that had actually succeeded server-side, so the user's retry hit
+// "you already have a pending submission". Scope this longer window to submit
+// only — do NOT lengthen the fast calls.
+const submitTimeout = 120 * time.Second
+
 // SubmissionsPath is the token-authenticated, self-scoped submission-status
 // route (GET; civitai/civitai src/pages/api/v1/blocks/submissions.ts).
 const SubmissionsPath = "/api/v1/blocks/submissions"
@@ -138,7 +151,7 @@ func NewWithSource(baseURL string, src TokenSource, submitPath string) *Client {
 		BaseURL:    strings.TrimRight(baseURL, "/"),
 		Tokens:     src,
 		SubmitPath: submitPath,
-		HTTP:       &http.Client{Timeout: 120 * time.Second},
+		HTTP:       &http.Client{Timeout: defaultTimeout},
 	}
 }
 
@@ -147,11 +160,18 @@ func NewWithSource(baseURL string, src TokenSource, submitPath string) *Client {
 // refreshing once on a 401 and retrying. The returned response body is fully
 // read into raw and the response is closed.
 func (c *Client) authedDo(ctx context.Context, build func() (*http.Request, error)) (int, []byte, error) {
+	return c.authedDoWith(ctx, c.HTTP, build)
+}
+
+// authedDoWith is authedDo against a specific *http.Client, so a slow call
+// (the submit upload) can use a longer-timeout client without affecting the
+// fast, interactive calls that share c.HTTP.
+func (c *Client) authedDoWith(ctx context.Context, httpClient *http.Client, build func() (*http.Request, error)) (int, []byte, error) {
 	token, err := c.Tokens.Token(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
-	status, raw, err := c.doOnce(ctx, build, token)
+	status, raw, err := c.doOnceWith(httpClient, build, token)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -160,13 +180,13 @@ func (c *Client) authedDo(ctx context.Context, build func() (*http.Request, erro
 		// ErrNoRefresh and we keep the original 401.
 		newTok, rerr := c.Tokens.Refresh(ctx)
 		if rerr == nil && newTok != "" {
-			return c.doOnce(ctx, build, newTok)
+			return c.doOnceWith(httpClient, build, newTok)
 		}
 	}
 	return status, raw, nil
 }
 
-func (c *Client) doOnce(ctx context.Context, build func() (*http.Request, error), token string) (int, []byte, error) {
+func (c *Client) doOnceWith(httpClient *http.Client, build func() (*http.Request, error), token string) (int, []byte, error) {
 	req, err := build()
 	if err != nil {
 		return 0, nil, err
@@ -174,7 +194,7 @@ func (c *Client) doOnce(ctx context.Context, build func() (*http.Request, error)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := c.HTTP.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -186,6 +206,24 @@ func (c *Client) doOnce(ctx context.Context, build func() (*http.Request, error)
 // submitBody mirrors submitVersionSchema: a base64-encoded ZIP.
 type submitBody struct {
 	BundleBase64 string `json:"bundleBase64"`
+}
+
+// submitClient returns an *http.Client for the submit upload: it mirrors the
+// shared client's Transport but uses the longer submitTimeout, so the slow
+// upload + server-side processing doesn't trip the short fast-call timeout
+// (which caused false "context deadline exceeded" failures on submits that had
+// already succeeded). If no shared client is set, a zero Client is used.
+func (c *Client) submitClient() *http.Client {
+	base := c.HTTP
+	if base == nil {
+		base = &http.Client{}
+	}
+	return &http.Client{
+		Timeout:       submitTimeout,
+		Transport:     base.Transport,
+		CheckRedirect: base.CheckRedirect,
+		Jar:           base.Jar,
+	}
 }
 
 // SubmitVersion uploads the bundle to the token-authenticated submit route,
@@ -205,7 +243,7 @@ func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte) (*SubmitRes
 		req.Header.Set("Content-Type", "application/json")
 		return req, nil
 	}
-	status, raw, err := c.authedDo(ctx, build)
+	status, raw, err := c.authedDoWith(ctx, c.submitClient(), build)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/api_extra_test.go
+++ b/internal/api/api_extra_test.go
@@ -34,7 +34,7 @@ func TestSubmitVersionStatusErrors(t *testing.T) {
 			_, _ = w.Write([]byte(`{"error":"boom"}`))
 		}))
 		c := New(srv.URL, "tok", "")
-		_, err := c.SubmitVersion(context.Background(), []byte("z"))
+		_, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0")
 		srv.Close()
 		if err == nil {
 			t.Errorf("status %d: expected error", tc.status)
@@ -52,7 +52,7 @@ func TestSubmitVersionGarbageResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	if _, err := c.SubmitVersion(context.Background(), []byte("z")); err == nil {
+	if _, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0"); err == nil {
 		t.Fatal("expected error for non-JSON 200 response")
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -9,7 +9,35 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestSubmitTimeoutIsLongAndScoped pins the F6 fix: the submit upload gets a
+// substantially longer timeout than the fast, interactive calls, scoped to the
+// submit client only. A short shared timeout previously produced false
+// "context deadline exceeded" failures on submits that had already succeeded
+// server-side, so the user's retry hit "you already have a pending submission".
+func TestSubmitTimeoutIsLongAndScoped(t *testing.T) {
+	if submitTimeout != 120*time.Second {
+		t.Errorf("submitTimeout = %v, want 120s", submitTimeout)
+	}
+	if defaultTimeout != 30*time.Second {
+		t.Errorf("defaultTimeout = %v, want 30s", defaultTimeout)
+	}
+	if submitTimeout <= defaultTimeout {
+		t.Errorf("submit timeout (%v) must exceed the fast-call timeout (%v)", submitTimeout, defaultTimeout)
+	}
+
+	c := New("https://example.com", "tok", "")
+	// The shared client stays on the short fast-call timeout...
+	if c.HTTP.Timeout != defaultTimeout {
+		t.Errorf("shared client timeout = %v, want %v (fast calls must not be lengthened)", c.HTTP.Timeout, defaultTimeout)
+	}
+	// ...while the submit client uses the long timeout.
+	if got := c.submitClient().Timeout; got != submitTimeout {
+		t.Errorf("submit client timeout = %v, want %v", got, submitTimeout)
+	}
+}
 
 func TestSubmitVersionSendsBearerAndBase64(t *testing.T) {
 	var gotAuth, gotBody string

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -55,7 +55,7 @@ func TestSubmitVersionSendsBearerAndBase64(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok123", "/api/blocks/submit-version")
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIPDATA"))
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIPDATA"), "my-block", "0.1.0")
 	if err != nil {
 		t.Fatalf("SubmitVersion: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSubmitVersionSurfacesServerMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok", "")
-	_, err := c.SubmitVersion(context.Background(), []byte("x"))
+	_, err := c.SubmitVersion(context.Background(), []byte("x"), "my-block", "0.1.0")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/api/client_refresh_test.go
+++ b/internal/api/client_refresh_test.go
@@ -95,7 +95,7 @@ func TestSubmitVersionUsesV1RouteAndRefreshes(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok", "")
-	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP")); err != nil {
+	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.1.0"); err != nil {
 		t.Fatalf("SubmitVersion: %v", err)
 	}
 	if path != DefaultSubmitPath {

--- a/internal/api/submit_recover_test.go
+++ b/internal/api/submit_recover_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newRecoverServer returns an httptest server that hangs on the submit POST
+// (forcing the client's short SubmitTimeout to fire as a net.Error timeout)
+// and answers GET /api/v1/blocks/submissions with whatever submissions is set
+// to at request time. release is closed on cleanup so the hung handler returns.
+func newRecoverServer(t *testing.T, submissions func() []Submission) (*httptest.Server, *int32) {
+	t.Helper()
+	release := make(chan struct{})
+	var listCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "submit-version"):
+			// Hang past the submit client's timeout, then unblock on teardown.
+			<-release
+		case r.Method == http.MethodGet && r.URL.Path == SubmissionsPath:
+			atomic.AddInt32(&listCalls, 1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"submissions": submissions()})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	return srv, &listCalls
+}
+
+func recoverClient(url string) *Client {
+	c := New(url, "tok", "")
+	c.SubmitTimeout = 50 * time.Millisecond // force a fast timeout on the hung POST
+	zero := time.Duration(0)
+	c.SubmitPollDelay = &zero // don't sleep between poll attempts in tests
+	return c
+}
+
+// TestSubmitVersionRecoversWhenSubmissionLanded pins the F6 root-cause fix: the
+// submit POST times out (response lost) but the submission actually landed, so
+// SubmitVersion polls /submissions, finds the pending row, and reports SUCCESS
+// surfacing the pubreq id rather than a false failure.
+func TestSubmitVersionRecoversWhenSubmissionLanded(t *testing.T) {
+	landed := Submission{
+		ID:      "pubreq_01KVY45JGYSAXK7DKMQ19T2HGE",
+		BlockID: "my-block",
+		Version: "0.2.0",
+		Status:  "pending",
+	}
+	srv, listCalls := newRecoverServer(t, func() []Submission {
+		return []Submission{landed}
+	})
+
+	c := recoverClient(srv.URL)
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err != nil {
+		t.Fatalf("SubmitVersion should recover on timeout, got error: %v", err)
+	}
+	if res.PublishRequestID != landed.ID {
+		t.Errorf("PublishRequestID = %q, want %q", res.PublishRequestID, landed.ID)
+	}
+	if res.Slug != "my-block" || res.Version != "0.2.0" || res.Status != "pending" {
+		t.Errorf("unexpected recovered result: %+v", res)
+	}
+	if atomic.LoadInt32(listCalls) < 1 {
+		t.Errorf("expected the recovery to poll /submissions at least once, got %d calls", *listCalls)
+	}
+}
+
+// TestSubmitVersionRecoveryErrorsWhenAbsent pins the other half: the submit
+// POST times out and NO matching submission shows up, so SubmitVersion returns
+// a clear, actionable error (upload may not have completed; check app status).
+func TestSubmitVersionRecoveryErrorsWhenAbsent(t *testing.T) {
+	srv, _ := newRecoverServer(t, func() []Submission {
+		// A different app/version is present, but not the one we submitted.
+		return []Submission{{ID: "pubreq_other", BlockID: "someone-else", Version: "9.9.9", Status: "pending"}}
+	})
+
+	c := recoverClient(srv.URL)
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err == nil {
+		t.Fatal("expected an error when no matching submission landed")
+	}
+	for _, want := range []string{"timed out", "may not have completed", "civitai app status my-block"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should contain %q", err.Error(), want)
+		}
+	}
+}
+
+// TestSubmitVersionRecoveryMatchesOnlyExactSlugVersion guards the matcher: a
+// pending submission for the same slug but a DIFFERENT version must not be
+// mistaken for this submit's success.
+func TestSubmitVersionRecoveryMatchesOnlyExactSlugVersion(t *testing.T) {
+	srv, _ := newRecoverServer(t, func() []Submission {
+		return []Submission{{ID: "pubreq_old", BlockID: "my-block", Version: "0.1.0", Status: "pending"}}
+	})
+
+	c := recoverClient(srv.URL)
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err == nil {
+		t.Fatal("expected an error: only a different version is pending, not 0.2.0")
+	}
+}
+
+// TestIsTimeoutErr unit-checks the classifier: a deadline-exceeded counts as a
+// timeout; a plain error does not.
+func TestIsTimeoutErr(t *testing.T) {
+	if !isTimeoutErr(context.DeadlineExceeded) {
+		t.Error("context.DeadlineExceeded should be classified as a timeout")
+	}
+	if isTimeoutErr(nil) {
+		t.Error("nil is not a timeout")
+	}
+	if isTimeoutErr(errPlain("boom")) {
+		t.Error("a plain error is not a timeout")
+	}
+}
+
+type errPlain string
+
+func (e errPlain) Error() string { return string(e) }

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -123,7 +123,7 @@ Defaults to the current directory.`,
 func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *manifest.Manifest) error {
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Submitting %s@%s ...\n", m.BlockID, m.Version)
-	r, err := client.SubmitVersion(context.Background(), zipBytes)
+	r, err := client.SubmitVersion(context.Background(), zipBytes, m.BlockID, m.Version)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/app_submit_test.go
+++ b/internal/cmd/app_submit_test.go
@@ -13,13 +13,17 @@ import (
 
 // fakeSubmitter records the bytes it was handed.
 type fakeSubmitter struct {
-	got    []byte
-	result *api.SubmitResult
-	err    error
+	got        []byte
+	gotSlug    string
+	gotVersion string
+	result     *api.SubmitResult
+	err        error
 }
 
-func (f *fakeSubmitter) SubmitVersion(_ context.Context, zip []byte) (*api.SubmitResult, error) {
+func (f *fakeSubmitter) SubmitVersion(_ context.Context, zip []byte, slug, version string) (*api.SubmitResult, error) {
 	f.got = zip
+	f.gotSlug = slug
+	f.gotVersion = version
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -40,6 +44,9 @@ func TestDoUploadHandsBytesToSubmitter(t *testing.T) {
 	}
 	if string(fs.got) != "ZIPBYTES" {
 		t.Errorf("submitter got %q, want ZIPBYTES", fs.got)
+	}
+	if fs.gotSlug != "demo" || fs.gotVersion != "0.1.0" {
+		t.Errorf("submitter got slug/version %q/%q, want demo/0.1.0", fs.gotSlug, fs.gotVersion)
 	}
 	if !strings.Contains(out.String(), "pr_9") || !strings.Contains(out.String(), "pending") {
 		t.Errorf("output should report the publish request + status, got: %s", out.String())


### PR DESCRIPTION
## Symptom (F6, dogfood-verified)

`civitai app submit` reported a **false failure**:

```
Error: Post "https://civitai.com/api/v1/blocks/submit-version": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

…yet the submission had **actually succeeded** server-side. The user's natural retry then hit:

```
400: you already have a pending submission for slug … (pubreq_01KVY45JGYSAXK7DKMQ19T2HGE)
```

## Root cause

`api.Client` used a **single shared `http.Client`** whose timeout governed *both* the slow submit upload and the fast interactive calls (`whoami`, `submissions`). The submit upload sends a multi-file base64 ZIP and then waits for server-side publish-request processing, which can exceed the client timeout — so the CLI aborts the request while the server is still (successfully) processing it, reporting a timeout on a request that succeeded.

## Fix

Scope the longer timeout to the submit upload only — do **not** globally lengthen the fast calls:

| call | before | after |
|------|--------|-------|
| fast calls (whoami, submissions) — shared client | 120s | **30s** (`defaultTimeout`) |
| submit upload — dedicated client | 120s (shared) | **120s** (`submitTimeout`, scoped) |

- The shared `http.Client` now uses a short `defaultTimeout` (30s) so a hung fast call surfaces quickly.
- `SubmitVersion` runs through `submitClient()`, a dedicated `http.Client` with `submitTimeout` (120s) that **mirrors the shared client's `Transport`/`CheckRedirect`/`Jar`** so connection reuse and config are preserved.
- `authedDo`/`doOnce` were refactored to `authedDoWith`/`doOnceWith` taking an explicit `*http.Client`, so the submit path uses the long-timeout client without touching the fast calls. The single-refresh-on-401 retry behavior is unchanged.

## Poll-on-timeout recovery (addresses the false-failure root symptom)

The scoped timeout alone doesn't fix F6's actual symptom: even with a longer window, if the upload **lands server-side but its HTTP response is slow or lost**, the CLI still reports a timeout on a submit that succeeded — and the user retries into "you already have a pending submission". So the submit path now recovers:

- `SubmitVersion` distinguishes a **timeout / deadline-exceeded / no-response** error from a clean HTTP error status via `isTimeoutErr` — matching `context.DeadlineExceeded`, `os.IsTimeout`, and any `net.Error` whose `Timeout()` is true (what `http.Client.Timeout` surfaces while awaiting headers).
- **Only on such a timeout**, before returning an error, it polls `GET /api/v1/blocks/submissions` (reusing the existing `ListSubmissions` helper) up to a small bounded number of attempts for a submission matching **this slug + version**.
  - **Found** → reports **SUCCESS**, surfacing the pubreq id (`PublishRequestID`/`Slug`/`Version`/`Status` from the landed row) — treating the submit as having landed.
  - **Not found** → returns a clear, actionable error: the upload may not have completed; run `civitai app status <slug>` to check before resubmitting.
- A clean HTTP error response (401/403/4xx/5xx) is **not** affected — it returns immediately as before, so the recovery only kicks in for genuine no-response timeouts.
- `SubmitVersion` gains `slug`/`version` params (threaded from the manifest in `doUpload`) so the recovery knows what to look for. The matcher requires an **exact slug+version** match and prefers a pending/submitted row.

## Verification

- `go build ./...` — OK
- `go vet ./...` — clean
- `go test ./...` — all packages pass (no real network)
- `TestSubmitTimeoutIsLongAndScoped` (no network) pins: `submitTimeout == 120s`, `defaultTimeout == 30s`, `submit > fast`, the shared client keeps the short timeout, and `submitClient()` uses the long one.
- New recovery tests (httptest, no real network — the submit POST hangs to force a real client-timeout, then the poll runs):
  - `TestSubmitVersionRecoversWhenSubmissionLanded` — timeout + a matching pending submission → success with the pubreq id.
  - `TestSubmitVersionRecoveryErrorsWhenAbsent` — timeout + no matching submission → clear "timed out / may not have completed / `civitai app status <slug>`" error.
  - `TestSubmitVersionRecoveryMatchesOnlyExactSlugVersion` — a pending row for the same slug but a different version is **not** mistaken for success.
  - `TestIsTimeoutErr` — the timeout classifier (deadline-exceeded yes, plain error / nil no).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
