### PR TITLE
fix(page-money): adopt the W6 /ui pack + bump blocks-react pin to ^0.12.0

### DIFF
--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -7,7 +7,13 @@ an image: estimate → (lazy consent) → submit → poll → result.
 
 ## What this is
 
-A sandboxed static web app served in an iframe by the Civitai host. The platform
+A sandboxed static web app served in an iframe by the Civitai host. Its entire
+UI is built from the **`@civitai/blocks-react/ui`** W6 component pack (Button,
+TextInput, Textarea, Card, Stack, Group, Alert, Modal, Badge) — no hand-rolled
+controls. The pack ships its own theme-aware styles; `injectBlocksStyles()` is
+called at module init in `src/App.tsx` so the first paint is already styled.
+
+The platform
 owns the build: it runs `npm ci` then the `buildCommand` from
 `block.manifest.json` (`npm run build`), serving the static output from
 `outputDir` (`dist/`). You do NOT commit `dist/` — the platform builds it.

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.13.0",
-    "@civitai/blocks-react": "^0.11.1",
+    "@civitai/blocks-react": "^0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -41,8 +41,11 @@ async function clickGenerate() {
   const user = userEvent.setup();
   render(<App />);
   const generate = await screen.findByTestId('pm-generate');
-  await user.type(screen.getByLabelText(/generation prompt/i), 'a serene mountain lake');
+  await user.type(screen.getByLabelText(/prompt/i), 'a serene mountain lake');
+  // The W6 /ui UI gates Generate behind a confirm Modal — open it, then confirm.
   await user.click(generate);
+  const dialog = await screen.findByRole('dialog', { name: /confirm generation/i });
+  await user.click(within(dialog).getByRole('button', { name: /generate/i }));
 }
 
 describe('App poll loop — transient-error robustness', () => {
@@ -68,9 +71,11 @@ describe('App poll loop — transient-error robustness', () => {
     // The loop retries the throw (500ms backoff) and then renders the SUCCESS.
     const result = await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
     expect(result).toHaveAttribute('src', 'https://img.test/ok.png');
-    // It retried exactly once before succeeding; never showed an error.
+    // It retried exactly once before succeeding; never showed a failure. (The
+    // pack's info/success Alerts carry role="alert", so assert the failure copy
+    // is absent rather than querying for any alert.)
     expect(pollFn).toHaveBeenCalledTimes(2);
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/generation failed/i)).not.toBeInTheDocument();
   });
 
   it('a GENUINE failed STATUS (a snapshot, not a throw) → terminal failure', async () => {
@@ -82,8 +87,10 @@ describe('App poll loop — transient-error robustness', () => {
 
     await clickGenerate();
 
-    const alert = await screen.findByRole('alert', {}, { timeout: 5000 });
-    expect(alert).toHaveTextContent(/NSFW prompt rejected/i);
+    // The failure surfaces as the error Alert (titled "Generation failed").
+    const failure = await screen.findByText(/NSFW prompt rejected/i, {}, { timeout: 5000 });
+    expect(failure).toBeInTheDocument();
+    expect(screen.getByText(/generation failed/i)).toBeInTheDocument();
     expect(pollFn).toHaveBeenCalledTimes(1); // a real failed status is not retried
     expect(screen.queryByAltText(/generated result/i)).not.toBeInTheDocument();
   });

--- a/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
@@ -40,7 +40,7 @@ describe('App (component)', () => {
     render(<App />);
 
     expect(await screen.findByTestId('pm-generate')).toBeInTheDocument();
-    expect(screen.getByLabelText(/generation prompt/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/prompt/i)).toBeInTheDocument();
     expect(screen.queryByTestId('pm-signin')).not.toBeInTheDocument();
   });
 });

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -8,6 +8,18 @@ import {
   useRequestConsent,
   useRequestSignIn,
 } from '@civitai/blocks-react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Modal,
+  Stack,
+  TextInput,
+  Textarea,
+  injectBlocksStyles,
+} from '@civitai/blocks-react/ui';
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
 import {
@@ -25,11 +37,19 @@ import {
   type GenPhase,
 } from './generation.js';
 
+// Inject the W6 component pack's stylesheet at module init (before first paint)
+// to avoid the documented one-frame FOUC (the pack's components also call
+// useBlocksStyles() internally, but injecting up front means the first paint is
+// already styled). Idempotent.
+injectBlocksStyles();
+
 /**
- * {{ .Name }} — a full-page (W10) money-path App Block. It exercises the page
- * money path end-to-end: estimate -> (lazy consent) -> submit -> poll -> real
- * Buzz spend, using the published SDK hooks (NEVER raw postMessage to the parent
- * with a wildcard origin — the SDK does the origin-checked messaging safely).
+ * {{ .Name }} — a full-page (W10) money-path App Block whose ENTIRE interface is
+ * built from the `@civitai/blocks-react/ui` W6 component pack (Button, TextInput,
+ * Textarea, Card, Stack, Group, Alert, Modal, Badge). It exercises the page money
+ * path end-to-end: estimate -> (lazy consent) -> submit -> poll -> real Buzz
+ * spend, using the published SDK hooks (NEVER raw postMessage to the parent with
+ * a wildcard origin — the SDK does the origin-checked messaging safely).
  *
  * Page-native constraints:
  *  - slot = app.page (entity=none) via the top-level `page:{}` manifest object.
@@ -49,8 +69,6 @@ export function App() {
   const { requestConsent } = useRequestConsent();
   const { requestSignIn } = useRequestSignIn();
 
-  const isDark = theme === 'dark';
-  const c = palette(isDark);
   const anon = ready && !viewer;
   const granted = hasBudgetedScope(token.scopes);
 
@@ -58,11 +76,14 @@ export function App() {
   useBlockResize(rootRef);
 
   const [prompt, setPrompt] = useState('');
+  const [touched, setTouched] = useState(false);
   const [phase, setPhase] = useState<GenPhase>('idle');
   const [estimatedCost, setEstimatedCost] = useState<number | null>(null);
   const [actualCost, setActualCost] = useState<number | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
 
   // True once the user clicked Generate while the scope was missing — so when
   // the consent grant lands (granted flips true) we auto-resume the submit.
@@ -212,7 +233,9 @@ export function App() {
     if (snap.workflowId) runPollLoop(snap.workflowId);
   }, [prompt, estimate, submit, applySnapshot, runPollLoop]);
 
-  const handleGenerate = useCallback(() => {
+  // The actual gate: sign-in -> consent -> generate. Called by the confirm modal.
+  const proceed = useCallback(() => {
+    setConfirmOpen(false);
     // Anon: convert the click into a host login prompt. Generate is server-gated
     // anyway (an anon token carries no budgeted scope).
     if (!viewer) {
@@ -239,263 +262,206 @@ export function App() {
     }
   }, [granted, runGeneration]);
 
+  const promptError =
+    touched && prompt.trim().length === 0 ? 'Enter a prompt to generate.' : undefined;
+  const busy = isBusyPhase(phase);
+
   // ---- Render ----
 
   if (!ready) {
     return (
-      <div ref={rootRef} data-theme={isDark ? 'dark' : 'light'} style={pageStyle(c)}>
-        <div style={loadingStyle}>Loading…</div>
+      // Theme the block's OWN root; that's what the pack's CSS reads.
+      <div ref={rootRef} data-theme={theme} style={shell}>
+        <Card padding="lg">
+          <Group gap={10}>
+            <Badge color="info" variant="light">
+              loading
+            </Badge>
+            <span>Connecting to host…</span>
+          </Group>
+        </Card>
       </div>
     );
   }
 
-  const busy = isBusyPhase(phase);
-  const showTopUp = phase === 'insufficient';
+  const onGenerateClick = () => {
+    setTouched(true);
+    if (prompt.trim().length === 0) return;
+    setConfirmOpen(true);
+  };
 
   return (
-    <div ref={rootRef} data-theme={isDark ? 'dark' : 'light'} style={pageStyle(c)}>
-      <div style={contentStyle}>
-        <header style={headerStyle}>
-          <h1 style={titleStyle}>{{ .Name }}</h1>
-          <p style={subtitleStyle(c)}>
+    <div ref={rootRef} data-theme={theme} style={shell}>
+      <Card padding="lg" style={cardStyle}>
+        <Stack gap={16}>
+          <Group justify="space-between">
+            <strong style={titleStyle}>{{ .Name }}</strong>
+            <Badge color={anon ? 'warning' : granted ? 'success' : 'info'} variant="light">
+              {anon ? 'signed out' : granted ? 'ready' : 'needs access'}
+            </Badge>
+          </Group>
+
+          <Alert color="info" title="How this works">
             Type a prompt and generate one image with <strong>{GEN_MODEL.label}</strong>. Each
-            generation spends a small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).
-          </p>
-        </header>
-
-        <div style={fieldStyle}>
-          <label htmlFor="pm-prompt" style={labelStyle}>
-            Prompt
-          </label>
-          <textarea
-            id="pm-prompt"
-            value={prompt}
-            maxLength={PROMPT_MAX}
-            placeholder="a serene mountain lake at golden hour, highly detailed"
-            onChange={(e) => setPrompt(e.target.value)}
-            aria-label="Generation prompt"
-            rows={4}
-            style={textareaStyle(c)}
-          />
-        </div>
-
-        {anon ? (
-          <button type="button" onClick={handleGenerate} style={primaryBtn(c)} data-testid="pm-signin">
-            Sign in to generate
-          </button>
-        ) : showTopUp ? (
-          <p style={noteStyle(c)} role="status" data-testid="pm-insufficient">
-            Not enough Buzz for this generation. Top up your Buzz balance and try again.
-          </p>
-        ) : (
-          <button
-            type="button"
-            onClick={handleGenerate}
-            disabled={busy || prompt.trim().length === 0}
-            style={primaryBtn(c, busy || prompt.trim().length === 0)}
-            data-testid="pm-generate"
-          >
-            <GenerateLabel phase={phase} estimatedCost={estimatedCost} />
-          </button>
-        )}
-
-        {phase === 'needs-consent' && (
-          <p role="status" style={noteStyle(c)}>
-            Grant access to generate — confirm in the Civitai dialog. If you dismissed it,{' '}
-            <button type="button" onClick={handleGenerate} style={linkBtn(c)}>
-              try again
+            generation spends a small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).{' '}
+            <button type="button" onClick={() => setAboutOpen(true)} style={linkButtonStyle}>
+              Details
             </button>
-            .
-          </p>
-        )}
-        {busy && (
-          <p role="status" style={noteStyle(c)}>
-            {phase === 'estimating'
-              ? 'Estimating cost…'
-              : phase === 'submitting'
-                ? 'Submitting generation…'
-                : 'Generating… this can take 10–60s.'}
-          </p>
-        )}
+          </Alert>
 
-        {phase === 'failed' && error && (
-          <div role="alert" style={errorBox(c)}>
-            {error}
-          </div>
-        )}
+          <Textarea
+            label="Prompt"
+            description="Describe what you want to generate."
+            placeholder="a serene mountain lake at golden hour, highly detailed"
+            value={prompt}
+            minRows={4}
+            maxLength={PROMPT_MAX}
+            required
+            error={promptError}
+            onChange={(e) => setPrompt(e.target.value)}
+            onBlur={() => setTouched(true)}
+          />
 
-        {phase === 'succeeded' && imageUrl && (
-          <figure style={figureStyle}>
-            <img src={imageUrl} alt="Generated result" style={imgStyle(c)} />
-            <figcaption style={captionStyle(c)}>
-              Done. Spent <strong style={strongFg(c)}>{formatCost(actualCost)}</strong> Buzz.
-            </figcaption>
-          </figure>
-        )}
-      </div>
+          <TextInput
+            label="Model"
+            description="A page block has no model picker, so the model is fixed."
+            value={GEN_MODEL.label}
+            readOnly
+            disabled
+          />
+
+          {anon ? (
+            <Button fullWidth onClick={() => requestSignIn()} data-testid="pm-signin">
+              Sign in to generate
+            </Button>
+          ) : (
+            <Group gap={8}>
+              <Button variant="subtle" onClick={() => setAboutOpen(true)}>
+                How it works
+              </Button>
+              <Button
+                fullWidth
+                loading={busy}
+                disabled={prompt.trim().length === 0}
+                onClick={onGenerateClick}
+                data-testid="pm-generate"
+              >
+                {busy
+                  ? phaseLabel(phase)
+                  : estimatedCost != null
+                    ? `Generate · ${formatCost(estimatedCost)} Buzz`
+                    : 'Generate'}
+              </Button>
+            </Group>
+          )}
+
+          {phase === 'needs-consent' && (
+            <Alert color="info" title="Grant access to generate">
+              Confirm in the Civitai dialog. If you dismissed it, click Generate again.
+            </Alert>
+          )}
+
+          {phase === 'insufficient' && (
+            <Alert color="warning" title="Not enough Buzz" data-testid="pm-insufficient">
+              Top up your Buzz balance and try again.
+            </Alert>
+          )}
+
+          {phase === 'failed' && error && (
+            <Alert
+              color="error"
+              title="Generation failed"
+              withCloseButton
+              onClose={() => setError(null)}
+            >
+              {error}
+            </Alert>
+          )}
+
+          {phase === 'succeeded' && imageUrl && (
+            <Stack gap={8}>
+              <Alert color="success" title="Done">
+                Spent <strong>{formatCost(actualCost)}</strong> Buzz.
+              </Alert>
+              <img src={imageUrl} alt="Generated result" style={imageStyle} />
+            </Stack>
+          )}
+        </Stack>
+      </Card>
+
+      {/* Confirm-spend modal — exercises Modal in its opened state with live data. */}
+      <Modal
+        opened={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        title="Confirm generation"
+        size="sm"
+      >
+        <Stack gap={14}>
+          <span>
+            Generate one image with <strong>{GEN_MODEL.label}</strong>? This spends up to{' '}
+            <strong>{PAGE_BUZZ_BUDGET}</strong> Buzz.
+          </span>
+          <Group justify="flex-end" gap={8}>
+            <Button variant="subtle" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button color="success" onClick={proceed}>
+              Generate
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* About modal — a second Modal instance, opened independently. */}
+      <Modal opened={aboutOpen} onClose={() => setAboutOpen(false)} title="About this block" size="md">
+        <Stack gap={10}>
+          <span>
+            This is a sandboxed Civitai App Block. The interface is built entirely with the{' '}
+            <strong>@civitai/blocks-react/ui</strong> W6 component pack — Button, TextInput,
+            Textarea, Card, Stack, Group, Alert, Badge and Modal.
+          </span>
+          <Alert color="info">
+            Generations run on the real Civitai backend and spend real Buzz when run in live mode.
+          </Alert>
+          <Group justify="flex-end">
+            <Button onClick={() => setAboutOpen(false)}>Got it</Button>
+          </Group>
+        </Stack>
+      </Modal>
     </div>
   );
 }
 
-function GenerateLabel({
-  phase,
-  estimatedCost,
-}: {
-  phase: GenPhase;
-  estimatedCost: number | null;
-}) {
-  if (phase === 'estimating') return <>Estimating…</>;
-  if (phase === 'submitting') return <>Submitting…</>;
-  if (phase === 'polling') return <>Generating…</>;
-  if (estimatedCost != null) return <>Generate · {formatCost(estimatedCost)} Buzz</>;
-  return <>Generate</>;
+function phaseLabel(phase: GenPhase): string {
+  if (phase === 'estimating') return 'Estimating…';
+  if (phase === 'submitting') return 'Submitting…';
+  if (phase === 'polling') return 'Generating…';
+  return 'Working…';
 }
 
-// ------------------------------------------------------------------
-// Theme — the host can't inject CSS into the iframe, so colors come from
-// useBlockContext().theme via inline styles.
-// ------------------------------------------------------------------
-interface Palette {
-  bg: string;
-  fg: string;
-  border: string;
-  inputBg: string;
-  accent: string;
-  accentFg: string;
-  danger: string;
-  dangerBg: string;
-  muted: string;
-}
-
-function palette(dark: boolean): Palette {
-  return dark
-    ? {
-        bg: '#1a1b1e',
-        fg: '#e9ecef',
-        border: '#373a40',
-        inputBg: '#2c2e33',
-        accent: '#fab005',
-        accentFg: '#1a1b1e',
-        danger: '#ff8787',
-        dangerBg: '#2c1f1f',
-        muted: '#909296',
-      }
-    : {
-        bg: '#ffffff',
-        fg: '#1a1b1e',
-        border: '#dee2e6',
-        inputBg: '#ffffff',
-        accent: '#f08c00',
-        accentFg: '#ffffff',
-        danger: '#e03131',
-        dangerBg: '#fff5f5',
-        muted: '#868e96',
-      };
-}
-
-const loadingStyle: React.CSSProperties = { margin: 'auto', opacity: 0.7 };
-const headerStyle: React.CSSProperties = { display: 'grid', gap: 4 };
-const titleStyle: React.CSSProperties = { fontSize: 24, margin: 0 };
-const fieldStyle: React.CSSProperties = { display: 'grid', gap: 6 };
-const labelStyle: React.CSSProperties = { fontSize: 13, fontWeight: 600 };
-const figureStyle: React.CSSProperties = { margin: 0, display: 'grid', gap: 8 };
-
-function pageStyle(c: Palette): React.CSSProperties {
-  return {
-    fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-    background: c.bg,
-    color: c.fg,
-    width: '100%',
-    minHeight: '100dvh',
-    display: 'flex',
-    boxSizing: 'border-box',
-  };
-}
-
-const contentStyle: React.CSSProperties = {
-  margin: '0 auto',
+// The pack themes everything via data-theme; the block root only needs layout +
+// a themed page background so the iframe surface matches the card.
+const shell: React.CSSProperties = {
+  minHeight: '100dvh',
   width: '100%',
-  maxWidth: 640,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'flex-start',
   padding: 24,
-  display: 'grid',
-  gap: 16,
-  alignContent: 'start',
   boxSizing: 'border-box',
+  background: 'var(--ci-color-surface-2)',
+  color: 'var(--ci-color-text)',
 };
 
-function subtitleStyle(c: Palette): React.CSSProperties {
-  return { fontSize: 14, color: c.muted, margin: 0, lineHeight: 1.5 };
-}
-
-function textareaStyle(c: Palette): React.CSSProperties {
-  return {
-    resize: 'vertical',
-    padding: 12,
-    borderRadius: 8,
-    border: '1px solid ' + c.border,
-    background: c.inputBg,
-    color: c.fg,
-    fontSize: 15,
-    lineHeight: 1.5,
-    fontFamily: 'inherit',
-    boxSizing: 'border-box',
-    width: '100%',
-    minHeight: 96,
-  };
-}
-
-function primaryBtn(c: Palette, disabled = false): React.CSSProperties {
-  return {
-    padding: '12px 18px',
-    border: 'none',
-    borderRadius: 8,
-    background: disabled ? c.border : c.accent,
-    color: disabled ? c.muted : c.accentFg,
-    fontWeight: 700,
-    fontSize: 15,
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-  };
-}
-
-function linkBtn(c: Palette): React.CSSProperties {
-  return {
-    background: 'none',
-    border: 'none',
-    color: c.accent,
-    cursor: 'pointer',
-    padding: 0,
-    font: 'inherit',
-    textDecoration: 'underline',
-  };
-}
-
-function noteStyle(c: Palette): React.CSSProperties {
-  return { fontSize: 13, color: c.muted, margin: 0, lineHeight: 1.5 };
-}
-
-function errorBox(c: Palette): React.CSSProperties {
-  return {
-    background: c.dangerBg,
-    color: c.danger,
-    border: '1px solid ' + c.danger,
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 13,
-  };
-}
-
-function imgStyle(c: Palette): React.CSSProperties {
-  return { width: '100%', borderRadius: 10, border: '1px solid ' + c.border };
-}
-
-function captionStyle(c: Palette): React.CSSProperties {
-  return { fontSize: 13, color: c.muted };
-}
-
-function strongFg(c: Palette): React.CSSProperties {
-  return { color: c.fg };
-}
+const cardStyle: React.CSSProperties = { width: '100%', maxWidth: 640 };
+const titleStyle: React.CSSProperties = { fontSize: 20 };
+const imageStyle: React.CSSProperties = { width: '100%', borderRadius: 8, display: 'block' };
+const linkButtonStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  color: 'inherit',
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  font: 'inherit',
+};

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -9,18 +9,25 @@ import { App } from './App.js';
 // End-to-end proof of the money wiring: this drives the FULL page money path
 // through the REAL SDK transport (NO hook mocking) against the published mock
 // host. It is the regression guard that estimate -> consent -> submit -> poll
-// stays wired:
+// stays wired. The UI is the @civitai/blocks-react/ui pack, so the Generate
+// click first opens a confirm Modal; confirming inside it proceeds:
 //
 //   render <App/> (consent WITHHELD)
 //     -> type a prompt
-//     -> click Generate
+//     -> click Generate -> confirm Modal opens
+//     -> click Generate INSIDE the modal
 //     -> App asks the host for consent (REQUEST_CONSENT)
 //     -> host grants + pushes a TOKEN_REFRESH carrying ai:write:budgeted
 //     -> App auto-resumes: estimate -> submit -> poll
-//     -> succeeded snapshot -> result image + spent-cost caption
+//     -> succeeded snapshot -> result image + spent-cost success Alert
 //
 // The mock host's internal timers all fire on setTimeout(0), so real timers +
 // findBy/waitFor resolve promptly — no fake-timer juggling required.
+
+async function confirmInModal(user: ReturnType<typeof userEvent.setup>) {
+  const dialog = await screen.findByRole('dialog', { name: /confirm generation/i });
+  await user.click(within(dialog).getByRole('button', { name: /generate/i }));
+}
 
 describe('App money path (e2e)', () => {
   let uninstall: (() => void) | undefined;
@@ -47,27 +54,30 @@ describe('App money path (e2e)', () => {
     const generate = await screen.findByTestId('pm-generate');
 
     // Enter a prompt (Generate is disabled while empty).
-    await user.type(screen.getByLabelText(/generation prompt/i), 'a serene mountain lake');
+    await user.type(screen.getByLabelText(/prompt/i), 'a serene mountain lake');
     expect(generate).toBeEnabled();
 
-    // Click Generate. Scope is withheld -> App requests consent first.
+    // Click Generate -> confirm Modal -> confirm. Scope is withheld so the App
+    // requests consent first, then auto-resumes.
     await user.click(generate);
+    await confirmInModal(user);
 
     // The host grants consent + token-refreshes; the App auto-resumes through
     // estimate -> submit -> poll -> succeeded. Assert the terminal success UI.
     const result = await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
     expect(result).toBeInTheDocument();
 
-    // The succeeded snapshot's cost is rendered in the caption.
+    // The succeeded snapshot's cost is rendered in the success Alert.
     await waitFor(() => {
       expect(screen.getByText(/spent/i)).toHaveTextContent('8');
     });
 
-    // No error surfaced anywhere in the happy path.
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // No ERROR alert surfaced on the happy path (the info + success Alerts do
+    // carry role="alert"; assert the failure copy is absent instead).
+    expect(screen.queryByText(/generation failed/i)).not.toBeInTheDocument();
   });
 
-  it('insufficient Buzz on submit -> Top-Up CTA, no result image', async () => {
+  it('insufficient Buzz on submit -> warning Alert, no result image', async () => {
     const user = userEvent.setup();
     uninstall = createMockHost({
       viewer: { id: 2, username: 'dev', status: 'active' },
@@ -78,12 +88,13 @@ describe('App money path (e2e)', () => {
     render(<App />);
 
     const generate = await screen.findByTestId('pm-generate');
-    await user.type(screen.getByLabelText(/generation prompt/i), 'a cat');
+    await user.type(screen.getByLabelText(/prompt/i), 'a cat');
     await user.click(generate);
+    await confirmInModal(user);
 
     // The failed snapshot carries insufficient-Buzz text -> the App swaps to
-    // the Top-Up CTA and renders no image.
-    expect(await screen.findByTestId('pm-insufficient')).toBeInTheDocument();
+    // the Top-Up warning Alert and renders no image.
+    expect(await screen.findByText(/not enough buzz/i)).toBeInTheDocument();
     expect(screen.queryByAltText(/generated result/i)).not.toBeInTheDocument();
   });
 });

--- a/internal/scaffold/templates/page-money/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-money/src/index.css.tmpl
@@ -19,15 +19,11 @@ body {
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
-/* Focus affordances key off the root data-theme (the host can't inject CSS). */
-[data-theme='dark'] textarea:focus-visible,
-[data-theme='dark'] button:focus-visible {
-  outline: 2px solid #fab005;
-  outline-offset: 2px;
-}
-
-[data-theme='light'] textarea:focus-visible,
-[data-theme='light'] button:focus-visible {
-  outline: 2px solid #f08c00;
+/* Focus affordance for any raw textarea/button (the W6 /ui pack styles its own
+   controls). Use the pack's brand accent so the outline matches, not a clashing
+   gold; --ci-color-primary is defined by the pack's injected stylesheet. */
+textarea:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--ci-color-primary);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Problem (version skew → broken `/ui` import in a fresh scaffold)

The `page-money` template pinned `"@civitai/blocks-react": "^0.11.1"`. For a **0.x** dependency, `^0.11.1` resolves to `>=0.11.1 <0.12.0`, so a fresh `npm install` pulled **0.11.2** — which **predates the W6 `/ui` component pack**. The pack (Button/TextInput/Textarea/Card/Stack/Group/Alert/Loader/Badge/Modal) ships in **0.12.0** (npm `latest`). So the published README's `/ui` import snippet failed in a brand-new scaffold:

```
TS2305: Module '@civitai/blocks-react/ui' has no exported member 'Button'
```

Three coupled problems fixed as one cohesive change — "page-money template adopts the W6 /ui pack":

### F1 — pin bump
`package.json.tmpl`: `@civitai/blocks-react` `^0.11.1` → `^0.12.0`, so a fresh scaffold installs **0.12.0** (the version that ships `/ui`). `@civitai/app-sdk` left at `^0.13.0`.

### F2 — UI built from the pack
`src/App.tsx.tmpl`: the UI is now built entirely from `@civitai/blocks-react/ui` (Button, TextInput, Textarea, Card, Stack, Group, Alert, Modal, Badge) instead of hand-rolled inline-style controls. Adds a confirm-spend Modal + an About Modal, loading/disabled/error states, and calls `injectBlocksStyles()` at module init to avoid FOUC. The **money-path wiring is unchanged** (estimate → lazy consent → submit → poll → real Buzz spend), and the **robust poll loop is preserved** (`MAX_TRANSIENT_ERRORS`/`consecutiveErrors` retry-on-throw — the round-5 regression guard). Inline JSX styles were hoisted to named `CSSProperties` constants because JSX `style={{…}}` double-braces collide with the Go `text/template` parser. All `{{ .Name }}` placeholders preserved.

### F3 — focus outline matches brand
`src/index.css.tmpl`: the `:focus-visible` outline hard-coded a **gold** color (`#fab005` dark / `#f08c00` light) that clashed with the pack's blue accent. Replaced the two theme-keyed rules with a single `outline: 2px solid var(--ci-color-primary)` rule (the pack defines that var), keeping the a11y affordance on-brand.

### Tests + README
- `App.test.tsx`, `e2e.test.tsx`, `App.pollretry.test.tsx` updated for the new UI: prompt label query `/generation prompt/i` → `/prompt/i`; the e2e flow now clicks **Generate → confirms inside the dialog** (`within(getByRole('dialog')).getByRole('button',{name:/generate/i})`); success/insufficient/failure assertions switched to the Alert-based UI. The pack's Alert carries `role="alert"`, so the happy path asserts the *failure copy is absent* rather than querying for any alert.
- `README.md.tmpl`: prose notes the `/ui` pack adoption + `injectBlocksStyles()`.

## Verification
- `go build ./...` and `go test ./...` pass (incl. `TestRenderPageMoney`, which still asserts `MAX_TRANSIENT_ERRORS`/`consecutiveErrors` and the `{{ .Name }}` heading — preserved).
- Built the modified CLI and scaffolded `page-money` with it:
  - `npm install` → **`@civitai/blocks-react` resolves to 0.12.0** ✅
  - `npm run build` (tsc typecheck + vite) → passes ✅
  - `npm test` → **16/16 pass** (4 files) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)