### PR TITLE
feat(money-path): civitai buzz + whoami capabilities + correct dev:live docs (#32-#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 | Command | What it does |
 | --- | --- |
 | `civitai login [--token <t>] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens); `--token` stores a personal API key instead. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
-| `civitai whoami` | Verify the stored token; print the authenticated user. |
+| `civitai whoami` | Verify the stored token; print the authenticated user **and a Capabilities section** (`Spend Buzz`, `Read Buzz balance`) decoded from the token's scope, so a money-path dead end (OAuth login can't spend) is visible before `dev:live`. |
+| `civitai buzz` | Show your spendable Buzz balance (blue / green / **yellow** — the generation-spend currency). Needs a full-scope personal API key to read; an OAuth login token can't, and gets a clear "switch to a personal key" message. |
 | `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App Block, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
 | `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
+| `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai version` | Print version / commit / build date. |
 | `civitai completion [shell]` | Generate a shell-completion script. |
 
@@ -130,12 +132,14 @@ hosts) with two modes:
 | `npm run dev:harness` | **mock** (default) | Mounts the SDK **mock host** — synthetic replies, **no real Buzz, no compute, no network.** Safe to spam; drive money/error/insufficient-Buzz UX via on-screen scenarios or `?` URL params. Start here. |
 | `npm run dev:live` | **live** | Mounts the SDK **live host** (`createLiveHost`) — forwards the App-Block protocol to the **real Civitai backend** with a pasted dev token (Bearer). **Spends REAL Buzz / real compute.** |
 
-> ⚠️ **`dev:live` needs an approved + deployed app.** It talks to a **deployed
-> block instance**, so the dev-token mint only succeeds once the app is approved
-> and deployed (deployState `live`). A brand-new app — even right after a
-> successful `civitai app submit` (status `pending`) — gets `App not found`. You
-> **can't `dev:live`-test your own first app before its first approval + deploy**;
-> validate with `dev:harness` (mock) until your first version is live.
+> ⚠️ **`dev:live` works on a pending (un-approved) app.** The dev-token mint
+> (`POST /api/v1/blocks/dev-token`) accepts a **pending** slug — right after a
+> successful `civitai app submit` (status `pending`) it returns `200` with
+> `appId: pending-pubreq_…` and `dev:live` mounts the live host against the
+> pending app. For **real generation** you must mint with a **full-scope personal
+> API key**; an OAuth (`civitai login`) token mints read-only (`user:read:self`)
+> and **cannot spend**. Use `civitai buzz` / `civitai whoami` to confirm your
+> credential can spend before a live run.
 
 **Live mode** needs a short-lived dev block token (mint via the moderator-gated
 `POST /api/v1/blocks/dev-token`), pasted into `.env.development` as
@@ -250,10 +254,25 @@ moderator review. The lifecycle is:
    at **`https://<blockId>.civit.ai/`**.
 
 Before approval, **`https://<blockId>.civit.ai/` 404s** — submitting does not
-make the subdomain serve. For the full end-to-end walkthrough (build → submit →
-review → deploy), see the
+make the subdomain serve (but `dev:live` works against a pending app — see
+[Local dev loop](#local-dev-loop-harness-mock-vs-live)). For the full end-to-end
+walkthrough (build → submit → review → deploy), see the
 [Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 guide.
+
+**Need to change the bundle while a request is still `pending`?** Withdraw it
+first to free the slug, then resubmit:
+
+```text
+$ civitai app status                          # find the pubreq_ id
+$ civitai app withdraw pubreq_01HZX           # frees the slug
+$ civitai app submit                          # resubmit the new bundle
+```
+
+`civitai app withdraw <pubreq-id>` (or `--id <pubreq>`) withdraws **your own**
+pending publish request. It is **idempotent** (an already-withdrawn request still
+returns success) and only a **`pending`** request can be withdrawn — an already
+approved/rejected one cannot.
 
 ## Submission status
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -112,7 +112,58 @@ type Submission struct {
 type Identity struct {
 	Username string `json:"username"`
 	ID       int    `json:"id"`
+	// TokenScope is the bearer token's scope bitmask as returned by
+	// GET /api/v1/me. Decode it with the Scope* bits below to learn what the
+	// credential can do (spend Buzz, read balance, …). A personal full-scope key
+	// has every bit; an OAuth device-login token typically has neither
+	// AIServicesWrite nor BuzzRead.
+	TokenScope int `json:"tokenScope"`
 }
+
+// Token-scope bits, mirrored from civitai/civitai
+// src/shared/constants/token-scope.constants.ts. These are STABLE bit positions
+// in the tokenScope bitmask GET /api/v1/me returns. Only the bits the CLI needs
+// are mirrored here.
+const (
+	// ScopeUserRead (1<<0) — read the authenticated user's identity.
+	ScopeUserRead = 1 << 0
+	// ScopeAIServicesWrite (1<<15) — spend Buzz on AI services (generation). A
+	// credential "can spend Buzz" iff tokenScope & ScopeAIServicesWrite != 0.
+	ScopeAIServicesWrite = 1 << 15
+	// ScopeBuzzRead (1<<16) — read the user's Buzz balance. A credential "can
+	// read balance" iff tokenScope & ScopeBuzzRead != 0.
+	ScopeBuzzRead = 1 << 16
+)
+
+// CanSpendBuzz reports whether the identity's token carries the AI-Services
+// (Buzz-spend) scope.
+func (id *Identity) CanSpendBuzz() bool { return id.TokenScope&ScopeAIServicesWrite != 0 }
+
+// CanReadBuzz reports whether the identity's token can read the Buzz balance.
+func (id *Identity) CanReadBuzz() bool { return id.TokenScope&ScopeBuzzRead != 0 }
+
+// BuzzAccount is the spendable Buzz balance from buzz.getBuzzAccount. Yellow is
+// the currency generation spend draws from.
+type BuzzAccount struct {
+	Blue   int64 `json:"blue"`
+	Green  int64 `json:"green"`
+	Yellow int64 `json:"yellow"`
+}
+
+// BuzzReader reads the caller's spendable Buzz balance.
+type BuzzReader interface {
+	// GetBuzzAccount returns the caller's Buzz balance. A credential lacking the
+	// Buzz-read scope yields ErrBuzzScope (the server answers 403).
+	GetBuzzAccount(ctx context.Context) (*BuzzAccount, error)
+}
+
+// ErrBuzzScope is returned by GetBuzzAccount when the stored credential lacks
+// the Buzz-read scope (the server answers 403 FORBIDDEN). The command layer maps
+// this to actionable, personal-key guidance.
+var ErrBuzzScope = fmt.Errorf("credential lacks the Buzz-read scope")
+
+// BuzzAccountPath is the tRPC route that returns the spendable Buzz balance.
+const BuzzAccountPath = "/api/trpc/buzz.getBuzzAccount"
 
 // SubmitResult is the publish-request result the server returns.
 type SubmitResult struct {
@@ -420,6 +471,46 @@ func (c *Client) WhoAmI(ctx context.Context) (*Identity, error) {
 		return nil, fmt.Errorf("unexpected /api/v1/me response: %s", string(raw))
 	}
 	return &id, nil
+}
+
+// GetBuzzAccount reads the caller's spendable Buzz balance via the
+// buzz.getBuzzAccount tRPC route, refreshing the OAuth access token if needed.
+// On 200 it returns the {blue,green,yellow} balance; on a 403 (the credential
+// lacks the Buzz-read scope) it returns ErrBuzzScope so the command layer can
+// print the personal-key guidance. The tRPC success envelope is
+// {"result":{"data":{"json":{...}}}}.
+func (c *Client) GetBuzzAccount(ctx context.Context) (*BuzzAccount, error) {
+	tok, err := c.Tokens.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if tok == "" {
+		return nil, fmt.Errorf("no token configured — run `civitai login` first")
+	}
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+BuzzAccountPath, nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusForbidden {
+		return nil, ErrBuzzScope
+	}
+	if status != http.StatusOK {
+		return nil, serverError(status, raw)
+	}
+	var env struct {
+		Result struct {
+			Data struct {
+				JSON *BuzzAccount `json:"json"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Result.Data.JSON == nil {
+		return nil, fmt.Errorf("unexpected buzz.getBuzzAccount response: %s", string(raw))
+	}
+	return env.Result.Data.JSON, nil
 }
 
 // submissionsURL builds the GET URL with optional id / blockId query params.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -113,5 +114,98 @@ func TestWhoAmIParsesIdentity(t *testing.T) {
 	}
 	if id.Username != "zach" || id.ID != 42 {
 		t.Errorf("identity = %+v", id)
+	}
+}
+
+func TestWhoAmIParsesTokenScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A full-scope personal key: UserRead | AIServicesWrite | BuzzRead.
+		_, _ = w.Write([]byte(`{"username":"zach","id":42,"tokenScope":98305}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	id, err := c.WhoAmI(context.Background())
+	if err != nil {
+		t.Fatalf("WhoAmI: %v", err)
+	}
+	if id.TokenScope != (ScopeUserRead | ScopeAIServicesWrite | ScopeBuzzRead) {
+		t.Errorf("tokenScope = %d", id.TokenScope)
+	}
+	if !id.CanSpendBuzz() {
+		t.Error("CanSpendBuzz should be true for a full-scope key")
+	}
+	if !id.CanReadBuzz() {
+		t.Error("CanReadBuzz should be true for a full-scope key")
+	}
+}
+
+func TestIdentityCapabilityBits(t *testing.T) {
+	// An OAuth login token: UserRead | AppBlocksSubmit (bit 25) — no spend, no
+	// balance-read.
+	oauth := &Identity{TokenScope: ScopeUserRead | (1 << 25)}
+	if oauth.CanSpendBuzz() {
+		t.Error("OAuth token must not be able to spend Buzz")
+	}
+	if oauth.CanReadBuzz() {
+		t.Error("OAuth token must not be able to read Buzz balance")
+	}
+
+	spendOnly := &Identity{TokenScope: ScopeAIServicesWrite}
+	if !spendOnly.CanSpendBuzz() || spendOnly.CanReadBuzz() {
+		t.Errorf("AIServicesWrite-only: spend=%v read=%v", spendOnly.CanSpendBuzz(), spendOnly.CanReadBuzz())
+	}
+
+	readOnly := &Identity{TokenScope: ScopeBuzzRead}
+	if readOnly.CanSpendBuzz() || !readOnly.CanReadBuzz() {
+		t.Errorf("BuzzRead-only: spend=%v read=%v", readOnly.CanSpendBuzz(), readOnly.CanReadBuzz())
+	}
+}
+
+func TestGetBuzzAccountParsesBalance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != BuzzAccountPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, BuzzAccountPath)
+		}
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":{"data":{"json":{"blue":10,"green":20,"yellow":1234}}}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	acct, err := c.GetBuzzAccount(context.Background())
+	if err != nil {
+		t.Fatalf("GetBuzzAccount: %v", err)
+	}
+	if acct.Yellow != 1234 || acct.Blue != 10 || acct.Green != 20 {
+		t.Errorf("balance = %+v", acct)
+	}
+}
+
+func TestGetBuzzAccount403ReturnsScopeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{
+				"message": "Your API key does not have the required scope for this action",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	_, err := c.GetBuzzAccount(context.Background())
+	if !errors.Is(err, ErrBuzzScope) {
+		t.Errorf("expected ErrBuzzScope, got %v", err)
+	}
+}
+
+func TestGetBuzzAccountRequiresToken(t *testing.T) {
+	c := New("https://example.com", "", "")
+	if _, err := c.GetBuzzAccount(context.Background()); err == nil {
+		t.Fatal("expected error with no token")
 	}
 }

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -129,6 +129,8 @@ func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *mani
 	}
 	fmt.Fprintf(out, "Submitted. Publish request %s (%s@%s) is now %s — pending moderator review.\n",
 		r.PublishRequestID, r.Slug, r.Version, r.Status)
+	fmt.Fprintln(out, "\nTip: real `dev:live` generation spends Buzz and needs a full-scope personal API key —")
+	fmt.Fprintln(out, "run `civitai whoami` to check if your current credential can spend (OAuth login can submit/withdraw but not spend).")
 	return nil
 }
 

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -120,6 +120,10 @@ func TestAppSubmitUploadsWhenTokenAndPathConfigured(t *testing.T) {
 	if !strings.Contains(stdout, "pr_42") || !strings.Contains(stdout, "pending") {
 		t.Errorf("output should report the publish request: %s", stdout)
 	}
+	// #34: a successful submit surfaces the personal-key money-path tip.
+	if !strings.Contains(stdout, "personal API key") || !strings.Contains(stdout, "civitai whoami") {
+		t.Errorf("submit success should print the personal-key tip: %s", stdout)
+	}
 }
 
 func TestAppSubmitUploadsToV1RouteByDefault(t *testing.T) {

--- a/internal/cmd/buzz.go
+++ b/internal/cmd/buzz.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// buzzScopeHint is the actionable message shown when the stored credential
+// cannot read the Buzz balance (a 403 from buzz.getBuzzAccount, typical of an
+// OAuth login token). It points at the only working path: a full-scope personal
+// API key.
+const buzzScopeHint = "This credential can't read your Buzz balance (needs a full-scope personal API key).\n" +
+	"Create one at https://civitai.com/user/account, then run:\n" +
+	"  civitai login --token <key>\n" +
+	"OAuth login tokens (`civitai login`) can't read balance or spend Buzz."
+
+func newBuzzCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "buzz",
+		Short: "Show your spendable Buzz balance",
+		Long: `Show your spendable Buzz balance (blue / green / yellow) using your stored
+credential. Yellow Buzz is the currency real dev:live generation spends.
+
+Reads buzz.getBuzzAccount with the same credential as ` + "`whoami`" + ` / ` + "`app status`" + `.
+A full-scope personal API key can read your balance; an OAuth login token
+(` + "`civitai login`" + `) cannot read balance or spend Buzz — in that case this prints
+how to switch to a personal key.`,
+		Example: `  civitai buzz`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if cfg.Token() == "" {
+				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+			}
+
+			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
+			acct, err := client.GetBuzzAccount(context.Background())
+			if err != nil {
+				if errors.Is(err, api.ErrBuzzScope) {
+					// Actionable guidance + a non-zero exit (a 403 is a real,
+					// fixable failure, not "balance is zero").
+					fmt.Fprintln(cmd.ErrOrStderr(), buzzScopeHint)
+					return fmt.Errorf("credential can't read Buzz balance")
+				}
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "Spendable Buzz:")
+			fmt.Fprintf(out, "  Yellow: %d  (the generation-spend currency)\n", acct.Yellow)
+			fmt.Fprintf(out, "  Blue:   %d\n", acct.Blue)
+			fmt.Fprintf(out, "  Green:  %d\n", acct.Green)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cmd/buzz_cmd_test.go
+++ b/internal/cmd/buzz_cmd_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuzzCommandPrintsBalance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer tok-buzz" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":{"data":{"json":{"blue":5,"green":7,"yellow":4242}}}}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "tok-buzz")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "buzz")
+	if err != nil {
+		t.Fatalf("buzz: %v", err)
+	}
+	if !strings.Contains(out, "4242") {
+		t.Errorf("buzz output should show the yellow balance: %s", out)
+	}
+	if !strings.Contains(out, "Yellow") || !strings.Contains(out, "generation-spend") {
+		t.Errorf("buzz output should label yellow as the generation-spend currency: %s", out)
+	}
+}
+
+func TestBuzzCommand403ShowsPersonalKeyGuidance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"json":{"message":"Your API key does not have the required scope for this action"}}}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "oauth-tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, errOut, err := run(t, "buzz")
+	if err == nil {
+		t.Fatal("a 403 should be a non-zero exit (actionable failure, not zero balance)")
+	}
+	if !strings.Contains(errOut, "personal API key") || !strings.Contains(errOut, "civitai login --token") {
+		t.Errorf("403 should print the personal-key guidance: %s", errOut)
+	}
+	if !strings.Contains(errOut, "OAuth login") {
+		t.Errorf("403 guidance should explain OAuth can't read/spend: %s", errOut)
+	}
+}
+
+func TestBuzzCommandWithoutToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	_, _, err := run(t, "buzz")
+	if err == nil {
+		t.Fatal("expected error when no token configured")
+	}
+	if !strings.Contains(err.Error(), "no token") {
+		t.Errorf("error should mention missing token: %v", err)
+	}
+}
+
+// TestWhoAmICapabilitiesSpendYes drives a full-scope key: both capabilities yes,
+// no hint.
+func TestWhoAmICapabilitiesSpendYes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// UserRead | AIServicesWrite | BuzzRead = 1 | 32768 | 65536 = 98305.
+		_, _ = w.Write([]byte(`{"username":"zach","id":1,"tokenScope":98305}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "full-key")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "whoami")
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if !strings.Contains(out, "Capabilities:") {
+		t.Errorf("whoami should print a Capabilities section: %s", out)
+	}
+	if !strings.Contains(out, "Spend Buzz (AI Services): yes") {
+		t.Errorf("full-scope key should show Spend Buzz: yes: %s", out)
+	}
+	if !strings.Contains(out, "Read Buzz balance:        yes") {
+		t.Errorf("full-scope key should show Read Buzz balance: yes: %s", out)
+	}
+	if strings.Contains(out, "can't spend Buzz") {
+		t.Errorf("no spend-hint should print for a full-scope key: %s", out)
+	}
+}
+
+// TestWhoAmICapabilitiesSpendNo drives an OAuth login token (UserRead +
+// AppBlocksSubmit, no spend/read): both no, hint shown.
+func TestWhoAmICapabilitiesSpendNo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// UserRead(1) | AppBlocksSubmit(1<<25=33554432) = 33554433. No spend/read.
+		_, _ = w.Write([]byte(`{"username":"zach","id":1,"tokenScope":33554433}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "oauth-tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "whoami")
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if !strings.Contains(out, "Spend Buzz (AI Services): no") {
+		t.Errorf("OAuth token should show Spend Buzz: no: %s", out)
+	}
+	if !strings.Contains(out, "Read Buzz balance:        no") {
+		t.Errorf("OAuth token should show Read Buzz balance: no: %s", out)
+	}
+	if !strings.Contains(out, "personal API key") || !strings.Contains(out, "civitai login --token") {
+		t.Errorf("Spend Buzz: no should print the personal-key hint: %s", out)
+	}
+}
+
+// TestWhoAmICapabilitiesReadOnly drives a BuzzRead-but-no-spend token: read yes,
+// spend no.
+func TestWhoAmICapabilitiesReadOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// UserRead | BuzzRead = 1 | 65536 = 65537. No AIServicesWrite.
+		_, _ = w.Write([]byte(`{"username":"zach","id":1,"tokenScope":65537}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "read-key")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "whoami")
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if !strings.Contains(out, "Spend Buzz (AI Services): no") {
+		t.Errorf("read-only token should show Spend Buzz: no: %s", out)
+	}
+	if !strings.Contains(out, "Read Buzz balance:        yes") {
+		t.Errorf("read-only token should show Read Buzz balance: yes: %s", out)
+	}
+}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -29,7 +29,7 @@ func TestRootHelpListsCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("--help: %v", err)
 	}
-	for _, want := range []string{"app", "login", "whoami", "version", "completion"} {
+	for _, want := range []string{"app", "login", "whoami", "buzz", "version", "completion"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("root help missing command %q\n%s", want, out)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -104,6 +104,7 @@ Get started:
 	root.AddCommand(newAppCmd())
 	root.AddCommand(newLoginCmd())
 	root.AddCommand(newWhoAmICmd())
+	root.AddCommand(newBuzzCmd())
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newCompletionCmd())
 

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -31,9 +31,29 @@ authenticated username. Reads the token from config or CIVITAI_TOKEN.`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s (id %d) at %s\n", id.Username, id.ID, cfg.BaseURL())
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Logged in as %s (id %d) at %s\n", id.Username, id.ID, cfg.BaseURL())
+
+			// Decode the token's scope bitmask so the money-path dead end (an
+			// OAuth login can't spend) is visible BEFORE a dev:live run.
+			fmt.Fprintln(out, "\nCapabilities:")
+			fmt.Fprintf(out, "  Spend Buzz (AI Services): %s\n", yesNo(id.CanSpendBuzz()))
+			fmt.Fprintf(out, "  Read Buzz balance:        %s\n", yesNo(id.CanReadBuzz()))
+			if !id.CanSpendBuzz() {
+				fmt.Fprintln(out, "\nThis credential can't spend Buzz — money-path `dev:live` generation needs a")
+				fmt.Fprintln(out, "full-scope personal API key: create one at https://civitai.com/user/account,")
+				fmt.Fprintln(out, "then `civitai login --token <key>`. (OAuth login can submit/withdraw but not spend.)")
+			}
 			return nil
 		},
 	}
 	return cmd
+}
+
+// yesNo renders a capability bit as "yes"/"no".
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
 }

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -71,15 +71,16 @@ target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 
 **Live mode setup.**
 
-> ⚠️ **Prerequisite — `dev:live` needs an approved + DEPLOYED app.** `dev:live`
-> talks to a **deployed block instance**, so the dev-token mint
-> (`POST /api/v1/blocks/dev-token`) only succeeds once **this app is approved and
-> deployed** (deployState `live`). For a brand-new app — even right after a
-> successful `civitai app submit` (status `pending`) — the mint returns
-> **`App not found`**. That's expected: you **cannot `dev:live`-test your own
-> first app before its first approval + deploy**. Until your first version is
-> live, validate everything with `dev:harness` (the mock host — no real Buzz, no
-> network). Once the app is live, come back here for real-spend testing.
+> ⚠️ **`dev:live` works on a PENDING (un-approved) app.** The dev-token mint
+> (`POST /api/v1/blocks/dev-token`) accepts a **pending** slug — right after a
+> successful `civitai app submit` (status `pending`) it returns `200` with
+> `appId: pending-pubreq_…`, and `dev:live` mounts the live host against the
+> pending app. You do **not** need to wait for approval + deploy to dev:live-test.
+> For **real generation** you must mint with a **full-scope personal API key**; an
+> OAuth (`civitai login`) token mints read-only (`user:read:self`) and **cannot
+> spend**. Use `civitai buzz` / `civitai whoami` to confirm your credential can
+> spend. With no `VITE_LIVE_BLOCK_TOKEN` `dev:live` fails safe (renders a notice,
+> never spends), and `dev:harness` (the mock host) needs no token at all.
 
 To use it:
 
@@ -211,9 +212,11 @@ After `civitai app submit`, your publish request is `pending` review — a
 Civitai-side **moderator** approves (or rejects) it. **This is not self-service
 today**; you cannot approve your own app. Track it with `civitai app status`.
 
-- **`dev:live` / live real-Buzz spend only works once the app is approved AND
-  deployed** (deployState `live`) — see the live-mode prerequisite above. Until
-  then, develop against `dev:harness` (the mock host).
+- **`dev:live` works on a pending (un-approved) app** — the dev-token mint accepts
+  a pending slug (returns `appId: pending-pubreq_…`), so you can real-spend-test
+  before approval. Real generation needs a **full-scope personal API key** (an
+  OAuth `civitai login` token mints read-only and can't spend); confirm with
+  `civitai buzz` / `civitai whoami`. See the live-mode prerequisite above.
 - Need to change the bundle while a request is still `pending`? **Withdraw your
   own pending submission** and resubmit a different one:
 

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -31,17 +31,22 @@ VITE_HARNESS_MODE=
 # it here to run `dev:live` against the real backend. ⚠️ A real token here spends
 # REAL Buzz; it's short-lived (~15min) — never commit one.
 #
+# The mint accepts a PENDING (un-approved) slug — right after `civitai app submit`
+# it returns 200 with appId: pending-pubreq_… , so you can dev:live-test before
+# approval (no need to wait for approval + deploy).
+#
 # For REAL generation (spends real Buzz), mint with a full-scope PERSONAL API KEY
 # (create at https://civitai.com/user/account — it carries AI Services):
 #   curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
 #     -H "Authorization: Bearer $CIVITAI_TOKEN" -H 'Content-Type: application/json' \
 #     -d '{"slug":"<your-app-slug>"}'
-# `civitai login` (OAuth) mints a READ/IDENTITY-ONLY token: the civitai-cli client
-# has App Blocks submit but NOT AI Services, so the server strips the budgeted-spend
-# scope. For a page-money (generation) app whose manifest declares only
-# `ai:write:budgeted`, that leaves the token read/identity-only — viewer + catalog +
+# `civitai login` (OAuth) mints a READ-ONLY token (user:read:self): the civitai-cli
+# client has App Blocks submit but NOT AI Services, so the server strips the
+# budgeted-spend scope. For a page-money (generation) app whose manifest declares
+# only `ai:write:budgeted`, that leaves the token read-only — viewer + catalog +
 # storage work, but real generation (estimate -> submit -> spend) does NOT. For that
-# use a full-scope PERSONAL API KEY. See README.
+# use a full-scope PERSONAL API KEY. Confirm with `civitai buzz` / `civitai whoami`.
+# See README.
 VITE_LIVE_BLOCK_TOKEN=
 
 # LIVE mode only. The TARGET the vite dev proxy forwards backend calls to.


### PR DESCRIPTION
Closes #32, #33, #34, #35

One cohesive **money-path DX** change surfaced by a blind external-dev dogfood — the four issues are all facets of "a newcomer following the happy path can't see (or hits) the OAuth-can't-spend dead end, and the dev:live docs are now wrong."

## What changed

### `civitai buzz` (#35)
New top-level command. Reads the spendable balance (blue / green / **yellow**, yellow labelled as the generation-spend currency) via `buzz.getBuzzAccount` with the stored credential (same auth path as `whoami` / `app status`).
- **200** → prints the balance.
- **403** (credential lacks the Buzz-read scope, e.g. an OAuth login token) → prints clear guidance ("needs a full-scope personal API key … `civitai login --token <key>` … OAuth login tokens can't read balance or spend Buzz") and exits **non-zero** (a 403 is an actionable failure, not "zero balance").
- No token → clean error.

### `civitai whoami` capabilities (#34 / #35)
`whoami` now decodes the `tokenScope` bitmask it already receives from `/api/v1/me` into a **Capabilities** section:
```
Capabilities:
  Spend Buzz (AI Services): yes/no
  Read Buzz balance:        yes/no
```
When **Spend Buzz: no**, it prints a one-line hint that money-path `dev:live` needs a full-scope personal API key via `civitai login --token <key>` (OAuth login can submit/withdraw but not spend). `tokenScope` is threaded through `Identity` and decoded with Go consts (`ScopeUserRead`/`ScopeAIServicesWrite`/`ScopeBuzzRead`) mirrored from civitai `src/shared/constants/token-scope.constants.ts`.

### `app submit` tip (#34)
After a successful submit, a 2-line tip: real `dev:live` generation spends Buzz and needs a full-scope personal API key — run `civitai whoami` to check.

### Corrected the stale "can't dev:live a pending app" docs (#32, 🔴)
The pending dev-token mint now returns **200** (`appId: pending-pubreq_…`); the old "App not found / can't dev:live before approval" claim is false. Replaced in **all three** surfaces:
- repo `README.md` `dev:live` section,
- scaffold `page-money/README.md.tmpl` (live-mode prerequisite + submission-lifecycle bullet),
- scaffold `page-money` `.env.example` (`VITE_LIVE_BLOCK_TOKEN` comment).
True wording: dev:live works on a pending app; **real generation still needs a full-scope personal API key** (OAuth mints read-only `user:read:self`).

### README command reference (#33)
Added `civitai app withdraw [pubreq-id] [--id]` to the command table + submission-lifecycle section, plus the new `civitai buzz` and `whoami`'s capability output.

## Tests
httptest-mock style matching the existing suites:
- api: `TestWhoAmIParsesTokenScope`, `TestIdentityCapabilityBits`, `TestGetBuzzAccountParsesBalance`, `TestGetBuzzAccount403ReturnsScopeError`, `TestGetBuzzAccountRequiresToken`
- cmd: `TestBuzzCommandPrintsBalance`, `TestBuzzCommand403ShowsPersonalKeyGuidance`, `TestBuzzCommandWithoutToken`, `TestWhoAmICapabilities{SpendYes,SpendNo,ReadOnly}`, plus a submit-tip assertion added to the existing upload test.

`go build`, `go vet`, `go test ./...`, `gofmt -l` all green.

> **Not end-to-end verified:** the live `/api/v1/me` and `buzz.getBuzzAccount` endpoints are exercised via httptest mocks only, not against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
