### PR TITLE
fix(version): stamp commit+date in Makefile builds + add release-update check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BINARY := civitai
 PKG := ./cmd/civitai
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -s -w -X main.version=$(VERSION)
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 .PHONY: all build install test vet lint fmt clean tidy ci
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -37,6 +37,8 @@ func TestRootHelpListsCommands(t *testing.T) {
 }
 
 func TestVersionCommand(t *testing.T) {
+	// Keep this test hermetic — don't reach out to GitHub for the update check.
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
 	out, _, err := run(t, "version")
 	if err != nil {
 		t.Fatalf("version: %v", err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,23 +46,58 @@ func applyBuildInfoFallback() {
 	if !ok || info == nil {
 		return
 	}
-	if isDevDefault(version) {
-		if v := info.Main.Version; v != "" && v != "(devel)" {
-			version = v
-		}
-	}
+	var mainVersion, rev, vcsTime, modified string
+	mainVersion = info.Main.Version
 	for _, s := range info.Settings {
 		switch s.Key {
 		case "vcs.revision":
-			if commit == "none" && s.Value != "" {
-				commit = s.Value
-			}
+			rev = s.Value
 		case "vcs.time":
-			if date == "unknown" && s.Value != "" {
-				date = s.Value
-			}
+			vcsTime = s.Value
+		case "vcs.modified":
+			modified = s.Value
 		}
 	}
+	version, commit, date = mergeBuildInfo(version, commit, date, mainVersion, rev, vcsTime, modified)
+}
+
+// mergeBuildInfo merges the (possibly ldflag-stamped) version/commit/date with
+// the values read from runtime/debug.ReadBuildInfo. The ldflag values are
+// authoritative: a field is only filled from build info when it's still its
+// dev/none/unknown default. Pure function so the merge logic is unit-testable
+// without mocking ReadBuildInfo.
+//
+//   - version: if dev/empty, use mainVersion (the module version from
+//     `go install module@vX`), unless it's "" or "(devel)".
+//   - commit:  if "none", use vcs.revision shortened to 12 chars, with "+dirty"
+//     appended when vcs.modified == "true".
+//   - date:    if "unknown", use vcs.time.
+func mergeBuildInfo(version, commit, date, mainVersion, rev, vcsTime, modified string) (string, string, string) {
+	if isDevDefault(version) {
+		if mainVersion != "" && mainVersion != "(devel)" {
+			version = mainVersion
+		}
+	}
+	if commit == "none" && rev != "" {
+		commit = shortenRevision(rev)
+		if modified == "true" {
+			commit += "+dirty"
+		}
+	}
+	if date == "unknown" && vcsTime != "" {
+		date = vcsTime
+	}
+	return version, commit, date
+}
+
+// shortenRevision trims a full 40-char git SHA to 12 chars; shorter values are
+// returned unchanged.
+func shortenRevision(rev string) string {
+	const n = 12
+	if len(rev) > n {
+		return rev[:n]
+	}
+	return rev
 }
 
 // isDevDefault reports whether v is one of the placeholder values that mean

--- a/internal/cmd/update_check.go
+++ b/internal/cmd/update_check.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// latestReleaseURL is the GitHub public API endpoint for the newest release of
+// this CLI. It's a package var so tests can point it at an httptest server.
+//
+// SECURITY: this is an UNAUTHENTICATED public API call — we never attach the
+// user's Civitai API token (or any Authorization header) to it.
+var latestReleaseURL = "https://api.github.com/repos/civitai/cli/releases/latest"
+
+// updateCheckTimeout bounds the GitHub round-trip. Kept short so `civitai
+// version` never hangs on a slow/offline network.
+const updateCheckTimeout = 2500 * time.Millisecond
+
+// updateCheckDisabled reports whether the GitHub update check should be skipped:
+// the --no-update-check flag (noFlag) or a non-empty CIVITAI_NO_UPDATE_CHECK env
+// var both opt out.
+func updateCheckDisabled(noFlag bool) bool {
+	return noFlag || os.Getenv("CIVITAI_NO_UPDATE_CHECK") != ""
+}
+
+// printUpdateNotice queries GitHub for the latest release and, if it's newer
+// than current, prints a one-line notice to w. It is deliberately best-effort:
+// any network error, non-200, or parse failure is swallowed silently (nothing
+// printed, never an error) so it can never break or slow down `civitai version`.
+//
+// current is the resolved running version (may be "dev"/a pseudo-version).
+func printUpdateNotice(w io.Writer, current string) {
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	latest, err := fetchLatestRelease(ctx, latestReleaseURL)
+	if err != nil || latest == "" {
+		return // fail-silent: offline, timeout, non-200, or parse error.
+	}
+
+	switch compareVersions(current, latest) {
+	case -1:
+		// current < latest (or current is unparseable) => newer is available.
+		if isParseableVersion(current) {
+			fmt.Fprintf(w, "\nA newer version is available: %s (you have %s) — https://github.com/civitai/cli/releases/latest\n", latest, current)
+		} else {
+			fmt.Fprintf(w, "\nLatest release: %s — https://github.com/civitai/cli/releases/latest\n", latest)
+		}
+		fmt.Fprintln(w, "Upgrade with: brew upgrade civitai")
+	default:
+		// current == latest or current > latest: nothing actionable.
+		fmt.Fprintln(w, "\nYou're on the latest version.")
+	}
+}
+
+// fetchLatestRelease does the unauthenticated GitHub call and returns the
+// release tag_name (e.g. "v0.1.10"). Returns an error on any non-200 or
+// transport/parse failure; callers treat that as "skip the notice".
+func fetchLatestRelease(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// NOTE: intentionally NO Authorization header — public, token-free call.
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases: status %d", resp.StatusCode)
+	}
+	// Cap the body so a misbehaving endpoint can't make us read forever.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return "", err
+	}
+	return rel.TagName, nil
+}
+
+// semver is a minimal parsed vMAJOR.MINOR.PATCH triple. Pre-release/build
+// suffixes (-rc1, +meta) are ignored for comparison.
+type semver struct {
+	major, minor, patch int
+}
+
+// parseSemver parses a "vMAJOR.MINOR.PATCH" (or "MAJOR.MINOR.PATCH") string,
+// tolerating a leading "v" and ignoring any "-prerelease"/"+build" suffix.
+// Missing minor/patch default to 0 (so "v1" and "v1.2" parse). Returns ok=false
+// for anything that isn't a numeric dotted version (e.g. "dev", a Go
+// pseudo-version, or a git describe like "v0.1.1-3-gabc123").
+func parseSemver(s string) (semver, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	if s == "" {
+		return semver{}, false
+	}
+	// Strip build metadata first, then pre-release.
+	if i := strings.IndexByte(s, '+'); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) > 3 {
+		return semver{}, false
+	}
+	var nums [3]int
+	for i := 0; i < 3; i++ {
+		if i >= len(parts) {
+			continue // missing minor/patch => 0
+		}
+		n, err := strconv.Atoi(parts[i])
+		if err != nil || n < 0 {
+			return semver{}, false
+		}
+		nums[i] = n
+	}
+	return semver{nums[0], nums[1], nums[2]}, true
+}
+
+// isParseableVersion reports whether s looks like a real semver we can compare.
+func isParseableVersion(s string) bool {
+	_, ok := parseSemver(s)
+	return ok
+}
+
+// compareVersions compares current vs latest by semver. Returns:
+//
+//	-1  current is older than latest, OR current is unparseable (treat any real
+//	    release as "available" when we can't tell what the user is running)
+//	 0  equal
+//	 1  current is newer than latest
+//
+// If latest itself is unparseable, returns 0 (nothing to recommend).
+func compareVersions(current, latest string) int {
+	lv, lok := parseSemver(latest)
+	if !lok {
+		return 0
+	}
+	cv, cok := parseSemver(current)
+	if !cok {
+		return -1 // unknown current => surface the latest as available.
+	}
+	switch {
+	case cv.major != lv.major:
+		return cmpInt(cv.major, lv.major)
+	case cv.minor != lv.minor:
+		return cmpInt(cv.minor, lv.minor)
+	default:
+		return cmpInt(cv.patch, lv.patch)
+	}
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/cmd/update_check.go
+++ b/internal/cmd/update_check.go
@@ -45,6 +45,12 @@ func printUpdateNotice(w io.Writer, current string) {
 		return // fail-silent: offline, timeout, non-200, or parse error.
 	}
 
+	// If we can't parse latest, the check effectively failed — stay silent
+	// rather than make an unfounded "up to date" claim (fail-silent contract).
+	if !isParseableVersion(latest) {
+		return
+	}
+
 	switch compareVersions(current, latest) {
 	case -1:
 		// current < latest (or current is unparseable) => newer is available.
@@ -54,9 +60,15 @@ func printUpdateNotice(w io.Writer, current string) {
 			fmt.Fprintf(w, "\nLatest release: %s — https://github.com/civitai/cli/releases/latest\n", latest)
 		}
 		fmt.Fprintln(w, "Upgrade with: brew upgrade civitai")
-	default:
-		// current == latest or current > latest: nothing actionable.
+	case 0:
+		// Verified equal: both current and latest parse and match. This is the
+		// ONLY path that may honestly claim the user is up to date.
 		fmt.Fprintln(w, "\nYou're on the latest version.")
+	default:
+		// current > latest (dev/pre-release build ahead of the newest release):
+		// don't claim "on the latest version" — say nothing actionable, just
+		// surface the latest release informationally and honestly.
+		fmt.Fprintf(w, "\nLatest release: %s — https://github.com/civitai/cli/releases/latest\n", latest)
 	}
 }
 

--- a/internal/cmd/update_check_test.go
+++ b/internal/cmd/update_check_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestMergeBuildInfo(t *testing.T) {
@@ -201,8 +202,14 @@ func TestPrintUpdateNotice_CurrentAhead(t *testing.T) {
 	if strings.Contains(out, "newer version is available") {
 		t.Errorf("should not prompt upgrade when current is ahead: %s", out)
 	}
-	if !strings.Contains(out, "latest version") {
-		t.Errorf("expected up-to-date message when ahead: %s", out)
+	// When ahead (a dev/pre-release build newer than the latest release), we must
+	// NOT claim "You're on the latest version." — that would be a false claim.
+	if strings.Contains(out, "You're on the latest version") {
+		t.Errorf("should not claim 'on the latest version' when current is ahead: %s", out)
+	}
+	// Instead it surfaces the latest release informationally and honestly.
+	if !strings.Contains(out, "Latest release: v0.1.9") {
+		t.Errorf("ahead build should surface the latest release informationally: %s", out)
 	}
 }
 
@@ -259,6 +266,93 @@ func TestPrintUpdateNotice_UnreachableFailsSilent(t *testing.T) {
 	printUpdateNotice(&buf, "v0.1.9")
 	if buf.Len() != 0 {
 		t.Errorf("unreachable endpoint should produce no output, got: %s", buf.String())
+	}
+}
+
+// TestPrintUpdateNotice_UnparseableLatestFailsSilent proves the 🟡 fix: when the
+// GitHub response carries a garbage or empty tag_name, compareVersions returns 0
+// by fallback — but we must NOT print "You're on the latest version." (that would
+// be an unfounded reassurance for a check that effectively failed). Stay silent.
+func TestPrintUpdateNotice_UnparseableLatestFailsSilent(t *testing.T) {
+	for _, tag := range []string{"", "garbage", "not-a-version", "vX.Y.Z"} {
+		t.Run("tag="+tag, func(t *testing.T) {
+			srv, hits := newReleaseServer(t, tag, http.StatusOK)
+			pointAtServer(t, srv.URL)
+
+			var buf bytes.Buffer
+			printUpdateNotice(&buf, "v0.1.9")
+
+			if *hits != 1 {
+				t.Errorf("expected exactly 1 GitHub hit, got %d", *hits)
+			}
+			if buf.Len() != 0 {
+				t.Errorf("unparseable latest %q must produce NO output (no 'up to date' claim), got: %s", tag, buf.String())
+			}
+		})
+	}
+}
+
+// TestPrintUpdateNotice_VerifiedEqual asserts the up-to-date line prints ONLY on a
+// verified equal (both current and latest parse and match).
+func TestPrintUpdateNotice_VerifiedEqual(t *testing.T) {
+	srv, _ := newReleaseServer(t, "v0.1.9", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+	out := buf.String()
+
+	if !strings.Contains(out, "You're on the latest version.") {
+		t.Errorf("verified-equal should print the up-to-date line: %s", out)
+	}
+	if strings.Contains(out, "newer version is available") {
+		t.Errorf("verified-equal must not prompt an upgrade: %s", out)
+	}
+}
+
+// TestPrintUpdateNotice_SlowBodyHonorsDeadline proves `civitai version` can never
+// hang on a slow server: the endpoint writes a 200 + headers, then STALLS past the
+// update-check deadline before writing the body. printUpdateNotice must return
+// within roughly the timeout, print nothing, and never error/panic.
+func TestPrintUpdateNotice_SlowBodyHonorsDeadline(t *testing.T) {
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush() // commit 200 + headers, then stall on the body.
+		}
+		// Stall well past updateCheckTimeout; bail early if the client gives up.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(updateCheckTimeout + 5*time.Second):
+		case <-released:
+		}
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	t.Cleanup(func() { close(released); srv.Close() })
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		printUpdateNotice(&buf, "v0.1.9")
+		close(done)
+	}()
+
+	// Generous ceiling above the 2.5s deadline but far below a hang.
+	select {
+	case <-done:
+	case <-time.After(updateCheckTimeout + 2*time.Second):
+		t.Fatalf("printUpdateNotice hung on a slow server (no return after %s)", updateCheckTimeout+2*time.Second)
+	}
+
+	if elapsed := time.Since(start); elapsed > updateCheckTimeout+2*time.Second {
+		t.Errorf("printUpdateNotice took %s, expected to bail near the %s deadline", elapsed, updateCheckTimeout)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("slow-body deadline hit should produce no output, got: %s", buf.String())
 	}
 }
 

--- a/internal/cmd/update_check_test.go
+++ b/internal/cmd/update_check_test.go
@@ -1,0 +1,342 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestMergeBuildInfo(t *testing.T) {
+	tests := []struct {
+		name                                string
+		version, commit, date               string
+		mainVersion, rev, vcsTime, modified string
+		wantVersion, wantCommit, wantDate   string
+	}{
+		{
+			name:    "ldflags authoritative — build info ignored",
+			version: "1.2.3", commit: "abc123", date: "2026-01-01",
+			mainVersion: "v9.9.9", rev: "frombuildinfo", vcsTime: "2000-01-01T00:00:00Z", modified: "true",
+			wantVersion: "1.2.3", wantCommit: "abc123", wantDate: "2026-01-01",
+		},
+		{
+			name:    "all defaults — filled from build info, rev shortened",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: "v0.1.1", rev: "0123456789abcdef0123", vcsTime: "2026-06-23T00:00:00Z", modified: "false",
+			wantVersion: "v0.1.1", wantCommit: "0123456789ab", wantDate: "2026-06-23T00:00:00Z",
+		},
+		{
+			name:    "dirty working tree appends +dirty",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: "v0.1.1", rev: "0123456789abcdef0123", vcsTime: "2026-06-23T00:00:00Z", modified: "true",
+			wantVersion: "v0.1.1", wantCommit: "0123456789ab+dirty", wantDate: "2026-06-23T00:00:00Z",
+		},
+		{
+			name:    "(devel) main version ignored, keeps dev",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: "(devel)", rev: "short", vcsTime: "", modified: "",
+			wantVersion: "dev", wantCommit: "short", wantDate: "unknown",
+		},
+		{
+			name:    "partial — version stamped, commit/date filled",
+			version: "1.0.0", commit: "none", date: "unknown",
+			mainVersion: "v0.1.1", rev: "rev123", vcsTime: "2026-06-23T00:00:00Z", modified: "false",
+			wantVersion: "1.0.0", wantCommit: "rev123", wantDate: "2026-06-23T00:00:00Z",
+		},
+		{
+			name:    "empty build info leaves defaults",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: "", rev: "", vcsTime: "", modified: "",
+			wantVersion: "dev", wantCommit: "none", wantDate: "unknown",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotC, gotD := mergeBuildInfo(tc.version, tc.commit, tc.date, tc.mainVersion, tc.rev, tc.vcsTime, tc.modified)
+			if gotV != tc.wantVersion {
+				t.Errorf("version: got %q want %q", gotV, tc.wantVersion)
+			}
+			if gotC != tc.wantCommit {
+				t.Errorf("commit: got %q want %q", gotC, tc.wantCommit)
+			}
+			if gotD != tc.wantDate {
+				t.Errorf("date: got %q want %q", gotD, tc.wantDate)
+			}
+		})
+	}
+}
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		in              string
+		wantOK          bool
+		maj, min, patch int
+	}{
+		{"v0.1.10", true, 0, 1, 10},
+		{"0.1.10", true, 0, 1, 10},
+		{"v1.2.3-rc1", true, 1, 2, 3},
+		{"v1.2.3+build.5", true, 1, 2, 3},
+		{"v1.2.3-rc1+build", true, 1, 2, 3},
+		{"v1", true, 1, 0, 0},
+		{"v1.2", true, 1, 2, 0},
+		{"dev", false, 0, 0, 0},
+		{"", false, 0, 0, 0},
+		{"v0.1.1-3-gabc123", true, 0, 1, 1}, // git describe: suffix dropped
+		{"v0.0.0-20260101000000-abcdef", true, 0, 0, 0},
+		{"vX.Y.Z", false, 0, 0, 0},
+		{"1.2.3.4", false, 0, 0, 0},
+	}
+	for _, tc := range tests {
+		sv, ok := parseSemver(tc.in)
+		if ok != tc.wantOK {
+			t.Errorf("parseSemver(%q) ok=%v want %v", tc.in, ok, tc.wantOK)
+			continue
+		}
+		if ok && (sv.major != tc.maj || sv.minor != tc.min || sv.patch != tc.patch) {
+			t.Errorf("parseSemver(%q) = %d.%d.%d want %d.%d.%d", tc.in, sv.major, sv.minor, sv.patch, tc.maj, tc.min, tc.patch)
+		}
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		current, latest string
+		want            int
+	}{
+		{"v0.1.9", "v0.1.10", -1},
+		{"v0.1.10", "v0.1.10", 0},
+		{"v0.2.0", "v0.1.10", 1},
+		{"v1.0.0", "v0.9.9", 1},
+		{"dev", "v0.1.10", -1},                // unparseable current => available
+		{"v0.0.0-20260101-abc", "v0.1.0", -1}, // pseudo-version parses to 0.0.0
+		{"v0.1.9", "garbage", 0},              // unparseable latest => nothing
+		{"v0.1.9-rc1", "v0.1.9", 0},           // suffix ignored => equal
+		{"v0.1.9+dirty", "v0.1.10", -1},       // build meta ignored
+	}
+	for _, tc := range tests {
+		if got := compareVersions(tc.current, tc.latest); got != tc.want {
+			t.Errorf("compareVersions(%q,%q) = %d want %d", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}
+
+// newReleaseServer returns an httptest server that serves the given tag_name and
+// records how many times it was hit.
+func newReleaseServer(t *testing.T, tag string, status int) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		// The call must be token-free.
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("update check sent an Authorization header — must be unauthenticated")
+		}
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = w.Write([]byte(`{"tag_name":"` + tag + `"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// pointAtServer swaps latestReleaseURL for the test and restores it after.
+func pointAtServer(t *testing.T, url string) {
+	t.Helper()
+	orig := latestReleaseURL
+	latestReleaseURL = url
+	t.Cleanup(func() { latestReleaseURL = orig })
+}
+
+func TestPrintUpdateNotice_NewerAvailable(t *testing.T) {
+	srv, hits := newReleaseServer(t, "v0.1.10", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+	out := buf.String()
+
+	if *hits != 1 {
+		t.Errorf("expected exactly 1 GitHub hit, got %d", *hits)
+	}
+	if !strings.Contains(out, "A newer version is available: v0.1.10") {
+		t.Errorf("missing newer-version notice: %s", out)
+	}
+	if !strings.Contains(out, "you have v0.1.9") {
+		t.Errorf("notice should show current version: %s", out)
+	}
+	if !strings.Contains(out, "brew upgrade") {
+		t.Errorf("notice should include brew upgrade hint: %s", out)
+	}
+}
+
+func TestPrintUpdateNotice_UpToDate(t *testing.T) {
+	srv, _ := newReleaseServer(t, "v0.1.9", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+	out := buf.String()
+
+	if !strings.Contains(out, "latest version") {
+		t.Errorf("expected up-to-date message: %s", out)
+	}
+	if strings.Contains(out, "newer version is available") {
+		t.Errorf("should not claim a newer version when equal: %s", out)
+	}
+}
+
+func TestPrintUpdateNotice_CurrentAhead(t *testing.T) {
+	srv, _ := newReleaseServer(t, "v0.1.9", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.2.0")
+	out := buf.String()
+
+	if strings.Contains(out, "newer version is available") {
+		t.Errorf("should not prompt upgrade when current is ahead: %s", out)
+	}
+	if !strings.Contains(out, "latest version") {
+		t.Errorf("expected up-to-date message when ahead: %s", out)
+	}
+}
+
+func TestPrintUpdateNotice_DevCurrent(t *testing.T) {
+	srv, _ := newReleaseServer(t, "v0.1.10", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "dev")
+	out := buf.String()
+
+	if !strings.Contains(out, "Latest release: v0.1.10") {
+		t.Errorf("dev current should surface the latest release: %s", out)
+	}
+}
+
+func TestPrintUpdateNotice_Non200FailsSilent(t *testing.T) {
+	srv, hits := newReleaseServer(t, "", http.StatusInternalServerError)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+
+	if *hits != 1 {
+		t.Errorf("expected 1 hit, got %d", *hits)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("non-200 should produce no output, got: %s", buf.String())
+	}
+}
+
+func TestPrintUpdateNotice_GarbageBodyFailsSilent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	t.Cleanup(srv.Close)
+	pointAtServer(t, srv.URL)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+	if buf.Len() != 0 {
+		t.Errorf("garbage body should produce no output, got: %s", buf.String())
+	}
+}
+
+func TestPrintUpdateNotice_UnreachableFailsSilent(t *testing.T) {
+	// Closed server => connection refused => fail-silent, no panic.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	pointAtServer(t, url)
+
+	var buf bytes.Buffer
+	printUpdateNotice(&buf, "v0.1.9")
+	if buf.Len() != 0 {
+		t.Errorf("unreachable endpoint should produce no output, got: %s", buf.String())
+	}
+}
+
+func TestFetchLatestRelease_TimeoutFailsSilent(t *testing.T) {
+	// Server that never responds within the context deadline.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // wait until the client cancels.
+	}))
+	t.Cleanup(func() { close(block); srv.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already-cancelled context => immediate failure.
+	if _, err := fetchLatestRelease(ctx, srv.URL); err == nil {
+		t.Error("expected error on cancelled context")
+	}
+}
+
+func TestUpdateCheckDisabled(t *testing.T) {
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "")
+	if updateCheckDisabled(false) {
+		t.Error("should be enabled with no flag and empty env")
+	}
+	if !updateCheckDisabled(true) {
+		t.Error("--no-update-check flag should disable")
+	}
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+	if !updateCheckDisabled(false) {
+		t.Error("CIVITAI_NO_UPDATE_CHECK=1 should disable")
+	}
+}
+
+// TestVersionCommandEnvOptOutMakesNoCall asserts the env opt-out path skips the
+// HTTP call entirely (the server must get zero hits).
+func TestVersionCommandEnvOptOut(t *testing.T) {
+	srv, hits := newReleaseServer(t, "v9.9.9", http.StatusOK)
+	pointAtServer(t, srv.URL)
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+
+	out, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if *hits != 0 {
+		t.Errorf("opt-out env should prevent any GitHub call, got %d hits", *hits)
+	}
+	if strings.Contains(out, "newer version") {
+		t.Errorf("opt-out should suppress the update notice: %s", out)
+	}
+}
+
+// TestVersionCommandNoUpdateFlag asserts --no-update-check skips the HTTP call.
+func TestVersionCommandNoUpdateFlag(t *testing.T) {
+	srv, hits := newReleaseServer(t, "v9.9.9", http.StatusOK)
+	pointAtServer(t, srv.URL)
+
+	if _, _, err := run(t, "version", "--no-update-check"); err != nil {
+		t.Fatalf("version --no-update-check: %v", err)
+	}
+	if *hits != 0 {
+		t.Errorf("--no-update-check should prevent any GitHub call, got %d hits", *hits)
+	}
+}
+
+// TestVersionCommandShowsUpdate exercises the full command path with a stub
+// server and asserts both the build-info lines and the update notice render.
+func TestVersionCommandShowsUpdate(t *testing.T) {
+	srv, _ := newReleaseServer(t, "v999.0.0", http.StatusOK)
+	pointAtServer(t, srv.URL)
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "")
+
+	out, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	for _, want := range []string{"civitai", "commit:", "built:", "go:", "v999.0.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("version output missing %q: %s", want, out)
+		}
+	}
+}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -8,22 +8,37 @@ import (
 )
 
 func newVersionCmd() *cobra.Command {
-	return &cobra.Command{
+	var noUpdateCheck bool
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the CLI version, commit, and build date",
 		Long: `Print detailed build information for this civitai binary.
 
 The version, commit, and date are stamped in at release time. For a plain
-"go install" or source build they read "dev" / "none" / "unknown".`,
-		Example: `  civitai version`,
-		Args:    cobra.NoArgs,
+"go install" or source build they fall back to the embedded Go build info
+(module version + VCS revision/time).
+
+After printing build info, this command makes a single unauthenticated call to
+the GitHub releases API to tell you if a newer release is available. The check
+is best-effort (short timeout, fails silently offline) and never sends your API
+token. Skip it with --no-update-check or by setting CIVITAI_NO_UPDATE_CHECK.`,
+		Example: `  civitai version
+  civitai version --no-update-check`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "civitai %s\n", version)
 			fmt.Fprintf(out, "  commit: %s\n", commit)
 			fmt.Fprintf(out, "  built:  %s\n", date)
 			fmt.Fprintf(out, "  go:     %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+			if !updateCheckDisabled(noUpdateCheck) {
+				printUpdateNotice(out, version)
+			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&noUpdateCheck, "no-update-check", false,
+		"skip the GitHub check for a newer release (also via CIVITAI_NO_UPDATE_CHECK)")
+	return cmd
 }


### PR DESCRIPTION
## What

Fixes two gaps in `civitai version` (one PR):

1. **Makefile didn't stamp commit + date.** It only injected `-X main.version`, so `make build`/`make install` binaries printed `commit: none / built: unknown`. LDFLAGS now also inject `main.commit` (git short SHA) and `main.date` (UTC RFC3339), with safe fallbacks if git is absent. goreleaser release binaries were already fine; this brings local builds in line.

2. **`civitai version` now reports if a newer release is available.** After printing build info it makes one *unauthenticated* GitHub releases API call (`Accept: application/vnd.github+json`, **no `Authorization` header — never sends the user's API token**), 2.5s timeout, **fails silent** on any network / non-200 / parse error so it can never break or block the command. Opt out with `--no-update-check` or `CIVITAI_NO_UPDATE_CHECK` (documented in `version --help`). Only the explicit `version` command does this.

Also hardens the existing `runtime/debug.ReadBuildInfo` fallback for plain `go install`/`go build` binaries: the merge is factored into a pure, unit-testable `mergeBuildInfo`; the VCS revision is shortened to 12 chars; `+dirty` is appended when `vcs.modified=true`.

A minimal `vMAJOR.MINOR.PATCH` semver parse/compare (no new dependency) backs the check; pre-release/build suffixes are ignored, an unparseable current version surfaces the latest release as available.

## Verification

`make build` now stamps real values:
```
civitai v0.1.10-dirty
  commit: 7d1e947
  built:  2026-06-25T19:46:28Z
  go:     go1.25.8 linux/amd64
```

Plain `go build` (no ldflags) recovers commit/date from embedded VCS info via the fallback:
```
civitai v0.1.11-0.20260625194726-e087c3a9abca
  commit: e087c3a9abca
  built:  2026-06-25T19:47:26Z
```

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt -l` clean.

Tests: `TestMergeBuildInfo` (ldflags-win / fallback / +dirty / (devel)-ignored / partial / empty), `TestParseSemver`, `TestCompareVersions`, `TestPrintUpdateNotice_*` (newer / up-to-date / ahead / dev-current / non-200 / garbage / unreachable fail-silent + Authorization-header assertion), `TestUpdateCheckDisabled`, `TestVersionCommandEnvOptOut` / `TestVersionCommandNoUpdateFlag` (assert **zero** HTTP hits on opt-out), `TestVersionCommandShowsUpdate`.

Not verified: the **live** `api.github.com` call (tests use an httptest stub; opt-out is set for local runs to stay hermetic/offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
