### PR TITLE
fix(version): recover commit/date for `go install` builds

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,7 +2,9 @@
 package cmd
 
 import (
+	"regexp"
 	"runtime/debug"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -72,6 +74,13 @@ func applyBuildInfoFallback() {
 //   - commit:  if "none", use vcs.revision shortened to 12 chars, with "+dirty"
 //     appended when vcs.modified == "true".
 //   - date:    if "unknown", use vcs.time.
+//
+// Precedence per field: ldflags > vcs.* > Go pseudo-version. The vcs.* settings
+// are absent for `go install module@version` builds (the module proxy cache has
+// no VCS checkout), so as a last resort we recover commit/date from a Go
+// pseudo-version mainVersion (the `vX.Y.Z-<timestamp>-<sha>` form used for
+// untagged/branch installs, which embeds both). A clean release tag (e.g.
+// `v0.1.12`) carries no commit/date, so those stay at their defaults here.
 func mergeBuildInfo(version, commit, date, mainVersion, rev, vcsTime, modified string) (string, string, string) {
 	if isDevDefault(version) {
 		if mainVersion != "" && mainVersion != "(devel)" {
@@ -87,7 +96,54 @@ func mergeBuildInfo(version, commit, date, mainVersion, rev, vcsTime, modified s
 	if date == "unknown" && vcsTime != "" {
 		date = vcsTime
 	}
+
+	// Last-resort recovery from a Go pseudo-version (no vcs.* present): fills
+	// only the fields still at their defaults; vcs.*/ldflags above already won.
+	if commit == "none" || date == "unknown" {
+		if psha, pdate, ok := parsePseudoVersion(mainVersion); ok {
+			if commit == "none" && psha != "" {
+				commit = shortenRevision(psha)
+			}
+			if date == "unknown" && pdate != "" {
+				date = pdate
+			}
+		}
+	}
 	return version, commit, date
+}
+
+// pseudoVersionRE matches the three Go pseudo-version forms and captures the
+// 14-digit `yyyymmddhhmmss` timestamp and the trailing 12-hex commit prefix:
+//
+//	vX.Y.Z-yyyymmddhhmmss-sha            (no known base tag below the commit)
+//	vX.Y.Z-0.yyyymmddhhmmss-sha          (base release tag)
+//	vX.Y.Z-pre.0.yyyymmddhhmmss-sha      (base pre-release tag, e.g. -pre / -beta.1)
+//
+// See https://go.dev/ref/mod#pseudo-versions. The timestamp is preceded by a
+// `-` (form 1, no base tag) or a `.` (forms 2/3, where it's the final dotted
+// segment of a `0` / `pre.0` pre-release), so we anchor on the unambiguous
+// `[.-]<14 digits>-<12 hex>$` tail. The optional pre-release run before it is
+// non-greedy so it can't swallow the timestamp.
+var pseudoVersionRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+?)?[.-](\d{14})-([0-9a-f]{12})$`)
+
+// parsePseudoVersion extracts the commit SHA and build date embedded in a Go
+// pseudo-version string. It returns (sha, rfc3339Date, true) on a match, or
+// ("", "", false) for any non-pseudo or malformed value (a clean release tag,
+// "dev", "", a git-describe string, etc.). Pure + offline.
+//
+// The date is the pseudo-version's `yyyymmddhhmmss` timestamp (always UTC),
+// formatted as RFC3339 (e.g. "2026-06-25T19:47:26Z") to match the shape of the
+// vcs.time value the rest of the command prints.
+func parsePseudoVersion(v string) (sha, date string, ok bool) {
+	m := pseudoVersionRE.FindStringSubmatch(v)
+	if m == nil {
+		return "", "", false
+	}
+	ts, err := time.Parse("20060102150405", m[1])
+	if err != nil {
+		return "", "", false
+	}
+	return m[2], ts.UTC().Format(time.RFC3339), true
 }
 
 // shortenRevision trims a full 40-char git SHA to 12 chars; shorter values are

--- a/internal/cmd/update_check.go
+++ b/internal/cmd/update_check.go
@@ -19,6 +19,13 @@ import (
 // user's Civitai API token (or any Authorization header) to it.
 var latestReleaseURL = "https://api.github.com/repos/civitai/cli/releases/latest"
 
+// commitsBaseURL is the GitHub public API base for resolving a tag/ref to its
+// commit (`<base>/<ref>` => the GitHub commit object). A package var so tests
+// can point it at an httptest server.
+//
+// SECURITY: like latestReleaseURL, this is UNAUTHENTICATED — never tokened.
+var commitsBaseURL = "https://api.github.com/repos/civitai/cli/commits"
+
 // updateCheckTimeout bounds the GitHub round-trip. Kept short so `civitai
 // version` never hangs on a slow/offline network.
 const updateCheckTimeout = 2500 * time.Millisecond
@@ -112,6 +119,97 @@ func fetchLatestRelease(ctx context.Context, url string) (string, error) {
 	return rel.TagName, nil
 }
 
+// enrichBuildInfoFromGitHub fills the commit and/or date from GitHub when a
+// go-install build left them unresolved AND the resolved version is a clean,
+// parseable release tag (a tagged `go install module@vX.Y.Z` build: the module
+// proxy has no VCS checkout, so the binary carries no commit/date, and the
+// pseudo-version offline path can't help because the version is a plain tag).
+//
+// It is deliberately best-effort and reuses the same contract as the update
+// check: a single UNAUTHENTICATED GET (no Authorization header), the shared
+// short context timeout, a 1 MiB body cap, and fail-silent on ANY error /
+// non-200 / timeout / parse failure (the inputs are returned unchanged). It
+// only fills fields that are still at their defaults; ldflag/vcs/pseudo values
+// already resolved upstream are never overwritten.
+//
+// It does NOTHING (no HTTP call) when:
+//   - both commit and date are already resolved (a fully-stamped build), or
+//   - the version isn't a clean parseable tag (dev / pseudo-version / empty), or
+//   - the update check is disabled (--no-update-check / CIVITAI_NO_UPDATE_CHECK).
+func enrichBuildInfoFromGitHub(commitIn, dateIn, version string, disabled bool) (commitOut, dateOut string) {
+	commitOut, dateOut = commitIn, dateIn
+	if disabled {
+		return
+	}
+	if commitIn != "none" && dateIn != "unknown" {
+		return // fully stamped — nothing to enrich, make no call.
+	}
+	if !isCleanReleaseTag(version) {
+		return // dev / pseudo-version / empty — not a clean tag we can resolve.
+	}
+
+	ctx, cancel := contextWithUpdateTimeout()
+	defer cancel()
+
+	sha, date, err := fetchCommitForRef(ctx, commitsBaseURL, version)
+	if err != nil {
+		return // fail-silent: offline, timeout, non-200, or parse error.
+	}
+	if commitOut == "none" && sha != "" {
+		commitOut = shortenRevision(sha)
+	}
+	if dateOut == "unknown" && date != "" {
+		dateOut = date
+	}
+	return
+}
+
+// fetchCommitForRef does the unauthenticated GitHub call to resolve a ref (tag)
+// to its commit, returning the full SHA and the committer (or author) date in
+// RFC3339. Returns an error on any non-200 or transport/parse failure; callers
+// treat that as "skip the enrichment".
+func fetchCommitForRef(ctx context.Context, base, ref string) (sha, date string, err error) {
+	url := strings.TrimRight(base, "/") + "/" + ref
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// NOTE: intentionally NO Authorization header — public, token-free call.
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("github commits: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", "", err
+	}
+	var c struct {
+		SHA    string `json:"sha"`
+		Commit struct {
+			Committer struct {
+				Date string `json:"date"`
+			} `json:"committer"`
+			Author struct {
+				Date string `json:"date"`
+			} `json:"author"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(body, &c); err != nil {
+		return "", "", err
+	}
+	date = c.Commit.Committer.Date
+	if date == "" {
+		date = c.Commit.Author.Date
+	}
+	return c.SHA, date, nil
+}
+
 // semver is a minimal parsed vMAJOR.MINOR.PATCH triple. Pre-release/build
 // suffixes (-rc1, +meta) are ignored for comparison.
 type semver struct {
@@ -158,6 +256,18 @@ func parseSemver(s string) (semver, bool) {
 func isParseableVersion(s string) bool {
 	_, ok := parseSemver(s)
 	return ok
+}
+
+// isCleanReleaseTag reports whether s is a real release tag we could resolve to
+// a GitHub commit — i.e. a parseable semver that is NOT a Go pseudo-version.
+// (parseSemver alone says "yes" to a pseudo-version because it strips at the
+// first '-', so we must exclude pseudo-versions explicitly; their commit/date
+// is recovered offline instead, not via the GitHub commits API.)
+func isCleanReleaseTag(s string) bool {
+	if _, _, ok := parsePseudoVersion(s); ok {
+		return false
+	}
+	return isParseableVersion(s)
 }
 
 // compareVersions compares current vs latest by semver. Returns:

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -7,6 +7,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// unresolvedMarker is the honest stand-in printed when commit/date couldn't be
+// resolved by any source (ldflags, vcs.*, pseudo-version, or GitHub). It names
+// the most likely build shape so the value reads as honestly-unavailable rather
+// than the misleading raw "none"/"unknown": a clean tag means a `go install`
+// build (proxy cache, no VCS, offline); anything else is a bare source build.
+func unresolvedMarker(version string) string {
+	if isCleanReleaseTag(version) {
+		return "unavailable (go install)"
+	}
+	return "unavailable (source build)"
+}
+
+// displayCommit renders the commit for `civitai version`, substituting the
+// honest marker for the still-unresolved default instead of the misleading
+// raw "none".
+func displayCommit(commit, version string) string {
+	if commit == "none" {
+		return unresolvedMarker(version)
+	}
+	return commit
+}
+
+// displayDate renders the build date, substituting the honest marker for the
+// still-unresolved default instead of the misleading raw "unknown".
+func displayDate(date, version string) string {
+	if date == "unknown" {
+		return unresolvedMarker(version)
+	}
+	return date
+}
+
 func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -26,14 +57,30 @@ token. Skip it with --no-update-check or by setting CIVITAI_NO_UPDATE_CHECK.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "civitai %s\n", version)
-			fmt.Fprintf(out, "  commit: %s\n", commit)
-			fmt.Fprintf(out, "  built:  %s\n", date)
-			fmt.Fprintf(out, "  go:     %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 			// --no-update-check is now a persistent flag inherited from root.
 			noUpdateCheck, _ := cmd.Flags().GetBool("no-update-check")
-			if !updateCheckDisabled(noUpdateCheck) {
+			disabled := updateCheckDisabled(noUpdateCheck)
+
+			// A go-install build (tagged module@vX) carries no commit/date. If
+			// we're online and not opted out, resolve them from GitHub for the
+			// resolved tag. Fail-silent: leaves the defaults on any error.
+			rCommit, rDate := enrichBuildInfoFromGitHub(commit, date, version, disabled)
+
+			fmt.Fprintf(out, "civitai %s\n", version)
+			fmt.Fprintf(out, "  commit: %s\n", displayCommit(rCommit, version))
+			fmt.Fprintf(out, "  built:  %s\n", displayDate(rDate, version))
+			fmt.Fprintf(out, "  go:     %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+			// Honest hint when metadata is genuinely unavailable (e.g. an offline
+			// tagged go-install): release/Homebrew builds (or being online)
+			// carry the full commit + date.
+			if rCommit == "none" || rDate == "unknown" {
+				fmt.Fprintln(out, "  note:   build metadata is unavailable for this build;")
+				fmt.Fprintln(out, "          release/Homebrew builds (or running a tagged install online) carry the full commit + date.")
+			}
+
+			if !disabled {
 				printUpdateNotice(out, version)
 			}
 			return nil

--- a/internal/cmd/version_goinstall_test.go
+++ b/internal/cmd/version_goinstall_test.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestParsePseudoVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantOK   bool
+		wantSHA  string
+		wantDate string
+	}{
+		{
+			name:     "base-tag form vX.Y.Z-0.ts-sha",
+			in:       "v0.1.12-0.20260625194726-4dbfb55abc12",
+			wantOK:   true,
+			wantSHA:  "4dbfb55abc12",
+			wantDate: "2026-06-25T19:47:26Z",
+		},
+		{
+			name:     "no-base form vX.Y.Z-ts-sha",
+			in:       "v0.0.0-20260101000000-abcdef012345",
+			wantOK:   true,
+			wantSHA:  "abcdef012345",
+			wantDate: "2026-01-01T00:00:00Z",
+		},
+		{
+			name:     "pre-release base form vX.Y.Z-pre.0.ts-sha",
+			in:       "v1.2.3-pre.0.20251231235959-0123456789ab",
+			wantOK:   true,
+			wantSHA:  "0123456789ab",
+			wantDate: "2025-12-31T23:59:59Z",
+		},
+		{
+			name:     "dotted pre-release base form",
+			in:       "v1.2.3-beta.1.0.20240615120000-fedcba987654",
+			wantOK:   true,
+			wantSHA:  "fedcba987654",
+			wantDate: "2024-06-15T12:00:00Z",
+		},
+		// Non-pseudo / malformed inputs must not match and must not panic.
+		{name: "clean release tag", in: "v0.1.12", wantOK: false},
+		{name: "dev", in: "dev", wantOK: false},
+		{name: "empty", in: "", wantOK: false},
+		{name: "(devel)", in: "(devel)", wantOK: false},
+		{name: "git describe", in: "v0.1.1-3-gabc123", wantOK: false},
+		{name: "short sha (not 12 hex)", in: "v0.0.0-20260101000000-abcdef", wantOK: false},
+		{name: "bad timestamp (13 digits)", in: "v0.0.0-2026010100000-abcdef012345", wantOK: false},
+		{name: "non-hex sha", in: "v0.0.0-20260101000000-zzzzzzzzzzzz", wantOK: false},
+		{name: "impossible date", in: "v0.0.0-20261301000000-abcdef012345", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sha, date, ok := parsePseudoVersion(tc.in)
+			if ok != tc.wantOK {
+				t.Fatalf("parsePseudoVersion(%q) ok=%v want %v (sha=%q date=%q)", tc.in, ok, tc.wantOK, sha, date)
+			}
+			if !ok {
+				if sha != "" || date != "" {
+					t.Errorf("non-match should return empty sha/date, got sha=%q date=%q", sha, date)
+				}
+				return
+			}
+			if sha != tc.wantSHA {
+				t.Errorf("sha: got %q want %q", sha, tc.wantSHA)
+			}
+			if date != tc.wantDate {
+				t.Errorf("date: got %q want %q", date, tc.wantDate)
+			}
+		})
+	}
+}
+
+// TestMergeBuildInfo_PseudoVersionFallback proves the FIX-1 precedence: a Go
+// pseudo-version recovers commit/date offline when vcs.* is absent, but ldflags
+// and vcs.* still win when present, and only defaulted fields get filled.
+func TestMergeBuildInfo_PseudoVersionFallback(t *testing.T) {
+	const pseudo = "v0.1.12-0.20260625194726-4dbfb55abc12"
+
+	tests := []struct {
+		name                                string
+		version, commit, date               string
+		mainVersion, rev, vcsTime, modified string
+		wantVersion, wantCommit, wantDate   string
+	}{
+		{
+			name:    "pseudo fills commit+date when no vcs.* present",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: pseudo,
+			wantVersion: pseudo, wantCommit: "4dbfb55abc12", wantDate: "2026-06-25T19:47:26Z",
+		},
+		{
+			name:    "vcs.* wins over pseudo-version",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: pseudo, rev: "vcsrevision00", vcsTime: "2020-01-01T00:00:00Z", modified: "false",
+			wantVersion: pseudo, wantCommit: "vcsrevision0", wantDate: "2020-01-01T00:00:00Z",
+		},
+		{
+			name:    "ldflags win over pseudo-version",
+			version: "1.2.3", commit: "abc123", date: "2026-01-01",
+			mainVersion: pseudo,
+			wantVersion: "1.2.3", wantCommit: "abc123", wantDate: "2026-01-01",
+		},
+		{
+			name:    "pseudo fills only the defaulted field (commit stamped, date default)",
+			version: "dev", commit: "ldflagsha", date: "unknown",
+			mainVersion: pseudo,
+			wantVersion: pseudo, wantCommit: "ldflagsha", wantDate: "2026-06-25T19:47:26Z",
+		},
+		{
+			name:    "clean tag mainVersion does not fill commit/date",
+			version: "dev", commit: "none", date: "unknown",
+			mainVersion: "v0.1.12",
+			wantVersion: "v0.1.12", wantCommit: "none", wantDate: "unknown",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotC, gotD := mergeBuildInfo(tc.version, tc.commit, tc.date, tc.mainVersion, tc.rev, tc.vcsTime, tc.modified)
+			if gotV != tc.wantVersion {
+				t.Errorf("version: got %q want %q", gotV, tc.wantVersion)
+			}
+			if gotC != tc.wantCommit {
+				t.Errorf("commit: got %q want %q", gotC, tc.wantCommit)
+			}
+			if gotD != tc.wantDate {
+				t.Errorf("date: got %q want %q", gotD, tc.wantDate)
+			}
+		})
+	}
+}
+
+// newCommitServer returns an httptest server that serves a GitHub commit object
+// for the requested ref and records hit count + asserts no Authorization header.
+func newCommitServer(t *testing.T, sha, date string, status int) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("enrichment sent an Authorization header — must be unauthenticated")
+		}
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = w.Write([]byte(`{"sha":"` + sha + `","commit":{"committer":{"date":"` + date + `"}}}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func pointCommitsAt(t *testing.T, base string) {
+	t.Helper()
+	orig := commitsBaseURL
+	commitsBaseURL = base
+	t.Cleanup(func() { commitsBaseURL = orig })
+}
+
+func TestEnrichBuildInfoFromGitHub_FillsCommitAndDate(t *testing.T) {
+	srv, hits := newCommitServer(t, "deadbeefcafef00dbabe", "2026-06-20T10:11:12Z", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", "v0.1.12", false)
+	if *hits != 1 {
+		t.Errorf("expected exactly 1 GitHub hit, got %d", *hits)
+	}
+	if gotCommit != "deadbeefcafe" {
+		t.Errorf("commit: got %q want deadbeefcafe (12-char)", gotCommit)
+	}
+	if gotDate != "2026-06-20T10:11:12Z" {
+		t.Errorf("date: got %q want 2026-06-20T10:11:12Z", gotDate)
+	}
+}
+
+func TestEnrichBuildInfoFromGitHub_AuthorDateFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// committer.date absent => fall back to author.date.
+		_, _ = w.Write([]byte(`{"sha":"abc123def4560000","commit":{"author":{"date":"2025-05-05T05:05:05Z"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	pointCommitsAt(t, srv.URL)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", "v0.1.12", false)
+	if gotCommit != "abc123def456" {
+		t.Errorf("commit: got %q want abc123def456", gotCommit)
+	}
+	if gotDate != "2025-05-05T05:05:05Z" {
+		t.Errorf("date: got %q want author.date fallback", gotDate)
+	}
+}
+
+func TestEnrichBuildInfoFromGitHub_FailSilent(t *testing.T) {
+	cases := []struct {
+		name   string
+		handle http.HandlerFunc
+	}{
+		{"non-200", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) }},
+		{"garbage body", func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`{not json`)) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handle)
+			t.Cleanup(srv.Close)
+			pointCommitsAt(t, srv.URL)
+
+			gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", "v0.1.12", false)
+			if gotCommit != "none" || gotDate != "unknown" {
+				t.Errorf("fail-silent should leave defaults, got commit=%q date=%q", gotCommit, gotDate)
+			}
+		})
+	}
+}
+
+func TestEnrichBuildInfoFromGitHub_UnreachableFailSilent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // connection refused
+	pointCommitsAt(t, url)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", "v0.1.12", false)
+	if gotCommit != "none" || gotDate != "unknown" {
+		t.Errorf("unreachable should leave defaults, got commit=%q date=%q", gotCommit, gotDate)
+	}
+}
+
+// TestEnrichBuildInfoFromGitHub_NoCallWhenStamped: a fully-stamped build (commit
+// AND date already resolved) must make ZERO HTTP calls.
+func TestEnrichBuildInfoFromGitHub_NoCallWhenStamped(t *testing.T) {
+	srv, hits := newCommitServer(t, "x", "y", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("abc123", "2026-01-01", "v0.1.12", false)
+	if *hits != 0 {
+		t.Errorf("fully-stamped build must make NO GitHub call, got %d hits", *hits)
+	}
+	if gotCommit != "abc123" || gotDate != "2026-01-01" {
+		t.Errorf("stamped values must be untouched, got commit=%q date=%q", gotCommit, gotDate)
+	}
+}
+
+// TestEnrichBuildInfoFromGitHub_NoCallForNonTag: dev / pseudo-version / empty are
+// not clean tags we can resolve, so no HTTP call fires.
+func TestEnrichBuildInfoFromGitHub_NoCallForNonTag(t *testing.T) {
+	for _, version := range []string{"dev", "", "v0.1.12-0.20260625194726-4dbfb55abc12", "(devel)"} {
+		t.Run("version="+version, func(t *testing.T) {
+			srv, hits := newCommitServer(t, "x", "y", http.StatusOK)
+			pointCommitsAt(t, srv.URL)
+
+			gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", version, false)
+			if *hits != 0 {
+				t.Errorf("non-tag version %q must make NO GitHub call, got %d hits", version, *hits)
+			}
+			if gotCommit != "none" || gotDate != "unknown" {
+				t.Errorf("non-tag should leave defaults, got commit=%q date=%q", gotCommit, gotDate)
+			}
+		})
+	}
+}
+
+// TestEnrichBuildInfoFromGitHub_NoCallWhenDisabled: opt-out makes ZERO HTTP hits.
+func TestEnrichBuildInfoFromGitHub_NoCallWhenDisabled(t *testing.T) {
+	srv, hits := newCommitServer(t, "x", "y", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("none", "unknown", "v0.1.12", true)
+	if *hits != 0 {
+		t.Errorf("disabled enrichment must make NO GitHub call, got %d hits", *hits)
+	}
+	if gotCommit != "none" || gotDate != "unknown" {
+		t.Errorf("disabled should leave defaults, got commit=%q date=%q", gotCommit, gotDate)
+	}
+}
+
+// TestEnrichBuildInfoFromGitHub_PartialFill: only date unresolved => fills date,
+// keeps the already-resolved commit; still makes the call.
+func TestEnrichBuildInfoFromGitHub_PartialFill(t *testing.T) {
+	srv, hits := newCommitServer(t, "shouldnotwin000", "2026-06-20T10:11:12Z", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+
+	gotCommit, gotDate := enrichBuildInfoFromGitHub("realcommit", "unknown", "v0.1.12", false)
+	if *hits != 1 {
+		t.Errorf("expected 1 hit when one field unresolved, got %d", *hits)
+	}
+	if gotCommit != "realcommit" {
+		t.Errorf("already-resolved commit must be preserved, got %q", gotCommit)
+	}
+	if gotDate != "2026-06-20T10:11:12Z" {
+		t.Errorf("date should be filled, got %q", gotDate)
+	}
+}
+
+// TestVersionCommand_HonestOutputWhenUnresolved: offline tagged go-install (no
+// enrichment) must print the honest marker, never raw "none"/"unknown".
+func TestVersionCommand_HonestOutputWhenUnresolved(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "v0.1.12", "none", "unknown"
+	// Opt out so neither enrichment nor the update notice touches the network.
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+
+	out, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if strings.Contains(out, "commit: none") {
+		t.Errorf("must not print raw 'commit: none': %s", out)
+	}
+	if strings.Contains(out, "built:  unknown") {
+		t.Errorf("must not print raw 'built:  unknown': %s", out)
+	}
+	if !strings.Contains(out, "unavailable (go install)") {
+		t.Errorf("should print the honest go-install marker: %s", out)
+	}
+	if !strings.Contains(out, "build metadata is unavailable") {
+		t.Errorf("should print the honest hint note: %s", out)
+	}
+}
+
+// TestVersionCommand_EnrichmentFillsCommitDate: online tagged go-install resolves
+// commit+date from GitHub and prints them (no honest marker, no note).
+func TestVersionCommand_EnrichmentFillsCommitDate(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "v0.1.12", "none", "unknown"
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "")
+
+	srv, hits := newCommitServer(t, "feedface1234abcd", "2026-06-24T08:09:10Z", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+	// Suppress the separate update-notice network call (point it at a dead URL
+	// so it fails silently) to keep the assertion focused on enrichment.
+	pointAtServer(t, "http://127.0.0.1:0")
+
+	out, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if *hits != 1 {
+		t.Errorf("expected exactly 1 enrichment hit, got %d", *hits)
+	}
+	if !strings.Contains(out, "commit: feedface1234") {
+		t.Errorf("should print enriched commit: %s", out)
+	}
+	if !strings.Contains(out, "built:  2026-06-24T08:09:10Z") {
+		t.Errorf("should print enriched date: %s", out)
+	}
+	if strings.Contains(out, "unavailable (go install)") {
+		t.Errorf("must NOT print the honest marker once enriched: %s", out)
+	}
+	if strings.Contains(out, "build metadata is unavailable") {
+		t.Errorf("must NOT print the hint note once enriched: %s", out)
+	}
+}
+
+// TestVersionCommand_NoEnrichmentWhenStamped: a fully-stamped build makes NO
+// enrichment call.
+func TestVersionCommand_NoEnrichmentWhenStamped(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "v0.1.12", "abc123def456", "2026-01-01T00:00:00Z"
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "")
+
+	srv, hits := newCommitServer(t, "x", "y", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+	pointAtServer(t, "http://127.0.0.1:0") // suppress update notice
+
+	out, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if *hits != 0 {
+		t.Errorf("stamped build must make NO enrichment call, got %d hits", *hits)
+	}
+	if !strings.Contains(out, "commit: abc123def456") {
+		t.Errorf("should print the stamped commit: %s", out)
+	}
+}
+
+// TestVersionCommand_EnrichmentSkippedWhenDisabled: opt-out env => zero
+// enrichment hits.
+func TestVersionCommand_EnrichmentSkippedWhenDisabled(t *testing.T) {
+	resetBuildVars(t)
+	version, commit, date = "v0.1.12", "none", "unknown"
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+
+	srv, hits := newCommitServer(t, "x", "y", http.StatusOK)
+	pointCommitsAt(t, srv.URL)
+
+	if _, _, err := run(t, "version"); err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if *hits != 0 {
+		t.Errorf("opt-out must prevent any enrichment call, got %d hits", *hits)
+	}
+}


### PR DESCRIPTION
## Problem

`civitai version` shows `commit: none` / `built: unknown` for any `go install` build. Root cause (verified via `go version -m`): `go install <module>@<version>` builds from the **module proxy cache, not a VCS checkout**, so the binary has **no `vcs.revision`/`vcs.time` build settings**. The existing `mergeBuildInfo` only recovered commit/date from those `vcs.*` settings, so for proxy installs only `version` was recovered.

## Fix (3 layers, each fail-safe; only fills fields still at their default — ldflags > vcs.* > these)

**FIX 1 — pseudo-version extraction (offline; `@branch`/untagged installs).** For an untagged/branch go-install, `Main.Version` is a Go **pseudo-version** that embeds the commit + timestamp. `mergeBuildInfo` now parses it as a last resort:

```
^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+?)?[.-](\d{14})-([0-9a-f]{12})$
```

Anchors on the unambiguous `[.-]<14-digit yyyymmddhhmmss>-<12 hex>$` tail, covering all three forms (`vX.Y.Z-ts-sha`, `vX.Y.Z-0.ts-sha`, `vX.Y.Z-pre.0.ts-sha`). e.g. `v0.1.12-0.20260625194726-4dbfb55abc12` → commit `4dbfb55abc12`, date `2026-06-25T19:47:26Z`. Pure + unit-tested.

**FIX 2 — GitHub enrichment (online; clean `@vX.Y.Z` installs).** A tagged go-install carries no commit/date anywhere. After resolving build info, if commit/date are still unresolved **and** the version is a clean release tag (not dev/pseudo/empty) **and** the update check isn't disabled, the `version` command makes a single best-effort `GET https://api.github.com/repos/civitai/cli/commits/<tag>` and parses `.sha` (shortened to 12) + `.commit.committer.date` (or `.commit.author.date`). It reuses the update-check contract exactly: **no Authorization header**, the shared ~2.5s context timeout, 1 MiB body cap, fail-silent on any error/non-200/timeout/parse failure, and honors `--no-update-check` / `CIVITAI_NO_UPDATE_CHECK`. Makes **zero** HTTP calls for a fully-stamped build, a non-tag version, or when opted out.

**FIX 3 — honest output.** When commit/date are still unresolved (offline tagged go-install), print `unavailable (go install)` (or `unavailable (source build)` for a bare `dev` build) + a one-line hint, instead of the misleading raw `none`/`unknown`.

goreleaser / brew / `make` builds are unaffected (they stamp via ldflags / have `vcs.*`).

## Verification

Live demos against a tagged build (`-X main.version=v0.1.12`):

- offline → `commit: unavailable (go install)` / `built: unavailable (go install)` + hint.
- online (local GitHub stub) → `commit: feedface1234` / `built: 2026-06-24T08:09:10Z`, no marker; stub confirmed **no Authorization header** sent.

Gates: `go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt -l` clean; cross-compiled windows/amd64, darwin/arm64, linux/amd64 (all rc=0).

New tests (`internal/cmd/version_goinstall_test.go`): `TestParsePseudoVersion` (3 forms + malformed/no-panic), `TestMergeBuildInfo_PseudoVersionFallback` (ldflags > vcs.* > pseudo precedence), `TestEnrichBuildInfoFromGitHub_*` (fills / author-date fallback / fail-silent / no-call-when-stamped / no-call-for-non-tag / no-call-when-disabled / partial-fill — all assert no-Authorization-header + hit counts), and `TestVersionCommand_*` (honest output, enrichment fills, no-call-when-stamped, skipped-when-disabled).

## Honest limitation

A clean-tag go-install **offline** genuinely has no commit/date anywhere in the binary — that case shows the honest `unavailable (go install)` marker (enrichment is the only way to fill it, and that needs the network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
