### PR TITLE
feat(scaffold): clarify dev:harness is a MOCK in app create/init next-steps

### DIFF
--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -49,6 +49,14 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	if !strings.Contains(stdout, "dev:harness") {
 		t.Errorf("create should print dev:harness next step:\n%s", stdout)
 	}
+	// The mock-vs-live clarification must be visible at the moment the user
+	// reads the next steps (a placeholder Generate result is the mock, not a bug).
+	if !strings.Contains(stdout, "MOCK") {
+		t.Errorf("create should flag dev:harness as a MOCK host:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dev:live") {
+		t.Errorf("create should point at dev:live for a real generation:\n%s", stdout)
+	}
 	if !strings.Contains(stdout, "civitai app validate") {
 		t.Errorf("create should print the validate next step:\n%s", stdout)
 	}

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -172,8 +172,12 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 	switch {
 	case tmpl.NeedsHarness():
 		// SDK/page-money apps render blank under plain `dev` (no host) —
-		// the dev loop needs the mock host via `dev:harness`.
+		// the dev loop needs the mock host via `dev:harness`. Spell out the
+		// mock-vs-live distinction here so a "Generate" returning a placeholder
+		// image isn't mistaken for a broken real generation.
 		fmt.Fprintf(out, "  cd %s && npm install && npm run dev:harness\n", destDir)
+		fmt.Fprintln(out, "    dev:harness mounts a MOCK host — synthetic results, no real Buzz/compute.")
+		fmt.Fprintln(out, "    For a real generation that spends Buzz: npm run dev:live  (needs a full-scope personal API key — see README).")
 	case tmpl == scaffold.PageVite:
 		fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", destDir)
 	default:


### PR DESCRIPTION
## Problem
A developer ran `civitai app create`, followed the printed `npm run dev:harness`, clicked **Generate**, got a placeholder image, and concluded the real generation was broken. The terminal next-steps never told them `dev:harness` mounts a **mock** host (synthetic results, no real Buzz/compute).

## Change
`printScaffoldResult` (`internal/cmd/app_init.go`) now prints a tight 2-line clarification under the `dev:harness` next-step — for the SDK / page-money templates only (`NeedsHarness()`), so `static` / `page-vite` output is unchanged:

```
Next steps:
  cd <dir> && npm install && npm run dev:harness
    dev:harness mounts a MOCK host — synthetic results, no real Buzz/compute.
    For a real generation that spends Buzz: npm run dev:live  (needs a full-scope personal API key — see README).
  civitai app validate
  civitai app submit
```

The page-money README already carries the authoritative mode table; this just surfaces the mock-vs-live distinction at the moment the user reads the terminal output. No README changes needed.

## Tests
Extended `TestAppCreateDefaultsToPageMoney` to assert the output contains `MOCK` and `dev:live`. `go build` / `go vet` / `go test ./...` green, `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)