### PR TITLE
feat(app): `civitai app dev-token` + mint one-liner on the dev:live screen

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -200,6 +200,16 @@ const SubmissionsPath = "/api/v1/blocks/submissions"
 // (pending) state.
 const WithdrawPath = "/api/v1/blocks/withdraw"
 
+// DevTokenPath is the moderator-gated route that mints a short-lived dev block
+// token for `npm run dev:live` (POST {"slug": ...}; civitai/civitai
+// src/pages/api/v1/blocks/dev-token.ts). 200 { token, ... } on success; a
+// PENDING (un-approved) slug is accepted (200 since #2777). Error bodies are
+// {message}: 404 not-found/not-yours, 403 not-mod/insufficient-scope, 429
+// rate-limited, 503 flag-off. The minted token's CAPABILITIES depend on the
+// bearer: a full-scope personal API key mints a spend-capable token; an OAuth
+// (`civitai login`) credential mints a read-only one.
+const DevTokenPath = "/api/v1/blocks/dev-token"
+
 // Client is the default HTTP implementation.
 type Client struct {
 	BaseURL    string
@@ -613,6 +623,76 @@ func (c *Client) WithdrawRequest(ctx context.Context, publishRequestID string) e
 		return withdrawError(status, raw)
 	}
 	return nil
+}
+
+// DevTokenMinter mints a short-lived dev block token for `npm run dev:live`.
+type DevTokenMinter interface {
+	// MintDevToken mints a dev block token for the given app slug and returns
+	// the JWT. A non-2xx is mapped to an actionable error by devTokenError.
+	MintDevToken(ctx context.Context, slug string) (string, error)
+}
+
+// devTokenBody is the POST /api/v1/blocks/dev-token request body.
+type devTokenBody struct {
+	Slug string `json:"slug"`
+}
+
+// MintDevToken mints a short-lived dev block token for the given app slug,
+// returning the JWT from the response's .token field. The OAuth access token is
+// refreshed transparently on a 401. A non-2xx is mapped by devTokenError.
+func (c *Client) MintDevToken(ctx context.Context, slug string) (string, error) {
+	body, err := json.Marshal(devTokenBody{Slug: slug})
+	if err != nil {
+		return "", err
+	}
+	build := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+DevTokenPath, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return "", err
+	}
+	if status != http.StatusOK {
+		return "", devTokenError(status, raw)
+	}
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return "", fmt.Errorf("unexpected /api/v1/blocks/dev-token response: %s", string(raw))
+	}
+	if out.Token == "" {
+		return "", fmt.Errorf("dev-token response had no token: %s", string(raw))
+	}
+	return out.Token, nil
+}
+
+// devTokenError maps a non-2xx dev-token response to a clear, actionable CLI
+// error. The route returns {"message": ...} on every error status: 404
+// not-found-or-not-yours, 403 not-moderator-or-insufficient-scope, 429
+// rate-limited, 503 flag-off. The 403 message is the key DX case — a spend
+// token needs a full-scope personal API key (an OAuth login mints read-only).
+func devTokenError(status int, raw []byte) error {
+	msg := serverMessage(raw)
+	switch status {
+	case http.StatusNotFound:
+		return fmt.Errorf("app not found (or not yours) (404): %s — check the slug, and that you've submitted the app (`civitai app status`)", msg)
+	case http.StatusUnauthorized:
+		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
+	case http.StatusForbidden:
+		return fmt.Errorf("not authorized (403): %s — minting needs moderator access AND a full-scope personal API key; an OAuth `civitai login` token can't mint a spend token (check with `civitai whoami`)", msg)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("App Blocks unavailable (503): %s", msg)
+	default:
+		return fmt.Errorf("server returned %d: %s", status, msg)
+	}
 }
 
 // withdrawError maps a non-2xx withdraw response to a clear, actionable CLI

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
+	var gotAuth, gotMethod, gotPath, gotCT, gotSlug string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotCT = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		var body struct {
+			Slug string `json:"slug"`
+		}
+		_ = json.Unmarshal(raw, &body)
+		gotSlug = body.Slug
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "jwt-x", "expiresAt": "soon"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	tok, err := c.MintDevToken(context.Background(), "my-block")
+	if err != nil {
+		t.Fatalf("MintDevToken: %v", err)
+	}
+	if tok != "jwt-x" {
+		t.Errorf("token = %q, want jwt-x", tok)
+	}
+	if gotAuth != "Bearer tok123" {
+		t.Errorf("auth header = %q, want Bearer tok123", gotAuth)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != DevTokenPath {
+		t.Errorf("path = %q, want %q", gotPath, DevTokenPath)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("content-type = %q, want application/json", gotCT)
+	}
+	if gotSlug != "my-block" {
+		t.Errorf("slug = %q, want my-block", gotSlug)
+	}
+}
+
+func TestMintDevTokenEmptyTokenErrors(t *testing.T) {
+	// A 200 with no token field is a malformed response, not a success.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"expiresAt": "soon"})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "tok", "")
+	if _, err := c.MintDevToken(context.Background(), "my-block"); err == nil {
+		t.Fatal("expected error when response has no token")
+	}
+}
+
+func TestMintDevTokenErrorMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		body   map[string]string
+		want   string
+	}{
+		{http.StatusNotFound, map[string]string{"message": "no such app"}, "app not found (or not yours)"},
+		{http.StatusForbidden, map[string]string{"message": "mods only"}, "not authorized (403)"},
+		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not logged in"},
+		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "flag off"}, "App Blocks unavailable (503)"},
+		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			_ = json.NewEncoder(w).Encode(tc.body)
+		}))
+		_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block")
+		srv.Close()
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
+		}
+	}
+}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -20,7 +20,8 @@ with a no-build static default (back-compat alias).`,
   civitai app validate ./my-block
   civitai app submit ./my-block
   civitai app status
-  civitai app withdraw pubreq_01H`,
+  civitai app withdraw pubreq_01H
+  civitai app dev-token my-block`,
 	}
 	cmd.AddCommand(newAppCreateCmd())
 	cmd.AddCommand(newAppInitCmd())
@@ -28,5 +29,6 @@ with a no-build static default (back-compat alias).`,
 	cmd.AddCommand(newAppSubmitCmd())
 	cmd.AddCommand(newAppStatusCmd())
 	cmd.AddCommand(newAppWithdrawCmd())
+	cmd.AddCommand(newAppDevTokenCmd())
 	return cmd
 }

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newAppDevTokenCmd() *cobra.Command {
+	var envOut bool
+
+	cmd := &cobra.Command{
+		Use:   "dev-token <slug>",
+		Short: "Mint a short-lived dev block token for `npm run dev:live`",
+		Long: `Mint a short-lived dev block token so a scaffolded page-money app can run
+"npm run dev:live" against the REAL Civitai backend.
+
+Calls the moderator-gated mint route (POST /api/v1/blocks/dev-token) with your
+stored credential and prints the token (a ~15-minute RS256 JWT). Paste it into
+VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart "npm run dev:live".
+
+The minted token's CAPABILITIES depend on the credential you mint with:
+  - REAL generation (spends real Buzz) needs a FULL-SCOPE PERSONAL API KEY
+    (create one at https://civitai.com/user/account — it carries AI Services).
+    Confirm yours can spend with "civitai whoami".
+  - An OAuth login ("civitai login") mints a READ/IDENTITY-ONLY dev token (no
+    spend) — dev:live shows your viewer + catalog/storage, but estimate →
+    submit → generation will NOT spend.
+
+Pre-GA the mint route is moderator-only; a PENDING (un-approved) slug is
+accepted. The token is short-lived — never commit it; re-mint when it expires.`,
+		Example: `  civitai app dev-token my-block               # print the token to stdout
+  civitai app dev-token my-block --env         # print VITE_LIVE_BLOCK_TOKEN=<token>
+  civitai app dev-token my-block --env >> .env.development.local`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if cfg.Token() == "" {
+				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+			}
+
+			var slug string
+			if len(args) == 1 {
+				slug = strings.TrimSpace(args[0])
+			}
+			if slug == "" {
+				return fmt.Errorf("an app slug is required — e.g. `civitai app dev-token my-block` (find it with `civitai app status`)")
+			}
+
+			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
+			token, err := client.MintDevToken(context.Background(), slug)
+			if err != nil {
+				return err
+			}
+
+			// Token to stdout (pipeable); the paste hint to stderr so it never
+			// pollutes a `--env >> .env.development.local` redirect.
+			out := cmd.OutOrStdout()
+			if envOut {
+				fmt.Fprintf(out, "VITE_LIVE_BLOCK_TOKEN=%s\n", token)
+			} else {
+				fmt.Fprintln(out, token)
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(),
+				"Paste into VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart `npm run dev:live`. "+
+					"Short-lived (~15min); never commit it. Real spend needs a full-scope personal API key (`civitai whoami`).")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&envOut, "env", false, "print VITE_LIVE_BLOCK_TOKEN=<token> (paste-ready into .env.development.local)")
+	return cmd
+}

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// devTokenRec records the request the CLI sent to the dev-token endpoint.
+type devTokenRec struct {
+	auth, method, path, contentType, slug string
+}
+
+// devTokenServer stands up an httptest server emulating
+// POST /api/v1/blocks/dev-token, returning the canned body+status and recording
+// the request (incl. the decoded slug).
+func devTokenServer(t *testing.T, body any, status int, rec *devTokenRec) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rec != nil {
+			rec.auth = r.Header.Get("Authorization")
+			rec.method = r.Method
+			rec.path = r.URL.Path
+			rec.contentType = r.Header.Get("Content-Type")
+			raw, _ := io.ReadAll(r.Body)
+			var parsed struct {
+				Slug string `json:"slug"`
+			}
+			_ = json.Unmarshal(raw, &parsed)
+			rec.slug = parsed.Slug
+		}
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func TestAppDevTokenSuccess(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x", "expiresAt": "soon"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "dev-token", "my-block")
+	if err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	// Request shape.
+	if rec.auth != "Bearer tok-1" {
+		t.Errorf("auth header = %q", rec.auth)
+	}
+	if rec.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", rec.method)
+	}
+	if rec.path != "/api/v1/blocks/dev-token" {
+		t.Errorf("path = %q", rec.path)
+	}
+	if rec.contentType != "application/json" {
+		t.Errorf("content-type = %q, want application/json", rec.contentType)
+	}
+	if rec.slug != "my-block" {
+		t.Errorf("slug body = %q, want my-block", rec.slug)
+	}
+	// The raw token goes to stdout, alone (pipeable).
+	if strings.TrimSpace(out) != "jwt-x" {
+		t.Errorf("stdout should be exactly the token, got %q", out)
+	}
+	// The paste hint goes to stderr, never stdout (so a redirect stays clean).
+	if strings.Contains(out, "VITE_LIVE_BLOCK_TOKEN") || strings.Contains(out, "Paste") {
+		t.Errorf("stdout should NOT carry the paste hint: %q", out)
+	}
+	if !strings.Contains(errOut, "VITE_LIVE_BLOCK_TOKEN") || !strings.Contains(errOut, "dev:live") {
+		t.Errorf("stderr should carry the paste hint: %q", errOut)
+	}
+}
+
+func TestAppDevTokenEnvFlag(t *testing.T) {
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "app", "dev-token", "my-block", "--env")
+	if err != nil {
+		t.Fatalf("app dev-token --env: %v", err)
+	}
+	if strings.TrimSpace(out) != "VITE_LIVE_BLOCK_TOKEN=jwt-x" {
+		t.Errorf("--env stdout = %q, want VITE_LIVE_BLOCK_TOKEN=jwt-x", out)
+	}
+}
+
+func TestAppDevTokenMissingSlugErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	_, _, err := run(t, "app", "dev-token")
+	if err == nil {
+		t.Fatal("expected error when no slug is given")
+	}
+	if !strings.Contains(err.Error(), "slug is required") {
+		t.Errorf("missing-slug error should explain: %v", err)
+	}
+}
+
+func TestAppDevTokenWhitespaceSlugErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	_, _, err := run(t, "app", "dev-token", "   ")
+	if err == nil {
+		t.Fatal("expected error for a whitespace-only slug")
+	}
+	if !strings.Contains(err.Error(), "slug is required") {
+		t.Errorf("whitespace-slug error should explain: %v", err)
+	}
+}
+
+func TestAppDevTokenMissingTokenErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected error with no token")
+	}
+	if !strings.Contains(err.Error(), "no token") || !strings.Contains(err.Error(), "civitai login") {
+		t.Errorf("missing-token error should point to login: %v", err)
+	}
+}
+
+func TestAppDevTokenErrorMapping(t *testing.T) {
+	// The server returns {"message": ...} on every error status.
+	cases := []struct {
+		status int
+		body   map[string]any
+		want   string
+	}{
+		{http.StatusNotFound, map[string]any{"message": "no such app"}, "app not found (or not yours)"},
+		{http.StatusForbidden, map[string]any{"message": "mods only"}, "not authorized"},
+		{http.StatusUnauthorized, map[string]any{"message": "bad key"}, "not logged in"},
+		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
+		{http.StatusServiceUnavailable, map[string]any{"message": "flag off"}, "App Blocks unavailable (503)"},
+	}
+	for _, tc := range cases {
+		srv := devTokenServer(t, tc.body, tc.status, nil)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("CIVITAI_TOKEN", "tok")
+		t.Setenv("CIVITAI_BASE_URL", srv.URL)
+		_, _, err := run(t, "app", "dev-token", "my-block")
+		srv.Close()
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
+		}
+	}
+}
+
+// TestAppDevTokenForbiddenNamesPersonalKey asserts the 403 guidance steers the
+// user to a full-scope personal API key + whoami (the key DX dead-end).
+func TestAppDevTokenForbiddenNamesPersonalKey(t *testing.T) {
+	srv := devTokenServer(t, map[string]any{"message": "insufficient scope"}, http.StatusForbidden, nil)
+	defer srv.Close()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected error for 403")
+	}
+	for _, want := range []string{"personal API key", "civitai whoami", "OAuth"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("403 error %q should mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestAppHelpListsDevToken(t *testing.T) {
+	out, _, err := run(t, "app", "--help")
+	if err != nil {
+		t.Fatalf("app --help: %v", err)
+	}
+	if !strings.Contains(out, "dev-token") {
+		t.Errorf("app help should list the dev-token subcommand:\n%s", out)
+	}
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -120,6 +120,20 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, manifest, `"name": "Money Block"`)
 	mustContain(t, app, "Money Block")
 
+	// The LiveUnavailable screen (shown by dev:live with no token) must tell the
+	// user HOW to get one: the CLI one-liner with the real slug, a copy handler,
+	// the VITE_LIVE_BLOCK_TOKEN paste instruction, and the personal-key note.
+	mainTSX := readFile(t, filepath.Join(dest, "src", "main.tsx"))
+	mustContain(t, mainTSX, "civitai app dev-token money-block")
+	mustContain(t, mainTSX, "clipboard?.writeText")
+	mustContain(t, mainTSX, "VITE_LIVE_BLOCK_TOKEN")
+	mustContain(t, mainTSX, ".env.development.local")
+	mustContain(t, mainTSX, "full-scope personal API key")
+	mustContain(t, mainTSX, "civitai whoami")
+	// Curl fallback for users without the CLI, carrying the real slug.
+	mustContain(t, mainTSX, `"slug":"money-block"`)
+	mustContain(t, mainTSX, "/api/v1/blocks/dev-token")
+
 	// README docs the live-mode Buzz-balance recipe (#30) — the only working path
 	// is the tRPC procedure with a bearer key (no public REST buzz endpoint).
 	readme := readFile(t, filepath.Join(dest, "README.md"))

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -79,18 +79,75 @@ function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: str
 }
 
 /**
+ * A small "copy to clipboard" button with a transient "Copied!" state. No deps —
+ * just `navigator.clipboard.writeText` + a `useState`. Used on the
+ * LiveUnavailable screen so the one-liner to mint a dev token is one click away.
+ */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      style={liveCopyBtnStyle}
+      onClick={() => {
+        void navigator.clipboard?.writeText(text).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+    >
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+
+/**
  * Fail-safe LIVE screen. Shown when `dev:live` is requested but no dev block
- * token is set — so a dev sees WHY nothing is spending instead of a silent mock
- * or a blank screen.
+ * token is set — so a dev sees WHY nothing is spending AND exactly how to get a
+ * token, instead of a silent mock or a blank screen.
  */
 function LiveUnavailable({ reason }: { reason: string }) {
+  const cliCmd = 'civitai app dev-token {{ .Slug }}';
+  const curlCmd =
+    `curl -s -X POST https://civitai.com/api/v1/blocks/dev-token ` +
+    `-H "Authorization: Bearer $CIVITAI_TOKEN" ` +
+    `-H 'Content-Type: application/json' ` +
+    `-d '{"slug":"{{ .Slug }}"}'`;
   return (
     <div data-harness-banner="live-unavailable" style={liveWrapStyle}>
       <div style={liveInnerStyle}>
         <div style={liveTitleStyle}>⚠️ LIVE MODE — spends REAL Buzz / real compute</div>
         <p style={liveReasonStyle}>{reason}</p>
+
+        <div style={liveSectionStyle}>
+          <div style={liveSectionTitleStyle}>How to get a dev token</div>
+          <div style={liveCmdRowStyle}>
+            <pre style={liveCmdStyle}>{cliCmd}</pre>
+            <CopyButton text={cliCmd} />
+          </div>
+          <p style={liveHintStyle}>
+            Paste the token into <code>VITE_LIVE_BLOCK_TOKEN</code> in{' '}
+            <code>.env.development.local</code>, then re-run{' '}
+            <code>npm run dev:live</code>.
+          </p>
+          <p style={liveHintStyle}>
+            Real generation needs a <strong>full-scope personal API key</strong>{' '}
+            (create one at <code>civitai.com/user/account</code>) — an OAuth{' '}
+            <code>civitai login</code> token can&apos;t spend. Confirm with{' '}
+            <code>civitai whoami</code>.
+          </p>
+        </div>
+
+        <div style={liveSectionStyle}>
+          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl</div>
+          <div style={liveCmdRowStyle}>
+            <pre style={liveCmdSmallStyle}>{curlCmd}</pre>
+            <CopyButton text={curlCmd} />
+          </div>
+        </div>
+
         <p style={liveHintStyle}>
-          Use <code>npm run dev:harness</code> (mock host) for free local
+          Or use <code>npm run dev:harness</code> (mock host) for free local
           development. See README → “Mock vs live”.
         </p>
       </div>
@@ -121,10 +178,52 @@ const liveWrapStyle: CSSProperties = {
   padding: 24,
   textAlign: 'center',
 };
-const liveInnerStyle: CSSProperties = { maxWidth: 560 };
-const liveTitleStyle: CSSProperties = { fontSize: 20, fontWeight: 800, color: '#ffa94d' };
-const liveReasonStyle: CSSProperties = { marginTop: 12, lineHeight: 1.5 };
-const liveHintStyle: CSSProperties = { marginTop: 12, opacity: 0.8 };
+const liveInnerStyle: CSSProperties = { maxWidth: 620, textAlign: 'left' };
+const liveTitleStyle: CSSProperties = { fontSize: 20, fontWeight: 800, color: '#ffa94d', textAlign: 'center' };
+const liveReasonStyle: CSSProperties = { marginTop: 12, lineHeight: 1.5, textAlign: 'center' };
+const liveHintStyle: CSSProperties = { marginTop: 12, opacity: 0.8, lineHeight: 1.5 };
+
+const liveSectionStyle: CSSProperties = {
+  marginTop: 20,
+  paddingTop: 16,
+  borderTop: '1px solid #5a3a17',
+};
+const liveSectionTitleStyle: CSSProperties = {
+  fontSize: 14,
+  fontWeight: 700,
+  color: '#ffa94d',
+  marginBottom: 8,
+};
+const liveCmdRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'stretch',
+  gap: 8,
+};
+const liveCmdStyle: CSSProperties = {
+  flex: 1,
+  margin: 0,
+  padding: '10px 12px',
+  background: '#0d0904',
+  border: '1px solid #5a3a17',
+  borderRadius: 6,
+  color: '#ffe8c2',
+  fontSize: 14,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+};
+const liveCmdSmallStyle: CSSProperties = { ...liveCmdStyle, fontSize: 12, opacity: 0.85 };
+const liveCopyBtnStyle: CSSProperties = {
+  flex: '0 0 auto',
+  padding: '0 14px',
+  background: '#7a1f1f',
+  color: '#ffd8a8',
+  border: '1px solid #a8492f',
+  borderRadius: 6,
+  fontFamily: 'inherit',
+  fontSize: 13,
+  fontWeight: 700,
+  cursor: 'pointer',
+};
 
 createRoot(container).render(
   <StrictMode>


### PR DESCRIPTION
## What

Closes the DX gap reported on `npm run dev:live`: a scaffolded **page-money** app run without a dev token shows a "LiveUnavailable" screen that names `VITE_LIVE_BLOCK_TOKEN` but never says **how to get one**. This adds the one-liner that mints it — as a CLI command and on the screen itself, with a copy button.

## Part 1 — `civitai app dev-token <slug>`

- `api.MintDevToken` + `DevTokenPath` (`POST /api/v1/blocks/dev-token`, body `{"slug":...}`, returns `.token`), reusing the existing `TokenSource`/`authedDo`/`serverMessage` machinery (same as `app status`/`withdraw`).
- Command prints the **token to stdout** (pipeable) and a paste hint to **stderr**; `--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>` (paste-ready, e.g. `>> .env.development.local`). Missing slug errors clearly.
- Error mapping → clean message + non-zero exit: 404 (not found / not yours), 403 (needs moderator + a **full-scope personal API key** — OAuth login can't mint a spend token; run `civitai whoami`), 429 (rate-limited), 503 (App Blocks unavailable).

## Part 2 — the LiveUnavailable screen (page-money `main.tsx` template)

- A **"How to get a dev token"** section showing `civitai app dev-token <slug>` (real slug interpolated) with a no-dep React **Copy** button (`navigator.clipboard.writeText` + transient "Copied!").
- The `VITE_LIVE_BLOCK_TOKEN` / `.env.development.local` paste instruction, the **full-scope personal API key** note (OAuth `civitai login` can't spend; confirm with `civitai whoami`), and a copyable **curl** fallback for users without the CLI. Keeps the existing `dev:harness` free-local-dev hint.

## Tests

- `internal/api/dev_token_test.go` — request shape (POST, path, Bearer, `{"slug"}`), empty-token-response guard, 404/403/401/429/503/500 mapping.
- `internal/cmd/app_dev_token_test.go` — token to stdout only / hint to stderr, `--env`, missing+whitespace slug, missing token, error mapping, the 403→personal-key guidance, and `app --help` lists `dev-token`.
- `internal/scaffold/scaffold_test.go` (`TestRenderPageMoney`) — rendered `main.tsx` carries `civitai app dev-token <slug>`, `clipboard.writeText`, `VITE_LIVE_BLOCK_TOKEN`, the personal-key note, and the curl fallback.

## Gates

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt -l` clean; cross-compile windows/amd64, darwin/arm64, linux/amd64 all rc=0. Rendered `main.tsx` syntax-checked through esbuild (valid TSX after `{{ }}` interpolation). `app dev-token --help` + `app --help` render.

## Not verified

The unit tests use an httptest stub — a **real** token mint isn't exercised (needs a live moderator full-scope key). The error-status mapping matches the documented server shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
