### PR TITLE
feat(app): simplify scaffold output — drop file tree, numbered next steps

### DIFF
--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -41,24 +41,40 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 		t.Fatalf("app create: %v\n%s", err, stdout)
 	}
 
-	// Defaulted to the batteries-included page-money template.
-	if !strings.Contains(stdout, "template: page-money") {
+	// Defaulted to the batteries-included page-money template (named in the
+	// one-line summary).
+	if !strings.Contains(stdout, "(page-money)") {
 		t.Errorf("create should default to page-money:\n%s", stdout)
+	}
+	// The summary reports a file COUNT, not a per-file tree.
+	if !strings.Contains(stdout, "files") {
+		t.Errorf("create should report a file count in the summary:\n%s", stdout)
+	}
+	// The per-file tree is gone: no individual scaffold filename leaks into output.
+	for _, leaked := range []string{"vite.config.ts", "block.manifest.json", "package.json"} {
+		if strings.Contains(stdout, leaked) {
+			t.Errorf("create should NOT list individual files (%q leaked):\n%s", leaked, stdout)
+		}
+	}
+	// Numbered, scannable next steps.
+	if !strings.Contains(stdout, "1. cd ") || !strings.Contains(stdout, "npm install") {
+		t.Errorf("create should print a numbered cd+install step:\n%s", stdout)
 	}
 	// Harness-aware next steps (page-money needs the mock host).
 	if !strings.Contains(stdout, "dev:harness") {
 		t.Errorf("create should print dev:harness next step:\n%s", stdout)
 	}
-	// The mock-vs-live clarification must be visible at the moment the user
-	// reads the next steps (a placeholder Generate result is the mock, not a bug).
+	// The mock-vs-live clarification must survive (a placeholder Generate
+	// result is the mock, not a bug).
 	if !strings.Contains(stdout, "MOCK") {
 		t.Errorf("create should flag dev:harness as a MOCK host:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "dev:live") {
 		t.Errorf("create should point at dev:live for a real generation:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "civitai app validate") {
-		t.Errorf("create should print the validate next step:\n%s", stdout)
+	// Validate is folded into the submit step.
+	if !strings.Contains(stdout, "civitai app submit") {
+		t.Errorf("create should print the submit next step:\n%s", stdout)
 	}
 
 	assertScaffoldValid(t, dest)
@@ -87,7 +103,7 @@ func TestAppCreateRespectsTemplateOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app create --template static: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "template: static") {
+	if !strings.Contains(stdout, "(static)") {
 		t.Errorf("--template static should override the page-money default:\n%s", stdout)
 	}
 	assertScaffoldValid(t, dest)
@@ -105,8 +121,11 @@ func TestAppCreateDerivesSlugFromDisplayName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app create with display name: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "slug: my-cool-block") {
-		t.Errorf("display name should slugify to my-cool-block:\n%s", stdout)
+	// The display name slugifies to my-cool-block in the manifest (the
+	// summary line no longer prints the slug separately).
+	manifest := readManifest(t, dest)
+	if !strings.Contains(manifest, `"blockId": "my-cool-block"`) {
+		t.Errorf("display name should slugify to my-cool-block:\n%s", manifest)
 	}
 	if !strings.Contains(stdout, `"My Cool Block"`) {
 		t.Errorf("output should report the display name:\n%s", stdout)
@@ -145,7 +164,7 @@ func TestAppInitStillDefaultsToStatic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app init: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "template: static") {
+	if !strings.Contains(stdout, "(static)") {
 		t.Errorf("init should still default to static:\n%s", stdout)
 	}
 	assertScaffoldValid(t, dest)
@@ -162,7 +181,7 @@ func TestAppInitPageMoneyViaFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app init --template page-money: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "template: page-money") {
+	if !strings.Contains(stdout, "(page-money)") {
 		t.Errorf("init --template page-money should scaffold page-money:\n%s", stdout)
 	}
 	assertScaffoldValid(t, dest)

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -155,36 +155,32 @@ init and copy the upstream files in manually.`)
 	return nil
 }
 
-// printScaffoldResult prints the created-files tree + harness-aware next steps.
+// printScaffoldResult prints a one-line summary (with a file count, not the
+// full tree) followed by a numbered, template-tailored "Next steps" sequence.
 func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Template, destDir, abs string, written []string) {
-	fmt.Fprintf(out, "Created App Block %q (slug: %s, template: %s)\n", display, slug, tmpl)
-	fmt.Fprintf(out, "  %s\n", abs)
-	for _, w := range written {
-		// `written` paths are relative to destDir's parent; show them
-		// relative to the project dir for a clean tree.
-		rel, err := filepath.Rel(destDir, w)
-		if err != nil {
-			rel = w
-		}
-		fmt.Fprintf(out, "    %s\n", rel)
-	}
+	// One scannable line: name, template, where, and how many files — no tree.
+	fmt.Fprintf(out, "✓ Created App Block %q (%s)  ·  %s/  ·  %d files\n", display, tmpl, destDir, len(written))
+
 	fmt.Fprintln(out, "\nNext steps:")
 	switch {
 	case tmpl.NeedsHarness():
-		// SDK/page-money apps render blank under plain `dev` (no host) —
-		// the dev loop needs the mock host via `dev:harness`. Spell out the
-		// mock-vs-live distinction here so a "Generate" returning a placeholder
-		// image isn't mistaken for a broken real generation.
-		fmt.Fprintf(out, "  cd %s && npm install && npm run dev:harness\n", destDir)
-		fmt.Fprintln(out, "    dev:harness mounts a MOCK host — synthetic results, no real Buzz/compute.")
-		fmt.Fprintln(out, "    For a real generation that spends Buzz: npm run dev:live  (needs a full-scope personal API key — see README).")
+		// SDK/page-money apps render blank under plain `dev` (no host) — the
+		// dev loop needs the mock host via `dev:harness`. Keep the mock-vs-live
+		// distinction as a clearly-separate tip so a placeholder "Generate"
+		// result isn't mistaken for a broken real generation.
+		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
+		fmt.Fprintln(out, "  2. npm run dev:harness      # preview locally — MOCK host, no real Buzz")
+		fmt.Fprintln(out, "  3. civitai app submit       # validate + submit for review")
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "  Real generation (spends Buzz)? npm run dev:live — needs a personal API key (see README)")
 	case tmpl == scaffold.PageVite:
-		fmt.Fprintf(out, "  cd %s && npm install && npm run dev\n", destDir)
+		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
+		fmt.Fprintln(out, "  2. npm run dev              # preview locally")
+		fmt.Fprintln(out, "  3. civitai app submit       # validate + submit for review")
 	default:
-		fmt.Fprintf(out, "  cd %s   # open index.html or serve the directory\n", destDir)
+		fmt.Fprintf(out, "  1. cd %s              # then open index.html or serve the directory\n", destDir)
+		fmt.Fprintln(out, "  2. civitai app submit       # validate + submit for review")
 	}
-	fmt.Fprintln(out, "  civitai app validate")
-	fmt.Fprintln(out, "  civitai app submit")
 }
 
 func joinLines(lines []string) string {


### PR DESCRIPTION
The post-scaffold output listed every created file (~22 lines of noise) and
the "Next steps" crammed the mock-vs-live note into the primary command,
making the happy path hard to scan.

Replace the per-file tree with a one-line summary that carries a file count
(name · template · dir · N files), and render a numbered, template-tailored
"Next steps" sequence:
  - page-money: cd+install → dev:harness (MOCK) → submit, with the dev:live
    (spends Buzz) note kept as a clearly-separate tip
  - page-vite: cd+install → dev → submit
  - static: cd → submit

Validate is folded into the submit step comment to keep the list short.
Tests updated to assert the file-count summary, numbered steps, surviving
MOCK/dev:live clarity, and that no individual filenames leak into output.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
