### PR TITLE
fix(scaffold): submit-first dev:live flow + postinstall next-step hint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -681,7 +681,7 @@ func devTokenError(status int, raw []byte) error {
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusNotFound:
-		return fmt.Errorf("app not found (or not yours) (404): %s — check the slug, and that you've submitted the app (`civitai app status`)", msg)
+		return fmt.Errorf("app not found (404): %s — run `civitai app submit` first to register it (the dev token is minted against your submitted app), then retry. (check status: `civitai app status`)", msg)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -70,7 +70,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 		body   map[string]string
 		want   string
 	}{
-		{http.StatusNotFound, map[string]string{"message": "no such app"}, "app not found (or not yours)"},
+		{http.StatusNotFound, map[string]string{"message": "no such app"}, "civitai app submit"},
 		{http.StatusForbidden, map[string]string{"message": "mods only"}, "not authorized (403)"},
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -141,7 +141,7 @@ func TestAppDevTokenErrorMapping(t *testing.T) {
 		body   map[string]any
 		want   string
 	}{
-		{http.StatusNotFound, map[string]any{"message": "no such app"}, "app not found (or not yours)"},
+		{http.StatusNotFound, map[string]any{"message": "no such app"}, "civitai app submit"},
 		{http.StatusForbidden, map[string]any{"message": "mods only"}, "not authorized"},
 		{http.StatusUnauthorized, map[string]any{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,9 +56,15 @@ func TestRenderPageVite(t *testing.T) {
 	mustContain(t, manifest, `"buildCommand": "npm run build"`)
 	mustContain(t, manifest, `"outputDir": "dist"`)
 
-	// package.json name should use the slug.
+	// package.json name should use the slug, carry a postinstall next-step hint,
+	// and stay valid JSON after rendering.
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"name": "vite-block"`)
+	mustContain(t, pkg, `"postinstall"`)
+	mustContain(t, pkg, "npm run dev")
+	if !json.Valid([]byte(pkg)) {
+		t.Errorf("page-vite package.json is not valid JSON:\n%s", pkg)
+	}
 }
 
 func TestRenderPageMoney(t *testing.T) {
@@ -93,7 +100,8 @@ func TestRenderPageMoney(t *testing.T) {
 		t.Error("page-money manifest must not declare trustTier")
 	}
 
-	// package.json: SDK deps + the dev:harness script + slug name.
+	// package.json: SDK deps + the dev:harness script + slug name + a postinstall
+	// next-step hint, all while staying valid JSON after rendering.
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"@civitai/blocks-react"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
@@ -101,6 +109,11 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, pkg, `"build"`)
 	mustContain(t, pkg, `"test"`)
 	mustContain(t, pkg, `"name": "money-block"`)
+	mustContain(t, pkg, `"postinstall"`)
+	mustContain(t, pkg, "dev:harness")
+	if !json.Valid([]byte(pkg)) {
+		t.Errorf("page-money package.json is not valid JSON:\n%s", pkg)
+	}
 
 	// App.tsx must use the SDK, never raw postMessage('*').
 	app := readFile(t, filepath.Join(dest, "src", "App.tsx"))
@@ -124,6 +137,10 @@ func TestRenderPageMoney(t *testing.T) {
 	// user HOW to get one: the CLI one-liner with the real slug, a copy handler,
 	// the VITE_LIVE_BLOCK_TOKEN paste instruction, and the personal-key note.
 	mainTSX := readFile(t, filepath.Join(dest, "src", "main.tsx"))
+	// The required order is submit-first (the token is minted against the
+	// submitted/pending app) — the screen must surface `civitai app submit`
+	// as the prerequisite step, not just the dev-token mint.
+	mustContain(t, mainTSX, "civitai app submit")
 	mustContain(t, mainTSX, "civitai app dev-token money-block")
 	mustContain(t, mainTSX, "clipboard?.writeText")
 	mustContain(t, mainTSX, "VITE_LIVE_BLOCK_TOKEN")

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -6,6 +6,7 @@
   "description": "Civitai App Block (page money path) — estimate -> consent -> submit -> poll -> real Buzz spend, wired to the published App SDK.",
   "license": "MIT",
   "scripts": {
+    "postinstall": "node -e \"console.log('\\n✓ Installed. Next: npm run dev:harness   (preview — mock host, no Buzz)\\n  When ready: civitai app submit   ·   real generation: npm run dev:live (see README)')\"",
     "dev": "vite",
     "dev:harness": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=mock vite --host localhost --port 5186",
     "dev:live": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=live vite --host localhost --port 5186",

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -121,15 +121,28 @@ function LiveUnavailable({ reason }: { reason: string }) {
 
         <div style={liveSectionStyle}>
           <div style={liveSectionTitleStyle}>How to get a dev token</div>
-          <div style={liveCmdRowStyle}>
-            <pre style={liveCmdStyle}>{cliCmd}</pre>
-            <CopyButton text={cliCmd} />
-          </div>
           <p style={liveHintStyle}>
-            Paste the token into <code>VITE_LIVE_BLOCK_TOKEN</code> in{' '}
-            <code>.env.development.local</code>, then re-run{' '}
-            <code>npm run dev:live</code>.
+            To run <code>dev:live</code> you need a dev token. Your app must be{' '}
+            <strong>submitted first</strong> — the token is minted against your
+            submitted (pending-review) app.
           </p>
+          <ol style={liveStepsStyle}>
+            <li style={liveStepStyle}>
+              <code style={liveStepCmdStyle}>civitai app submit</code>{' '}
+              <span style={liveStepNoteStyle}># registers the app (pending review)</span>
+            </li>
+            <li style={liveStepStyle}>
+              <div style={liveCmdRowStyle}>
+                <pre style={liveCmdStyle}>{cliCmd}</pre>
+                <CopyButton text={cliCmd} />
+              </div>
+            </li>
+            <li style={liveStepStyle}>
+              Paste the token into <code>VITE_LIVE_BLOCK_TOKEN</code> in{' '}
+              <code>.env.development.local</code>, then re-run{' '}
+              <code>npm run dev:live</code>.
+            </li>
+          </ol>
           <p style={liveHintStyle}>
             Real generation needs a <strong>full-scope personal API key</strong>{' '}
             (create one at <code>civitai.com/user/account</code>) — an OAuth{' '}
@@ -139,7 +152,7 @@ function LiveUnavailable({ reason }: { reason: string }) {
         </div>
 
         <div style={liveSectionStyle}>
-          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl</div>
+          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl (after submitting)</div>
           <div style={liveCmdRowStyle}>
             <pre style={liveCmdSmallStyle}>{curlCmd}</pre>
             <CopyButton text={curlCmd} />
@@ -194,6 +207,22 @@ const liveSectionTitleStyle: CSSProperties = {
   color: '#ffa94d',
   marginBottom: 8,
 };
+const liveStepsStyle: CSSProperties = {
+  marginTop: 12,
+  marginBottom: 0,
+  paddingLeft: 22,
+  display: 'grid',
+  gap: 10,
+};
+const liveStepStyle: CSSProperties = { lineHeight: 1.5 };
+const liveStepCmdStyle: CSSProperties = {
+  background: '#0d0904',
+  border: '1px solid #5a3a17',
+  borderRadius: 4,
+  padding: '2px 6px',
+  color: '#ffe8c2',
+};
+const liveStepNoteStyle: CSSProperties = { opacity: 0.7 };
 const liveCmdRowStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'stretch',

--- a/internal/scaffold/templates/page-vite/package.json.tmpl
+++ b/internal/scaffold/templates/page-vite/package.json.tmpl
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "postinstall": "node -e \"console.log('\\n✓ Installed. Next: npm run dev   (local preview)\\n  When ready: civitai app submit (see README)')\"",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"


### PR DESCRIPTION
Two DX gaps reported by a user doing the App Blocks `dev:live` flow.

## Fix 1 — live-mode screen shows the `submit`-first step (the 404 fix)
`civitai app dev-token <slug>` mints against the app **as it exists server-side** (an approved block OR a pending submission owned by the caller). A freshly-scaffolded app exists only locally, so the mint returns **404 "App not found"** until `civitai app submit` registers a pending request. The live-mode setup screen previously showed `dev-token` without the submit-first step, so users hit the 404.

Reworked the `LiveUnavailable` "How to get a dev token" section into a numbered sequence: `civitai app submit` → `civitai app dev-token <slug>` (Copy button) → paste into `VITE_LIVE_BLOCK_TOKEN` → re-run `dev:live`. The curl fallback now notes "(after submitting)".

## Fix 2 — `postinstall` next-step hint
Added a cross-platform `postinstall` (`node -e`, never fails the install) to the **page-money** and **page-vite** scaffolds so the next step prints after `npm install`. Not added to the **static** template (no npm install).

## Fix 3 — sharpened the dev-token 404 message
`internal/api/api.go` now leads with the actionable fix:
`app not found (404): … — run \`civitai app submit\` first to register it (the dev token is minted against your submitted app), then retry. (check status: \`civitai app status\`)`

## Verification
- `go build`/`go vet`/`go test ./...` green; `gofmt -l` clean.
- Scaffolded a page-money + page-vite demo: rendered `package.json` is valid JSON, `npm install` ran the postinstall hook and printed the hint, and the rendered `main.tsx` typechecks clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
