### PR TITLE
feat(dev-token): mint from local manifest scopes; drop submit-first guidance

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -201,10 +201,13 @@ const SubmissionsPath = "/api/v1/blocks/submissions"
 const WithdrawPath = "/api/v1/blocks/withdraw"
 
 // DevTokenPath is the moderator-gated route that mints a short-lived dev block
-// token for `npm run dev:live` (POST {"slug": ...}; civitai/civitai
-// src/pages/api/v1/blocks/dev-token.ts). 200 { token, ... } on success; a
-// PENDING (un-approved) slug is accepted (200 since #2777). Error bodies are
-// {message}: 404 not-found/not-yours, 403 not-mod/insufficient-scope, 429
+// token for `npm run dev:live` (POST {"slug": ..., "scopes"?: [...]};
+// civitai/civitai src/pages/api/v1/blocks/dev-token.ts). 200 { token, ... } on
+// success; a PENDING (un-approved) slug is accepted, and a slug with NO app row
+// yet mints from the request-body `scopes` (the dev's LOCAL manifest scopes,
+// clamped server-side) — so `create → dev-token → dev:live` works with no
+// submit step. Error bodies are {message}: 404 slug registered to a different
+// account / genuinely not found, 403 not-mod/insufficient-scope, 429
 // rate-limited, 503 flag-off. The minted token's CAPABILITIES depend on the
 // bearer: a full-scope personal API key mints a spend-capable token; an OAuth
 // (`civitai login`) credential mints a read-only one.
@@ -628,20 +631,29 @@ func (c *Client) WithdrawRequest(ctx context.Context, publishRequestID string) e
 // DevTokenMinter mints a short-lived dev block token for `npm run dev:live`.
 type DevTokenMinter interface {
 	// MintDevToken mints a dev block token for the given app slug and returns
-	// the JWT. A non-2xx is mapped to an actionable error by devTokenError.
-	MintDevToken(ctx context.Context, slug string) (string, error)
+	// the JWT. scopes carries the caller's LOCAL block.manifest.json scopes for
+	// the server's no-row mint path (clamped server-side); pass nil/empty when
+	// no manifest is available. A non-2xx is mapped by devTokenError.
+	MintDevToken(ctx context.Context, slug string, scopes []string) (string, error)
 }
 
-// devTokenBody is the POST /api/v1/blocks/dev-token request body.
+// devTokenBody is the POST /api/v1/blocks/dev-token request body. Scopes is the
+// caller's LOCAL manifest scopes; it is omitted (not sent) when empty so a
+// registered app's server-side scopes still govern.
 type devTokenBody struct {
-	Slug string `json:"slug"`
+	Slug   string   `json:"slug"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // MintDevToken mints a short-lived dev block token for the given app slug,
-// returning the JWT from the response's .token field. The OAuth access token is
-// refreshed transparently on a 401. A non-2xx is mapped by devTokenError.
-func (c *Client) MintDevToken(ctx context.Context, slug string) (string, error) {
-	body, err := json.Marshal(devTokenBody{Slug: slug})
+// returning the JWT from the response's .token field. scopes carries the
+// caller's local manifest scopes for the server's no-row (no app registered
+// yet) mint path; they are clamped server-side and omitted from the body when
+// empty/nil (registered-app and read-only paths are unaffected). The OAuth
+// access token is refreshed transparently on a 401. A non-2xx is mapped by
+// devTokenError.
+func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string) (string, error) {
+	body, err := json.Marshal(devTokenBody{Slug: slug, Scopes: scopes})
 	if err != nil {
 		return "", err
 	}
@@ -681,7 +693,7 @@ func devTokenError(status int, raw []byte) error {
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusNotFound:
-		return fmt.Errorf("app not found (404): %s — run `civitai app submit` first to register it (the dev token is minted against your submitted app), then retry. (check status: `civitai app status`)", msg)
+		return fmt.Errorf("app not found (404): %s — check the slug. (dev-token mints from your local block.manifest.json; a 404 means the slug is registered to a different account.)", msg)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
 	var gotAuth, gotMethod, gotPath, gotCT, gotSlug string
+	var gotScopes []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		gotMethod = r.Method
@@ -19,16 +21,18 @@ func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
 		gotCT = r.Header.Get("Content-Type")
 		raw, _ := io.ReadAll(r.Body)
 		var body struct {
-			Slug string `json:"slug"`
+			Slug   string   `json:"slug"`
+			Scopes []string `json:"scopes"`
 		}
 		_ = json.Unmarshal(raw, &body)
 		gotSlug = body.Slug
+		gotScopes = body.Scopes
 		_ = json.NewEncoder(w).Encode(map[string]any{"token": "jwt-x", "expiresAt": "soon"})
 	}))
 	defer srv.Close()
 
 	c := New(srv.URL, "tok123", "")
-	tok, err := c.MintDevToken(context.Background(), "my-block")
+	tok, err := c.MintDevToken(context.Background(), "my-block", []string{"ai:write:budgeted"})
 	if err != nil {
 		t.Fatalf("MintDevToken: %v", err)
 	}
@@ -50,6 +54,39 @@ func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
 	if gotSlug != "my-block" {
 		t.Errorf("slug = %q, want my-block", gotSlug)
 	}
+	if !reflect.DeepEqual(gotScopes, []string{"ai:write:budgeted"}) {
+		t.Errorf("scopes = %v, want [ai:write:budgeted]", gotScopes)
+	}
+}
+
+// TestMintDevTokenOmitsEmptyScopes proves the body carries NO `scopes` key when
+// no scopes are passed (registered-app + read-only paths must be unchanged).
+func TestMintDevTokenOmitsEmptyScopes(t *testing.T) {
+	var hasScopesKey bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var generic map[string]any
+		_ = json.Unmarshal(raw, &generic)
+		_, hasScopesKey = generic["scopes"]
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "jwt-x"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	if _, err := c.MintDevToken(context.Background(), "my-block", nil); err != nil {
+		t.Fatalf("MintDevToken: %v", err)
+	}
+	if hasScopesKey {
+		t.Error("body should NOT carry a scopes key when scopes is nil")
+	}
+
+	// An empty (non-nil) slice must also be omitted (omitempty).
+	if _, err := c.MintDevToken(context.Background(), "my-block", []string{}); err != nil {
+		t.Fatalf("MintDevToken: %v", err)
+	}
+	if hasScopesKey {
+		t.Error("body should NOT carry a scopes key when scopes is empty")
+	}
 }
 
 func TestMintDevTokenEmptyTokenErrors(t *testing.T) {
@@ -59,7 +96,7 @@ func TestMintDevTokenEmptyTokenErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	if _, err := c.MintDevToken(context.Background(), "my-block"); err == nil {
+	if _, err := c.MintDevToken(context.Background(), "my-block", nil); err == nil {
 		t.Fatal("expected error when response has no token")
 	}
 }
@@ -70,7 +107,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 		body   map[string]string
 		want   string
 	}{
-		{http.StatusNotFound, map[string]string{"message": "no such app"}, "civitai app submit"},
+		{http.StatusNotFound, map[string]string{"message": "no such app"}, "registered to a different account"},
 		{http.StatusForbidden, map[string]string{"message": "mods only"}, "not authorized (403)"},
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
@@ -82,7 +119,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 			w.WriteHeader(tc.status)
 			_ = json.NewEncoder(w).Encode(tc.body)
 		}))
-		_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block")
+		_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
 		srv.Close()
 		if err == nil {
 			t.Fatalf("status %d: expected error", tc.status)
@@ -90,5 +127,25 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 		if !strings.Contains(err.Error(), tc.want) {
 			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
 		}
+	}
+}
+
+// TestMintDevToken404DropsSubmitFirst asserts the 404 message no longer tells
+// the user to submit first (the no-row path means a 404 is a slug collision).
+func TestMintDevToken404DropsSubmitFirst(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "not found"})
+	}))
+	defer srv.Close()
+	_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
+	if err == nil {
+		t.Fatal("expected a 404 error")
+	}
+	if strings.Contains(err.Error(), "civitai app submit") {
+		t.Errorf("404 message should no longer mention submit-first: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "block.manifest.json") {
+		t.Errorf("404 message should mention the local manifest: %q", err.Error())
 	}
 }

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/manifest"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +33,11 @@ The minted token's CAPABILITIES depend on the credential you mint with:
     spend) — dev:live shows your viewer + catalog/storage, but estimate →
     submit → generation will NOT spend.
 
-Pre-GA the mint route is moderator-only; a PENDING (un-approved) slug is
-accepted. The token is short-lived — never commit it; re-mint when it expires.`,
+Pre-GA the mint route is moderator-only. You do NOT need to submit the app
+first — for a brand-new slug with no app row yet, the token is minted from the
+scopes in your local block.manifest.json (clamped server-side), so
+"create → dev-token → dev:live" works directly. The token is short-lived —
+never commit it; re-mint when it expires.`,
 		Example: `  civitai app dev-token my-block               # print the token to stdout
   civitai app dev-token my-block --env         # print VITE_LIVE_BLOCK_TOKEN=<token>
   civitai app dev-token my-block --env >> .env.development.local`,
@@ -55,8 +59,16 @@ accepted. The token is short-lived — never commit it; re-mint when it expires.
 				return fmt.Errorf("an app slug is required — e.g. `civitai app dev-token my-block` (find it with `civitai app status`)")
 			}
 
+			// Read the LOCAL manifest scopes (current working directory — the
+			// user runs this from the scaffolded project dir) so the server can
+			// mint a token for a slug with no app row yet (no submit needed).
+			// Degrade gracefully: a missing/malformed manifest sends no scopes
+			// (read-only token), and a registered app's server-side scopes still
+			// govern when none are sent.
+			scopes := manifest.LoadScopes(".")
+
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
-			token, err := client.MintDevToken(context.Background(), slug)
+			token, err := client.MintDevToken(context.Background(), slug, scopes)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -12,6 +15,8 @@ import (
 // devTokenRec records the request the CLI sent to the dev-token endpoint.
 type devTokenRec struct {
 	auth, method, path, contentType, slug string
+	scopes                                []string
+	hasScopesKey                          bool
 }
 
 // devTokenServer stands up an httptest server emulating
@@ -27,10 +32,15 @@ func devTokenServer(t *testing.T, body any, status int, rec *devTokenRec) *httpt
 			rec.contentType = r.Header.Get("Content-Type")
 			raw, _ := io.ReadAll(r.Body)
 			var parsed struct {
-				Slug string `json:"slug"`
+				Slug   string   `json:"slug"`
+				Scopes []string `json:"scopes"`
 			}
 			_ = json.Unmarshal(raw, &parsed)
 			rec.slug = parsed.Slug
+			rec.scopes = parsed.Scopes
+			var generic map[string]any
+			_ = json.Unmarshal(raw, &generic)
+			_, rec.hasScopesKey = generic["scopes"]
 		}
 		if status != 0 && status != http.StatusOK {
 			w.WriteHeader(status)
@@ -141,7 +151,7 @@ func TestAppDevTokenErrorMapping(t *testing.T) {
 		body   map[string]any
 		want   string
 	}{
-		{http.StatusNotFound, map[string]any{"message": "no such app"}, "civitai app submit"},
+		{http.StatusNotFound, map[string]any{"message": "no such app"}, "registered to a different account"},
 		{http.StatusForbidden, map[string]any{"message": "mods only"}, "not authorized"},
 		{http.StatusUnauthorized, map[string]any{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
@@ -179,6 +189,96 @@ func TestAppDevTokenForbiddenNamesPersonalKey(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("403 error %q should mention %q", err.Error(), want)
 		}
+	}
+}
+
+// writeDevTokenManifest writes a block.manifest.json with the given raw body
+// into dir.
+func writeDevTokenManifest(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAppDevTokenSendsManifestScopes: a block.manifest.json with `scopes` in the
+// current working directory is read and its scopes are POSTed in the body — this
+// is the no-row local-manifest mint path.
+func TestAppDevTokenSendsManifestScopes(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	writeDevTokenManifest(t, dir, `{
+  "blockId": "my-block",
+  "version": "0.1.0",
+  "name": "My Block",
+  "scopes": ["ai:write:budgeted", "identity:read"]
+}`)
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	if _, _, err := run(t, "app", "dev-token", "my-block"); err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	if rec.slug != "my-block" {
+		t.Errorf("slug = %q, want my-block", rec.slug)
+	}
+	want := []string{"ai:write:budgeted", "identity:read"}
+	if !reflect.DeepEqual(rec.scopes, want) {
+		t.Errorf("scopes = %v, want %v", rec.scopes, want)
+	}
+}
+
+// TestAppDevTokenNoManifestSendsNoScopes: with no manifest in cwd the body has
+// no `scopes` key (just the slug) — the slug still identifies a registered app.
+func TestAppDevTokenNoManifestSendsNoScopes(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	chdir(t, t.TempDir()) // empty dir, no manifest
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	if _, _, err := run(t, "app", "dev-token", "my-block"); err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	if rec.slug != "my-block" {
+		t.Errorf("slug = %q, want my-block", rec.slug)
+	}
+	if rec.hasScopesKey {
+		t.Errorf("body should carry NO scopes key without a manifest, got %v", rec.scopes)
+	}
+}
+
+// TestAppDevTokenMalformedManifestDegrades: a malformed manifest must not crash
+// or fail the command — it degrades to sending no scopes (still mints for a
+// registered app / read-only token).
+func TestAppDevTokenMalformedManifestDegrades(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	writeDevTokenManifest(t, dir, `{ this is not valid json `)
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	if _, _, err := run(t, "app", "dev-token", "my-block"); err != nil {
+		t.Fatalf("malformed manifest should degrade, not fail: %v", err)
+	}
+	if rec.hasScopesKey {
+		t.Errorf("malformed manifest should send NO scopes, got %v", rec.scopes)
 	}
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -17,11 +17,30 @@ const Filename = "block.manifest.json"
 // reads directly. Full validation is done against the JSON Schema, not this
 // struct, so unknown fields are intentionally ignored here.
 type Manifest struct {
-	BlockID      string `json:"blockId"`
-	Version      string `json:"version"`
-	Name         string `json:"name"`
-	BuildCommand string `json:"buildCommand"`
-	OutputDir    string `json:"outputDir"`
+	BlockID      string   `json:"blockId"`
+	Version      string   `json:"version"`
+	Name         string   `json:"name"`
+	BuildCommand string   `json:"buildCommand"`
+	OutputDir    string   `json:"outputDir"`
+	Scopes       []string `json:"scopes"`
+}
+
+// LoadScopes reads the `scopes` array from the manifest in dir, degrading
+// gracefully: a missing manifest, an unreadable file, or malformed JSON all
+// return nil (no scopes) with no error. This is used by `civitai app dev-token`
+// to send the dev's LOCAL manifest scopes for the server's no-row mint path —
+// the slug arg still identifies a registered app even when the manifest is
+// absent, so a read failure must never block minting.
+func LoadScopes(dir string) []string {
+	raw, err := os.ReadFile(Path(dir))
+	if err != nil {
+		return nil
+	}
+	var m Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m.Scopes
 }
 
 // Path returns the manifest path for a project directory.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -88,6 +88,35 @@ func TestLoadRawMissingAndInvalid(t *testing.T) {
 	}
 }
 
+func TestLoadScopes(t *testing.T) {
+	// Present scopes are returned.
+	dir := t.TempDir()
+	write(t, dir, `{"blockId":"x","scopes":["ai:write:budgeted","identity:read"]}`)
+	got := LoadScopes(dir)
+	if len(got) != 2 || got[0] != "ai:write:budgeted" || got[1] != "identity:read" {
+		t.Errorf("LoadScopes = %v", got)
+	}
+
+	// No scopes field → nil.
+	dir2 := t.TempDir()
+	write(t, dir2, `{"blockId":"x"}`)
+	if got := LoadScopes(dir2); got != nil {
+		t.Errorf("LoadScopes (no scopes) = %v, want nil", got)
+	}
+
+	// Missing manifest → nil, no error (graceful degrade).
+	if got := LoadScopes(t.TempDir()); got != nil {
+		t.Errorf("LoadScopes (missing) = %v, want nil", got)
+	}
+
+	// Malformed JSON → nil, no error (graceful degrade).
+	dir3 := t.TempDir()
+	write(t, dir3, `{ not json `)
+	if got := LoadScopes(dir3); got != nil {
+		t.Errorf("LoadScopes (malformed) = %v, want nil", got)
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -137,18 +137,22 @@ func TestRenderPageMoney(t *testing.T) {
 	// user HOW to get one: the CLI one-liner with the real slug, a copy handler,
 	// the VITE_LIVE_BLOCK_TOKEN paste instruction, and the personal-key note.
 	mainTSX := readFile(t, filepath.Join(dest, "src", "main.tsx"))
-	// The required order is submit-first (the token is minted against the
-	// submitted/pending app) — the screen must surface `civitai app submit`
-	// as the prerequisite step, not just the dev-token mint.
-	mustContain(t, mainTSX, "civitai app submit")
+	// dev-token now mints from the LOCAL manifest (server no-row path), so the
+	// dev:live screen no longer requires submit-first: step 1 is the dev-token
+	// mint with the real slug, and the screen says you don't need to submit
+	// first. (`civitai app submit` must NOT be a prerequisite step here.)
 	mustContain(t, mainTSX, "civitai app dev-token money-block")
+	mustNotContain(t, mainTSX, "civitai app submit")
+	mustContain(t, mainTSX, "don&apos;t need to submit the app first")
 	mustContain(t, mainTSX, "clipboard?.writeText")
 	mustContain(t, mainTSX, "VITE_LIVE_BLOCK_TOKEN")
 	mustContain(t, mainTSX, ".env.development.local")
 	mustContain(t, mainTSX, "full-scope personal API key")
 	mustContain(t, mainTSX, "civitai whoami")
-	// Curl fallback for users without the CLI, carrying the real slug.
+	// Curl fallback for users without the CLI, carrying the real slug AND the
+	// local manifest scopes (so the no-row mint path works via curl too).
 	mustContain(t, mainTSX, `"slug":"money-block"`)
+	mustContain(t, mainTSX, `"scopes":["ai:write:budgeted"]`)
 	mustContain(t, mainTSX, "/api/v1/blocks/dev-token")
 
 	// README docs the live-mode Buzz-balance recipe (#30) — the only working path
@@ -281,6 +285,13 @@ func mustContain(t *testing.T, haystack, needle string) {
 	t.Helper()
 	if !contains(haystack, needle) {
 		t.Errorf("expected to contain %q\n--- content ---\n%s", needle, haystack)
+	}
+}
+
+func mustNotContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if contains(haystack, needle) {
+		t.Errorf("expected NOT to contain %q\n--- content ---\n%s", needle, haystack)
 	}
 }
 

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -71,11 +71,12 @@ target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 
 **Live mode setup.**
 
-> ⚠️ **`dev:live` works on a PENDING (un-approved) app.** The dev-token mint
-> (`POST /api/v1/blocks/dev-token`) accepts a **pending** slug — right after a
-> successful `civitai app submit` (status `pending`) it returns `200` with
-> `appId: pending-pubreq_…`, and `dev:live` mounts the live host against the
-> pending app. You do **not** need to wait for approval + deploy to dev:live-test.
+> ⚠️ **`dev:live` works WITHOUT submitting first.** The dev-token mint
+> (`POST /api/v1/blocks/dev-token`) accepts a brand-new slug with **no app row
+> yet** — it mints from the `scopes` in your local `block.manifest.json` (clamped
+> server-side), so `create → dev-token → dev:live` works directly. (A pending
+> slug after `civitai app submit` is accepted too.) You do **not** need to submit
+> or wait for approval to dev:live-test — submit when you're ready to publish.
 > For **real generation** you must mint with a **full-scope personal API key**; an
 > OAuth (`civitai login`) token mints read-only (`user:read:self`) and **cannot
 > spend**. Use `civitai buzz` / `civitai whoami` to confirm your credential can
@@ -96,7 +97,7 @@ To use it:
      curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
        -H "Authorization: Bearer $CIVITAI_TOKEN" \
        -H 'Content-Type: application/json' \
-       -d '{"slug":"{{ .Slug }}"}'   # → { token, expiresAt, scopes, buzzBudget }
+       -d '{"slug":"{{ .Slug }}","scopes":["ai:write:budgeted"]}'   # → { token, expiresAt, scopes, buzzBudget }
      ```
    - **`civitai login` (the OAuth device flow) mints a read/identity-only dev
      token for this app.** The `civitai-cli` client carries App Blocks submit but
@@ -212,9 +213,10 @@ After `civitai app submit`, your publish request is `pending` review — a
 Civitai-side **moderator** approves (or rejects) it. **This is not self-service
 today**; you cannot approve your own app. Track it with `civitai app status`.
 
-- **`dev:live` works on a pending (un-approved) app** — the dev-token mint accepts
-  a pending slug (returns `appId: pending-pubreq_…`), so you can real-spend-test
-  before approval. Real generation needs a **full-scope personal API key** (an
+- **`dev:live` works before you submit** — the dev-token mint accepts a brand-new
+  slug with no app row yet (minting from your local manifest scopes) as well as a
+  pending slug, so you can real-spend-test before submit/approval. Real generation
+  needs a **full-scope personal API key** (an
   OAuth `civitai login` token mints read-only and can't spend); confirm with
   `civitai buzz` / `civitai whoami`. See the live-mode prerequisite above.
 - Need to change the bundle while a request is still `pending`? **Withdraw your

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -6,7 +6,7 @@
   "description": "Civitai App Block (page money path) — estimate -> consent -> submit -> poll -> real Buzz spend, wired to the published App SDK.",
   "license": "MIT",
   "scripts": {
-    "postinstall": "node -e \"console.log('\\n✓ Installed. Next: npm run dev:harness   (preview — mock host, no Buzz)\\n  When ready: civitai app submit   ·   real generation: npm run dev:live (see README)')\"",
+    "postinstall": "node -e \"console.log('\\n✓ Installed. Next: npm run dev:harness   (preview — mock host, no Buzz)\\n  real generation: civitai app dev-token <slug> -> npm run dev:live (no submit needed; see README)   ·   publish: civitai app submit')\"",
     "dev": "vite",
     "dev:harness": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=mock vite --host localhost --port 5186",
     "dev:live": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=live vite --host localhost --port 5186",

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -215,14 +215,6 @@ const liveStepsStyle: CSSProperties = {
   gap: 10,
 };
 const liveStepStyle: CSSProperties = { lineHeight: 1.5 };
-const liveStepCmdStyle: CSSProperties = {
-  background: '#0d0904',
-  border: '1px solid #5a3a17',
-  borderRadius: 4,
-  padding: '2px 6px',
-  color: '#ffe8c2',
-};
-const liveStepNoteStyle: CSSProperties = { opacity: 0.7 };
 const liveCmdRowStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'stretch',

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -112,7 +112,7 @@ function LiveUnavailable({ reason }: { reason: string }) {
     `curl -s -X POST https://civitai.com/api/v1/blocks/dev-token ` +
     `-H "Authorization: Bearer $CIVITAI_TOKEN" ` +
     `-H 'Content-Type: application/json' ` +
-    `-d '{"slug":"{{ .Slug }}"}'`;
+    `-d '{"slug":"{{ .Slug }}","scopes":["ai:write:budgeted"]}'`;
   return (
     <div data-harness-banner="live-unavailable" style={liveWrapStyle}>
       <div style={liveInnerStyle}>
@@ -122,15 +122,10 @@ function LiveUnavailable({ reason }: { reason: string }) {
         <div style={liveSectionStyle}>
           <div style={liveSectionTitleStyle}>How to get a dev token</div>
           <p style={liveHintStyle}>
-            To run <code>dev:live</code> you need a dev token. Your app must be{' '}
-            <strong>submitted first</strong> — the token is minted against your
-            submitted (pending-review) app.
+            To run <code>dev:live</code> you need a dev token (minted from your
+            local manifest):
           </p>
           <ol style={liveStepsStyle}>
-            <li style={liveStepStyle}>
-              <code style={liveStepCmdStyle}>civitai app submit</code>{' '}
-              <span style={liveStepNoteStyle}># registers the app (pending review)</span>
-            </li>
             <li style={liveStepStyle}>
               <div style={liveCmdRowStyle}>
                 <pre style={liveCmdStyle}>{cliCmd}</pre>
@@ -149,10 +144,15 @@ function LiveUnavailable({ reason }: { reason: string }) {
             <code>civitai login</code> token can&apos;t spend. Confirm with{' '}
             <code>civitai whoami</code>.
           </p>
+          <p style={liveHintStyle}>
+            You don&apos;t need to submit the app first — <code>dev-token</code>{' '}
+            mints against your local <code>block.manifest.json</code>. Submit
+            when you&apos;re ready to publish.
+          </p>
         </div>
 
         <div style={liveSectionStyle}>
-          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl (after submitting)</div>
+          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl</div>
           <div style={liveCmdRowStyle}>
             <pre style={liveCmdSmallStyle}>{curlCmd}</pre>
             <CopyButton text={curlCmd} />


### PR DESCRIPTION
## What

`civitai app dev-token <slug>` now reads the local `block.manifest.json` (in the cwd — the scaffolded project dir) and sends its `scopes` array in the request body (`{"slug", "scopes"}`). This lets a **brand-new app that hasn't been submitted yet** mint a dev token: once the paired civitai server change ships, `create → dev-token → dev:live` works with **no `civitai app submit` step**.

This **pairs with the civitai server "no-row local-manifest" dev-token change** — when no app row exists server-side for the slug, the server mints from the `scopes` the CLI sends in the body (clamped server-side). Until that server PR deploys, the no-row path is verified here only against mocks.

## Changes

- **`MintDevToken(ctx, slug, scopes)`** (`internal/api/api.go`): threads `scopes` into the body; `omitempty` so it's dropped when nil/empty (registered-app + read-only paths unchanged).
- **`manifest.LoadScopes(dir)`** (`internal/manifest/manifest.go`): graceful reader — missing / unreadable / malformed manifest all return `nil` (never errors), so a read failure can't block minting. The `dev-token` command reads `"."`.
- **404 message**: dropped "run `civitai app submit` first"; a 404 now means the slug is registered to a **different account** (server no-shadow guard) — points at the local manifest.
- **page-money dev:live `LiveUnavailable` screen**: direct `dev-token → dev:live` flow, "you don't need to submit first" note, curl fallback now sends the manifest scopes.
- **page-money postinstall hint + README**: dev:live works before submit; submit is for publishing.

## Verification

- `go build`/`go vet`/`go test ./...` green; `gofmt -l` clean; cross-compiled windows/amd64, darwin/arm64, linux/amd64 (rc=0).
- Scaffolded a page-money app and ran `civitai app dev-token` against a mock server from the project dir → body was `{"slug":"demo-block","scopes":["ai:write:budgeted"]}`; from a dir with no manifest → `{"slug":"some-registered-app"}` (no `scopes` key).
- New tests: manifest-present sends scopes, no-manifest sends none, malformed-manifest degrades; 404 message no longer mentions submit-first.

> Not verified against the live server no-row path — that doesn't exist until its civitai PR deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
