### PR TITLE
fix(dx): gitignore live dev token + steer scaffold to app create/dev-token

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -178,12 +178,12 @@ for submission, so you don't have to hand-format a ZIP.
 Get started:
 
   civitai login                    store your API token
-  civitai app init my-app          scaffold a ready-to-build App Block
+  civitai app create my-app        scaffold a ready-to-build App Block
   civitai app validate             check the manifest before you submit
   civitai app submit               package + submit for review`,
 		Example: `  # First time: authenticate, then scaffold and submit an app.
   civitai login
-  civitai app init my-first-app --template page-vite
+  civitai app create my-first-app
   cd my-first-app
   civitai app validate
   civitai app submit`,

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -85,14 +85,21 @@ target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 
 To use it:
 
-1. Mint a short-lived dev block token via the moderator-gated endpoint
-   `POST /api/v1/blocks/dev-token` (the token is a ~15-minute RS256 JWT; re-mint
-   + restart when it expires). **Auth — the credential you mint with decides what
-   the dev token can do:**
+1. Mint a short-lived dev block token (a ~15-minute RS256 JWT; re-mint + restart
+   when it expires). The friendly path is the CLI — it calls the moderator-gated
+   mint route with your stored credential and writes a paste-ready line:
+   ```bash
+   civitai app dev-token {{ .Slug }} --env >> .env.development.local
+   ```
+   (drop `--env >> …` to just print the token). **Auth — the credential you mint
+   with decides what the dev token can do:**
    - The mint needs a credential carrying the **App Blocks submit** scope.
    - **Real generation (spends real Buzz) needs a full-scope personal API key.**
      Create one at `https://civitai.com/user/account` (a personal key carries
-     every scope, including AI Services):
+     every scope, including AI Services), store it with
+     `civitai login --token <key>` (plain `civitai login` is OAuth and can't
+     spend), then `civitai app dev-token` mints a spendable token. Or pass the
+     key as the Bearer to the raw route directly:
      ```bash
      curl -s -X POST https://civitai.com/api/v1/blocks/dev-token \
        -H "Authorization: Bearer $CIVITAI_TOKEN" \
@@ -110,8 +117,11 @@ To use it:
      above. (A separate civitai server change grants `user:read:self` so the
      viewer/identity resolves cleanly for OAuth dev:live; until that lands, OAuth
      dev:live is limited.)
-2. Paste the returned `token` into `.env.development` as `VITE_LIVE_BLOCK_TOKEN=`
-   (never commit it; `submit` excludes `.env.development`).
+2. If you printed the token instead of using `--env >> …`, paste it into
+   `.env.development.local` as `VITE_LIVE_BLOCK_TOKEN=<token>`. Keep the secret in
+   `.env.development.local` (git-ignored), NOT the committed `.env.development`.
+   (Never commit it; `submit` excludes every dotenv but `.env.example` /
+   `.env.production` anyway.)
 3. `npm run dev:live` — a persistent **⚠️ LIVE HOST** banner stays on screen; a
    successful Generate spends your own real Buzz.
 

--- a/internal/scaffold/templates/page-money/gitignore.tmpl
+++ b/internal/scaffold/templates/page-money/gitignore.tmpl
@@ -3,3 +3,10 @@ dist/
 *.log
 .DS_Store
 .vite/
+
+# Local secrets — a pasted VITE_LIVE_BLOCK_TOKEN spends REAL Buzz; never commit it.
+# `civitai app dev-token <slug> --env >> .env.development.local` writes here.
+# The committed .env.development / .env.example / .env.production hold only
+# non-secret VITE_ values and ARE tracked.
+.env.local
+.env.*.local


### PR DESCRIPTION
## What

Four authoring-DX gaps found by a **blind dogfood of the full `create → dev-token → dev:live` loop on v0.1.18** (the first run where the no-submit local-manifest mint exists). All are scaffold-template / help-text fixes — no command behavior changes.

| # | Defect | Fix |
|---|---|---|
| 1 | **Security-adjacent:** the page-money scaffold's `.gitignore` ignored **no** `.env*` files, so a pasted `VITE_LIVE_BLOCK_TOKEN` (a real, Buzz-spending dev token) would be swept up by `git add`. | Ignore `.env.local` + `.env.*.local`; keep the non-secret `.env.development`/`.env.example`/`.env.production` tracked. |
| 2 | README "Live mode setup" led with a raw `curl` to the mint route and never named the friendly `civitai app dev-token <slug>` command. | Lead with the CLI (`--env >> .env.development.local`); curl kept as manual fallback. |
| 3 | Dotenv target mismatch: the CLI writes the token to `.env.development.local`, the README said `.env.development`. | README matches the CLI + the new gitignore. |
| 4 | Root `--help` "Get started"/Examples steered to `app init --template page-vite` (plain-JS, no SDK) instead of `app create` (batteries-included SDK money-path). | Lead with `app create`. |

Also corrects the personal-key auth wording: store a full-scope key with `civitai login --token <key>` (plain `civitai login` is OAuth and **can't** spend).

## Why it matters

The whole point of v0.1.18 is `create → dev-token → dev:live` with **no submit**. The dev token is a real RS256 JWT that **spends Buzz**; not gitignoring it is the sharpest gap. The other three are friction/consistency on the exact path the scaffold now advertises in its own postinstall.

## Verification

- `go build ./...` + full `go test ./internal/...` green.
- Re-scaffolded from the patched binary; `git check-ignore` confirms `.env.development.local` + `.env.local` are ignored while `.env.development`/`.env.example`/`.env.production` stay tracked.
- Root help now leads with `civitai app create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)