### PR TITLE
fix(dev-token): warn at mint when the token can't spend (read-only/OAuth)

### DIFF
--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -11,6 +13,42 @@ import (
 	"github.com/civitai/cli/internal/manifest"
 	"github.com/spf13/cobra"
 )
+
+// budgetedScope is the spend scope a dev token must carry for `npm run dev:live`
+// to actually generate (spend Buzz). The server strips it from an OAuth-minted
+// token (the civitai-cli OAuth client lacks AI Services), so an OAuth login
+// yields a read-only token whose Generate button silently dead-ends in the live
+// harness. We decode the minted JWT to detect that case and warn loudly.
+const budgetedScope = "ai:write:budgeted"
+
+// tokenCanSpend reports whether the minted dev-token JWT carries the budgeted
+// spend scope. It decodes the JWT payload segment WITHOUT verifying the
+// signature (that's the server's job on every API call) — we only need the
+// claims to give an early, actionable warning. Any malformed input returns
+// false conservatively (the worst case is an extra warning, never a missed
+// spend). Mirrors the SDK live host's decodeBlockTokenPayload.
+func tokenCanSpend(jwt string) bool {
+	parts := strings.Split(jwt, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		Scopes []string `json:"scopes"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false
+	}
+	for _, s := range claims.Scopes {
+		if s == budgetedScope {
+			return true
+		}
+	}
+	return false
+}
 
 func newAppDevTokenCmd() *cobra.Command {
 	var envOut bool
@@ -81,9 +119,23 @@ never commit it; re-mint when it expires.`,
 			} else {
 				fmt.Fprintln(out, token)
 			}
-			fmt.Fprintln(cmd.ErrOrStderr(),
+			errOut := cmd.ErrOrStderr()
+			fmt.Fprintln(errOut,
 				"Paste into VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart `npm run dev:live`. "+
-					"Short-lived (~15min); never commit it. Real spend needs a full-scope personal API key (`civitai whoami`).")
+					"Short-lived (~15min); never commit it.")
+
+			// Catch the #1 dev:live dead-end EARLY: a token minted from an OAuth
+			// login carries no spend scope, so `dev:live` Generate silently does
+			// nothing (the live host can't grant consent for a scope the token
+			// lacks). Warn at the source — the mint — not after a wasted click.
+			if !tokenCanSpend(token) {
+				fmt.Fprintln(errOut,
+					"\n⚠  This token is READ-ONLY — it has no `ai:write:budgeted` scope, so "+
+						"`npm run dev:live` will NOT spend Buzz or generate (Generate dead-ends silently).\n"+
+						"   You're authenticated with an OAuth login. Real generation needs a full-scope personal API key:\n"+
+						"     civitai login --token <key>      # create one at https://civitai.com/user/account\n"+
+						"     civitai app dev-token "+slug+" --env >> .env.development.local   # re-mint, then restart dev:live")
+			}
 			return nil
 		},
 	}

--- a/internal/cmd/app_dev_token_warn_test.go
+++ b/internal/cmd/app_dev_token_warn_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// makeJWT builds a syntactically-valid JWT whose payload carries the given
+// scopes. The signature segment is a dummy — tokenCanSpend decodes the payload
+// WITHOUT verifying the signature (the server verifies on every real call).
+func makeJWT(t *testing.T, scopes []string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]any{"scopes": scopes, "sub": "user:1"})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + body + ".sig"
+}
+
+func TestTokenCanSpend(t *testing.T) {
+	cases := []struct {
+		name string
+		jwt  string
+		want bool
+	}{
+		{"budgeted", makeJWT(t, []string{"user:read:self", "ai:write:budgeted"}), true},
+		{"read-only", makeJWT(t, []string{"user:read:self"}), false},
+		{"empty-scopes", makeJWT(t, []string{}), false},
+		{"not-a-jwt", "garbage", false},
+		{"two-segments", "a.b", false},
+		{"bad-base64-payload", "a.!!!.c", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tokenCanSpend(tc.jwt); got != tc.want {
+				t.Errorf("tokenCanSpend(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// A read-only (OAuth-minted) token must trigger the loud "can't spend" warning
+// on stderr — the early catch for the silent dev:live dead-end.
+func TestAppDevTokenReadOnlyWarns(t *testing.T) {
+	jwt := makeJWT(t, []string{"user:read:self"})
+	srv := devTokenServer(t, map[string]any{"token": jwt}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "dev-token", "my-block")
+	if err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	// The token still goes to stdout cleanly (warning must not pollute it).
+	if strings.TrimSpace(out) != jwt {
+		t.Errorf("stdout should be exactly the token, got %q", out)
+	}
+	for _, want := range []string{"READ-ONLY", "ai:write:budgeted", "civitai login --token", "will NOT spend"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, errOut)
+		}
+	}
+}
+
+// A spendable (personal-key-minted) token must NOT trigger the warning.
+func TestAppDevTokenSpendableNoWarn(t *testing.T) {
+	jwt := makeJWT(t, []string{"user:read:self", "ai:write:budgeted"})
+	srv := devTokenServer(t, map[string]any{"token": jwt}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, errOut, err := run(t, "app", "dev-token", "my-block")
+	if err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	if strings.Contains(errOut, "READ-ONLY") {
+		t.Errorf("spendable token should NOT warn; stderr:\n%s", errOut)
+	}
+	// The normal paste hint still prints.
+	if !strings.Contains(errOut, "VITE_LIVE_BLOCK_TOKEN") {
+		t.Errorf("paste hint missing; stderr:\n%s", errOut)
+	}
+}


### PR DESCRIPTION
## What

A dogfood of `dev:live` hit a silent dead-end: Generate did nothing — no network, no console, no error. Root cause: the dev token was minted from an **OAuth login** (`civitai login`), so the server stripped `ai:write:budgeted`. The resulting read-only token makes the live host's Generate post `REQUEST_CONSENT`, which live mode can't grant → silent hang.

This catches it **at the source**: `app dev-token` now decodes the minted JWT payload and, when `ai:write:budgeted` is absent, prints a loud, actionable stderr warning:

```
⚠  This token is READ-ONLY — it has no `ai:write:budgeted` scope, so `npm run dev:live`
   will NOT spend Buzz or generate (Generate dead-ends silently).
   You're authenticated with an OAuth login. Real generation needs a full-scope personal API key:
     civitai login --token <key>      # create one at https://civitai.com/user/account
     civitai app dev-token <slug> --env >> .env.development.local   # re-mint, then restart dev:live
```

The token still goes to **stdout** cleanly, so `--env >> .env.development.local` is unaffected.

## Verification

`go build ./...` + `go test ./internal/...` green. New tests: `tokenCanSpend` table (budgeted / read-only / empty / malformed JWTs) + the command warns on a read-only minted JWT and stays silent on a spendable one.

## Sibling fix

The runtime half is `civitai/civitai-app-starters` (the live host now also warns at startup + logs on REQUEST_CONSENT instead of silently swallowing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)