### PR TITLE
fix(dev-token): name the actual read-only cause via whoami (don't presume OAuth)

### DIFF
--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -50,6 +50,40 @@ func tokenCanSpend(jwt string) bool {
 	return false
 }
 
+// readOnlyTokenWarning builds the stderr warning shown when a minted dev token
+// can't spend. It names the ACTUAL cause instead of presuming OAuth:
+//   - credential CAN spend (per whoami) → the request never asked for the
+//     scope; the fix is the manifest, not the credential.
+//   - credential can't spend + OAuth login → OAuth grants no Buzz-spend.
+//   - credential can't spend + personal key → that key lacks AI Services.
+//
+// It's a pure function (canSpend from whoami, authKind from config) so the
+// branch logic is unit-testable without a network round-trip.
+func readOnlyTokenWarning(canSpend bool, authKind, slug string) string {
+	const header = "\n⚠  This token is READ-ONLY (no `ai:write:budgeted` scope) — " +
+		"`npm run dev:live` will NOT spend Buzz or generate; Generate dead-ends silently."
+	remint := "     civitai app dev-token " + slug + " --env >> .env.development.local   # re-mint, then restart dev:live"
+
+	switch {
+	case canSpend:
+		// The stored credential CAN spend, so the token is read-only because the
+		// mint request didn't carry the scope — i.e. the manifest omits it.
+		return header + "\n" +
+			"   Cause: your credential CAN spend, but `ai:write:budgeted` wasn't requested — add it to `scopes` in block.manifest.json, then re-mint:\n" +
+			remint
+	case authKind == config.AuthKindOAuth:
+		return header + "\n" +
+			"   Cause: you're signed in with an OAuth login (`civitai login`), which can't spend Buzz. Use a full-scope personal API key:\n" +
+			"     civitai login --token <key>      # create one at https://civitai.com/user/account\n" +
+			remint
+	default:
+		return header + "\n" +
+			"   Cause: your stored personal API key lacks the AI Services (Buzz-spend) scope. Create a full-scope key, then re-store it:\n" +
+			"     civitai login --token <key>      # https://civitai.com/user/account\n" +
+			remint
+	}
+}
+
 func newAppDevTokenCmd() *cobra.Command {
 	var envOut bool
 
@@ -124,17 +158,19 @@ never commit it; re-mint when it expires.`,
 				"Paste into VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart `npm run dev:live`. "+
 					"Short-lived (~15min); never commit it.")
 
-			// Catch the #1 dev:live dead-end EARLY: a token minted from an OAuth
-			// login carries no spend scope, so `dev:live` Generate silently does
-			// nothing (the live host can't grant consent for a scope the token
-			// lacks). Warn at the source — the mint — not after a wasted click.
+			// Catch the #1 dev:live dead-end EARLY: a read-only token makes
+			// `dev:live` Generate silently do nothing (the live host can't grant
+			// consent for a scope the token lacks). Warn at the source — the
+			// mint — not after a wasted click, and name the ACTUAL cause: a
+			// read-only token can come from an OAuth login, a personal key
+			// lacking AI Services, OR a manifest that never asked for the spend
+			// scope. Disambiguate with whoami (the credential's real capability).
 			if !tokenCanSpend(token) {
-				fmt.Fprintln(errOut,
-					"\n⚠  This token is READ-ONLY — it has no `ai:write:budgeted` scope, so "+
-						"`npm run dev:live` will NOT spend Buzz or generate (Generate dead-ends silently).\n"+
-						"   You're authenticated with an OAuth login. Real generation needs a full-scope personal API key:\n"+
-						"     civitai login --token <key>      # create one at https://civitai.com/user/account\n"+
-						"     civitai app dev-token "+slug+" --env >> .env.development.local   # re-mint, then restart dev:live")
+				canSpend := false
+				if id, whoErr := client.WhoAmI(context.Background()); whoErr == nil {
+					canSpend = id.CanSpendBuzz()
+				}
+				fmt.Fprintln(errOut, readOnlyTokenWarning(canSpend, cfg.AuthKind(), slug))
 			}
 			return nil
 		},

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -21,10 +21,16 @@ type devTokenRec struct {
 
 // devTokenServer stands up an httptest server emulating
 // POST /api/v1/blocks/dev-token, returning the canned body+status and recording
-// the request (incl. the decoded slug).
+// the request (incl. the decoded slug). It also answers GET /api/v1/me with a
+// minimal non-spendable identity — the dev-token command calls WhoAmI in the
+// read-only warning path, and that call must neither error nor pollute `rec`.
 func devTokenServer(t *testing.T, body any, status int, rec *devTokenRec) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/me") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"username": "u", "id": 1, "tokenScope": 0})
+			return
+		}
 		if rec != nil {
 			rec.auth = r.Header.Get("Authorization")
 			rec.method = r.Method

--- a/internal/cmd/app_dev_token_warn_test.go
+++ b/internal/cmd/app_dev_token_warn_test.go
@@ -4,8 +4,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/config"
 )
 
 // makeJWT builds a syntactically-valid JWT whose payload carries the given
@@ -90,5 +94,90 @@ func TestAppDevTokenSpendableNoWarn(t *testing.T) {
 	// The normal paste hint still prints.
 	if !strings.Contains(errOut, "VITE_LIVE_BLOCK_TOKEN") {
 		t.Errorf("paste hint missing; stderr:\n%s", errOut)
+	}
+}
+
+// The warning must name the ACTUAL cause, not presume OAuth.
+func TestReadOnlyTokenWarning(t *testing.T) {
+	cases := []struct {
+		name      string
+		canSpend  bool
+		authKind  string
+		wantHas   []string
+		wantNotHa []string
+	}{
+		{
+			name:      "credential can spend → blame the manifest",
+			canSpend:  true,
+			authKind:  config.AuthKindToken,
+			wantHas:   []string{"credential CAN spend", "block.manifest.json", "re-mint"},
+			wantNotHa: []string{"OAuth", "lacks the AI Services", "civitai login --token"},
+		},
+		{
+			name:      "oauth login → blame OAuth",
+			canSpend:  false,
+			authKind:  config.AuthKindOAuth,
+			wantHas:   []string{"OAuth login", "civitai login --token", "personal API key"},
+			wantNotHa: []string{"credential CAN spend", "lacks the AI Services"},
+		},
+		{
+			name:      "personal key without AI Services → blame the key scope",
+			canSpend:  false,
+			authKind:  config.AuthKindToken,
+			wantHas:   []string{"personal API key lacks the AI Services", "civitai login --token"},
+			wantNotHa: []string{"OAuth login", "credential CAN spend"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readOnlyTokenWarning(tc.canSpend, tc.authKind, "my-block")
+			if !strings.Contains(got, "READ-ONLY") {
+				t.Errorf("missing READ-ONLY header; got:\n%s", got)
+			}
+			for _, w := range tc.wantHas {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q; got:\n%s", w, got)
+				}
+			}
+			for _, w := range tc.wantNotHa {
+				if strings.Contains(got, w) {
+					t.Errorf("should NOT contain %q; got:\n%s", w, got)
+				}
+			}
+		})
+	}
+}
+
+// End-to-end: when whoami reports the credential CAN spend but the minted token
+// is still read-only, the cause is the manifest — the warning must say so and
+// NOT send the dev chasing a credential fix.
+func TestAppDevTokenReadOnlyManifestCause(t *testing.T) {
+	readOnly := makeJWT(t, []string{"user:read:self"})
+	// Path-aware server: /api/v1/me reports a spend-capable credential; the
+	// dev-token route returns a read-only token (manifest didn't ask).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/me") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"username": "m", "id": 7, "tokenScope": api.ScopeAIServicesWrite | api.ScopeUserRead,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": readOnly})
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, errOut, err := run(t, "app", "dev-token", "my-block")
+	if err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	if !strings.Contains(errOut, "credential CAN spend") || !strings.Contains(errOut, "block.manifest.json") {
+		t.Errorf("expected a manifest-cause warning; got:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "lacks the AI Services") || strings.Contains(errOut, "OAuth login") {
+		t.Errorf("must NOT blame the credential when it can spend; got:\n%s", errOut)
 	}
 }


### PR DESCRIPTION
## What

The mint-time read-only warning (shipped in #48) hard-asserted *"You're authenticated with an OAuth login"*. But a dev token can be read-only for **three** distinct reasons, and that line misdiagnoses two of them:

1. The stored credential **can** spend, but the **manifest** never requested `ai:write:budgeted`.
2. **OAuth login** — grants submit, never Buzz-spend.
3. A **personal key that lacks AI Services**.

Now the warning disambiguates with **whoami** (the credential's real capability), so it names the actual cause and the right fix:

- can-spend + read-only token → *"your credential CAN spend, but `ai:write:budgeted` wasn't requested — add it to `scopes` in block.manifest.json"*
- can't-spend + OAuth → *"OAuth login can't spend — `civitai login --token <key>`"*
- can't-spend + personal key → *"your personal API key lacks the AI Services scope"*

whoami is queried **only in the read-only branch**, so the happy path pays nothing. The message logic is a pure helper (`readOnlyTokenWarning`) — also tightened so each case is ~3 lines, addressing the earlier "too noisy" feedback.

## Verification

`go build ./...` + full `go test ./...` green; gofmt clean. New tests: `readOnlyTokenWarning` table (all 3 causes, asserting each does NOT leak the other causes' text) + an end-to-end test where whoami reports can-spend → the manifest-cause message (no credential blame). `devTokenServer` now answers `/api/v1/me` so the new whoami call neither errors nor pollutes the recorded request.

Follow-up to #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)