### PR TITLE
fix(scaffold): rebuild dev:live missing-token page on /ui, lead with login --token

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -133,27 +133,26 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, manifest, `"name": "Money Block"`)
 	mustContain(t, app, "Money Block")
 
-	// The LiveUnavailable screen (shown by dev:live with no token) must tell the
-	// user HOW to get one: the CLI one-liner with the real slug, a copy handler,
-	// the VITE_LIVE_BLOCK_TOKEN paste instruction, and the personal-key note.
+	// The LiveUnavailable screen (shown by dev:live with no token) is built from
+	// the W6 /ui component pack and LEADS with the credential step — live mode
+	// always spends real Buzz, so a personal API key (not an OAuth login) is the
+	// first thing it asks for, then the dev-token mint (no submit-first).
 	mainTSX := readFile(t, filepath.Join(dest, "src", "main.tsx"))
-	// dev-token now mints from the LOCAL manifest (server no-row path), so the
-	// dev:live screen no longer requires submit-first: step 1 is the dev-token
-	// mint with the real slug, and the screen says you don't need to submit
-	// first. (`civitai app submit` must NOT be a prerequisite step here.)
+	// Built on the component pack, not bespoke HTML + inline styles.
+	mustContain(t, mainTSX, "@civitai/blocks-react/ui")
+	mustContain(t, mainTSX, "injectBlocksStyles")
+	// Leads with the spendable-credential step (the #1 dev:live dead-end).
+	mustContain(t, mainTSX, "civitai login --token")
+	mustContain(t, mainTSX, "personal API key")
+	// Then the dev-token mint with the real slug, writing straight to the env
+	// file (no manual VITE_LIVE_BLOCK_TOKEN paste, no submit-first).
 	mustContain(t, mainTSX, "civitai app dev-token money-block")
-	mustNotContain(t, mainTSX, "civitai app submit")
-	mustContain(t, mainTSX, "don&apos;t need to submit the app first")
-	mustContain(t, mainTSX, "clipboard?.writeText")
-	mustContain(t, mainTSX, "VITE_LIVE_BLOCK_TOKEN")
 	mustContain(t, mainTSX, ".env.development.local")
-	mustContain(t, mainTSX, "full-scope personal API key")
+	mustNotContain(t, mainTSX, "civitai app submit")
+	mustContain(t, mainTSX, "clipboard?.writeText")
 	mustContain(t, mainTSX, "civitai whoami")
-	// Curl fallback for users without the CLI, carrying the real slug AND the
-	// local manifest scopes (so the no-row mint path works via curl too).
-	mustContain(t, mainTSX, `"slug":"money-block"`)
-	mustContain(t, mainTSX, `"scopes":["ai:write:budgeted"]`)
-	mustContain(t, mainTSX, "/api/v1/blocks/dev-token")
+	// The mock-host escape hatch is still offered for free local dev.
+	mustContain(t, mainTSX, "dev:harness")
 
 	// README docs the live-mode Buzz-balance recipe (#30) — the only working path
 	// is the tRPC procedure with a bearer key (no public REST buzz endpoint).

--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -87,7 +87,7 @@ export function resolveLiveConfig(): LiveConfig {
     return {
       ready: false,
       reason:
-        'Live mode needs a dev block token (VITE_LIVE_BLOCK_TOKEN). Mint a short-lived token via the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token) and paste it into .env.development — never commit it.',
+        'No VITE_LIVE_BLOCK_TOKEN set, so dev:live has nothing to spend with. Follow the steps below to authenticate and mint a short-lived dev token (never commit it).',
     };
   }
   return { ready: true, token, backendBaseUrl };

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -1,5 +1,7 @@
-import { StrictMode, useEffect, useState, type CSSProperties } from 'react';
+import { StrictMode, useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
+
+import { Alert, Badge, Button, Card, Group, Stack, injectBlocksStyles } from '@civitai/blocks-react/ui';
 
 import { App } from './App.js';
 import { Harness } from './Harness.js';
@@ -79,16 +81,15 @@ function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: str
 }
 
 /**
- * A small "copy to clipboard" button with a transient "Copied!" state. No deps —
- * just `navigator.clipboard.writeText` + a `useState`. Used on the
- * LiveUnavailable screen so the one-liner to mint a dev token is one click away.
+ * A small "copy to clipboard" button with a transient "Copied!" state, built on
+ * the W6 component pack's Button. Used on the LiveUnavailable screen so each
+ * setup command is one click away.
  */
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   return (
-    <button
-      type="button"
-      style={liveCopyBtnStyle}
+    <Button
+      variant="subtle"
       onClick={() => {
         void navigator.clipboard?.writeText(text).then(() => {
           setCopied(true);
@@ -97,73 +98,83 @@ function CopyButton({ text }: { text: string }) {
       }}
     >
       {copied ? 'Copied!' : 'Copy'}
-    </button>
+    </Button>
+  );
+}
+
+/** One numbered setup step: a label plus a copyable command row. */
+function CmdStep({ n, label, cmd }: { n: number; label: ReactNode; cmd: string }) {
+  return (
+    <Stack gap={6}>
+      <span style={stepLabelStyle}>
+        <strong>{n}.</strong> {label}
+      </span>
+      <Group gap={8} align="stretch" wrap={false}>
+        <pre style={cmdStyle}>{cmd}</pre>
+        <CopyButton text={cmd} />
+      </Group>
+    </Stack>
   );
 }
 
 /**
- * Fail-safe LIVE screen. Shown when `dev:live` is requested but no dev block
- * token is set — so a dev sees WHY nothing is spending AND exactly how to get a
- * token, instead of a silent mock or a blank screen.
+ * Fail-safe LIVE screen — shown when `dev:live` is requested but no spendable
+ * dev token is set, so the dev sees WHY nothing generates AND the exact steps,
+ * instead of a silent mock or a blank screen. Built entirely from the
+ * `@civitai/blocks-react/ui` pack. Live mode ALWAYS spends real Buzz, so it
+ * leads with the credential step: authenticate with a personal API key (an
+ * OAuth `civitai login` can't spend), then mint a dev token.
  */
 function LiveUnavailable({ reason }: { reason: string }) {
-  const cliCmd = 'civitai app dev-token {{ .Slug }}';
-  const curlCmd =
-    `curl -s -X POST https://civitai.com/api/v1/blocks/dev-token ` +
-    `-H "Authorization: Bearer $CIVITAI_TOKEN" ` +
-    `-H 'Content-Type: application/json' ` +
-    `-d '{"slug":"{{ .Slug }}","scopes":["ai:write:budgeted"]}'`;
+  injectBlocksStyles();
+  const loginCmd = 'civitai login --token <your-personal-api-key>';
+  const mintCmd = 'civitai app dev-token {{ .Slug }} --env >> .env.development.local';
   return (
-    <div data-harness-banner="live-unavailable" style={liveWrapStyle}>
-      <div style={liveInnerStyle}>
-        <div style={liveTitleStyle}>⚠️ LIVE MODE — spends REAL Buzz / real compute</div>
-        <p style={liveReasonStyle}>{reason}</p>
+    <div data-harness-banner="live-unavailable" data-theme="dark" style={liveScreenStyle}>
+      <Card padding="lg" style={liveCardStyle}>
+        <Stack gap={16}>
+          <Group justify="space-between">
+            <strong style={liveCardTitleStyle}>Live mode setup</strong>
+            <Badge color="warning" variant="light">
+              spends REAL Buzz
+            </Badge>
+          </Group>
 
-        <div style={liveSectionStyle}>
-          <div style={liveSectionTitleStyle}>How to get a dev token</div>
-          <p style={liveHintStyle}>
-            To run <code>dev:live</code> you need a dev token (minted from your
-            local manifest):
-          </p>
-          <ol style={liveStepsStyle}>
-            <li style={liveStepStyle}>
-              <div style={liveCmdRowStyle}>
-                <pre style={liveCmdStyle}>{cliCmd}</pre>
-                <CopyButton text={cliCmd} />
-              </div>
-            </li>
-            <li style={liveStepStyle}>
-              Paste the token into <code>VITE_LIVE_BLOCK_TOKEN</code> in{' '}
-              <code>.env.development.local</code>, then re-run{' '}
-              <code>npm run dev:live</code>.
-            </li>
-          </ol>
-          <p style={liveHintStyle}>
-            Real generation needs a <strong>full-scope personal API key</strong>{' '}
-            (create one at <code>civitai.com/user/account</code>) — an OAuth{' '}
-            <code>civitai login</code> token can&apos;t spend. Confirm with{' '}
-            <code>civitai whoami</code>.
-          </p>
-          <p style={liveHintStyle}>
-            You don&apos;t need to submit the app first — <code>dev-token</code>{' '}
-            mints against your local <code>block.manifest.json</code>. Submit
-            when you&apos;re ready to publish.
-          </p>
-        </div>
+          <Alert color="warning" title="dev:live needs a spendable dev token">
+            {reason}
+          </Alert>
 
-        <div style={liveSectionStyle}>
-          <div style={liveSectionTitleStyle}>No CLI? Mint it with curl</div>
-          <div style={liveCmdRowStyle}>
-            <pre style={liveCmdSmallStyle}>{curlCmd}</pre>
-            <CopyButton text={curlCmd} />
-          </div>
-        </div>
+          <span style={stepLabelStyle}>
+            Live mode runs real generations and <strong>spends real Buzz</strong>, so you need a
+            full-scope <strong>personal API key</strong> — an OAuth <code>civitai login</code>{' '}
+            can&apos;t spend. Create one at <code>civitai.com/user/account</code>.
+          </span>
 
-        <p style={liveHintStyle}>
-          Or use <code>npm run dev:harness</code> (mock host) for free local
-          development. See README → “Mock vs live”.
-        </p>
-      </div>
+          <CmdStep
+            n={1}
+            label="Authenticate with that personal key (not plain `civitai login`):"
+            cmd={loginCmd}
+          />
+          <CmdStep
+            n={2}
+            label={
+              <>
+                Mint a dev token into <code>.env.development.local</code> (no submit needed):
+              </>
+            }
+            cmd={mintCmd}
+          />
+          <span style={stepLabelStyle}>
+            <strong>3.</strong> Restart <code>npm run dev:live</code>. Confirm your key can spend
+            with <code>civitai whoami</code> (look for <em>Spend Buzz: yes</em>).
+          </span>
+
+          <Alert color="info">
+            Just exploring? <code>npm run dev:harness</code> (the mock host) runs free — no token,
+            no Buzz, no network.
+          </Alert>
+        </Stack>
+      </Card>
     </div>
   );
 }
@@ -181,69 +192,34 @@ const liveBannerStyle: CSSProperties = {
   textAlign: 'center',
 };
 
-const liveWrapStyle: CSSProperties = {
+// The fail-safe screen themes its OWN root (data-theme) so the W6 pack's CSS
+// vars resolve, then uses the pack's surface/text tokens — matching the real
+// app instead of the old bespoke amber theme.
+const liveScreenStyle: CSSProperties = {
   minHeight: '100dvh',
-  display: 'grid',
-  placeItems: 'center',
-  background: '#1a1207',
-  color: '#ffd8a8',
-  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
-  padding: 24,
-  textAlign: 'center',
-};
-const liveInnerStyle: CSSProperties = { maxWidth: 620, textAlign: 'left' };
-const liveTitleStyle: CSSProperties = { fontSize: 20, fontWeight: 800, color: '#ffa94d', textAlign: 'center' };
-const liveReasonStyle: CSSProperties = { marginTop: 12, lineHeight: 1.5, textAlign: 'center' };
-const liveHintStyle: CSSProperties = { marginTop: 12, opacity: 0.8, lineHeight: 1.5 };
-
-const liveSectionStyle: CSSProperties = {
-  marginTop: 20,
-  paddingTop: 16,
-  borderTop: '1px solid #5a3a17',
-};
-const liveSectionTitleStyle: CSSProperties = {
-  fontSize: 14,
-  fontWeight: 700,
-  color: '#ffa94d',
-  marginBottom: 8,
-};
-const liveStepsStyle: CSSProperties = {
-  marginTop: 12,
-  marginBottom: 0,
-  paddingLeft: 22,
-  display: 'grid',
-  gap: 10,
-};
-const liveStepStyle: CSSProperties = { lineHeight: 1.5 };
-const liveCmdRowStyle: CSSProperties = {
   display: 'flex',
-  alignItems: 'stretch',
-  gap: 8,
+  justifyContent: 'center',
+  alignItems: 'flex-start',
+  padding: 24,
+  boxSizing: 'border-box',
+  background: 'var(--ci-color-surface-2)',
+  color: 'var(--ci-color-text)',
 };
-const liveCmdStyle: CSSProperties = {
+const liveCardStyle: CSSProperties = { width: '100%', maxWidth: 640 };
+const liveCardTitleStyle: CSSProperties = { fontSize: 20 };
+const stepLabelStyle: CSSProperties = { lineHeight: 1.5 };
+const cmdStyle: CSSProperties = {
   flex: 1,
   margin: 0,
   padding: '10px 12px',
-  background: '#0d0904',
-  border: '1px solid #5a3a17',
+  background: 'var(--ci-color-surface)',
+  border: '1px solid var(--ci-color-border)',
   borderRadius: 6,
-  color: '#ffe8c2',
-  fontSize: 14,
+  color: 'var(--ci-color-text)',
+  fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+  fontSize: 13,
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
-};
-const liveCmdSmallStyle: CSSProperties = { ...liveCmdStyle, fontSize: 12, opacity: 0.85 };
-const liveCopyBtnStyle: CSSProperties = {
-  flex: '0 0 auto',
-  padding: '0 14px',
-  background: '#7a1f1f',
-  color: '#ffd8a8',
-  border: '1px solid #a8492f',
-  borderRadius: 6,
-  fontFamily: 'inherit',
-  fontSize: 13,
-  fontWeight: 700,
-  cursor: 'pointer',
 };
 
 createRoot(container).render(


### PR DESCRIPTION
## What

The `dev:live` fail-safe screen (shown when no token is set) buried the personal-key step behind a `civitai app dev-token` one-liner + a curl fallback, and was built from bespoke HTML + inline amber styles. Two changes per dogfood feedback:

1. **Lead with `civitai login --token`.** Anyone running `dev:live` wants to spend real Buzz, so the screen now opens with *"you need a full-scope personal API key — an OAuth `civitai login` can't spend"* and step 1 is `civitai login --token <key>`. Step 2 mints the dev token straight into `.env.development.local` (`--env >>`, no manual paste, no submit-first). Dropped the curl fallback + redundant prose.
2. **Rebuilt on the W6 `/ui` pack** — `Card` / `Alert` / `Badge` / `Button` / `Stack` / `Group` + `injectBlocksStyles`, replacing all the bespoke HTML + inline styles, so it matches the real app's theme.

Also tightened the no-token `reason` string to point at the on-screen steps instead of repeating a stale endpoint recipe.

## Screenshot

Rendered via Playwright (`dev:live`, no token):

- "Live mode setup" + amber **SPENDS REAL BUZZ** badge
- warning Alert → intro (personal key, OAuth can't spend)
- **1.** `civitai login --token <your-personal-api-key>` + Copy
- **2.** `civitai app dev-token <slug> --env >> .env.development.local` + Copy
- **3.** restart + `civitai whoami`
- info Alert → `dev:harness` free escape hatch

## Verification

- `go test ./internal/...` green (scaffold golden assertions updated to the new content + new checks that the page is built on `@civitai/blocks-react/ui` and leads with `civitai login --token`).
- Scaffolded from the built binary → `npm install` + `npm run typecheck` + `npm run build` all clean (no `noUnusedLocals` break — all dead style consts removed).
- Rendered page confirmed via Playwright (structure + theming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)