### PR TITLE
fix(scaffold): make civitai.com/user/account an anchor that deeplinks the API-key dialog

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -144,6 +144,11 @@ func TestRenderPageMoney(t *testing.T) {
 	// Leads with the spendable-credential step (the #1 dev:live dead-end).
 	mustContain(t, mainTSX, "civitai login --token")
 	mustContain(t, mainTSX, "personal API key")
+	// "personal API key" is an anchor that deeplinks to the Add-API-Key modal,
+	// pre-filled with a name + the minimal AI Services scope.
+	mustContain(t, mainTSX, "<a href={apiKeyUrl}")
+	mustContain(t, mainTSX, "user/account?addApiKey=1")
+	mustContain(t, mainTSX, "scope=AIServices")
 	// Then the dev-token mint with the real slug, writing straight to the env
 	// file (no manual VITE_LIVE_BLOCK_TOKEN paste, no submit-first).
 	mustContain(t, mainTSX, "civitai app dev-token money-block")

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -151,6 +151,12 @@ function LiveUnavailable({ reason }: { reason: string }) {
   injectBlocksStyles();
   const loginCmd = 'civitai login --token <your-personal-api-key>';
   const mintCmd = 'civitai app dev-token {{ .Slug }} --env >> .env.development.local';
+  // Deeplink: opens the Add-API-Key modal pre-filled with a name + the minimal
+  // "AI Services" scope (the only scope a personal key needs to mint a spendable
+  // dev token). The query params are inert on older civitai builds — the link
+  // still lands on /user/account, so it degrades gracefully.
+  const apiKeyUrl =
+    'https://civitai.com/user/account?addApiKey=1&name=App%20Blocks%20dev%3Alive&scope=AIServices';
   return (
     <div data-harness-banner="live-unavailable" data-theme="dark" style={liveScreenStyle}>
       <Card padding="lg" style={liveCardStyle}>
@@ -170,8 +176,11 @@ function LiveUnavailable({ reason }: { reason: string }) {
             n={1}
             label={
               <>
-                Sign in with a <strong>personal API key</strong> from{' '}
-                <code>civitai.com/user/account</code> (an OAuth login can&apos;t spend):
+                Sign in with a{' '}
+                <a href={apiKeyUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                  personal API key
+                </a>{' '}
+                (opens the key dialog pre-filled; an OAuth login can&apos;t spend):
               </>
             }
             cmd={loginCmd}
@@ -228,6 +237,7 @@ const liveScreenStyle: CSSProperties = {
 const liveCardStyle: CSSProperties = { width: '100%', maxWidth: 640 };
 const liveCardTitleStyle: CSSProperties = { fontSize: 20 };
 const stepLabelStyle: CSSProperties = { lineHeight: 1.5 };
+const linkStyle: CSSProperties = { color: 'var(--ci-color-primary)', fontWeight: 600 };
 const cmdStyle: CSSProperties = {
   flex: 1,
   margin: 0,


### PR DESCRIPTION
## What

In the `dev:live` setup card, **"personal API key"** is now a clickable link that deeplinks straight into civitai's Add-API-Key dialog, pre-filled with a name and the minimal scope:

```
https://civitai.com/user/account?addApiKey=1&name=App%20Blocks%20dev%3Alive&scope=AIServices
```

So instead of "create a key with the right permissions" (find the button, guess the scopes), it's one click → review → Generate.

## Minimal scope

`scope=AIServices` = `UserRead | AIServicesWrite | AIServicesRead | BuzzRead` — for a personal key, `AIServicesWrite` is the only scope the `dev-token` mint needs to produce a *spendable* token (AppBlocksSubmit is OAuth-only; mod status is account-level).

## Graceful degradation

The query params are inert on civitai builds that don't support them yet — the link still lands on `/user/account`. The deeplink becomes functional once **civitai/civitai#2794** ships.

## Verification

- `go test ./internal/scaffold/` green (golden assertions updated: anchor + `addApiKey=1` + `scope=AIServices`).
- Scaffolded → `npm install` + `typecheck` + `build` clean.
- Rendered via Playwright — confirmed it's an `<a>` with the correct href, styled as a link.

Pairs with **civitai/civitai#2794** (the account-page deeplink handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)