### PR TITLE
fix(scaffold): progressive 4-step wizard for the dev:live setup card

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -133,29 +133,34 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, manifest, `"name": "Money Block"`)
 	mustContain(t, app, "Money Block")
 
-	// The LiveUnavailable screen (shown by dev:live with no token) is built from
-	// the W6 /ui component pack and LEADS with the credential step — live mode
-	// always spends real Buzz, so a personal API key (not an OAuth login) is the
-	// first thing it asks for, then the dev-token mint (no submit-first).
+	// The LiveUnavailable screen (shown by dev:live with no token) is a 4-step
+	// progressive wizard built from the W6 /ui pack: create key -> authenticate ->
+	// mint -> restart. Live mode always spends real Buzz, so it's credential-first.
 	mainTSX := readFile(t, filepath.Join(dest, "src", "main.tsx"))
 	// Built on the component pack, not bespoke HTML + inline styles.
 	mustContain(t, mainTSX, "@civitai/blocks-react/ui")
 	mustContain(t, mainTSX, "injectBlocksStyles")
-	// Leads with the spendable-credential step (the #1 dev:live dead-end).
-	mustContain(t, mainTSX, "civitai login --token")
-	mustContain(t, mainTSX, "personal API key")
-	// "personal API key" is an anchor that deeplinks to the Add-API-Key modal,
-	// pre-filled with a name + the minimal AI Services scope.
+	// Progressive wizard: a step counter that advances via Next buttons.
+	mustContain(t, mainTSX, "function WizardStep")
+	mustContain(t, mainTSX, "setStep(")
+	// Step 1 deeplinks to the Add-API-Key modal, pre-filled with an APP-SPECIFIC
+	// token name + the minimal AI Services scope; the link is masked as the URL
+	// (NOT "personal API key"), and there's an input to paste the key.
 	mustContain(t, mainTSX, "<a href={apiKeyUrl}")
+	mustContain(t, mainTSX, "civitai.com/user/account")
+	mustNotContain(t, mainTSX, "personal API key</a>")
+	mustContain(t, mainTSX, "App Money Block dev token")
 	mustContain(t, mainTSX, "user/account?addApiKey=1")
 	mustContain(t, mainTSX, "scope=AIServices")
-	// Then the dev-token mint with the real slug, writing straight to the env
-	// file (no manual VITE_LIVE_BLOCK_TOKEN paste, no submit-first).
+	mustContain(t, mainTSX, "TextInput")
+	mustContain(t, mainTSX, "setApiKey(")
+	// Step 2 authenticates WITH the pasted key (not a bare placeholder line).
+	mustContain(t, mainTSX, "'civitai login --token ' + (trimmedKey")
+	// Step 3: the dev-token mint with the real slug, straight to the env file.
 	mustContain(t, mainTSX, "civitai app dev-token money-block")
 	mustContain(t, mainTSX, ".env.development.local")
 	mustNotContain(t, mainTSX, "civitai app submit")
 	mustContain(t, mainTSX, "clipboard?.writeText")
-	mustContain(t, mainTSX, "civitai whoami")
 	// The mock-host escape hatch is still offered for free local dev.
 	mustContain(t, mainTSX, "dev:harness")
 

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -1,7 +1,16 @@
 import { StrictMode, useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { Alert, Badge, Button, Card, Group, Stack, injectBlocksStyles } from '@civitai/blocks-react/ui';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Stack,
+  TextInput,
+  injectBlocksStyles,
+} from '@civitai/blocks-react/ui';
 
 import { App } from './App.js';
 import { Harness } from './Harness.js';
@@ -128,35 +137,66 @@ function CmdRow({ cmd }: { cmd: string }) {
   );
 }
 
-/** One numbered setup step: a short label above a copyable command row. */
-function CmdStep({ n, label, cmd }: { n: number; label: ReactNode; cmd: string }) {
+/**
+ * One step of the progressive setup wizard. Hidden until reached (`n <= current`);
+ * once the user advances past it (`n < current`) the number badge becomes a green
+ * check, but the step's content (commands) stays visible so the full recipe is
+ * always there to re-copy.
+ */
+function WizardStep({
+  n,
+  current,
+  title,
+  children,
+}: {
+  n: number;
+  current: number;
+  title: ReactNode;
+  children: ReactNode;
+}) {
+  if (n > current) return null;
+  const done = n < current;
   return (
-    <Stack gap={6}>
-      <span style={stepLabelStyle}>
-        <strong>{n}.</strong> {label}
-      </span>
-      <CmdRow cmd={cmd} />
+    <Stack gap={8}>
+      <Group gap={10} align="center">
+        <Badge color={done ? 'success' : 'primary'} variant={done ? 'filled' : 'light'}>
+          {done ? '✓' : n}
+        </Badge>
+        <strong style={stepLabelStyle}>{title}</strong>
+      </Group>
+      {children}
     </Stack>
   );
 }
 
 /**
  * Fail-safe LIVE screen — shown when `dev:live` is requested but no spendable
- * dev token is set. Built entirely from the `@civitai/blocks-react/ui` pack.
- * Live mode ALWAYS spends real Buzz, so it leads with the credential step:
- * authenticate with a personal API key (an OAuth `civitai login` can't spend),
- * then mint a dev token.
+ * dev token is set. Built from the `@civitai/blocks-react/ui` pack as a 4-step
+ * wizard: create a personal API key (deeplinked, pre-filled name + minimal AI
+ * Services scope), authenticate the CLI WITH the pasted key, mint the dev token,
+ * restart. Each step unlocks the next so there's no wall of text. Live mode
+ * ALWAYS spends real Buzz, hence the credential-first flow (an OAuth login can't
+ * spend).
  */
 function LiveUnavailable({ reason }: { reason: string }) {
   injectBlocksStyles();
-  const loginCmd = 'civitai login --token <your-personal-api-key>';
-  const mintCmd = 'civitai app dev-token {{ .Slug }} --env >> .env.development.local';
-  // Deeplink: opens the Add-API-Key modal pre-filled with a name + the minimal
-  // "AI Services" scope (the only scope a personal key needs to mint a spendable
-  // dev token). The query params are inert on older civitai builds — the link
-  // still lands on /user/account, so it degrades gracefully.
+  const [step, setStep] = useState(1);
+  const [apiKey, setApiKey] = useState('');
+  const trimmedKey = apiKey.trim();
+
+  // The minted key's name is app-specific so it's recognizable in the user's key
+  // list; the scope is the minimal "AI Services" preset (all a personal key needs
+  // to mint a spendable dev token). Params are inert on older civitai builds —
+  // the link still lands on /user/account, so it degrades gracefully.
+  const tokenName = 'App {{ .Name }} dev token';
   const apiKeyUrl =
-    'https://civitai.com/user/account?addApiKey=1&name=App%20Blocks%20dev%3Alive&scope=AIServices';
+    'https://civitai.com/user/account?addApiKey=1&name=' +
+    encodeURIComponent(tokenName) +
+    '&scope=AIServices';
+  // Step 2's command carries the pasted key (placeholder until they paste).
+  const loginCmd = 'civitai login --token ' + (trimmedKey || '<your-personal-api-key>');
+  const mintCmd = 'civitai app dev-token {{ .Slug }} --env >> .env.development.local';
+
   return (
     <div data-harness-banner="live-unavailable" data-theme="dark" style={liveScreenStyle}>
       <Card padding="lg" style={liveCardStyle}>
@@ -172,29 +212,56 @@ function LiveUnavailable({ reason }: { reason: string }) {
             {reason}
           </Alert>
 
-          <CmdStep
-            n={1}
-            label={
-              <>
-                Sign in with a{' '}
+          <WizardStep n={1} current={step} title="Create your API key">
+            <Stack gap={10}>
+              <span style={stepLabelStyle}>
+                Opens the key dialog pre-filled (name + minimal scope) on{' '}
                 <a href={apiKeyUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                  personal API key
-                </a>{' '}
-                (opens the key dialog pre-filled; an OAuth login can&apos;t spend):
-              </>
-            }
-            cmd={loginCmd}
-          />
-          <CmdStep n={2} label="Mint a dev token (no submit needed):" cmd={mintCmd} />
-          <CmdStep
-            n={3}
-            label={
-              <>
-                Restart — then check <code>civitai whoami</code> shows <em>Spend Buzz: yes</em>:
-              </>
-            }
-            cmd="npm run dev:live"
-          />
+                  civitai.com/user/account
+                </a>
+                . An OAuth login can&apos;t spend, so create a key, then paste it:
+              </span>
+              <TextInput
+                label="Your API key"
+                placeholder="paste the key you just created"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+              />
+              {step === 1 && (
+                <Group justify="flex-end">
+                  <Button disabled={!trimmedKey} onClick={() => setStep(2)}>
+                    Next
+                  </Button>
+                </Group>
+              )}
+            </Stack>
+          </WizardStep>
+
+          <WizardStep n={2} current={step} title="Authenticate the CLI with your key">
+            <Stack gap={10}>
+              <CmdRow cmd={loginCmd} />
+              {step === 2 && (
+                <Group justify="flex-end">
+                  <Button onClick={() => setStep(3)}>Next</Button>
+                </Group>
+              )}
+            </Stack>
+          </WizardStep>
+
+          <WizardStep n={3} current={step} title="Mint the dev token (no submit needed)">
+            <Stack gap={10}>
+              <CmdRow cmd={mintCmd} />
+              {step === 3 && (
+                <Group justify="flex-end">
+                  <Button onClick={() => setStep(4)}>Next</Button>
+                </Group>
+              )}
+            </Stack>
+          </WizardStep>
+
+          <WizardStep n={4} current={step} title="Restart dev:live">
+            <CmdRow cmd="npm run dev:live" />
+          </WizardStep>
 
           <Alert color="info">
             <Stack gap={8}>


### PR DESCRIPTION
## What

Three changes to the `dev:live` "Live mode setup" screen:

1. **Progressive 4-step wizard** (replaces the wall of stacked command rows). Each step unlocks the next:
   1. **Create your API key** — the deeplink + a `TextInput` to paste the key; **Next is disabled until a key is entered**.
   2. **Authenticate the CLI with your key** — `civitai login --token <THE PASTED KEY>` (the key is **injected into the command**, not a placeholder) + copy-icon + Next.
   3. **Mint the dev token** — `civitai app dev-token <slug> --env >> .env.development.local` + copy + Next.
   4. **Restart** — `npm run dev:live`.

   Completed steps flip their number badge to a green ✓ but keep their command visible to re-copy.

2. **App-specific token name** — the deeplink now requests `App <AppName> dev token` (was a fixed "App Blocks dev:live"), so the minted key is recognizable in the user's key list. E.g. an app named "Wiztest" → `name=App%20Wiztest%20dev%20token`.

3. **Masked link** — the key-dialog link now reads **`civitai.com/user/account`** instead of the words "personal API key".

## Verification

- `go test ./internal/scaffold/` green (golden assertions updated: wizard, masked link, app-specific token name, key-injected login command).
- Scaffolded → `npm install` + `typecheck` + `build` clean (no `noUnusedLocals` break — removed the old `CmdStep`).
- **Full wizard click-path driven via Playwright**: typed a key → Next enabled → advanced through all 4 steps; confirmed step 1 link/token-name, the pasted key injected into step 2's `civitai login --token …`, the mint slug in step 3, and the green-check completed states.

Follow-up to #52 (which paired with civitai/civitai#2794, the deeplink handler — already merged + deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)