### PR TITLE
scaffold(page-money): model picker + drop confirm modal & "just exploring"

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -78,7 +78,9 @@ func TestRenderPageMoney(t *testing.T) {
 	for _, expect := range []string{
 		"block.manifest.json", "package.json", "vite.config.ts", "tsconfig.json", "index.html",
 		"src/main.tsx", "src/App.tsx", "src/Harness.tsx", "src/generation.ts",
-		"src/generation.test.ts", "src/App.pollretry.test.tsx", "src/index.css",
+		"src/models.ts", "src/catalog-api.ts",
+		"src/generation.test.ts", "src/models.test.ts", "src/catalog-api.test.ts",
+		"src/App.pollretry.test.tsx", "src/index.css",
 		"README.md", ".gitignore", ".env.development", ".env.production", ".env.example",
 	} {
 		if !containsStr(got, expect) {
@@ -128,6 +130,47 @@ func TestRenderPageMoney(t *testing.T) {
 	// a poll blip marked a server-side SUCCESS as FAILED.
 	mustContain(t, app, "MAX_TRANSIENT_ERRORS")
 	mustContain(t, app, "consecutiveErrors")
+
+	// The confirm-spend modal was removed: Generate is one click → consent →
+	// spend (the button already shows the cost). The "About" modal stays (it
+	// demonstrates Modal), so we assert the CONFIRM modal specifically is gone.
+	mustNotContain(t, app, "Confirm generation")
+	mustNotContain(t, app, "setConfirmOpen")
+	// The Generate click runs the gate directly (no intermediate confirm state).
+	mustContain(t, app, "proceed()")
+
+	// Model picker: the page ships a curated default checkpoint + an in-block
+	// picker (entity=none means no host model context). The old hardcoded
+	// GEN_MODEL is gone; the picker is wired into the workflow body.
+	mustNotContain(t, app, "GEN_MODEL")
+	mustContain(t, app, "DEFAULT_CHECKPOINT")
+	mustContain(t, app, "pm-model-select")
+	mustContain(t, app, "buildWorkflowBody(prompt, checkpoint)")
+	mustContain(t, app, "fetchCatalog")
+
+	// generation.ts threads the chosen checkpoint into modelId/modelVersionId
+	// instead of a hardcoded constant.
+	gen := readFile(t, filepath.Join(dest, "src", "generation.ts"))
+	mustNotContain(t, gen, "GEN_MODEL")
+	mustContain(t, gen, "checkpoint: CheckpointOption")
+	mustContain(t, gen, "modelVersionId: checkpoint.versionId")
+
+	// models.ts ships the curated, verified checkpoint ids the app starts on /
+	// falls back to (Public + generation-covered + SFW).
+	models := readFile(t, filepath.Join(dest, "src", "models.ts"))
+	mustContain(t, models, "CheckpointOption")
+	mustContain(t, models, "DEFAULT_CHECKPOINT")
+	mustContain(t, models, "128078") // SD XL 1.0 version id
+	mustContain(t, models, "290640") // Pony V6 XL version id
+
+	// catalog-api.ts uses the token-authoritative block endpoint (Bearer-gated,
+	// server-maturity-clamped) with a public, advisory-SFW fallback. The picks
+	// are server-revalidated, so no extra manifest scope is needed.
+	catalog := readFile(t, filepath.Join(dest, "src", "catalog-api.ts"))
+	mustContain(t, catalog, "/api/v1/blocks/models")
+	mustContain(t, catalog, "/api/v1/models")
+	mustContain(t, catalog, "Authorization")
+	mustContain(t, catalog, "catalogSfwOnly")
 
 	// The display name should land in the manifest + App heading.
 	mustContain(t, manifest, `"name": "Money Block"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -3,15 +3,16 @@
 A Civitai **page money-path** App Block (Vite + React + TypeScript), wired to
 the published App SDK (`@civitai/blocks-react` + `@civitai/app-sdk`). It mounts
 as a full-page (W10) app at `/apps/run/{{ .Slug }}` and spends Buzz to generate
-an image: estimate → (lazy consent) → submit → poll → result.
+an image: pick a checkpoint → estimate → (lazy consent) → submit → poll → result.
 
 ## What this is
 
-A sandboxed static web app served in an iframe by the Civitai host. Its entire
-UI is built from the **`@civitai/blocks-react/ui`** W6 component pack (Button,
-TextInput, Textarea, Card, Stack, Group, Alert, Modal, Badge) — no hand-rolled
-controls. The pack ships its own theme-aware styles; `injectBlocksStyles()` is
-called at module init in `src/App.tsx` so the first paint is already styled.
+A sandboxed static web app served in an iframe by the Civitai host. Its UI is
+built from the **`@civitai/blocks-react/ui`** W6 component pack (Button, Textarea,
+Card, Stack, Group, Alert, Loader, Modal, Badge) — the one exception is the model
+picker, a themed native `<select>` (the pack ships no Select yet). The pack ships
+its own theme-aware styles; `injectBlocksStyles()` is called at module init in
+`src/App.tsx` so the first paint is already styled.
 
 The platform
 owns the build: it runs `npm ci` then the `buildCommand` from
@@ -26,10 +27,32 @@ The money path uses the SDK hooks — never raw `window.parent.postMessage`:
   `TOKEN_REFRESH` and the app auto-resumes the click.
 - `useBlockResize()` — the SDK reports height to the host safely.
 
-Page constraints: a page is `entity=none` (no model context, no model-picker), so
-the model is hardcoded (`GEN_MODEL` in `src/generation.ts`). A page hard-forbids
+Page constraints: a page is `entity=none` — it carries no HOST model context (a
+model slot would deliver `modelId`/`modelVersionId` via `BLOCK_INIT`; a page does
+not). So this app ships its OWN model choice: a curated default checkpoint
+(`DEFAULT_CHECKPOINT` in `src/models.ts`, works at first paint / offline) plus an
+in-block picker that browses the catalog (`src/catalog-api.ts`). A page hard-forbids
 `buzz:read:self`, so insufficient Buzz is detected from a failed snapshot, not
 read proactively. The budget comes from `page.buzzBudgetPerGen` in the manifest.
+
+### Model picker (server-revalidated)
+
+The picker reads the public model catalog so the user can choose any checkpoint:
+
+- **`src/models.ts`** — a curated `CHECKPOINTS` set (verified Public +
+  generation-covered + SFW) and the `DEFAULT_CHECKPOINT` the app starts on. The
+  app never blocks on the network: the curated set always populates the picker.
+- **`src/catalog-api.ts`** — fetches more checkpoints. Signed-in, it uses the
+  **token-authoritative** `/api/v1/blocks/models` (Bearer = the block token),
+  which the server **maturity-clamps** to the token's signed ceiling — the client
+  never sends `nsfw`/`browsingLevel`. Anon (or as a fallback), it uses the public
+  `/api/v1/models` with `nsfw=false` advisory-SFW, gated by the block's domain
+  maturity. No extra manifest scope is needed — the block token alone gates it.
+
+A pick is **discovery only**. Nothing about a client-chosen checkpoint is trusted:
+the server **re-validates** (public? generation-covered? SFW for the domain?) and
+**re-prices** the body at every `estimate` AND `submit`. A client can't smuggle a
+non-generatable or mis-priced model through `buildWorkflowBody`.
 
 ## Develop
 
@@ -183,6 +206,12 @@ npm run build         # what the platform produces (tsc typecheck + vite build)
 `npm test` runs both vitest projects in one go (split in `vite.config.ts`):
 
 - **`src/generation.test.ts`** — pure-logic units (node env).
+- **`src/models.test.ts`** — the curated checkpoint set + the pick→option
+  helpers (`checkpointFromPick`, `mergeCheckpoints`). Locks the verified curated
+  ids so an accidental edit is caught.
+- **`src/catalog-api.test.ts`** — the in-block catalog client: URL builder, the
+  response→option mapper, the SFW clamp, and the injectable-`fetch` client
+  (success / empty / network-throw / authoritative→public fallback). No network.
 - **`src/App.test.tsx`** — component tests: render `<App/>` against
   `createMockHost()` and assert the UI (anon → sign-in, signed-in → prompt).
 - **`src/e2e.test.tsx`** — the money-path proof: drives the FULL

--- a/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -23,10 +23,15 @@ vi.mock('@civitai/blocks-react', () => ({
   useBlockContext: () => ({ ready: true, viewer: { id: 2, username: 'dev' }, theme: 'dark' }),
   useBlockResize: () => {},
   useBlockToken: () => ({ scopes: ['ai:write:budgeted'], raw: 't', expiresAt: '' }),
+  useDomainMaturity: () => ({ isSfw: true }),
   useBuzzWorkflow: () => ({ estimate: estimateFn, submit: submitFn, poll: pollFn }),
   useRequestConsent: () => ({ requestConsent: vi.fn() }),
   useRequestSignIn: () => ({ requestSignIn: vi.fn() }),
 }));
+
+// The App's catalog-load effect calls global fetch; stub it so the picker stays
+// on the curated set (this test is about the poll loop, not the catalog).
+vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in unit test')));
 
 // Imported AFTER the mock is registered.
 const { App } = await import('./App.js');
@@ -42,10 +47,9 @@ async function clickGenerate() {
   render(<App />);
   const generate = await screen.findByTestId('pm-generate');
   await user.type(screen.getByLabelText(/prompt/i), 'a serene mountain lake');
-  // The W6 /ui UI gates Generate behind a confirm Modal — open it, then confirm.
+  // Generate is one click — no confirm modal (the scope is granted in the mock,
+  // so this goes straight to estimate -> submit -> poll).
   await user.click(generate);
-  const dialog = await screen.findByRole('dialog', { name: /confirm generation/i });
-  await user.click(within(dialog).getByRole('button', { name: /generate/i }));
 }
 
 describe('App poll loop — transient-error robustness', () => {

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -5,6 +5,7 @@ import {
   useBlockResize,
   useBlockToken,
   useBuzzWorkflow,
+  useDomainMaturity,
   useRequestConsent,
   useRequestSignIn,
 } from '@civitai/blocks-react';
@@ -14,16 +15,15 @@ import {
   Button,
   Card,
   Group,
+  Loader,
   Modal,
   Stack,
-  TextInput,
   Textarea,
   injectBlocksStyles,
 } from '@civitai/blocks-react/ui';
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
 import {
-  GEN_MODEL,
   PAGE_BUZZ_BUDGET,
   PROMPT_MAX,
   buildWorkflowBody,
@@ -36,6 +36,13 @@ import {
   phaseForSnapshot,
   type GenPhase,
 } from './generation.js';
+import {
+  CHECKPOINTS,
+  DEFAULT_CHECKPOINT,
+  mergeCheckpoints,
+  type CheckpointOption,
+} from './models.js';
+import { catalogSfwOnly, defaultFetch, fetchCatalog } from './catalog-api.js';
 
 // Inject the W6 component pack's stylesheet at module init (before first paint)
 // to avoid the documented one-frame FOUC (the pack's components also call
@@ -57,7 +64,10 @@ injectBlocksStyles();
  *    so we CANNOT read the viewer's balance — insufficient Buzz is detected from
  *    the `failed` snapshot, never proactively.
  *  - budget comes from manifest `page.buzzBudgetPerGen`; a page is stateless.
- *  - the model is hardcoded (a page has no slot model) — see GEN_MODEL.
+ *  - a page has no HOST model context (entity=none), so the app ships a curated
+ *    default checkpoint (DEFAULT_CHECKPOINT) and an in-block picker that browses
+ *    the catalog (see models.ts / catalog-api.ts). A pick is DISCOVERY ONLY —
+ *    the server re-validates + re-prices it at estimate/submit.
  *  - `ai:write:budgeted` is consent-gated -> withheld at mint, requested lazily
  *    on first Generate via useRequestConsent; the grant arrives as a
  *    TOKEN_REFRESH carrying the scope, which we observe + retry.
@@ -65,6 +75,7 @@ injectBlocksStyles();
 export function App() {
   const { ready, viewer, theme } = useBlockContext();
   const token = useBlockToken();
+  const { isSfw: domainIsSfw } = useDomainMaturity();
   const { estimate, submit, poll } = useBuzzWorkflow();
   const { requestConsent } = useRequestConsent();
   const { requestSignIn } = useRequestSignIn();
@@ -82,8 +93,17 @@ export function App() {
   const [actualCost, setActualCost] = useState<number | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
+
+  // The selected checkpoint. Starts on the curated DEFAULT (works at first paint
+  // / offline / before the catalog loads); the in-block picker can replace it.
+  // A pick is DISCOVERY ONLY — the server re-validates + re-prices it.
+  const [checkpoint, setCheckpoint] = useState<CheckpointOption>(DEFAULT_CHECKPOINT);
+  // Catalog-browsed options, merged with the curated set in the picker. Empty
+  // until the catalog read resolves (or stays empty if it's unreachable — the
+  // curated set always works, so the picker is never blocked on the network).
+  const [catalogOptions, setCatalogOptions] = useState<CheckpointOption[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(false);
 
   // True once the user clicked Generate while the scope was missing — so when
   // the consent grant lands (granted flips true) we auto-resume the submit.
@@ -191,7 +211,7 @@ export function App() {
     setError(null);
     setImageUrl(null);
     setActualCost(null);
-    const body = buildWorkflowBody(prompt);
+    const body = buildWorkflowBody(prompt, checkpoint);
 
     // 1) Estimate (best-effort — a failed estimate doesn't block submit; the
     //    host re-prices at submit anyway).
@@ -231,11 +251,12 @@ export function App() {
     // 3) Poll to terminal.
     setPhase('polling');
     if (snap.workflowId) runPollLoop(snap.workflowId);
-  }, [prompt, estimate, submit, applySnapshot, runPollLoop]);
+  }, [prompt, checkpoint, estimate, submit, applySnapshot, runPollLoop]);
 
-  // The actual gate: sign-in -> consent -> generate. Called by the confirm modal.
+  // The actual gate: sign-in -> consent -> generate. Wired straight to the
+  // Generate button — the cost is already shown on the button, so there's no
+  // separate confirm step (consent is the real, host-driven spend gate).
   const proceed = useCallback(() => {
-    setConfirmOpen(false);
     // Anon: convert the click into a host login prompt. Generate is server-gated
     // anyway (an anon token carries no budgeted scope).
     if (!viewer) {
@@ -262,6 +283,40 @@ export function App() {
     }
   }, [granted, runGeneration]);
 
+  // Load the in-block catalog once the host is ready: token-authoritative
+  // (maturity-clamped) when signed in, public + advisory-SFW otherwise. The
+  // curated CHECKPOINTS already populate the picker, so a failed/empty read just
+  // leaves the picker on the curated set — the catalog only ADDS options.
+  // DISCOVERY ONLY: every option is re-validated + re-priced server-side.
+  useEffect(() => {
+    if (!ready) return;
+    let cancelled = false;
+    setCatalogLoading(true);
+    fetchCatalog(
+      {},
+      {
+        fetch: defaultFetch,
+        auth: { token: token.raw },
+        anonSfwOnly: catalogSfwOnly(domainIsSfw),
+      },
+    )
+      .then((res) => {
+        if (cancelled) return;
+        setCatalogOptions(res.kind === 'ok' ? res.options : []);
+      })
+      .finally(() => {
+        if (!cancelled) setCatalogLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, token.raw, domainIsSfw]);
+
+  // The picker's option list: curated set first, then catalog-browsed options,
+  // de-duplicated by versionId. The curated entries always lead so the default
+  // is stable across catalog states.
+  const pickerOptions = mergeCheckpoints(CHECKPOINTS, catalogOptions);
+
   const promptError =
     touched && prompt.trim().length === 0 ? 'Enter a prompt to generate.' : undefined;
   const busy = isBusyPhase(phase);
@@ -284,10 +339,20 @@ export function App() {
     );
   }
 
+  // Generate is one click: validate the prompt, then run the gate
+  // (sign-in -> consent -> spend). The button already shows the live cost, so
+  // there's no separate confirm step — consent is the real host-driven gate.
   const onGenerateClick = () => {
     setTouched(true);
     if (prompt.trim().length === 0) return;
-    setConfirmOpen(true);
+    proceed();
+  };
+
+  // Resolve a picker <option> value (the versionId) back to a CheckpointOption.
+  const onCheckpointChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const versionId = Number(e.target.value);
+    const next = pickerOptions.find((o) => o.versionId === versionId);
+    if (next) setCheckpoint(next);
   };
 
   return (
@@ -302,8 +367,8 @@ export function App() {
           </Group>
 
           <Alert color="info" title="How this works">
-            Type a prompt and generate one image with <strong>{GEN_MODEL.label}</strong>. Each
-            generation spends a small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).{' '}
+            Pick a checkpoint, type a prompt, and generate one image. Each generation spends a
+            small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).{' '}
             <button type="button" onClick={() => setAboutOpen(true)} style={linkButtonStyle}>
               Details
             </button>
@@ -322,13 +387,37 @@ export function App() {
             onBlur={() => setTouched(true)}
           />
 
-          <TextInput
-            label="Model"
-            description="A page block has no model picker, so the model is fixed."
-            value={GEN_MODEL.label}
-            readOnly
-            disabled
-          />
+          {/* Model picker. The W6 pack ships no Select, so this is a themed
+              native <select> (theme tokens via the pack's CSS vars). The curated
+              CHECKPOINTS always work; the catalog ADDS more once it loads. Every
+              pick is DISCOVERY ONLY — the server re-validates + re-prices it. */}
+          <label style={fieldStyle}>
+            <span style={fieldLabelStyle}>Model</span>
+            <span style={fieldDescStyle}>
+              Pick a checkpoint to generate with. The server validates + prices every generation.
+            </span>
+            <span style={selectWrapStyle}>
+              <select
+                value={checkpoint.versionId}
+                onChange={onCheckpointChange}
+                aria-label="Model"
+                style={selectStyle}
+                data-testid="pm-model-select"
+              >
+                {pickerOptions.map((opt) => (
+                  <option key={opt.versionId} value={opt.versionId}>
+                    {opt.label}
+                    {opt.baseModel ? ` (${opt.baseModel})` : ''}
+                  </option>
+                ))}
+              </select>
+              {catalogLoading && (
+                <span style={selectLoaderStyle} aria-hidden>
+                  <Loader size="sm" />
+                </span>
+              )}
+            </span>
+          </label>
 
           {anon ? (
             <Button fullWidth onClick={() => requestSignIn()} data-testid="pm-signin">
@@ -389,39 +478,19 @@ export function App() {
         </Stack>
       </Card>
 
-      {/* Confirm-spend modal — exercises Modal in its opened state with live data. */}
-      <Modal
-        opened={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
-        title="Confirm generation"
-        size="sm"
-      >
-        <Stack gap={14}>
-          <span>
-            Generate one image with <strong>{GEN_MODEL.label}</strong>? This spends up to{' '}
-            <strong>{PAGE_BUZZ_BUDGET}</strong> Buzz.
-          </span>
-          <Group justify="flex-end" gap={8}>
-            <Button variant="subtle" onClick={() => setConfirmOpen(false)}>
-              Cancel
-            </Button>
-            <Button color="success" onClick={proceed}>
-              Generate
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
-
-      {/* About modal — a second Modal instance, opened independently. */}
+      {/* About modal — demonstrates the pack's Modal, opened independently. */}
       <Modal opened={aboutOpen} onClose={() => setAboutOpen(false)} title="About this block" size="md">
         <Stack gap={10}>
           <span>
-            This is a sandboxed Civitai App Block. The interface is built entirely with the{' '}
-            <strong>@civitai/blocks-react/ui</strong> W6 component pack — Button, TextInput,
-            Textarea, Card, Stack, Group, Alert, Badge and Modal.
+            This is a sandboxed Civitai App Block. The interface is built from the{' '}
+            <strong>@civitai/blocks-react/ui</strong> W6 component pack — Button, Textarea, Card,
+            Stack, Group, Alert, Badge, Loader and Modal — plus a themed native{' '}
+            <code>&lt;select&gt;</code> for the model picker (the pack ships no Select yet).
           </span>
           <Alert color="info">
-            Generations run on the real Civitai backend and spend real Buzz when run in live mode.
+            Pick any checkpoint and we send it to generate — but a pick is just discovery. The
+            Civitai backend re-validates and re-prices every generation, so a client choice is
+            never trusted. Generations spend real Buzz when run in live mode.
           </Alert>
           <Group justify="flex-end">
             <Button onClick={() => setAboutOpen(false)}>Got it</Button>
@@ -464,4 +533,33 @@ const linkButtonStyle: React.CSSProperties = {
   textDecoration: 'underline',
   cursor: 'pointer',
   font: 'inherit',
+};
+
+// The W6 pack has no Select, so the model picker is a themed native <select>.
+// These read the same pack CSS vars the pack's own inputs use, so it matches the
+// Textarea/TextInput surface across light/dark themes.
+const fieldStyle: React.CSSProperties = { display: 'grid', gap: 4 };
+const fieldLabelStyle: React.CSSProperties = { fontSize: 14, fontWeight: 600 };
+const fieldDescStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--ci-color-text-muted, var(--ci-color-text))',
+  opacity: 0.8,
+};
+const selectWrapStyle: React.CSSProperties = { position: 'relative', display: 'block' };
+const selectStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 8,
+  border: '1px solid var(--ci-color-border)',
+  background: 'var(--ci-color-surface)',
+  color: 'var(--ci-color-text)',
+  fontSize: 14,
+  appearance: 'none',
+};
+const selectLoaderStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  right: 12,
+  transform: 'translateY(-50%)',
+  pointerEvents: 'none',
 };

--- a/internal/scaffold/templates/page-money/src/catalog-api.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/catalog-api.test.ts.tmpl
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  CATALOG_API_BASE,
+  CATALOG_API_BASE_BLOCKS,
+  buildCatalogUrl,
+  catalogSfwOnly,
+  fetchCatalog,
+  modelToCheckpoint,
+  responseToCheckpoints,
+  type FetchLike,
+} from './catalog-api.js';
+
+// Pure + injectable-fetch units for the in-block catalog client. No network —
+// the fetch client takes an injectable `fetch`, so success / empty / non-OK /
+// network-throw / authoritative-fallback are all driven deterministically.
+
+describe('buildCatalogUrl', () => {
+  it('always scopes to Checkpoints and clamps the limit', () => {
+    const url = new URL(buildCatalogUrl({ limit: 9999 }));
+    expect(url.origin + url.pathname).toBe(CATALOG_API_BASE);
+    expect(url.searchParams.get('types')).toBe('Checkpoint');
+    expect(url.searchParams.get('limit')).toBe('100');
+  });
+  it('omits an empty query and only adds nsfw=false when sfwOnly', () => {
+    const plain = new URL(buildCatalogUrl({ query: '   ' }));
+    expect(plain.searchParams.has('query')).toBe(false);
+    expect(plain.searchParams.has('nsfw')).toBe(false);
+
+    const sfw = new URL(buildCatalogUrl({ query: 'anime' }, { sfwOnly: true }));
+    expect(sfw.searchParams.get('query')).toBe('anime');
+    expect(sfw.searchParams.get('nsfw')).toBe('false');
+  });
+});
+
+describe('catalogSfwOnly (fail-closed SFW for the anon read)', () => {
+  it('only a red domain (isSfw=false) relaxes; unknown stays SFW', () => {
+    expect(catalogSfwOnly(true)).toBe(true);
+    expect(catalogSfwOnly(undefined)).toBe(true);
+    expect(catalogSfwOnly(false)).toBe(false);
+  });
+});
+
+describe('modelToCheckpoint / responseToCheckpoints', () => {
+  it('maps a model via its first version; skips rows with no version id', () => {
+    expect(
+      modelToCheckpoint({
+        id: 101055,
+        name: 'SD XL',
+        modelVersions: [{ id: 128078, name: '1.0', baseModel: 'SDXL 1.0' }],
+      }),
+    ).toEqual({ versionId: 128078, modelId: 101055, label: 'SD XL — 1.0', baseModel: 'SDXL 1.0' });
+
+    expect(modelToCheckpoint({ id: 1, modelVersions: [] })).toBeNull();
+    expect(modelToCheckpoint(null)).toBeNull();
+  });
+  it('drops malformed rows but keeps usable ones', () => {
+    const page = responseToCheckpoints({
+      items: [
+        { id: 1, name: 'Good', modelVersions: [{ id: 11, baseModel: 'SD 1.5' }] },
+        { id: 2, name: 'NoVersion' },
+      ],
+    });
+    expect(page).toHaveLength(1);
+    expect(page[0].versionId).toBe(11);
+  });
+});
+
+const okRes = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+describe('fetchCatalog', () => {
+  const page = { items: [{ id: 1, name: 'M', modelVersions: [{ id: 11, baseModel: 'SD 1.5' }] }] };
+
+  it('anon → public endpoint, advisory SFW honored', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes(page));
+    const res = await fetchCatalog({}, { fetch: fetchMock, anonSfwOnly: true });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') expect(res.authoritative).toBe(false);
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain(CATALOG_API_BASE);
+    expect(calledUrl).toContain('nsfw=false');
+  });
+
+  it('signed-in → authoritative /blocks/models with a Bearer header', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes(page));
+    const res = await fetchCatalog({}, { fetch: fetchMock, auth: { token: 'jwt' } });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') expect(res.authoritative).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toContain(CATALOG_API_BASE_BLOCKS);
+    expect(fetchMock.mock.calls[0][1]?.headers?.Authorization).toBe('Bearer jwt');
+    // The authoritative URL never leaks client maturity (server clamps).
+    expect(fetchMock.mock.calls[0][0]).not.toContain('nsfw=');
+  });
+
+  it('authoritative 404 → graceful fallback to the public read', async () => {
+    const fetchMock = vi
+      .fn<FetchLike>()
+      .mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) })
+      .mockResolvedValueOnce(okRes(page));
+    const res = await fetchCatalog({}, { fetch: fetchMock, auth: { token: 'jwt' } });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') expect(res.authoritative).toBe(false); // fell back to public
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toContain(CATALOG_API_BASE);
+  });
+
+  it('a public network throw → error result (never throws)', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockRejectedValue(new Error('CORS'));
+    const res = await fetchCatalog({}, { fetch: fetchMock });
+    expect(res.kind).toBe('error');
+  });
+
+  it('an empty public page → empty result', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes({ items: [] }));
+    const res = await fetchCatalog({}, { fetch: fetchMock });
+    expect(res.kind).toBe('empty');
+  });
+});

--- a/internal/scaffold/templates/page-money/src/catalog-api.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/catalog-api.ts.tmpl
@@ -1,0 +1,246 @@
+// Catalog client for the in-block checkpoint picker.
+//
+// TWO READ PATHS, chosen by whether a block token is available:
+//
+//  1. AUTHORITATIVE (signed-in): when the block has a block-scoped JWT we fetch
+//     the block-gated endpoint `/api/v1/blocks/models` with an
+//     `Authorization: Bearer <token>` header. Same response shape as the public
+//     `/api/v1/models`, but it AUTHORITATIVELY CLAMPS the catalog's browsing
+//     level to the token's signed `maxBrowsingLevel` ceiling. The client NEVER
+//     sends `nsfw`/`browsingLevel` — maturity is server-enforced. This is gated
+//     by the block token alone; no extra manifest scope is needed.
+//
+//  2. PUBLIC (anon, or graceful fallback): the public REST endpoint
+//     `https://civitai.com/api/v1/models` returns `Access-Control-Allow-Origin`
+//     for the block, so a sandboxed iframe can call it with a plain `fetch`. We
+//     pass `nsfw=false` for an advisory-SFW view (gated by the block's domain
+//     maturity). Runs for anon viewers AND as a deploy-order fallback.
+//
+// MONEY-SAFETY: this only DISCOVERS checkpoints. Every pick is re-validated AND
+// re-priced server-side at estimate/submit, so a public/anon read is money-safe
+// — a client can't smuggle a non-generatable or mis-priced model through here.
+//
+// All non-trivial logic here is pure + node-testable: the URL builder, the
+// response→Option mapper, and a thin fetch client that takes an INJECTABLE
+// `fetch` (so tests mock success / empty / error / malformed without a network).
+
+import type { CheckpointOption, PickedResource } from './models.js';
+import { checkpointFromPick } from './models.js';
+
+/** The public REST base. Overridable for tests / a future env pin. */
+export const CATALOG_API_BASE = 'https://civitai.com/api/v1/models';
+
+/** The authoritative, block-token-gated, maturity-clamped catalog base. */
+export const CATALOG_API_BASE_BLOCKS = 'https://civitai.com/api/v1/blocks/models';
+
+export interface CatalogQuery {
+  /** Meili text search; empty/whitespace → omitted (default popular view). */
+  query?: string;
+  /** ≤100 (server cap). Defaults to DEFAULT_LIMIT. */
+  limit?: number;
+}
+
+/** Default page size — small enough to keep the picker list + payload light. */
+export const DEFAULT_LIMIT = 20;
+
+export interface BuildUrlOptions {
+  base?: string;
+  /**
+   * Append `nsfw=false` (advisory SFW). Only the PUBLIC endpoint reads this; the
+   * authoritative `/blocks/models` IGNORES client maturity (server clamps), so we
+   * never send it there. Defaults to `false`.
+   */
+  sfwOnly?: boolean;
+}
+
+/**
+ * Build a catalog URL for a query (Checkpoints only). Pure + deterministic.
+ * Empty query is omitted (the default popular view). `limit` is clamped to
+ * [1, 100]. `sfwOnly` appends `nsfw=false` — public endpoint only.
+ */
+export function buildCatalogUrl(
+  q: CatalogQuery,
+  baseOrOpts: string | BuildUrlOptions = CATALOG_API_BASE,
+): string {
+  const opts: BuildUrlOptions = typeof baseOrOpts === 'string' ? { base: baseOrOpts } : baseOrOpts;
+  const base = opts.base ?? CATALOG_API_BASE;
+  const params = new URLSearchParams();
+  params.set('types', 'Checkpoint');
+  params.set('sort', 'Most Downloaded');
+  const query = q.query?.trim();
+  if (query) params.set('query', query);
+  params.set('limit', String(clampLimit(q.limit ?? DEFAULT_LIMIT)));
+  if (opts.sfwOnly) params.set('nsfw', 'false');
+  return `${base}?${params.toString()}`;
+}
+
+function clampLimit(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(100, Math.floor(n)));
+}
+
+/**
+ * Resolve the advisory-SFW flag for the ANON public read from the block's domain
+ * maturity (`useDomainMaturity().isSfw`). Fail-closed SFW: a green/blue domain
+ * (isSfw true, or unknown) browses SFW-only; only a red domain (isSfw false)
+ * relaxes it. Does NOT affect the authoritative path (server-clamped).
+ */
+export function catalogSfwOnly(domainIsSfw: boolean | undefined): boolean {
+  return domainIsSfw !== false;
+}
+
+// ---------------------------------------------------------------------------
+// Response shapes (minimal — only the fields we read). Tolerant of missing
+// fields (malformed payload → skipped, never throws).
+// ---------------------------------------------------------------------------
+
+interface RawModelVersion {
+  id?: number;
+  name?: string;
+  baseModel?: string;
+}
+interface RawModel {
+  id?: number;
+  name?: string;
+  modelVersions?: RawModelVersion[];
+}
+interface RawResponse {
+  items?: RawModel[];
+}
+
+/**
+ * Map ONE raw model → a CheckpointOption using its FIRST modelVersion (REST
+ * default order puts the latest/primary first). Returns `null` for an unusable
+ * row (no version id). Tolerant of any missing field.
+ */
+export function modelToCheckpoint(raw: RawModel | null | undefined): CheckpointOption | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const version = raw.modelVersions?.[0];
+  const versionId = version?.id;
+  if (typeof versionId !== 'number' || !Number.isFinite(versionId)) return null;
+  const modelId = typeof raw.id === 'number' ? raw.id : 0;
+  const picked: PickedResource = {
+    versionId,
+    modelId,
+    modelName: (raw.name ?? '').trim() || undefined,
+    versionName: (version?.name ?? '').trim() || undefined,
+    baseModel: (version?.baseModel ?? '').trim(),
+  };
+  return checkpointFromPick(picked);
+}
+
+/** Map a full raw response → a list of checkpoint options. Never throws. */
+export function responseToCheckpoints(raw: RawResponse | null | undefined): CheckpointOption[] {
+  const items = Array.isArray(raw?.items) ? raw!.items! : [];
+  const out: CheckpointOption[] = [];
+  for (const item of items) {
+    const opt = modelToCheckpoint(item);
+    if (opt) out.push(opt);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The fetch client. Takes an injectable `fetch` so tests drive success / empty /
+// network-error / non-OK / malformed without a real network. Returns a
+// discriminated result instead of throwing so the UI can show retry/empty.
+// ---------------------------------------------------------------------------
+
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export type CatalogResult =
+  | { kind: 'ok'; options: CheckpointOption[]; authoritative: boolean }
+  | { kind: 'empty'; authoritative: boolean }
+  | { kind: 'error'; status?: number; message: string };
+
+export interface CatalogAuth {
+  /** Raw block JWT (`useBlockToken().raw`). Absent → anon. */
+  token?: string | null;
+}
+
+/** Statuses that mean "not available yet, fall back to public". */
+function isFallbackStatus(status: number): boolean {
+  return status === 404 || status === 401 || status === 403;
+}
+
+async function toResult(
+  res: Awaited<ReturnType<FetchLike>>,
+  authoritative: boolean,
+): Promise<CatalogResult> {
+  if (!res.ok) {
+    return { kind: 'error', status: res.status, message: `request failed (${res.status})` };
+  }
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return {
+      kind: 'error',
+      status: res.status,
+      message: err instanceof Error ? err.message : 'bad JSON',
+    };
+  }
+  const options = responseToCheckpoints(body as RawResponse);
+  if (options.length === 0) return { kind: 'empty', authoritative };
+  return { kind: 'ok', options, authoritative };
+}
+
+/**
+ * Fetch one catalog page, choosing the authoritative (token, maturity-clamped)
+ * or public (anon, advisory-SFW) endpoint and gracefully falling back from the
+ * former to the latter when it isn't deployed / authorized yet, or throws
+ * (CORS/preflight/network). A failure on the PUBLIC path is a hard error (no
+ * infinite loop). Never throws.
+ */
+export async function fetchCatalog(
+  q: CatalogQuery,
+  deps: {
+    fetch: FetchLike;
+    auth?: CatalogAuth;
+    /** Advisory SFW for the ANON public read. Defaults to true (fail-closed SFW). */
+    anonSfwOnly?: boolean;
+    publicBase?: string;
+    blocksBase?: string;
+  },
+): Promise<CatalogResult> {
+  const token = deps.auth?.token;
+  const publicBase = deps.publicBase ?? CATALOG_API_BASE;
+  const blocksBase = deps.blocksBase ?? CATALOG_API_BASE_BLOCKS;
+  const anonSfwOnly = deps.anonSfwOnly !== false;
+
+  const fetchPublic = async (sfwOnly: boolean): Promise<CatalogResult> => {
+    const url = buildCatalogUrl(q, { base: publicBase, sfwOnly });
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+      res = await deps.fetch(url);
+    } catch (err) {
+      return { kind: 'error', message: err instanceof Error ? err.message : 'network error' };
+    }
+    return toResult(res, false);
+  };
+
+  // Anon: public endpoint, advisory SFW per the domain ceiling.
+  if (!token) return fetchPublic(anonSfwOnly);
+
+  // Signed-in: authoritative, maturity-clamped endpoint (server clamps maturity).
+  const authUrl = buildCatalogUrl(q, { base: blocksBase });
+  let authRes: Awaited<ReturnType<FetchLike>>;
+  try {
+    authRes = await deps.fetch(authUrl, { headers: { Authorization: `Bearer ${token}` } });
+  } catch {
+    return fetchPublic(true);
+  }
+
+  if (!authRes.ok && isFallbackStatus(authRes.status)) {
+    return fetchPublic(true);
+  }
+
+  return toResult(authRes, true);
+}
+
+/** Default real-network fetch adapter for the app (tests inject their own). */
+export const defaultFetch: FetchLike = (url, init) =>
+  fetch(url, init ? { headers: init.headers } : undefined);

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -9,13 +9,12 @@ import { App } from './App.js';
 // End-to-end proof of the money wiring: this drives the FULL page money path
 // through the REAL SDK transport (NO hook mocking) against the published mock
 // host. It is the regression guard that estimate -> consent -> submit -> poll
-// stays wired. The UI is the @civitai/blocks-react/ui pack, so the Generate
-// click first opens a confirm Modal; confirming inside it proceeds:
+// stays wired. Generate is ONE click — no confirm modal (consent is the real,
+// host-driven spend gate):
 //
 //   render <App/> (consent WITHHELD)
 //     -> type a prompt
-//     -> click Generate -> confirm Modal opens
-//     -> click Generate INSIDE the modal
+//     -> click Generate
 //     -> App asks the host for consent (REQUEST_CONSENT)
 //     -> host grants + pushes a TOKEN_REFRESH carrying ai:write:budgeted
 //     -> App auto-resumes: estimate -> submit -> poll
@@ -23,11 +22,6 @@ import { App } from './App.js';
 //
 // The mock host's internal timers all fire on setTimeout(0), so real timers +
 // findBy/waitFor resolve promptly — no fake-timer juggling required.
-
-async function confirmInModal(user: ReturnType<typeof userEvent.setup>) {
-  const dialog = await screen.findByRole('dialog', { name: /confirm generation/i });
-  await user.click(within(dialog).getByRole('button', { name: /generate/i }));
-}
 
 describe('App money path (e2e)', () => {
   let uninstall: (() => void) | undefined;
@@ -53,14 +47,20 @@ describe('App money path (e2e)', () => {
     // Wait for BLOCK_INIT -> the Generate button appears.
     const generate = await screen.findByTestId('pm-generate');
 
+    // The model picker is present, defaulted to SD XL 1.0; switch to Pony so the
+    // generation runs against the user's pick (still server-revalidated).
+    const picker = screen.getByTestId('pm-model-select') as HTMLSelectElement;
+    expect(picker.value).toBe('128078'); // DEFAULT_CHECKPOINT (SD XL 1.0)
+    await user.selectOptions(picker, '290640'); // Pony V6 XL
+    expect(picker.value).toBe('290640');
+
     // Enter a prompt (Generate is disabled while empty).
     await user.type(screen.getByLabelText(/prompt/i), 'a serene mountain lake');
     expect(generate).toBeEnabled();
 
-    // Click Generate -> confirm Modal -> confirm. Scope is withheld so the App
-    // requests consent first, then auto-resumes.
+    // Click Generate. Scope is withheld so the App requests consent first, then
+    // auto-resumes once the host grants it.
     await user.click(generate);
-    await confirmInModal(user);
 
     // The host grants consent + token-refreshes; the App auto-resumes through
     // estimate -> submit -> poll -> succeeded. Assert the terminal success UI.
@@ -90,7 +90,6 @@ describe('App money path (e2e)', () => {
     const generate = await screen.findByTestId('pm-generate');
     await user.type(screen.getByLabelText(/prompt/i), 'a cat');
     await user.click(generate);
-    await confirmInModal(user);
 
     // The failed snapshot carries insufficient-Buzz text -> the App swaps to
     // the Top-Up warning Alert and renders no image.

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
 import {
-  GEN_MODEL,
   PROMPT_MAX,
   buildWorkflowBody,
   clampPrompt,
@@ -13,6 +12,7 @@ import {
   isTerminalStatus,
   phaseForSnapshot,
 } from './generation.js';
+import { DEFAULT_CHECKPOINT } from './models.js';
 
 // A couple of pure-logic tests so authors inherit a working test setup. Run with
 // `npm test`. Add cases here as you grow the app's logic.
@@ -50,13 +50,19 @@ describe('clampPrompt', () => {
 });
 
 describe('buildWorkflowBody', () => {
-  it('builds a textToImage body with the hardcoded model + trimmed prompt', () => {
-    expect(buildWorkflowBody('  a cat  ')).toEqual({
+  it('builds a textToImage body with the chosen checkpoint + trimmed prompt', () => {
+    expect(buildWorkflowBody('  a cat  ', DEFAULT_CHECKPOINT)).toEqual({
       kind: 'textToImage',
-      modelId: GEN_MODEL.modelId,
-      modelVersionId: GEN_MODEL.modelVersionId,
+      modelId: DEFAULT_CHECKPOINT.modelId,
+      modelVersionId: DEFAULT_CHECKPOINT.versionId,
       params: { prompt: 'a cat' },
     });
+  });
+  it('threads the picked checkpoint into modelId/modelVersionId', () => {
+    const pick = { versionId: 290640, modelId: 257749, label: 'Pony V6 XL', baseModel: 'Pony' };
+    const body = buildWorkflowBody('x', pick);
+    expect(body.modelId).toBe(257749);
+    expect(body.modelVersionId).toBe(290640);
   });
 });
 

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -5,21 +5,7 @@
 
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
-/**
- * The hardcoded model this app generates with.
- *
- * A W10 page slot is entity=none: it carries NO model/entity context (unlike a
- * model slot), and the SDK exposes NO model-picker to a page app. The trust
- * model for page generation is "any public, generatable model, server-validated"
- * — so we hardcode a single known-good base. The canonical Stability AI "SD XL"
- * base is public + generation-covered + SFW. Swap to your preferred public,
- * generation-covered model if you like.
- */
-export const GEN_MODEL = {
-  modelId: 101055,
-  modelVersionId: 128078,
-  label: 'SD XL 1.0',
-} as const;
+import type { CheckpointOption } from './models.js';
 
 /** Server cap mirror — prompts over this are rejected by the workflow schema. */
 export const PROMPT_MAX = 1500;
@@ -90,15 +76,20 @@ export function clampPrompt(raw: string): string {
 }
 
 /**
- * Build the textToImage submit/estimate body. Page apps keep the param surface
- * minimal: just the prompt — the host fills sensible defaults for
- * dimensions/sampler/steps from the base-model family.
+ * Build the textToImage submit/estimate body for the chosen checkpoint. Page
+ * apps keep the param surface minimal: just the prompt — the host fills sensible
+ * defaults for dimensions/sampler/steps from the base-model family.
+ *
+ * MONEY-SAFETY: the checkpoint is the user's in-block PICK (default or catalog-
+ * browsed), which is DISCOVERY ONLY. The server re-validates (public? covered?
+ * SFW for the domain?) AND re-prices this body at estimate AND submit — a client
+ * can't force a non-generatable or mis-priced model through here.
  */
-export function buildWorkflowBody(prompt: string) {
+export function buildWorkflowBody(prompt: string, checkpoint: CheckpointOption) {
   return {
     kind: 'textToImage' as const,
-    modelId: GEN_MODEL.modelId,
-    modelVersionId: GEN_MODEL.modelVersionId,
+    modelId: checkpoint.modelId,
+    modelVersionId: checkpoint.versionId,
     params: { prompt: clampPrompt(prompt.trim()) },
   };
 }

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -262,13 +262,6 @@ function LiveUnavailable({ reason }: { reason: string }) {
           <WizardStep n={4} current={step} title="Restart dev:live">
             <CmdRow cmd="npm run dev:live" />
           </WizardStep>
-
-          <Alert color="info">
-            <Stack gap={8}>
-              <span>Just exploring? The mock host runs free — no token, no Buzz:</span>
-              <CmdRow cmd="npm run dev:harness" />
-            </Stack>
-          </Alert>
         </Stack>
       </Card>
     </div>

--- a/internal/scaffold/templates/page-money/src/models.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/models.test.ts.tmpl
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHECKPOINTS,
+  DEFAULT_CHECKPOINT,
+  checkpointFromPick,
+  mergeCheckpoints,
+  pickedCheckpointLabel,
+} from './models.js';
+
+// Pure-logic units for the curated checkpoint set + pick→option helpers. The
+// curated ids are load-bearing (verified Public + generation-covered + SFW), so
+// they're asserted here so an accidental edit is caught.
+
+describe('curated checkpoints', () => {
+  it('ships the verified default + Pony bases', () => {
+    expect(DEFAULT_CHECKPOINT).toEqual(CHECKPOINTS[0]);
+    expect(DEFAULT_CHECKPOINT).toMatchObject({ versionId: 128078, modelId: 101055 });
+    expect(CHECKPOINTS.some((c) => c.versionId === 290640 && c.modelId === 257749)).toBe(true);
+  });
+});
+
+describe('pickedCheckpointLabel', () => {
+  it('prefers the public display name (model — version)', () => {
+    expect(
+      pickedCheckpointLabel(8, 'SDXL', { modelName: 'DreamShaper', versionName: 'v8' }),
+    ).toBe('DreamShaper — v8');
+  });
+  it('falls back to "Model #id (base)" with no names', () => {
+    expect(pickedCheckpointLabel(128078, 'SDXL 1.0')).toBe('Model #128078 (SDXL 1.0)');
+  });
+});
+
+describe('checkpointFromPick', () => {
+  it('maps a pick into a CheckpointOption', () => {
+    expect(
+      checkpointFromPick({
+        versionId: 290640,
+        modelId: 257749,
+        modelName: 'Pony Diffusion V6 XL',
+        baseModel: 'Pony',
+      }),
+    ).toEqual({
+      versionId: 290640,
+      modelId: 257749,
+      label: 'Pony Diffusion V6 XL',
+      baseModel: 'Pony',
+    });
+  });
+});
+
+describe('mergeCheckpoints', () => {
+  it('keeps curated entries first and de-dupes by versionId', () => {
+    const extra = [
+      { versionId: 128078, modelId: 101055, label: 'dup', baseModel: 'SDXL 1.0' }, // already curated
+      { versionId: 999, modelId: 888, label: 'New Model', baseModel: 'SD 1.5' },
+    ];
+    const merged = mergeCheckpoints(CHECKPOINTS, extra);
+    // Curated lead, the dup is dropped, the genuinely new one is appended.
+    expect(merged[0]).toEqual(CHECKPOINTS[0]);
+    expect(merged.filter((m) => m.versionId === 128078)).toHaveLength(1);
+    expect(merged.some((m) => m.versionId === 999)).toBe(true);
+  });
+});

--- a/internal/scaffold/templates/page-money/src/models.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/models.ts.tmpl
@@ -1,0 +1,121 @@
+// Curated checkpoint set for {{ .Name }}, plus pick→option helpers.
+//
+// WHY A CURATED DEFAULT SET (the page platform reality):
+//   A W10 page slot is entity=none — it carries NO model context (unlike a model
+//   slot, which delivers modelId/modelVersionId via BLOCK_INIT). So a page app
+//   must ship a known-good DEFAULT checkpoint that works at first paint / offline
+//   / before the in-block catalog loads, and let the user pick others via the
+//   in-block catalog browser (see catalog-api.ts). Each curated entry below is a
+//   foundational, multi-million-generation public base verified to be
+//   generation-covered + SFW — the same bar the reference apps use.
+//
+// MONEY-SAFETY: a pick here is DISCOVERY ONLY. Nothing about a client-chosen
+// checkpoint is trusted — the SERVER re-validates (public? covered? SFW for the
+// domain?) and RE-PRICES every estimate and submit. We never imply otherwise.
+
+export interface CheckpointOption {
+  /** ModelVersion id submitted to the workflow as `modelVersionId`. */
+  versionId: number;
+  /** Parent Model id submitted as `modelId`. */
+  modelId: number;
+  /** Short display label for the picker. */
+  label: string;
+  /** Base-model family — display/label only; compatibility is a SERVER authority. */
+  baseModel: string;
+}
+
+/**
+ * Curated checkpoints. Foundational, multi-million-generation public bases that
+ * effectively never lose coverage:
+ *  - SD XL 1.0 (VAE fix) — the canonical SDXL base (101055/128078).
+ *  - Pony Diffusion V6 XL — the single most-generated model on the platform
+ *    (257749/290640).
+ * Both are Public + generation-covered + SFW. The first is the default a fresh
+ * session starts with.
+ */
+export const CHECKPOINTS: readonly CheckpointOption[] = [
+  { versionId: 128078, modelId: 101055, label: 'SD XL 1.0', baseModel: 'SDXL 1.0' },
+  { versionId: 290640, modelId: 257749, label: 'Pony V6 XL', baseModel: 'Pony' },
+] as const;
+
+/** The default checkpoint a fresh session starts with (the first curated entry). */
+export const DEFAULT_CHECKPOINT: CheckpointOption = CHECKPOINTS[0]!;
+
+// ---------------------------------------------------------------------------
+// Pick → option helpers.
+//
+// The in-block catalog browser produces a BlockResourceInfo-shaped pick =
+// { versionId, modelId, modelName, versionName, baseModel, modelType }.
+// `modelName`/`versionName` are the public display names. Everything here is
+// DISCOVERY ONLY — the wire is re-validated + re-priced server-side at
+// estimate/submit. These turn a pick into a CheckpointOption with the same
+// money-safety invariants as the curated entries.
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a picked resource (mirrors the SDK's BlockResourceInfo). */
+export interface PickedResource {
+  versionId: number;
+  modelId: number;
+  /** Public display name of the picked model (e.g. "DreamShaper"). */
+  modelName?: string;
+  /** Public display name of the picked model version (e.g. "v8"). */
+  versionName?: string;
+  baseModel: string;
+  modelType?: string;
+}
+
+/**
+ * Build a human display name from a pick's `modelName`/`versionName`, or
+ * `undefined` when neither is present. Prefers "<model> — <version>" when both
+ * exist (e.g. "DreamShaper — v8"); falls back to whichever single name is set.
+ * Whitespace-only names are treated as absent.
+ */
+function resourceDisplayName(names?: { modelName?: string; versionName?: string }): string | undefined {
+  const model = names?.modelName?.trim();
+  const version = names?.versionName?.trim();
+  if (model && version) return `${model} — ${version}`;
+  return model || version || undefined;
+}
+
+/**
+ * Label a picked checkpoint. PREFER the public display name; fall back to the
+ * version id + base model ("Model #128078 (SDXL 1.0)") when no name is present.
+ * The fallback is deterministic, dedupes, and still tells the user the family.
+ */
+export function pickedCheckpointLabel(
+  versionId: number,
+  baseModel: string,
+  names?: { modelName?: string; versionName?: string },
+): string {
+  return resourceDisplayName(names) ?? `Model #${versionId} (${baseModel})`;
+}
+
+/** Turn a picked resource into a `CheckpointOption`. */
+export function checkpointFromPick(picked: PickedResource): CheckpointOption {
+  return {
+    versionId: picked.versionId,
+    modelId: picked.modelId,
+    label: pickedCheckpointLabel(picked.versionId, picked.baseModel, picked),
+    baseModel: picked.baseModel,
+  };
+}
+
+/**
+ * Merge the curated set with catalog-browsed options, de-duplicated by
+ * versionId. Curated entries lead (so the default checkpoint is stable across
+ * catalog states); a catalog option whose versionId is already curated is
+ * dropped. Pure + total — drives the picker's option list.
+ */
+export function mergeCheckpoints(
+  curated: readonly CheckpointOption[],
+  extra: readonly CheckpointOption[],
+): CheckpointOption[] {
+  const seen = new Set<number>();
+  const out: CheckpointOption[] = [];
+  for (const opt of [...curated, ...extra]) {
+    if (seen.has(opt.versionId)) continue;
+    seen.add(opt.versionId);
+    out.push(opt);
+  }
+  return out;
+}

--- a/internal/scaffold/templates/page-money/src/test-setup.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/test-setup.ts.tmpl
@@ -3,9 +3,19 @@
 
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach, beforeEach } from 'vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
 
 import { resetHarnessTransport } from './dev-transport.js';
+
+// The App's catalog-load effect calls the real `fetch` (the civitai catalog
+// endpoint). jsdom has no network, so stub it to reject — `fetchCatalog` catches
+// that gracefully and the picker stays on the curated set. Component/e2e tests
+// drive the money path through the SDK postMessage transport, not HTTP, so this
+// never touches the flows under test. (A test that wants catalog options can
+// override this stub locally.)
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in test')));
+});
 
 // The SDK transport is a process-wide singleton — reset it before each test so
 // each gets a fresh instance whose allowlist contains the jsdom origin, and so


### PR DESCRIPTION
## What

Three changes to the **page-money** scaffold template (`internal/scaffold/templates/page-money/`) — the batteries-included starter every new money-path App Block author begins from.

### 1. Remove the "Just exploring" Alert
In `main.tsx`'s `LiveUnavailable` (dev:live, no-token) screen, the trailing `<Alert>` re-pointing to `npm run dev:harness` was redundant with the README + the npm scripts. Removed; the rest of the 4-step setup wizard is unchanged.

### 2. Remove the "Confirm generation" modal
The confirm Modal was pure ceremony: `proceed()` already does the load-bearing work (anon → `requestSignIn`, ungranted scope → `requestConsent`, else `runGeneration`), and the **Generate button already shows the live cost**. The modal only re-stated that cost. Now the Generate button calls `proceed()` directly — **one click → consent (first time) → spend**. The separate **"About" / "How it works" modal is kept** (it still demonstrates the pack's `Modal`).

### 3. Model picker (the main change)
A W10 page slot is `entity=none` — it carries **no host model context**, so the old template hardcoded `GEN_MODEL`. This replaces that with a curated default **plus** an in-block picker (ported + simplified from the seed-explorer reference app):

- **`models.ts`** — `CheckpointOption`, a curated `CHECKPOINTS` set (verified ids: SD XL 1.0 `128078/101055`, Pony V6 XL `290640/257749`) + `DEFAULT_CHECKPOINT`, so the app works at first paint / offline / before the catalog loads. Plus the pick→option helpers and a pure `mergeCheckpoints` (curated-first, de-duped).
- **`catalog-api.ts`** — the catalog client: token-authoritative `/api/v1/blocks/models` (`Authorization: Bearer <blockToken>`, server maturity-clamps), with a graceful public `/api/v1/models` advisory-SFW fallback (fail-closed SFW via domain maturity). Pure URL builder + response→option mapper + an **injectable `fetch`** for tests. Pagination/thumbnails trimmed (the picker is a list, not an image grid).
- **`App.tsx`** — holds the selected checkpoint in state (default `DEFAULT_CHECKPOINT`), loads the catalog once ready, and renders a **themed native `<select>`** (the W6 pack ships no Select). `buildWorkflowBody(prompt, checkpoint)` threads `versionId → modelVersionId` / `modelId → modelId`.

**Money-safety:** a pick is **discovery only**. The server re-validates (public? generation-covered? SFW for the domain?) and **re-prices** every `estimate`/`submit` — comments and README say so explicitly. Manifest scopes stay `["ai:write:budgeted"]`; the catalog fetch is gated by the block token alone (no extra scope — seed-explorer proves this).

## Tests
- New `models.test.ts` + `catalog-api.test.ts` — pure + injectable-fetch units (curated ids, mappers, SFW clamp, success/empty/network-throw/authoritative→public fallback).
- `generation.test.ts` — asserts the checkpoint is threaded into the body.
- `e2e.test.tsx` / `App.pollretry.test.tsx` — updated for the one-click flow (no confirm modal); e2e now also switches the picker to Pony before generating.
- `scaffold_test.go` — golden assertions updated: confirm modal gone, `GEN_MODEL` gone, picker + curated ids + catalog endpoint locked in, new files in the expected set.
- `test-setup.ts` — stubs global `fetch` so the catalog-load effect doesn't hit the network in jsdom (the picker falls back to the curated set).

## Verification
- `go test ./internal/...` — **green**.
- **Scaffold-typecheck gotcha** (not caught by `go test`): built the patched binary, scaffolded a fresh app, `npm install`, then in the scaffold:
  - `npm run typecheck` (strict `noUnusedLocals`) — **pass**
  - `npm run build` (tsc + vite build) — **pass**
  - `npm test` — **32 passed / 6 files** (incl. the new units + the updated e2e/pollretry)
- **Playwright on `dev:harness`** (mock host — no real Buzz): the picker renders defaulted to SD XL 1.0; switched to **Pony V6 XL**; the in-block catalog merged ~20 real options after the curated set; **one-click Generate** ran consent → estimate → submit → poll → **"Done · Spent 8 Buzz" + result image**, with **no confirm modal**. Screenshots captured (default + success states).

## Unsure / descoped
- The picker is a native `<select>` (lightweight), not seed-explorer's full searchable image grid — intentional per the task (the pack has no Select, and the grid is heavier than a starter needs).
- In the localhost harness the first catalog fetch logs a CORS error before the public read succeeds (cross-origin from `localhost`); that's the documented opaque-origin path and is handled gracefully (picker stays on the curated set, then merges options once the read lands). On a real `<slug>.civit.ai` origin the authoritative block-token read is the primary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)