### PR TITLE
scaffold(page-money): add a multi-LoRA selector + clean up the chrome

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -132,12 +132,25 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "consecutiveErrors")
 
 	// The confirm-spend modal was removed: Generate is one click → consent →
-	// spend (the button already shows the cost). The "About" modal stays (it
-	// demonstrates Modal), so we assert the CONFIRM modal specifically is gone.
+	// spend (the button already shows the cost).
 	mustNotContain(t, app, "Confirm generation")
 	mustNotContain(t, app, "setConfirmOpen")
 	// The Generate click runs the gate directly (no intermediate confirm state).
 	mustContain(t, app, "proceed()")
+
+	// The "About this block" modal + the "How this works" section/button were
+	// removed (a clean, minimal scaffold). The status Badge near the title was
+	// removed too — but its underlying consent/auth logic (granted/anon) stays.
+	mustNotContain(t, app, "About this block")
+	mustNotContain(t, app, "aboutOpen")
+	mustNotContain(t, app, "How this works")
+	mustNotContain(t, app, "How it works")
+	mustNotContain(t, app, "signed out") // the removed status-Badge copy
+	mustNotContain(t, app, "needs access")
+	// The load-bearing consent/auth logic the removed Badge merely surfaced MUST
+	// remain — it's what makes the first Generate request consent.
+	mustContain(t, app, "hasBudgetedScope")
+	mustContain(t, app, "requestConsent")
 
 	// Model picker: the page ships a curated default checkpoint + an in-block
 	// picker (entity=none means no host model context). The old hardcoded
@@ -145,32 +158,52 @@ func TestRenderPageMoney(t *testing.T) {
 	mustNotContain(t, app, "GEN_MODEL")
 	mustContain(t, app, "DEFAULT_CHECKPOINT")
 	mustContain(t, app, "pm-model-select")
-	mustContain(t, app, "buildWorkflowBody(prompt, checkpoint)")
+	mustContain(t, app, "buildWorkflowBody(prompt, checkpoint, loras)")
 	mustContain(t, app, "fetchCatalog")
 
+	// LoRA selector (the main feature): the user can add up to MAX_LORAS LoRAs
+	// on top of the checkpoint, each with a weight, threaded into the body as
+	// additionalResources. The App holds the selection + wires the catalog read.
+	mustContain(t, app, "fetchLoraCatalog")
+	mustContain(t, app, "LoraSelector")
+	mustContain(t, app, "pm-lora-add")
+	mustContain(t, app, "pm-lora-weight")
+	mustContain(t, app, "addLora")
+
 	// generation.ts threads the chosen checkpoint into modelId/modelVersionId
-	// instead of a hardcoded constant.
+	// instead of a hardcoded constant, AND emits the selected LoRAs as
+	// additionalResources (only when non-empty).
 	gen := readFile(t, filepath.Join(dest, "src", "generation.ts"))
 	mustNotContain(t, gen, "GEN_MODEL")
 	mustContain(t, gen, "checkpoint: CheckpointOption")
 	mustContain(t, gen, "modelVersionId: checkpoint.versionId")
+	mustContain(t, gen, "loras: readonly LoraOption[]")
+	mustContain(t, gen, "body.additionalResources = loras.map")
 
 	// models.ts ships the curated, verified checkpoint ids the app starts on /
-	// falls back to (Public + generation-covered + SFW).
+	// falls back to (Public + generation-covered + SFW), PLUS the LoRA types +
+	// the selection helpers (cap + weight clamp) and the curated LoRA fallback.
 	models := readFile(t, filepath.Join(dest, "src", "models.ts"))
 	mustContain(t, models, "CheckpointOption")
 	mustContain(t, models, "DEFAULT_CHECKPOINT")
 	mustContain(t, models, "128078") // SD XL 1.0 version id
 	mustContain(t, models, "290640") // Pony V6 XL version id
+	mustContain(t, models, "LoraOption")
+	mustContain(t, models, "MAX_LORAS")
+	mustContain(t, models, "clampLoraWeight")
+	mustContain(t, models, "LORA_STRENGTH_MAX")
 
 	// catalog-api.ts uses the token-authoritative block endpoint (Bearer-gated,
-	// server-maturity-clamped) with a public, advisory-SFW fallback. The picks
-	// are server-revalidated, so no extra manifest scope is needed.
+	// server-maturity-clamped) with a public, advisory-SFW fallback, for BOTH
+	// the checkpoint and the LoRA (types=LORA) catalogs. The picks are
+	// server-revalidated, so no extra manifest scope is needed.
 	catalog := readFile(t, filepath.Join(dest, "src", "catalog-api.ts"))
 	mustContain(t, catalog, "/api/v1/blocks/models")
 	mustContain(t, catalog, "/api/v1/models")
 	mustContain(t, catalog, "Authorization")
 	mustContain(t, catalog, "catalogSfwOnly")
+	mustContain(t, catalog, "fetchLoraCatalog")
+	mustContain(t, catalog, "'LORA'")
 
 	// The display name should land in the manifest + App heading.
 	mustContain(t, manifest, `"name": "Money Block"`)
@@ -206,6 +239,18 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, mainTSX, "clipboard?.writeText")
 	// The mock-host escape hatch is still offered for free local dev.
 	mustContain(t, mainTSX, "dev:harness")
+	// The LIVE banner reads exactly "LIVE HOST · spends REAL Buzz" (the longer
+	// emoji + extra-clauses banner was trimmed to this exact string).
+	mustContain(t, mainTSX, "LIVE HOST · spends REAL Buzz")
+	mustNotContain(t, mainTSX, "real compute · backend via vite proxy")
+
+	// Harness.tsx: the mock chrome reads as a console/terminal strip. The MOCK
+	// banner is exactly "MOCK HOST · no real Buzz spent" and the scenario panel
+	// is labelled "mock scenarios".
+	harness := readFile(t, filepath.Join(dest, "src", "Harness.tsx"))
+	mustContain(t, harness, "MOCK HOST · no real Buzz spent")
+	mustNotContain(t, harness, "no real compute")
+	mustContain(t, harness, "mock scenarios")
 
 	// README docs the live-mode Buzz-balance recipe (#30) — the only working path
 	// is the tRPC procedure with a bearer key (no public REST buzz endpoint).

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -3,16 +3,18 @@
 A Civitai **page money-path** App Block (Vite + React + TypeScript), wired to
 the published App SDK (`@civitai/blocks-react` + `@civitai/app-sdk`). It mounts
 as a full-page (W10) app at `/apps/run/{{ .Slug }}` and spends Buzz to generate
-an image: pick a checkpoint → estimate → (lazy consent) → submit → poll → result.
+an image: pick a checkpoint, optionally layer on a few LoRAs (each with a
+weight) → estimate → (lazy consent) → submit → poll → result.
 
 ## What this is
 
 A sandboxed static web app served in an iframe by the Civitai host. Its UI is
 built from the **`@civitai/blocks-react/ui`** W6 component pack (Button, Textarea,
-Card, Stack, Group, Alert, Loader, Modal, Badge) — the one exception is the model
-picker, a themed native `<select>` (the pack ships no Select yet). The pack ships
-its own theme-aware styles; `injectBlocksStyles()` is called at module init in
-`src/App.tsx` so the first paint is already styled.
+Card, Stack, Group, Alert, Loader, Badge) — the two exceptions are the model
+picker (a themed native `<select>`) and each LoRA's weight control (a themed
+native range `<input>`), since the pack ships no Select/Slider yet. The pack
+ships its own theme-aware styles; `injectBlocksStyles()` is called at module init
+in `src/App.tsx` so the first paint is already styled.
 
 The platform
 owns the build: it runs `npm ci` then the `buildCommand` from
@@ -53,6 +55,26 @@ A pick is **discovery only**. Nothing about a client-chosen checkpoint is truste
 the server **re-validates** (public? generation-covered? SFW for the domain?) and
 **re-prices** the body at every `estimate` AND `submit`. A client can't smuggle a
 non-generatable or mis-priced model through `buildWorkflowBody`.
+
+### LoRA selector (server-revalidated)
+
+On top of the checkpoint the user can layer up to **5 LoRAs**, each with an
+adjustable **weight** (the LoRA's `strength`, clamped to the server's `[-1, 2]`
+bound). They ride along as `additionalResources` in the workflow body — one
+`{ modelVersionId, strength }` entry per selected LoRA, emitted only when at
+least one is selected (a checkpoint-only body stays backward compatible).
+
+- **`src/models.ts`** — a curated `LORAS` fallback set (first paint / offline)
+  plus the pure selection helpers (`addLora` / `removeLora` / `setLoraWeight`)
+  that enforce the dedup, the 5-LoRA cap (`MAX_LORAS`), and the weight clamp.
+- **`src/catalog-api.ts`** — `fetchLoraCatalog` reads the SAME authoritative
+  (`/api/v1/blocks/models`, Bearer) / public (`/api/v1/models`, advisory-SFW)
+  catalog, only `types=LORA` differs. No extra manifest scope is needed.
+
+LoRA picks + weights are **discovery only**, exactly like the checkpoint: the
+server is LoRA-only for additional resources and **re-validates** base-model
+compatibility + per-resource entitlement (early-access / Private) AND
+**re-prices** the whole body **before any Buzz spend**.
 
 ## Develop
 
@@ -207,11 +229,14 @@ npm run build         # what the platform produces (tsc typecheck + vite build)
 
 - **`src/generation.test.ts`** — pure-logic units (node env).
 - **`src/models.test.ts`** — the curated checkpoint set + the pick→option
-  helpers (`checkpointFromPick`, `mergeCheckpoints`). Locks the verified curated
-  ids so an accidental edit is caught.
-- **`src/catalog-api.test.ts`** — the in-block catalog client: URL builder, the
-  response→option mapper, the SFW clamp, and the injectable-`fetch` client
-  (success / empty / network-throw / authoritative→public fallback). No network.
+  helpers (`checkpointFromPick`, `mergeCheckpoints`), AND the LoRA selection
+  helpers (`addLora`/`removeLora`/`setLoraWeight`, the dedup + 5-LoRA cap + the
+  weight clamp). Locks the verified curated ids so an accidental edit is caught.
+- **`src/catalog-api.test.ts`** — the in-block catalog client: URL builder
+  (Checkpoint + `types=LORA`), the response→option mappers (checkpoint + LoRA),
+  the SFW clamp, and the injectable-`fetch` client for BOTH `fetchCatalog` and
+  `fetchLoraCatalog` (success / empty / network-throw / authoritative→public
+  fallback). No network.
 - **`src/App.test.tsx`** — component tests: render `<App/>` against
   `createMockHost()` and assert the UI (anon → sign-in, signed-in → prompt).
 - **`src/e2e.test.tsx`** — the money-path proof: drives the FULL

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -16,7 +16,6 @@ import {
   Card,
   Group,
   Loader,
-  Modal,
   Stack,
   Textarea,
   injectBlocksStyles,
@@ -24,7 +23,6 @@ import {
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
 import {
-  PAGE_BUZZ_BUDGET,
   PROMPT_MAX,
   buildWorkflowBody,
   firstImageUrl,
@@ -39,10 +37,25 @@ import {
 import {
   CHECKPOINTS,
   DEFAULT_CHECKPOINT,
+  LORAS,
+  LORA_STRENGTH_MAX,
+  LORA_STRENGTH_MIN,
+  MAX_LORAS,
+  addLora,
+  loraOption,
   mergeCheckpoints,
+  removeLora,
+  selectedLoraIds,
+  setLoraWeight,
   type CheckpointOption,
+  type LoraOption,
 } from './models.js';
-import { catalogSfwOnly, defaultFetch, fetchCatalog } from './catalog-api.js';
+import {
+  catalogSfwOnly,
+  defaultFetch,
+  fetchCatalog,
+  fetchLoraCatalog,
+} from './catalog-api.js';
 
 // Inject the W6 component pack's stylesheet at module init (before first paint)
 // to avoid the documented one-frame FOUC (the pack's components also call
@@ -68,6 +81,10 @@ injectBlocksStyles();
  *    default checkpoint (DEFAULT_CHECKPOINT) and an in-block picker that browses
  *    the catalog (see models.ts / catalog-api.ts). A pick is DISCOVERY ONLY —
  *    the server re-validates + re-prices it at estimate/submit.
+ *  - on top of the checkpoint the user can add up to MAX_LORAS LoRAs, each with
+ *    an adjustable weight; they ride along as `additionalResources` in the body.
+ *    LoRA picks + weights are ALSO discovery only — the server re-validates
+ *    (LoRA-only? base-model compatible? entitled?) + re-prices before any spend.
  *  - `ai:write:budgeted` is consent-gated -> withheld at mint, requested lazily
  *    on first Generate via useRequestConsent; the grant arrives as a
  *    TOKEN_REFRESH carrying the scope, which we observe + retry.
@@ -93,7 +110,6 @@ export function App() {
   const [actualCost, setActualCost] = useState<number | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [aboutOpen, setAboutOpen] = useState(false);
 
   // The selected checkpoint. Starts on the curated DEFAULT (works at first paint
   // / offline / before the catalog loads); the in-block picker can replace it.
@@ -104,6 +120,17 @@ export function App() {
   // curated set always works, so the picker is never blocked on the network).
   const [catalogOptions, setCatalogOptions] = useState<CheckpointOption[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(false);
+
+  // The LoRAs the user has layered on top of the checkpoint, with their weights.
+  // Drives `additionalResources` in the body. All mutations go through the pure
+  // models.ts helpers (dedup, MAX_LORAS cap, weight clamp). DISCOVERY ONLY.
+  const [loras, setLoras] = useState<LoraOption[]>([]);
+  // The LoRA catalog to ADD from: the curated LORAS fallback first paint, then
+  // catalog-browsed LoRAs once the read resolves (stays curated if unreachable).
+  const [loraCatalog, setLoraCatalog] = useState<LoraOption[]>(() =>
+    LORAS.map((l) => loraOption(l)),
+  );
+  const [loraCatalogLoading, setLoraCatalogLoading] = useState(false);
 
   // True once the user clicked Generate while the scope was missing — so when
   // the consent grant lands (granted flips true) we auto-resume the submit.
@@ -211,7 +238,7 @@ export function App() {
     setError(null);
     setImageUrl(null);
     setActualCost(null);
-    const body = buildWorkflowBody(prompt, checkpoint);
+    const body = buildWorkflowBody(prompt, checkpoint, loras);
 
     // 1) Estimate (best-effort — a failed estimate doesn't block submit; the
     //    host re-prices at submit anyway).
@@ -251,7 +278,7 @@ export function App() {
     // 3) Poll to terminal.
     setPhase('polling');
     if (snap.workflowId) runPollLoop(snap.workflowId);
-  }, [prompt, checkpoint, estimate, submit, applySnapshot, runPollLoop]);
+  }, [prompt, checkpoint, loras, estimate, submit, applySnapshot, runPollLoop]);
 
   // The actual gate: sign-in -> consent -> generate. Wired straight to the
   // Generate button — the cost is already shown on the button, so there's no
@@ -312,10 +339,51 @@ export function App() {
     };
   }, [ready, token.raw, domainIsSfw]);
 
+  // Load the in-block LoRA catalog the same way (token-authoritative, public
+  // fallback) — only `types=LORA` + the LoRA mapper differ. The curated LORAS
+  // already populate the add-list, so a failed/empty read just leaves it on the
+  // curated set. DISCOVERY ONLY: every LoRA + weight is re-validated server-side.
+  useEffect(() => {
+    if (!ready) return;
+    let cancelled = false;
+    setLoraCatalogLoading(true);
+    fetchLoraCatalog(
+      {},
+      {
+        fetch: defaultFetch,
+        auth: { token: token.raw },
+        anonSfwOnly: catalogSfwOnly(domainIsSfw),
+      },
+    )
+      .then((res) => {
+        if (cancelled) return;
+        // Curated LoRAs lead; append catalog LoRAs that aren't already curated.
+        const curated = LORAS.map((l) => loraOption(l));
+        const seen = new Set(curated.map((l) => l.versionId));
+        const extra = res.kind === 'ok' ? res.options.filter((l) => !seen.has(l.versionId)) : [];
+        setLoraCatalog([...curated, ...extra]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoraCatalogLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, token.raw, domainIsSfw]);
+
   // The picker's option list: curated set first, then catalog-browsed options,
   // de-duplicated by versionId. The curated entries always lead so the default
   // is stable across catalog states.
   const pickerOptions = mergeCheckpoints(CHECKPOINTS, catalogOptions);
+
+  // LoRA selection mutators — all routed through the pure models.ts helpers so
+  // the dedup / MAX_LORAS cap / weight clamp stay in one tested place.
+  const selectedIds = selectedLoraIds(loras);
+  const onAddLora = (lora: LoraOption) => setLoras((cur) => addLora(cur, lora));
+  const onRemoveLora = (versionId: number) => setLoras((cur) => removeLora(cur, versionId));
+  const onLoraWeight = (versionId: number, weight: number) =>
+    setLoras((cur) => setLoraWeight(cur, versionId, weight));
+  const loraCapReached = loras.length >= MAX_LORAS;
 
   const promptError =
     touched && prompt.trim().length === 0 ? 'Enter a prompt to generate.' : undefined;
@@ -359,20 +427,7 @@ export function App() {
     <div ref={rootRef} data-theme={theme} style={shell}>
       <Card padding="lg" style={cardStyle}>
         <Stack gap={16}>
-          <Group justify="space-between">
-            <strong style={titleStyle}>{{ .Name }}</strong>
-            <Badge color={anon ? 'warning' : granted ? 'success' : 'info'} variant="light">
-              {anon ? 'signed out' : granted ? 'ready' : 'needs access'}
-            </Badge>
-          </Group>
-
-          <Alert color="info" title="How this works">
-            Pick a checkpoint, type a prompt, and generate one image. Each generation spends a
-            small amount of Buzz (budget {PAGE_BUZZ_BUDGET} per generation).{' '}
-            <button type="button" onClick={() => setAboutOpen(true)} style={linkButtonStyle}>
-              Details
-            </button>
-          </Alert>
+          <strong style={titleStyle}>{{ .Name }}</strong>
 
           <Textarea
             label="Prompt"
@@ -419,29 +474,41 @@ export function App() {
             </span>
           </label>
 
+          {/* LoRA selector. Add up to MAX_LORAS LoRAs on top of the checkpoint,
+              each with an adjustable weight (a themed native range input — the W6
+              pack ships no Slider). Every LoRA + weight is DISCOVERY ONLY: the
+              server re-validates (LoRA-only? base-model compatible? entitled?) +
+              re-prices the whole body at estimate/submit, so a client choice is
+              never trusted. */}
+          <LoraSelector
+            catalog={loraCatalog}
+            catalogLoading={loraCatalogLoading}
+            selected={loras}
+            selectedIds={selectedIds}
+            capReached={loraCapReached}
+            onAdd={onAddLora}
+            onRemove={onRemoveLora}
+            onWeight={onLoraWeight}
+          />
+
           {anon ? (
             <Button fullWidth onClick={() => requestSignIn()} data-testid="pm-signin">
               Sign in to generate
             </Button>
           ) : (
-            <Group gap={8}>
-              <Button variant="subtle" onClick={() => setAboutOpen(true)}>
-                How it works
-              </Button>
-              <Button
-                fullWidth
-                loading={busy}
-                disabled={prompt.trim().length === 0}
-                onClick={onGenerateClick}
-                data-testid="pm-generate"
-              >
-                {busy
-                  ? phaseLabel(phase)
-                  : estimatedCost != null
-                    ? `Generate · ${formatCost(estimatedCost)} Buzz`
-                    : 'Generate'}
-              </Button>
-            </Group>
+            <Button
+              fullWidth
+              loading={busy}
+              disabled={prompt.trim().length === 0}
+              onClick={onGenerateClick}
+              data-testid="pm-generate"
+            >
+              {busy
+                ? phaseLabel(phase)
+                : estimatedCost != null
+                  ? `Generate · ${formatCost(estimatedCost)} Buzz`
+                  : 'Generate'}
+            </Button>
           )}
 
           {phase === 'needs-consent' && (
@@ -477,26 +544,118 @@ export function App() {
           )}
         </Stack>
       </Card>
+    </div>
+  );
+}
 
-      {/* About modal — demonstrates the pack's Modal, opened independently. */}
-      <Modal opened={aboutOpen} onClose={() => setAboutOpen(false)} title="About this block" size="md">
-        <Stack gap={10}>
-          <span>
-            This is a sandboxed Civitai App Block. The interface is built from the{' '}
-            <strong>@civitai/blocks-react/ui</strong> W6 component pack — Button, Textarea, Card,
-            Stack, Group, Alert, Badge, Loader and Modal — plus a themed native{' '}
-            <code>&lt;select&gt;</code> for the model picker (the pack ships no Select yet).
-          </span>
-          <Alert color="info">
-            Pick any checkpoint and we send it to generate — but a pick is just discovery. The
-            Civitai backend re-validates and re-prices every generation, so a client choice is
-            never trusted. Generations spend real Buzz when run in live mode.
-          </Alert>
-          <Group justify="flex-end">
-            <Button onClick={() => setAboutOpen(false)}>Got it</Button>
-          </Group>
+/**
+ * The LoRA selector: an ADD list (from the curated/catalog LoRAs) + the selected
+ * rows, each with a weight control. Built from the W6 pack (Group/Stack/Badge/
+ * Button/Loader) plus a themed native range input (the pack ships no Slider).
+ * Every pick + weight is DISCOVERY ONLY — server-revalidated + re-priced.
+ */
+function LoraSelector({
+  catalog,
+  catalogLoading,
+  selected,
+  selectedIds,
+  capReached,
+  onAdd,
+  onRemove,
+  onWeight,
+}: {
+  catalog: readonly LoraOption[];
+  catalogLoading: boolean;
+  selected: readonly LoraOption[];
+  selectedIds: Set<number>;
+  capReached: boolean;
+  onAdd: (lora: LoraOption) => void;
+  onRemove: (versionId: number) => void;
+  onWeight: (versionId: number, weight: number) => void;
+}) {
+  // The LoRAs available to add: catalog minus the already-selected ones.
+  const addable = catalog.filter((l) => !selectedIds.has(l.versionId));
+
+  return (
+    <div style={fieldStyle}>
+      <span style={fieldLabelStyle}>
+        LoRAs{' '}
+        <Badge color="info" variant="light">
+          {selected.length}/{MAX_LORAS}
+        </Badge>
+      </span>
+      <span style={fieldDescStyle}>
+        Optional. Layer up to {MAX_LORAS} LoRAs on the checkpoint, each with a weight. The server
+        validates compatibility + prices every generation.
+      </span>
+
+      {/* Selected LoRAs, each with a weight control + remove. */}
+      {selected.length > 0 && (
+        <Stack gap={8} style={loraListStyle}>
+          {selected.map((l) => (
+            <div key={l.versionId} style={loraRowStyle} data-testid="pm-lora-row">
+              <div style={loraRowHeadStyle}>
+                <span style={loraNameStyle} title={l.label}>
+                  {l.label}
+                  {l.baseModel ? ` (${l.baseModel})` : ''}
+                </span>
+                <Button
+                  variant="subtle"
+                  size="sm"
+                  color="error"
+                  onClick={() => onRemove(l.versionId)}
+                  aria-label={`Remove ${l.label}`}
+                >
+                  Remove
+                </Button>
+              </div>
+              <label style={loraWeightRowStyle}>
+                <span style={loraWeightLabelStyle}>weight</span>
+                <input
+                  type="range"
+                  min={LORA_STRENGTH_MIN}
+                  max={LORA_STRENGTH_MAX}
+                  step={0.05}
+                  value={l.weight}
+                  onChange={(e) => onWeight(l.versionId, Number(e.target.value))}
+                  aria-label={`${l.label} weight`}
+                  data-testid="pm-lora-weight"
+                  style={loraRangeStyle}
+                />
+                <span style={loraWeightValueStyle}>{l.weight.toFixed(2)}</span>
+              </label>
+            </div>
+          ))}
         </Stack>
-      </Modal>
+      )}
+
+      {/* Add a LoRA — one chip-button per addable catalog LoRA. */}
+      <span style={loraAddWrapStyle}>
+        {capReached ? (
+          <span style={fieldDescStyle}>Max {MAX_LORAS} LoRAs selected.</span>
+        ) : addable.length > 0 ? (
+          addable.map((l) => (
+            <Button
+              key={l.versionId}
+              variant="light"
+              size="sm"
+              onClick={() => onAdd(l)}
+              data-testid="pm-lora-add"
+            >
+              + {l.label}
+            </Button>
+          ))
+        ) : (
+          <span style={fieldDescStyle}>
+            {catalogLoading ? 'Loading LoRAs…' : 'No more LoRAs to add.'}
+          </span>
+        )}
+        {catalogLoading && !capReached && (
+          <span aria-hidden>
+            <Loader size="sm" />
+          </span>
+        )}
+      </span>
     </div>
   );
 }
@@ -525,15 +684,6 @@ const shell: React.CSSProperties = {
 const cardStyle: React.CSSProperties = { width: '100%', maxWidth: 640 };
 const titleStyle: React.CSSProperties = { fontSize: 20 };
 const imageStyle: React.CSSProperties = { width: '100%', borderRadius: 8, display: 'block' };
-const linkButtonStyle: React.CSSProperties = {
-  background: 'none',
-  border: 'none',
-  padding: 0,
-  color: 'inherit',
-  textDecoration: 'underline',
-  cursor: 'pointer',
-  font: 'inherit',
-};
 
 // The W6 pack has no Select, so the model picker is a themed native <select>.
 // These read the same pack CSS vars the pack's own inputs use, so it matches the
@@ -562,4 +712,45 @@ const selectLoaderStyle: React.CSSProperties = {
   right: 12,
   transform: 'translateY(-50%)',
   pointerEvents: 'none',
+};
+
+// The W6 pack ships no Slider, so each LoRA's weight uses a themed native range
+// input. These read the same pack CSS vars so the LoRA list matches the surface.
+const loraListStyle: React.CSSProperties = { marginTop: 4 };
+const loraRowStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 6,
+  padding: '8px 10px',
+  borderRadius: 8,
+  border: '1px solid var(--ci-color-border)',
+  background: 'var(--ci-color-surface)',
+};
+const loraRowHeadStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 8,
+};
+const loraNameStyle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+const loraWeightRowStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
+const loraWeightLabelStyle: React.CSSProperties = { fontSize: 12, opacity: 0.8, minWidth: 44 };
+const loraRangeStyle: React.CSSProperties = { flex: 1, accentColor: 'var(--ci-color-primary)' };
+const loraWeightValueStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontVariantNumeric: 'tabular-nums',
+  minWidth: 36,
+  textAlign: 'right',
+};
+const loraAddWrapStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+  alignItems: 'center',
+  marginTop: 4,
 };

--- a/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
@@ -66,7 +66,7 @@ export function Harness({ children }: { children: ReactNode }) {
 function MockBanner() {
   return (
     <div data-harness-banner="mock" style={bannerStyle}>
-      🧪 MOCK HOST · no real Buzz spent · no real compute
+      MOCK HOST · no real Buzz spent
     </div>
   );
 }
@@ -82,18 +82,34 @@ function ScenarioPanel({ onApply }: { onApply: (patch: MockHostOptions) => void 
 
   return (
     <details data-harness-scenario-panel="true" style={panelStyle}>
-      <summary style={summaryStyle}>scenarios</summary>
+      <summary style={summaryStyle}>mock scenarios</summary>
       <div style={panelBodyStyle}>
-        <button type="button" onClick={() => onApply({ failMode: 'none', buzz: undefined })}>
+        <button
+          type="button"
+          style={btnStyle}
+          onClick={() => onApply({ failMode: 'none', buzz: undefined })}
+        >
           reset (all succeed)
         </button>
-        <button type="button" onClick={() => onApply({ failMode: 'insufficient' })}>
+        <button
+          type="button"
+          style={btnStyle}
+          onClick={() => onApply({ failMode: 'insufficient' })}
+        >
           force insufficient Buzz
         </button>
-        <button type="button" onClick={() => onApply({ generation: { failNext: 1 } })}>
+        <button
+          type="button"
+          style={btnStyle}
+          onClick={() => onApply({ generation: { failNext: 1 } })}
+        >
           fail next generation
         </button>
-        <button type="button" onClick={() => onApply({ generation: { failRate: 0.5 } })}>
+        <button
+          type="button"
+          style={btnStyle}
+          onClick={() => onApply({ generation: { failRate: 0.5 } })}
+        >
           50% failure rate
         </button>
         <label style={rowStyle}>
@@ -106,6 +122,7 @@ function ScenarioPanel({ onApply }: { onApply: (patch: MockHostOptions) => void 
           />
           <button
             type="button"
+            style={btnStyle}
             onClick={() => {
               const n = Number(balance);
               if (Number.isFinite(n)) onApply({ buzz: { balance: n } });
@@ -124,6 +141,7 @@ function ScenarioPanel({ onApply }: { onApply: (patch: MockHostOptions) => void 
           />
           <button
             type="button"
+            style={btnStyle}
             onClick={() => {
               const n = Number(latency);
               if (Number.isFinite(n)) onApply({ generation: { latencyMs: n } });
@@ -137,7 +155,15 @@ function ScenarioPanel({ onApply }: { onApply: (patch: MockHostOptions) => void 
   );
 }
 
-const MONO = 'ui-monospace, SFMono-Regular, monospace';
+// Cohesive console/terminal aesthetic for the mock chrome: a tidy dark terminal
+// strip (the banner) over a compact, monospace console panel — minimal, dark,
+// subtle borders, console-green accent — so the whole mock chrome reads as one
+// unobtrusive developer console and is never mistaken for the real (live) host.
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+const TERMINAL_BG = '#0d1117'; // near-black terminal background
+const TERMINAL_BORDER = '#30363d'; // subtle console border
+const TERMINAL_TEXT = '#c9d1d9'; // muted console foreground
+const TERMINAL_ACCENT = '#3fb950'; // console-green accent
 
 const rootStyle: CSSProperties = { position: 'relative', minHeight: '100dvh' };
 
@@ -147,14 +173,15 @@ const bannerStyle: CSSProperties = {
   left: 0,
   right: 0,
   zIndex: 10000,
-  background: '#1971c2',
-  color: '#fff',
+  background: TERMINAL_BG,
+  color: TERMINAL_ACCENT,
   fontFamily: MONO,
   fontSize: 12,
-  fontWeight: 700,
+  fontWeight: 600,
   textAlign: 'center',
   padding: '4px 8px',
   letterSpacing: 0.3,
+  borderBottom: `1px solid ${TERMINAL_BORDER}`,
 };
 
 const panelStyle: CSSProperties = {
@@ -162,16 +189,21 @@ const panelStyle: CSSProperties = {
   top: 28,
   left: 8,
   zIndex: 10000,
-  background: 'rgba(17,17,17,0.92)',
-  color: '#7fc',
+  background: TERMINAL_BG,
+  color: TERMINAL_TEXT,
   fontFamily: MONO,
   fontSize: 11,
   padding: '6px 10px',
   borderRadius: 6,
+  border: `1px solid ${TERMINAL_BORDER}`,
   maxWidth: 300,
 };
 
-const summaryStyle: CSSProperties = { cursor: 'pointer' };
+const summaryStyle: CSSProperties = {
+  cursor: 'pointer',
+  color: TERMINAL_ACCENT,
+  letterSpacing: 0.3,
+};
 
 const panelBodyStyle: CSSProperties = {
   display: 'flex',
@@ -182,4 +214,25 @@ const panelBodyStyle: CSSProperties = {
 
 const rowStyle: CSSProperties = { display: 'flex', gap: 4, alignItems: 'center' };
 
-const inputStyle: CSSProperties = { width: 60 };
+const inputStyle: CSSProperties = {
+  width: 60,
+  background: '#161b22',
+  color: TERMINAL_TEXT,
+  border: `1px solid ${TERMINAL_BORDER}`,
+  borderRadius: 4,
+  fontFamily: MONO,
+  fontSize: 11,
+  padding: '2px 4px',
+};
+
+const btnStyle: CSSProperties = {
+  background: '#161b22',
+  color: TERMINAL_TEXT,
+  border: `1px solid ${TERMINAL_BORDER}`,
+  borderRadius: 4,
+  fontFamily: MONO,
+  fontSize: 11,
+  padding: '3px 6px',
+  cursor: 'pointer',
+  textAlign: 'left',
+};

--- a/internal/scaffold/templates/page-money/src/catalog-api.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/catalog-api.test.ts.tmpl
@@ -6,21 +6,29 @@ import {
   buildCatalogUrl,
   catalogSfwOnly,
   fetchCatalog,
+  fetchLoraCatalog,
   modelToCheckpoint,
+  modelToLora,
   responseToCheckpoints,
+  responseToLoras,
   type FetchLike,
 } from './catalog-api.js';
+import { DEFAULT_LORA_WEIGHT } from './models.js';
 
 // Pure + injectable-fetch units for the in-block catalog client. No network —
 // the fetch client takes an injectable `fetch`, so success / empty / non-OK /
 // network-throw / authoritative-fallback are all driven deterministically.
 
 describe('buildCatalogUrl', () => {
-  it('always scopes to Checkpoints and clamps the limit', () => {
+  it('defaults to Checkpoints and clamps the limit', () => {
     const url = new URL(buildCatalogUrl({ limit: 9999 }));
     expect(url.origin + url.pathname).toBe(CATALOG_API_BASE);
     expect(url.searchParams.get('types')).toBe('Checkpoint');
     expect(url.searchParams.get('limit')).toBe('100');
+  });
+  it('honors an explicit type (LORA)', () => {
+    const url = new URL(buildCatalogUrl({ type: 'LORA' }));
+    expect(url.searchParams.get('types')).toBe('LORA');
   });
   it('omits an empty query and only adds nsfw=false when sfwOnly', () => {
     const plain = new URL(buildCatalogUrl({ query: '   ' }));
@@ -63,6 +71,38 @@ describe('modelToCheckpoint / responseToCheckpoints', () => {
     });
     expect(page).toHaveLength(1);
     expect(page[0].versionId).toBe(11);
+  });
+});
+
+describe('modelToLora / responseToLoras', () => {
+  it('maps a model into a LoraOption at the default weight; skips no-version rows', () => {
+    expect(
+      modelToLora({
+        id: 122359,
+        name: 'Detail Tweaker XL',
+        modelVersions: [{ id: 135867, name: 'v1', baseModel: 'SDXL 1.0' }],
+      }),
+    ).toEqual({
+      versionId: 135867,
+      modelId: 122359,
+      label: 'Detail Tweaker XL — v1',
+      baseModel: 'SDXL 1.0',
+      weight: DEFAULT_LORA_WEIGHT,
+    });
+
+    expect(modelToLora({ id: 1, modelVersions: [] })).toBeNull();
+    expect(modelToLora(null)).toBeNull();
+  });
+  it('responseToLoras drops malformed rows but keeps usable ones', () => {
+    const page = responseToLoras({
+      items: [
+        { id: 1, name: 'Good LoRA', modelVersions: [{ id: 11, baseModel: 'SDXL 1.0' }] },
+        { id: 2, name: 'NoVersion' },
+      ],
+    });
+    expect(page).toHaveLength(1);
+    expect(page[0].versionId).toBe(11);
+    expect(page[0].weight).toBe(DEFAULT_LORA_WEIGHT);
   });
 });
 
@@ -114,5 +154,34 @@ describe('fetchCatalog', () => {
     const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes({ items: [] }));
     const res = await fetchCatalog({}, { fetch: fetchMock });
     expect(res.kind).toBe('empty');
+  });
+});
+
+describe('fetchLoraCatalog', () => {
+  const loraPage = {
+    items: [{ id: 122359, name: 'Detail Tweaker XL', modelVersions: [{ id: 135867, baseModel: 'SDXL 1.0' }] }],
+  };
+
+  it('queries types=LORA and maps to LoraOptions (anon → public)', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes(loraPage));
+    const res = await fetchLoraCatalog({}, { fetch: fetchMock });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') {
+      expect(res.options[0].versionId).toBe(135867);
+      expect(res.options[0].weight).toBe(DEFAULT_LORA_WEIGHT);
+    }
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain('types=LORA');
+    expect(calledUrl).toContain(CATALOG_API_BASE);
+  });
+
+  it('signed-in → authoritative /blocks/models with a Bearer header + types=LORA', async () => {
+    const fetchMock = vi.fn<FetchLike>().mockResolvedValue(okRes(loraPage));
+    const res = await fetchLoraCatalog({}, { fetch: fetchMock, auth: { token: 'jwt' } });
+    expect(res.kind).toBe('ok');
+    if (res.kind === 'ok') expect(res.authoritative).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toContain(CATALOG_API_BASE_BLOCKS);
+    expect(fetchMock.mock.calls[0][0]).toContain('types=LORA');
+    expect(fetchMock.mock.calls[0][1]?.headers?.Authorization).toBe('Bearer jwt');
   });
 });

--- a/internal/scaffold/templates/page-money/src/catalog-api.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/catalog-api.ts.tmpl
@@ -24,8 +24,11 @@
 // response→Option mapper, and a thin fetch client that takes an INJECTABLE
 // `fetch` (so tests mock success / empty / error / malformed without a network).
 
-import type { CheckpointOption, PickedResource } from './models.js';
-import { checkpointFromPick } from './models.js';
+import type { CheckpointOption, LoraOption, PickedResource } from './models.js';
+import { checkpointFromPick, loraFromPick } from './models.js';
+
+/** The REST model types this client browses (maps to the `types` param). */
+export type CatalogType = 'Checkpoint' | 'LORA';
 
 /** The public REST base. Overridable for tests / a future env pin. */
 export const CATALOG_API_BASE = 'https://civitai.com/api/v1/models';
@@ -34,6 +37,8 @@ export const CATALOG_API_BASE = 'https://civitai.com/api/v1/models';
 export const CATALOG_API_BASE_BLOCKS = 'https://civitai.com/api/v1/blocks/models';
 
 export interface CatalogQuery {
+  /** Model type to browse. Defaults to `Checkpoint`. `LORA` for the LoRA picker. */
+  type?: CatalogType;
   /** Meili text search; empty/whitespace → omitted (default popular view). */
   query?: string;
   /** ≤100 (server cap). Defaults to DEFAULT_LIMIT. */
@@ -54,9 +59,10 @@ export interface BuildUrlOptions {
 }
 
 /**
- * Build a catalog URL for a query (Checkpoints only). Pure + deterministic.
- * Empty query is omitted (the default popular view). `limit` is clamped to
- * [1, 100]. `sfwOnly` appends `nsfw=false` — public endpoint only.
+ * Build a catalog URL for a query. Pure + deterministic. `type` selects the
+ * REST `types` param (Checkpoint default, or LORA for the LoRA picker). Empty
+ * query is omitted (the default popular view). `limit` is clamped to [1, 100].
+ * `sfwOnly` appends `nsfw=false` — public endpoint only.
  */
 export function buildCatalogUrl(
   q: CatalogQuery,
@@ -65,7 +71,7 @@ export function buildCatalogUrl(
   const opts: BuildUrlOptions = typeof baseOrOpts === 'string' ? { base: baseOrOpts } : baseOrOpts;
   const base = opts.base ?? CATALOG_API_BASE;
   const params = new URLSearchParams();
-  params.set('types', 'Checkpoint');
+  params.set('types', q.type ?? 'Checkpoint');
   params.set('sort', 'Most Downloaded');
   const query = q.query?.trim();
   if (query) params.set('query', query);
@@ -140,6 +146,39 @@ export function responseToCheckpoints(raw: RawResponse | null | undefined): Chec
   return out;
 }
 
+/**
+ * Map ONE raw model → a `LoraOption` (default weight) using its first
+ * modelVersion. Same shape + tolerance as `modelToCheckpoint`; only the
+ * pick→option mapper differs (a LoRA maps to an `additionalResources[]` entry,
+ * not the checkpoint). Returns `null` for an unusable row (no version id).
+ */
+export function modelToLora(raw: RawModel | null | undefined): LoraOption | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const version = raw.modelVersions?.[0];
+  const versionId = version?.id;
+  if (typeof versionId !== 'number' || !Number.isFinite(versionId)) return null;
+  const modelId = typeof raw.id === 'number' ? raw.id : 0;
+  const picked: PickedResource = {
+    versionId,
+    modelId,
+    modelName: (raw.name ?? '').trim() || undefined,
+    versionName: (version?.name ?? '').trim() || undefined,
+    baseModel: (version?.baseModel ?? '').trim(),
+  };
+  return loraFromPick(picked);
+}
+
+/** Map a full raw response → a list of LoRA options (default weight). Never throws. */
+export function responseToLoras(raw: RawResponse | null | undefined): LoraOption[] {
+  const items = Array.isArray(raw?.items) ? raw!.items! : [];
+  const out: LoraOption[] = [];
+  for (const item of items) {
+    const opt = modelToLora(item);
+    if (opt) out.push(opt);
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // The fetch client. Takes an injectable `fetch` so tests drive success / empty /
 // network-error / non-OK / malformed without a real network. Returns a
@@ -156,6 +195,11 @@ export type CatalogResult =
   | { kind: 'empty'; authoritative: boolean }
   | { kind: 'error'; status?: number; message: string };
 
+export type LoraCatalogResult =
+  | { kind: 'ok'; options: LoraOption[]; authoritative: boolean }
+  | { kind: 'empty'; authoritative: boolean }
+  | { kind: 'error'; status?: number; message: string };
+
 export interface CatalogAuth {
   /** Raw block JWT (`useBlockToken().raw`). Absent → anon. */
   token?: string | null;
@@ -166,10 +210,21 @@ function isFallbackStatus(status: number): boolean {
   return status === 404 || status === 401 || status === 403;
 }
 
-async function toResult(
+/**
+ * Reduce a fetch response to a discriminated result, mapping the JSON body with
+ * the caller-supplied mapper (checkpoints or LoRAs). Never throws. Generic over
+ * the option type so both the checkpoint and the LoRA catalogs share the exact
+ * same OK/empty/error reduction.
+ */
+async function toResult<T>(
   res: Awaited<ReturnType<FetchLike>>,
   authoritative: boolean,
-): Promise<CatalogResult> {
+  map: (raw: RawResponse | null | undefined) => T[],
+): Promise<
+  | { kind: 'ok'; options: T[]; authoritative: boolean }
+  | { kind: 'empty'; authoritative: boolean }
+  | { kind: 'error'; status?: number; message: string }
+> {
   if (!res.ok) {
     return { kind: 'error', status: res.status, message: `request failed (${res.status})` };
   }
@@ -183,9 +238,18 @@ async function toResult(
       message: err instanceof Error ? err.message : 'bad JSON',
     };
   }
-  const options = responseToCheckpoints(body as RawResponse);
+  const options = map(body as RawResponse);
   if (options.length === 0) return { kind: 'empty', authoritative };
   return { kind: 'ok', options, authoritative };
+}
+
+export interface FetchCatalogDeps {
+  fetch: FetchLike;
+  auth?: CatalogAuth;
+  /** Advisory SFW for the ANON public read. Defaults to true (fail-closed SFW). */
+  anonSfwOnly?: boolean;
+  publicBase?: string;
+  blocksBase?: string;
 }
 
 /**
@@ -193,33 +257,34 @@ async function toResult(
  * or public (anon, advisory-SFW) endpoint and gracefully falling back from the
  * former to the latter when it isn't deployed / authorized yet, or throws
  * (CORS/preflight/network). A failure on the PUBLIC path is a hard error (no
- * infinite loop). Never throws.
+ * infinite loop). Never throws. Generic over the option type via `map`.
  */
-export async function fetchCatalog(
+async function fetchCatalogWith<T>(
   q: CatalogQuery,
-  deps: {
-    fetch: FetchLike;
-    auth?: CatalogAuth;
-    /** Advisory SFW for the ANON public read. Defaults to true (fail-closed SFW). */
-    anonSfwOnly?: boolean;
-    publicBase?: string;
-    blocksBase?: string;
-  },
-): Promise<CatalogResult> {
+  deps: FetchCatalogDeps,
+  map: (raw: RawResponse | null | undefined) => T[],
+): Promise<
+  | { kind: 'ok'; options: T[]; authoritative: boolean }
+  | { kind: 'empty'; authoritative: boolean }
+  | { kind: 'error'; status?: number; message: string }
+> {
   const token = deps.auth?.token;
   const publicBase = deps.publicBase ?? CATALOG_API_BASE;
   const blocksBase = deps.blocksBase ?? CATALOG_API_BASE_BLOCKS;
   const anonSfwOnly = deps.anonSfwOnly !== false;
 
-  const fetchPublic = async (sfwOnly: boolean): Promise<CatalogResult> => {
+  const fetchPublic = async (sfwOnly: boolean) => {
     const url = buildCatalogUrl(q, { base: publicBase, sfwOnly });
     let res: Awaited<ReturnType<FetchLike>>;
     try {
       res = await deps.fetch(url);
     } catch (err) {
-      return { kind: 'error', message: err instanceof Error ? err.message : 'network error' };
+      return {
+        kind: 'error' as const,
+        message: err instanceof Error ? err.message : 'network error',
+      };
     }
-    return toResult(res, false);
+    return toResult(res, false, map);
   };
 
   // Anon: public endpoint, advisory SFW per the domain ceiling.
@@ -238,7 +303,25 @@ export async function fetchCatalog(
     return fetchPublic(true);
   }
 
-  return toResult(authRes, true);
+  return toResult(authRes, true, map);
+}
+
+/** Fetch one CHECKPOINT catalog page (the model picker). */
+export function fetchCatalog(q: CatalogQuery, deps: FetchCatalogDeps): Promise<CatalogResult> {
+  return fetchCatalogWith({ ...q, type: 'Checkpoint' }, deps, responseToCheckpoints);
+}
+
+/**
+ * Fetch one LORA catalog page (the LoRA selector). Same two-path
+ * (authoritative/public) + graceful-fallback logic as `fetchCatalog`, only the
+ * `types=LORA` query + the LoRA mapper differ. DISCOVERY ONLY — the server
+ * re-validates (LoRA? compatible? entitled?) + re-prices at estimate/submit.
+ */
+export function fetchLoraCatalog(
+  q: CatalogQuery,
+  deps: FetchCatalogDeps,
+): Promise<LoraCatalogResult> {
+  return fetchCatalogWith({ ...q, type: 'LORA' }, deps, responseToLoras);
 }
 
 /** Default real-network fetch adapter for the app (tests inject their own). */

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -53,6 +53,20 @@ describe('App money path (e2e)', () => {
     expect(picker.value).toBe('128078'); // DEFAULT_CHECKPOINT (SD XL 1.0)
     await user.selectOptions(picker, '290640'); // Pony V6 XL
     expect(picker.value).toBe('290640');
+
+    // Add TWO LoRAs from the curated add-list (they ride along as
+    // additionalResources in the body — server-revalidated + re-priced).
+    const addButtons = screen.getAllByTestId('pm-lora-add');
+    expect(addButtons.length).toBeGreaterThanOrEqual(2);
+    await user.click(addButtons[0]);
+    await user.click(screen.getAllByTestId('pm-lora-add')[0]); // list re-renders; click the next
+    const rows = screen.getAllByTestId('pm-lora-row');
+    expect(rows).toHaveLength(2);
+
+    // Change the first LoRA's weight via its range input.
+    const weight = screen.getAllByTestId('pm-lora-weight')[0] as HTMLInputElement;
+    fireEvent.change(weight, { target: { value: '0.6' } });
+    expect(weight.value).toBe('0.6');
 
     // Enter a prompt (Generate is disabled while empty).
     await user.type(screen.getByLabelText(/prompt/i), 'a serene mountain lake');

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -12,7 +12,7 @@ import {
   isTerminalStatus,
   phaseForSnapshot,
 } from './generation.js';
-import { DEFAULT_CHECKPOINT } from './models.js';
+import { DEFAULT_CHECKPOINT, type LoraOption } from './models.js';
 
 // A couple of pure-logic tests so authors inherit a working test setup. Run with
 // `npm test`. Add cases here as you grow the app's logic.
@@ -63,6 +63,22 @@ describe('buildWorkflowBody', () => {
     const body = buildWorkflowBody('x', pick);
     expect(body.modelId).toBe(257749);
     expect(body.modelVersionId).toBe(290640);
+  });
+  it('omits additionalResources when no LoRAs are selected', () => {
+    const body = buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, []);
+    expect(body.additionalResources).toBeUndefined();
+  });
+  it('emits one additionalResources entry per selected LoRA (version + clamped strength)', () => {
+    const loras: LoraOption[] = [
+      { versionId: 135867, modelId: 122359, label: 'Detail Tweaker XL', baseModel: 'SDXL 1.0', weight: 0.8 },
+      // weight out of the [-1, 2] bound is clamped at build time too.
+      { versionId: 152309, modelId: 136749, label: 'Add More Details XL', baseModel: 'SDXL 1.0', weight: 9 },
+    ];
+    const body = buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, loras);
+    expect(body.additionalResources).toEqual([
+      { modelVersionId: 135867, strength: 0.8 },
+      { modelVersionId: 152309, strength: 2 },
+    ]);
   });
 });
 

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -5,7 +5,8 @@
 
 import type { BlockWorkflowSnapshot } from '@civitai/app-sdk/blocks';
 
-import type { CheckpointOption } from './models.js';
+import type { CheckpointOption, LoraOption } from './models.js';
+import { clampLoraWeight, roundLoraWeight } from './models.js';
 
 /** Server cap mirror — prompts over this are rejected by the workflow schema. */
 export const PROMPT_MAX = 1500;
@@ -76,22 +77,47 @@ export function clampPrompt(raw: string): string {
 }
 
 /**
- * Build the textToImage submit/estimate body for the chosen checkpoint. Page
- * apps keep the param surface minimal: just the prompt — the host fills sensible
- * defaults for dimensions/sampler/steps from the base-model family.
+ * Build the textToImage submit/estimate body for the chosen checkpoint + the
+ * selected LoRAs. Page apps keep the param surface minimal: just the prompt —
+ * the host fills sensible defaults for dimensions/sampler/steps from the
+ * base-model family.
  *
- * MONEY-SAFETY: the checkpoint is the user's in-block PICK (default or catalog-
- * browsed), which is DISCOVERY ONLY. The server re-validates (public? covered?
- * SFW for the domain?) AND re-prices this body at estimate AND submit — a client
- * can't force a non-generatable or mis-priced model through here.
+ * LoRAs are layered on as `additionalResources` — ONE entry per selected LoRA,
+ * `{ modelVersionId, strength }` where strength is the user's weight (clamped +
+ * rounded to the server's [-1, 2] bound). The key is emitted ONLY when at least
+ * one LoRA is selected, so a checkpoint-only body stays backward compatible.
+ *
+ * MONEY-SAFETY: both the checkpoint AND every LoRA + weight are the user's
+ * in-block PICKS (curated default or catalog-browsed), which are DISCOVERY ONLY.
+ * The server re-validates (public? covered? SFW? LoRA-only? base-model
+ * compatible? entitled?) AND re-prices this body at estimate AND submit — a
+ * client can't force a non-generatable / incompatible / mis-priced resource
+ * through here.
  */
-export function buildWorkflowBody(prompt: string, checkpoint: CheckpointOption) {
-  return {
-    kind: 'textToImage' as const,
+export function buildWorkflowBody(
+  prompt: string,
+  checkpoint: CheckpointOption,
+  loras: readonly LoraOption[] = [],
+) {
+  const body: {
+    kind: 'textToImage';
+    modelId: number;
+    modelVersionId: number;
+    params: { prompt: string };
+    additionalResources?: Array<{ modelVersionId: number; strength: number }>;
+  } = {
+    kind: 'textToImage',
     modelId: checkpoint.modelId,
     modelVersionId: checkpoint.versionId,
     params: { prompt: clampPrompt(prompt.trim()) },
   };
+  if (loras.length > 0) {
+    body.additionalResources = loras.map((l) => ({
+      modelVersionId: l.versionId,
+      strength: roundLoraWeight(clampLoraWeight(l.weight)),
+    }));
+  }
+  return body;
 }
 
 /** Pull the single displayable image url from a succeeded snapshot, if any. */

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -81,8 +81,7 @@ function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: str
   return (
     <>
       <div data-harness-banner="live" style={liveBannerStyle}>
-        ⚠️ LIVE HOST · spends REAL Buzz / real compute · backend via vite proxy →{' '}
-        {import.meta.env.VITE_LIVE_HOST_ORIGIN || 'https://civitai.com'}
+        LIVE HOST · spends REAL Buzz
       </div>
       {ready ? <App /> : null}
     </>

--- a/internal/scaffold/templates/page-money/src/models.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/models.test.ts.tmpl
@@ -3,9 +3,18 @@ import { describe, expect, it } from 'vitest';
 import {
   CHECKPOINTS,
   DEFAULT_CHECKPOINT,
+  LORAS,
+  MAX_LORAS,
+  addLora,
   checkpointFromPick,
+  clampLoraWeight,
+  loraFromPick,
+  loraOption,
   mergeCheckpoints,
   pickedCheckpointLabel,
+  removeLora,
+  setLoraWeight,
+  type LoraOption,
 } from './models.js';
 
 // Pure-logic units for the curated checkpoint set + pick→option helpers. The
@@ -60,5 +69,68 @@ describe('mergeCheckpoints', () => {
     expect(merged[0]).toEqual(CHECKPOINTS[0]);
     expect(merged.filter((m) => m.versionId === 128078)).toHaveLength(1);
     expect(merged.some((m) => m.versionId === 999)).toBe(true);
+  });
+});
+
+// --- LoRA selection (the main feature) ---
+
+const lora = (versionId: number, weight = 1): LoraOption =>
+  loraOption({ versionId, modelId: versionId * 10, label: `L${versionId}`, baseModel: 'SDXL 1.0' }, weight);
+
+describe('clampLoraWeight', () => {
+  it('clamps to the server [-1, 2] bound; non-finite → default 1', () => {
+    expect(clampLoraWeight(0.5)).toBe(0.5);
+    expect(clampLoraWeight(9)).toBe(2);
+    expect(clampLoraWeight(-9)).toBe(-1);
+    expect(clampLoraWeight(undefined)).toBe(1);
+    expect(clampLoraWeight(NaN)).toBe(1);
+  });
+});
+
+describe('loraFromPick', () => {
+  it('maps a picked resource into a LoraOption (default weight, clamped)', () => {
+    expect(
+      loraFromPick({ versionId: 135867, modelId: 122359, modelName: 'Detail Tweaker XL', baseModel: 'SDXL 1.0' }),
+    ).toEqual({
+      versionId: 135867,
+      modelId: 122359,
+      label: 'Detail Tweaker XL',
+      baseModel: 'SDXL 1.0',
+      weight: 1,
+    });
+  });
+});
+
+describe('addLora / removeLora / setLoraWeight', () => {
+  it('adds a LoRA, dedups by versionId, and caps at MAX_LORAS', () => {
+    let sel: LoraOption[] = [];
+    sel = addLora(sel, lora(1));
+    sel = addLora(sel, lora(1)); // dup → ignored
+    expect(sel).toHaveLength(1);
+
+    // Fill to the cap, then prove a further add is a no-op.
+    sel = [];
+    for (let i = 0; i < MAX_LORAS; i++) sel = addLora(sel, lora(100 + i));
+    expect(sel).toHaveLength(MAX_LORAS);
+    sel = addLora(sel, lora(999));
+    expect(sel).toHaveLength(MAX_LORAS);
+    expect(sel.some((l) => l.versionId === 999)).toBe(false);
+  });
+  it('removeLora drops the matching versionId', () => {
+    const sel = [lora(1), lora(2)];
+    expect(removeLora(sel, 1).map((l) => l.versionId)).toEqual([2]);
+  });
+  it('setLoraWeight clamps + rounds the weight in place', () => {
+    const sel = [lora(1, 1)];
+    expect(setLoraWeight(sel, 1, 9)[0].weight).toBe(2); // clamped
+    expect(setLoraWeight(sel, 1, 0.333333)[0].weight).toBe(0.33); // rounded
+    expect(setLoraWeight(sel, 2, 0.5)).toEqual(sel); // no match → unchanged
+  });
+});
+
+describe('curated LORAs', () => {
+  it('ships a small fallback set used at first paint', () => {
+    expect(LORAS.length).toBeGreaterThan(0);
+    expect(LORAS.every((l) => Number.isFinite(l.versionId))).toBe(true);
   });
 });

--- a/internal/scaffold/templates/page-money/src/models.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/models.ts.tmpl
@@ -24,6 +24,65 @@ export interface CheckpointOption {
   baseModel: string;
 }
 
+// ---------------------------------------------------------------------------
+// LoRAs — the main feature. A LoRA is an ADDITIONAL resource layered on top of
+// the checkpoint, each with an adjustable weight (its `strength`). It maps to a
+// `body.additionalResources[]` entry, NOT to `modelVersionId` (that's the
+// checkpoint). The SDK's WorkflowBody documents the server bounds we mirror:
+//   - max 5 entries (MAX_LORAS)
+//   - each strength in [-1, 2] (LORA_STRENGTH_MIN/MAX), default 1
+//   - LoRA-only; the server rejects non-LoRA versions AND re-checks base-model
+//     compatibility + entitlement BEFORE any Buzz spend.
+//
+// MONEY-SAFETY: a LoRA pick + its weight are DISCOVERY ONLY. The server
+// re-validates (LoRA? compatible? entitled?) AND re-prices the whole body at
+// every estimate AND submit, so a client choice is never trusted.
+// ---------------------------------------------------------------------------
+
+/** Server `additionalResources[].strength` bounds (mirrors WorkflowBody). */
+export const LORA_STRENGTH_MIN = -1;
+export const LORA_STRENGTH_MAX = 2;
+/** Server default strength when none is given. */
+export const DEFAULT_LORA_WEIGHT = 1;
+/** Server cap on additional resources (max 5 LoRAs per body). */
+export const MAX_LORAS = 5;
+
+/** A LoRA the user has added on top of the checkpoint, with its weight. */
+export interface LoraOption {
+  /** ModelVersion id → an `additionalResources[].modelVersionId` entry. */
+  versionId: number;
+  /** Parent Model id — display/label only (the wire only needs versionId). */
+  modelId: number;
+  /** Short display label for the list. */
+  label: string;
+  /** Base-model family — display/label only; compatibility is a SERVER authority. */
+  baseModel: string;
+  /** The LoRA's weight → its `additionalResources[].strength`. Clamped to [-1, 2]. */
+  weight: number;
+}
+
+/**
+ * A small curated LoRA fallback set so the picker has something to ADD at first
+ * paint / offline / before the catalog loads — the same role the curated
+ * CHECKPOINTS play. Foundational, broadly-compatible public SDXL LoRAs (the
+ * curated checkpoints are SDXL/Pony). DISCOVERY ONLY — server-revalidated.
+ */
+export const LORAS: readonly Omit<LoraOption, 'weight'>[] = [
+  { versionId: 135867, modelId: 122359, label: 'Detail Tweaker XL', baseModel: 'SDXL 1.0' },
+  { versionId: 152309, modelId: 136749, label: 'Add More Details XL', baseModel: 'SDXL 1.0' },
+] as const;
+
+/** Clamp a LoRA weight into the server-accepted [-1, 2] range; non-finite → default. */
+export function clampLoraWeight(weight: number | null | undefined): number {
+  const w = weight == null || !Number.isFinite(weight) ? DEFAULT_LORA_WEIGHT : weight;
+  return Math.max(LORA_STRENGTH_MIN, Math.min(LORA_STRENGTH_MAX, w));
+}
+
+/** Round a weight to 2 decimals so display + dedup agree (0.30000001 → 0.3). */
+export function roundLoraWeight(weight: number): number {
+  return Math.round(weight * 100) / 100;
+}
+
 /**
  * Curated checkpoints. Foundational, multi-million-generation public bases that
  * effectively never lose coverage:
@@ -118,4 +177,70 @@ export function mergeCheckpoints(
     out.push(opt);
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// LoRA pick → option + the selected-LoRA list mutators (pure + total). The App
+// holds the selected list in state and drives every change through these so the
+// money-relevant invariants (the MAX_LORAS cap, the weight clamp, no duplicate
+// versionId) live in one tested place.
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn a discovered LoRA (curated or catalog-browsed) into a selectable
+ * LoraOption at a given weight (defaults to DEFAULT_LORA_WEIGHT). The weight is
+ * clamped + rounded so the value the user sees is exactly what's submitted.
+ */
+export function loraOption(
+  src: Omit<LoraOption, 'weight'>,
+  weight: number = DEFAULT_LORA_WEIGHT,
+): LoraOption {
+  return { ...src, weight: roundLoraWeight(clampLoraWeight(weight)) };
+}
+
+/** Turn a picked resource into a LoraOption (label-resolved like a checkpoint). */
+export function loraFromPick(picked: PickedResource, weight?: number): LoraOption {
+  return loraOption(
+    {
+      versionId: picked.versionId,
+      modelId: picked.modelId,
+      label: resourceDisplayName(picked) ?? `LoRA #${picked.versionId} (${picked.baseModel})`,
+      baseModel: picked.baseModel,
+    },
+    weight,
+  );
+}
+
+/**
+ * Add a LoRA to the selected list. No-ops if it's already present (dedup by
+ * versionId) OR the MAX_LORAS cap is already reached (the server caps at 5; we
+ * never let the UI build a body that would be rejected). Returns a new array.
+ */
+export function addLora(
+  selected: readonly LoraOption[],
+  lora: LoraOption,
+): LoraOption[] {
+  if (selected.length >= MAX_LORAS) return [...selected];
+  if (selected.some((l) => l.versionId === lora.versionId)) return [...selected];
+  return [...selected, loraOption(lora, lora.weight)];
+}
+
+/** Remove a LoRA from the selected list by versionId. Returns a new array. */
+export function removeLora(selected: readonly LoraOption[], versionId: number): LoraOption[] {
+  return selected.filter((l) => l.versionId !== versionId);
+}
+
+/** Set a selected LoRA's weight (clamped + rounded). Returns a new array. */
+export function setLoraWeight(
+  selected: readonly LoraOption[],
+  versionId: number,
+  weight: number,
+): LoraOption[] {
+  const w = roundLoraWeight(clampLoraWeight(weight));
+  return selected.map((l) => (l.versionId === versionId ? { ...l, weight: w } : l));
+}
+
+/** versionIds already selected — drives the "add" list's disabled/added state. */
+export function selectedLoraIds(selected: readonly LoraOption[]): Set<number> {
+  return new Set(selected.map((l) => l.versionId));
 }


### PR DESCRIPTION
Reworks the `page-money` scaffold template — the starting point every new App Block author gets — to add the **multi-LoRA selector** (the headline feature) and trim the noisier chrome so the scaffold is clean, minimal, and idiomatic.

## The 8 changes

1. **Live banner text** → exactly `LIVE HOST · spends REAL Buzz` (dropped the emoji + the "real compute / backend via vite proxy →" clauses). `src/main.tsx`.
2. **Mock banner text** → exactly `MOCK HOST · no real Buzz spent` (dropped "· no real compute"). `src/Harness.tsx`.
3. **Removed the "About this block" modal** — the `aboutOpen` state, the `<Modal>`, and its triggers. The now-unused `Modal` import is dropped (`Badge` stays — it's still used in the loading state). `src/App.tsx`.
4. **Removed the "How this works" Alert/Details section + the "How it works" button.** With both gone the Generate group is a single button. `src/App.tsx`.
5. **LoRA selector (the main feature)** — the user can layer up to **5 LoRAs** on top of the checkpoint, each with an adjustable **weight**, threaded into the workflow body:
   - `src/catalog-api.ts` gains `fetchLoraCatalog` (`types=LORA`) sharing the *same* authoritative (Bearer `/blocks/models`, server-maturity-clamped) + public-fallback read as the checkpoint catalog. The `toResult`/fetch core was made generic over a mapper so checkpoint + LoRA reads share one code path. Pure, testable mappers (`modelToLora`/`responseToLoras`).
   - `src/models.ts` gains `LoraOption`, a small curated `LORAS` fallback set (first paint / offline), and the pure selection helpers `addLora` / `removeLora` / `setLoraWeight` that enforce **dedup**, the **5-LoRA cap** (`MAX_LORAS`), and the **`[-1, 2]` weight clamp** (the SDK's `WorkflowBody` bound; default `1`).
   - `src/generation.ts`: `buildWorkflowBody(prompt, checkpoint, loras)` emits `additionalResources: loras.map(l => ({ modelVersionId: l.versionId, strength: l.weight }))` **only when non-empty** — a checkpoint-only body stays backward compatible.
   - `src/App.tsx` holds the selected list in state and renders a `LoraSelector` (an add-list of chip buttons from the curated/catalog LoRAs + selected rows with a themed native `range` weight input — the W6 pack ships no Slider).
   - **Money-safety:** LoRA picks + weights are **DISCOVERY ONLY**. The server is LoRA-only for additional resources and **re-validates** base-model compatibility + per-resource entitlement AND **re-prices** the whole body at every estimate/submit. **No manifest scope change** — the block token already gates the catalog. Commented throughout.
6. **Removed the status Badge** near the title. It surfaced the consent/auth state: anon → `signed out`, budgeted-scope-granted → `ready`, else → `needs access`. **Only the visual badge is removed** — the load-bearing `granted` / `anon` / consent logic in `proceed()` and the consent effect (what makes the first Generate request consent) is untouched, and the golden test now asserts that logic survives.
7. **Scenario panel** (`src/Harness.tsx`): `<summary>` renamed `scenarios` → `mock scenarios`, and the panel restyled to a minimal console/terminal aesthetic (monospace, near-black terminal bg, subtle console borders, console-green accent; the inputs/buttons match).
8. **Cohesive console-styled mock chrome** — the MockBanner + scenarios panel now read as one clean dark console strip.

## Verification

- **`go test ./internal/...` green** (including the updated golden `scaffold_test.go`: dropped assertions for the About modal, How-it-works, the old badge copy, and the old banner strings; added the new banner texts, the `additionalResources`/LoRA wiring, `types=LORA`, the consent-logic-survives checks, and `mock scenarios`).
- **Scaffold-typecheck gotcha (not caught by `go test`):** built the binary, scaffolded a fresh "Money Block", `npm install`, then the scaffold's own **`npm run typecheck` AND `npm run build` both pass** under strict `noUnusedLocals` (all dead code from the removals is gone), and **`npm test` (vitest) is green — 45 tests** across 6 files.
- **Playwright on `dev:harness`** (mock host — no real Buzz):
  - (a) mock banner reads exactly `MOCK HOST · no real Buzz spent` ✓
  - (b) no status badge, no "How it works"/About ✓
  - (c) added **2 LoRAs**, changed the first's weight to **0.6**, typed a prompt, clicked Generate → it **completed** ("Spent 8 Buzz" + result image). Imported the live `generation.ts` in-page to confirm the body carries `additionalResources: [{modelVersionId:135867, strength:0.6}, {modelVersionId:152309, strength:1}]` and **omits it when no LoRAs are selected**. (The mock host doesn't route the body through `window.postMessage`/`MessagePort` in an observable way, so the body was confirmed by invoking the exact builder the click path calls.) As a bonus, the in-block LoRA catalog read was observed falling back from the CORS-blocked authoritative `/blocks/models?types=LORA` to the public `/api/v1/models?types=LORA`, which returned real LoRAs — proving the fetch + fallback end-to-end.
  - (d) the **`mock scenarios`** panel label + console styling ✓

  Final-state screenshot showed: title with no badge, the 2/5 LoRA selector with both weight sliders, the single Generate · 8 Buzz button, the Done/Spent success, and the console-styled mock chrome. Dev server was stopped by exact PID; temp dirs removed.

## Notes / descopes

- The mock host's body isn't observable via the postMessage/MessagePort hooks (its transport is in-process), so the on-the-wire `additionalResources` for the *live click path* is proven by the deterministic e2e/unit tests + the in-page builder import rather than a captured outbound message. The generation completing successfully with LoRAs selected is the click-path proof.
- The curated `LORAS` fallback ids are foundational public SDXL LoRAs; like the curated checkpoints they're discovery-only and server-revalidated, so a stale id degrades gracefully (the catalog read ADDS the real set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
