### PR TITLE
fix(scaffold): simplify no-token alert + clarify step-1 API-key copy

### DIFF
--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -86,8 +86,7 @@ export function resolveLiveConfig(): LiveConfig {
   if (!token) {
     return {
       ready: false,
-      reason:
-        'No VITE_LIVE_BLOCK_TOKEN set — follow the steps below to mint one (never commit it).',
+      reason: 'Set one up below to run against your own account.',
     };
   }
   return { ready: true, token, backendBaseUrl };

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -305,11 +305,11 @@ function LiveUnavailable({ reason }: { reason: string }) {
           <WizardStep n={1} current={step} title="Create your API key">
             <Stack gap={10}>
               <span style={stepLabelStyle}>
-                Opens the key dialog pre-filled (name + minimal scope) on{' '}
+                Create your personal API key so your app can spend Buzz from your local dev
+                environment.{' '}
                 <a href={apiKeyUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
                   civitai.com/user/account
                 </a>
-                . An OAuth login can&apos;t spend, so create a key, then paste it:
               </span>
               <TextInput
                 label="Your API key"


### PR DESCRIPTION
Two copy tweaks to the `dev:live` setup wizard:

1. **"No spendable dev token" alert** — dropped the `VITE_LIVE_BLOCK_TOKEN` jargon; now reads *"Set one up below to run against your own account."*
2. **Step 1 copy** → *"Create your personal API key so your app can spend Buzz from your local dev environment."* followed by the `civitai.com/user/account` deeplink (unchanged).

Verified: `go test` + scaffold `typecheck`/`build` green; rendered both lines via the dev:live fail-safe screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)