### PR TITLE
feat(scaffold/page-money): surface expired dev:live token instead of silently degrading

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -117,8 +117,11 @@ func TestRenderPageMoney(t *testing.T) {
 	// next-step hint, all while staying valid JSON after rendering.
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"@civitai/blocks-react"`)
-	// The SDK live host that SERVES the resource picker locally ships in 0.13.0.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.13.0"`)
+	// The SDK live host that SERVES the resource picker locally ships in 0.13.0;
+	// 0.14.1 adds the picker + storage fixes new scaffolds should get.
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.14.1"`)
+	// @civitai/app-sdk stays on 0.13.0 (only blocks-react was bumped).
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.13.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)
@@ -233,6 +236,11 @@ func TestRenderPageMoney(t *testing.T) {
 	// (vite.config.ts) injects it server-side.
 	mustNotContain(t, nav, "CIVITAI_HOST_KEY")
 	mustNotContain(t, nav, "VITE_LIVE_BLOCK_TOKEN")
+	// Dev-token expiry surfacing: pure helpers that name the dead-token state so
+	// an expired (~15min) token stops masquerading as feature bugs.
+	mustContain(t, nav, "decodeTokenExp")
+	mustContain(t, nav, "isTokenExpired")
+	mustContain(t, nav, "shouldPromptReMint")
 
 	// The display name should land in the manifest + App heading.
 	mustContain(t, manifest, `"name": "Money Block"`)
@@ -313,6 +321,18 @@ func TestRenderPageMoney(t *testing.T) {
 	// The personal key is NEVER referenced in client code (main.tsx). Only the
 	// vite proxy injects it server-side.
 	mustNotContain(t, mainTSX, "CIVITAI_HOST_KEY")
+	// Expired-dev-token surfacing: the nav captures the /blocks/me HTTP status
+	// (a 401 = server-rejected token) + computes promptReMint, and renders a
+	// re-mint banner with the dev-token mint command instead of silently
+	// degrading to the neutral 'viewer'.
+	mustContain(t, mainTSX, "meStatus")
+	mustContain(t, mainTSX, "promptReMint")
+	mustContain(t, mainTSX, "isTokenExpired")
+	mustContain(t, mainTSX, "shouldPromptReMint")
+	mustContain(t, mainTSX, `data-testid="pm-nav-remint"`)
+	mustContain(t, mainTSX, `data-harness-banner="token-expired"`)
+	mustContain(t, mainTSX, "Dev token expired — re-mint to restore your session")
+	mustContain(t, mainTSX, "civitai app dev-token money-block")
 
 	// Harness.tsx: the mock chrome reads as a console/terminal strip. The MOCK
 	// banner is exactly "MOCK HOST · no real Buzz spent" and the scenario panel

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.13.0",
-    "@civitai/blocks-react": "^0.13.0",
+    "@civitai/blocks-react": "^0.14.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -20,7 +20,13 @@ import {
   installLiveHost,
   resolveLiveConfig,
 } from './dev-transport.js';
-import { navDisplay, parseBuzzBalance, parseViewerName } from './nav.js';
+import {
+  isTokenExpired,
+  navDisplay,
+  parseBuzzBalance,
+  parseViewerName,
+  shouldPromptReMint,
+} from './nav.js';
 import './index.css';
 
 // Dev harness entry. The mode decides the surface:
@@ -107,25 +113,43 @@ function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: str
  *    vite.config.ts). The key is NEVER `VITE_`-bundled — this client code never
  *    references it; it just fetches the same-origin route. With no key set the
  *    balance route 401s and the nav GRACEFULLY shows the name only (no error).
+ *
+ * EXPIRED-TOKEN SURFACING: dev block tokens live ~15min. An expired token
+ * SILENTLY degrades (the block still renders — `createLiveHost` reads claims
+ * unverified — and the balance still resolves via the personal key), so a dead
+ * token looks like feature bugs. We detect it two ways — a client-side `exp`
+ * read AND a 401 from `/blocks/me` (server reject) — and render a prominent
+ * re-mint banner ABOVE the nav strip instead of the misleading neutral 'viewer'.
  */
 function HostNav({ blockToken, backendBaseUrl }: { blockToken: string; backendBaseUrl: string }) {
   const [name, setName] = useState<string | null>(null);
   const [balance, setBalance] = useState<number | null>(null);
+  // The HTTP status of the LAST `/blocks/me` failure (a 401 = server rejected
+  // the token), or `null` on success / network error. Distinct from `name` so a
+  // 401 surfaces the re-mint banner even when the name can't resolve.
+  const [meStatus, setMeStatus] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const base = backendBaseUrl.replace(/\/+$/, '');
 
-    // Profile name: block token, same-origin via the proxy.
+    // Profile name: block token, same-origin via the proxy. CAPTURE the HTTP
+    // status on failure (don't discard it) — a 401 means the server rejected the
+    // token (expired / bad kid) and we must prompt a re-mint.
     void fetch(`${base}/api/v1/blocks/me`, {
       headers: { Authorization: `Bearer ${blockToken}` },
     })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((body) => {
-        if (!cancelled) setName(parseViewerName(body));
+      .then(async (r) => {
+        if (cancelled) return;
+        if (!r.ok) {
+          setMeStatus(r.status); // name stays null; status drives the banner
+          return;
+        }
+        setMeStatus(null);
+        setName(parseViewerName(await r.json()));
       })
       .catch(() => {
-        /* name stays null → nav shows the neutral fallback */
+        /* network error → name stays null, no server status (no banner from here) */
       });
 
     // Buzz balance: NO Authorization header here — the dev proxy injects the
@@ -145,27 +169,68 @@ function HostNav({ blockToken, backendBaseUrl }: { blockToken: string; backendBa
     };
   }, [blockToken, backendBaseUrl]);
 
+  // The token is static, so a component-body Date.now() is fine. clientExpired =
+  // our unverified exp-read; promptReMint folds in the server's 401.
+  const clientExpired = isTokenExpired(blockToken, Date.now());
+  const promptReMint = shouldPromptReMint(clientExpired, meStatus);
+
   const display = navDisplay(name, balance);
 
   return (
-    <nav data-harness-banner="live" data-theme="dark" style={navStyle}>
-      <span style={navProfileStyle} data-testid="pm-nav-name">
-        <span style={navAvatarStyle} aria-hidden>
-          {display.name.charAt(0).toUpperCase()}
+    <>
+      {promptReMint && (
+        <div data-testid="pm-nav-remint" data-theme="dark" style={remintBannerStyle}>
+          <Alert
+            color="warning"
+            title="Dev token expired — re-mint to restore your session"
+            data-harness-banner="token-expired"
+          >
+            <Stack gap={8}>
+              <span style={stepLabelStyle}>
+                Your dev block token is no longer valid (they last ~15&nbsp;min). The block still
+                renders and your Buzz balance still shows (those use your personal key), but the
+                live session is running on a dead token — re-mint it:
+              </span>
+              <CmdRow cmd="civitai app dev-token {{ .Slug }} --env >> .env.development.local" />
+              <span style={stepLabelStyle}>
+                then restart <code>dev:live</code> (or it auto-restarts when <code>.env</code>{' '}
+                changes).
+              </span>
+            </Stack>
+          </Alert>
+        </div>
+      )}
+      <nav data-harness-banner="live" data-theme="dark" style={navStyle}>
+        <span style={navProfileStyle} data-testid="pm-nav-name">
+          {promptReMint ? (
+            <span style={navExpiredStyle}>token expired</span>
+          ) : (
+            <>
+              <span style={navAvatarStyle} aria-hidden>
+                {display.name.charAt(0).toUpperCase()}
+              </span>
+              {display.name}
+            </>
+          )}
         </span>
-        {display.name}
-      </span>
-      <span style={navRightStyle}>
-        {display.balance != null && (
-          <span style={navBalanceStyle} data-testid="pm-nav-balance">
-            ⚡ {display.balance} Buzz
-          </span>
-        )}
-        <span style={navPillStyle} data-testid="pm-nav-pill">
-          LIVE · spends real Buzz
+        <span style={navRightStyle}>
+          {display.balance != null && (
+            <span style={navBalanceStyle} data-testid="pm-nav-balance">
+              ⚡ {display.balance} Buzz
+            </span>
+          )}
+          {promptReMint ? (
+            <span style={navExpiredPillStyle} data-testid="pm-nav-pill">
+              token expired
+            </span>
+          ) : (
+            <span style={navPillStyle} data-testid="pm-nav-pill">
+              LIVE · spends real Buzz
+            </span>
+          )}
         </span>
-      </span>
-    </nav>
+      </nav>
+    </>
   );
 }
 
@@ -489,6 +554,27 @@ const navPillStyle: CSSProperties = {
   padding: '3px 10px',
   borderRadius: 999,
   whiteSpace: 'nowrap',
+};
+// When the dev token is expired, the name area + pill go honest ("token expired")
+// instead of the misleading neutral 'viewer' + the LIVE-spend pill.
+const navExpiredStyle: CSSProperties = { color: '#ffa94d', fontWeight: 700 };
+const navExpiredPillStyle: CSSProperties = {
+  background: '#7a5a1f',
+  color: '#ffe8cc',
+  fontWeight: 700,
+  padding: '3px 10px',
+  borderRadius: 999,
+  whiteSpace: 'nowrap',
+};
+// The re-mint banner sits sticky ABOVE the nav strip, themed so the W6 Alert's
+// CSS vars resolve against the dark host chrome.
+const remintBannerStyle: CSSProperties = {
+  position: 'sticky',
+  top: 0,
+  zIndex: 10000,
+  padding: '10px 14px',
+  background: '#0e0f12',
+  borderBottom: '1px solid #2a2c31',
 };
 
 // The fail-safe screen themes its OWN root (data-theme) so the W6 pack's CSS

--- a/internal/scaffold/templates/page-money/src/nav.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/nav.test.ts.tmpl
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatBalance, navDisplay, parseBuzzBalance, parseViewerName } from './nav.js';
+import {
+  decodeTokenExp,
+  formatBalance,
+  isTokenExpired,
+  navDisplay,
+  parseBuzzBalance,
+  parseViewerName,
+  shouldPromptReMint,
+} from './nav.js';
+
+/** Build an (unsigned-payload) JWT from a payload object: header.payload.sig. */
+function makeJwt(payload: unknown): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.sig`;
+}
 
 // Pure-logic units for the dev:live host nav. The parsers must be SAFE on any
 // shape (tRPC envelope, bare, malformed, empty) so a bad response degrades the
@@ -69,5 +84,62 @@ describe('navDisplay', () => {
   it('falls back to a neutral name when unresolved (never blank)', () => {
     expect(navDisplay(null, null)).toEqual({ name: 'viewer', balance: null });
     expect(navDisplay('   ', 100)).toEqual({ name: 'viewer', balance: (100).toLocaleString() });
+  });
+});
+
+// ── Dev-token expiry surfacing ──────────────────────────────────────────────
+// An expired dev:live token silently degrades (the block still renders, balance
+// still resolves via the personal key), so these helpers must reliably name the
+// dead-token state — and be SAFE on any garbage input (never throw).
+
+describe('decodeTokenExp', () => {
+  it('reads a numeric exp out of a JWT payload', () => {
+    expect(decodeTokenExp(makeJwt({ exp: 1735689600, sub: 'u' }))).toBe(1735689600);
+  });
+  it('returns null when the payload has no exp', () => {
+    expect(decodeTokenExp(makeJwt({ sub: 'u' }))).toBeNull();
+  });
+  it('returns null for a non-numeric / non-finite exp', () => {
+    expect(decodeTokenExp(makeJwt({ exp: 'soon' }))).toBeNull();
+    expect(decodeTokenExp(makeJwt({ exp: null }))).toBeNull();
+    expect(decodeTokenExp(makeJwt({ exp: Infinity }))).toBeNull(); // JSON → null
+  });
+  it('returns null for malformed / empty / too-few-segments / non-string input', () => {
+    expect(decodeTokenExp('')).toBeNull();
+    expect(decodeTokenExp('x.y')).toBeNull(); // payload 'y' isn't valid JSON
+    expect(decodeTokenExp('onlyonesegment')).toBeNull();
+    expect(decodeTokenExp('a..c')).toBeNull(); // empty payload segment
+    // @ts-expect-error — guarding the non-string runtime path
+    expect(decodeTokenExp(null)).toBeNull();
+    // @ts-expect-error — guarding the non-string runtime path
+    expect(decodeTokenExp(12345)).toBeNull();
+  });
+});
+
+describe('isTokenExpired', () => {
+  const now = 1_700_000_000_000; // fixed nowMs — never call Date.now() in tests
+  it('is true when exp is in the past relative to nowMs', () => {
+    expect(isTokenExpired(makeJwt({ exp: 1_699_999_000 }), now)).toBe(true);
+  });
+  it('is false when exp is in the future relative to nowMs', () => {
+    expect(isTokenExpired(makeJwt({ exp: 1_700_001_000 }), now)).toBe(false);
+  });
+  it('is false for a token with no/unreadable exp (the 401 path covers that)', () => {
+    expect(isTokenExpired(makeJwt({ sub: 'u' }), now)).toBe(false);
+    expect(isTokenExpired('garbage', now)).toBe(false);
+  });
+});
+
+describe('shouldPromptReMint', () => {
+  it('prompts when the client-side exp read says expired', () => {
+    expect(shouldPromptReMint(true, null)).toBe(true);
+  });
+  it('prompts on a 401 from /blocks/me even if the client exp read disagreed', () => {
+    expect(shouldPromptReMint(false, 401)).toBe(true);
+  });
+  it('does NOT prompt on a healthy token / non-401 status', () => {
+    expect(shouldPromptReMint(false, 200)).toBe(false);
+    expect(shouldPromptReMint(false, null)).toBe(false);
+    expect(shouldPromptReMint(false, 403)).toBe(false);
   });
 });

--- a/internal/scaffold/templates/page-money/src/nav.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/nav.ts.tmpl
@@ -96,3 +96,65 @@ export function navDisplay(name: string | null, balance: number | null): NavDisp
     balance: formatBalance(balance),
   };
 }
+
+// ── Dev-token expiry detection ──────────────────────────────────────────────
+// Dev block tokens are short-lived (~15min). When the pasted block token (the
+// app's dev:live credential) expires the harness SILENTLY degrades —
+// `createLiveHost` decodes the token's
+// claims client-side WITHOUT verifying (so the block still renders), and the Buzz
+// balance comes from the dev's PERSONAL key via the proxy (not the block token) —
+// so a dead token masquerades as feature bugs. These pure helpers let the nav
+// SURFACE "your dev token expired — re-mint" instead. No imports, never throw.
+
+/**
+ * Decode a JWT's `exp` (seconds since epoch) WITHOUT verifying the signature.
+ * Mirrors the SDK's base64url→base64 padding. Returns the numeric `exp` if the
+ * payload carries a finite number, else `null` (no exp / non-numeric exp /
+ * malformed / non-string input). SAFE on any input — never throws.
+ */
+export function decodeTokenExp(token: string): number | null {
+  try {
+    if (typeof token !== 'string') return null;
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const payloadSeg = parts[1];
+    if (!payloadSeg) return null;
+    // base64url → base64 + pad to a multiple of 4.
+    let b64 = payloadSeg.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) b64 += '=';
+    let json: string;
+    if (typeof atob === 'function') {
+      json = atob(b64);
+    } else if (typeof Buffer !== 'undefined') {
+      json = Buffer.from(b64, 'base64').toString('utf8');
+    } else {
+      return null;
+    }
+    const payload = JSON.parse(json) as unknown;
+    if (payload == null || typeof payload !== 'object') return null;
+    const exp = (payload as Record<string, unknown>).exp;
+    return typeof exp === 'number' && Number.isFinite(exp) ? exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the token's `exp` is in the past relative to `nowMs` (ms since epoch).
+ * A token with no/non-numeric exp is NOT treated as expired by this client check
+ * (→ `false`) — the server's 401 path covers that. Pure + total.
+ */
+export function isTokenExpired(token: string, nowMs: number): boolean {
+  const exp = decodeTokenExp(token);
+  return exp != null && exp * 1000 <= nowMs;
+}
+
+/**
+ * Whether to prompt the dev to re-mint their token. True when our client-side
+ * exp-read says it's expired OR the server rejected the token with a 401 from
+ * `/blocks/me` (e.g. bad kid / past maxTokenAge even if our exp-read disagreed).
+ * Pure + total.
+ */
+export function shouldPromptReMint(clientExpired: boolean, meHttpStatus: number | null): boolean {
+  return clientExpired || meHttpStatus === 401;
+}


### PR DESCRIPTION
## Problem
In `dev:live`, an expired (~15min) or rejected dev block token (`VITE_LIVE_BLOCK_TOKEN`) **silently degrades**: the host nav falls back to a neutral 'viewer' name and the picker falls back to the public catalog — so a dead token looks like feature bugs. The block still *renders* because `createLiveHost` decodes the token claims client-side **without verifying**, and the Buzz balance uses the dev's personal key via the proxy (not the block token) — both mask the dead token.

## Fix
Surface "your dev token expired — re-mint" visibly in the page-money scaffold's host nav.

- **`src/nav.ts.tmpl`** — pure, import-free, never-throw helpers:
  - `decodeTokenExp(token)` — unverified JWT `exp` read (base64url→base64 padding, `atob` + Node `Buffer` paths), `null` on any malformed input.
  - `isTokenExpired(token, nowMs)` — client-side exp check; no/non-numeric exp → `false` (the 401 path covers that).
  - `shouldPromptReMint(clientExpired, meHttpStatus)` — folds in a 401 from `/blocks/me` (server-rejected token, e.g. bad kid / past maxTokenAge).
  - Existing exports unchanged.
- **`src/main.tsx.tmpl`** — `HostNav` now captures the `/blocks/me` HTTP status (a 401 drives the banner even when the name can't resolve), computes `promptReMint`, and renders a prominent W6 `Alert` re-mint banner (`color="warning"`, `data-testid="pm-nav-remint"`, `data-harness-banner="token-expired"`) above the nav strip, carrying the `civitai app dev-token <slug> --env >> .env.development.local` command via the reused `CmdRow`. The name area + pill go honest ("token expired") instead of the misleading neutral 'viewer'. Balance display unchanged (still useful signal the proxy/personal key is fine and only the block token is dead). Mock-mode, `LiveUnavailable`, and the credential split are untouched.
- **`src/nav.test.ts.tmpl`** — node unit tests for the three new helpers.
- **`package.json.tmpl`** — `@civitai/blocks-react` `^0.13.0` → `^0.14.1` (picker + storage fixes); `@civitai/app-sdk` left at `^0.13.0`.
- **`scaffold_test.go`** — track the pin bump + assert the new helpers/banner render (the existing test pinned the old version, so it had to move with it).

## Validation
- `go test ./...` — green.
- Scaffolded a real page-money app (slug `tmp-tmp-expiry-check`) and ran its own gates: `npm install` (resolved `@civitai/blocks-react@0.14.1`), `npm run typecheck`, `npm run build`, `npm run test` — **84 tests pass** (21 in `nav.test.ts`). Throwaway dir deleted, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
