### PR TITLE
docs: dev:live block tokens now live ~4h (was 15min) — civitai #2795

### DIFF
--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -94,7 +94,7 @@ func newAppDevTokenCmd() *cobra.Command {
 "npm run dev:live" against the REAL Civitai backend.
 
 Calls the moderator-gated mint route (POST /api/v1/blocks/dev-token) with your
-stored credential and prints the token (a ~15-minute RS256 JWT). Paste it into
+stored credential and prints the token (a ~4-hour RS256 JWT). Paste it into
 VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart "npm run dev:live".
 
 The minted token's CAPABILITIES depend on the credential you mint with:
@@ -156,7 +156,7 @@ never commit it; re-mint when it expires.`,
 			errOut := cmd.ErrOrStderr()
 			fmt.Fprintln(errOut,
 				"Paste into VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart `npm run dev:live`. "+
-					"Short-lived (~15min); never commit it.")
+					"Short-lived (~4h); never commit it.")
 
 			// Catch the #1 dev:live dead-end EARLY: a read-only token makes
 			// `dev:live` Generate silently do nothing (the live host can't grant

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -237,7 +237,7 @@ func TestRenderPageMoney(t *testing.T) {
 	mustNotContain(t, nav, "CIVITAI_HOST_KEY")
 	mustNotContain(t, nav, "VITE_LIVE_BLOCK_TOKEN")
 	// Dev-token expiry surfacing: pure helpers that name the dead-token state so
-	// an expired (~15min) token stops masquerading as feature bugs.
+	// an expired (~4h) token stops masquerading as feature bugs.
 	mustContain(t, nav, "decodeTokenExp")
 	mustContain(t, nav, "isTokenExpired")
 	mustContain(t, nav, "shouldPromptReMint")

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -131,7 +131,7 @@ target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 
 To use it:
 
-1. Mint a short-lived dev block token (a ~15-minute RS256 JWT; re-mint + restart
+1. Mint a short-lived dev block token (a ~4-hour RS256 JWT; re-mint + restart
    when it expires). The friendly path is the CLI — it calls the moderator-gated
    mint route with your stored credential and writes a paste-ready line:
    ```bash

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -29,7 +29,7 @@ VITE_HARNESS_MODE=
 # LIVE mode only. A short-lived, scoped dev block token minted for local dev via
 # the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token). Paste
 # it here to run `dev:live` against the real backend. ⚠️ A real token here spends
-# REAL Buzz; it's short-lived (~15min) — never commit one.
+# REAL Buzz; it's short-lived (~4h) — never commit one.
 #
 # The mint accepts a PENDING (un-approved) slug — right after `civitai app submit`
 # it returns 200 with appId: pending-pubreq_… , so you can dev:live-test before

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -114,7 +114,7 @@ function LiveApp({ token, backendBaseUrl }: { token: string; backendBaseUrl: str
  *    references it; it just fetches the same-origin route. With no key set the
  *    balance route 401s and the nav GRACEFULLY shows the name only (no error).
  *
- * EXPIRED-TOKEN SURFACING: dev block tokens live ~15min. An expired token
+ * EXPIRED-TOKEN SURFACING: dev block tokens live ~4h. An expired token
  * SILENTLY degrades (the block still renders — `createLiveHost` reads claims
  * unverified — and the balance still resolves via the personal key), so a dead
  * token looks like feature bugs. We detect it two ways — a client-side `exp`
@@ -187,7 +187,7 @@ function HostNav({ blockToken, backendBaseUrl }: { blockToken: string; backendBa
           >
             <Stack gap={8}>
               <span style={stepLabelStyle}>
-                Your dev block token is no longer valid (they last ~15&nbsp;min). The block still
+                Your dev block token is no longer valid (they last ~4&nbsp;h). The block still
                 renders and your Buzz balance still shows (those use your personal key), but the
                 live session is running on a dead token — re-mint it:
               </span>

--- a/internal/scaffold/templates/page-money/src/nav.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/nav.ts.tmpl
@@ -98,7 +98,7 @@ export function navDisplay(name: string | null, balance: number | null): NavDisp
 }
 
 // ── Dev-token expiry detection ──────────────────────────────────────────────
-// Dev block tokens are short-lived (~15min). When the pasted block token (the
+// Dev block tokens are short-lived (~4h). When the pasted block token (the
 // app's dev:live credential) expires the harness SILENTLY degrades —
 // `createLiveHost` decodes the token's
 // claims client-side WITHOUT verifying (so the block still renders), and the Buzz


### PR DESCRIPTION
Updates the dev:live block-token lifetime docs from "~15 min" to "~4 h" across the CLI to match the server change (civitai #2795, merged) that makes **dev** block tokens live 4 hours. Production block tokens stay 15 min and are untouched; OAuth/device-login access-token (1h) / refresh-token (30d) wording is untouched.

COPY/COMMENT-only — no logic changes.

Edits (old → new):
- `internal/cmd/app_dev_token.go` — `Long` help: "a ~15-minute RS256 JWT" → "a ~4-hour RS256 JWT"; stderr hint: "Short-lived (~15min)" → "Short-lived (~4h)"
- `internal/scaffold/templates/page-money/README.md.tmpl` — "a ~15-minute RS256 JWT" → "a ~4-hour RS256 JWT"
- `internal/scaffold/templates/page-money/env.example.tmpl` — "short-lived (~15min)" → "short-lived (~4h)"
- `internal/scaffold/templates/page-money/src/main.tsx.tmpl` — comment "dev block tokens live ~15min" → "~4h"; JSX banner "they last ~15&nbsp;min" → "~4&nbsp;h"
- `internal/scaffold/templates/page-money/src/nav.ts.tmpl` — comment "short-lived (~15min)" → "~4h"
- `internal/scaffold/scaffold_test.go` — comment "expired (~15min) token" → "(~4h)"

Validation:
- `go test ./...` green
- Scaffolded a throwaway page-money app → `npm install && npm run typecheck && npm run build` all green (the JSX template still compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
