### PR TITLE
feat(login): print the code-prefilled verification_uri_complete link

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -93,12 +94,7 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 	}
 
 	// Tell the user what to do. Never print the device_code (secret).
-	uri := da.VerificationURI
-	if uri == "" {
-		uri = cfg.BaseURL() + "/login/oauth/device"
-	}
-	fmt.Fprintln(out, "To authenticate, open this URL in your browser and enter the code:")
-	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", uri, da.UserCode)
+	renderDeviceInstructions(out, da, cfg.BaseURL())
 
 	if !noBrowser && da.VerificationURIComplete != "" {
 		if err := openBrowser(da.VerificationURIComplete); err == nil {
@@ -122,6 +118,27 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 	fmt.Fprintf(out, "\nLogged in. Tokens saved to %s\n", cfg.Path())
 	fmt.Fprintln(out, "Verify with: civitai whoami")
 	return nil
+}
+
+// renderDeviceInstructions prints the device-flow instructions to out. When the
+// server supplies verification_uri_complete (the code pre-filled in the URL) it
+// is printed as the PRIMARY, copyable link so a user who pastes it gets the code
+// prefilled (matters for --no-browser / headless / when openBrowser fails), with
+// the bare URL + code kept as a clearly-labeled manual fallback. When it's empty
+// it falls back to the bare URL + Code form. Never prints the device_code (secret).
+func renderDeviceInstructions(out io.Writer, da *api.DeviceAuth, baseURL string) {
+	uri := da.VerificationURI
+	if uri == "" {
+		uri = baseURL + "/login/oauth/device"
+	}
+	if da.VerificationURIComplete != "" {
+		fmt.Fprintln(out, "To authenticate, open this URL (your code is pre-filled):")
+		fmt.Fprintf(out, "\n  %s\n\n", da.VerificationURIComplete)
+		fmt.Fprintf(out, "Or open %s and enter the code manually:  %s\n\n", uri, da.UserCode)
+		return
+	}
+	fmt.Fprintln(out, "To authenticate, open this URL in your browser and enter the code:")
+	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", uri, da.UserCode)
 }
 
 // openBrowser best-effort opens url in the default browser. A failure is

--- a/internal/cmd/login_render_test.go
+++ b/internal/cmd/login_render_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// TestRenderDeviceInstructionsComplete: when the server supplies
+// verification_uri_complete, the printed output uses it as the PRIMARY copyable
+// (code pre-filled) link, and still surfaces the bare URL + user_code as a
+// manual fallback. The device_code (secret) is never printed.
+func TestRenderDeviceInstructionsComplete(t *testing.T) {
+	da := &api.DeviceAuth{
+		DeviceCode:              "dev-secret-code",
+		UserCode:                "ABCD-1234",
+		VerificationURI:         "https://civitai.com/login/oauth/device",
+		VerificationURIComplete: "https://civitai.com/login/oauth/device?code=ABCD-1234",
+	}
+	var buf bytes.Buffer
+	renderDeviceInstructions(&buf, da, "https://civitai.com")
+	out := buf.String()
+
+	if !strings.Contains(out, da.VerificationURIComplete) {
+		t.Errorf("expected the code-prefilled complete URL %q in output:\n%s", da.VerificationURIComplete, out)
+	}
+	if !strings.Contains(out, "?code=") {
+		t.Errorf("expected a ?code= prefilled link in output:\n%s", out)
+	}
+	if !strings.Contains(out, da.VerificationURI) {
+		t.Errorf("expected the bare verification_uri %q as manual fallback:\n%s", da.VerificationURI, out)
+	}
+	if !strings.Contains(out, da.UserCode) {
+		t.Errorf("expected the user_code %q for manual entry:\n%s", da.UserCode, out)
+	}
+	if strings.Contains(out, da.DeviceCode) {
+		t.Errorf("device_code (secret) must NEVER be printed:\n%s", out)
+	}
+}
+
+// TestRenderDeviceInstructionsNoComplete: when verification_uri_complete is
+// empty, the output falls back to the bare URL:/Code: form and contains no
+// ?code= prefilled link. The device_code is never printed.
+func TestRenderDeviceInstructionsNoComplete(t *testing.T) {
+	da := &api.DeviceAuth{
+		DeviceCode:      "dev-secret-code",
+		UserCode:        "ABCD-1234",
+		VerificationURI: "https://civitai.com/login/oauth/device",
+	}
+	var buf bytes.Buffer
+	renderDeviceInstructions(&buf, da, "https://civitai.com")
+	out := buf.String()
+
+	if strings.Contains(out, "?code=") {
+		t.Errorf("no prefilled ?code= link expected when complete URI is empty:\n%s", out)
+	}
+	if !strings.Contains(out, "URL:  "+da.VerificationURI) {
+		t.Errorf("expected bare URL: form:\n%s", out)
+	}
+	if !strings.Contains(out, "Code: "+da.UserCode) {
+		t.Errorf("expected bare Code: form:\n%s", out)
+	}
+	if strings.Contains(out, da.DeviceCode) {
+		t.Errorf("device_code (secret) must NEVER be printed:\n%s", out)
+	}
+}
+
+// TestRenderDeviceInstructionsEmptyURIFallback: when both verification_uri and
+// the complete URI are empty, the bare URL falls back to baseURL + the device
+// path (preserving the existing behavior).
+func TestRenderDeviceInstructionsEmptyURIFallback(t *testing.T) {
+	da := &api.DeviceAuth{UserCode: "ABCD-1234"}
+	var buf bytes.Buffer
+	renderDeviceInstructions(&buf, da, "https://civitai.com")
+	out := buf.String()
+
+	if !strings.Contains(out, "https://civitai.com/login/oauth/device") {
+		t.Errorf("expected baseURL-derived device path fallback:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What

`civitai login` (OAuth device flow) printed the **bare** `verification_uri` plus the code separately, so a user who *copied* the printed link landed on the device page with no code prefilled. The CLI already parses `verification_uri_complete` and auto-opens the browser to it — but the printed block didn't use it.

This makes the printed block use `verification_uri_complete` (the link with `?code=XXXX-XXXX` prefilled) as the **primary, copyable** link, keeping the bare URL + code as a clearly-labeled manual fallback. This matters for `--no-browser`, SSH/headless, or when `openBrowser` fails.

## Change

- Extracted the print step into a pure helper `renderDeviceInstructions(out io.Writer, da *api.DeviceAuth, baseURL string)` in `internal/cmd/login.go`.
- When `da.VerificationURIComplete != ""`:
  ```
  To authenticate, open this URL (your code is pre-filled):

    <verification_uri_complete>

  Or open <verification_uri> and enter the code manually:  <user_code>
  ```
- When it's empty: **unchanged** bare `URL:`/`Code:` form (incl. the existing `baseURL + /login/oauth/device` fallback).
- Browser auto-open logic unchanged (already opens the complete URL). No changes to `oauth.go`, polling, or anything else.
- The secret `device_code` is never printed — invariant asserted in tests.

## Tests

Added `internal/cmd/login_render_test.go` (3 cases): complete-present (asserts the `?code=` prefilled link + bare URL + user_code all present), complete-empty (asserts no `?code=` link, bare `URL:`/`Code:` form), and the empty-URI baseURL fallback. All assert the `device_code` is absent.

`go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)