### PR TITLE
feat(submit): concise submit output with next-steps + submission link

### DIFF
--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
@@ -92,7 +93,7 @@ Defaults to the current directory.`,
 			canUpload := !packageOnly && cfg.Token() != ""
 			if canUpload {
 				client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), submitPath)
-				return doUpload(cmd, client, pkg.Zip, m)
+				return doUpload(cmd, client, pkg.Zip, m, cfg.BaseURL())
 			}
 
 			// 3b. Fallback: write the canonical .zip + print next steps.
@@ -120,17 +121,19 @@ Defaults to the current directory.`,
 	return cmd
 }
 
-func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *manifest.Manifest) error {
+func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *manifest.Manifest, baseURL string) error {
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Submitting %s@%s ...\n", m.BlockID, m.Version)
+	fmt.Fprintf(out, "Submitting %s@%s …\n", m.BlockID, m.Version)
 	r, err := client.SubmitVersion(context.Background(), zipBytes, m.BlockID, m.Version)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "Submitted. Publish request %s (%s@%s) is now %s — pending moderator review.\n",
-		r.PublishRequestID, r.Slug, r.Version, r.Status)
-	fmt.Fprintln(out, "\nTip: real `dev:live` generation spends Buzz and needs a full-scope personal API key —")
-	fmt.Fprintln(out, "run `civitai whoami` to check if your current credential can spend (OAuth login can submit/withdraw but not spend).")
+	base := strings.TrimRight(baseURL, "/")
+	fmt.Fprintf(out, "✓ Submitted — %s is pending moderator review.\n", r.PublishRequestID)
+	fmt.Fprintf(out, "\nWhat's next: a moderator reviews it; on approval it builds + deploys to https://%s.civit.ai (usually a few minutes).\n", r.Slug)
+	fmt.Fprintln(out, "\nTrack it:")
+	fmt.Fprintln(out, "  civitai app status                          # review + deploy status")
+	fmt.Fprintf(out, "  %s/apps/my-submissions               # your submissions\n", base)
 	return nil
 }
 

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -120,9 +120,13 @@ func TestAppSubmitUploadsWhenTokenAndPathConfigured(t *testing.T) {
 	if !strings.Contains(stdout, "pr_42") || !strings.Contains(stdout, "pending") {
 		t.Errorf("output should report the publish request: %s", stdout)
 	}
-	// #34: a successful submit surfaces the personal-key money-path tip.
-	if !strings.Contains(stdout, "personal API key") || !strings.Contains(stdout, "civitai whoami") {
-		t.Errorf("submit success should print the personal-key tip: %s", stdout)
+	// A successful submit surfaces actionable next-steps: the per-app deploy URL
+	// and the submissions link — and drops the old, unrelated dev:live Buzz tip.
+	if !strings.Contains(stdout, "https://demo-block.civit.ai") || !strings.Contains(stdout, "/apps/my-submissions") {
+		t.Errorf("submit success should print the deploy URL + submissions link: %s", stdout)
+	}
+	if strings.Contains(stdout, "spends Buzz") || strings.Contains(stdout, "dev:live") {
+		t.Errorf("submit success should not print the dev:live Buzz tip: %s", stdout)
 	}
 }
 

--- a/internal/cmd/app_submit_test.go
+++ b/internal/cmd/app_submit_test.go
@@ -39,7 +39,7 @@ func TestDoUploadHandsBytesToSubmitter(t *testing.T) {
 	c.SetOut(&out)
 
 	m := &manifest.Manifest{BlockID: "demo", Version: "0.1.0", Name: "Demo"}
-	if err := doUpload(c, fs, []byte("ZIPBYTES"), m); err != nil {
+	if err := doUpload(c, fs, []byte("ZIPBYTES"), m, "https://civitai.com/"); err != nil {
 		t.Fatalf("doUpload: %v", err)
 	}
 	if string(fs.got) != "ZIPBYTES" {
@@ -50,5 +50,47 @@ func TestDoUploadHandsBytesToSubmitter(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "pr_9") || !strings.Contains(out.String(), "pending") {
 		t.Errorf("output should report the publish request + status, got: %s", out.String())
+	}
+}
+
+// TestDoUploadSuccessOutput pins the concise, actionable success output: it must
+// surface the publish-request id, the per-app deploy URL, and the submissions
+// link — and must NOT carry the old, unrelated dev:live-Buzz "Tip" or the
+// doubled "pending — pending" phrasing.
+func TestDoUploadSuccessOutput(t *testing.T) {
+	fs := &fakeSubmitter{result: &api.SubmitResult{
+		PublishRequestID: "pubreq_abc", Slug: "my-block", Version: "0.2.0", Status: "pending",
+	}}
+	var out bytes.Buffer
+	c := &cobra.Command{}
+	c.SetOut(&out)
+
+	m := &manifest.Manifest{BlockID: "my-block", Version: "0.2.0", Name: "My Block"}
+	// trailing slash on baseURL must be trimmed when composing the link.
+	if err := doUpload(c, fs, []byte("ZIP"), m, "https://civitai.com/"); err != nil {
+		t.Fatalf("doUpload: %v", err)
+	}
+	s := out.String()
+
+	for _, want := range []string{
+		"pubreq_abc",                              // the publish-request id
+		"https://my-block.civit.ai",               // per-app deploy URL (from slug)
+		"https://civitai.com/apps/my-submissions", // submissions link (no doubled slash)
+		"civitai app status",                      // the CLI status command
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("success output missing %q, got:\n%s", want, s)
+		}
+	}
+
+	for _, bad := range []string{
+		"spends Buzz",       // the dropped dev:live Buzz tip
+		"dev:live",          // ditto
+		"pending — pending", // the old doubled phrasing
+		"is now pending",    // the old redundant phrasing
+	} {
+		if strings.Contains(s, bad) {
+			t.Errorf("success output should not contain %q, got:\n%s", bad, s)
+		}
 	}
 }


### PR DESCRIPTION
## What

Rewrites the `civitai app submit` success output. It was noisy and unhelpful:

- a redundant **"is now pending — pending"**,
- an **irrelevant `dev:live`-Buzz "Tip"** (unrelated to submitting),
- **no next-steps** and no link to track the submission or see where it deploys.

### Before
```
Submitting dogfood-manual@0.1.0 ...
Submitted. Publish request pubreq_… (slug@ver) is now pending — pending moderator review.

Tip: real `dev:live` generation spends Buzz and needs a full-scope personal API key —
run `civitai whoami` to check if your current credential can spend (OAuth login can submit/withdraw but not spend).
```

### After
```
Submitting <blockId>@<version> …
✓ Submitted — <pubReqID> is pending moderator review.

What's next: a moderator reviews it; on approval it builds + deploys to https://<slug>.civit.ai (usually a few minutes).

Track it:
  civitai app status                          # review + deploy status
  <baseURL>/apps/my-submissions               # your submissions
```

## How

- `doUpload` now takes the base URL (`cfg.BaseURL()` passed from the call site; trailing slash trimmed when composing links).
- Per-app deploy URL uses `r.Slug` → `https://<slug>.civit.ai`; submissions link is `<baseURL>/apps/my-submissions`.
- Dropped the `dev:live` Buzz tip entirely.
- Untouched: the no-token `printManualNextSteps` path, validation, the `Packaged …` line, the `Wrote canonical bundle` line.

## Tests

- Extended `TestDoUploadSuccessOutput` (new) — asserts the pubReqID, the `https://<slug>.civit.ai` deploy URL, the `/apps/my-submissions` link (no doubled slash), and that the old "spends Buzz" / "dev:live" / doubled-"pending" text is gone.
- Updated `TestAppSubmitUploadsWhenTokenAndPathConfigured` — its old assertion required the now-removed Buzz tip; swapped to assert the new deploy/submissions links and absence of the Buzz tip.
- `go test ./...`, `go build ./...`, `go vet ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)