### PR TITLE
docs(readme): improve App Blocks discoverability — SDK packages section + document `dev-token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ Enable shell completion (optional):
 source <(civitai completion bash)   # bash; see `civitai completion --help` for zsh/fish/powershell
 ```
 
+## SDK packages
+
+This CLI scaffolds, validates, and submits — but the code your block actually
+imports lives in two published npm packages (the `page-money` / `page-vite`
+templates wire them for you):
+
+| Package | What it is |
+| --- | --- |
+| [`@civitai/blocks-react`](https://www.npmjs.com/package/@civitai/blocks-react) | The React hooks + iframe transport block authors call — `useBlockContext`, `useBuzzWorkflow`, `useBlockResize`, the `/ui` component pack, and the `/testing` dev hosts. **Start here for the hook reference.** |
+| [`@civitai/app-sdk`](https://www.npmjs.com/package/@civitai/app-sdk) | The framework-agnostic contract under the hooks — manifest types, scope strings, the `postMessage` protocol, and the `defineBlock` validator (`@civitai/app-sdk/blocks`). |
+
+```bash
+# Already installed by the scaffold; this is the explicit install line:
+pnpm add @civitai/blocks-react @civitai/app-sdk react
+```
+
+The full hook-by-hook reference (with snippets) lives in each package's npm
+README. For the end-to-end walkthrough, see
+[Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md).
+
 ## Command reference
 
 | Command | What it does |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ README. For the end-to-end walkthrough, see
 | `civitai buzz` | Show your spendable Buzz balance (blue / green / **yellow** — the generation-spend currency). Needs a full-scope personal API key to read; an OAuth login token can't, and gets a clear "switch to a personal key" message. |
 | `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App Block, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
+| `civitai app dev-token <slug> [--env]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the moderator-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
 | `civitai app validate [dir] [--strict]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
@@ -161,12 +162,24 @@ hosts) with two modes:
 > and **cannot spend**. Use `civitai buzz` / `civitai whoami` to confirm your
 > credential can spend before a live run.
 
-**Live mode** needs a short-lived dev block token (mint via the moderator-gated
-`POST /api/v1/blocks/dev-token`), pasted into `.env.development` as
-`VITE_LIVE_BLOCK_TOKEN=` (never committed — `submit` excludes `.env.development`).
-With no token it **fails safe** (renders a notice, never spends). Live v1 covers
-the money path (`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set,
-App-Storage KV, and in-band Buzz purchase are mock-only.
+**Live mode** needs a short-lived dev block token. Mint it with **`civitai app
+dev-token`** (the CLI handles the moderator-gated `POST /api/v1/blocks/dev-token`
+call with your stored credential — no hand-rolled curl) and paste it into
+`.env.development.local` as `VITE_LIVE_BLOCK_TOKEN=`:
+
+```bash
+# From your scaffolded project dir (reads scopes from block.manifest.json):
+civitai app dev-token my-block --env >> .env.development.local
+npm run dev:live
+```
+
+`.env.development*` is never committed (`submit` excludes it) and the token is
+short-lived (~4h) — re-run `dev-token` when it expires. Mint with a **full-scope
+personal API key** for real generation; an OAuth login mints a read-only token
+(the command warns you at mint time). With no token, `dev:live` **fails safe**
+(renders a notice, never spends). Live v1 covers the money path
+(`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set, App-Storage KV,
+and in-band Buzz purchase are mock-only.
 
 **Under the hood (the scaffold wires this — you don't configure it):** `dev:live`
 routes the live host's backend calls through the **vite dev proxy**


### PR DESCRIPTION
A blind discoverability audit (new external dev starting from the CLI README) surfaced two gaps. Both fixes are **docs-only** (no code changes; build green, existing tests pass). Kept in one PR since both touch the README and are closely related.

## 1. Add a prominent "SDK packages" section

The two runtime packages a block imports were under-linked:
- `@civitai/app-sdk` was **never linked to npm** (plain text only, inside the `page-money` bullet).
- `@civitai/blocks-react`'s only npm link was buried mid-"Local dev loop" under the anchor `@civitai/blocks-react/testing`.
- No single place listed both with npm URLs.

Adds a `## SDK packages` section between Quickstart and Command reference: a two-row table linking **both** packages to npm, the explicit `pnpm add` line, and a pointer to the guide. (The npm READMEs themselves are excellent — the gap was purely *getting there*.)

## 2. Document `civitai app dev-token`

The `dev-token` command (added in #43, refined in #46/#48/#49/#61) is fully implemented, registered, and tested — but the README never documented it. The "Local dev loop" section still told users to mint the live-mode token by hand via `POST /api/v1/blocks/dev-token` with no instructions, so the trail went cold at the exact step that turns a mock app into a real `dev:live` run.

- Adds a `civitai app dev-token <slug> [--env]` row to the Command reference.
- Rewrites the "Live mode needs a token" paragraph to lead with the command + a copy-paste example (`civitai app dev-token my-block --env >> .env.development.local`), keeping the API path as an under-the-hood detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)