### PR TITLE
docs(readme): lead Install with Homebrew/binary, demote go install (F6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ contract, and **packages/submits** it for review.
 
 ## Install
 
-### Go install (Go 1.25+)
+Pick whichever fits — Homebrew is the quickest on macOS/Linux; the prebuilt
+binary needs no toolchain; `go install` builds from source.
+
+### Homebrew (macOS / Linux)
 
 ```bash
-go install github.com/civitai/cli/cmd/civitai@latest
-# installs the `civitai` binary into $(go env GOPATH)/bin
+brew install civitai/tap/civitai
 ```
 
 ### Prebuilt binary
@@ -45,10 +47,11 @@ sudo mv civitai /usr/local/bin/
 civitai version
 ```
 
-### Homebrew
+### Go install (from source, Go 1.25+)
 
 ```bash
-brew install civitai/tap/civitai
+go install github.com/civitai/cli/cmd/civitai@latest
+# installs the `civitai` binary into $(go env GOPATH)/bin
 ```
 
 ## Quickstart


### PR DESCRIPTION
From the App Blocks discoverability audit (F6). Docs-only.

`go install` was listed first and requires **Go 1.25+** — a bleeding-edge toolchain most web devs building App Blocks won't have, so the default-read install path failed for them.

Reorders the Install section to **Homebrew → prebuilt binary → go install (from source)**, with a one-line "pick whichever fits" intro. Content unchanged. (The Homebrew tap is live — goreleaser-published since 2026-06-24.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)