### PR TITLE
ci: drift-check vendored schema against the published canonical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,17 @@ jobs:
       - name: build
         run: go build ./...
 
+  # Drift-guard: the vendored block-manifest schema (go:embed'd for offline
+  # `civitai app validate`) must stay identical to the canonical the platform
+  # publishes at civitai.com/schemas/app-block/v1.json (the single source of
+  # truth). Fails if a server-side contract change leaves the CLI stale.
+  schema-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: check canonical schema
+        run: ./scripts/check-canonical-schema.sh
+
   # Rot-guard: scaffold the page-money template and run its JS toolchain against
   # the PUBLISHED SDK (@civitai/blocks-react). Catches a template that renders
   # but no longer installs / typechecks / tests / builds after an SDK bump — the

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://civitai.com/schemas/app-block/v1.json",
   "title": "Civitai App Block Manifest",
-  "description": "Schema for block.manifest.json — the ONLY mandatory file in a Civitai App Block. Derived from the server-side validator (src/server/services/block-manifest-validator.service.ts). This is the shared contract between the `civitai` CLI and the platform; it is intended to be published server-side so both sides validate against one source of truth.",
+  "description": "THE canonical, server-published schema for block.manifest.json — the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
   "type": "object",
   "required": ["blockId", "version", "name", "contentRating", "scopes"],
   "properties": {
@@ -183,7 +183,7 @@
   },
   "allOf": [
     {
-      "$comment": "outputDir is required whenever buildCommand is set. NOTE: the server-owned iframe.src and trustTier fields are rejected by the CLI in Go (clearer error messages than JSON Schema's `not`); they are declared in `properties` above only so the schema documents them.",
+      "$comment": "outputDir is required whenever buildCommand is set. NOTE: the server-owned iframe.src and trustTier fields are rejected by the platform validator (and the CLI in Go) with clearer error messages than JSON Schema's `not`; they are declared in `properties` above only so the schema documents them.",
       "if": {
         "required": ["buildCommand"]
       },

--- a/scripts/check-canonical-schema.sh
+++ b/scripts/check-canonical-schema.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Drift-check: the vendored block-manifest schema must match the canonical one
+# published by the platform at https://civitai.com/schemas/app-block/v1.json.
+#
+# The CLI go:embeds schema/app-block.manifest.schema.json for offline `civitai
+# app validate`. That copy is a vendored mirror of the single source of truth
+# (the platform validator publishes the canonical schema at the URL above). This
+# script fails CI if the two drift apart, so a server-side contract change can't
+# silently leave the CLI validating against stale rules.
+#
+# Comparison is normalized (jq -S) so insignificant key-ordering/whitespace
+# differences don't cause false failures; any real content difference does.
+set -euo pipefail
+
+CANONICAL_URL="${CANONICAL_URL:-https://civitai.com/schemas/app-block/v1.json}"
+VENDORED="$(cd "$(dirname "$0")/.." && pwd)/schema/app-block.manifest.schema.json"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+code="$(curl -fsS -o "$tmp" -w '%{http_code}' "$CANONICAL_URL" || true)"
+if [ "$code" != "200" ]; then
+  echo "FAIL: could not fetch canonical schema from $CANONICAL_URL (HTTP ${code:-000})" >&2
+  exit 1
+fi
+if ! jq empty "$tmp" >/dev/null 2>&1; then
+  echo "FAIL: canonical schema at $CANONICAL_URL is not valid JSON" >&2
+  exit 1
+fi
+
+if diff <(jq -S . "$VENDORED") <(jq -S . "$tmp"); then
+  echo "OK: vendored schema matches the canonical at $CANONICAL_URL"
+else
+  echo "" >&2
+  echo "FAIL: schema/app-block.manifest.schema.json has DRIFTED from the canonical." >&2
+  echo "  Resync with: curl -s $CANONICAL_URL -o schema/app-block.manifest.schema.json" >&2
+  echo "  (and update internal/validate/ if the rule changes require it)." >&2
+  exit 1
+fi


### PR DESCRIPTION
Completes path A for the CLI side. The platform now publishes the canonical block-manifest schema at **https://civitai.com/schemas/app-block/v1.json** (live, via civitai/civitai#2808). This wires the CLI's vendored copy to it.

- **Sync** `schema/app-block.manifest.schema.json` to the canonical — byte-identical now (sha256 `054a2e3b…`, same as the server's published file and the SDK's vendored copy). Only the description/`$comment` prose differed; the rules were already identical.
- **`scripts/check-canonical-schema.sh`** — fetches the canonical and fails on any normalized (`jq -S`) diff vs the vendored copy (non-200 also fails).
- **`schema-drift` CI job** runs it, so a future server-side contract change can't silently leave the CLI validating against stale rules.

Verified: `go build ./...` + `go test ./...` pass; the drift-check passes locally (`OK: vendored schema matches the canonical`).

Part of the cross-repo single-sourcing: civitai/civitai#2808 (server validator + publish, merged) · civitai-app-starters#108 (SDK align + drift-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)