### PR TITLE
fix(cli): login single-URL, dev:live slug-collision auto-rename, +coverage

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -628,6 +628,16 @@ func (c *Client) WithdrawRequest(ctx context.Context, publishRequestID string) e
 	return nil
 }
 
+// ErrSlugRegisteredToOtherAccount is wrapped by MintDevToken's error when the
+// dev-token route 404s with the bare "App not found" — the server's anti-shadow
+// guard: the requested slug is an APPROVED app owned by a DIFFERENT account, so
+// the no-row local-manifest mint path is refused. It is the ONLY rename-retriable
+// 404 (the caller can pick a new, free slug and retry). Other 404s (e.g. an
+// owned-but-not-yet-deployed app, which carries a "no live deployment" message)
+// are NOT retriable and do NOT wrap this sentinel. Callers branch with
+// errors.Is(err, ErrSlugRegisteredToOtherAccount) rather than matching strings.
+var ErrSlugRegisteredToOtherAccount = errors.New("slug is registered to a different account")
+
 // DevTokenMinter mints a short-lived dev block token for `npm run dev:live`.
 type DevTokenMinter interface {
 	// MintDevToken mints a dev block token for the given app slug and returns
@@ -693,7 +703,15 @@ func devTokenError(status int, raw []byte) error {
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusNotFound:
-		return fmt.Errorf("app not found (404): %s — check the slug. (dev-token mints from your local block.manifest.json; a 404 means the slug is registered to a different account.)", msg)
+		// Two 404 shapes: the anti-shadow guard returns a bare "App not found"
+		// when the slug is an approved app owned by another account (the no-row
+		// mint is refused) — that one is rename-retriable, so wrap the sentinel.
+		// The owned-but-not-yet-deployed 404 carries a "no live deployment"
+		// message and is NOT retriable (you own the slug; renaming is wrong).
+		if strings.Contains(strings.ToLower(msg), "no live deployment") {
+			return fmt.Errorf("app not found (404): %s", msg)
+		}
+		return fmt.Errorf("app not found (404): %s — check the slug. (dev-token mints from your local block.manifest.json; a 404 means the slug is registered to a different account.): %w", msg, ErrSlugRegisteredToOtherAccount)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,37 @@ import (
 	"strings"
 	"testing"
 )
+
+// TestMintDevToken404SentinelWrapping: the bare "App not found" 404 wraps
+// ErrSlugRegisteredToOtherAccount (rename-retriable); the owned-but-undeployed
+// "no live deployment" 404 does NOT.
+func TestMintDevToken404SentinelWrapping(t *testing.T) {
+	cases := []struct {
+		name        string
+		message     string
+		wantWrapped bool
+	}{
+		{"bare app-not-found is the collision", "App not found", true},
+		{"generic 404 is treated as a collision", "no such app", true},
+		{"no-live-deployment is NOT a collision", "block 'x' has no live deployment — deploy first", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": tc.message})
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
+			if err == nil {
+				t.Fatal("expected a 404 error")
+			}
+			if got := errors.Is(err, ErrSlugRegisteredToOtherAccount); got != tc.wantWrapped {
+				t.Errorf("errors.Is(err, sentinel) = %v, want %v (err=%q)", got, tc.wantWrapped, err)
+			}
+		})
+	}
+}
 
 func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
 	var gotAuth, gotMethod, gotPath, gotCT, gotSlug string

--- a/internal/api/oauth_msg_test.go
+++ b/internal/api/oauth_msg_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOAuthMsg(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"error+description", `{"error":"invalid_grant","error_description":"bad code"}`, "invalid_grant: bad code"},
+		{"error only", `{"error":"slow_down"}`, "slow_down"},
+		{"non-json falls back to trimmed body", "  boom  ", "boom"},
+		{"json without error field falls back", `{"foo":1}`, `{"foo":1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := oauthMsg([]byte(tc.raw)); got != tc.want {
+				t.Errorf("oauthMsg(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeviceFlowErrorMessage(t *testing.T) {
+	cases := []struct {
+		err  *DeviceFlowError
+		want string
+	}{
+		{&DeviceFlowError{Code: "access_denied", Description: "user said no"}, "user said no"},
+		{&DeviceFlowError{Code: "expired_token"}, "expired"},
+		{&DeviceFlowError{Code: "access_denied"}, "denied"},
+		{&DeviceFlowError{Code: "weird_thing"}, "weird_thing"},
+	}
+	for _, tc := range cases {
+		if got := tc.err.Error(); !strings.Contains(got, tc.want) {
+			t.Errorf("DeviceFlowError{%q,%q}.Error() = %q, want contains %q",
+				tc.err.Code, tc.err.Description, got, tc.want)
+		}
+	}
+}

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -4,15 +4,27 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/internal/manifest"
+	"github.com/civitai/cli/internal/scaffold"
 	"github.com/spf13/cobra"
 )
+
+// maxDevTokenRenameAttempts bounds the auto-rename-on-collision retry loop: after
+// this many generated alternatives still collide, dev-token gives up.
+const maxDevTokenRenameAttempts = 5
+
+// devTokenSuffixGen generates the random lowercase-alphanumeric suffix appended
+// to a colliding slug. It is a package var so tests can inject a deterministic
+// sequence.
+var devTokenSuffixGen = func() string { return scaffold.RandomSuffix(5) }
 
 // budgetedScope is the spend scope a dev token must carry for `npm run dev:live`
 // to actually generate (spend Buzz). The server strips it from an OAuth-minted
@@ -140,7 +152,8 @@ never commit it; re-mint when it expires.`,
 			scopes := manifest.LoadScopes(".")
 
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
-			token, err := client.MintDevToken(context.Background(), slug, scopes)
+			errOut := cmd.ErrOrStderr()
+			token, slug, err := mintDevTokenWithRename(context.Background(), client, errOut, ".", slug, scopes)
 			if err != nil {
 				return err
 			}
@@ -153,7 +166,6 @@ never commit it; re-mint when it expires.`,
 			} else {
 				fmt.Fprintln(out, token)
 			}
-			errOut := cmd.ErrOrStderr()
 			fmt.Fprintln(errOut,
 				"Paste into VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart `npm run dev:live`. "+
 					"Short-lived (~4h); never commit it.")
@@ -177,4 +189,47 @@ never commit it; re-mint when it expires.`,
 	}
 	cmd.Flags().BoolVar(&envOut, "env", false, "print VITE_LIVE_BLOCK_TOKEN=<token> (paste-ready into .env.development.local)")
 	return cmd
+}
+
+// mintDevTokenWithRename mints a dev token for slug, and on the anti-shadow
+// collision (api.ErrSlugRegisteredToOtherAccount — the slug is an approved app
+// owned by another account) it appends a random suffix to the ORIGINAL slug,
+// PERMANENTLY rewrites block.manifest.json's blockId, notifies on errOut, and
+// retries — up to maxDevTokenRenameAttempts. It returns the token and the FINAL
+// slug used (so callers reference the renamed slug in follow-up hints).
+//
+// Renaming only applies when a local manifest exists in dir (nothing to rewrite
+// otherwise); any non-collision error, or a collision with no manifest, is
+// surfaced verbatim without a rename.
+func mintDevTokenWithRename(ctx context.Context, client *api.Client, errOut io.Writer, dir, slug string, scopes []string) (string, string, error) {
+	original := slug
+	for attempt := 0; ; attempt++ {
+		token, err := client.MintDevToken(ctx, slug, scopes)
+		if err == nil {
+			return token, slug, nil
+		}
+		if !errors.Is(err, api.ErrSlugRegisteredToOtherAccount) {
+			return "", slug, err
+		}
+		// Auto-rename only makes sense when there's a local manifest to rewrite.
+		if _, lerr := manifest.Load(dir); lerr != nil {
+			return "", slug, err
+		}
+		if attempt >= maxDevTokenRenameAttempts {
+			return "", slug, fmt.Errorf(
+				"slug %q and %d generated alternatives are all registered to other accounts — choose a different blockId in %s",
+				original, maxDevTokenRenameAttempts, manifest.Filename)
+		}
+		newSlug, gerr := scaffold.SuffixSlug(original, devTokenSuffixGen())
+		if gerr != nil {
+			return "", slug, fmt.Errorf("could not generate an alternative slug for %q: %w", original, gerr)
+		}
+		if serr := manifest.SetBlockID(dir, newSlug); serr != nil {
+			return "", slug, fmt.Errorf("could not update %s with the renamed slug %q: %w", manifest.Filename, newSlug, serr)
+		}
+		fmt.Fprintf(errOut,
+			"Slug %q is registered to another account — renamed to %q for your app (%s updated).\n",
+			slug, newSlug, manifest.Filename)
+		slug = newSlug
+	}
 }

--- a/internal/cmd/app_dev_token_rename_test.go
+++ b/internal/cmd/app_dev_token_rename_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// devTokenRenameServer emulates POST /api/v1/blocks/dev-token: it 404s (bare
+// "App not found" — the anti-shadow collision) for any request whose slug is in
+// collide, and 200s with a token otherwise. It also answers GET .../me for the
+// read-only warning path. reqs counts mint calls.
+func devTokenRenameServer(t *testing.T, collide map[string]bool, reqs *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/me") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"username": "u", "id": 1, "tokenScope": 0})
+			return
+		}
+		atomic.AddInt32(reqs, 1)
+		var body struct {
+			Slug string `json:"slug"`
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		if collide[body.Slug] {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "App not found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "jwt-x"})
+	}))
+}
+
+func readBlockID(t *testing.T, dir string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "block.manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m struct {
+		BlockID string `json:"blockId"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	return m.BlockID
+}
+
+// TestAppDevTokenRenamesOnCollisionAndRetries: on the anti-shadow 404 the command
+// appends a random suffix (deterministic here), rewrites block.manifest.json's
+// blockId, prints a notice, retries, and succeeds on the free slug.
+func TestAppDevTokenRenamesOnCollisionAndRetries(t *testing.T) {
+	var reqs int32
+	srv := devTokenRenameServer(t, map[string]bool{"my-block": true}, &reqs)
+	defer srv.Close()
+
+	prev := devTokenSuffixGen
+	devTokenSuffixGen = func() string { return "abc12" }
+	defer func() { devTokenSuffixGen = prev }()
+
+	dir := t.TempDir()
+	writeDevTokenManifest(t, dir, `{
+  "blockId": "my-block",
+  "version": "0.1.0",
+  "name": "My Block",
+  "scopes": ["identity:read"]
+}`)
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "dev-token", "my-block")
+	if err != nil {
+		t.Fatalf("app dev-token: %v\n%s", err, errOut)
+	}
+	if strings.TrimSpace(out) != "jwt-x" {
+		t.Errorf("stdout should be the token after retry, got %q", out)
+	}
+	if reqs != 2 {
+		t.Errorf("expected 2 mint calls (collision + retry), got %d", reqs)
+	}
+	// The manifest on disk now carries the renamed slug.
+	if got := readBlockID(t, dir); got != "my-block-abc12" {
+		t.Errorf("manifest blockId = %q, want my-block-abc12", got)
+	}
+	// Other fields survive the rewrite.
+	raw, _ := os.ReadFile(filepath.Join(dir, "block.manifest.json"))
+	if !strings.Contains(string(raw), `"name": "My Block"`) || !strings.Contains(string(raw), `"identity:read"`) {
+		t.Errorf("rewrite should preserve other fields:\n%s", raw)
+	}
+	// The rename notice goes to stderr.
+	if !strings.Contains(errOut, `Slug "my-block" is registered to another account`) ||
+		!strings.Contains(errOut, `renamed to "my-block-abc12"`) {
+		t.Errorf("expected a rename notice on stderr:\n%s", errOut)
+	}
+}
+
+// TestAppDevTokenRenameIsBounded: when every generated alternative also collides,
+// the retry loop gives up after maxDevTokenRenameAttempts with a clear message.
+func TestAppDevTokenRenameIsBounded(t *testing.T) {
+	var reqs int32
+	// Collide on EVERY slug (the map lookup below always returns true).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&reqs, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "App not found"})
+	}))
+	defer srv.Close()
+
+	var n int32
+	prev := devTokenSuffixGen
+	devTokenSuffixGen = func() string { n++; return "s" + string(rune('a'+n)) } // sb, sc, ...
+	defer func() { devTokenSuffixGen = prev }()
+
+	dir := t.TempDir()
+	writeDevTokenManifest(t, dir, `{"blockId":"my-block","version":"0.1.0","name":"My Block"}`)
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected a give-up error when every alternative collides")
+	}
+	if !strings.Contains(err.Error(), "all registered to other accounts") {
+		t.Errorf("give-up error should be actionable: %v", err)
+	}
+	// original attempt + maxDevTokenRenameAttempts renamed attempts.
+	if want := int32(1 + maxDevTokenRenameAttempts); reqs != want {
+		t.Errorf("expected %d mint calls, got %d", want, reqs)
+	}
+}
+
+// TestAppDevTokenNonCollision404DoesNotRename: a 404 that is NOT the anti-shadow
+// collision (e.g. an owned-but-undeployed app: "no live deployment") must surface
+// the raw error WITHOUT renaming the manifest.
+func TestAppDevTokenNonCollision404DoesNotRename(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "block 'my-block' has no live deployment — dev:live requires an approved + deployed version",
+		})
+	}))
+	defer srv.Close()
+
+	prev := devTokenSuffixGen
+	devTokenSuffixGen = func() string { t.Fatal("suffix generator must not be called for a non-collision 404"); return "" }
+	defer func() { devTokenSuffixGen = prev }()
+
+	dir := t.TempDir()
+	writeDevTokenManifest(t, dir, `{"blockId":"my-block","version":"0.1.0","name":"My Block"}`)
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected the raw 404 error")
+	}
+	if !strings.Contains(err.Error(), "no live deployment") {
+		t.Errorf("non-collision 404 should surface verbatim: %v", err)
+	}
+	// The manifest must be untouched.
+	if got := readBlockID(t, dir); got != "my-block" {
+		t.Errorf("manifest blockId changed to %q; a non-collision 404 must not rename", got)
+	}
+}
+
+// TestAppDevTokenCollisionNoManifestSurfacesError: without a local manifest to
+// rewrite, the collision 404 is surfaced verbatim (nothing to rename).
+func TestAppDevTokenCollisionNoManifestSurfacesError(t *testing.T) {
+	var reqs int32
+	srv := devTokenRenameServer(t, map[string]bool{"my-block": true}, &reqs)
+	defer srv.Close()
+
+	chdir(t, t.TempDir()) // empty dir, no manifest
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected the collision 404 error")
+	}
+	if !strings.Contains(err.Error(), "registered to a different account") {
+		t.Errorf("collision error should surface: %v", err)
+	}
+	if reqs != 1 {
+		t.Errorf("expected exactly 1 mint call with no manifest to rename, got %d", reqs)
+	}
+}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -93,18 +93,24 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 		return err
 	}
 
-	// Tell the user what to do. Never print the device_code (secret).
-	renderDeviceInstructions(out, da, cfg.BaseURL())
-
+	// Primary action: auto-open the code-prefilled URL. Only when that FAILS (or
+	// --no-browser / no complete URL) do we print the full manual instructions.
+	// Never print the device_code (secret).
+	opened := false
 	if !noBrowser && da.VerificationURIComplete != "" {
-		if err := openBrowser(da.VerificationURIComplete); err == nil {
-			fmt.Fprintln(out, "Opened your browser. Waiting for approval...")
-		} else {
-			fmt.Fprintln(out, "Waiting for approval...")
+		if err := browserOpener(da.VerificationURIComplete); err == nil {
+			opened = true
 		}
-	} else {
-		fmt.Fprintln(out, "Waiting for approval...")
 	}
+	if opened {
+		// The browser is already open on the prefilled URL — print a single
+		// "or open ..." fallback (the BARE url + the code, not the complete URL).
+		fmt.Fprintf(out, "Opened your browser to approve. Or open %s and enter code %s\n",
+			deviceVerificationURI(da, cfg.BaseURL()), da.UserCode)
+	} else {
+		renderDeviceInstructions(out, da, cfg.BaseURL())
+	}
+	fmt.Fprintln(out, "Waiting for approval...")
 
 	tr, err := oc.PollToken(ctx, da, nil)
 	if err != nil {
@@ -120,26 +126,33 @@ func loginWithDevice(cmd *cobra.Command, cfg *config.Config, noBrowser bool) err
 	return nil
 }
 
-// renderDeviceInstructions prints the device-flow instructions to out. When the
-// server supplies verification_uri_complete (the code pre-filled in the URL) it
-// is printed as the PRIMARY, copyable link so a user who pastes it gets the code
-// prefilled (matters for --no-browser / headless / when openBrowser fails), with
-// the bare URL + code kept as a clearly-labeled manual fallback. When it's empty
-// it falls back to the bare URL + Code form. Never prints the device_code (secret).
-func renderDeviceInstructions(out io.Writer, da *api.DeviceAuth, baseURL string) {
-	uri := da.VerificationURI
-	if uri == "" {
-		uri = baseURL + "/login/oauth/device"
+// deviceVerificationURI returns the BARE verification URI (no code prefilled),
+// falling back to the base URL's device path when the server omits it.
+func deviceVerificationURI(da *api.DeviceAuth, baseURL string) string {
+	if da.VerificationURI != "" {
+		return da.VerificationURI
 	}
+	return baseURL + "/login/oauth/device"
+}
+
+// renderDeviceInstructions prints the MANUAL device-flow instructions used when
+// the browser was not opened (--no-browser, headless, or openBrowser failed). It
+// prints a SINGLE actionable form — the code-prefilled complete URL when the
+// server supplies one, otherwise the bare URL + code — rather than both URLs up
+// front. Never prints the device_code (secret).
+func renderDeviceInstructions(out io.Writer, da *api.DeviceAuth, baseURL string) {
 	if da.VerificationURIComplete != "" {
 		fmt.Fprintln(out, "To authenticate, open this URL (your code is pre-filled):")
 		fmt.Fprintf(out, "\n  %s\n\n", da.VerificationURIComplete)
-		fmt.Fprintf(out, "Or open %s and enter the code manually:  %s\n\n", uri, da.UserCode)
 		return
 	}
 	fmt.Fprintln(out, "To authenticate, open this URL in your browser and enter the code:")
-	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", uri, da.UserCode)
+	fmt.Fprintf(out, "\n  URL:  %s\n  Code: %s\n\n", deviceVerificationURI(da, baseURL), da.UserCode)
 }
+
+// browserOpener opens a URL in the default browser. It is a package var so tests
+// can simulate open success/failure without spawning a real browser.
+var browserOpener = openBrowser
 
 // openBrowser best-effort opens url in the default browser. A failure is
 // non-fatal (the user can use the printed URL).

--- a/internal/cmd/login_device_test.go
+++ b/internal/cmd/login_device_test.go
@@ -169,6 +169,124 @@ func TestLoginTokenFlagStillWorks(t *testing.T) {
 	}
 }
 
+// loginDeviceServer stands up an httptest server for the device flow: discovery,
+// device-init (with a code-prefilled complete URL), and an immediate 200 token.
+func loginDeviceServer(t *testing.T) (*httptest.Server, *string) {
+	t.Helper()
+	var base string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeLoginDiscovery(w, base)
+		case "/api/auth/oauth/device":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":               "dev-secret-code",
+				"user_code":                 "ABCD-1234",
+				"verification_uri":          "https://civitai.com/oauth/device",
+				"verification_uri_complete": "https://civitai.com/oauth/device?user_code=ABCD-1234",
+				"expires_in":                900,
+				"interval":                  1,
+			})
+		case "/api/auth/oauth/device-token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-123", "token_type": "Bearer",
+				"expires_in": 3600, "refresh_token": "refresh-456", "scope": "33554433",
+			})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	return srv, &base
+}
+
+// TestLoginDeviceOpensBrowserAndPrintsSingleFallback: with browser-open enabled
+// and SUCCEEDING, the primary action is the auto-open and the output carries a
+// SINGLE "or open ..." fallback (bare URL + code) — NOT the code-prefilled
+// complete URL again, and never the device_code.
+func TestLoginDeviceOpensBrowserAndPrintsSingleFallback(t *testing.T) {
+	srv, base := loginDeviceServer(t)
+	defer srv.Close()
+	*base = srv.URL
+
+	var openedURL string
+	prev := browserOpener
+	browserOpener = func(u string) error { openedURL = u; return nil }
+	defer func() { browserOpener = prev }()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "login") // browser-open ENABLED
+	if err != nil {
+		t.Fatalf("login: %v\n%s", err, out)
+	}
+
+	// The browser was auto-opened on the code-prefilled complete URL.
+	if openedURL != "https://civitai.com/oauth/device?user_code=ABCD-1234" {
+		t.Errorf("browser should open the complete URL, opened %q", openedURL)
+	}
+	if !strings.Contains(out, "Opened your browser to approve.") {
+		t.Errorf("expected the opened-browser primary line:\n%s", out)
+	}
+	// Single "or open ..." fallback: the BARE url + the code shown separately.
+	if !strings.Contains(out, "Or open https://civitai.com/oauth/device and enter code ABCD-1234") {
+		t.Errorf("expected the single bare-URL fallback line:\n%s", out)
+	}
+	// The complete (code-prefilled) URL must NOT be printed again in the happy path.
+	if strings.Contains(out, "?user_code=") {
+		t.Errorf("happy path must not reprint the code-prefilled complete URL:\n%s", out)
+	}
+	// The old both-URLs manual block must be gone.
+	if strings.Contains(out, "URL:  ") {
+		t.Errorf("happy path must not print the manual URL:/Code: block:\n%s", out)
+	}
+	if strings.Contains(out, "dev-secret-code") {
+		t.Errorf("device_code (secret) must never be printed:\n%s", out)
+	}
+	if !strings.Contains(out, "Logged in") {
+		t.Errorf("login should confirm success:\n%s", out)
+	}
+}
+
+// TestLoginDeviceBrowserOpenFailureFallsBack: when browser-open FAILS, the flow
+// falls back to the full manual instructions (the complete URL to open) and does
+// NOT claim it opened a browser. The device_code is never printed.
+func TestLoginDeviceBrowserOpenFailureFallsBack(t *testing.T) {
+	srv, base := loginDeviceServer(t)
+	defer srv.Close()
+	*base = srv.URL
+
+	prev := browserOpener
+	browserOpener = func(string) error { return errStub }
+	defer func() { browserOpener = prev }()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, _, err := run(t, "login") // browser-open ENABLED but fails
+	if err != nil {
+		t.Fatalf("login: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "Opened your browser") {
+		t.Errorf("must not claim it opened a browser when open failed:\n%s", out)
+	}
+	if !strings.Contains(out, "your code is pre-filled") || !strings.Contains(out, "?user_code=ABCD-1234") {
+		t.Errorf("expected the manual complete-URL instructions on open failure:\n%s", out)
+	}
+	if strings.Contains(out, "dev-secret-code") {
+		t.Errorf("device_code (secret) must never be printed:\n%s", out)
+	}
+}
+
+// errStub is a fixed non-nil error for simulating browser-open failure.
+var errStub = stubErr("open failed")
+
+type stubErr string
+
+func (e stubErr) Error() string { return string(e) }
+
 // writeLoginDiscovery serves an OpenID discovery doc whose endpoints point back
 // at the test server `base`, mirroring how the real auth host advertises its
 // OAuth endpoints. The CLI resolves these before the device-init POST.

--- a/internal/cmd/login_render_test.go
+++ b/internal/cmd/login_render_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/civitai/cli/internal/api"
 )
 
-// TestRenderDeviceInstructionsComplete: when the server supplies
-// verification_uri_complete, the printed output uses it as the PRIMARY copyable
-// (code pre-filled) link, and still surfaces the bare URL + user_code as a
-// manual fallback. The device_code (secret) is never printed.
+// TestRenderDeviceInstructionsComplete: renderDeviceInstructions is the MANUAL
+// fallback (browser not opened). When the server supplies
+// verification_uri_complete it prints a SINGLE actionable form — the
+// code-prefilled complete URL — and does NOT also print the bare URL:/Code:
+// form. The device_code (secret) is never printed.
 func TestRenderDeviceInstructionsComplete(t *testing.T) {
 	da := &api.DeviceAuth{
 		DeviceCode:              "dev-secret-code",
@@ -26,14 +27,9 @@ func TestRenderDeviceInstructionsComplete(t *testing.T) {
 	if !strings.Contains(out, da.VerificationURIComplete) {
 		t.Errorf("expected the code-prefilled complete URL %q in output:\n%s", da.VerificationURIComplete, out)
 	}
-	if !strings.Contains(out, "?code=") {
-		t.Errorf("expected a ?code= prefilled link in output:\n%s", out)
-	}
-	if !strings.Contains(out, da.VerificationURI) {
-		t.Errorf("expected the bare verification_uri %q as manual fallback:\n%s", da.VerificationURI, out)
-	}
-	if !strings.Contains(out, da.UserCode) {
-		t.Errorf("expected the user_code %q for manual entry:\n%s", da.UserCode, out)
+	// The old "both URLs" form is gone: no separate bare URL:/Code: manual block.
+	if strings.Contains(out, "URL:  ") || strings.Contains(out, "Code: ") {
+		t.Errorf("did not expect the bare URL:/Code: block when a complete URL is present:\n%s", out)
 	}
 	if strings.Contains(out, da.DeviceCode) {
 		t.Errorf("device_code (secret) must NEVER be printed:\n%s", out)
@@ -78,5 +74,15 @@ func TestRenderDeviceInstructionsEmptyURIFallback(t *testing.T) {
 
 	if !strings.Contains(out, "https://civitai.com/login/oauth/device") {
 		t.Errorf("expected baseURL-derived device path fallback:\n%s", out)
+	}
+}
+
+// TestDeviceVerificationURIFallback covers the bare-URI helper's baseURL fallback.
+func TestDeviceVerificationURIFallback(t *testing.T) {
+	if got := deviceVerificationURI(&api.DeviceAuth{VerificationURI: "https://x/y"}, "https://b"); got != "https://x/y" {
+		t.Errorf("expected the server-supplied URI, got %q", got)
+	}
+	if got := deviceVerificationURI(&api.DeviceAuth{}, "https://b"); got != "https://b/login/oauth/device" {
+		t.Errorf("expected baseURL fallback, got %q", got)
 	}
 }

--- a/internal/cmd/spawn_unix_test.go
+++ b/internal/cmd/spawn_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestDetachAndStartTrivial fire-and-forgets a trivial command (`true`, which
+// exits immediately) and asserts Start() succeeded. The child is a harmless
+// no-op that reaps itself; we never Wait on it.
+func TestDetachAndStartTrivial(t *testing.T) {
+	path, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("no `true` binary available")
+	}
+	if err := detachAndStart(exec.Command(path)); err != nil {
+		t.Fatalf("detachAndStart(true): %v", err)
+	}
+}
+
+// TestDetachAndStartMissingBinary surfaces the fork/exec failure for a
+// nonexistent binary.
+func TestDetachAndStartMissingBinary(t *testing.T) {
+	if err := detachAndStart(exec.Command("/nonexistent/civitai-does-not-exist")); err == nil {
+		t.Fatal("expected an error starting a nonexistent binary")
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -7,7 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 )
+
+// blockIDField matches the top-level `"blockId": "<value>"` pair. Slug values
+// never contain a double-quote, so `[^"]*` captures the value exactly. Group 1 is
+// the key + separator prefix, preserved verbatim on rewrite.
+var blockIDField = regexp.MustCompile(`("blockId"\s*:\s*)"[^"]*"`)
 
 // Filename is the one mandatory file in an App Block, at the project root.
 // The server matches this exact path inside the ZIP (no nesting).
@@ -61,6 +68,78 @@ func Load(dir string) (*Manifest, error) {
 		return nil, fmt.Errorf("%s is not valid JSON: %w", Filename, err)
 	}
 	return &m, nil
+}
+
+// SetBlockID rewrites the manifest's `blockId` field in place, preserving every
+// other field, its ordering, and the file's formatting (it edits only the
+// blockId value in the raw bytes). It validates that the result still parses as
+// JSON before writing, and writes atomically (temp file + rename) preserving the
+// original file mode, so a failure never clobbers the existing manifest. Used by
+// `civitai app dev-token` to auto-rename a slug that collides with another
+// account's app.
+func SetBlockID(dir, newBlockID string) error {
+	p := Path(dir)
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no %s found in %s — is this an App Block project?", Filename, dir)
+		}
+		return err
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return err
+	}
+	if _, err := json.Marshal(newBlockID); err != nil { // defensive; string always marshals
+		return err
+	}
+
+	loc := blockIDField.FindSubmatchIndex(raw)
+	var updated []byte
+	if loc != nil {
+		// loc[2]:loc[3] is group 1 (the `"blockId": ` prefix); loc[1] is the end
+		// of the whole match (just past the closing quote of the old value).
+		updated = make([]byte, 0, len(raw)+len(newBlockID))
+		updated = append(updated, raw[:loc[3]]...)
+		updated = append(updated, []byte(strconv.Quote(newBlockID))...)
+		updated = append(updated, raw[loc[1]:]...)
+	} else {
+		// No blockId key present: fall back to a structural rewrite (order not
+		// preserved, but the file is re-emitted as valid indented JSON).
+		var generic map[string]any
+		if err := json.Unmarshal(raw, &generic); err != nil {
+			return fmt.Errorf("%s is not valid JSON: %w", Filename, err)
+		}
+		generic["blockId"] = newBlockID
+		b, err := json.MarshalIndent(generic, "", "  ")
+		if err != nil {
+			return err
+		}
+		updated = append(b, '\n')
+	}
+
+	// Never write something that no longer parses.
+	if !json.Valid(updated) {
+		return fmt.Errorf("refusing to write %s: result is not valid JSON after setting blockId=%q", Filename, newBlockID)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".block.manifest.*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(updated); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, info.Mode().Perm()); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, p)
 }
 
 // LoadRaw reads the manifest and returns the decoded generic value (for schema

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -117,6 +117,94 @@ func TestLoadScopes(t *testing.T) {
 	}
 }
 
+func TestSetBlockIDPreservesOrderAndFields(t *testing.T) {
+	dir := t.TempDir()
+	src := `{
+  "blockId": "my-block",
+  "version": "0.1.0",
+  "name": "My Block",
+  "scopes": ["identity:read"]
+}`
+	write(t, dir, src)
+	if err := SetBlockID(dir, "my-block-abc12"); err != nil {
+		t.Fatalf("SetBlockID: %v", err)
+	}
+	raw, _ := os.ReadFile(Path(dir))
+	out := string(raw)
+	if !contains(out, `"blockId": "my-block-abc12"`) {
+		t.Errorf("blockId not updated:\n%s", out)
+	}
+	// Other fields + their order preserved (surgical value replace).
+	if !contains(out, `"name": "My Block"`) || !contains(out, `"identity:read"`) {
+		t.Errorf("other fields not preserved:\n%s", out)
+	}
+	if indexOf(out, "blockId") >= indexOf(out, "version") {
+		t.Errorf("field order not preserved:\n%s", out)
+	}
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if m.BlockID != "my-block-abc12" {
+		t.Errorf("reloaded blockId = %q", m.BlockID)
+	}
+	// Mode preserved at 0600.
+	info, _ := os.Stat(Path(dir))
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %o, want 600", perm)
+	}
+}
+
+func TestSetBlockIDMissingKeyFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, `{"version":"0.1.0","name":"X"}`)
+	if err := SetBlockID(dir, "new-slug"); err != nil {
+		t.Fatalf("SetBlockID (no key): %v", err)
+	}
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if m.BlockID != "new-slug" {
+		t.Errorf("blockId = %q, want new-slug", m.BlockID)
+	}
+	if m.Name != "X" {
+		t.Errorf("other fields lost: name = %q", m.Name)
+	}
+}
+
+func TestSetBlockIDMissingFileErrors(t *testing.T) {
+	if err := SetBlockID(t.TempDir(), "x-slug"); err == nil {
+		t.Error("expected an error when no manifest exists")
+	}
+}
+
+// TestSetBlockIDRefusesInvalidResultDoesNotClobber: a blockId key inside otherwise
+// malformed JSON is value-replaced, but the result fails the json.Valid guard, so
+// SetBlockID errors WITHOUT writing (the original file is left intact).
+func TestSetBlockIDRefusesInvalidResultDoesNotClobber(t *testing.T) {
+	dir := t.TempDir()
+	broken := `{ "blockId": "old-slug" this is not valid json`
+	write(t, dir, broken)
+	if err := SetBlockID(dir, "new-slug"); err == nil {
+		t.Fatal("expected an error when the rewrite would produce invalid JSON")
+	}
+	raw, _ := os.ReadFile(Path(dir))
+	if string(raw) != broken {
+		t.Errorf("file must be untouched on a refused write:\n%s", raw)
+	}
+}
+
+// TestSetBlockIDInvalidJSONNoKeyErrors: with no blockId key AND invalid JSON, the
+// fallback structural rewrite fails to parse and returns an error (no write).
+func TestSetBlockIDInvalidJSONNoKeyErrors(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, `{ not valid and no key `)
+	if err := SetBlockID(dir, "x-slug"); err == nil {
+		t.Error("expected an error rewriting invalid JSON with no blockId key")
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
 }

--- a/internal/scaffold/slug.go
+++ b/internal/scaffold/slug.go
@@ -1,10 +1,64 @@
 package scaffold
 
 import (
+	"crypto/rand"
 	"fmt"
 	"regexp"
 	"strings"
 )
+
+// slugSuffixAlphabet is lowercase-alphanumeric only (no hyphens) so a generated
+// suffix is always safe to append and to end a slug on.
+const slugSuffixAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// RandomSuffix returns a lowercase-alphanumeric string of length n, suitable as
+// a slug suffix (contains no hyphens, so it can safely start/end a slug). It uses
+// crypto/rand; on the (near-impossible) read error it falls back to a fixed pad
+// so callers never get an empty suffix.
+func RandomSuffix(n int) string {
+	if n <= 0 {
+		n = 5
+	}
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return strings.Repeat("x", n)
+	}
+	out := make([]byte, n)
+	for i, c := range b {
+		out[i] = slugSuffixAlphabet[int(c)%len(slugSuffixAlphabet)]
+	}
+	return string(out)
+}
+
+// SuffixSlug returns "<original>-<suffix>", truncating original if needed so the
+// result stays within the 3-40 char slug bounds, and validates it against the
+// server slug contract. suffix must be lowercase-alphanumeric (as RandomSuffix
+// produces). It is used to auto-rename a slug that collides with an app owned by
+// another account.
+func SuffixSlug(original, suffix string) (string, error) {
+	suffix = strings.ToLower(strings.TrimSpace(suffix))
+	if suffix == "" || nonSlugChars.MatchString(suffix) || strings.Contains(suffix, "-") {
+		return "", fmt.Errorf("slug suffix %q must be lowercase-alphanumeric", suffix)
+	}
+	// Reserve room for the hyphen + suffix within the 40-char cap.
+	maxBase := 40 - 1 - len(suffix)
+	if maxBase < 1 {
+		return "", fmt.Errorf("slug suffix %q is too long", suffix)
+	}
+	base := strings.ToLower(strings.TrimSpace(original))
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	base = strings.Trim(base, "-")
+	if base == "" {
+		return "", fmt.Errorf("cannot derive a base slug from %q", original)
+	}
+	candidate := base + "-" + suffix
+	if err := ValidateSlug(candidate); err != nil {
+		return "", err
+	}
+	return candidate, nil
+}
 
 // slugPattern mirrors the server SLUG_REGEX: starts with a letter, lowercase,
 // hyphen-separated, ends alphanumeric, 3-40 chars.

--- a/internal/scaffold/slug_test.go
+++ b/internal/scaffold/slug_test.go
@@ -1,6 +1,9 @@
 package scaffold
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTitleFromSlug(t *testing.T) {
 	cases := map[string]string{
@@ -39,5 +42,60 @@ func TestSlugifyAllTemplates(t *testing.T) {
 	ts := AllTemplates()
 	if len(ts) != 3 {
 		t.Errorf("AllTemplates = %v, want 3", ts)
+	}
+}
+
+func TestRandomSuffix(t *testing.T) {
+	for _, n := range []int{1, 5, 12} {
+		s := RandomSuffix(n)
+		if len(s) != n {
+			t.Errorf("RandomSuffix(%d) len = %d", n, len(s))
+		}
+		for _, r := range s {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+				t.Errorf("RandomSuffix(%d)=%q has non-alphanumeric %q", n, s, r)
+			}
+		}
+	}
+	// n<=0 falls back to a non-empty default.
+	if got := RandomSuffix(0); len(got) == 0 {
+		t.Error("RandomSuffix(0) should not be empty")
+	}
+}
+
+func TestSuffixSlug(t *testing.T) {
+	got, err := SuffixSlug("my-block", "abc12")
+	if err != nil {
+		t.Fatalf("SuffixSlug: %v", err)
+	}
+	if got != "my-block-abc12" {
+		t.Errorf("SuffixSlug = %q, want my-block-abc12", got)
+	}
+	if err := ValidateSlug(got); err != nil {
+		t.Errorf("result should be a valid slug: %v", err)
+	}
+
+	// A long original is truncated so the result stays within 40 chars.
+	long, err := SuffixSlug(strings.Repeat("a", 60), "abc12")
+	if err != nil {
+		t.Fatalf("SuffixSlug(long): %v", err)
+	}
+	if len(long) > 40 {
+		t.Errorf("SuffixSlug(long) = %q exceeds 40 chars (%d)", long, len(long))
+	}
+	if err := ValidateSlug(long); err != nil {
+		t.Errorf("truncated result should be valid: %v", err)
+	}
+
+	// Empty / hyphenated / non-alphanumeric suffixes are rejected (uppercase is
+	// normalized to lowercase, not rejected).
+	for _, bad := range []string{"", "a-b", "a!b"} {
+		if _, err := SuffixSlug("my-block", bad); err == nil {
+			t.Errorf("SuffixSlug with suffix %q should error", bad)
+		}
+	}
+	// Uppercase is normalized.
+	if got, err := SuffixSlug("my-block", "ABCDE"); err != nil || got != "my-block-abcde" {
+		t.Errorf("SuffixSlug normalize uppercase = %q, %v", got, err)
 	}
 }

--- a/internal/scaffold/templates/page-money/src/setup-dev-live.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/setup-dev-live.test.ts.tmpl
@@ -10,6 +10,10 @@ import {
   mapMintError,
   mintDevToken,
   runDevLiveSetup,
+  renameSlug,
+  setManifestBlockId,
+  randomSlugSuffix,
+  MAX_RENAME_ATTEMPTS,
   type FetchLike,
 } from './setup-dev-live.js';
 
@@ -280,5 +284,122 @@ describe('runDevLiveSetup (the orchestration the middleware calls)', () => {
       envPath,
     });
     expect(res).toEqual({ ok: false, error: expect.stringMatching(/manifest\.json not found/) });
+  });
+
+  it('auto-renames + retries on the slug-collision 404, then succeeds', async () => {
+    const fs = memFs({
+      [manifestPath]: JSON.stringify({ blockId: 'money-block', scopes: ['identity:read'] }),
+    });
+    const notes: string[] = [];
+    let calls = 0;
+    const res = await runDevLiveSetup('pk-personal', {
+      // Collide on the original slug, succeed on the renamed one.
+      fetch: async (_url, init) => {
+        calls++;
+        const slug = JSON.parse(init.body).slug as string;
+        if (slug === 'money-block') {
+          return { status: 404, ok: false, text: async () => JSON.stringify({ message: 'App not found' }) };
+        }
+        return { status: 200, ok: true, text: async () => JSON.stringify({ token: 'JWT.live' }) };
+      },
+      backendOrigin: 'https://civitai.com',
+      readFile: fs.readFile,
+      writeFile: fs.writeFile,
+      manifestPath,
+      envPath,
+      randomSuffix: () => 'abc12',
+      notify: (m) => void notes.push(m),
+    });
+    expect(res).toEqual({ ok: true });
+    expect(calls).toBe(2); // collision + retry
+    // The manifest on "disk" now carries the renamed slug (other fields kept).
+    const manifest = JSON.parse(fs.files.get(manifestPath)!);
+    expect(manifest.blockId).toBe('money-block-abc12');
+    expect(manifest.scopes).toEqual(['identity:read']);
+    expect(notes.some((m) => /renamed to "money-block-abc12"/.test(m))).toBe(true);
+    expect(fs.files.get(envPath)).toContain('VITE_LIVE_BLOCK_TOKEN=JWT.live');
+  });
+
+  it('bounds the rename loop when every alternative also collides', async () => {
+    const fs = memFs({ [manifestPath]: JSON.stringify({ blockId: 'money-block' }) });
+    let calls = 0;
+    let i = 0;
+    const res = await runDevLiveSetup('pk', {
+      fetch: async () => {
+        calls++;
+        return { status: 404, ok: false, text: async () => JSON.stringify({ message: 'App not found' }) };
+      },
+      backendOrigin: 'https://civitai.com',
+      readFile: fs.readFile,
+      writeFile: fs.writeFile,
+      manifestPath,
+      envPath,
+      randomSuffix: () => `ab${i++}`,
+      notify: () => {},
+    });
+    expect(res.ok).toBe(false);
+    expect('error' in res && res.error).toMatch(/all\s+registered to other accounts/);
+    expect(calls).toBe(1 + MAX_RENAME_ATTEMPTS);
+    expect(fs.files.has(envPath)).toBe(false);
+  });
+
+  it('does NOT rename on a non-collision 404 (owned-but-undeployed app)', async () => {
+    const fs = memFs({ [manifestPath]: JSON.stringify({ blockId: 'money-block' }) });
+    let calls = 0;
+    const res = await runDevLiveSetup('pk', {
+      fetch: async () => {
+        calls++;
+        return {
+          status: 404,
+          ok: false,
+          text: async () => JSON.stringify({ message: "block 'money-block' has no live deployment" }),
+        };
+      },
+      backendOrigin: 'https://civitai.com',
+      readFile: fs.readFile,
+      writeFile: fs.writeFile,
+      manifestPath,
+      envPath,
+      randomSuffix: () => {
+        throw new Error('must not rename on a non-collision 404');
+      },
+      notify: () => {},
+    });
+    expect(res.ok).toBe(false);
+    expect(calls).toBe(1);
+    // The manifest is untouched.
+    expect(JSON.parse(fs.files.get(manifestPath)!).blockId).toBe('money-block');
+  });
+});
+
+describe('slug rename helpers', () => {
+  it('renameSlug appends a suffix and stays within the 3-40 bound', () => {
+    expect(renameSlug('money-block', 'abc12')).toBe('money-block-abc12');
+    const long = renameSlug('a'.repeat(60), 'abc12');
+    expect(long.length).toBeLessThanOrEqual(40);
+    expect(/^[a-z][a-z0-9-]*[a-z0-9]$/.test(long)).toBe(true);
+  });
+
+  it('renameSlug rejects a non-alphanumeric suffix', () => {
+    expect(() => renameSlug('money-block', 'BAD!')).toThrow(/lowercase-alphanumeric/);
+  });
+
+  it('randomSlugSuffix yields a lowercase-alphanumeric string of length n', () => {
+    const s = randomSlugSuffix(5);
+    expect(s).toHaveLength(5);
+    expect(/^[a-z0-9]+$/.test(s)).toBe(true);
+  });
+
+  it('setManifestBlockId rewrites only blockId, preserving order + other fields', () => {
+    const src = `{
+  "blockId": "money-block",
+  "version": "0.1.0",
+  "name": "My Block"
+}`;
+    const out = setManifestBlockId(src, 'money-block-abc12');
+    expect(out).toContain('"blockId": "money-block-abc12"');
+    expect(out).toContain('"name": "My Block"');
+    expect(out.indexOf('blockId')).toBeLessThan(out.indexOf('version'));
+    expect(JSON.parse(out).blockId).toBe('money-block-abc12');
   });
 });

--- a/internal/scaffold/templates/page-money/src/setup-dev-live.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/setup-dev-live.ts.tmpl
@@ -146,7 +146,12 @@ export interface MintDeps {
   backendOrigin: string;
 }
 
-export type MintResult = { token: string } | { error: string };
+export type MintResult =
+  | { token: string }
+  // `slugCollision` marks the anti-shadow 404 (the slug is an approved app owned
+  // by ANOTHER account) — the only rename-retriable failure. Other 404s (e.g. an
+  // owned-but-undeployed app: "no live deployment") do NOT set it.
+  | { error: string; slugCollision?: boolean };
 
 /**
  * Mint the dev block token via `POST <backendOrigin>/api/v1/blocks/dev-token`
@@ -195,7 +200,15 @@ export async function mintDevToken(
   }
 
   const raw = await res.text();
-  if (!res.ok) return { error: mapMintError(res.status, raw) };
+  if (!res.ok) {
+    const error = mapMintError(res.status, raw);
+    // A bare 404 ("App not found") is the anti-shadow collision → rename-retriable.
+    // The owned-but-undeployed 404 carries "no live deployment" and is not.
+    if (res.status === 404 && !/no live deployment/i.test(raw)) {
+      return { error, slugCollision: true };
+    }
+    return { error };
+  }
 
   let parsed: { token?: unknown };
   try {
@@ -207,6 +220,66 @@ export async function mintDevToken(
     return { error: 'Mint succeeded but the response had no token.' };
   }
   return { token: parsed.token };
+}
+
+// The server slug contract: starts with a letter, lowercase, hyphen-separated,
+// ends alphanumeric, 3-40 chars. Mirrors the CLI's scaffold/slug.go.
+const SLUG_REGEX = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+const SLUG_SUFFIX_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+/** Bound the auto-rename-on-collision retry loop (mirrors the CLI). */
+export const MAX_RENAME_ATTEMPTS = 5;
+
+/**
+ * A lowercase-alphanumeric slug suffix of length `n` (no hyphens, so it can
+ * safely start/end a slug). Uses Math.random — a suffix collision is harmless
+ * (the retry loop just tries again).
+ */
+export function randomSlugSuffix(n = 5): string {
+  let s = '';
+  for (let i = 0; i < n; i++) {
+    s += SLUG_SUFFIX_ALPHABET[Math.floor(Math.random() * SLUG_SUFFIX_ALPHABET.length)];
+  }
+  return s;
+}
+
+/**
+ * Return `<original>-<suffix>`, truncating `original` if needed so the result
+ * stays within the 3-40 char slug bounds, and validate it against SLUG_REGEX.
+ * Mirrors the CLI's scaffold.SuffixSlug. Throws on an unusable suffix/base.
+ */
+export function renameSlug(original: string, suffix: string): string {
+  const suf = suffix.trim().toLowerCase();
+  if (suf === '' || !/^[a-z0-9]+$/.test(suf)) {
+    throw new Error(`slug suffix "${suffix}" must be lowercase-alphanumeric`);
+  }
+  const maxBase = 40 - 1 - suf.length;
+  if (maxBase < 1) throw new Error(`slug suffix "${suffix}" is too long`);
+  let base = original.trim().toLowerCase();
+  if (base.length > maxBase) base = base.slice(0, maxBase);
+  base = base.replace(/^-+|-+$/g, '');
+  if (base === '') throw new Error(`cannot derive a base slug from "${original}"`);
+  const candidate = `${base}-${suf}`;
+  if (candidate.length < 3 || candidate.length > 40 || !SLUG_REGEX.test(candidate)) {
+    throw new Error(`generated slug "${candidate}" is invalid`);
+  }
+  return candidate;
+}
+
+/**
+ * Rewrite the manifest text's `blockId` value in place, preserving every other
+ * field, its order, and the file's formatting (it edits only the blockId value).
+ * Falls back to a structural re-emit if no `blockId` key is present. Mirrors the
+ * CLI's manifest.SetBlockID.
+ */
+export function setManifestBlockId(manifestJson: string, newBlockId: string): string {
+  const re = /("blockId"\s*:\s*)"[^"]*"/;
+  if (re.test(manifestJson)) {
+    return manifestJson.replace(re, `$1${JSON.stringify(newBlockId)}`);
+  }
+  const parsed = JSON.parse(manifestJson) as Record<string, unknown>;
+  parsed.blockId = newBlockId;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
 /** Filesystem + fetch surface `runDevLiveSetup` needs, all injectable. */
@@ -221,6 +294,10 @@ export interface SetupDeps {
   manifestPath: string;
   /** Absolute path to the `.env.development.local` to merge-write. */
   envPath: string;
+  /** Generate a random slug suffix; injectable for deterministic tests. */
+  randomSuffix?: () => string;
+  /** Notify the dev of a slug rename; defaults to console.error. */
+  notify?: (message: string) => void;
 }
 
 export type SetupResult = { ok: true } | { ok: false; error: string };
@@ -236,20 +313,67 @@ export async function runDevLiveSetup(apiKey: string, deps: SetupDeps): Promise<
   const key = apiKey.trim();
   if (key === '') return { ok: false, error: 'Paste your personal API key first.' };
 
-  const manifestJson = deps.readFile(deps.manifestPath);
+  let manifestJson = deps.readFile(deps.manifestPath);
   if (manifestJson === undefined) {
     return { ok: false, error: 'block.manifest.json not found in the project root.' };
   }
 
-  const minted = await mintDevToken(key, manifestJson, {
-    fetch: deps.fetch,
-    backendOrigin: deps.backendOrigin,
-  });
-  if ('error' in minted) return { ok: false, error: minted.error };
+  let originalSlug: string;
+  try {
+    originalSlug = manifestToMintRequest(manifestJson).slug;
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
+  const randomSuffix = deps.randomSuffix ?? (() => randomSlugSuffix(5));
+  const notify = deps.notify ?? ((m: string) => console.error(m));
+
+  // Mint, and on the anti-shadow collision auto-rename the slug (append a random
+  // suffix to the ORIGINAL), rewrite block.manifest.json's blockId, notify, and
+  // retry — bounded by MAX_RENAME_ATTEMPTS. Any non-collision error aborts.
+  let currentSlug = originalSlug;
+  let token: string | undefined;
+  for (let attempt = 0; attempt <= MAX_RENAME_ATTEMPTS; attempt++) {
+    const minted = await mintDevToken(key, manifestJson, {
+      fetch: deps.fetch,
+      backendOrigin: deps.backendOrigin,
+    });
+    if (!('error' in minted)) {
+      token = minted.token;
+      break;
+    }
+    if (!minted.slugCollision) return { ok: false, error: minted.error };
+    if (attempt === MAX_RENAME_ATTEMPTS) {
+      return {
+        ok: false,
+        error:
+          `Slug "${originalSlug}" and ${MAX_RENAME_ATTEMPTS} generated alternatives are all ` +
+          `registered to other accounts — choose a different blockId in block.manifest.json.`,
+      };
+    }
+    let newSlug: string;
+    try {
+      newSlug = renameSlug(originalSlug, randomSuffix());
+    } catch (e) {
+      return { ok: false, error: `Could not generate an alternative slug: ${e instanceof Error ? e.message : String(e)}` };
+    }
+    manifestJson = setManifestBlockId(manifestJson, newSlug);
+    deps.writeFile(deps.manifestPath, manifestJson);
+    notify(
+      `Slug "${currentSlug}" is registered to another account — renamed to "${newSlug}" ` +
+        `for your app (block.manifest.json updated).`,
+    );
+    currentSlug = newSlug;
+  }
+
+  if (token === undefined) {
+    // Defensive: the loop only exits via return or a successful mint.
+    return { ok: false, error: 'Mint failed after auto-rename retries.' };
+  }
 
   const existing = deps.readFile(deps.envPath);
   const merged = mergeEnvFile(existing, {
-    VITE_LIVE_BLOCK_TOKEN: minted.token,
+    VITE_LIVE_BLOCK_TOKEN: token,
     CIVITAI_HOST_KEY: key,
   });
   deps.writeFile(deps.envPath, merged);

--- a/internal/scaffold/templates/page-money/vite-plugin-civitai-setup.ts.tmpl
+++ b/internal/scaffold/templates/page-money/vite-plugin-civitai-setup.ts.tmpl
@@ -119,6 +119,9 @@ export function civitaiSetupPlugin(): Plugin {
           writeFile: (p, contents) => writeFileSync(p, contents, 'utf8'),
           manifestPath: resolve(root, 'block.manifest.json'),
           envPath: resolve(root, '.env.development.local'),
+          // Surface a slug auto-rename (collision with another account's app) in
+          // the dev-server log so the developer sees block.manifest.json changed.
+          notify: (message) => server.config.logger.info(`[civitai] ${message}`),
         });
 
         if (result.ok) {


### PR DESCRIPTION
Three pieces of CLI feedback from a non-mod dev:live dogfood.

### 1. `civitai login` — open the code URL, print one fallback
Was printing BOTH the code-prefilled `verification_uri_complete` and the bare URL+code, then auto-opening. Now the primary action is the auto-open, and only a single **"or open `<bare-url>` and enter code `XXXX`"** line prints. On `--no-browser` / open-failure it falls back to the full manual instructions. `device_code` (the secret) is never printed. Injectable `browserOpener` for tests.
```
Opened your browser to approve. Or open https://civitai.com/login/oauth/device and enter code WXYZ-7890
Waiting for approval...
```

### 2. dev:live / dev-token slug collision → auto-rename + retry
Repro: `npm run dev:live` → `App not found (404) — the slug is registered to a different account` (the server's anti-shadow guard: the local `block.manifest.json` slug is an **approved app owned by another account**, so the no-row mint is refused). Now, on that specific 404, the CLI appends a random suffix to the slug, **permanently rewrites `block.manifest.json`'s `blockId`**, prints a clear notice, and retries (bounded, 5 attempts) — because a foreign-owned slug is unusable for `civitai app submit` too, so renaming is the honest outcome.

Applied in **both** mint paths:
- **Go `civitai app dev-token`** — new sentinel `api.ErrSlugRegisteredToOtherAccount` (wrapped ONLY on the bare "App not found" 404; the owned-but-undeployed "no live deployment" 404 is NOT rename-retriable), caller branches via `errors.Is`. `mintDevTokenWithRename` loop + `manifest.SetBlockID` (atomic, order/format-preserving, refuses invalid) + `scaffold.SuffixSlug` (reuses the existing slug validator, 3–40 bound). Suffixes the *original* base (no pileup); renames only when a manifest exists; non-collision errors abort.
- **`npm run dev:live` scaffold (TS)** — `setup-dev-live.ts` mirrors the Go: `slugCollision` flag (bare-404 only), `renameSlug`/`setManifestBlockId`/bounded `MAX_RENAME_ATTEMPTS`, notice via the vite logger.

### 3. Coverage
`go test ./... -cover`: api 79.5→81.8, cmd 88.3→89.6, scaffold 83.3→83.5 (manifest dipped to 83.3 only because net-new `SetBlockID` has a couple of untestable I/O-error branches; its guard branches are covered). New tests: login opened/fallback paths, the 404 sentinel wrapping, dev-token rename-retry (success / bounded / non-collision-abort / no-manifest), `SuffixSlug`/`RandomSuffix`, `SetBlockID`, + OAuth error helpers and detached-process launch.

**Verified:** `go build ./...` / `go vet ./...` / `gofmt -l` / `go test ./...` all clean (ground-truth run, not just the LSP). The emitted TS transpiles under esbuild and its logic was exercised via a Node harness. **Read-verified only:** the scaffold's shipped vitest `.test.ts` cases (they render to valid TS but aren't run by the Go CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)