### PR TITLE
docs/copy: rename 'App Blocks' → 'Apps', invite-only beta, pre-GA notice to top

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,7 +73,7 @@ homebrew_casks:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/civitai/cli"
-    description: "Civitai CLI — author and ship App Blocks"
+    description: "Civitai CLI — author and ship Apps"
     commit_author:
       name: civitai-bot
       email: bot@civitai.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ contributor checklist see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## What this is
 
-`civitai` is the App Blocks authoring CLI. `civitai app` scaffolds a correct
+`civitai` is the Apps authoring CLI. `civitai app` scaffolds a correct
 project, validates the manifest against the platform contract, packages it, and
 submits it for review. See the README command reference — don't re-derive it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ command, and the release process. The short version:
 - `cmd/civitai` — the binary entrypoint.
 - `internal/cmd` — the Cobra command tree (one file per command).
 - `internal/{scaffold,validate,pkgzip,manifest,api,config}` — the building blocks.
-- `schema/` — the vendored App Block manifest JSON Schema.
+- `schema/` — the vendored App manifest JSON Schema.
 
 ## The validate fidelity caveat
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
 # civitai CLI
 
-The command-line interface for [Civitai](https://civitai.com) — a single static
-binary for authoring and shipping **App Blocks**.
+> ⚠️ **Apps is in a limited, invite-only beta (pre-GA).** You can install this
+> CLI, `login`, scaffold, validate, and run an app locally right now — but
+> **`civitai app submit` and `dev:live` require an invite**: submission and
+> `dev:live` are limited to **invited beta testers** while the feature is in a
+> limited (pre-GA) beta, until Apps opens to the public. There is no public
+> self-serve "request access" form yet — watch [civitai.com](https://civitai.com) and the
+> [issues on this repo](https://github.com/civitai/cli/issues) for the
+> general-availability announcement.
 
-An **App Block** is a small, sandboxed web app that runs inside Civitai
+The command-line interface for [Civitai](https://civitai.com) — a single static
+binary for authoring and shipping **Apps**.
+
+An **App** is a small, sandboxed web app that runs inside Civitai
 surfaces (it's served in an iframe; the platform owns the build and the
 runtime). The CLI replaces the error-prone "hand-format a ZIP" flow: it
 **scaffolds** a correct project, **validates** the manifest against the platform
 contract, and **packages/submits** it for review.
 
 > New here? The
-> [Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
+> [Build your first App](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 > guide is the full end-to-end walkthrough.
-
-> ⚠️ **App Blocks is in a limited, moderator-gated preview (pre-GA).** You can
-> install this CLI, `login`, scaffold, validate, and run a block locally right
-> now — but **`civitai app submit` requires App Blocks access**. While the
-> feature is dark, submission is restricted to **Civitai moderators / the team**:
-> a non-moderator account can't submit (or its block won't be reviewed/approved,
-> so it won't go live) until App Blocks opens to the public. There is no public
-> self-serve "request access" form yet — watch [civitai.com](https://civitai.com) and the
-> [issues on this repo](https://github.com/civitai/cli/issues) for the
-> general-availability announcement.
 
 ## Install
 
@@ -60,7 +59,7 @@ go install github.com/civitai/cli/cmd/civitai@latest
 # 1. Authenticate once (browser device login; or `civitai login --token <t>`).
 civitai login
 
-# 2. Scaffold a ready-to-build App Block (batteries-included page-money default).
+# 2. Scaffold a ready-to-build App (batteries-included page-money default).
 civitai app create my-app
 cd my-app
 
@@ -85,14 +84,14 @@ civitai app status
 > a dev token with `civitai app dev-token` and run `npm run dev:live` — see
 > [Local dev loop](#local-dev-loop-harness-mock-vs-live).
 
-> **Submit ≠ live.** `civitai app submit` enters your block into **moderator
+> **Submit ≠ live.** `civitai app submit` enters your app into **moderator
 > review** — it is **not** published immediately. The lifecycle is
 > **submit → review → approve → build + deploy → `https://<blockId>.civit.ai/`**:
 > that URL **404s until a moderator approves your submission and the platform
 > builds + deploys it** (a few minutes after approval). Until then, track status
 > on **`/apps/my-submissions`** (a fresh submission sits at `pending`). See
-> [Submit & auth](#submit--auth) for the full flow. (And note App Blocks is a
-> gated preview — see the warning above.)
+> [Submit & auth](#submit--auth) for the full flow. (And note Apps is in an
+> invite-only beta — see the warning above.)
 
 Enable shell completion (optional):
 
@@ -102,13 +101,13 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 
 ## SDK packages
 
-This CLI scaffolds, validates, and submits — but the code your block actually
+This CLI scaffolds, validates, and submits — but the code your app actually
 imports lives in two published npm packages (the `page-money` / `page-vite`
 templates wire them for you):
 
 | Package | What it is |
 | --- | --- |
-| [`@civitai/blocks-react`](https://www.npmjs.com/package/@civitai/blocks-react) | The React hooks + iframe transport block authors call — `useBlockContext`, `useBuzzWorkflow`, `useBlockResize`, the `/ui` component pack, and the `/testing` dev hosts. **Start here for the hook reference.** |
+| [`@civitai/blocks-react`](https://www.npmjs.com/package/@civitai/blocks-react) | The React hooks + iframe transport app authors call — `useBlockContext`, `useBuzzWorkflow`, `useBlockResize`, the `/ui` component pack, and the `/testing` dev hosts. **Start here for the hook reference.** |
 | [`@civitai/app-sdk`](https://www.npmjs.com/package/@civitai/app-sdk) | The framework-agnostic contract under the hooks — manifest types, scope strings, the `postMessage` protocol, and the `defineBlock` validator (`@civitai/app-sdk/blocks`). |
 
 ```bash
@@ -118,7 +117,7 @@ pnpm add @civitai/blocks-react @civitai/app-sdk react
 
 The full hook-by-hook reference (with snippets) lives in each package's npm
 README. For the end-to-end walkthrough, see
-[Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md).
+[Build your first App](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md).
 
 ## Command reference
 
@@ -127,9 +126,9 @@ README. For the end-to-end walkthrough, see
 | `civitai login [--token <t>] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens); `--token` stores a personal API key instead. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
 | `civitai whoami [--json]` | Verify the stored token; print the authenticated user **and a Capabilities section** (`Spend Buzz`, `Read Buzz balance`) decoded from the token's scope, so a money-path dead end (OAuth login can't spend) is visible before `dev:live`. `--json` emits the user + capabilities as a JSON object (scriptable). |
 | `civitai buzz [--json]` | Show your spendable Buzz balance (blue / green / **yellow** — the generation-spend currency). Needs a full-scope personal API key to read; an OAuth login token can't, and gets a clear "switch to a personal key" message. `--json` emits the balances as a JSON object (scriptable). |
-| `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App Block, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
+| `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
-| `civitai app dev-token <slug> [--env]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the moderator-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
+| `civitai app dev-token <slug> [--env]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the invite-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message`) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
@@ -142,12 +141,12 @@ full details and examples.
 
 ### Templates
 
-- **`static`** — a no-build page block (`index.html` + a tiny `app.js`,
+- **`static`** — a no-build page app (`index.html` + a tiny `app.js`,
   `block.manifest.json` with `page:{}`, no build step).
-- **`page-vite`** — a Vite + React page block with config-as-code build fields
+- **`page-vite`** — a Vite + React page app with config-as-code build fields
   (`buildCommand: "npm run build"` + `outputDir: "dist"`).
 - **`page-money`** — a Vite + React + TypeScript full-page (W10) **money-path**
-  block wired to the published App SDK (`@civitai/blocks-react` +
+  app wired to the published App SDK (`@civitai/blocks-react` +
   `@civitai/app-sdk`): prompt → estimate → lazy consent → submit → poll → real
   Buzz spend, via `useBuzzWorkflow` / `useRequestConsent` / `useBlockResize`
   (never raw `postMessage`). Ships a `dev:harness` mock host, `.env.*` allowed
@@ -156,7 +155,7 @@ full details and examples.
 
 ### Local dev loop (harness: mock vs live)
 
-A scaffolded App Block is a sandboxed iframe — `npm run dev` alone shows a blank
+A scaffolded App is a sandboxed iframe — `npm run dev` alone shows a blank
 screen because there's no host to send `BLOCK_INIT`. The `page-money` /
 `page-vite` templates ship a dev **harness** (the SDK's
 [`@civitai/blocks-react/testing`](https://www.npmjs.com/package/@civitai/blocks-react)
@@ -165,7 +164,7 @@ hosts) with two modes:
 | Command | Mode | What it does |
 |---|---|---|
 | `npm run dev:harness` | **mock** (default) | Mounts the SDK **mock host** — synthetic replies, **no real Buzz, no compute, no network.** Safe to spam; drive money/error/insufficient-Buzz UX via on-screen scenarios or `?` URL params. Start here. |
-| `npm run dev:live` | **live** | Mounts the SDK **live host** (`createLiveHost`) — forwards the App-Block protocol to the **real Civitai backend** with a pasted dev token (Bearer). **Spends REAL Buzz / real compute.** |
+| `npm run dev:live` | **live** | Mounts the SDK **live host** (`createLiveHost`) — forwards the App protocol to the **real Civitai backend** with a pasted dev token (Bearer). **Spends REAL Buzz / real compute.** |
 
 > ⚠️ **`dev:live` works on a pending (un-approved) app.** The dev-token mint
 > (`POST /api/v1/blocks/dev-token`) accepts a **pending** slug — right after a
@@ -177,7 +176,7 @@ hosts) with two modes:
 > credential can spend before a live run.
 
 **Live mode** needs a short-lived dev block token. Mint it with **`civitai app
-dev-token`** (the CLI handles the moderator-gated `POST /api/v1/blocks/dev-token`
+dev-token`** (the CLI handles the invite-gated `POST /api/v1/blocks/dev-token`
 call with your stored credential — no hand-rolled curl) and paste it into
 `.env.development.local` as `VITE_LIVE_BLOCK_TOKEN=`:
 
@@ -261,7 +260,7 @@ prints a URL + a short code, you approve in your browser, and the CLI stores a
 short-lived access token (1h) plus a refresh token (30d) that it rotates
 automatically before requests and once on a `401`. It **requests** the scopes
 `UserRead | AppBlocksSubmit` (== `33554433`, exactly the `civitai-cli` OAuth
-client's `allowedScopes`) — identity plus App-Blocks submit, which gates both
+client's `allowedScopes`) — identity plus Apps submit, which gates both
 `app submit` and the dev-token mint. It deliberately does **not** request
 `AIServicesWrite`: the server's device-flow scope check is all-or-nothing, so
 asking for a scope the client doesn't allow would reject the whole login. A
@@ -288,14 +287,14 @@ Services.
 
 ### After you submit: review → approve → deploy
 
-A successful `submit` does **not** publish your block — it queues it for
+A successful `submit` does **not** publish your app — it queues it for
 moderator review. The lifecycle is:
 
 1. **submit** → your submission lands at `/apps/my-submissions` with status
    `pending`.
 2. **review** → a moderator reviews the manifest + files. They either **approve**
    or **reject** (with a reason you can read inline, then fix and resubmit).
-3. **deploy** → on **approval**, the platform builds and deploys your block
+3. **deploy** → on **approval**, the platform builds and deploys your app
    (injects its build recipe → builds the image → deploys → programs the
    `<blockId>.civit.ai` DNS record). A few minutes after approval it serves live
    at **`https://<blockId>.civit.ai/`**.
@@ -304,7 +303,7 @@ Before approval, **`https://<blockId>.civit.ai/` 404s** — submitting does not
 make the subdomain serve (but `dev:live` works against a pending app — see
 [Local dev loop](#local-dev-loop-harness-mock-vs-live)). For the full end-to-end
 walkthrough (build → submit → review → deploy), see the
-[Build your first App Block](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
+[Build your first App](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 guide.
 
 **Need to change the bundle while a request is still `pending`?** Withdraw it
@@ -327,7 +326,7 @@ approved/rejected one cannot.
 without leaving the terminal. It calls the token-authenticated, self-scoped route
 `GET /api/v1/blocks/submissions` with your stored credential — you only ever see
 your own submissions (the same token that submitted can read its status; OAuth
-tokens need the App Blocks submit scope).
+tokens need the Apps submit scope).
 
 With no argument it lists every submission, newest first:
 
@@ -382,9 +381,9 @@ written owner-readable only.
   again. For a personal key, create a new one at
   `https://civitai.com/user/account` and `civitai login --token <key>`.
 - **`forbidden (403)` / `service unavailable (503)`** — your account may lack
-  App Blocks access while the feature is in its gated preview (see the warning at
-  the top of this README). Submission is limited to Civitai moderators / the team
-  until App Blocks reaches general availability.
+  Apps access while the feature is in its invite-only beta (see the warning at
+  the top of this README). Submission is limited to invited beta testers
+  until Apps reaches general availability.
 - **`validation failed`** — read each `- ...` line; fix the manifest, or pass
   `--skip-validate` to package anyway (the server will still re-validate).
 - **`<dir> is not empty — refusing to overwrite`** — `app init` won't clobber an

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,4 +1,4 @@
-// Package api is the (thin) HTTP client for the Civitai App Blocks surface.
+// Package api is the (thin) HTTP client for the Civitai Apps surface.
 //
 // Auth/submit contract (civitai/civitai PR #2644):
 //
@@ -200,14 +200,14 @@ const SubmissionsPath = "/api/v1/blocks/submissions"
 // (pending) state.
 const WithdrawPath = "/api/v1/blocks/withdraw"
 
-// DevTokenPath is the moderator-gated route that mints a short-lived dev block
+// DevTokenPath is the invite-gated route that mints a short-lived dev block
 // token for `npm run dev:live` (POST {"slug": ..., "scopes"?: [...]};
 // civitai/civitai src/pages/api/v1/blocks/dev-token.ts). 200 { token, ... } on
 // success; a PENDING (un-approved) slug is accepted, and a slug with NO app row
 // yet mints from the request-body `scopes` (the dev's LOCAL manifest scopes,
 // clamped server-side) — so `create → dev-token → dev:live` works with no
 // submit step. Error bodies are {message}: 404 slug registered to a different
-// account / genuinely not found, 403 not-mod/insufficient-scope, 429
+// account / genuinely not found, 403 not-invited/insufficient-scope, 429
 // rate-limited, 503 flag-off. The minted token's CAPABILITIES depend on the
 // bearer: a full-scope personal API key mints a spend-capable token; an OAuth
 // (`civitai login`) credential mints a read-only one.
@@ -696,7 +696,7 @@ func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string)
 
 // devTokenError maps a non-2xx dev-token response to a clear, actionable CLI
 // error. The route returns {"message": ...} on every error status: 404
-// not-found-or-not-yours, 403 not-moderator-or-insufficient-scope, 429
+// not-found-or-not-yours, 403 not-invited-or-insufficient-scope, 429
 // rate-limited, 503 flag-off. The 403 message is the key DX case — a spend
 // token needs a full-scope personal API key (an OAuth login mints read-only).
 func devTokenError(status int, raw []byte) error {
@@ -715,11 +715,11 @@ func devTokenError(status int, raw []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("not authorized (403): %s — minting needs moderator access AND a full-scope personal API key; an OAuth `civitai login` token can't mint a spend token (check with `civitai whoami`)", msg)
+		return fmt.Errorf("not authorized (403): %s — minting needs an invite (invite-only beta) AND a full-scope personal API key; an OAuth `civitai login` token can't mint a spend token (check with `civitai whoami`)", msg)
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("App Blocks unavailable (503): %s", msg)
+		return fmt.Errorf("Apps unavailable (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
@@ -734,7 +734,7 @@ func withdrawError(status int, raw []byte) error {
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("not authorized (check your API key / moderator access) (%d): %s", status, msg)
+		return fmt.Errorf("not authorized (check your API key / Apps invite) (%d): %s", status, msg)
 	case http.StatusNotFound:
 		return fmt.Errorf("publish request not found (or not yours) (404): %s", msg)
 	case http.StatusConflict:
@@ -744,27 +744,27 @@ func withdrawError(status int, raw []byte) error {
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("App Blocks unavailable (503): %s", msg)
+		return fmt.Errorf("Apps unavailable (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
 }
 
 // submissionsError maps a non-2xx submissions response to a clear, actionable
-// error, with App-Blocks-specific guidance for 403/404/429/503.
+// error, with Apps-specific guidance for 403/404/429/503.
 func submissionsError(status int, raw []byte) error {
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login`", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("App Blocks access required (gated preview) (403): %s", msg)
+		return fmt.Errorf("Apps access required — invite-only beta (403): %s", msg)
 	case http.StatusNotFound:
 		return fmt.Errorf("no such submission (404): %s", msg)
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited (429): %s — wait a moment and retry", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("App Blocks is not enabled (503): %s", msg)
+		return fmt.Errorf("Apps is not enabled (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
@@ -796,9 +796,9 @@ func serverError(status int, raw []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("unauthorized (401): %s — check your token with `civitai login`", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("forbidden (403): %s — your account may lack App Blocks access", msg)
+		return fmt.Errorf("forbidden (403): %s — your account may lack Apps access", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("service unavailable (503): %s — App Blocks may not be enabled", msg)
+		return fmt.Errorf("service unavailable (503): %s — Apps may not be enabled", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -143,7 +143,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 		{http.StatusForbidden, map[string]string{"message": "mods only"}, "not authorized (403)"},
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "flag off"}, "App Blocks unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "flag off"}, "Apps unavailable (503)"},
 		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
 	}
 	for _, tc := range cases {

--- a/internal/api/submissions_test.go
+++ b/internal/api/submissions_test.go
@@ -141,7 +141,7 @@ func TestSubmissionsErrorMapping(t *testing.T) {
 		want   string
 	}{
 		{http.StatusUnauthorized, map[string]string{"message": "Invalid API key"}, "civitai login"},
-		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "App Blocks access required (gated preview)"},
+		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "Apps access required — invite-only beta"},
 		{http.StatusNotFound, map[string]string{"message": "Submission not found"}, "no such submission"},
 		{http.StatusTooManyRequests, map[string]string{"message": "Rate limit exceeded"}, "rate limited"},
 		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "not enabled"},

--- a/internal/api/withdraw_test.go
+++ b/internal/api/withdraw_test.go
@@ -74,7 +74,7 @@ func TestWithdrawRequestErrorMapping(t *testing.T) {
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not authorized"},
 		{http.StatusForbidden, map[string]string{"message": "no mod"}, "not authorized"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "App Blocks unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "Apps unavailable (503)"},
 		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
 	}
 	for _, tc := range cases {

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -2,14 +2,14 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// newAppCmd is the `civitai app` command group for App Blocks authoring.
+// newAppCmd is the `civitai app` command group for Apps authoring.
 func newAppCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "app",
-		Short: "Author and ship Civitai App Blocks",
-		Long: `Author and ship Civitai App Blocks.
+		Short: "Author and ship Civitai Apps",
+		Long: `Author and ship Civitai Apps.
 
-An App Block is a sandboxed static web app served in an iframe. The platform
+An App is a sandboxed static web app served in an iframe. The platform
 owns the build and the runtime; the only mandatory file is block.manifest.json.
 The typical lifecycle is create -> validate -> submit.
 

--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -17,20 +17,20 @@ func newAppCreateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create [name] [dir]",
-		Short: "Create a ready-to-build App Block (batteries-included, SDK money-path)",
-		Long: `Create a ready-to-build App Block, batteries included.
+		Short: "Create a ready-to-build App (batteries-included, SDK money-path)",
+		Long: `Create a ready-to-build App, batteries included.
 
 This is the friendly happy path: a thin superset of "civitai app init" that
 defaults to the rich page-money template — a Vite + React + TypeScript full-page
-block wired to the published App SDK (estimate -> consent -> submit -> poll ->
+app wired to the published App SDK (estimate -> consent -> submit -> poll ->
 Buzz spend), with a mock-host dev harness and a unit test. The scaffold is
 immediately runnable (npm install && npm run dev:harness), test-green, and
 validates clean.
 
 Templates (override with --template):
-  static      a no-build page block (index.html + a tiny JS, no build step)
-  page-vite   a vite + React page block (config-as-code build: buildCommand + outputDir)
-  page-money  a vite + React + TS full-page (W10) money-path block wired to the
+  static      a no-build page app (index.html + a tiny JS, no build step)
+  page-vite   a vite + React page app (config-as-code build: buildCommand + outputDir)
+  page-money  a vite + React + TS full-page (W10) money-path app wired to the
               published App SDK (estimate -> consent -> submit -> poll -> Buzz spend)
               [default for create]
 
@@ -44,13 +44,13 @@ a positional [dir] or --dir <path>; override the display name independently with
 Note: ` + "`civitai login`" + ` (OAuth) grants submit but NOT Buzz-spend. To run
 ` + "`dev:live`" + ` real generations, authenticate with a full-scope personal API key
 (` + "`civitai login --token <key>`" + `, created at https://civitai.com/user/account).`,
-		Example: `  # A page-money block in ./my-block (the batteries-included default).
+		Example: `  # A page-money app in ./my-block (the batteries-included default).
   civitai app create my-block
 
   # "My Cool Block" -> slug my-cool-block, dir ./my-cool-block.
   civitai app create "My Cool Block"
 
-  # Same as init: a no-build static block.
+  # Same as init: a no-build static app.
   civitai app create my-block --template static
 
   # Custom output directory (slug stays my-block; created in ./apps/foo).
@@ -64,7 +64,7 @@ Note: ` + "`civitai login`" + ` (OAuth) grants submit but NOT Buzz-spend. To run
 	// create defaults to the batteries-included page-money template; every
 	// other flag matches init exactly.
 	cmd.Flags().StringVarP(&templateFlag, "template", "t", string(scaffold.PageMoney), "project template: static | page-vite | page-money")
-	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published block slug (not yet wired)")
+	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published app slug (not yet wired)")
 	cmd.Flags().StringVar(&dirFlag, "dir", "", "output directory (default ./<slug>)")
 	cmd.Flags().StringVar(&nameFlag, "name", "", "display name (default derived from the name argument)")
 	return cmd

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -105,7 +105,7 @@ func newAppDevTokenCmd() *cobra.Command {
 		Long: `Mint a short-lived dev block token so a scaffolded page-money app can run
 "npm run dev:live" against the REAL Civitai backend.
 
-Calls the moderator-gated mint route (POST /api/v1/blocks/dev-token) with your
+Calls the invite-gated mint route (POST /api/v1/blocks/dev-token) with your
 stored credential and prints the token (a ~4-hour RS256 JWT). Paste it into
 VITE_LIVE_BLOCK_TOKEN in .env.development.local, then restart "npm run dev:live".
 
@@ -117,7 +117,7 @@ The minted token's CAPABILITIES depend on the credential you mint with:
     spend) — dev:live shows your viewer + catalog/storage, but estimate →
     submit → generation will NOT spend.
 
-Pre-GA the mint route is moderator-only. You do NOT need to submit the app
+Pre-GA the mint route is invite-only. You do NOT need to submit the app
 first — for a brand-new slug with no app row yet, the token is minted from the
 scopes in your local block.manifest.json (clamped server-side), so
 "create → dev-token → dev:live" works directly. The token is short-lived —

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -161,7 +161,7 @@ func TestAppDevTokenErrorMapping(t *testing.T) {
 		{http.StatusForbidden, map[string]any{"message": "mods only"}, "not authorized"},
 		{http.StatusUnauthorized, map[string]any{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]any{"message": "flag off"}, "App Blocks unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]any{"message": "flag off"}, "Apps unavailable (503)"},
 	}
 	for _, tc := range cases {
 		srv := devTokenServer(t, tc.body, tc.status, nil)

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -18,13 +18,13 @@ func newAppInitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init [name] [dir]",
-		Short: "Scaffold a ready-to-build App Block project",
-		Long: `Scaffold a correct, ready-to-build App Block project.
+		Short: "Scaffold a ready-to-build App project",
+		Long: `Scaffold a correct, ready-to-build App project.
 
 Templates:
-  static      a no-build page block (index.html + a tiny JS, no build step)
-  page-vite   a vite + React page block (config-as-code build: buildCommand + outputDir)
-  page-money  a vite + React + TS full-page (W10) money-path block wired to the
+  static      a no-build page app (index.html + a tiny JS, no build step)
+  page-vite   a vite + React page app (config-as-code build: buildCommand + outputDir)
+  page-money  a vite + React + TS full-page (W10) money-path app wired to the
               published App SDK (estimate -> consent -> submit -> poll -> Buzz spend)
 
 The display name can be free-form ("My Cool Block"); it is slugified for the
@@ -33,10 +33,10 @@ blockId. A slug-shaped name is used verbatim.
 By default the project is created in ./<slug>. Override the output directory with
 a positional [dir] or --dir <path>; override the display name independently with
 --name (so name, slug, and directory can all differ).`,
-		Example: `  # A no-build static block in ./my-block.
+		Example: `  # A no-build static app in ./my-block.
   civitai app init my-block
 
-  # A page-money block; "My Cool Block" -> slug my-cool-block, dir ./my-cool-block.
+  # A page-money app; "My Cool Block" -> slug my-cool-block, dir ./my-cool-block.
   civitai app init "My Cool Block" --template page-money
 
   # Custom output directory (slug stays my-block; created in ./apps/foo).
@@ -51,7 +51,7 @@ a positional [dir] or --dir <path>; override the display name independently with
 	}
 
 	cmd.Flags().StringVarP(&templateFlag, "template", "t", string(scaffold.Static), "project template: static | page-vite | page-money")
-	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published block slug (not yet wired)")
+	cmd.Flags().StringVar(&fromSlug, "from", "", "fork from an existing published app slug (not yet wired)")
 	cmd.Flags().StringVar(&dirFlag, "dir", "", "output directory (default ./<slug>)")
 	cmd.Flags().StringVar(&nameFlag, "name", "", "display name (default derived from the name argument)")
 	return cmd
@@ -67,10 +67,10 @@ func runAppScaffold(cmd *cobra.Command, args []string, templateFlag, fromSlug, d
 	if fromSlug != "" {
 		return fmt.Errorf(`--from is not yet wired up.
 
-Forking an existing published block requires fetching its source from the
-server, which this CLI cannot do yet (no programmatic block-source endpoint).
+Forking an existing published app requires fetching its source from the
+server, which this CLI cannot do yet (no programmatic app-source endpoint).
 
-TODO(server): expose a read endpoint that returns a published block's canonical
+TODO(server): expose a read endpoint that returns a published app's canonical
 source tree by slug, then --from can scaffold from it. For now, run a plain
 init and copy the upstream files in manually.`)
 	}
@@ -159,7 +159,7 @@ init and copy the upstream files in manually.`)
 // full tree) followed by a numbered, template-tailored "Next steps" sequence.
 func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Template, destDir, abs string, written []string) {
 	// One scannable line: name, template, where, and how many files — no tree.
-	fmt.Fprintf(out, "✓ Created App Block %q (%s)  ·  %s/  ·  %d files\n", display, tmpl, destDir, len(written))
+	fmt.Fprintf(out, "✓ Created App %q (%s)  ·  %s/  ·  %d files\n", display, tmpl, destDir, len(written))
 
 	fmt.Fprintln(out, "\nNext steps:")
 	switch {

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -20,13 +20,13 @@ func newAppStatusCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "status [blockId]",
-		Short: "Check the review/deploy status of your App Block submissions",
-		Long: `Check the review and deploy status of your own App Block submissions.
+		Short: "Check the review/deploy status of your App submissions",
+		Long: `Check the review and deploy status of your own App submissions.
 
 Calls the token-authenticated, self-scoped status route
 (GET /api/v1/blocks/submissions) with your stored credential — you only ever see
 your OWN submissions. Both a personal API key and an OAuth login (civitai login)
-work; the OAuth token must carry the App Blocks submit scope (the same gate the
+work; the OAuth token must carry the Apps submit scope (the same gate the
 submit route uses).
 
 With no argument it lists all your submissions (newest first). Pass a blockId

--- a/internal/cmd/app_status_test.go
+++ b/internal/cmd/app_status_test.go
@@ -201,7 +201,7 @@ func TestAppStatusErrorMapping(t *testing.T) {
 		want   string
 	}{
 		{http.StatusUnauthorized, "Invalid API key", "civitai login"},
-		{http.StatusForbidden, "restricted to the civitai team", "gated preview"},
+		{http.StatusForbidden, "restricted to the civitai team", "invite-only beta"},
 		{http.StatusNotFound, "Submission not found", "no such submission"},
 		{http.StatusTooManyRequests, "Rate limit exceeded", "rate limited"},
 		{http.StatusServiceUnavailable, "App Blocks is not enabled", "not enabled"},

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -23,8 +23,8 @@ func newAppSubmitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "submit [dir]",
-		Short: "Package and submit an App Block for review",
-		Long: `Package the canonical App Block source tree and submit it for moderator
+		Short: "Package and submit an App for review",
+		Long: `Package the canonical App source tree and submit it for moderator
 review.
 
 The package is the SOURCE tree (manifest + src + build config) — NOT a
@@ -145,5 +145,5 @@ func printManualNextSteps(cmd *cobra.Command, cfg *config.Config, m *manifest.Ma
 	fmt.Fprintln(out, "     civitai app submit")
 	fmt.Fprintf(out, "\n  2) Or upload %s via the web UI:\n", filepath.Base(zipPath))
 	fmt.Fprintf(out, "     %s/apps/submit\n", cfg.BaseURL())
-	fmt.Fprintln(out, "     (requires a moderator account while App Blocks is mod-gated).")
+	fmt.Fprintln(out, "     (requires an invite while Apps is in invite-only beta).")
 }

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -14,8 +14,8 @@ func newAppValidateCmd() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "validate [dir]",
-		Short: "Validate block.manifest.json against the App Block schema",
-		Long: `Validate an App Block project.
+		Short: "Validate block.manifest.json against the App schema",
+		Long: `Validate an App project.
 
 This is a best-effort LOCAL pre-check that mirrors the platform's approve-time
 validator (BlockManifestValidator). It catches most rejections before you

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -16,14 +16,14 @@ func newAppWithdrawCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "withdraw [pubreq-id]",
-		Short: "Withdraw your own pending App Block submission",
-		Long: `Withdraw your own pending App Block submission so you can resubmit a new bundle
+		Short: "Withdraw your own pending App submission",
+		Long: `Withdraw your own pending App submission so you can resubmit a new bundle
 for the same slug.
 
 Calls the token-authenticated, self-scoped withdraw route
 (POST /api/v1/blocks/withdraw) with your stored credential — you can only ever
 withdraw your OWN submissions. Both a personal API key and an OAuth login
-(civitai login) work; the OAuth token must carry the App Blocks submit scope
+(civitai login) work; the OAuth token must carry the Apps submit scope
 (the same gate the submit route uses).
 
 Only a submission still in the 'pending' review state can be withdrawn; an

--- a/internal/cmd/app_withdraw_test.go
+++ b/internal/cmd/app_withdraw_test.go
@@ -150,7 +150,7 @@ func TestAppWithdrawErrorMapping(t *testing.T) {
 		{http.StatusUnauthorized, map[string]any{"message": "invalid key"}, "not authorized"},
 		{http.StatusForbidden, map[string]any{"message": "no access"}, "not authorized"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]any{"message": "Rate limiter unavailable; please retry"}, "App Blocks unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]any{"message": "Rate limiter unavailable; please retry"}, "Apps unavailable (503)"},
 	}
 	for _, tc := range cases {
 		srv := withdrawServer(t, tc.body, tc.status, nil)

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -103,7 +103,7 @@ func TestAppInitScaffoldsAndValidates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app init: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "Created App Block") {
+	if !strings.Contains(out, "Created App") {
 		t.Errorf("unexpected init output: %s", out)
 	}
 	// Manifest must exist and validate clean.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -167,10 +167,10 @@ func NewRootCmd() *cobra.Command {
 	var noUpdateCheck bool
 	root := &cobra.Command{
 		Use:   "civitai",
-		Short: "Civitai CLI — author and ship App Blocks",
+		Short: "Civitai CLI — author and ship Apps",
 		Long: `civitai is the command-line interface for Civitai (https://civitai.com).
 
-Its first feature group is App Blocks authoring — App Blocks are small,
+Its first feature group is Apps authoring — Apps are small,
 sandboxed web apps that run inside Civitai surfaces. The CLI scaffolds a
 correct project, validates it against the platform contract, and packages it
 for submission, so you don't have to hand-format a ZIP.
@@ -178,7 +178,7 @@ for submission, so you don't have to hand-format a ZIP.
 Get started:
 
   civitai login                    store your API token
-  civitai app create my-app        scaffold a ready-to-build App Block
+  civitai app create my-app        scaffold a ready-to-build App
   civitai app validate             check the manifest before you submit
   civitai app submit               package + submit for review`,
 		Example: `  # First time: authenticate, then scaffold and submit an app.

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,4 +1,4 @@
-// Package manifest holds the App Block manifest filename constant and a
+// Package manifest holds the App manifest filename constant and a
 // lightweight reader for the fields the CLI needs (slug/version/name).
 package manifest
 
@@ -16,7 +16,7 @@ import (
 // the key + separator prefix, preserved verbatim on rewrite.
 var blockIDField = regexp.MustCompile(`("blockId"\s*:\s*)"[^"]*"`)
 
-// Filename is the one mandatory file in an App Block, at the project root.
+// Filename is the one mandatory file in an App, at the project root.
 // The server matches this exact path inside the ZIP (no nesting).
 const Filename = "block.manifest.json"
 
@@ -59,7 +59,7 @@ func Load(dir string) (*Manifest, error) {
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("no %s found in %s — is this an App Block project? run `civitai app init` to create one", Filename, dir)
+			return nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app init` to create one", Filename, dir)
 		}
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func SetBlockID(dir, newBlockID string) error {
 	info, err := os.Stat(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("no %s found in %s — is this an App Block project?", Filename, dir)
+			return fmt.Errorf("no %s found in %s — is this an App project?", Filename, dir)
 		}
 		return err
 	}
@@ -149,7 +149,7 @@ func LoadRaw(dir string) (any, *Manifest, error) {
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, fmt.Errorf("no %s found in %s — is this an App Block project? run `civitai app init` to create one", Filename, dir)
+			return nil, nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app init` to create one", Filename, dir)
 		}
 		return nil, nil, err
 	}

--- a/internal/pkgzip/pkgzip.go
+++ b/internal/pkgzip/pkgzip.go
@@ -1,4 +1,4 @@
-// Package pkgzip packages an App Block project directory into the canonical
+// Package pkgzip packages an App project directory into the canonical
 // ZIP the platform build recipe expects: the SOURCE tree (manifest + src +
 // build config), with build artifacts and VCS/dependency dirs excluded.
 //

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -1,4 +1,4 @@
-// Package scaffold renders embedded App Block project templates onto disk.
+// Package scaffold renders embedded App project templates onto disk.
 package scaffold
 
 import (

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -1,6 +1,6 @@
 # {{ .Name }}
 
-A Civitai **page money-path** App Block (Vite + React + TypeScript), wired to
+A Civitai **page money-path** App (Vite + React + TypeScript), wired to
 the published App SDK (`@civitai/blocks-react` + `@civitai/app-sdk`). It mounts
 as a full-page (W10) app at `/apps/run/{{ .Slug }}` and spends Buzz to generate
 an image: pick a checkpoint, optionally layer on a few LoRAs (each with a
@@ -12,7 +12,7 @@ A sandboxed static web app served in an iframe by the Civitai host. Its UI is
 built from the **`@civitai/blocks-react/ui`** W6 component pack (Button, Textarea,
 Card, Stack, Group, Alert, Badge) — the one exception is each LoRA's weight
 control (a themed native range `<input>`, since the pack ships no Slider yet).
-The model + LoRA pickers are the HOST's own — the block never browses a catalog;
+The model + LoRA pickers are the HOST's own — the app never browses a catalog;
 it calls the SDK's `useCheckpointPicker` / `useResourcePicker` hooks and the host
 opens its native resource modal. The pack ships its own theme-aware styles;
 `injectBlocksStyles()` is called at module init in `src/App.tsx` so the first
@@ -27,7 +27,7 @@ The money path uses the SDK hooks — never raw `window.parent.postMessage`:
 
 - `useBuzzWorkflow()` — `estimate` / `submit` / `poll` (the spend).
 - `useCheckpointPicker()` / `useResourcePicker()` — open the HOST's native
-  resource picker for the checkpoint + LoRAs (the block never browses a catalog).
+  resource picker for the checkpoint + LoRAs (the app never browses a catalog).
 - `useRequestConsent()` — lazy, on first Generate: `ai:write:budgeted` is
   consent-gated, so the token mints WITHOUT it; the grant arrives as a
   `TOKEN_REFRESH` and the app auto-resumes the click.
@@ -46,7 +46,7 @@ read proactively. The budget comes from `page.buzzBudgetPerGen` in the manifest.
 The **Change model** button calls `useCheckpointPicker().open({ baseModelGroup,
 currentVersionId })`. The HOST opens its own native checkpoint picker (in
 `dev:live` the SDK live host serves a protocol-identical in-harness catalog
-overlay; on the real platform it's civitai's own modal); the block never sees a
+overlay; on the real platform it's civitai's own modal); the app never sees a
 catalog, a list, or any resource the user didn't pick. The picker resolves with a
 `BlockCheckpointInfo`, which `checkpointFromPick` (`src/models.ts`) maps into the
 selected checkpoint.
@@ -103,7 +103,7 @@ set it for you):
 | `npm run dev:live` | **live** | The SDK **live host** (`createLiveHost`) — forwards the protocol to the **real Civitai backend** with a real dev token. **Spends REAL Buzz / real compute.** |
 
 **How `dev:live` reaches the backend.** `dev:live` mounts `createLiveHost` from
-`@civitai/blocks-react/testing`, which forwards the App-Block postMessage
+`@civitai/blocks-react/testing`, which forwards the App postMessage
 protocol to the real backend using a pasted dev token (Bearer). The live host's
 backend calls go through the **vite dev proxy** (`server.proxy['/api']` in
 `vite.config.ts`), NOT straight to `civitai.com`: `createLiveHost` is configured
@@ -132,14 +132,14 @@ target with `VITE_LIVE_HOST_ORIGIN` (default `https://civitai.com`).
 To use it:
 
 1. Mint a short-lived dev block token (a ~4-hour RS256 JWT; re-mint + restart
-   when it expires). The friendly path is the CLI — it calls the moderator-gated
+   when it expires). The friendly path is the CLI — it calls the invite-gated
    mint route with your stored credential and writes a paste-ready line:
    ```bash
    civitai app dev-token {{ .Slug }} --env >> .env.development.local
    ```
    (drop `--env >> …` to just print the token). **Auth — the credential you mint
    with decides what the dev token can do:**
-   - The mint needs a credential carrying the **App Blocks submit** scope.
+   - The mint needs a credential carrying the **Apps submit** scope.
    - **Real generation (spends real Buzz) needs a full-scope personal API key.**
      Create one at `https://civitai.com/user/account` (a personal key carries
      every scope, including AI Services), store it with
@@ -153,7 +153,7 @@ To use it:
        -d '{"slug":"{{ .Slug }}","scopes":["ai:write:budgeted"]}'   # → { token, expiresAt, scopes, buzzBudget }
      ```
    - **`civitai login` (the OAuth device flow) mints a read/identity-only dev
-     token for this app.** The `civitai-cli` client carries App Blocks submit but
+     token for this app.** The `civitai-cli` client carries Apps submit but
      NOT AI Services (by design — login shouldn't grant general Buzz spend). A
      page-money app's manifest declares only `ai:write:budgeted`, and the server
      strips that budgeted-spend scope from an OAuth-minted token (no AI Services),
@@ -182,7 +182,7 @@ pill. Both reads go same-origin through the vite dev proxy.
 The two reads use **different credentials** — by design, and security-critical:
 
 - **Profile name** — `/api/v1/blocks/me`, authed with the page-scoped
-  **block token** (`VITE_LIVE_BLOCK_TOKEN`). Faithful to prod: a page block can
+  **block token** (`VITE_LIVE_BLOCK_TOKEN`). Faithful to prod: a page app can
   read its own viewer.
 - **Buzz balance** — `/api/trpc/buzz.getBuzzAccount`. The page block token can't
   read Buzz (no `buzz:read:self`), so the balance needs a buzz-read credential:

--- a/internal/scaffold/templates/page-money/env.example.tmpl
+++ b/internal/scaffold/templates/page-money/env.example.tmpl
@@ -27,7 +27,7 @@ VITE_DEV_HARNESS=
 VITE_HARNESS_MODE=
 
 # LIVE mode only. A short-lived, scoped dev block token minted for local dev via
-# the moderator-gated dev-token endpoint (POST /api/v1/blocks/dev-token). Paste
+# the invite-gated dev-token endpoint (POST /api/v1/blocks/dev-token). Paste
 # it here to run `dev:live` against the real backend. ⚠️ A real token here spends
 # REAL Buzz; it's short-lived (~4h) — never commit one.
 #
@@ -41,7 +41,7 @@ VITE_HARNESS_MODE=
 #     -H "Authorization: Bearer $CIVITAI_TOKEN" -H 'Content-Type: application/json' \
 #     -d '{"slug":"<your-app-slug>"}'
 # `civitai login` (OAuth) mints a READ-ONLY token (user:read:self): the civitai-cli
-# client has App Blocks submit but NOT AI Services, so the server strips the
+# client has Apps submit but NOT AI Services, so the server strips the
 # budgeted-spend scope. For a page-money (generation) app whose manifest declares
 # only `ai:write:budgeted`, that leaves the token read-only — viewer + catalog +
 # storage work, but real generation (estimate -> submit -> spend) does NOT. For that

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "Civitai App Block (page money path) — estimate -> consent -> submit -> poll -> real Buzz spend, wired to the published App SDK.",
+  "description": "Civitai App (page money path) — estimate -> consent -> submit -> poll -> real Buzz spend, wired to the published App SDK.",
   "license": "MIT",
   "scripts": {
     "postinstall": "node -e \"console.log('\\n✓ Installed. Next: npm run dev:harness   (preview — mock host, no Buzz)\\n  real generation: civitai app dev-token <slug> -> npm run dev:live (no submit needed; see README)   ·   publish: civitai app submit')\"",

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -55,7 +55,7 @@ import {
 injectBlocksStyles();
 
 /**
- * {{ .Name }} — a full-page (W10) money-path App Block whose ENTIRE interface is
+ * {{ .Name }} — a full-page (W10) money-path App whose ENTIRE interface is
  * built from the `@civitai/blocks-react/ui` W6 component pack (Button, Textarea,
  * Card, Stack, Group, Alert, Badge). It exercises the page money path end-to-end:
  * estimate -> (lazy consent) -> submit -> poll -> real Buzz spend, using the

--- a/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-transport.ts.tmpl
@@ -20,7 +20,7 @@ import { createLiveHost, resetTransport } from '@civitai/blocks-react/testing';
  *    network. Safe to spam.
  *  - `'live'`  — talk to a REAL host with a REAL block token (spends REAL Buzz
  *    and real compute) via the SDK's `createLiveHost`, which forwards the
- *    App-Block postMessage protocol to the real Civitai backend (Bearer = the
+ *    App postMessage protocol to the real Civitai backend (Bearer = the
  *    pasted dev token). Needs a `VITE_LIVE_BLOCK_TOKEN`; until you paste one,
  *    live mode FAILS SAFE (see {@link resolveLiveConfig}) — it never silently
  *    spends.
@@ -69,7 +69,7 @@ export type LiveConfig =
  * unless a dev block token (`VITE_LIVE_BLOCK_TOKEN`) is present — returning
  * `{ ready: false }` with a clear reason otherwise. The token is a short-lived
  * RS256 JWT minted by the server dev-token endpoint (`POST /api/v1/blocks/dev-token`,
- * moderator-gated); paste it into `VITE_LIVE_BLOCK_TOKEN` (never commit it).
+ * invite-gated); paste it into `VITE_LIVE_BLOCK_TOKEN` (never commit it).
  */
 export function resolveLiveConfig(): LiveConfig {
   const token = import.meta.env.VITE_LIVE_BLOCK_TOKEN as string | undefined;
@@ -94,7 +94,7 @@ export function resolveLiveConfig(): LiveConfig {
 
 /**
  * Mount the SDK's real LIVE host (`createLiveHost`) for `dev:live`. It forwards
- * the App-Block postMessage protocol to the real Civitai backend using the
+ * the App postMessage protocol to the real Civitai backend using the
  * pasted dev token (Bearer), so a successful submit SPENDS REAL BUZZ against
  * real compute. Like the mock host, it replies from `window.location.origin`,
  * so the SDK transport must allow this origin first ({@link installHarnessTransport}).

--- a/internal/scaffold/templates/page-money/src/setup-dev-live.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/setup-dev-live.test.ts.tmpl
@@ -108,8 +108,8 @@ describe('mapMintError', () => {
   it('maps 401 → invalid key', () => {
     expect(mapMintError(401, '{}')).toMatch(/Invalid API key/);
   });
-  it('maps 403 → needs moderator access (pre-GA)', () => {
-    expect(mapMintError(403, '{}')).toMatch(/moderator access/);
+  it('maps 403 → needs an invite (invite-only beta)', () => {
+    expect(mapMintError(403, '{}')).toMatch(/invite/);
   });
   it('maps 404 → registered to a different account', () => {
     expect(mapMintError(404, '{}')).toMatch(/different account/);
@@ -166,7 +166,7 @@ describe('mintDevToken', () => {
       fetch: fakeFetch(403, JSON.stringify({ message: 'not a mod' }), {}),
       backendOrigin: 'https://civitai.com',
     });
-    expect(res).toEqual({ error: expect.stringMatching(/moderator access/) });
+    expect(res).toEqual({ error: expect.stringMatching(/invite/) });
   });
 
   it('maps a 401 to an invalid-key error', async () => {

--- a/internal/scaffold/templates/page-money/src/setup-dev-live.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/setup-dev-live.ts.tmpl
@@ -103,10 +103,10 @@ export function mergeEnvFile(existing: string | undefined, vars: DevLiveEnv): st
  * the CLI's `devTokenError` mapping (api.go) so the auto-setup path and the
  * manual path explain failures the same way.
  *  - 401 → invalid / not-a-spend key
- *  - 403 → needs moderator access (pre-GA) + a full-scope personal key
+ *  - 403 → needs an invite (invite-only beta) + a full-scope personal key
  *  - 404 → slug registered to a different account
  *  - 429 → rate limited
- *  - 503 → App Blocks unavailable
+ *  - 503 → Apps unavailable
  * `body` is the raw response text; a `{ "message": ... }` field is surfaced.
  */
 export function mapMintError(status: number, body: string): string {
@@ -122,13 +122,13 @@ export function mapMintError(status: number, body: string): string {
     case 401:
       return `Invalid API key (401)${suffix}. Paste a full-scope personal API key from civitai.com/user/account.`;
     case 403:
-      return `Not authorized (403)${suffix}. Minting a dev token needs moderator access (pre-GA) AND a full-scope personal API key — an OAuth login key can't spend.`;
+      return `Not authorized (403)${suffix}. Minting a dev token needs an invite (invite-only beta) AND a full-scope personal API key — an OAuth login key can't spend.`;
     case 404:
       return `App not found (404)${suffix}. The slug is registered to a different account.`;
     case 429:
       return `Rate limited (429)${suffix}. Try again shortly.`;
     case 503:
-      return `App Blocks is unavailable (503)${suffix}. Try again later.`;
+      return `Apps is unavailable (503)${suffix}. Try again later.`;
     default:
       return `Mint failed (${status})${suffix}.`;
   }

--- a/internal/scaffold/templates/page-money/src/setup-plugin.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/setup-plugin.test.ts.tmpl
@@ -170,7 +170,7 @@ describe('civitaiSetupPlugin middleware', () => {
     expect(res.statusCode).toBe(200);
     const parsed = JSON.parse(res.body);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toMatch(/moderator access/);
+    expect(parsed.error).toMatch(/invite/);
     expect(existsSync(join(dir, '.env.development.local'))).toBe(false);
   });
 

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -1,6 +1,6 @@
 # {{ .Name }}
 
-A Civitai App Block (Vite + React, config-as-code build).
+A Civitai App (Vite + React, config-as-code build).
 
 ## What this is
 

--- a/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
+++ b/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-// {{ .Name }} — Civitai App Block (vite + React page template).
+// {{ .Name }} — Civitai App (vite + React page template).
 //
 // The host serves this bundle in a sandboxed iframe and communicates over
 // window.postMessage. The example below reports the document height to the
@@ -23,7 +23,7 @@ export default function App() {
   return (
     <main className="app">
       <h1>{{ .Name }}</h1>
-      <p>A Civitai App Block built with Vite + React.</p>
+      <p>A Civitai App built with Vite + React.</p>
       <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
     </main>
   );

--- a/internal/scaffold/templates/page-vite/vite.config.js.tmpl
+++ b/internal/scaffold/templates/page-vite/vite.config.js.tmpl
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// The platform builds the block with `npm run build` and serves the static
+// The platform builds the app with `npm run build` and serves the static
 // output from `dist/` (see block.manifest.json: buildCommand + outputDir).
 //
 // base: './' makes all asset URLs relative so the bundle works regardless of

--- a/internal/scaffold/templates/static/README.md.tmpl
+++ b/internal/scaffold/templates/static/README.md.tmpl
@@ -1,6 +1,6 @@
 # {{ .Name }}
 
-A Civitai App Block (static, no-build).
+A Civitai App (static, no-build).
 
 ## What this is
 

--- a/internal/scaffold/templates/static/app.js.tmpl
+++ b/internal/scaffold/templates/static/app.js.tmpl
@@ -1,10 +1,10 @@
-// {{ .Name }} — Civitai App Block (static template).
+// {{ .Name }} — Civitai App (static template).
 //
-// A block is a sandboxed static web app served in an iframe by the Civitai
+// An app is a sandboxed static web app served in an iframe by the Civitai
 // host. The host owns the build and the runtime; this file is served as-is.
 //
-// The host and the block talk over window.postMessage. The minimal useful
-// thing a block can do is tell the host how tall it is so the iframe resizes.
+// The host and the app talk over window.postMessage. The minimal useful
+// thing an app can do is tell the host how tall it is so the iframe resizes.
 // See the App SDK for the full message protocol and the available scopes.
 
 (function () {

--- a/internal/scaffold/templates/static/index.html.tmpl
+++ b/internal/scaffold/templates/static/index.html.tmpl
@@ -10,7 +10,7 @@
   <body>
     <main id="app">
       <h1>{{ .Name }}</h1>
-      <p>This is a Civitai App Block (static template). Edit <code>app.js</code> to build your block.</p>
+      <p>This is a Civitai App (static template). Edit <code>app.js</code> to build your app.</p>
       <button id="ping">Tell the host my height</button>
     </main>
     <script src="./app.js"></script>

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -60,7 +60,7 @@ func schema() (*jsonschema.Schema, error) {
 	return s, nil
 }
 
-// Dir validates the App Block project in dir.
+// Dir validates the App project in dir.
 func Dir(dir string) (Result, error) {
 	var res Result
 

--- a/schema.go
+++ b/schema.go
@@ -2,7 +2,7 @@ package cli
 
 import "embed"
 
-// SchemaJSON is the vendored App Block manifest JSON Schema, embedded so the
+// SchemaJSON is the vendored App manifest JSON Schema, embedded so the
 // CLI validates against the same contract it ships. The file is the canonical
 // copy intended to also be published server-side (see README).
 //


### PR DESCRIPTION
Copy-only (no behavior change), per feedback: reframe for the invite-only beta + adopt the site's "Apps" naming.

### 1. README pre-GA notice → top + invite-only beta
Moved the pre-GA blockquote directly under the `# civitai CLI` H1 and reworded it from "moderator-gated preview" to **invite-only beta**:
> ⚠️ **Apps is in a limited, invite-only beta (pre-GA).** You can install this CLI, `login`, scaffold, validate, and run an app locally right now — but **`civitai app submit` and `dev:live` require an invite**: submission and `dev:live` are limited to **invited beta testers** … until Apps opens to the public.

### 2. Repo-wide user-facing rename
"App Block(s)" → "App(s)" (and standalone product-noun "block" → "app" in prose/UI); "moderator-gated / mod-only / gated preview" access framing → **invite-only beta**. Spans README, AGENTS.md, CONTRIBUTING.md, `.goreleaser.yaml`, all `internal/**/*.go` (Cobra help, output, error messages), and the scaffold templates. ~100+ strings across 39 files. **Genuine mod-REVIEW references kept** — submission still enters moderator review/approval; only the *eligibility* framing changed (invited non-mods can now submit + dev:live).

### Preserved (identifiers — grep-verified unchanged)
`block.manifest.json` (96), `VITE_LIVE_BLOCK_TOKEN` (57), `/api/v1/blocks/` (52), `@civitai/blocks-react` (26), `blockId` (161), `AppBlocksSubmit`, `civit.ai`, "block token", the `build-your-first-app-block.md` URL (link text only became "Build your first App"). No over-rename signatures (`app.manifest.json`, `VITE_LIVE_APP_TOKEN`, `/api/v1/apps/`, `@civitai/apps-react` all 0).

### Verified
`go build` / `go vet` / `gofmt -l` (empty) / `go test ./...` all clean; scaffold render tests + updated string-assertion tests (cmd/error-mapping/scaffold-vitest) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)