### PR TITLE
docs: self-serve request-access issue form + README button

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Build your first app (walkthrough)
+    url: https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md
+    about: The end-to-end guide to scaffolding, validating, and running an app locally.
+  - name: 🐛 Bug or feature request
+    url: https://github.com/civitai/cli/issues/new
+    about: Something broken or missing in the CLI? Open a blank issue.

--- a/.github/ISSUE_TEMPLATE/request-access.yml
+++ b/.github/ISSUE_TEMPLATE/request-access.yml
@@ -1,0 +1,41 @@
+name: Request access (invite-only beta)
+description: Request access to the Apps invite-only beta — unlocks `civitai app submit` + `dev:live`.
+title: "[Access request] "
+labels: ["access-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Apps is in an invite-only beta.** You can already install the CLI, `login`, scaffold, validate, and run an app **locally** without an invite — an invite unlocks **`civitai app submit`** and **`dev:live`** (real generations).
+
+        Fill this out and we'll review your request. Only the username is required.
+  - type: input
+    id: username
+    attributes:
+      label: Civitai username
+      description: The account you'll build and submit with.
+      placeholder: your-civitai-username
+    validations:
+      required: true
+  - type: textarea
+    id: building
+    attributes:
+      label: What do you want to build?
+      description: A sentence or two about the app you have in mind. Optional, but it helps us prioritize.
+      placeholder: "e.g. a checkpoint × LoRA matrix generator, a prompt library, a seed explorer…"
+    validations:
+      required: false
+  - type: input
+    id: links
+    attributes:
+      label: Anything to show? (optional)
+      description: Links to prior work, a repo, a portfolio — anything that helps.
+    validations:
+      required: false
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Getting started
+      options:
+        - label: I've installed the CLI (`brew install civitai/tap/civitai`) — and ideally scaffolded an app locally with `civitai app create`.
+          required: false

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 > CLI, `login`, scaffold, validate, and run an app locally right now — but
 > **`civitai app submit` and `dev:live` require an invite**: submission and
 > `dev:live` are limited to **invited beta testers** while the feature is in a
-> limited (pre-GA) beta, until Apps opens to the public. There is no public
-> self-serve "request access" form yet — watch [civitai.com](https://civitai.com) and the
-> [issues on this repo](https://github.com/civitai/cli/issues) for the
-> general-availability announcement.
+> limited (pre-GA) beta, until Apps opens to the public.
+>
+> **Anyone can request an invite** — open a request below and we'll review it:
+
+[![Request access](https://img.shields.io/badge/Request%20access-invite--only%20beta-3b82f6?style=for-the-badge&logo=github)](https://github.com/civitai/cli/issues/new?template=request-access.yml)
 
 The command-line interface for [Civitai](https://civitai.com) — a single static
 binary for authoring and shipping **Apps**.


### PR DESCRIPTION
Lets **any** user request an invite to the Apps beta, instead of "watch for GA."

- **`.github/ISSUE_TEMPLATE/request-access.yml`** — a structured issue form: Civitai username (required), what you want to build (optional), links (optional), a getting-started ack. Auto-labeled `access-request` + titled `[Access request] …`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — keeps blank issues enabled (bug reports) and adds docs + bug contact links to the New-issue chooser.
- **README** — a "Request access" badge-button under the invite-only notice, linking to the prefilled form (`issues/new?template=request-access.yml`); removed the stale "no self-serve request-access form yet" sentence.

Docs/infra only — no Go changed. The civitai.com get-started "Civitai CLI" CTA points at this repo, so its New-issue chooser now surfaces the request-access form too.