### PR TITLE
chore(scaffold): re-pin page-money to @civitai/blocks-react@^0.17.0 (dev:live balance)

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -118,8 +118,9 @@ func TestRenderPageMoney(t *testing.T) {
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"@civitai/blocks-react"`)
 	// Per-account Buzz (useBuzzBalance / body.accountType / snapshot.spentAccountType)
-	// needs @civitai/blocks-react@0.16.0 + @civitai/app-sdk@0.14.0.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.16.0"`)
+	// needs @civitai/blocks-react@0.17.0 (createLiveHost answers GET_BUZZ_BALANCE so
+	// dev:live shows the balance too) + @civitai/app-sdk@0.14.0.
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.17.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.14.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.14.0",
-    "@civitai/blocks-react": "^0.16.0",
+    "@civitai/blocks-react": "^0.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
Re-pins the `page-money` scaffold's `@civitai/blocks-react` `^0.16.0` → `^0.17.0` to pick up the SDK **Phase 5** fix (`createLiveHost` now answers `GET_BUZZ_BALANCE` via the token-bound `blocks.getMyBuzzBalance` mutation).

**Effect:** newly scaffolded page-money apps now show the per-pool Buzz balance panel in **`dev:live`** too — previously it only worked in `dev:harness` (mock) + production, because the SDK's dev:live proxy host didn't forward the balance read.

`@civitai/app-sdk` stays `^0.14.0` (Phase 5 was blocks-react-only; the `GET_BUZZ_BALANCE`/`BUZZ_BALANCE_RESULT` message types were already in 0.14). The `scaffold_test.go` version assertion is updated in lockstep. `@civitai/blocks-react@0.17.0` is published to npm.

Final piece of the per-account-buzz feature (backend #2890 / SDK 0.14→0.17 / host #2893 / scaffold #78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)