### PR TITLE
docs: fix stale scaffold README SDK pin + App-Blocks rebrand leftovers

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -830,7 +830,7 @@ func cloneInfoError(status int, raw []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not authenticated — run `civitai login` (or set CIVITAI_TOKEN): %s", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("not permitted (are you the app owner, and is App Blocks enabled for your account?): %s", msg)
+		return fmt.Errorf("not permitted (are you the app owner, and is Apps enabled for your account?): %s", msg)
 	case http.StatusNotFound:
 		return fmt.Errorf("no such app for your account — check the slug with `civitai app status`: %s", msg)
 	default:

--- a/internal/cmd/app_pull.go
+++ b/internal/cmd/app_pull.go
@@ -50,7 +50,7 @@ func newAppPullCmd() *cobra.Command {
 		Use:   "pull [dir]",
 		Short: "Clone or sync your app's repository from Civitai",
 		Long: `Clone (or, if [dir] is already a checkout, pull) the canonical repository
-backing one of YOUR approved App Blocks. This is the read side of git authoring:
+backing one of YOUR approved Apps. This is the read side of git authoring:
 it fetches the current block.manifest.json + source so you can edit locally and
 then submit (` + "`civitai app submit`" + `) or push.
 

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -111,7 +111,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.14.0` + `@civitai/blocks-react@^0.16.0` (already pinned in
+`@civitai/app-sdk@^0.14.0` + `@civitai/blocks-react@^0.17.0` (already pinned in
 `package.json`).
 
 ## Develop


### PR DESCRIPTION
Doc/help-copy drift sweep of the CLI (help text, READMEs, template docs, comments). Docs/strings only — no behavior, flag, template-code, or identifier changes. `go build ./...` and `go test ./...` both pass.

## Fixed

| File | Change | Why |
|---|---|---|
| `internal/scaffold/templates/page-money/README.md.tmpl` | Prose SDK pin `@civitai/blocks-react@^0.16.0` → `^0.17.0` | The template's `package.json.tmpl` pins `^0.17.0` (commit #79) and the scaffold render test asserts `^0.17.0`; the README prose still said `^0.16.0`. Now consistent. |
| `internal/api/api.go` (403 branch) | User-facing error `…is App Blocks enabled for your account?` → `…is Apps enabled…` | Leftover the v0.1.37 "App Blocks" → "Apps" user-facing rename missed. |
| `internal/cmd/app_pull.go` (`Long`) | Help text `backing one of YOUR approved App Blocks.` → `…approved Apps.` | Same rename leftover, in cobra help output. |

## Scanned & deliberately left (not clear-cut / out of guardrails)

- **Wire/identifier "AppBlocks" references** — `ScopeAppBlocksSubmit` const, the `"AppBlocksSubmit"` scope string, and the comments/README that name the scope bitflag (`api.go`, `oauth.go:42/45`, `README.md:263`). These are protocol/identifier names, not prose — renaming is out of guardrails and would be wrong.
- **Internal comments** referencing the product as "App-Blocks" (`oauth.go:53` "App-Blocks dev token", `api.go:748` "App-Blocks-flag-gated"). Not user-facing; sit directly adjacent to the `AppBlocksSubmit` scope discussion. Left for human review rather than churn internal comments.
- **Test fixtures** in `submissions_test.go` / `withdraw_test.go` / `app_status_test.go` that use `"App Blocks is not enabled"` as a **mock server response** — that simulates what the backend returns; changing it is a behavior/fidelity question, not doc drift.
- **`page-money` template blurb in the main README** (`### Templates`) lists `useBuzzWorkflow / useRequestConsent / useBlockResize` but not the newer `useBuzzBalance` / account picker (Phase 4). It's an abbreviated—not incorrect—feature list; left as-is (no false claim).
- `page-vite` + `static` template READMEs: already clean ("A Civitai App", no "App Blocks").

## Verification

- `go build ./...` — OK
- `go test ./...` — all packages pass (incl. `internal/scaffold` render test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)