### PR TITLE
test: fill coverage gaps on money-path api/cmd + page-money template

### DIFF
--- a/internal/api/buzz_account_extra_test.go
+++ b/internal/api/buzz_account_extra_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetBuzzAccountGarbageResponse: a 200 that isn't the tRPC success envelope
+// (or a null .json) must error clearly rather than nil-deref the balance.
+func TestGetBuzzAccountGarbageResponse(t *testing.T) {
+	for _, body := range []string{
+		`not json`,
+		`{"result":{"data":{"json":null}}}`,
+		`{}`,
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		c := New(srv.URL, "tok", "")
+		_, err := c.GetBuzzAccount(context.Background())
+		srv.Close()
+		if err == nil {
+			t.Errorf("expected error for garbage buzz body %q", body)
+		}
+		if errors.Is(err, ErrBuzzScope) {
+			t.Errorf("a garbage 200 must not be classified as ErrBuzzScope: %v", err)
+		}
+	}
+}
+
+// TestGetBuzzAccountServerError: a non-200, non-403 status (e.g. 500) maps
+// through serverError — NOT ErrBuzzScope (only a 403 means missing scope).
+func TestGetBuzzAccountServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"json":{"message":"boom"}}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	_, err := c.GetBuzzAccount(context.Background())
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrBuzzScope) {
+		t.Errorf("a 500 must not be classified as ErrBuzzScope: %v", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("500 error should surface the status: %v", err)
+	}
+}

--- a/internal/api/clone_info_test.go
+++ b/internal/api/clone_info_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetForgejoCloneInfoSendsSlugInput pins the tRPC input encoding: the app is
+// sent under ?input={"json":{"slug":"<app>"}} and the success envelope
+// {result:{data:{json:{...}}}} decodes into ForgejoCloneInfo.
+func TestGetForgejoCloneInfoSendsSlugInput(t *testing.T) {
+	var gotPath, gotInput, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotInput = r.URL.Query().Get("input")
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{"json": map[string]any{
+				"notYetAvailable": false,
+				"slug":            "my-block",
+				"forgejoUsername": "dev-7",
+				"token":           "tok-sha1",
+				"httpUrl":         "https://forgejo.example.com/apps/my-block.git",
+				"cloneUrl":        "https://dev-7:tok-sha1@forgejo.example.com/apps/my-block.git",
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	info, err := c.GetForgejoCloneInfo(context.Background(), "my-block")
+	if err != nil {
+		t.Fatalf("GetForgejoCloneInfo: %v", err)
+	}
+	if gotPath != CloneInfoPath {
+		t.Errorf("path = %q, want %q", gotPath, CloneInfoPath)
+	}
+	if gotAuth != "Bearer tok123" {
+		t.Errorf("auth header = %q, want Bearer tok123", gotAuth)
+	}
+	// The slug travels under {"json":{"slug":...}}.
+	if !strings.Contains(gotInput, `"slug":"my-block"`) || !strings.Contains(gotInput, `"json"`) {
+		t.Errorf("tRPC input should carry {json:{slug}}: %q", gotInput)
+	}
+	if info.Slug != "my-block" || info.ForgejoUsername != "dev-7" {
+		t.Errorf("info = %+v", info)
+	}
+	if !strings.HasPrefix(info.CloneURL, "https://dev-7:tok-sha1@") {
+		t.Errorf("clone URL should embed the basic-auth credential: %q", info.CloneURL)
+	}
+}
+
+// TestGetForgejoCloneInfoNotYetAvailable: the server returns notYetAvailable=true
+// (no credential minted) — the parse must surface the flag + message so the pull
+// command can print the friendly "approve your first version" guidance.
+func TestGetForgejoCloneInfoNotYetAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{"json": map[string]any{
+				"notYetAvailable": true,
+				"slug":            "my-block",
+				"message":         "approve your first version first",
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	info, err := c.GetForgejoCloneInfo(context.Background(), "my-block")
+	if err != nil {
+		t.Fatalf("GetForgejoCloneInfo: %v", err)
+	}
+	if !info.NotYetAvailable || info.Message != "approve your first version first" {
+		t.Errorf("info = %+v, want NotYetAvailable with message", info)
+	}
+	if info.CloneURL != "" {
+		t.Errorf("no clone URL should be minted yet: %q", info.CloneURL)
+	}
+}
+
+func TestGetForgejoCloneInfoRequiresToken(t *testing.T) {
+	c := New("https://example.com", "", "")
+	if _, err := c.GetForgejoCloneInfo(context.Background(), "my-block"); err == nil {
+		t.Fatal("expected error with no token")
+	}
+}
+
+// TestGetForgejoCloneInfoGarbageResponse: a 200 whose body is not the expected
+// tRPC envelope (or a null .json) must be a clear error, not a nil-deref.
+func TestGetForgejoCloneInfoGarbageResponse(t *testing.T) {
+	for _, body := range []string{
+		`not json at all`,
+		`{"result":{"data":{"json":null}}}`,
+		`{"result":{}}`,
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		}))
+		c := New(srv.URL, "tok", "")
+		_, err := c.GetForgejoCloneInfo(context.Background(), "my-block")
+		srv.Close()
+		if err == nil {
+			t.Errorf("expected error for garbage body %q", body)
+		}
+	}
+}
+
+// TestCloneInfoErrorMapping pins the status->message mapping AND the tRPC-message
+// extraction ({error:{json:{message}}}), with a raw-body fallback when the body
+// isn't a tRPC error envelope.
+func TestCloneInfoErrorMapping(t *testing.T) {
+	trpcBody := func(msg string) []byte {
+		b, _ := json.Marshal(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": msg, "code": -32600}},
+		})
+		return b
+	}
+	cases := []struct {
+		name       string
+		status     int
+		body       []byte
+		wantSubstr string // must appear (the actionable prefix)
+		wantMsg    string // extracted/echoed server message that must appear
+	}{
+		{"401 tRPC message", http.StatusUnauthorized, trpcBody("token expired"), "not authenticated", "token expired"},
+		{"403 tRPC message", http.StatusForbidden, trpcBody("not the owner"), "not permitted", "not the owner"},
+		{"404 tRPC message", http.StatusNotFound, trpcBody("App not found"), "no such app", "App not found"},
+		{"500 default", http.StatusInternalServerError, trpcBody("kaboom"), "getMyForgejoCloneInfo failed (HTTP 500)", "kaboom"},
+		{"non-tRPC raw fallback", http.StatusForbidden, []byte("plain text denial"), "not permitted", "plain text denial"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cloneInfoError(tc.status, tc.body)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error %q should contain %q", err, tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error %q should echo the server message %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestGetForgejoCloneInfoMapsStatusError confirms a non-200 flows through
+// cloneInfoError end to end (403 -> "not permitted").
+func TestGetForgejoCloneInfoMapsStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": "App Blocks not enabled"}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	_, err := c.GetForgejoCloneInfo(context.Background(), "my-block")
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !strings.Contains(err.Error(), "not permitted") || !strings.Contains(err.Error(), "App Blocks not enabled") {
+		t.Errorf("403 should map to not-permitted + server message: %v", err)
+	}
+}

--- a/internal/api/scope_unmarshal_test.go
+++ b/internal/api/scope_unmarshal_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestScopeUnmarshalShapes covers the two valid wire shapes plus the null/empty
+// degradation and the malformed-input error paths of Scope.UnmarshalJSON — the
+// device-login route emits a plain string, the refresh route emits an array.
+func TestScopeUnmarshalShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"string shape", `"33554433"`, "33554433", false},
+		{"single-element array", `["33554433"]`, "33554433", false},
+		{"multi-element array", `["a","b","c"]`, "a b c", false},
+		{"empty array", `[]`, "", false},
+		{"json null degrades to empty", `null`, "", false},
+		{"malformed array element", `[123]`, "", true},
+		{"non-string non-array", `123`, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Scope
+			err := json.Unmarshal([]byte(tc.in), &s)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error unmarshaling %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.in, err)
+			}
+			if s.String() != tc.want {
+				t.Errorf("scope = %q, want %q", s.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestScopeUnmarshalWithinStruct confirms the custom unmarshaler engages when the
+// field is decoded as part of the token response envelope (both shapes).
+func TestScopeUnmarshalWithinStruct(t *testing.T) {
+	var arr TokenResponse
+	if err := json.Unmarshal([]byte(`{"access_token":"a","scope":["1","2"]}`), &arr); err != nil {
+		t.Fatalf("array-scope response: %v", err)
+	}
+	if arr.Scope.String() != "1 2" {
+		t.Errorf("array scope = %q, want '1 2'", arr.Scope.String())
+	}
+
+	var str TokenResponse
+	if err := json.Unmarshal([]byte(`{"access_token":"a","scope":"7"}`), &str); err != nil {
+		t.Fatalf("string-scope response: %v", err)
+	}
+	if str.Scope.String() != "7" {
+		t.Errorf("string scope = %q, want '7'", str.Scope.String())
+	}
+}

--- a/internal/cmd/money_path_note_test.go
+++ b/internal/cmd/money_path_note_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/manifest"
+)
+
+// TestManifestNeedsSpend pins the money-path predicate: only a manifest that
+// declares an `ai:write*` (Buzz-spend) scope is a money app. Matching is
+// case-insensitive and tolerant of surrounding whitespace; a non-spend scope
+// (even one containing "write") does NOT count.
+func TestManifestNeedsSpend(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []string
+		want   bool
+	}{
+		{"budgeted spend", []string{"user:read:self", "ai:write:budgeted"}, true},
+		{"bare ai:write", []string{"ai:write"}, true},
+		{"upper-case + padding", []string{"  AI:WRITE:BUDGETED  "}, true},
+		{"no scopes", nil, false},
+		{"read-only", []string{"user:read:self", "identity:read"}, false},
+		{"other write scope is not spend", []string{"models:write"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &manifest.Manifest{Scopes: tc.scopes}
+			if got := manifestNeedsSpend(m); got != tc.want {
+				t.Errorf("manifestNeedsSpend(%v) = %v, want %v", tc.scopes, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrintMoneyPathNotePrintsForSpendApps: a money app gets the OAuth-can't-spend
+// reminder (full-scope personal key needed for real dev:live Buzz spend); a
+// non-money app gets nothing (the note stays scoped to money apps).
+func TestPrintMoneyPathNotePrintsForSpendApps(t *testing.T) {
+	var spend bytes.Buffer
+	printMoneyPathNote(&spend, &manifest.Manifest{Scopes: []string{"ai:write:budgeted"}})
+	got := spend.String()
+	for _, want := range []string{
+		"full-scope personal API key",
+		"civitai login --token",
+		"cannot spend Buzz",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("money-path note should mention %q:\n%s", want, got)
+		}
+	}
+
+	var noSpend bytes.Buffer
+	printMoneyPathNote(&noSpend, &manifest.Manifest{Scopes: []string{"user:read:self"}})
+	if noSpend.Len() != 0 {
+		t.Errorf("non-money app should print no money-path note, got:\n%s", noSpend.String())
+	}
+}

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -7,8 +7,10 @@ import {
   accountLabel,
   buildWorkflowBody,
   clampPrompt,
+  firstImageUrl,
   formatCost,
   hasBudgetedScope,
+  isBusyPhase,
   isDisallowedAccountError,
   isInsufficientBuzz,
   isTerminalStatus,
@@ -25,9 +27,15 @@ describe('formatCost', () => {
   it('renders an integer with separators', () => {
     expect(formatCost(1234)).toBe('1,234');
   });
-  it('renders a dash for null / non-finite', () => {
+  it('renders a dash for null / undefined / non-finite', () => {
     expect(formatCost(null)).toBe('—');
+    expect(formatCost(undefined)).toBe('—');
     expect(formatCost(NaN)).toBe('—');
+    expect(formatCost(Infinity)).toBe('—');
+  });
+  it('rounds fractional costs and separates large ones', () => {
+    expect(formatCost(1234.6)).toBe('1,235');
+    expect(formatCost(1_234_567)).toBe((1_234_567).toLocaleString());
   });
 });
 
@@ -44,6 +52,14 @@ describe('isInsufficientBuzz', () => {
     expect(isInsufficientBuzz('Insufficient Buzz')).toBe(true);
     expect(isInsufficientBuzz('prompt rejected by audit')).toBe(false);
     expect(isInsufficientBuzz(null)).toBe(false);
+    expect(isInsufficientBuzz(undefined)).toBe(false);
+  });
+  it('catches each budget/balance phrasing the sniff covers', () => {
+    // Each substring the heuristic keys on should independently match.
+    expect(isInsufficientBuzz('not enough funds')).toBe(true);
+    expect(isInsufficientBuzz('over your per-gen budget')).toBe(true);
+    expect(isInsufficientBuzz('your balance is too low')).toBe(true);
+    expect(isInsufficientBuzz('needs more buzz')).toBe(true);
   });
 });
 
@@ -91,11 +107,10 @@ describe('buildWorkflowBody', () => {
     // Passing 'auto' explicitly is identical to omitting it.
     expect(buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'auto')).toEqual(base);
   });
-  it('a picked pool is threaded as accountType', () => {
-    const body = buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'yellow');
-    expect(body.accountType).toBe('yellow');
-    const green = buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'green');
-    expect(green.accountType).toBe('green');
+  it('a picked pool is threaded as accountType (blue/green/yellow)', () => {
+    expect(buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'yellow').accountType).toBe('yellow');
+    expect(buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'green').accountType).toBe('green');
+    expect(buildWorkflowBody('a cat', DEFAULT_CHECKPOINT, [], 'blue').accountType).toBe('blue');
   });
 });
 
@@ -108,6 +123,8 @@ describe('accountLabel / spentAccountLabel', () => {
   });
   it('spentAccountLabel is the pool label, or null when absent', () => {
     expect(spentAccountLabel('yellow')).toBe('Yellow');
+    expect(spentAccountLabel('blue')).toBe('Blue');
+    expect(spentAccountLabel('green')).toBe('Green');
     expect(spentAccountLabel(undefined)).toBeNull();
   });
 });
@@ -168,5 +185,48 @@ describe('phaseForSnapshot', () => {
         }),
       ),
     ).toBe('account-rejected');
+  });
+  it('routes expired / canceled terminal statuses through the error classifier', () => {
+    // Both non-success terminal states reduce via phaseForError: a plain reason
+    // -> failed, an insufficient-Buzz reason -> insufficient.
+    expect(phaseForSnapshot(snap({ status: 'expired' }))).toBe('failed');
+    expect(phaseForSnapshot(snap({ status: 'canceled' }))).toBe('failed');
+    expect(phaseForSnapshot(snap({ status: 'expired', error: 'Insufficient Buzz' }))).toBe(
+      'insufficient',
+    );
+  });
+});
+
+describe('isBusyPhase', () => {
+  it('true only for the in-flight phases', () => {
+    for (const p of ['estimating', 'submitting', 'polling'] as const) {
+      expect(isBusyPhase(p)).toBe(true);
+    }
+    for (const p of [
+      'idle',
+      'needs-consent',
+      'succeeded',
+      'failed',
+      'insufficient',
+      'account-rejected',
+    ] as const) {
+      expect(isBusyPhase(p)).toBe(false);
+    }
+  });
+});
+
+describe('firstImageUrl', () => {
+  const snap = (over: Partial<BlockWorkflowSnapshot>): BlockWorkflowSnapshot => ({
+    workflowId: 'wf',
+    status: 'succeeded',
+    ...over,
+  });
+  it('returns the first image url when present', () => {
+    expect(firstImageUrl(snap({ imageUrls: ['a.png', 'b.png'] }))).toBe('a.png');
+  });
+  it('returns null for a null snapshot / empty or missing imageUrls', () => {
+    expect(firstImageUrl(null)).toBeNull();
+    expect(firstImageUrl(snap({ imageUrls: [] }))).toBeNull();
+    expect(firstImageUrl(snap({}))).toBeNull();
   });
 });

--- a/internal/scaffold/templates/page-money/src/mock-buzz.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/mock-buzz.test.tsx.tmpl
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_MOCK_BALANCE, mockBuzzBalance } from './mock-buzz.js';
+
+// Pure-logic tests for the dev/test-only Buzz mock. `mockBuzzBalance` projects
+// the mock host's single spendable wallet number into a plausible 3-pool split
+// for the balance display. Lives in a `.test.tsx` (jsdom) file because mock-buzz
+// imports the SDK testing host at module load. No DOM assertions here — just the
+// projection math.
+
+describe('mockBuzzBalance', () => {
+  it('falls back to the default set when the wallet is not simulated', () => {
+    expect(mockBuzzBalance(undefined)).toEqual(DEFAULT_MOCK_BALANCE);
+    expect(mockBuzzBalance(NaN)).toEqual(DEFAULT_MOCK_BALANCE);
+  });
+
+  it('splits a simulated total 80% yellow / 20% blue, no green', () => {
+    const b = mockBuzzBalance(1000);
+    expect(b).toEqual({ yellow: 800, blue: 200, green: 0 });
+    // The split preserves (rounds to) the input total.
+    expect(b.yellow + b.blue + b.green).toBe(1000);
+  });
+
+  it('clamps a negative wallet to zero (all pools zero)', () => {
+    expect(mockBuzzBalance(-50)).toEqual({ yellow: 0, blue: 0, green: 0 });
+  });
+
+  it('shows all zeros for an explicit zero balance', () => {
+    expect(mockBuzzBalance(0)).toEqual({ yellow: 0, blue: 0, green: 0 });
+  });
+});


### PR DESCRIPTION
## What

Test-only PR filling coverage gaps, prioritizing the money path. No behavior changes.

## Gaps found & filled

**Go — `internal/api` (77.0% → 84.4%)**
- `GetForgejoCloneInfo` + `cloneInfoError` were **0% in-package** — only exercised cross-package by the `app pull` cmd tests, so the api package itself had no direct coverage of the malformed/error branches. New `clone_info_test.go`: slug tRPC-input encoding + bearer, success/`notYetAvailable` parse, garbage-response guards (no nil-deref), and the full `401/403/404/default` status mapping incl. tRPC `{error:{json:{message}}}` extraction with a raw-body fallback. → `cloneInfoError` 100%, `GetForgejoCloneInfo` 86.4%.
- `GetBuzzAccount` (77.8% → 88.9%): the malformed-envelope path and the non-200/non-403 server-error path (must **not** be misclassified as `ErrBuzzScope`).
- `Scope.UnmarshalJSON` (71.4% → 100%): string / array / multi-element / null / malformed-element / non-string-non-array shapes, plus decode within the `TokenResponse` envelope.

**Go — `internal/cmd` (88.5% → 89.0%)**
- `manifestNeedsSpend` (50% → 100%) + `printMoneyPathNote` (40% → 100%): `ai:write*` detection (case/whitespace tolerant; a non-spend `*:write` scope does not count) and the note printing only for money apps.

**Total: 85.6% → 87.5%.**

**page-money vitest template** (not counted by Go coverage — validated via a scaffolded app)
- `generation.test.ts`: `isBusyPhase` + `firstImageUrl` (both exported+used but had **no** direct tests), `expired`/`canceled` snapshot routing through the error classifier, additional insufficient-Buzz phrasings, `blue` accountType threading, `formatCost` undefined/Infinity/rounding/large-separator edges.
- new `mock-buzz.test.tsx`: `mockBuzzBalance` projection (default fallback, 80/20 split preserving the total, negative-clamp, explicit zero).

## Validation (all green)
- `go test ./...` — pass (all packages)
- `go vet ./...` — clean
- `gofmt -s -l` — clean
- Scaffolded `page-money` → `npm install` → `npm run typecheck` → `npm test` (**115 pass, 9 files**) → `npm run build` — all pass.

## Remaining gaps (honest)
- `GetForgejoCloneInfo` residual ~14% = the `json.Marshal(map)` error path (effectively unreachable) + token-source error path — low value.
- Coverage was already high; unchanged low-value spots remain (e.g. `openBrowser`, `spawnDetachedRefresh`, `main`) — OS/process-level, not money-path, intentionally left.
- Template TS coverage is validated by the vitest suite passing, not a line-coverage number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)