### PR TITLE
test: sync mocked server strings to the 'Apps' copy rebrand (civitai #2915)

### DIFF
--- a/internal/api/clone_info_test.go
+++ b/internal/api/clone_info_test.go
@@ -154,7 +154,7 @@ func TestGetForgejoCloneInfoMapsStatusError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]any{"json": map[string]any{"message": "App Blocks not enabled"}},
+			"error": map[string]any{"json": map[string]any{"message": "Apps are not enabled"}},
 		})
 	}))
 	defer srv.Close()
@@ -164,7 +164,7 @@ func TestGetForgejoCloneInfoMapsStatusError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 403")
 	}
-	if !strings.Contains(err.Error(), "not permitted") || !strings.Contains(err.Error(), "App Blocks not enabled") {
+	if !strings.Contains(err.Error(), "not permitted") || !strings.Contains(err.Error(), "Apps are not enabled") {
 		t.Errorf("403 should map to not-permitted + server message: %v", err)
 	}
 }

--- a/internal/api/submissions_test.go
+++ b/internal/api/submissions_test.go
@@ -144,7 +144,7 @@ func TestSubmissionsErrorMapping(t *testing.T) {
 		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "Apps access required — invite-only beta"},
 		{http.StatusNotFound, map[string]string{"message": "Submission not found"}, "no such submission"},
 		{http.StatusTooManyRequests, map[string]string{"message": "Rate limit exceeded"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "not enabled"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "Apps are not enabled"}, "not enabled"},
 	}
 	for _, tc := range cases {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/withdraw_test.go
+++ b/internal/api/withdraw_test.go
@@ -74,7 +74,7 @@ func TestWithdrawRequestErrorMapping(t *testing.T) {
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not authorized"},
 		{http.StatusForbidden, map[string]string{"message": "no mod"}, "not authorized"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "App Blocks is not enabled"}, "Apps unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "Apps are not enabled"}, "Apps unavailable (503)"},
 		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
 	}
 	for _, tc := range cases {

--- a/internal/cmd/app_status_test.go
+++ b/internal/cmd/app_status_test.go
@@ -204,7 +204,7 @@ func TestAppStatusErrorMapping(t *testing.T) {
 		{http.StatusForbidden, "restricted to the civitai team", "invite-only beta"},
 		{http.StatusNotFound, "Submission not found", "no such submission"},
 		{http.StatusTooManyRequests, "Rate limit exceeded", "rate limited"},
-		{http.StatusServiceUnavailable, "App Blocks is not enabled", "not enabled"},
+		{http.StatusServiceUnavailable, "Apps are not enabled", "not enabled"},
 	}
 	for _, tc := range cases {
 		srv := statusServer(t, map[string]string{"message": tc.msg}, tc.status, nil)


### PR DESCRIPTION
civitai #2915 rebranded the server's user-facing copy `App Blocks (is) not enabled` → `Apps are not enabled`. These CLI test fixtures mock that server response to exercise the CLI's error handling; syncing them keeps the mocks faithful to the real server contract. Purely cosmetic (self-contained mocks, no runtime coupling). `go test ./...` green. Files: clone_info_test.go, submissions_test.go, withdraw_test.go, app_status_test.go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)