### PR TITLE
refactor(scaffold): simplify page-money mock-buzz shim for blocks-react@0.18

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -118,9 +118,11 @@ func TestRenderPageMoney(t *testing.T) {
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"@civitai/blocks-react"`)
 	// Per-account Buzz (useBuzzBalance / body.accountType / snapshot.spentAccountType)
-	// needs @civitai/blocks-react@0.17.0 (createLiveHost answers GET_BUZZ_BALANCE so
-	// dev:live shows the balance too) + @civitai/app-sdk@0.14.0.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.17.0"`)
+	// needs @civitai/blocks-react@0.18.0 (createMockHost now answers GET_BUZZ_BALANCE
+	// from the `buzzBalance` option AND stamps spentAccountType on succeeded
+	// snapshots natively — so the scaffold no longer ships a mock balance shim) +
+	// @civitai/app-sdk@0.14.0.
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.18.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.14.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.14.0",
-    "@civitai/blocks-react": "^0.17.0",
+    "@civitai/blocks-react": "^0.18.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
@@ -4,13 +4,15 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createMockHost } from '@civitai/blocks-react/testing';
 
 import { App } from './App.js';
-import { installMockMoneyHost } from './mock-buzz.js';
+import { installMockMoneyHost, mockBuzzBalance } from './mock-buzz.js';
 
 // Component tests: render <App/> against the SDK mock host under a scenario and
-// assert the rendered UI. `installMockMoneyHost` is the createMockHost wrapper
-// that ALSO answers the per-account-buzz messages the SDK mock host doesn't (the
-// balance read + the spentAccountType stamp). Each test controls its own scenario
-// + teardown; the transport is reset before each test by src/test-setup.ts.
+// assert the rendered UI. `installMockMoneyHost` is a thin createMockHost wrapper:
+// the 3-pool balance + spentAccountType are answered NATIVELY by 0.18 (pass the
+// `buzzBalance` / `viewer` options straight through); the wrapper only adds the
+// two behaviours 0.18 doesn't model — a balance-read error + the domain-clamp
+// rejection. Each test controls its own scenario + teardown; the transport is
+// reset before each test by src/test-setup.ts.
 
 describe('App (component)', () => {
   let uninstall: (() => void) | undefined;
@@ -55,10 +57,11 @@ describe('App (component)', () => {
   });
 
   it('renders the 3-pool Buzz balance (blue/green/yellow + total) from useBuzzBalance', async () => {
-    // A simulated wallet of 100 splits to yellow 80 / blue 20 / green 0 (mock-buzz).
+    // A simulated wallet of 100 splits to yellow 80 / blue 20 / green 0 (mock-buzz),
+    // handed to 0.18's native `buzzBalance` option (what useBuzzBalance reads).
     uninstall = installMockMoneyHost({
       viewer: { id: 2, username: 'dev', status: 'active' },
-      buzz: { balance: 100 },
+      buzzBalance: mockBuzzBalance(100),
     });
     render(<App />);
 

--- a/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/Harness.tsx.tmpl
@@ -6,7 +6,7 @@ import {
   type MockHostOptions,
 } from '@civitai/blocks-react/testing';
 
-import { makeMockBuzzOnOutbound } from './mock-buzz.js';
+import { mockBuzzBalance } from './mock-buzz.js';
 
 /**
  * Local dev mock host for the {{ .Name }} PAGE app.
@@ -52,23 +52,19 @@ export function Harness({ children }: { children: ReactNode }) {
     setScenarioKey((k) => k + 1);
   };
 
-  // The SDK mock host doesn't answer GET_BUZZ_BALANCE (the `useBuzzBalance` read)
-  // as of 0.16, so we answer it here via onOutbound — projecting the current
-  // scenario's simulated wallet (`buzz.balance`, the same knob the panel/URL
-  // drives) into a { blue, green, yellow } split. A stable handler that reads a
-  // live ref, so the answer tracks the panel without re-installing the host.
-  const scenarioRef = useRef(scenario);
-  scenarioRef.current = scenario;
-  const onBuzz = useRef(
-    makeMockBuzzOnOutbound({ getBalance: () => scenarioRef.current.buzz?.balance }),
-  ).current;
+  // 0.18's mock host answers GET_BUZZ_BALANCE natively from the `buzzBalance`
+  // option (which `<SdkHarness>` forwards to `createMockHost`). Project the
+  // current scenario's simulated wallet (`buzz.balance`, the same knob the
+  // panel/URL drives) into a { blue, green, yellow } split. `key={scenarioKey}`
+  // remounts <SdkHarness> on each panel `apply`, so the new wallet is re-applied.
+  const buzzBalance = mockBuzzBalance(scenario.buzz?.balance);
 
   return (
     <div style={rootStyle}>
       <MockBanner />
       <ScenarioPanel onApply={apply} />
       {/* applyUrlToggles=false: the panel is authoritative once mounted. */}
-      <SdkHarness key={scenarioKey} applyUrlToggles={false} {...scenario} onOutbound={onBuzz}>
+      <SdkHarness key={scenarioKey} applyUrlToggles={false} {...scenario} buzzBalance={buzzBalance}>
         {children}
       </SdkHarness>
     </div>

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -20,9 +20,12 @@ import { installMockMoneyHost } from './mock-buzz.js';
 //     -> App auto-resumes: estimate -> submit -> poll
 //     -> succeeded snapshot -> result image + spent-cost success Alert
 //
-// `installMockMoneyHost` is the createMockHost wrapper that ALSO answers the
-// balance read + stamps spentAccountType (the SDK mock host doesn't). Its timers
-// all fire on setTimeout(0), so real timers + findBy/waitFor resolve promptly.
+// `installMockMoneyHost` is a thin createMockHost wrapper. 0.18 answers the
+// balance read + stamps `spentAccountType` (the largest-debit `buzzBalance` pool)
+// NATIVELY; the wrapper only adds the domain-clamp rejection the mock host doesn't
+// model. The funder note therefore reflects the wallet's primary funder — the pick
+// itself is proven by the `accountType` on the submit body (asserted below). Its
+// timers all fire on setTimeout(0), so real timers + findBy/waitFor resolve promptly.
 
 describe('App money path (e2e)', () => {
   let uninstall: (() => void) | undefined;
@@ -41,6 +44,9 @@ describe('App money path (e2e)', () => {
       consentGranted: false,
       cost: 8,
       pollsUntilDone: 2,
+      // A blue-only wallet -> the native primary-funder stamp reports `blue` on
+      // the succeeded snapshot (Auto funds from the only funded pool).
+      buzzBalance: { blue: 100, green: 0, yellow: 0 },
     });
 
     render(<App />);
@@ -82,7 +88,8 @@ describe('App money path (e2e)', () => {
     const result = await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
     expect(result).toBeInTheDocument();
 
-    // The succeeded snapshot's cost + funded-from note render (Auto -> blue funder).
+    // The succeeded snapshot's cost + funded-from note render (blue-only wallet
+    // -> primary funder is blue).
     const spent = screen.getByTestId('pm-spent');
     expect(spent).toHaveTextContent('8');
     expect(spent).toHaveTextContent(/from your blue account/i);
@@ -91,7 +98,7 @@ describe('App money path (e2e)', () => {
     expect(screen.queryByText(/generation failed/i)).not.toBeInTheDocument();
   });
 
-  it('picking a pool -> accountType rides on the submit body; the funder note reflects it', async () => {
+  it('picking a pool -> accountType rides on the submit body; the funder note renders', async () => {
     const user = userEvent.setup();
     const submittedBodies: Array<{ accountType?: string }> = [];
     uninstall = installMockMoneyHost({
@@ -99,6 +106,8 @@ describe('App money path (e2e)', () => {
       consentGranted: true,
       cost: 8,
       pollsUntilDone: 2,
+      // A yellow-only wallet -> the native primary-funder stamp reports `yellow`.
+      buzzBalance: { blue: 0, green: 0, yellow: 100 },
       onOutbound: (m) => {
         if (m.type === 'SUBMIT_WORKFLOW') {
           submittedBodies.push((m.payload as { body: { accountType?: string } }).body);
@@ -117,7 +126,9 @@ describe('App money path (e2e)', () => {
 
     await screen.findByAltText(/generated result/i, {}, { timeout: 5000 });
 
-    // The picked pool was threaded into the body, and the funder note reflects it.
+    // The picked pool is threaded into the submit body (the real proof of the
+    // pick wiring). The funder note reflects the wallet's primary funder — yellow
+    // here — which the mock host stamps natively from `buzzBalance`.
     expect(submittedBodies.at(-1)?.accountType).toBe('yellow');
     expect(screen.getByTestId('pm-spent')).toHaveTextContent(/from your yellow account/i);
   });

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -20,7 +20,6 @@ import {
   installLiveHost,
   resolveLiveConfig,
 } from './dev-transport.js';
-import { installSpentAccountStamper } from './mock-buzz.js';
 import {
   isTokenExpired,
   navDisplay,
@@ -50,10 +49,9 @@ const mode = getHarnessMode();
 // BLOCK_INIT lands. (Prod uses VITE_BLOCK_ALLOWED_PARENT_ORIGINS instead.)
 // Live mode does the same inside installLiveHost (deferred to mount).
 if (useHarness && mode === 'mock') {
-  // Register the spentAccountType stamper BEFORE the transport so it mutates the
-  // mock host's succeeded snapshots first (registration order — see mock-buzz.ts).
-  // The balance read is answered via Harness's onOutbound.
-  installSpentAccountStamper();
+  // 0.18's mock host natively answers the balance read (from the `buzzBalance`
+  // option <Harness> passes) and stamps `spentAccountType` on succeeded
+  // snapshots, so no local shim is registered here.
   installHarnessTransport();
 }
 

--- a/internal/scaffold/templates/page-money/src/mock-buzz.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/mock-buzz.ts.tmpl
@@ -1,57 +1,53 @@
 // Test/dev-only mock augmentation. NOT imported by production code.
 //
-// The published SDK mock host (`@civitai/blocks-react/testing` `createMockHost`)
-// answers the estimate → submit → poll money path, but as of 0.16 it does NOT
-// answer the two newer per-account-buzz behaviours this app uses:
+// As of @civitai/blocks-react@0.18, the SDK mock host (`createMockHost`) natively:
+//   • answers GET_BUZZ_BALANCE from its `buzzBalance?: { blue, green, yellow }`
+//     option (what `useBuzzBalance()` reads), and
+//   • stamps `spentAccountType` on succeeded snapshots (the "funded from your
+//     <pool>" note) — the largest-debit wallet pool (`primaryFunder`).
+// So the old hand-rolled balance answer + spentAccountType stamper are GONE: they
+// only ever fired via `setTimeout(0)`, and 0.18's native replies are dispatched
+// SYNCHRONOUSLY (they now pre-empt any deferred override), so those shims are dead.
 //
-//   1. GET_BUZZ_BALANCE  → BUZZ_BALANCE_RESULT   (the `useBuzzBalance()` read)
-//   2. `spentAccountType` on a succeeded snapshot (the "funded from your <pool>"
-//      note the App shows after a generation)
+// TWO per-account behaviours the 0.18 mock host still does NOT model remain here —
+// both test-only, both layered on `createMockHost` via `installMockMoneyHost`:
 //
-// So the dev harness AND the vitest suites layer these two on top of the mock
-// host — entirely synthetically, no real Buzz, no network. In PRODUCTION the
-// real civitai host answers both natively (Phase 3), so none of this ships.
+//   1. GET_BUZZ_BALANCE returning an ERROR (the "balance unavailable" UI). The
+//      mock host always answers with a balance; there is no error mode. We answer
+//      SYNCHRONOUSLY from `onOutbound` (which 0.18 invokes BEFORE its own
+//      GET_BUZZ_BALANCE handler), so the error settles the read first.
+//   2. The server's domain-clamp rejection of a disallowed pool pick. The mock
+//      host's failure snapshots carry a generic error, not the clamp text — so we
+//      rewrite a failed snapshot's error in place when a pool was picked.
+//
+// In PRODUCTION the real civitai host answers all of this natively, so none of
+// this ships.
 //
 // DOM ordering note (load-bearing): a message dispatched directly on `window`
-// invokes the target's listeners in REGISTRATION ORDER (the `capture` flag does
-// NOT reorder at the target). The `spentAccountType` stamper below mutates the
-// inbound snapshot IN PLACE before the SDK transport reads it, so it MUST be
-// registered BEFORE the transport's listener — hence its callers register it
-// first (main.tsx before `installHarnessTransport()`; `installMockMoneyHost`
-// before re-creating the transport).
+// invokes the target's listeners in REGISTRATION ORDER. The disallowed-pool error
+// rewriter below mutates the inbound snapshot IN PLACE before the SDK transport
+// reads it, so it MUST be registered BEFORE the transport's listener — hence
+// `installMockMoneyHost` registers it first, then re-creates the transport.
 
 import { createMockHost, mockParentMessage, type MockHostOptions } from '@civitai/blocks-react/testing';
-import type { BuzzAccountType } from '@civitai/app-sdk/blocks';
 import type { BuzzBalance } from '@civitai/blocks-react';
 
 import { resetHarnessTransport } from './dev-transport.js';
-
-// The pool the block most recently submitted with (null = Auto / host-chosen).
-// Written by the outbound handler, read by the inbound stamper — module state so
-// the two halves stay in sync across the harness and the tests.
-let lastSubmittedAccountType: BuzzAccountType | null = null;
-
-// When true, the stamper rewrites the next FAILED snapshot's error into the
-// server's domain-clamp rejection — but only when the last submit named a pool.
-// Lets a test exercise the "disallowed account → friendly reset to Auto" path.
-let rejectAccountMode = false;
-
-const isBuzzAccountType = (v: unknown): v is BuzzAccountType =>
-  v === 'blue' || v === 'green' || v === 'yellow';
 
 /** The server's domain-clamp rejection text (mirrors generation.ts). */
 export const DISALLOWED_ACCOUNT_ERROR =
   "buzz account is not spendable for this app's content rating";
 
-/** A sensible 3-pool balance when the mock host isn't simulating a wallet. */
+/** A sensible 3-pool balance when no wallet total is being simulated. */
 export const DEFAULT_MOCK_BALANCE: BuzzBalance = { blue: 1500, green: 250, yellow: 6000 };
 
 /**
- * Project the mock host's single spendable wallet number (the `buzz.balance`
- * knob that drives the insufficient-Buzz UX) into a plausible 3-pool split for
- * the balance display: mostly yellow (purchased) with a little blue (free), so
- * all three pools render and `?balance=0` shows zeros. `undefined` (wallet not
- * simulated) -> the default set.
+ * Project a single spendable wallet number (the harness `?balance=` / panel knob
+ * that drives the insufficient-Buzz UX) into a plausible 3-pool split for the
+ * balance display: mostly yellow (purchased) with a little blue (free), so all
+ * three pools render and `?balance=0` shows zeros. `undefined` (wallet not
+ * simulated) -> the default set. Fed to `createMockHost`'s `buzzBalance` option
+ * (via `<SdkHarness buzzBalance=...>` in the harness) so 0.18 answers the read.
  */
 export function mockBuzzBalance(total: number | undefined): BuzzBalance {
   if (total == null || !Number.isFinite(total)) return DEFAULT_MOCK_BALANCE;
@@ -63,83 +59,8 @@ export function mockBuzzBalance(total: number | undefined): BuzzBalance {
   };
 }
 
-interface MockBuzzOutboundOptions {
-  /** Reads the mock host's current wallet (its `buzz.balance`), or `undefined`. */
-  getBalance: () => number | undefined;
-  /** Reply to the balance read with an error instead of a balance. */
-  balanceError?: boolean;
-}
-
-/**
- * Build an `onOutbound` handler (fed to `createMockHost` / `<Harness>`) that:
- *  - tracks the pool the block submits with (for the `spentAccountType` stamp),
- *  - answers a `GET_BUZZ_BALANCE` request by dispatching a `BUZZ_BALANCE_RESULT`
- *    from `window.location.origin` (so the SDK transport accepts it).
- */
-export function makeMockBuzzOnOutbound(opts: MockBuzzOutboundOptions) {
-  return (msg: { type: string; payload?: unknown }) => {
-    if (msg.type === 'SUBMIT_WORKFLOW') {
-      const at = (msg.payload as { body?: { accountType?: unknown } } | undefined)?.body
-        ?.accountType;
-      lastSubmittedAccountType = isBuzzAccountType(at) ? at : null;
-    }
-    if (msg.type === 'GET_BUZZ_BALANCE') {
-      const requestId = (msg.payload as { requestId?: string } | undefined)?.requestId;
-      const payload = opts.balanceError
-        ? { requestId, error: 'mock host: balance unavailable' }
-        : { requestId, balance: mockBuzzBalance(opts.getBalance()) };
-      // Mimic the host's async reply, from window.location.origin so the SDK
-      // transport's origin filter accepts it.
-      setTimeout(() => {
-        window.dispatchEvent(
-          mockParentMessage({ type: 'BUZZ_BALANCE_RESULT', payload }, window.location.origin),
-        );
-      }, 0);
-    }
-  };
-}
-
-/**
- * Install the inbound `spentAccountType` stamper on `window`. Returns a teardown.
- * MUST be registered before the SDK transport's message listener (see the DOM
- * ordering note at the top of this file).
- */
-export function installSpentAccountStamper(): () => void {
-  const stamp = (event: MessageEvent) => {
-    const data = event.data as
-      | {
-          type?: string;
-          payload?: { snapshot?: { status?: string; error?: string; spentAccountType?: string } };
-        }
-      | null
-      | undefined;
-    if (!data || (data.type !== 'WORKFLOW_STATUS' && data.type !== 'WORKFLOW_SUBMITTED')) return;
-    const snap = data.payload?.snapshot;
-    if (!snap) return;
-    if (snap.status === 'succeeded' && snap.spentAccountType == null) {
-      // Auto (no pick) → report `blue` (free/earned) as the primary funder, which
-      // mirrors the real host's "spentAccountType can be blue" semantics; a
-      // picked pool → report that pool.
-      snap.spentAccountType = lastSubmittedAccountType ?? 'blue';
-    }
-    if (
-      rejectAccountMode &&
-      snap.status === 'failed' &&
-      lastSubmittedAccountType != null &&
-      snap.error != null
-    ) {
-      snap.error = DISALLOWED_ACCOUNT_ERROR;
-    }
-  };
-  window.addEventListener('message', stamp);
-  return () => window.removeEventListener('message', stamp);
-}
-
-/** Reset the module state the tests rely on. Call between tests. */
-export function resetMockBuzz() {
-  lastSubmittedAccountType = null;
-  rejectAccountMode = false;
-}
+const isBuzzAccountType = (v: unknown): boolean =>
+  v === 'blue' || v === 'green' || v === 'yellow';
 
 /** Extra knobs for {@link installMockMoneyHost} on top of the SDK mock options. */
 export interface MockMoneyHostOptions extends MockHostOptions {
@@ -150,45 +71,71 @@ export interface MockMoneyHostOptions extends MockHostOptions {
 }
 
 /**
- * Install a full mock host for the App's money path, with the per-account-buzz
- * extras the SDK mock host doesn't natively answer wired in (the balance read +
- * the `spentAccountType` stamp). Returns an `uninstall()`.
- *
- * Registers the inbound stamper FIRST, then re-creates the transport (so the
- * stamper mutates snapshots before the transport reads them — see the DOM
- * ordering note at the top of this file), then installs the SDK mock host with
- * an `onOutbound` that answers `GET_BUZZ_BALANCE`.
+ * Install the SDK mock host for the App's money path, plus the two behaviours the
+ * 0.18 mock host doesn't natively model (balance-read error + domain-clamp
+ * rejection). Returns an `uninstall()`.
  *
  * Test-only — mirrors the `createMockHost(...).install()` shape the suites use.
+ * For the happy 3-pool balance + `spentAccountType` funder note, pass the SDK's
+ * native `buzzBalance` / `viewer` options straight through (no shim needed).
  */
 export function installMockMoneyHost(options: MockMoneyHostOptions = {}): () => void {
   const { balanceError, rejectAccount, onOutbound, ...hostOptions } = options;
-  resetMockBuzz();
-  rejectAccountMode = !!rejectAccount;
 
-  const removeStamper = installSpentAccountStamper();
-  // Re-create the transport AFTER the stamper so the stamper's listener is
+  // Tracks whether the block's last submit named a pool — gates the disallowed
+  // rewrite so only a picked-pool failure becomes the domain-clamp rejection.
+  let pickedPool = false;
+
+  // Inbound: rewrite a failed snapshot's error into the domain-clamp rejection.
+  // Registered BEFORE the transport (see the DOM ordering note above) so it
+  // mutates the snapshot before the transport reads it.
+  const rewriteDisallowed = (event: MessageEvent) => {
+    const data = event.data as
+      | { type?: string; payload?: { snapshot?: { status?: string; error?: string } } }
+      | null
+      | undefined;
+    if (!data || (data.type !== 'WORKFLOW_STATUS' && data.type !== 'WORKFLOW_SUBMITTED')) return;
+    const snap = data.payload?.snapshot;
+    if (rejectAccount && snap?.status === 'failed' && pickedPool && snap.error != null) {
+      snap.error = DISALLOWED_ACCOUNT_ERROR;
+    }
+  };
+  window.addEventListener('message', rewriteDisallowed);
+  // Re-create the transport AFTER the rewriter so the rewriter's listener is
   // earlier in registration order than the transport's.
   resetHarnessTransport();
 
-  // The mock host's wallet handle isn't known until after createMockHost, so
-  // read it lazily through a mutable reference.
-  let getBalance: () => number | undefined = () => hostOptions.buzz?.balance;
-  const onBuzz = makeMockBuzzOnOutbound({ getBalance: () => getBalance(), balanceError });
-
   const host = createMockHost({
     ...hostOptions,
-    onOutbound: (m) => {
-      onOutbound?.(m);
-      onBuzz(m);
+    onOutbound: (msg) => {
+      onOutbound?.(msg);
+      if (msg.type === 'SUBMIT_WORKFLOW') {
+        const at = (msg.payload as { body?: { accountType?: unknown } } | undefined)?.body
+          ?.accountType;
+        pickedPool = isBuzzAccountType(at);
+      }
+      // Balance-unavailable: reply SYNCHRONOUSLY (0.18 invokes onOutbound before
+      // its own GET_BUZZ_BALANCE handler), so the error settles the read first and
+      // the mock host's later balance reply is ignored. Dispatch from
+      // window.location.origin so the SDK transport's origin filter accepts it.
+      if (balanceError && msg.type === 'GET_BUZZ_BALANCE') {
+        const requestId = (msg.payload as { requestId?: string } | undefined)?.requestId;
+        window.dispatchEvent(
+          mockParentMessage(
+            {
+              type: 'BUZZ_BALANCE_RESULT',
+              payload: { requestId, error: 'mock host: balance unavailable' },
+            },
+            window.location.origin,
+          ),
+        );
+      }
     },
   });
-  getBalance = host.buzz.getBalance;
   const uninstallHost = host.install();
 
   return () => {
     uninstallHost();
-    removeStamper();
-    resetMockBuzz();
+    window.removeEventListener('message', rewriteDisallowed);
   };
 }


### PR DESCRIPTION
Bumps the `page-money` scaffold template's `@civitai/blocks-react` pin **^0.17.0 → ^0.18.0** and removes the mock-buzz shims that 0.18 makes redundant, while keeping the two behaviours 0.18 still doesn't model.

## Why now
0.18's `createMockHost` now:
- answers `GET_BUZZ_BALANCE` natively from a `buzzBalance?: { blue, green, yellow }` option (what `useBuzzBalance()` reads), and
- stamps `spentAccountType` on succeeded snapshots (`primaryFunder` = largest-debit pool).

Both native replies are dispatched **synchronously** (`dispatchToBlock` → `win.dispatchEvent`), so they pre-empt the old shims' `setTimeout(0)` replies — the old balance answer + spentAccountType stamper are now **dead code that never wins the requestId race**. Bumping to 0.18 forces the migration (leaving them would double-answer the read).

## Does `SdkHarness` forward `buzzBalance`? — YES (evidence)
In `@civitai/blocks-react@0.18.0`, `packages/civitai-blocks-react/src/testing.tsx`:
```ts
export interface HarnessProps extends MockHostOptions { ... }        // buzzBalance is a MockHostOptions field
export function Harness({ children, applyUrlToggles = true, showLog = true, ...options }: HarnessProps) {
  ...
  optionsRef.current = { ...options, ...urlOverlay };
  const host = createMockHost({ ...optionsRef.current!, onOutbound: ... });   // options (incl. buzzBalance) forwarded
```
So `<SdkHarness buzzBalance={...}>` reaches `createMockHost`. `MockHostOptions.buzzBalance` is documented as the per-pool wallet reported on `GET_BUZZ_BALANCE`, distinct from `buzz.balance` (the insufficient-Buzz SUBMIT knob).

## Dynamic-control approach landed (the crux)
The harness passes `buzzBalance={mockBuzzBalance(scenario.buzz?.balance)}` to `<SdkHarness>`. `mockBuzzBalance` projects the panel/`?balance=` scalar into a `{ blue, green, yellow }` split; the **pre-existing `key={scenarioKey}` remount** re-creates the mock host with the new wallet on each panel `apply`. This drops the `makeMockBuzzOnOutbound` + `onOutbound` wiring entirely for the harness.

## Removed vs kept
**Removed (now native / dead code):**
- `makeMockBuzzOnOutbound` + the harness `onOutbound` `GET_BUZZ_BALANCE` answer → native `buzzBalance` option.
- `installSpentAccountStamper` + its `main.tsx` registration/ordering dance → native `spentAccountType` stamp.
- `resetMockBuzz`, the module-level `lastSubmittedAccountType`/`rejectAccountMode` state, `MockBuzzOutboundOptions`.

**Kept (0.18 does NOT model these — test-only, layered on `createMockHost` via a slimmed `installMockMoneyHost`):**
- **balance-read ERROR** (the "balance unavailable" UI). 0.18 has no error mode. Answered **synchronously from `onOutbound`**, which 0.18 invokes *before* its own `GET_BUZZ_BALANCE` handler — so the error settles the read first and the native balance reply is ignored. (Verified: the App.test "balance unavailable" test passes.)
- **`DISALLOWED_ACCOUNT_ERROR`** — the server's domain-clamp rejection of a disallowed pool pick. Mock failure snapshots carry a generic error; rewritten in place before the transport reads it.
- `mockBuzzBalance` + `DEFAULT_MOCK_BALANCE` (the wallet-projection helper + its `undefined` default).

## Tests adjusted (no coverage weakened)
- 3-pool display test → `buzzBalance: mockBuzzBalance(100)` (native read).
- Funder-note e2e tests → set a single-pool wallet so the native primary-funder stamp is deterministic; the **pick itself is still proven by `accountType` on the submit body** (the real wiring), and the note reflects the wallet's primary funder.

## SDK follow-up (would allow fuller removal)
The kept pieces are pure SDK gaps. To delete `installMockMoneyHost` entirely, `createMockHost` (`@civitai/blocks-react` testing) would need:
1. a **balance-read error** option (e.g. `buzzBalanceError?: boolean`) so the "balance unavailable" UI is exercisable without a synchronous `onOutbound` override; and
2. a way to model the **domain-clamp rejection** of a disallowed pool pick (e.g. a `failMode: 'disallowed-account'` producing the clamp error text) so the friendly-reset-to-Auto path is exercisable natively.
   - Optional: stamp `spentAccountType` from the submitted `SUBMIT_WORKFLOW` body's `accountType` (falling back to `primaryFunder` for Auto) so the funder note can reflect the *picked* pool, letting the e2e funder-note assertions prove the pick end-to-end instead of via a single-pool wallet.

## Verification
Scaffolded a `page-money` app from this template:
- `npm install` resolves `@civitai/blocks-react@0.18.0`
- `npm run typecheck` — clean
- `npm test` — **115/115 pass** (incl. the 3-pool balance, balance-unavailable, funder-note, disallowed-pool, and insufficient-Buzz paths)
- `npm run build` — succeeds
- `go test ./internal/scaffold/...` — passes (version assertion updated to `^0.18.0`)

Also confirmed the dev:harness renders the native 3-pool balance in-Harness, and that the mid-session panel-remount "Loading" state in jsdom is **pre-existing** (identical on the ^0.17.0 baseline) — a jsdom timing artifact, not a regression; real-browser timers resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)