### PR TITLE
feat(release): add npm as an additive distribution channel (@civitai/cli wrapper)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,76 @@
+name: Release npm
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (no leading v), e.g. 0.1.40"
+        required: true
+permissions:
+  contents: read
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      has_npm_token: ${{ steps.c.outputs.has }}
+    steps:
+      - id: c
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "NPM_TOKEN not set — skipping npm publish."
+            echo "has=false" >> "$GITHUB_OUTPUT"
+          fi
+  publish:
+    needs: guard
+    if: needs.guard.outputs.has_npm_token == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Resolve version
+        id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            V="$INPUT_VERSION"
+          else
+            V="${RELEASE_TAG#v}"
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+      - name: Stamp version + license
+        working-directory: ./npm
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          cp ../LICENSE ./LICENSE
+      - name: Skip if already published (idempotent)
+        id: pub
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          if npm view "@civitai/cli@$VERSION" version >/dev/null 2>&1; then
+            echo "Already on npm; skipping."; echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish
+        if: steps.pub.outputs.skip == 'false'
+        working-directory: ./npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -51,6 +51,30 @@ jobs:
             V="${RELEASE_TAG#v}"
           fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
+      - name: Assert release carries the raw-binary assets
+        # Guards against publishing an npm version that points at a release with
+        # no `civitai-raw` bare binary (e.g. any pre-#85 tag, or a bad manual
+        # dispatch) — that would be a package that 404s on postinstall forever.
+        # Cheap correctness check; runs for both triggers.
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          assets="$(gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name')" || {
+            echo "::error::GitHub release v$VERSION not found (or not readable)."
+            exit 1
+          }
+          if ! printf '%s\n' "$assets" | grep -qx "civitai_${VERSION}_linux_amd64"; then
+            echo "::error::Release v$VERSION is missing the raw binary asset civitai_${VERSION}_linux_amd64. Refusing to publish a package that would 404 on postinstall."
+            printf 'assets present:\n%s\n' "$assets"
+            exit 1
+          fi
+          if ! printf '%s\n' "$assets" | grep -qx "checksums.txt"; then
+            echo "::error::Release v$VERSION is missing checksums.txt. Refusing to publish."
+            exit 1
+          fi
+          echo "Release v$VERSION carries civitai-raw assets + checksums.txt — OK."
       - name: Stamp version + license
         working-directory: ./npm
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,15 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+  # Raw (uncompressed) binary archive so the npm wrapper can download a bare
+  # executable directly from the GitHub Release — no tar/zip extraction in the
+  # postinstall. Named e.g. civitai_0.1.40_linux_amd64 (+ .exe on windows).
+  # These also get sha256 entries in checksums.txt for the wrapper to verify.
+  - id: civitai-raw
+    ids: [civitai]
+    formats: [binary]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
 
 checksum:
   name_template: "checksums.txt"
@@ -66,6 +75,13 @@ changelog:
 # pushes the updated cask formula to the tap on each tag.
 homebrew_casks:
   - name: civitai
+    # Pin the cask to the tar.gz archive only. Without this, the added
+    # `civitai-raw` (bare binary) archive gives two archives per OS/Arch and
+    # goreleaser errors ("one tap can handle only one archive of an OS/Arch
+    # combination"). This keeps Homebrew's output identical to before the raw
+    # archive was added.
+    ids:
+      - civitai
     binaries:
       - civitai
     repository:

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,7 @@
+# Downloaded at install time — never commit or ship these.
+lib/binaries/
+*.tgz
+
+# Copied from the repo root at publish/pack time by the workflow (and local
+# `cp ../LICENSE .`); keep the duplicate out of the committed tree.
+LICENSE

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,41 @@
+# @civitai/cli
+
+The Civitai CLI — author and ship [Civitai App Blocks](https://github.com/civitai/cli).
+
+This npm package is a **thin wrapper** over the Go CLI. On install it downloads
+the prebuilt binary for your platform from the project's
+[GitHub Releases](https://github.com/civitai/cli/releases) and verifies its
+sha256 checksum.
+
+## Install
+
+```bash
+npm install -g @civitai/cli
+civitai version
+```
+
+Or run without installing:
+
+```bash
+npx @civitai/cli app create my-app
+```
+
+## How it works
+
+- On `npm install`, a `postinstall` step downloads
+  `civitai_<version>_<os>_<arch>` from the matching GitHub Release and verifies
+  it against `checksums.txt`.
+- The `civitai` command then execs that binary, forwarding all arguments and
+  the exit code.
+- Set `CIVITAI_CLI_BINARY=/path/to/civitai` to point the wrapper at a specific
+  binary (escape hatch / local development).
+
+Supported platforms: linux, macOS, and Windows on x64/arm64 (Windows/arm64 is
+not built).
+
+## Other install methods
+
+This is one of several distribution channels — you can also use
+`go install github.com/civitai/cli/cmd/civitai@latest`, Homebrew, or download a
+release archive directly. See the
+[project README](https://github.com/civitai/cli#readme).

--- a/npm/bin/civitai.js
+++ b/npm/bin/civitai.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+"use strict";
+
+// Thin launcher for the @civitai/cli wrapper: locate (or lazily download) the
+// prebuilt Go binary and exec it, forwarding args, stdio, and exit status.
+
+const fs = require("fs");
+const { spawnSync } = require("child_process");
+const { ensureBinary, binaryPath } = require("../lib/install.js");
+
+async function resolveBinary() {
+  // Escape hatch + test hook: use an explicit binary if provided and present.
+  const override = process.env.CIVITAI_CLI_BINARY;
+  if (override && fs.existsSync(override)) return override;
+
+  const bin = binaryPath();
+  if (fs.existsSync(bin)) return bin;
+
+  // Missing (e.g. `npm install --ignore-scripts`) — download it now.
+  return ensureBinary();
+}
+
+(async () => {
+  let bin;
+  try {
+    bin = await resolveBinary();
+  } catch (err) {
+    console.error(
+      `civitai: could not obtain the CLI binary.\n${err && err.message ? err.message : err}`
+    );
+    process.exit(1);
+  }
+
+  const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+
+  if (result.error) {
+    console.error(`civitai: failed to launch ${bin}: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (typeof result.status === "number") {
+    process.exit(result.status);
+  }
+  // Killed by a signal → conventional 128 + signal, or just nonzero.
+  process.exit(1);
+})();

--- a/npm/lib/install.js
+++ b/npm/lib/install.js
@@ -81,8 +81,14 @@ function download(url, redirectsLeft = 5) {
           reject(new Error(`Too many redirects fetching ${url}`));
           return;
         }
-        const next = new URL(res.headers.location, url).toString();
-        resolve(download(next, redirectsLeft - 1));
+        const nextUrl = new URL(res.headers.location, url);
+        if (nextUrl.protocol !== "https:") {
+          reject(
+            new Error(`Refusing to follow non-https redirect to ${nextUrl.toString()}`)
+          );
+          return;
+        }
+        resolve(download(nextUrl.toString(), redirectsLeft - 1));
         return;
       }
       if (status === 404) {
@@ -108,6 +114,12 @@ function download(url, redirectsLeft = 5) {
     req.on("error", (err) =>
       reject(new Error(`Network error fetching ${url}: ${err.message}`))
     );
+    // Fail-closed on a silent stall: a stuck CDN socket never emits 'error',
+    // so postinstall would hang forever without this. destroy(err) surfaces
+    // through the 'error' handler above.
+    req.setTimeout(30000, () => {
+      req.destroy(new Error(`download timed out after 30s fetching ${url}`));
+    });
   });
 }
 

--- a/npm/lib/install.js
+++ b/npm/lib/install.js
@@ -1,0 +1,172 @@
+"use strict";
+
+// Dependency-free installer for the @civitai/cli wrapper.
+//
+// Downloads the prebuilt Go binary produced by GoReleaser from the matching
+// GitHub Release, verifies its sha256 against checksums.txt, and drops it at
+// lib/binaries/civitai(.exe). Runs from the npm `postinstall` hook, and is also
+// exported as ensureBinary() so the launcher can lazily download on first run
+// (covers `npm install --ignore-scripts`).
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const https = require("https");
+const crypto = require("crypto");
+
+const REPO = "civitai/cli";
+const PLACEHOLDER_VERSION = "0.0.0-dev";
+
+const BINARIES_DIR = path.join(__dirname, "binaries");
+
+// Map Node's platform/arch onto GoReleaser's os/arch tokens.
+const OS_MAP = { linux: "linux", darwin: "darwin", win32: "windows" };
+const ARCH_MAP = { x64: "amd64", arm64: "arm64" };
+
+// Combos GoReleaser does NOT build (see .goreleaser.yaml `ignore:`).
+const UNSUPPORTED = new Set(["windows/arm64"]);
+
+function target() {
+  const goos = OS_MAP[process.platform];
+  const goarch = ARCH_MAP[process.arch];
+  if (!goos || !goarch) {
+    throw new Error(
+      `Unsupported platform for @civitai/cli: ${process.platform}/${process.arch}. ` +
+        `Supported: linux, darwin, windows on x64/arm64. ` +
+        `Install the CLI another way: https://github.com/${REPO}#installation`
+    );
+  }
+  if (UNSUPPORTED.has(`${goos}/${goarch}`)) {
+    throw new Error(
+      `@civitai/cli has no prebuilt binary for ${goos}/${goarch} (not built by GoReleaser). ` +
+        `Install the CLI another way: https://github.com/${REPO}#installation`
+    );
+  }
+  return { goos, goarch, windows: goos === "windows" };
+}
+
+function binaryPath() {
+  const exe = process.platform === "win32" ? "civitai.exe" : "civitai";
+  return path.join(BINARIES_DIR, exe);
+}
+
+function resolveVersion() {
+  const { version } = require("../package.json");
+  if (!version || version === PLACEHOLDER_VERSION) {
+    throw new Error(
+      `@civitai/cli package version is the unstamped placeholder "${PLACEHOLDER_VERSION}". ` +
+        `A real install always carries a stamped version; this looks like an unpublished/local checkout. ` +
+        `Publish via the release workflow (which stamps the version) or install a released version from npm.`
+    );
+  }
+  return version;
+}
+
+function assetName(version, t) {
+  return `civitai_${version}_${t.goos}_${t.goarch}${t.windows ? ".exe" : ""}`;
+}
+
+function releaseUrl(version, file) {
+  return `https://github.com/${REPO}/releases/download/v${version}/${file}`;
+}
+
+// GET with redirect following (GitHub 302s to its asset CDN). Resolves to a Buffer.
+function download(url, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: { "User-Agent": "civitai-cli-npm-installer" } }, (res) => {
+      const status = res.statusCode || 0;
+      if (status >= 300 && status < 400 && res.headers.location) {
+        res.resume();
+        if (redirectsLeft <= 0) {
+          reject(new Error(`Too many redirects fetching ${url}`));
+          return;
+        }
+        const next = new URL(res.headers.location, url).toString();
+        resolve(download(next, redirectsLeft - 1));
+        return;
+      }
+      if (status === 404) {
+        res.resume();
+        reject(
+          new Error(
+            `404 fetching ${url}. The GitHub release may still be a draft (assets aren't public until it's ` +
+              `published) — try again once the release is published.`
+          )
+        );
+        return;
+      }
+      if (status !== 200) {
+        res.resume();
+        reject(new Error(`Unexpected HTTP ${status} fetching ${url}`));
+        return;
+      }
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+      res.on("error", reject);
+    });
+    req.on("error", (err) =>
+      reject(new Error(`Network error fetching ${url}: ${err.message}`))
+    );
+  });
+}
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+// checksums.txt lines are "<sha256>  <filename>".
+function findChecksum(checksumsText, asset) {
+  for (const line of checksumsText.split("\n")) {
+    const m = line.trim().match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (m && m[2] === asset) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+async function ensureBinary() {
+  const dest = binaryPath();
+  if (fs.existsSync(dest)) return dest;
+
+  const t = target();
+  const version = resolveVersion();
+  const asset = assetName(version, t);
+
+  const [binBuf, checksumsBuf] = await Promise.all([
+    download(releaseUrl(version, asset)),
+    download(releaseUrl(version, "checksums.txt")),
+  ]);
+
+  const want = findChecksum(checksumsBuf.toString("utf8"), asset);
+  if (!want) {
+    throw new Error(
+      `Could not find a checksum entry for ${asset} in checksums.txt for v${version}.`
+    );
+  }
+  const got = sha256(binBuf);
+  if (got !== want) {
+    throw new Error(
+      `Checksum mismatch for ${asset}: expected ${want}, got ${got}. Refusing to install.`
+    );
+  }
+
+  fs.mkdirSync(BINARIES_DIR, { recursive: true });
+  const tmp = dest + ".download";
+  fs.writeFileSync(tmp, binBuf, { mode: 0o755 });
+  fs.chmodSync(tmp, 0o755);
+  fs.renameSync(tmp, dest);
+  return dest;
+}
+
+module.exports = { ensureBinary, binaryPath };
+
+if (require.main === module) {
+  ensureBinary()
+    .then((p) => {
+      console.log(`@civitai/cli: installed binary at ${p}`);
+    })
+    .catch((err) => {
+      console.error(`@civitai/cli: failed to install binary.\n${err.message}`);
+      process.exit(1);
+    });
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@civitai/cli",
+  "version": "0.0.0-dev",
+  "description": "The Civitai CLI — author and ship Civitai App Blocks. Installs the prebuilt Go binary.",
+  "bin": { "civitai": "bin/civitai.js" },
+  "files": ["bin/", "lib/", "README.md", "LICENSE"],
+  "scripts": { "postinstall": "node lib/install.js" },
+  "engines": { "node": ">=18" },
+  "license": "Apache-2.0",
+  "publishConfig": { "access": "public" },
+  "repository": { "type": "git", "url": "git+https://github.com/civitai/cli.git" },
+  "homepage": "https://github.com/civitai/cli#readme",
+  "bugs": { "url": "https://github.com/civitai/cli/issues" },
+  "keywords": ["civitai", "app-blocks", "cli", "civitai-apps"],
+  "os": ["linux", "darwin", "win32"],
+  "cpu": ["x64", "arm64"]
+}


### PR DESCRIPTION
Adds **npm** as an additional distribution channel for the Go CLI, alongside GoReleaser GitHub Releases, `go install`, and Homebrew. Purely additive — the existing release flow is untouched.

`@civitai/cli` is a **thin wrapper**: on install it downloads the matching prebuilt GoReleaser binary from the GitHub Release, verifies its sha256, and execs it.

## What changed
- **`.goreleaser.yaml`** (+16 lines, two edits):
  1. A new `civitai-raw` archive (`formats: [binary]`) that uploads bare, uncompressed binaries named `civitai_<ver>_<os>_<arch>` (+`.exe` on Windows) with sha256 entries in `checksums.txt`. The existing `civitai` tar.gz/zip archive is unchanged.
  2. An `ids: [civitai]` pin **added to the existing (enabled) `homebrew_casks` cask**. This is a functional line: without it, the new raw archive creates a second archive per OS/Arch and `goreleaser release` fails with `one tap can handle only one archive of an OS/Arch combination`. The pin points the cask at the tar.gz archive it already used, so the **cask's output is unchanged** — but the cask stanza did gain a line. (The Homebrew cask is enabled and has been pushing to `civitai/homebrew-tap` since ~v0.1.39; this PR keeps that working.)
- **`npm/`**: dependency-free wrapper (Node built-ins only — https/crypto/fs/path/os).
  - `bin/civitai.js` execs the binary forwarding args + exit code; honors `CIVITAI_CLI_BINARY`; lazily downloads if missing (covers `--ignore-scripts`).
  - `lib/install.js` (`postinstall` + exported `ensureBinary()`): maps platform → GoReleaser os/arch, rejects unsupported combos (incl. windows/arm64), downloads the asset + `checksums.txt`, follows GitHub's 302 redirects (**https-only**), verifies sha256, `chmod 0755`. Has a **30s download timeout** (fail-closed on a silent CDN stall so postinstall can't hang forever). Clear errors on 404 (hints the release may still be a draft) and on the `0.0.0-dev` placeholder version.
- **`.github/workflows/release-npm.yml`**: triggers on `release: published` (binaries are public only after the draft is published — which is exactly this trigger, so ordering is safe) or manual dispatch. It:
  - is gated on `NPM_TOKEN` (guard job keeps the workflow green until a human sets the secret);
  - **asserts the release carries the `civitai-raw` bare binary + `checksums.txt`** before publishing (both triggers) — prevents publishing an npm version that points at a release with no raw assets (a package that would 404 on postinstall forever);
  - is idempotent (`npm view` skip on re-run);
  - is provenance-enabled (`--provenance` + `id-token: write`). Provenance is CI-only (not in `publishConfig`) so a local human `npm publish` still works.
  - Existing `release.yml`/`ci.yml` untouched.

## Human activation checklist
- [ ] Add repo secret **`NPM_TOKEN`** — a **granular npm automation token** for the `@civitai` scope with publish rights (automation token so 2FA doesn't block CI).
- [ ] Confirm the `@civitai/cli` name is free/owned — it is currently **404** and the `@civitai` scope is owned by the team (owns `@civitai/app-sdk`, `@civitai/blocks-react`), so first publish will claim it.
- [ ] Then: on the next `vX.Y.Z` tag, publish the GoReleaser draft release as usual → `release: published` fires → this workflow verifies the raw assets, stamps the version, copies `LICENSE`, and runs `npm publish --provenance`. No further action needed.
- Ordering is safe by construction: the npm postinstall downloads from the GitHub Release, and the workflow only runs once that release is **published**.

## Test evidence (no real publish — dry-run/pack only)
**Launcher** (`CIVITAI_CLI_BINARY=$PWD/bin/civitai node npm/bin/civitai.js version`): prints the version banner, exit 0; arg forwarding (`--help`) works; bad subcommand → exit 1. Placeholder-version guard errors clearly. Download-timeout fail-closed pattern verified against a silent-stall local server.

**`npm pack`** (5 files, no `.go`/`src/`/`lib/binaries/`/`node_modules`/`.tgz`):
```
package/LICENSE
package/bin/civitai.js
package/lib/install.js
package/package.json
package/README.md
```

**`npm publish --dry-run --access public`**: `@civitai/cli@0.1.40`, 5 files, package size 7.8 kB.

**`goreleaser check`**: 1 configuration file(s) validated. Snapshot build (`goreleaser release --snapshot --clean`, exit 0) confirms bare-binary assets `civitai_<ver>_<os>_<arch>` (+`.exe` on windows) in `checksums.txt` and as `type=Binary, ID=civitai-raw` in `artifacts.json`; the Homebrew cask still writes.

**`actionlint`** on all three workflows: clean (exit 0).

**`go build ./...` / `go test ./...`**: pass (Go untouched).

## Not verified (honest gaps)
- The **real postinstall download** is untested — it needs a published GitHub Release carrying the new `civitai-raw` assets, which won't exist until the next tagged release with this `.goreleaser.yaml`.
- npm provenance attestation is only validated by CI at real publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)