### PR TITLE
ci(release-npm): switch @civitai/cli publish to npm OIDC Trusted Publishing (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -10,34 +10,28 @@ on:
 permissions:
   contents: read
 jobs:
-  guard:
-    runs-on: ubuntu-latest
-    outputs:
-      has_npm_token: ${{ steps.c.outputs.has }}
-    steps:
-      - id: c
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -n "$NPM_TOKEN" ]; then
-            echo "has=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "NPM_TOKEN not set — skipping npm publish."
-            echo "has=false" >> "$GITHUB_OUTPUT"
-          fi
   publish:
-    needs: guard
-    if: needs.guard.outputs.has_npm_token == 'true'
     runs-on: ubuntu-latest
+    # OIDC trusted publishing: no NPM_TOKEN secret. The runner presents a
+    # short-lived OIDC token to npm; npm verifies it against the trusted
+    # publisher configured on the @civitai/cli package (repo civitai/cli +
+    # this workflow file). id-token:write is what mints that token.
     permissions:
       contents: read
-      id-token: write # npm provenance
+      id-token: write # required for OIDC trusted publishing (+ provenance)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+      - name: Ensure npm supports OIDC trusted publishing (>= 11.5.1)
+        # The npm bundled with Node 22 (npm 10.x) predates OIDC trusted
+        # publishing. npm auto-detects the OIDC env and uses it before any
+        # token, but only on 11.5.1+. Pin the floor and print it for the log.
+        run: |
+          npm install -g npm@latest
+          npm --version
       - name: Resolve version
         id: v
         env:
@@ -95,6 +89,9 @@ jobs:
       - name: Publish
         if: steps.pub.outputs.skip == 'false'
         working-directory: ./npm
+        # No NODE_AUTH_TOKEN: npm authenticates via OIDC. `--access public`
+        # keeps the scoped @civitai/cli package public. `--provenance` is kept
+        # explicit — docs say provenance is automatic under trusted publishing,
+        # but practitioners report it is not always emitted without the flag;
+        # passing it is idempotent and guarantees the attestation.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Replaces the long-lived `NPM_TOKEN` secret with **npm OIDC Trusted Publishing** — token-free publishing from GitHub Actions. The runner mints a short-lived OIDC token that npm verifies against a trusted-publisher config on the package; no secret is stored in the repo or org.

## Status / sequencing

The bootstrap is already done:
- ✅ **#85 merged** — `release-npm.yml` is on `main` (this PR is opened off `main`, **not stacked**).
- ✅ **`@civitai/cli@0.1.40` published** and verified live end-to-end (npm wrapper → downloads the GoReleaser binary → sha256-verifies → execs). The chicken-and-egg (a trusted publisher can only be set on an *existing* package, and the initial version can't be OIDC-published — npm/cli#8544) is satisfied.

**Remaining, in order:**
1. **Configure the trusted publisher** on npmjs.com (runbook below) — one-time, needs an npm org owner / package maintainer.
2. **Merge this PR.** ⚠️ Do NOT merge before step 1 — after this merges, `release-npm.yml` publishes with no token, so if no trusted publisher is configured the next release's publish fails.
3. **Delete the `NPM_TOKEN` secret** from the repo — it's no longer referenced; removing it makes accidental token fallback impossible.

The current CI auto-publish is failing on the old token's scope (a `404` on the `@civitai` scope); this PR removes that path entirely rather than fixing the token.

## What changes (`.github/workflows/release-npm.yml`)

- **Removed** the `guard` job that gated publish on `secrets.NPM_TOKEN` presence, and the `publish` job's `needs: guard` / `if:`.
- **Removed** `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.
- **Kept** `permissions: { contents: read, id-token: write }` (minimal; `id-token` mints the OIDC token).
- **Added** `npm install -g npm@latest` — the npm bundled with Node 22 (npm 10.x) predates OIDC support (floor is npm 11.5.1+).
- **Kept** `npm publish --provenance --access public`.
- **Unchanged / transport-independent** (still enforced): the release-asset guard (`civitai_<ver>_linux_amd64` + `checksums.txt` must exist on the GH release before publish), the `npm view` idempotency skip, the `release: published` trigger, and `workflow_dispatch` (same asset guard).

## Confirmed OIDC mechanics (cited)

- **npm floor: 11.5.1+ / Node 22.14.0+.** setup-node's default npm on Node 22 is 10.x → too old, hence the upgrade step. (npm docs; philna.sh)
- **Permissions:** `id-token: write` (mandatory) + `contents: read`. (npm docs)
- **No token needed:** npm auto-detects the OIDC env and uses it before falling back to any token. (npm docs)
- **Provenance:** documented as *automatic* under trusted publishing, but a practitioner reports it was **not** always emitted without the flag — so we keep `--provenance` explicit (idempotent, guarantees the attestation). (npm docs vs philna.sh)
- **`--access public`:** kept so the scoped `@civitai/cli` stays public.

Sources: npm Docs — Trusted publishing (https://docs.npmjs.com/trusted-publishers/) · GitHub Changelog — npm trusted publishing GA 2025-07-31 · npm/cli#8544 · philna.sh trusted-publishing writeup.

## npmjs.com trusted-publisher setup runbook (step 1, one-time)

Package **@civitai/cli** → **Settings** → **Trusted Publisher** → add a GitHub Actions publisher:

| Field | Value |
|---|---|
| Organization or user | `civitai` |
| Repository | `cli` |
| Workflow filename | `release-npm.yml` *(filename only, not the full path)* |
| Environment name | *(leave blank)* |
| Allowed actions | `npm publish` |

## Verify

`actionlint` clean; single-file diff. First real OIDC publish is the next tagged release (`v0.1.41`) after the trusted publisher is configured and this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
