### PR TITLE
docs(install): add npm/npx as a CLI install method (README + release footer)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -102,3 +102,16 @@ homebrew_casks:
 
 release:
   draft: true
+  footer: |
+    ## Install
+
+    ```bash
+    # npm (Node) — downloads + sha256-verifies the matching binary on install
+    npm install -g @civitai/cli        # or: npx @civitai/cli
+    # Homebrew (macOS / Linux)
+    brew install civitai/tap/civitai
+    # Go (from source)
+    go install github.com/civitai/cli/cmd/civitai@latest
+    ```
+
+    Or grab a prebuilt binary from the assets below and verify it against `checksums.txt`.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,20 @@ contract, and **packages/submits** it for review.
 
 ## Install
 
-Pick whichever fits — Homebrew is the quickest on macOS/Linux; the prebuilt
+Pick whichever fits — **npm** is the most convenient if you already have Node
+(App authors usually do); Homebrew is quickest on macOS/Linux; the prebuilt
 binary needs no toolchain; `go install` builds from source.
+
+### npm (Node)
+
+A thin wrapper that downloads the matching prebuilt binary for your OS/arch on
+install and verifies its sha256 against the release `checksums.txt`:
+
+```bash
+npm install -g @civitai/cli
+# or run it without installing:
+npx @civitai/cli --help
+```
 
 ### Homebrew (macOS / Linux)
 


### PR DESCRIPTION
`@civitai/cli` is live on npm (a thin wrapper that downloads + sha256-verifies the prebuilt binary on install), but it was missing from the two places users look:

- **README `## Install`** listed only Homebrew / prebuilt binary / `go install` — no npm.
- **Release notes** had no install instructions (GoReleaser `changelog:` is a bare commit list, no `release.footer`).

This adds:
- An **npm (Node)** subsection to the README, listed **first** (App authors already have Node), with `npm i -g @civitai/cli` + `npx @civitai/cli`.
- A GoReleaser **`release.footer`** so every future release body lists all four install methods (npm / Homebrew / Go / prebuilt binary).

`goreleaser check` passes. Docs/config only — no build or binary change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)