### PR TITLE
fix(devtunnel): pin sish host key on the ssh -R dial, fail closed (P4 R1)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -968,6 +968,13 @@ type DevTunnelSession struct {
 	ExpiresAt int64 `json:"expiresAt"`
 	// SpendCapBuzz is the per-session cumulative Buzz ceiling (backstop).
 	SpendCapBuzz int64 `json:"spendCapBuzz"`
+	// SSHHostPublicKey is the sish endpoint's OpenSSH host public-key line
+	// (`ssh-ed25519 AAAA...`) — a NON-SECRET value the CLI PINS as the SSH
+	// HostKeyCallback so the `ssh -R` bind can't be MITM'd (an on-path attacker
+	// impersonating sish would reach the dev's localhost + tamper tunneled
+	// traffic). The mint returns it; the CLI fails closed if it is absent
+	// (never falls back to InsecureIgnoreHostKey).
+	SSHHostPublicKey string `json:"sshHostPublicKey"`
 }
 
 // DevTunnelController mints + revokes a dev-tunnel session. Behind an interface

--- a/internal/api/dev_tunnel_test.go
+++ b/internal/api/dev_tunnel_test.go
@@ -23,11 +23,12 @@ func TestStartDevTunnelRequestResponse(t *testing.T) {
 		gotBody = string(raw)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"result": map[string]any{"data": map[string]any{"json": map[string]any{
-				"sessionId":    "bki_abc",
-				"host":         "dev-0123456789abcdef.civit.ai",
-				"url":          "https://civitai.com/apps/dev/my-block",
-				"expiresAt":    1893456000,
-				"spendCapBuzz": 5000,
+				"sessionId":        "bki_abc",
+				"host":             "dev-0123456789abcdef.civit.ai",
+				"url":              "https://civitai.com/apps/dev/my-block",
+				"expiresAt":        1893456000,
+				"spendCapBuzz":     5000,
+				"sshHostPublicKey": "ssh-ed25519 AAAAHOSTKEY",
 			}}},
 		})
 	}))
@@ -67,6 +68,10 @@ func TestStartDevTunnelRequestResponse(t *testing.T) {
 	}
 	if sess.ExpiresAt != 1893456000 {
 		t.Errorf("expiresAt = %d", sess.ExpiresAt)
+	}
+	// R1: the sish host public key the CLI pins is decoded from the mint response.
+	if sess.SSHHostPublicKey != "ssh-ed25519 AAAAHOSTKEY" {
+		t.Errorf("sshHostPublicKey = %q, want the pinned host key line", sess.SSHHostPublicKey)
 	}
 }
 

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -209,10 +209,11 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	}
 
 	tunnel, err := d.dialer.Dial(ctx, devtunnel.DialOptions{
-		Endpoint:   d.endpoint,
-		RemoteHost: sess.Host,
-		LocalPort:  d.port,
-		Signer:     key.Signer,
+		Endpoint:         d.endpoint,
+		RemoteHost:       sess.Host,
+		LocalPort:        d.port,
+		Signer:           key.Signer,
+		SSHHostPublicKey: sess.SSHHostPublicKey,
 	})
 	if err != nil {
 		// The mint succeeded but we couldn't bind — revoke so we don't orphan the
@@ -275,13 +276,22 @@ func printTunnelReady(out io.Writer, sess *api.DevTunnelSession, port int) {
 
 // validateMintResponse asserts the server-returned session is well-formed before
 // the CLI acts on it: the host matches the P1 `dev-<16hex>.<domain>` shape (it
-// becomes the reverse-forward bind name) and the URL is same-origin (scheme +
-// host) as the configured Civitai base (it is what the developer opens). Either
-// failing is a hard error — a mint that tries to steer the bind name or hand the
-// dev an attacker-influenced URL is refused, not followed.
+// becomes the reverse-forward bind name), the URL is same-origin (scheme + host)
+// as the configured Civitai base (it is what the developer opens), and a sish
+// host public key is present to PIN (it secures the `ssh -R` hop). Any failing
+// is a hard error — a mint that tries to steer the bind name, hand the dev an
+// attacker-influenced URL, or omit the host key to pin is refused, not followed.
+//
+// FAIL CLOSED (host key): an absent sshHostPublicKey is rejected here so the CLI
+// never dials without a pinned host key. The dialer independently fails closed
+// too (pinnedHostKeyCallback), so there is no reachable InsecureIgnoreHostKey
+// path from either layer.
 func validateMintResponse(sess *api.DevTunnelSession, baseURL string) error {
 	if !devHostPrefixRE.MatchString(sess.Host) {
 		return fmt.Errorf("server returned an unexpected tunnel host %q (want dev-<16hex>.<domain>) — refusing to bind", sess.Host)
+	}
+	if strings.TrimSpace(sess.SSHHostPublicKey) == "" {
+		return fmt.Errorf("server did not provide a sish host key to pin; refusing to connect")
 	}
 	base, err := url.Parse(baseURL)
 	if err != nil || base.Host == "" {

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -124,13 +124,25 @@ func (t *fakeTimer) resetCount() int {
 // goodKeygen mints a real ephemeral key (cheap, keeps the pubkey plumbing real).
 func goodKeygen() (*devtunnel.EphemeralKey, error) { return devtunnel.GenerateEphemeralKey() }
 
+// sampleHostKey is a real OpenSSH ed25519 public-key line the tests use as the
+// mint's sshHostPublicKey (the value the CLI pins). Generated once so the
+// happy-path session carries a valid, pinnable host key.
+var sampleHostKey = func() string {
+	k, err := devtunnel.GenerateEphemeralKey()
+	if err != nil {
+		panic(err)
+	}
+	return k.AuthorizedKey
+}()
+
 func sampleSession() *api.DevTunnelSession {
 	return &api.DevTunnelSession{
-		SessionID:    "bki_test",
-		Host:         "dev-0123456789abcdef.civit.ai",
-		URL:          "https://civitai.com/apps/dev/my-block",
-		ExpiresAt:    time.Now().Add(8 * time.Hour).Unix(),
-		SpendCapBuzz: 5000,
+		SessionID:        "bki_test",
+		Host:             "dev-0123456789abcdef.civit.ai",
+		URL:              "https://civitai.com/apps/dev/my-block",
+		ExpiresAt:        time.Now().Add(8 * time.Hour).Unix(),
+		SpendCapBuzz:     5000,
+		SSHHostPublicKey: sampleHostKey,
 	}
 }
 
@@ -172,19 +184,24 @@ func TestValidateMintResponse(t *testing.T) {
 		name    string
 		host    string
 		url     string
+		hostKey string
 		wantErr string // "" = should pass
 	}{
-		{"valid", "dev-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/my-block", ""},
-		{"bad host prefix", "evil-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/x", "unexpected tunnel host"},
-		{"bad host not-hex", "dev-zzzzzzzzzzzzzzzz.civit.ai", "https://civitai.com/apps/dev/x", "unexpected tunnel host"},
-		{"bad host too-short", "dev-abc.civit.ai", "https://civitai.com/apps/dev/x", "unexpected tunnel host"},
-		{"cross-origin host", "dev-0123456789abcdef.civit.ai", "https://evil.example/apps/dev/x", "cross-origin"},
-		{"cross-origin scheme", "dev-0123456789abcdef.civit.ai", "http://civitai.com/apps/dev/x", "cross-origin"},
-		{"unparseable url", "dev-0123456789abcdef.civit.ai", "://nope", "unparseable"},
+		{"valid", "dev-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/my-block", sampleHostKey, ""},
+		{"bad host prefix", "evil-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/x", sampleHostKey, "unexpected tunnel host"},
+		{"bad host not-hex", "dev-zzzzzzzzzzzzzzzz.civit.ai", "https://civitai.com/apps/dev/x", sampleHostKey, "unexpected tunnel host"},
+		{"bad host too-short", "dev-abc.civit.ai", "https://civitai.com/apps/dev/x", sampleHostKey, "unexpected tunnel host"},
+		{"cross-origin host", "dev-0123456789abcdef.civit.ai", "https://evil.example/apps/dev/x", sampleHostKey, "cross-origin"},
+		{"cross-origin scheme", "dev-0123456789abcdef.civit.ai", "http://civitai.com/apps/dev/x", sampleHostKey, "cross-origin"},
+		{"unparseable url", "dev-0123456789abcdef.civit.ai", "://nope", sampleHostKey, "unparseable"},
+		// FAIL CLOSED: an absent host key to pin is a hard rejection (no
+		// InsecureIgnoreHostKey fallback anywhere).
+		{"missing host key", "dev-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/x", "", "sish host key to pin"},
+		{"blank host key", "dev-0123456789abcdef.civit.ai", "https://civitai.com/apps/dev/x", "   ", "sish host key to pin"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateMintResponse(&api.DevTunnelSession{Host: tc.host, URL: tc.url}, base)
+			err := validateMintResponse(&api.DevTunnelSession{Host: tc.host, URL: tc.url, SSHHostPublicKey: tc.hostKey}, base)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected pass, got %v", err)
@@ -453,5 +470,33 @@ func TestRunTunnelSessionDialOptions(t *testing.T) {
 	}
 	if dialer.lastOpt.Signer == nil {
 		t.Error("dial must carry the ephemeral signer")
+	}
+	// R1: the mint's sish host key is plumbed through to the dialer so it can be
+	// PINNED (never InsecureIgnoreHostKey).
+	if dialer.lastOpt.SSHHostPublicKey != sampleHostKey {
+		t.Errorf("dial SSHHostPublicKey = %q, want the mint-provided host key %q", dialer.lastOpt.SSHHostPublicKey, sampleHostKey)
+	}
+}
+
+// TestRunTunnelSessionRejectsMissingHostKey: FAIL CLOSED — a mint response that
+// omits sshHostPublicKey is refused (clear message), the just-minted session is
+// revoked (no orphan), and the tunnel is NEVER dialed (so no unverified/
+// InsecureIgnoreHostKey connection is ever attempted).
+func TestRunTunnelSessionRejectsMissingHostKey(t *testing.T) {
+	bad := sampleSession()
+	bad.SSHHostPublicKey = "" // mint did not provide a host key to pin
+	apiStub := &fakeTunnelAPI{startResult: bad}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil || !strings.Contains(err.Error(), "sish host key to pin") {
+		t.Fatalf("expected a fail-closed missing-host-key rejection, got %v", err)
+	}
+	if dialer.dialed {
+		t.Error("must NOT dial the tunnel when no host key was provided to pin")
+	}
+	if apiStub.stopCount() != 1 || apiStub.stopCalls[0].sessionID != "bki_test" {
+		t.Errorf("a rejected mint must be revoked (avoid orphan), stop calls=%+v", apiStub.stopCalls)
 	}
 }

--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,21 +43,44 @@ func (d *sshDialer) logf(format string, a ...any) {
 	fmt.Fprintf(d.log, format, a...)
 }
 
+// pinnedHostKeyCallback builds a FixedHostKey callback from the mint-provided
+// OpenSSH host public-key line, PINNING the sish host key so an on-path attacker
+// impersonating the sish endpoint is rejected at the SSH handshake (a MITM there
+// would otherwise reach the dev's localhost + read/tamper tunneled traffic).
+//
+// FAIL CLOSED: an empty/absent host key is a hard error — the dialer refuses to
+// connect rather than fall back to ssh.InsecureIgnoreHostKey. A malformed key
+// yields a clear parse error. There is NO code path here that accepts an
+// unverified host key.
+func pinnedHostKeyCallback(hostPublicKey string) (ssh.HostKeyCallback, error) {
+	if strings.TrimSpace(hostPublicKey) == "" {
+		return nil, fmt.Errorf("server did not provide a sish host key to pin; refusing to connect")
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostPublicKey))
+	if err != nil {
+		return nil, fmt.Errorf("parse sish host key %q: %w", hostPublicKey, err)
+	}
+	return ssh.FixedHostKey(pub), nil
+}
+
 // Dial opens the SSH connection to the sish endpoint and requests a reverse
 // forward for the assigned host, then proxies inbound connections to the local
 // dev server.
 //
-// SECURITY (host key): host-key verification is deferred to P3 — the sish
-// endpoint + its host key are not provisioned yet. Until then this uses
-// InsecureIgnoreHostKey; P3 MUST pin the sish host key (known_hosts) before the
-// public listener is exposed. The tunnel's security boundary is the edge
-// forwardAuth + the pubkey-bound credential (design §5/§6), not this leg, but a
-// pinned host key closes MITM on the first-party SSH hop.
+// SECURITY (host key): the sish host key is PINNED from the mint's
+// sshHostPublicKey (opts.SSHHostPublicKey) via ssh.FixedHostKey — this closes
+// MITM on the first-party SSH hop. If the mint did not supply a host key the
+// dial FAILS CLOSED (see pinnedHostKeyCallback); it never uses
+// InsecureIgnoreHostKey.
 func (d *sshDialer) Dial(ctx context.Context, opts DialOptions) (Tunnel, error) {
+	hostKeyCallback, err := pinnedHostKeyCallback(opts.SSHHostPublicKey)
+	if err != nil {
+		return nil, err
+	}
 	cfg := &ssh.ClientConfig{
 		User:            sshDialUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(opts.Signer)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // TODO(P3): pin the sish host key
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         dialTimeout,
 	}
 

--- a/internal/devtunnel/ssh_dialer_test.go
+++ b/internal/devtunnel/ssh_dialer_test.go
@@ -43,8 +43,12 @@ func TestSSHDialerDialErrorFast(t *testing.T) {
 	// 127.0.0.1:1 is reliably closed; DialContext should fail promptly.
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
+	hostKey, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
 	start := time.Now()
-	_, err = d.Dial(ctx, DialOptions{Endpoint: "127.0.0.1:1", RemoteHost: "dev-x.civit.ai", LocalPort: 5186, Signer: key.Signer})
+	_, err = d.Dial(ctx, DialOptions{Endpoint: "127.0.0.1:1", RemoteHost: "dev-x.civit.ai", LocalPort: 5186, Signer: key.Signer, SSHHostPublicKey: hostKey.AuthorizedKey})
 	if err == nil {
 		t.Fatal("expected a dial error against a closed port")
 	}
@@ -105,6 +109,13 @@ func newForwardServer(t *testing.T) *forwardServer {
 
 func (fs *forwardServer) addr() string { return fs.ln.Addr().String() }
 func (fs *forwardServer) close()       { _ = fs.ln.Close() }
+
+// hostAuthorizedKey is the server's host public key in OpenSSH authorized-key
+// line form — the value the dialer must pin (opts.SSHHostPublicKey) to complete
+// the handshake against this server.
+func (fs *forwardServer) hostAuthorizedKey() string {
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(fs.hostSigner.PublicKey())))
+}
 
 func (fs *forwardServer) accept() {
 	nconn, err := fs.ln.Accept()
@@ -187,7 +198,7 @@ func TestSSHDialerReverseForwardProxies(t *testing.T) {
 	d := NewSSHDialer(io.Discard)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	tunnel, err := d.Dial(ctx, DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: localPort, Signer: key.Signer})
+	tunnel, err := d.Dial(ctx, DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: localPort, Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -262,7 +273,7 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 
 	var logbuf syncBuffer
 	d := NewSSHDialer(&logbuf)
-	tunnel, err := d.Dial(context.Background(), DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: deadPort, Signer: key.Signer})
+	tunnel, err := d.Dial(context.Background(), DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: deadPort, Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -287,5 +298,119 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 		default:
 			time.Sleep(5 * time.Millisecond)
 		}
+	}
+}
+
+// TestPinnedHostKeyCallback proves the host-key pin: a valid host key yields a
+// FixedHostKey callback that ACCEPTS the matching host key and REJECTS a
+// DIFFERENT one; an empty key fails closed; a malformed key gives a parse error.
+func TestPinnedHostKeyCallback(t *testing.T) {
+	pinned, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid key → non-nil callback.
+	cb, err := pinnedHostKeyCallback(pinned.AuthorizedKey)
+	if err != nil {
+		t.Fatalf("valid host key should build a callback, got %v", err)
+	}
+	if cb == nil {
+		t.Fatal("expected a non-nil HostKeyCallback for a valid host key")
+	}
+	addr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2224}
+	// Accepts the matching host key.
+	if err := cb("sish.example:2224", addr, pinned.Signer.PublicKey()); err != nil {
+		t.Errorf("callback should ACCEPT the matching host key, got %v", err)
+	}
+	// Rejects a different host key (the MITM case).
+	if err := cb("sish.example:2224", addr, other.Signer.PublicKey()); err == nil {
+		t.Error("callback must REJECT a different host key (MITM), got nil")
+	}
+
+	// Empty → fail closed, NO callback.
+	if _, err := pinnedHostKeyCallback(""); err == nil || !strings.Contains(err.Error(), "sish host key to pin") {
+		t.Errorf("empty host key must fail closed, got %v", err)
+	}
+	if _, err := pinnedHostKeyCallback("   "); err == nil || !strings.Contains(err.Error(), "sish host key to pin") {
+		t.Errorf("blank host key must fail closed, got %v", err)
+	}
+
+	// Malformed → clear parse error, NO callback.
+	if _, err := pinnedHostKeyCallback("not-a-valid-openssh-key"); err == nil || !strings.Contains(err.Error(), "parse sish host key") {
+		t.Errorf("malformed host key must yield a parse error, got %v", err)
+	}
+}
+
+// TestSSHDialerFailsClosedWithoutHostKey proves the dialer refuses to connect
+// when the mint provided no host key to pin — it NEVER falls back to
+// InsecureIgnoreHostKey. The error surfaces before any TCP dial.
+func TestSSHDialerFailsClosedWithoutHostKey(t *testing.T) {
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := NewSSHDialer(io.Discard)
+	// Endpoint is irrelevant: the fail-closed check precedes the dial.
+	_, err = d.Dial(context.Background(), DialOptions{
+		Endpoint: "sish.example:2224", RemoteHost: "dev-0123456789abcdef.civit.ai",
+		LocalPort: 5186, Signer: key.Signer, SSHHostPublicKey: "",
+	})
+	if err == nil || !strings.Contains(err.Error(), "sish host key to pin") {
+		t.Fatalf("expected a fail-closed error with no host key, got %v", err)
+	}
+}
+
+// TestSSHDialerMalformedHostKey proves a malformed pinned host key is a clear
+// parse error (still no InsecureIgnoreHostKey path).
+func TestSSHDialerMalformedHostKey(t *testing.T) {
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := NewSSHDialer(io.Discard)
+	_, err = d.Dial(context.Background(), DialOptions{
+		Endpoint: "sish.example:2224", RemoteHost: "dev-0123456789abcdef.civit.ai",
+		LocalPort: 5186, Signer: key.Signer, SSHHostPublicKey: "ssh-ed25519 not-base64!!!",
+	})
+	if err == nil || !strings.Contains(err.Error(), "parse sish host key") {
+		t.Fatalf("expected a parse error for a malformed host key, got %v", err)
+	}
+}
+
+// TestSSHDialerRejectsWrongPinnedHostKey is the end-to-end MITM guard: the
+// dialer pins a host key that does NOT match the server's actual host key, so
+// the SSH handshake is rejected and Dial fails (the impersonated endpoint can't
+// complete). Proves FixedHostKey is enforced on the real handshake.
+func TestSSHDialerRejectsWrongPinnedHostKey(t *testing.T) {
+	fs := newForwardServer(t)
+	defer fs.close()
+
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pin a DIFFERENT key than the server presents.
+	wrong, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewSSHDialer(io.Discard)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = d.Dial(ctx, DialOptions{
+		Endpoint: fs.addr(), RemoteHost: "dev-0123456789abcdef.civit.ai",
+		LocalPort: 5186, Signer: key.Signer, SSHHostPublicKey: wrong.AuthorizedKey,
+	})
+	if err == nil {
+		t.Fatal("expected the handshake to FAIL when the pinned host key does not match the server")
+	}
+	if !strings.Contains(err.Error(), "ssh handshake") {
+		t.Errorf("expected an ssh handshake failure, got %v", err)
 	}
 }

--- a/internal/devtunnel/tunnel.go
+++ b/internal/devtunnel/tunnel.go
@@ -18,6 +18,11 @@ type DialOptions struct {
 	LocalPort int
 	// Signer is the ephemeral private key authenticating the `ssh -R` bind.
 	Signer ssh.Signer
+	// SSHHostPublicKey is the sish endpoint's OpenSSH host public-key line
+	// (`ssh-ed25519 AAAA...`, from StartDevTunnel's sshHostPublicKey) that the
+	// dialer PINS as its HostKeyCallback. The dialer FAILS CLOSED when this is
+	// empty (refuses to connect) — it NEVER falls back to InsecureIgnoreHostKey.
+	SSHHostPublicKey string
 }
 
 // Tunnel is a live reverse tunnel. Consumers select on Done (terminated),


### PR DESCRIPTION
## What

P4-security finding **R1**: the `civitai app dev-tunnel` CLI→sish `ssh -R` dial shipped `ssh.InsecureIgnoreHostKey()` (with a `TODO(P3)`). That's a hard blocker before the public sish listener is exposed — an on-path MITM impersonating sish reaches the dev's localhost and can read/tamper tunneled traffic. This pins the sish host key.

## Changes

- **`internal/api/api.go`** — `DevTunnelSession` gains `sshHostPublicKey` (the non-secret OpenSSH host pubkey line the `blocks.startDevTunnel` mint now returns, R1 contract shared with the civitai mint PR).
- **`internal/devtunnel/tunnel.go`** — `DialOptions` gains `SSHHostPublicKey`.
- **`internal/devtunnel/ssh_dialer.go`** — new `pinnedHostKeyCallback`: parses the pubkey with `ssh.ParseAuthorizedKey` and pins it via `ssh.FixedHostKey` as the `HostKeyCallback`, replacing `InsecureIgnoreHostKey`. Removed the `TODO(P3)`.
- **`internal/cmd/app_dev_tunnel.go`** — plumbs `sess.SSHHostPublicKey` into `DialOptions`; `validateMintResponse` rejects an absent host key early (revoking the just-minted session).

## Fail-closed (no reachable InsecureIgnoreHostKey path)

An empty/absent `sshHostPublicKey` is a **hard error in BOTH layers**:
- the command (`validateMintResponse`) — `"server did not provide a sish host key to pin; refusing to connect"`, before any dial, and revokes the session;
- the dialer (`pinnedHostKeyCallback`) — defense-in-depth so the dialer is safe for any caller.

A malformed key yields a clear `parse sish host key ...` error. There is **no code path** that accepts an unverified host key.

## Tests

- Valid key → `FixedHostKey` callback **accepts the matching** host key and **rejects a different** one; end-to-end handshake is **rejected** when the pinned key mismatches the server.
- Empty/blank key → fail-closed error, **no dial**, session revoked.
- Malformed key → parse error.
- API decodes the new `sshHostPublicKey` field.
- Existing tunnel tests updated to pass the server's host key (still green).

`go build ./...`, `go vet ./...`, `go test ./... -race` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)