### PR TITLE
fix(devtunnel): bind the subdomain LABEL on ssh -R, not the full host (sish domain-doubling 404)

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -188,11 +188,15 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 		return err
 	}
 
-	// Defense-in-depth: never trust the mint response blindly. The assigned host
-	// feeds the `ssh -R` bind name and the URL is what the developer clicks, so a
-	// compromised/malicious response must not be able to steer either. Validate
-	// the host shape + that the URL is same-origin as the configured base, and
-	// revoke the just-minted session on rejection so nothing is orphaned.
+	// Defense-in-depth: never trust the mint response blindly. The assigned host's
+	// subdomain LABEL feeds the `ssh -R` bind (the dialer binds
+	// subdomainLabel(host), NOT the full host — sish appends its own domain to the
+	// requested subdomain, so binding the full `dev-<16hex>.civit.ai` would
+	// double-append to `dev-<16hex>.civit.ai.civit.ai` and 404 the browser), and the
+	// URL is what the developer clicks — so a compromised/malicious response must
+	// not be able to steer either. Validate the host shape + that the URL is
+	// same-origin as the configured base, and revoke the just-minted session on
+	// rejection so nothing is orphaned.
 	if verr := validateMintResponse(sess, d.baseURL); verr != nil {
 		_, _ = d.api.StopDevTunnel(context.Background(), sess.SessionID, "")
 		return verr

--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -18,6 +18,26 @@ import (
 // it against the real sish image.
 const remoteBindPort = 80
 
+// subdomainLabel returns the first DNS label of a host — the piece BEFORE the
+// first `.` (e.g. "dev-0123456789abcdef.civit.ai" → "dev-0123456789abcdef").
+//
+// WHY this matters for the `ssh -R` bind: sish forms the served HTTP vhost as
+// `<requested-bind-subdomain>.<sish-domain>` (sish is configured `domain: civit.ai`,
+// `force-requested-subdomains: true`). So the reverse forward must request the
+// SUBDOMAIN LABEL, not the full assigned host: binding the full host
+// `dev-<16hex>.civit.ai` makes sish register the vhost as
+// `dev-<16hex>.civit.ai.civit.ai` (domain DOUBLED) — the SSH auth + the forward
+// reservation both succeed, but the browser's real `Host: dev-<16hex>.civit.ai`
+// (via Traefik) 404s and the tunnel never serves. Binding the label
+// `dev-<16hex>` makes sish form `dev-<16hex>.civit.ai`, which matches.
+//
+// The assigned host is always `dev-<16hex>.<domain>` (regex-validated upstream in
+// app_dev_tunnel.go before we ever dial), so the label is the first component. A
+// bare host with no `.` (shouldn't happen) is returned unchanged.
+func subdomainLabel(host string) string {
+	return strings.SplitN(host, ".", 2)[0]
+}
+
 // sshDialUser is the SSH username presented on the bind. sish authorizes by the
 // PUBLIC KEY (the callback), not the username, so this is cosmetic/log-only.
 const sshDialUser = "civitai-dev"
@@ -96,7 +116,12 @@ func (d *sshDialer) Dial(ctx context.Context, opts DialOptions) (Tunnel, error) 
 	}
 	client := ssh.NewClient(sshConn, chans, reqs)
 
-	bindAddr := fmt.Sprintf("%s:%d", opts.RemoteHost, remoteBindPort)
+	// Bind the SUBDOMAIN LABEL, not the full host: sish appends its own domain to
+	// the requested subdomain, so requesting the full `dev-<16hex>.civit.ai`
+	// double-appends to `dev-<16hex>.civit.ai.civit.ai` and the browser's real
+	// `Host: dev-<16hex>.civit.ai` request 404s. See subdomainLabel. opts.RemoteHost
+	// stays the full host for logging / the ready-URL / upstream validation.
+	bindAddr := fmt.Sprintf("%s:%d", subdomainLabel(opts.RemoteHost), remoteBindPort)
 	listener, err := client.Listen("tcp", bindAddr)
 	if err != nil {
 		_ = client.Close()

--- a/internal/devtunnel/ssh_dialer_test.go
+++ b/internal/devtunnel/ssh_dialer_test.go
@@ -85,6 +85,7 @@ type forwardServer struct {
 	hostSigner   ssh.Signer
 	sconnCh      chan *ssh.ServerConn
 	forwardReady chan struct{}
+	boundAddr    chan string // the address the client requested in `tcpip-forward`
 }
 
 func newForwardServer(t *testing.T) *forwardServer {
@@ -102,6 +103,7 @@ func newForwardServer(t *testing.T) *forwardServer {
 		hostSigner:   host.Signer,
 		sconnCh:      make(chan *ssh.ServerConn, 1),
 		forwardReady: make(chan struct{}, 1),
+		boundAddr:    make(chan string, 1),
 	}
 	go fs.accept()
 	return fs
@@ -142,6 +144,19 @@ func (fs *forwardServer) accept() {
 	go func() {
 		for req := range reqs {
 			if req.Type == "tcpip-forward" {
+				// The `tcpip-forward` payload is `string addr, uint32 port`
+				// (RFC 4254 §7.1). Capture the requested bind ADDRESS so the test
+				// can assert the client bound the subdomain LABEL, not the full host.
+				var fwd struct {
+					Addr string
+					Port uint32
+				}
+				if err := ssh.Unmarshal(req.Payload, &fwd); err == nil {
+					select {
+					case fs.boundAddr <- fwd.Addr:
+					default:
+					}
+				}
 				if req.WantReply {
 					_ = req.Reply(true, nil)
 				}
@@ -217,8 +232,10 @@ func TestSSHDialerReverseForwardProxies(t *testing.T) {
 		t.Fatal("server never saw the tcpip-forward request")
 	}
 
-	// Simulate a browser connection: open a forwarded channel on the assigned host.
-	ch := fs.pushConnection(t, sconn, host, uint32(remoteBindPort))
+	// Simulate a browser connection: sish opens the forwarded-tcpip channel keyed
+	// by the bound SUBDOMAIN LABEL (the address the client requested), so push with
+	// the label — the full host would not match the client's registered forward.
+	ch := fs.pushConnection(t, sconn, subdomainLabel(host), uint32(remoteBindPort))
 	defer ch.Close()
 
 	// The dialer should proxy this to the local echo server → round-trip.
@@ -254,6 +271,59 @@ func TestSSHDialerReverseForwardProxies(t *testing.T) {
 	}
 }
 
+// TestSSHDialerBindsSubdomainLabel is the regression guard for the sish
+// domain-doubling bug: the reverse forward MUST request the subdomain LABEL
+// (`dev-<16hex>`), NOT the full assigned host (`dev-<16hex>.civit.ai`). sish
+// forms the served vhost as `<requested-subdomain>.<sish-domain>`, so binding the
+// full host makes sish register `dev-<16hex>.civit.ai.civit.ai` — the SSH forward
+// succeeds but the browser's real `Host: dev-<16hex>.civit.ai` 404s. This test
+// captures the `tcpip-forward` bind address the client actually requested and
+// asserts it is the label. It FAILS against the old full-host bind.
+func TestSSHDialerBindsSubdomainLabel(t *testing.T) {
+	fs := newForwardServer(t)
+	defer fs.close()
+
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const fullHost = "dev-0123456789abcdef.civit.ai"
+	const wantLabel = "dev-0123456789abcdef"
+
+	d := NewSSHDialer(io.Discard)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tunnel, err := d.Dial(ctx, DialOptions{Endpoint: fs.addr(), RemoteHost: fullHost, LocalPort: 5186, Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer tunnel.Close()
+
+	select {
+	case got := <-fs.boundAddr:
+		if got != wantLabel {
+			t.Errorf("reverse forward bound %q; want the subdomain LABEL %q (binding the full host %q makes sish double-append its domain → 404)", got, wantLabel, fullHost)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("server never saw the tcpip-forward bind address")
+	}
+}
+
+// TestSubdomainLabel unit-covers the label extraction across the shapes the
+// dialer can see (the full assigned host, and defensively a bare host with no dot).
+func TestSubdomainLabel(t *testing.T) {
+	cases := map[string]string{
+		"dev-0123456789abcdef.civit.ai":         "dev-0123456789abcdef",
+		"dev-0123456789abcdef.apps.example.com": "dev-0123456789abcdef",
+		"dev-0123456789abcdef":                  "dev-0123456789abcdef", // no dot → unchanged
+	}
+	for host, want := range cases {
+		if got := subdomainLabel(host); got != want {
+			t.Errorf("subdomainLabel(%q) = %q; want %q", host, got, want)
+		}
+	}
+}
+
 // TestSSHDialerLocalDevDown: when the local dev server is NOT running, a
 // forwarded connection is accepted but the proxy can't reach localhost — the
 // tunnel logs guidance and stays up (doesn't crash).
@@ -281,7 +351,7 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 
 	sconn := <-fs.sconnCh
 	<-fs.forwardReady
-	ch := fs.pushConnection(t, sconn, host, uint32(remoteBindPort))
+	ch := fs.pushConnection(t, sconn, subdomainLabel(host), uint32(remoteBindPort))
 	defer ch.Close()
 
 	// The proxy dial to the dead local port fails; the channel closes. Poll the


### PR DESCRIPTION
## The bug (confirmed live against sish v2.23.0 in-cluster)

The dev-tunnel CLI binds the **wrong** `ssh -R` remote address, so the tunnel never serves.

`internal/devtunnel/ssh_dialer.go` built the reverse-forward bind as `fmt.Sprintf("%s:%d", opts.RemoteHost, 80)`, and `internal/cmd/app_dev_tunnel.go` sets `RemoteHost: sess.Host` — the **full** assigned host `dev-<16hex>.civit.ai`.

sish forms the served HTTP vhost as `<requested-bind-subdomain>.<sish-domain>` (sish configured `domain: civit.ai`, `force-requested-subdomains: true`). So binding the **full** host `dev-<16hex>.civit.ai:80` makes sish register the vhost as **`dev-<16hex>.civit.ai.civit.ai`** (domain DOUBLED). The SSH auth and the reverse-forward reservation both **succeed**, but the browser's real request — `Host: dev-<16hex>.civit.ai` via Traefik — **404s**. The tunnel never serves.

Proven empirically:
- `Host: dev-<hex>.civit.ai.civit.ai` → 200 + content
- `Host: dev-<hex>.civit.ai` → 404

## The fix

Bind the **subdomain LABEL** — the first DNS component of the assigned host (`dev-<16hex>`), via a new `subdomainLabel(host)` helper (`strings.SplitN(host, ".", 2)[0]`). sish then forms `dev-<16hex>.civit.ai`, which matches what Traefik/the browser send.

`opts.RemoteHost` is kept as the **full** host for logging, the "Dev tunnel ready — serving … as `<full host>`" output, the clickable URL, and the existing `^dev-[a-f0-9]{16}\.` regex validation (unchanged — not weakened). Only the `ssh -R` bind uses the label. Stale comments in `ssh_dialer.go` and `app_dev_tunnel.go` updated to explain the label bind and why (double-append → 404).

## Test — real regression guard

The in-process mock ssh server (`ssh_dialer_test.go`) now parses the `tcpip-forward` request payload (RFC 4254 §7.1) and exposes the requested bind **address**. New `TestSSHDialerBindsSubdomainLabel` asserts it equals the LABEL (`dev-0123456789abcdef`), not the full host. Plus a `TestSubdomainLabel` unit test for the helper.

Verified it is not a tautology — reverting the source to the old full-host bind:

```
--- FAIL: TestSSHDialerBindsSubdomainLabel
    reverse forward bound "dev-0123456789abcdef.civit.ai"; want the subdomain LABEL "dev-0123456789abcdef" ...
--- FAIL: TestSSHDialerReverseForwardProxies
    open forwarded-tcpip: ssh: rejected: administratively prohibited (no forward for address)
```

(The end-to-end proxy test also depends on the label match — x/crypto/ssh registers the forward keyed by the requested bind address, so a full-host bind no longer matches the label-keyed forwarded channel, exactly as real sish would behave.) With the fix restored, `go test ./...` is all green.

## Verification

- `go build ./...` — OK
- `go vet ./internal/devtunnel/...` — OK
- `go test -count=1 ./...` — all packages pass
- The datapacket-talos `scripts/dev-tunnel-harness` (`BIND_MODE=label`) confirmed all three assertions pass with the label bind.

## Note / assumption

`subdomainLabel` returns the input unchanged when there is no `.` (defensive — the assigned host is regex-validated `dev-<16hex>.<domain>` upstream before we ever dial, so a bare label can't reach here in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)