### PR TITLE
feat(devtunnel): default blockId from block.manifest.json in the CWD

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/internal/devtunnel"
+	"github.com/civitai/cli/internal/manifest"
 	"github.com/spf13/cobra"
 )
 
@@ -97,6 +98,10 @@ Start your dev server first, in another terminal:
 then run this against the SAME port. Authentication uses your stored credential
 (` + "`civitai login`" + ` or a personal API key); you can only tunnel your OWN app.
 
+The blockId is resolved from (in order): the ` + "`--block`" + ` flag, the positional
+argument, then the ` + "`blockId`" + ` in ` + "`block.manifest.json`" + ` in the current
+directory. Run it from your App project dir and you can omit the blockId entirely.
+
 ⚠️ PRE-GA / DARK: dev tunnels are gated behind an Apps-author invite AND a
 kill-switch flag that is OFF today, and the public tunnel endpoint is not exposed
 yet — so end-to-end this will report "not available" until it ships. The command,
@@ -105,17 +110,30 @@ pending.`,
 		Example: `  # In terminal 1: start the embeddable dev server.
   npm run dev:tunnel
   # In terminal 2: open the tunnel (Ctrl-C to tear down).
+  civitai app dev-tunnel                 # blockId from block.manifest.json in the CWD
   civitai app dev-tunnel my-block
   civitai app dev-tunnel my-block --port 5173
   civitai app dev-tunnel --block my-block --idle-timeout 15m`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Precedence: --block flag > positional arg > block.manifest.json in the
+			// CWD. The manifest fallback mirrors `civitai app submit` (which defaults
+			// to the current directory) so a dev in their App project dir can run
+			// `civitai app dev-tunnel` with no args.
 			blockID := strings.TrimSpace(blockFlag)
 			if blockID == "" && len(args) == 1 {
 				blockID = strings.TrimSpace(args[0])
 			}
 			if blockID == "" {
-				return fmt.Errorf("a blockId is required — e.g. `civitai app dev-tunnel my-block` (find it with `civitai app status`)")
+				// Fall back to the local project manifest. A missing/unreadable/
+				// malformed manifest is NOT fatal here — fall through to the error
+				// below so an absent manifest still yields the clear guidance.
+				if m, merr := manifest.Load("."); merr == nil {
+					blockID = strings.TrimSpace(m.BlockID)
+				}
+			}
+			if blockID == "" {
+				return fmt.Errorf("a blockId is required — pass it (`civitai app dev-tunnel my-block`), or run from an App directory containing %s (list your submitted apps with `civitai app status`)", manifest.Filename)
 			}
 			if port < 1 || port > 65535 {
 				return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
@@ -164,7 +182,7 @@ pending.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&blockFlag, "block", "", "the blockId (app slug) to tunnel (or pass it positionally)")
+	cmd.Flags().StringVar(&blockFlag, "block", "", "the blockId (app slug) to tunnel (or pass it positionally; defaults to the blockId in "+manifest.Filename+" in the CWD)")
 	cmd.Flags().IntVar(&port, "port", defaultDevTunnelPort, "local dev-server port to tunnel (matches the scaffold's dev:tunnel)")
 	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+"; P3-provisioned)")
 	cmd.Flags().DurationVar(&idle, "idle-timeout", defaultDevTunnelIdle, "tear the tunnel down after this much inactivity")

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -5,13 +5,17 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// TestAppDevTunnelMissingBlockErrors: no blockId (positional or --block) is a
-// clear, non-network error.
+// TestAppDevTunnelMissingBlockErrors: no blockId (positional, --block, or a
+// manifest in the CWD) is a clear, non-network error. Run from a temp dir with
+// NO block.manifest.json so the manifest fallback can't accidentally resolve one.
 func TestAppDevTunnelMissingBlockErrors(t *testing.T) {
+	chdir(t, t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("CIVITAI_TOKEN", "tok")
 	_, _, err := run(t, "app", "dev-tunnel")
@@ -20,6 +24,57 @@ func TestAppDevTunnelMissingBlockErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "blockId is required") {
 		t.Errorf("missing-block error should explain: %v", err)
+	}
+}
+
+// TestAppDevTunnelBlockIdFromManifest: with NO flag/arg, run from an App project
+// dir containing block.manifest.json, the blockId is resolved from the manifest
+// (mirroring `civitai app submit`) — the dev never has to retype it. Guard: this
+// fails without the manifest fallback (it would short-circuit on "blockId is
+// required" before ever reaching the network). We point the CLI at a local tRPC
+// server so no real network is touched, and assert (a) the request carried the
+// manifest's blockId and (b) the error is NOT the blockId-required one (it fails
+// later, on the dark/forbidden mint, which is expected pre-GA).
+func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		gotBody = string(raw)
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+		})
+	}))
+	defer srv.Close()
+
+	// App project dir with a valid manifest; blockId "demo".
+	dir := t.TempDir()
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "demo",
+  "version": "0.1.0",
+  "name": "Demo",
+  "type": "block",
+  "page": { "path": "/", "title": "Demo" }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(m), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "app", "dev-tunnel")
+	// It must get PAST the blockId check — the only remaining failure is the
+	// (expected, pre-GA) forbidden mint, never "blockId is required".
+	if err != nil && strings.Contains(err.Error(), "blockId is required") {
+		t.Fatalf("blockId should have been resolved from the manifest, got: %v", err)
+	}
+	// Proof the resolved blockId came from the manifest and reached the request.
+	if !strings.Contains(gotBody, `"blockId":"demo"`) {
+		t.Errorf("start body should carry the manifest blockId 'demo': %s", gotBody)
 	}
 }
 


### PR DESCRIPTION
## Problem (surfaced dogfooding)

Running \`civitai app dev-tunnel\` from inside an App project directory errored:

> Error: a blockId is required — e.g. \`civitai app dev-tunnel my-block\` (find it with \`civitai app status\`)

…even though the project dir already has a \`block.manifest.json\` carrying the blockId. The dev had to redundantly retype it. \`civitai app submit\` does **not** have this problem — it reads the manifest.

## Fix

Add a manifest fallback that mirrors \`app submit\`. blockId is now resolved with precedence:

**\`--block\` flag > positional arg > \`blockId\` in \`block.manifest.json\` in the CWD**

- Uses the same \`internal/manifest\` package (\`manifest.Load(".")\` → \`.BlockID\`) as submit.
- A missing / unreadable / malformed manifest is **non-fatal** — it falls through to the (now-improved) error, so behaviour outside an app dir is unchanged.
- So a dev in their app dir can just run \`civitai app dev-tunnel\` with no args.

Also:
- Improved the truly-missing error: \`a blockId is required — pass it (\`civitai app dev-tunnel my-block\`), or run from an App directory containing block.manifest.json (list your submitted apps with \`civitai app status\`)\`. It still contains the \`blockId is required\` substring an existing test asserts. The \`civitai app status\` reference is kept because it **is** accurate — \`app status\` prints a \`BLOCK_ID\` column (and \`Block ID:\` in detail) — but reworded to "list your **submitted** apps", since status only surfaces submitted ones, whereas the manifest is the reliable local source.
- Updated \`Long\` / \`Example\` (added \`civitai app dev-tunnel   # blockId from block.manifest.json in the CWD\`) and \`--block\` flag help to document the manifest default.

## Tests

Added \`TestAppDevTunnelBlockIdFromManifest\`: with no flag/arg, run from a temp dir containing a valid \`block.manifest.json\` (blockId \`demo\`), the CLI resolves the blockId from the manifest and gets **past** the blockId check (it then fails on the expected pre-GA forbidden mint against a local httptest server — never "blockId is required"), and the request body carries \`"blockId":"demo"\`.

**Real guard — before/after:**
- With the fix: \`PASS\`
- With the fallback disabled: \`FAIL: blockId should have been resolved from the manifest, got: a blockId is required …\`

Updated the existing \`TestAppDevTunnelMissingBlockErrors\` to \`chdir\` into an empty temp dir (no manifest) so the new fallback can't accidentally resolve a blockId and mask the missing-block path. Full suite: \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all green.

## Other dev-tunnel DX friction spotted (not fixed here — noting for dogfooding)

1. **No pre-flight check that the local dev server is actually up.** The command mints the server session and opens the reverse tunnel regardless of whether anything is listening on \`127.0.0.1:<port>\`. If the dev forgot \`npm run dev:tunnel\`, the tunnel comes up "ready" but the browser gets a blank/connection-refused via the tunnel, with no hint. A quick \`net.DialTimeout("tcp", 127.0.0.1:port)\` before minting could produce a clear "your dev server isn't running on :5186 — start it with \`npm run dev:tunnel\`" instead. Small, but would remove a confusing failure mode.
2. **\`--block\` flag + positional arg both supplied and differing** → the flag silently wins with no warning. Minor; a mismatch warning would be friendlier.
3. Endpoint is still the documented placeholder (\`sish.civitai.com:2224\`) pending P3 — already called out in \`Long\`, no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)