### PR TITLE
feat(devtunnel): pre-flight probe, --block/arg conflict warning, refresh help copy

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"os/signal"
@@ -34,11 +35,8 @@ const (
 	// defaultDevTunnelIdle is the client-side idle timeout (design §9: 30m). The
 	// server reaper is the authoritative backstop; this is the CLI doing its part.
 	defaultDevTunnelIdle = 30 * time.Minute
-	// defaultDevTunnelEndpoint is the public sish SSH listener. ⚠️ PLACEHOLDER —
-	// the real endpoint is provisioned in P3 (a fresh port on the shared proxy,
-	// design Revision #1/#2). Override with --tunnel-endpoint or
-	// CIVITAI_DEV_TUNNEL_ENDPOINT until then; the command is inert end-to-end
-	// without it.
+	// defaultDevTunnelEndpoint is the live public sish SSH listener. Override with
+	// --tunnel-endpoint or CIVITAI_DEV_TUNNEL_ENDPOINT for a different deployment.
 	defaultDevTunnelEndpoint = "sish.civitai.com:2224"
 	// devTunnelEndpointEnv overrides the endpoint from the environment.
 	devTunnelEndpointEnv = "CIVITAI_DEV_TUNNEL_ENDPOINT"
@@ -55,12 +53,18 @@ type tunnelAPI interface {
 // side effect (API, keygen, tunnel, clock, signals, IO) goes through here so the
 // lifecycle is unit-testable with no network.
 type tunnelSessionDeps struct {
-	api      tunnelAPI
-	keygen   func() (*devtunnel.EphemeralKey, error)
-	dialer   devtunnel.Dialer
-	blockID  string
-	port     int
-	endpoint string
+	api tunnelAPI
+	// probeLocal pre-flight-checks that the developer's local dev server is
+	// actually listening on 127.0.0.1:<port> BEFORE anything is minted server-side.
+	// A non-nil error aborts the session before keygen/StartDevTunnel, so a
+	// not-running dev server fails fast with clear guidance instead of minting a
+	// rate-limited/reaper-tracked session that would only serve connection-refused.
+	probeLocal func(port int) error
+	keygen     func() (*devtunnel.EphemeralKey, error)
+	dialer     devtunnel.Dialer
+	blockID    string
+	port       int
+	endpoint   string
 	// baseURL is the configured Civitai origin; the mint response's URL must be
 	// same-origin as this (defense-in-depth against an attacker-influenced URL).
 	baseURL  string
@@ -102,11 +106,9 @@ The blockId is resolved from (in order): the ` + "`--block`" + ` flag, the posit
 argument, then the ` + "`blockId`" + ` in ` + "`block.manifest.json`" + ` in the current
 directory. Run it from your App project dir and you can omit the blockId entirely.
 
-⚠️ PRE-GA / DARK: dev tunnels are gated behind an Apps-author invite AND a
-kill-switch flag that is OFF today, and the public tunnel endpoint is not exposed
-yet — so end-to-end this will report "not available" until it ships. The command,
-its contract, and its teardown are complete; only the server flag + endpoint are
-pending.`,
+⚠️ GATED: dev tunnels are limited to invited Apps authors / moderators and are
+guarded by a server kill-switch flag. The tunnel endpoint is live; if you are not
+enrolled the mint reports "not available" — ask to be added to the cohort.`,
 		Example: `  # In terminal 1: start the embeddable dev server.
   npm run dev:tunnel
   # In terminal 2: open the tunnel (Ctrl-C to tear down).
@@ -121,6 +123,15 @@ pending.`,
 			// to the current directory) so a dev in their App project dir can run
 			// `civitai app dev-tunnel` with no args.
 			blockID := strings.TrimSpace(blockFlag)
+			// If BOTH --block and a positional blockId were given and they DIFFER,
+			// the positional is silently ignored (--block wins). Warn so the dev
+			// isn't confused about which one took effect. Equal values are redundant,
+			// not a conflict — stay silent.
+			if blockFlag != "" && len(args) == 1 && strings.TrimSpace(args[0]) != strings.TrimSpace(blockFlag) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: both --block %q and positional blockId %q were given; using --block (%q)\n",
+					strings.TrimSpace(blockFlag), strings.TrimSpace(args[0]), strings.TrimSpace(blockFlag))
+			}
 			if blockID == "" && len(args) == 1 {
 				blockID = strings.TrimSpace(args[0])
 			}
@@ -166,25 +177,26 @@ pending.`,
 			defer signal.Stop(sigCh)
 
 			return runTunnelSession(context.Background(), tunnelSessionDeps{
-				api:      client,
-				keygen:   devtunnel.GenerateEphemeralKey,
-				dialer:   devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
-				blockID:  blockID,
-				port:     port,
-				endpoint: ep,
-				baseURL:  cfg.BaseURL(),
-				idle:     idle,
-				newTimer: devtunnel.NewRealTimer,
-				signals:  sigCh,
-				out:      cmd.OutOrStdout(),
-				errw:     cmd.ErrOrStderr(),
+				api:        client,
+				probeLocal: probeLocalDevServer,
+				keygen:     devtunnel.GenerateEphemeralKey,
+				dialer:     devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
+				blockID:    blockID,
+				port:       port,
+				endpoint:   ep,
+				baseURL:    cfg.BaseURL(),
+				idle:       idle,
+				newTimer:   devtunnel.NewRealTimer,
+				signals:    sigCh,
+				out:        cmd.OutOrStdout(),
+				errw:       cmd.ErrOrStderr(),
 			})
 		},
 	}
 
 	cmd.Flags().StringVar(&blockFlag, "block", "", "the blockId (app slug) to tunnel (or pass it positionally; defaults to the blockId in "+manifest.Filename+" in the CWD)")
 	cmd.Flags().IntVar(&port, "port", defaultDevTunnelPort, "local dev-server port to tunnel (matches the scaffold's dev:tunnel)")
-	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+"; P3-provisioned)")
+	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+")")
 	cmd.Flags().DurationVar(&idle, "idle-timeout", defaultDevTunnelIdle, "tear the tunnel down after this much inactivity")
 	return cmd
 }
@@ -196,6 +208,14 @@ pending.`,
 // injected via deps so this is exercised with mocks (no SSH, no network, no real
 // clock).
 func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
+	// Pre-flight FIRST: fail fast if the local dev server isn't listening, BEFORE
+	// minting anything server-side. Nothing to tear down yet — return directly.
+	if d.probeLocal != nil {
+		if err := d.probeLocal(d.port); err != nil {
+			return err
+		}
+	}
+
 	key, err := d.keygen()
 	if err != nil {
 		return fmt.Errorf("generate ephemeral tunnel key: %w", err)
@@ -283,6 +303,20 @@ loop:
 
 	_ = tunnel.Close()
 	stop(reason)
+	return nil
+}
+
+// probeLocalDevServer is the production probeLocal: a short TCP dial of
+// 127.0.0.1:<port>. A successful connect means the dev server is up; a refused
+// connection / timeout is a HARD error with actionable guidance. Run BEFORE the
+// mint so a not-running dev server never burns a rate-limited/reaper-tracked
+// server session (which would only serve the browser connection-refused).
+func probeLocalDevServer(port int) error {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 2*time.Second)
+	if err != nil {
+		return fmt.Errorf("no local dev server is listening on 127.0.0.1:%d — start it first (e.g. `npm run dev:tunnel`), then re-run. (override the port with --port)", port)
+	}
+	_ = conn.Close()
 	return nil
 }
 

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,20 @@ import (
 	"strings"
 	"testing"
 )
+
+// listenLocal opens a listener on an ephemeral 127.0.0.1 port and returns the
+// port, so a full-path dev-tunnel test can pass `--port <port>` and satisfy the
+// pre-flight local-dev-server probe (which TCP-dials 127.0.0.1:<port> before the
+// mint). The listener is closed at test end.
+func listenLocal(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("open local listener: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l.Addr().(*net.TCPAddr).Port
+}
 
 // TestAppDevTunnelMissingBlockErrors: no blockId (positional, --block, or a
 // manifest in the CWD) is a clear, non-network error. Run from a temp dir with
@@ -66,7 +82,9 @@ func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
 	t.Setenv("CIVITAI_TOKEN", "tok-1")
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 
-	_, _, err := run(t, "app", "dev-tunnel")
+	// A live local listener so the pre-flight probe passes and we reach the mint.
+	port := listenLocal(t)
+	_, _, err := run(t, "app", "dev-tunnel", "--port", fmt.Sprint(port))
 	// It must get PAST the blockId check — the only remaining failure is the
 	// (expected, pre-GA) forbidden mint, never "blockId is required".
 	if err != nil && strings.Contains(err.Error(), "blockId is required") {
@@ -75,6 +93,64 @@ func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
 	// Proof the resolved blockId came from the manifest and reached the request.
 	if !strings.Contains(gotBody, `"blockId":"demo"`) {
 		t.Errorf("start body should carry the manifest blockId 'demo': %s", gotBody)
+	}
+}
+
+// TestAppDevTunnelBlockFlagWinsOverPositionalWithWarning: passing BOTH --block
+// and a DIFFERENT positional blockId warns on stderr that --block wins, and the
+// resolved blockId (carried to the mint request) is the --block value.
+func TestAppDevTunnelBlockFlagWinsOverPositionalWithWarning(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		gotBody = string(raw)
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	_, errOut, _ := run(t, "app", "dev-tunnel", "positional-block", "--block", "flag-block", "--port", fmt.Sprint(port))
+
+	// The conflict warning names both values and says --block wins.
+	if !strings.Contains(errOut, "flag-block") || !strings.Contains(errOut, "positional-block") ||
+		!strings.Contains(strings.ToLower(errOut), "using --block") {
+		t.Errorf("expected a --block-wins conflict warning on stderr, got: %s", errOut)
+	}
+	// --block wins: the mint request carries flag-block, NOT positional-block.
+	if !strings.Contains(gotBody, `"blockId":"flag-block"`) {
+		t.Errorf("resolved blockId should be the --block value: %s", gotBody)
+	}
+	if strings.Contains(gotBody, `"blockId":"positional-block"`) {
+		t.Errorf("the positional blockId must be ignored when --block is set: %s", gotBody)
+	}
+}
+
+// TestAppDevTunnelBlockFlagEqualsPositionalNoWarning: when --block and the
+// positional are the SAME value they are redundant, not a conflict — no warning.
+func TestAppDevTunnelBlockFlagEqualsPositionalNoWarning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	_, errOut, _ := run(t, "app", "dev-tunnel", "same-block", "--block", "same-block", "--port", fmt.Sprint(port))
+	if strings.Contains(strings.ToLower(errOut), "using --block") {
+		t.Errorf("equal --block and positional must NOT warn: %s", errOut)
 	}
 }
 
@@ -150,7 +226,9 @@ func TestAppDevTunnelForbiddenMapsToGuidance(t *testing.T) {
 	t.Setenv("CIVITAI_TOKEN", "tok-1")
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 
-	_, _, err := run(t, "app", "dev-tunnel", "my-block")
+	// A live local listener so the pre-flight probe passes and we reach the mint.
+	port := listenLocal(t)
+	_, _, err := run(t, "app", "dev-tunnel", "my-block", "--port", fmt.Sprint(port))
 	if err == nil {
 		t.Fatal("expected a forbidden error while the flag is dark")
 	}

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -53,6 +53,12 @@ func (f *fakeTunnelAPI) stopCount() int {
 	return len(f.stopCalls)
 }
 
+func (f *fakeTunnelAPI) startCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.startCalls)
+}
+
 // fakeTunnel is a controllable devtunnel.Tunnel.
 type fakeTunnel struct {
 	done      chan struct{}
@@ -151,18 +157,19 @@ func baseDeps(t *testing.T, apiStub *fakeTunnelAPI, dialer *fakeDialer, timer *f
 	t.Helper()
 	var out, errw strings.Builder
 	return tunnelSessionDeps{
-		api:      apiStub,
-		keygen:   goodKeygen,
-		dialer:   dialer,
-		blockID:  "my-block",
-		port:     5186,
-		endpoint: "sish.example:2224",
-		baseURL:  "https://civitai.com",
-		idle:     30 * time.Minute,
-		newTimer: func(time.Duration) devtunnel.Timer { return timer },
-		signals:  sigs,
-		out:      &out,
-		errw:     &errw,
+		api:        apiStub,
+		probeLocal: func(int) error { return nil }, // no-op: local dev server "up"
+		keygen:     goodKeygen,
+		dialer:     dialer,
+		blockID:    "my-block",
+		port:       5186,
+		endpoint:   "sish.example:2224",
+		baseURL:    "https://civitai.com",
+		idle:       30 * time.Minute,
+		newTimer:   func(time.Duration) devtunnel.Timer { return timer },
+		signals:    sigs,
+		out:        &out,
+		errw:       &errw,
 	}
 }
 
@@ -430,6 +437,37 @@ func TestRunTunnelSessionDialError(t *testing.T) {
 	}
 	if apiStub.stopCount() != 1 {
 		t.Errorf("a failed dial must revoke the minted session (avoid orphan), stop calls=%d", apiStub.stopCount())
+	}
+}
+
+// TestRunTunnelSessionProbeError: the pre-flight local-dev-server probe runs
+// FIRST — a probe failure returns that error verbatim and NEVER mints (no
+// keygen-dependent StartDevTunnel, no dial), so a not-running dev server can't
+// burn a rate-limited/reaper-tracked server session.
+func TestRunTunnelSessionProbeError(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	probeErr := errors.New("no local dev server is listening on 127.0.0.1:5186")
+	deps.probeLocal = func(port int) error {
+		if port != 5186 {
+			t.Errorf("probe got port %d, want the session port 5186", port)
+		}
+		return probeErr
+	}
+
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil || !errors.Is(err, probeErr) {
+		t.Fatalf("expected the probe error to propagate verbatim, got %v", err)
+	}
+	if apiStub.startCount() != 0 {
+		t.Errorf("a failed pre-flight probe must NOT mint (StartDevTunnel calls=%d)", apiStub.startCount())
+	}
+	if dialer.dialed {
+		t.Error("a failed pre-flight probe must NOT dial the tunnel")
+	}
+	if apiStub.stopCount() != 0 {
+		t.Error("nothing was minted, so there is nothing to stop")
 	}
 }
 


### PR DESCRIPTION
Three DX follow-ups for `civitai app dev-tunnel` (v0.1.43 batch — **no release tagged here**).

### 1. Pre-flight check the local dev server is listening BEFORE minting
`runTunnelSession` now runs a TCP probe of `127.0.0.1:<port>` as its **first** step, before `keygen()`/`StartDevTunnel`. If the dev server isn't up, it fails fast with actionable guidance (`no local dev server is listening on 127.0.0.1:<port> — start it first (e.g. \`npm run dev:tunnel\`)…`) instead of minting a rate-limited/reaper-tracked server session that would only serve the browser connection-refused. Injected via `tunnelSessionDeps.probeLocal` (default = `net.DialTimeout` ~2s); unit-tested for the "probe fails → never mints/dials/stops" path.

### 2. Warn when `--block` AND a positional blockId conflict
Precedence stays `--block` > positional > manifest. When both are given and **differ**, the CLI now warns on stderr (naming both values) that `--block` wins; silent when they're equal (redundant, not a conflict).

### 3. Refresh stale "DARK / pending P3" help copy
P3 shipped — the endpoint is live (`sish.civitai.com:2224`) and the flag is moderators-on. Updated the `Long` gated-access paragraph, the `defaultDevTunnelEndpoint` comment (dropped PLACEHOLDER language), and the `--tunnel-endpoint` flag help (dropped the `P3-provisioned` parenthetical). No general-availability claim.

Full-path cmd tests that reach the mint (`TestAppDevTunnelForbiddenMapsToGuidance`, `TestAppDevTunnelBlockIdFromManifest`) open an ephemeral listener + pass `--port` so pre-flight passes; assertions unchanged. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)