### PR TITLE
fix(devtunnel): dial both loopback families (127.0.0.1 + ::1) for probe + proxy

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/url"
 	"os"
 	"os/signal"
@@ -306,15 +305,19 @@ loop:
 	return nil
 }
 
-// probeLocalDevServer is the production probeLocal: a short TCP dial of
-// 127.0.0.1:<port>. A successful connect means the dev server is up; a refused
-// connection / timeout is a HARD error with actionable guidance. Run BEFORE the
-// mint so a not-running dev server never burns a rate-limited/reaper-tracked
-// server session (which would only serve the browser connection-refused).
+// probeLocalDevServer is the production probeLocal: a short TCP dial of the local
+// dev server on <port>, trying BOTH loopback families (127.0.0.1 and ::1) so a
+// server bound only to IPv6 (`--host localhost` → `::1` on a dual-stack box) is
+// not falsely reported down. Uses the SAME dialer as the live tunnel proxy, so
+// "probe passed" implies "the proxy can reach it too." A successful connect means
+// the dev server is up; a refused connection / timeout is a HARD error with
+// actionable guidance. Run BEFORE the mint so a not-running dev server never
+// burns a rate-limited/reaper-tracked server session (which would only serve the
+// browser connection-refused).
 func probeLocalDevServer(port int) error {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 2*time.Second)
+	conn, err := devtunnel.DialLocalDevServer(port, 2*time.Second)
 	if err != nil {
-		return fmt.Errorf("no local dev server is listening on 127.0.0.1:%d — start it first (e.g. `npm run dev:tunnel`), then re-run. (override the port with --port)", port)
+		return fmt.Errorf("no local dev server is listening on port %d (tried 127.0.0.1 and ::1) — start it first (e.g. `npm run dev:tunnel`), then re-run. (override the port with --port)", port)
 	}
 	_ = conn.Close()
 	return nil

--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +46,37 @@ const sshDialUser = "civitai-dev"
 // dialTimeout bounds the initial SSH handshake so a dead/unreachable endpoint
 // (the common case pre-P3) fails fast instead of hanging.
 const dialTimeout = 15 * time.Second
+
+// localDialTimeout bounds each attempt to reach the developer's local dev server.
+// Loopback connects/refusals resolve in well under a millisecond, so this only
+// matters for a wedged (accepting-but-never-completing) local server.
+const localDialTimeout = 3 * time.Second
+
+// loopbackHosts are the addresses a local dev server may be bound to. A dev
+// server launched with `--host localhost` (the scaffold's `dev:tunnel`) binds to
+// whichever family `localhost` resolves to — `::1` on a dual-stack box, else
+// `127.0.0.1` — and to that ONE family only. So the CLI must try both loopback
+// families rather than assume IPv4; otherwise a perfectly-running dev server on
+// `::1` looks "unreachable" to both the pre-flight probe and the tunnel proxy.
+// IPv4 is tried first (still the common bind), IPv6 second.
+var loopbackHosts = []string{"127.0.0.1", "::1"}
+
+// DialLocalDevServer connects to the developer's local dev server on `port`,
+// trying each loopback family in turn with a per-attempt timeout, and returns
+// the first successful connection. Shared by the pre-flight probe (which closes
+// the returned conn) and the live tunnel proxy (which uses it) so the two always
+// agree on whether the dev server is reachable.
+func DialLocalDevServer(port int, timeout time.Duration) (net.Conn, error) {
+	var lastErr error
+	for _, host := range loopbackHosts {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
 
 // sshDialer is the production Dialer: an in-process `ssh -R` via
 // golang.org/x/crypto/ssh, so the ephemeral private key never touches disk.
@@ -183,12 +215,13 @@ func (t *sshTunnel) serve() {
 	}
 }
 
-// proxy bridges one forwarded connection to 127.0.0.1:<localPort>.
+// proxy bridges one forwarded connection to the local dev server on
+// 127.0.0.1/::1:<localPort> (whichever loopback family it is bound to).
 func (t *sshTunnel) proxy(remote net.Conn) {
 	defer remote.Close()
-	local, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", t.localPort))
+	local, err := DialLocalDevServer(t.localPort, localDialTimeout)
 	if err != nil {
-		t.logf("  tunnel: local dev server 127.0.0.1:%d unreachable (%v) — is `npm run dev` running?\n", t.localPort, err)
+		t.logf("  tunnel: local dev server on port %d unreachable (%v) — is your dev server running (`npm run dev:tunnel`)?\n", t.localPort, err)
 		return
 	}
 	defer local.Close()

--- a/internal/devtunnel/ssh_dialer_test.go
+++ b/internal/devtunnel/ssh_dialer_test.go
@@ -358,7 +358,7 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 	// log for the guidance line.
 	deadline := time.After(2 * time.Second)
 	for {
-		if strings.Contains(logbuf.String(), fmt.Sprintf("127.0.0.1:%d", deadPort)) {
+		if strings.Contains(logbuf.String(), fmt.Sprintf("on port %d unreachable", deadPort)) {
 			return
 		}
 		select {
@@ -369,6 +369,56 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 			time.Sleep(5 * time.Millisecond)
 		}
 	}
+}
+
+// TestDialLocalDevServerBothFamilies proves the loopback dialer reaches a dev
+// server bound to EITHER family. The IPv6-only case is the real regression: a
+// `--host localhost` dev server binds `::1` only on a dual-stack box, and the
+// old 127.0.0.1-hardcoded dialer/probe falsely reported it unreachable.
+func TestDialLocalDevServerBothFamilies(t *testing.T) {
+	t.Run("ipv4", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		port := ln.Addr().(*net.TCPAddr).Port
+		conn, err := DialLocalDevServer(port, 2*time.Second)
+		if err != nil {
+			t.Fatalf("expected to reach the IPv4 dev server on port %d: %v", port, err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("ipv6", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "[::1]:0")
+		if err != nil {
+			t.Skipf("IPv6 loopback unavailable on this host: %v", err)
+		}
+		defer ln.Close()
+		port := ln.Addr().(*net.TCPAddr).Port
+		// Regression guard: on the old code this returned "connection refused"
+		// because it only ever dialed 127.0.0.1.
+		conn, err := DialLocalDevServer(port, 2*time.Second)
+		if err != nil {
+			t.Fatalf("expected to reach the IPv6-only dev server on port %d (this is the localhost→::1 fix): %v", port, err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("nothing-listening", func(t *testing.T) {
+		// A port that is (almost certainly) closed: bind then immediately free.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		deadPort := ln.Addr().(*net.TCPAddr).Port
+		_ = ln.Close()
+		if conn, err := DialLocalDevServer(deadPort, 500*time.Millisecond); err == nil {
+			_ = conn.Close()
+			t.Fatalf("expected an error dialing the closed port %d", deadPort)
+		}
+	})
 }
 
 // TestPinnedHostKeyCallback proves the host-key pin: a valid host key yields a


### PR DESCRIPTION
## What
The dev tunnel's local-end connection (both the tunnel proxy and the v0.1.43 pre-flight probe) hardcoded IPv4 `127.0.0.1`. A dev server started with `--host localhost` (the scaffold's `dev:tunnel` script) binds to whichever family `localhost` resolves to — **`::1` on a dual-stack machine** — and only that family. Result: a healthy dev server on `::1` was reported "unreachable", and the browser-facing tunnel never served. Feature-breaking, not just a probe annoyance.

## How it surfaced
First real-CLI Stage-3 dogfood. `civitai app dev-tunnel` reported the dev server down; `curl 127.0.0.1:5186` refused while `curl localhost:5186` (→ `::1`) returned the app. The Stage-2 in-cluster harness missed it because it seeded its own `127.0.0.1` listener rather than driving `vite --host localhost`.

## Fix
Shared `DialLocalDevServer(port, timeout)` in `internal/devtunnel` that tries `127.0.0.1` then `::1`, returning the first connection — used by **both** the proxy (`ssh_dialer.proxy`) and the probe (`probeLocalDevServer`), so "probe passed" implies "the proxy can reach it too."

## Tests
`TestDialLocalDevServerBothFamilies`: IPv4, **IPv6-only** (the regression the old hardcode failed), and nothing-listening. `TestSSHDialerLocalDevDown` assertion updated for the new (family-agnostic) log message. Full suite + `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)