### PR TITLE
feat(devtunnel): name the signed-in account + how to switch on a 403 mint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1082,6 +1082,16 @@ func (c *Client) StopDevTunnel(ctx context.Context, sessionID, blockID string) (
 	return env.Result.Data.JSON.Stopped, nil
 }
 
+// DevTunnelForbiddenError is returned when the dev-tunnel mint is refused with 403
+// — the authenticated account lacks the Apps-author invite + dev-tunnel flag. Typed
+// so the command layer can errors.As it and enrich the message with the signed-in
+// identity + account-switch guidance.
+type DevTunnelForbiddenError struct{ ServerMsg string }
+
+func (e *DevTunnelForbiddenError) Error() string {
+	return fmt.Sprintf("dev tunnels are not available for your account (403): %s — needs an Apps-author invite AND the dev-tunnel flag (dark until GA)", e.ServerMsg)
+}
+
 // devTunnelError maps a non-200 dev-tunnel tRPC response to an actionable CLI
 // error. tRPC error bodies are {error:{json:{message,code,...}}}; the HTTP
 // status carries the mapped code (403 flag-off/not-author, 404 not-your-app).
@@ -1101,7 +1111,7 @@ func devTunnelError(status int, raw []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("dev tunnels are not available for your account (403): %s — needs an Apps-author invite AND the dev-tunnel flag (dark until GA)", msg)
+		return &DevTunnelForbiddenError{ServerMsg: msg}
 	case http.StatusNotFound:
 		return fmt.Errorf("app not found (404): %s — check the blockId with `civitai app status` (you can only tunnel your OWN app)", msg)
 	case http.StatusTooManyRequests:

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -46,6 +47,10 @@ const (
 type tunnelAPI interface {
 	StartDevTunnel(ctx context.Context, blockID, sshPublicKey string) (*api.DevTunnelSession, error)
 	StopDevTunnel(ctx context.Context, sessionID, blockID string) (bool, error)
+	// WhoAmI resolves the signed-in identity — used to enrich a 403 mint refusal
+	// with which account the CLI is authenticated as (the usual cause is being
+	// logged in as the wrong account). The real *api.Client already implements it.
+	WhoAmI(ctx context.Context) (*api.Identity, error)
 }
 
 // tunnelSessionDeps are the injectable dependencies of runTunnelSession — every
@@ -222,7 +227,10 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 
 	sess, err := d.api.StartDevTunnel(ctx, d.blockID, key.AuthorizedKey)
 	if err != nil {
-		return err
+		// A 403 mint refusal is the common "wrong account" case — enrich it with
+		// the signed-in identity + how to switch accounts. This runs on the
+		// mint-error path, BEFORE any tunnel dial, so a forbidden mint never dials.
+		return enrichDevTunnelAuthError(ctx, d, err)
 	}
 
 	// Defense-in-depth: never trust the mint response blindly. The assigned host's
@@ -303,6 +311,21 @@ loop:
 	_ = tunnel.Close()
 	stop(reason)
 	return nil
+}
+
+// enrichDevTunnelAuthError augments a 403 mint refusal with the identity the CLI is
+// signed in as + how to switch accounts (the usual cause is "wrong account"). Best
+// effort: a failed WhoAmI just omits the name. Non-forbidden errors pass through.
+func enrichDevTunnelAuthError(ctx context.Context, d tunnelSessionDeps, err error) error {
+	var forbidden *api.DevTunnelForbiddenError
+	if !errors.As(err, &forbidden) {
+		return err
+	}
+	who := ""
+	if id, werr := d.api.WhoAmI(ctx); werr == nil && id != nil {
+		who = fmt.Sprintf(" You are signed in as %s (id %d).", id.Username, id.ID)
+	}
+	return fmt.Errorf("%w.%s Switch accounts with `civitai login` (browser) or `civitai login --token <key>`, then re-run; check the active account any time with `civitai whoami`", err, who)
 }
 
 // probeLocalDevServer is the production probeLocal: a short TCP dial of the local

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -13,6 +13,11 @@ import (
 	"testing"
 )
 
+// startDevTunnelRoute is the non-batched tRPC mint route. The forbidden-mint
+// tests must record ONLY this request's body/path — the 403 now triggers a
+// follow-up WhoAmI (/api/v1/me), which would otherwise clobber the recorders.
+const startDevTunnelRoute = "/api/trpc/blocks.startDevTunnel"
+
 // listenLocal opens a listener on an ephemeral 127.0.0.1 port and returns the
 // port, so a full-path dev-tunnel test can pass `--port <port>` and satisfy the
 // pre-flight local-dev-server probe (which TCP-dials 127.0.0.1:<port> before the
@@ -54,12 +59,18 @@ func TestAppDevTunnelMissingBlockErrors(t *testing.T) {
 func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		gotBody = string(raw)
-		w.WriteHeader(http.StatusForbidden)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
-		})
+		// The forbidden mint now triggers a follow-up WhoAmI (/api/v1/me) to enrich
+		// the error — only record the START request so WhoAmI can't clobber gotBody.
+		if r.URL.Path == startDevTunnelRoute {
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
 	}))
 	defer srv.Close()
 
@@ -102,12 +113,16 @@ func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
 func TestAppDevTunnelBlockFlagWinsOverPositionalWithWarning(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		gotBody = string(raw)
-		w.WriteHeader(http.StatusForbidden)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
-		})
+		if r.URL.Path == startDevTunnelRoute {
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
 	}))
 	defer srv.Close()
 
@@ -212,13 +227,20 @@ func TestAppHelpListsDevTunnel(t *testing.T) {
 func TestAppDevTunnelForbiddenMapsToGuidance(t *testing.T) {
 	var gotPath, gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		raw, _ := io.ReadAll(r.Body)
-		gotBody = string(raw)
-		w.WriteHeader(http.StatusForbidden)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
-		})
+		// Record ONLY the mint request — the 403 now triggers a follow-up WhoAmI
+		// (/api/v1/me) to name the signed-in account, which we serve a valid
+		// identity for so the enriched error can be asserted.
+		if r.URL.Path == startDevTunnelRoute {
+			gotPath = r.URL.Path
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
 	}))
 	defer srv.Close()
 
@@ -235,7 +257,14 @@ func TestAppDevTunnelForbiddenMapsToGuidance(t *testing.T) {
 	if !strings.Contains(err.Error(), "not available") || !strings.Contains(err.Error(), "403") {
 		t.Errorf("403 should map to dark/pre-GA guidance: %v", err)
 	}
-	if gotPath != "/api/trpc/blocks.startDevTunnel" {
+	// The 403 is enriched with the signed-in identity + how to switch/check accounts.
+	if !strings.Contains(err.Error(), "tester") {
+		t.Errorf("403 should name the signed-in account (tester): %v", err)
+	}
+	if !strings.Contains(err.Error(), "civitai login") || !strings.Contains(err.Error(), "civitai whoami") {
+		t.Errorf("403 should carry account-switch guidance (civitai login / civitai whoami): %v", err)
+	}
+	if gotPath != startDevTunnelRoute {
 		t.Errorf("start path = %q, want the tRPC startDevTunnel route", gotPath)
 	}
 	// The request carries the ephemeral pubkey + blockId under the tRPC `json` key.

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -25,6 +25,29 @@ type fakeTunnelAPI struct {
 
 	stopErr   error
 	stopCalls []struct{ sessionID, blockID string }
+
+	// whoami / whoamiErr are the canned WhoAmI result used to enrich a 403 mint
+	// refusal; whoamiCalls counts invocations so a test can assert WhoAmI is NOT
+	// called on a non-forbidden error.
+	whoami     *api.Identity
+	whoamiErr  error
+	whoamiCall int
+}
+
+func (f *fakeTunnelAPI) WhoAmI(_ context.Context) (*api.Identity, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.whoamiCall++
+	if f.whoamiErr != nil {
+		return nil, f.whoamiErr
+	}
+	return f.whoami, nil
+}
+
+func (f *fakeTunnelAPI) whoamiCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.whoamiCall
 }
 
 func (f *fakeTunnelAPI) StartDevTunnel(_ context.Context, blockID, pubKey string) (*api.DevTunnelSession, error) {
@@ -420,6 +443,94 @@ func TestRunTunnelSessionStartError(t *testing.T) {
 	}
 	if apiStub.stopCount() != 0 {
 		t.Error("should NOT call stop when nothing was started")
+	}
+}
+
+// TestRunTunnelSessionForbiddenEnrichedWithIdentity: a 403 mint refusal is
+// enriched with the signed-in account + account-switch guidance, still errors.As
+// to *api.DevTunnelForbiddenError, and NEVER dials/stops (it's on the mint-error
+// path, before any tunnel dial).
+func TestRunTunnelSessionForbiddenEnrichedWithIdentity(t *testing.T) {
+	apiStub := &fakeTunnelAPI{
+		startErr: &api.DevTunnelForbiddenError{ServerMsg: "Dev tunnels are not available"},
+		whoami:   &api.Identity{Username: "zach", ID: 42},
+	}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil {
+		t.Fatal("expected the forbidden mint to error")
+	}
+	// (a) still unwraps to the typed forbidden error.
+	var forbidden *api.DevTunnelForbiddenError
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("enriched error must still errors.As to *api.DevTunnelForbiddenError, got %v", err)
+	}
+	// (b) names the account + carries the switch/check guidance.
+	msg := err.Error()
+	for _, want := range []string{"signed in as zach", "id 42", "civitai login", "civitai whoami", "not available", "403"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("enriched error missing %q: %v", want, msg)
+		}
+	}
+	// (c) never dialed and never stopped (nothing was minted).
+	if dialer.dialed {
+		t.Error("a forbidden mint must NOT dial the tunnel")
+	}
+	if apiStub.stopCount() != 0 {
+		t.Errorf("a forbidden mint must NOT stop (nothing minted), stop calls=%d", apiStub.stopCount())
+	}
+	if apiStub.whoamiCount() != 1 {
+		t.Errorf("WhoAmI should be consulted once to name the account, got %d", apiStub.whoamiCount())
+	}
+}
+
+// TestRunTunnelSessionForbiddenWhoAmIFails: a 403 mint with a failing WhoAmI still
+// carries the switch guidance but omits the account name (best effort).
+func TestRunTunnelSessionForbiddenWhoAmIFails(t *testing.T) {
+	apiStub := &fakeTunnelAPI{
+		startErr:  &api.DevTunnelForbiddenError{ServerMsg: "Dev tunnels are not available"},
+		whoamiErr: errors.New("token expired"),
+	}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil {
+		t.Fatal("expected the forbidden mint to error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "civitai login") || !strings.Contains(msg, "civitai whoami") {
+		t.Errorf("guidance must survive a failed WhoAmI: %v", msg)
+	}
+	if strings.Contains(msg, "signed in as") {
+		t.Errorf("a failed WhoAmI must NOT claim an account name: %v", msg)
+	}
+	if dialer.dialed {
+		t.Error("a forbidden mint must NOT dial the tunnel")
+	}
+}
+
+// TestRunTunnelSessionNonForbiddenErrorPassesThrough: a NON-forbidden mint error
+// passes through unchanged and does NOT consult WhoAmI.
+func TestRunTunnelSessionNonForbiddenErrorPassesThrough(t *testing.T) {
+	apiStub := &fakeTunnelAPI{
+		startErr: errors.New("boom: transient server error"),
+		whoami:   &api.Identity{Username: "zach", ID: 42},
+	}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil || err.Error() != "boom: transient server error" {
+		t.Fatalf("a non-forbidden error must pass through unchanged, got %v", err)
+	}
+	if apiStub.whoamiCount() != 0 {
+		t.Errorf("a non-forbidden error must NOT consult WhoAmI, got %d", apiStub.whoamiCount())
+	}
+	if dialer.dialed {
+		t.Error("a failed mint must NOT dial the tunnel")
 	}
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -36,10 +36,15 @@ CIVITAI_TOKEN environment variable still overrides the stored credential.
 
 Note: ` + "`civitai login`" + ` (OAuth) grants submit but NOT Buzz-spend. To run
 ` + "`dev:live`" + ` real generations, authenticate with a full-scope personal API key
-(` + "`civitai login --token <key>`" + `, created at https://civitai.com/user/account).`,
+(` + "`civitai login --token <key>`" + `, created at https://civitai.com/user/account).
+
+Switching accounts: running ` + "`civitai login`" + ` again overwrites the stored
+credential with the new account — no separate logout needed. (Check the active
+account with ` + "`civitai whoami`" + `.)`,
 		Example: `  civitai login                 # browser device login (recommended)
   civitai login --no-browser    # device login without auto-opening a browser
-  civitai login --token <token> # store a personal API key instead`,
+  civitai login --token <token> # store a personal API key instead
+  civitai login                 # run again to SWITCH the active account (overwrites the stored credential)`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()


### PR DESCRIPTION
## Why
When `civitai app dev-tunnel` is refused with **403**, the bare error hides the most common cause: **being signed in as the wrong account** (one lacking the Apps-author invite + the dev-tunnel flag). The user was left guessing.

## What
- **`api`**: new exported typed error `DevTunnelForbiddenError` (its `Error()` keeps the exact existing `"not available"` and `"(403)"` substrings so existing assertions hold). `devTunnelError`'s `http.StatusForbidden` case now returns it; 401/404/429/503 unchanged.
- **`cmd`**: `tunnelAPI` gains `WhoAmI` (the real `*api.Client` already implements it — production wiring unchanged). A forbidden mint is routed through `enrichDevTunnelAuthError`, which `errors.As`-detects the typed 403, best-effort names the signed-in account (`You are signed in as <user> (id N).`), and appends switch guidance — ``civitai login`` (browser) / ``civitai login --token <key>`` — plus ``civitai whoami``. It runs on the mint-error path **before any tunnel dial**, so a forbidden mint never dials, and `%w` preserves the typed-error chain.
- **`login`**: `Long`/`Example` now document that re-running ``civitai login`` **switches** the active account (overwrites the stored credential — no separate logout). Verified against the code: `SetToken` / `SetOAuthTokens` persist unconditionally with no "already logged in" guard, and each clears the other auth kind.

## Tests
- Made the forbidden-mint cmd tests **path-aware**: the new post-403 `WhoAmI` (`/api/v1/me`) request would otherwise clobber the handlers' recorded start body/path. The whoami route now returns a valid `Identity`, and `TestAppDevTunnelForbiddenMapsToGuidance` additionally asserts the enriched error names the account + carries `civitai login` / `civitai whoami` (keeping the existing `not available` / `403` assertions).
- New focused unit tests: enriched-with-identity (still `errors.As` to the typed error, never dials/stops, WhoAmI consulted once), failed-WhoAmI degradation (guidance survives, no account name), and non-forbidden pass-through (unchanged error, WhoAmI not consulted).

`gofmt -l` clean · `go vet ./...` clean · `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)