### PR TITLE
fix(devtunnel): token-scope 403 → full-scope-key guidance, not account-switching

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1082,14 +1082,32 @@ func (c *Client) StopDevTunnel(ctx context.Context, sessionID, blockID string) (
 	return env.Result.Data.JSON.Stopped, nil
 }
 
-// DevTunnelForbiddenError is returned when the dev-tunnel mint is refused with 403
-// — the authenticated account lacks the Apps-author invite + dev-tunnel flag. Typed
-// so the command layer can errors.As it and enrich the message with the signed-in
-// identity + account-switch guidance.
-type DevTunnelForbiddenError struct{ ServerMsg string }
+// DevTunnelForbiddenError is returned when the dev-tunnel mint is refused with 403.
+// Typed so the command layer can errors.As it and give the RIGHT fix, which differs
+// by cause:
+//   - InsufficientScope: the CLI's credential lacks Full scope (the token-scope
+//     gate runs before the author/flag gates) → fix is a full-scope personal API
+//     key, NOT a different account.
+//   - otherwise: the account lacks the Apps-author invite + dev-tunnel flag → fix
+//     is signing in as an enrolled account.
+type DevTunnelForbiddenError struct {
+	ServerMsg         string
+	InsufficientScope bool
+}
 
 func (e *DevTunnelForbiddenError) Error() string {
+	if e.InsufficientScope {
+		return fmt.Sprintf("dev tunnels need a full-scope credential (403): %s", e.ServerMsg)
+	}
 	return fmt.Sprintf("dev tunnels are not available for your account (403): %s — needs an Apps-author invite AND the dev-tunnel flag (dark until GA)", e.ServerMsg)
+}
+
+// isInsufficientScopeMsg detects the server's token-SCOPE refusal. It is the only
+// wire signal that distinguishes it from the author/flag 403s — both are TRPCError
+// FORBIDDEN with no distinct code — so we classify on the stable core of the server
+// message "Your API key does not have the required scope for this action".
+func isInsufficientScopeMsg(msg string) bool {
+	return strings.Contains(strings.ToLower(msg), "required scope")
 }
 
 // devTunnelError maps a non-200 dev-tunnel tRPC response to an actionable CLI
@@ -1111,7 +1129,7 @@ func devTunnelError(status int, raw []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
 	case http.StatusForbidden:
-		return &DevTunnelForbiddenError{ServerMsg: msg}
+		return &DevTunnelForbiddenError{ServerMsg: msg, InsufficientScope: isInsufficientScopeMsg(msg)}
 	case http.StatusNotFound:
 		return fmt.Errorf("app not found (404): %s — check the blockId with `civitai app status` (you can only tunnel your OWN app)", msg)
 	case http.StatusTooManyRequests:

--- a/internal/api/dev_tunnel_test.go
+++ b/internal/api/dev_tunnel_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -172,5 +173,44 @@ func TestStartDevTunnelErrorMapping(t *testing.T) {
 		if !strings.Contains(err.Error(), tc.want) {
 			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
 		}
+	}
+}
+
+// TestStartDevTunnelForbiddenClassifiesScope: a 403 is split by its server
+// message into a token-SCOPE refusal (fix = full-scope key) vs the author/flag
+// gate (fix = enrolled account). Both are FORBIDDEN with no distinct code, so
+// the message is the only signal.
+func TestStartDevTunnelForbiddenClassifiesScope(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverMsg string
+		wantScope bool
+		wantText  string
+	}{
+		{"scope", "Your API key does not have the required scope for this action", true, "full-scope credential"},
+		{"authorFlag", "Dev tunnels are not available", false, "not available for your account"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{"json": map[string]any{"message": tc.serverMsg}},
+				})
+			}))
+			defer srv.Close()
+			c := New(srv.URL, "tok", "")
+			_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+			var forbidden *DevTunnelForbiddenError
+			if !errors.As(err, &forbidden) {
+				t.Fatalf("403 should map to *DevTunnelForbiddenError, got %v", err)
+			}
+			if forbidden.InsufficientScope != tc.wantScope {
+				t.Errorf("InsufficientScope = %v, want %v (msg %q)", forbidden.InsufficientScope, tc.wantScope, tc.serverMsg)
+			}
+			if !strings.Contains(err.Error(), tc.wantText) || !strings.Contains(err.Error(), "403") {
+				t.Errorf("error %q should contain %q and 403", err.Error(), tc.wantText)
+			}
+		})
 	}
 }

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -321,6 +321,13 @@ func enrichDevTunnelAuthError(ctx context.Context, d tunnelSessionDeps, err erro
 	if !errors.As(err, &forbidden) {
 		return err
 	}
+	// A token-SCOPE refusal is a different fix from the author/flag gate: the
+	// credential needs FULL scope, not a different account. Don't misdirect the
+	// user to account-switching — an OAuth `civitai login` token can't open dev
+	// tunnels; a full-scope personal API key can.
+	if forbidden.InsufficientScope {
+		return fmt.Errorf("%w — this credential lacks Full scope. Create a full-scope personal API key at https://civitai.com/user/account, then `civitai login --token <key>` (an OAuth `civitai login` token can't open dev tunnels); check your credential + scopes with `civitai whoami`", err)
+	}
 	who := ""
 	if id, werr := d.api.WhoAmI(ctx); werr == nil && id != nil {
 		who = fmt.Sprintf(" You are signed in as %s (id %d).", id.Username, id.ID)

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -486,6 +486,47 @@ func TestRunTunnelSessionForbiddenEnrichedWithIdentity(t *testing.T) {
 	}
 }
 
+// TestRunTunnelSessionForbiddenScopeGuidance: a token-SCOPE 403 gives full-scope-key
+// guidance (NOT account-switching), and does NOT consult WhoAmI (the account is
+// fine — the credential's scope is the problem).
+func TestRunTunnelSessionForbiddenScopeGuidance(t *testing.T) {
+	apiStub := &fakeTunnelAPI{
+		startErr: &api.DevTunnelForbiddenError{
+			ServerMsg:         "Your API key does not have the required scope for this action",
+			InsufficientScope: true,
+		},
+		whoami: &api.Identity{Username: "zach", ID: 42},
+	}
+	dialer := &fakeDialer{tunnel: newFakeTunnel()}
+
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
+	err := runTunnelSession(context.Background(), deps)
+	if err == nil {
+		t.Fatal("expected the forbidden mint to error")
+	}
+	var forbidden *api.DevTunnelForbiddenError
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("enriched error must still errors.As to *api.DevTunnelForbiddenError, got %v", err)
+	}
+	msg := err.Error()
+	// Scope-specific guidance — full-scope key + whoami, NOT account-switching.
+	for _, want := range []string{"full-scope personal API key", "civitai login --token", "civitai whoami", "403"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("scope-403 guidance missing %q: %v", want, msg)
+		}
+	}
+	if strings.Contains(msg, "Switch accounts") || strings.Contains(msg, "signed in as") {
+		t.Errorf("a scope-403 must NOT misdirect to account-switching: %v", msg)
+	}
+	// The account is not the problem, so WhoAmI is not consulted; nothing dialed.
+	if apiStub.whoamiCount() != 0 {
+		t.Errorf("a scope-403 must NOT consult WhoAmI, got %d", apiStub.whoamiCount())
+	}
+	if dialer.dialed {
+		t.Error("a forbidden mint must NOT dial the tunnel")
+	}
+}
+
 // TestRunTunnelSessionForbiddenWhoAmIFails: a 403 mint with a failing WhoAmI still
 // carries the switch guidance but omits the account name (best effort).
 func TestRunTunnelSessionForbiddenWhoAmIFails(t *testing.T) {


### PR DESCRIPTION
## What
`civitai app dev-tunnel`'s 403 has **two causes that need opposite fixes**, and the CLI conflated them:
- **token-scope** gate (`enforceTokenScope` requires `TokenScope.Full`, and runs *before* the author/flag gates) — server: *"Your API key does not have the required scope for this action"* → fix is a **full-scope personal API key**.
- **author/flag** gate — fix is signing in as an enrolled (mod/cohort) account.

Both are `TRPCError` `FORBIDDEN` with no distinct code, so the server message is the only signal. Previously **every** 403 got "you are signed in as X / switch accounts / need an invite", which **actively misdirects** the scope case (the account is fine — the credential lacks Full scope).

## How it surfaced
Dogfooding as a **moderator**: all three flags (`app-blocks-dev-tunnel`, `app-blocks-author`, `app-blocks-enabled`) are mods-on, but `civitai login`'s OAuth token isn't Full-scope, so the mint 403'd at the scope gate — and the CLI told the mod to switch accounts / get an invite.

## Fix
- `api`: `DevTunnelForbiddenError` gains `InsufficientScope` (set via `isInsufficientScopeMsg`); `Error()` branches. Author/flag substrings preserved (back-compat).
- `cmd`: `enrichDevTunnelAuthError` branches — scope → full-scope key + `civitai login --token <key>` + `civitai whoami`, and does **not** consult `WhoAmI` (the account isn't the problem).
- tests: classification (scope vs author/flag) + the scope-guidance path asserts full-scope-key text, no account-switching text, and no `WhoAmI` call.

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)