### PR TITLE
feat(login): request AppBlocksDevTunnel scope for dev-tunnel over OAuth [BLOCKED on server]

### DIFF
--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -39,25 +39,34 @@ const (
 	// ClientID is the public OAuth client id for the CLI.
 	ClientID = "civitai-cli"
 
-	// DeviceScope is UserRead|AppBlocksSubmit (bit flags), the fixed scope the CLI
-	// requests on login. 33554433 == (1<<0)|(1<<25) in the server's scope bitset:
-	//   - UserRead        (1<<0  = 1)        — whoami / identity.
-	//   - AppBlocksSubmit (1<<25 = 33554432) — `app submit` AND the dev-token mint
+	// DeviceScope is UserRead|AppBlocksSubmit|AppBlocksDevTunnel (bit flags), the
+	// fixed scope the CLI requests on login. 100663297 == (1<<0)|(1<<25)|(1<<26):
+	//   - UserRead           (1<<0  = 1)        — whoami / identity.
+	//   - AppBlocksSubmit     (1<<25 = 33554432) — `app submit` AND the dev-token mint
 	//     gate (both require this on an OAuth token).
-	// This is exactly the civitai-cli OauthClient.allowedScopes set (33554433). We
+	//   - AppBlocksDevTunnel  (1<<26 = 67108864) — `app dev-tunnel` (start/stop/status).
+	//     The dev-tunnel tRPC procs require this bit on an OAuth token; without it a
+	//     login token 403s the scope gate and only a Full personal API key works.
+	// This is exactly the civitai-cli OauthClient.allowedScopes set (100663297). We
 	// deliberately do NOT request AIServicesWrite: the server's device-flow
 	// validateScope is all-or-nothing — requesting any scope the client doesn't
 	// allow REJECTS the whole login — and we don't want every login token to carry
 	// general Buzz-spend authority.
 	//
-	// What a login token can do: it can MINT an App-Blocks dev token (the mint gate
-	// only needs AppBlocksSubmit) and drive the read/estimate harness paths — cost
-	// preview / whatif, catalog browsing, and app storage. It CANNOT run a real
-	// generation: the dev-token mint applies a uniform AIServicesWrite ceiling on
-	// the budgeted-spend scope, so a login-minted dev token has ai:write:budgeted
-	// STRIPPED (read/estimate only). Real-Buzz dev:live needs a personal API key
-	// with full scope (civitai.com/user/account), which carries AIServicesWrite.
-	DeviceScope = "33554433"
+	// 🔴 SERVER DEPENDENCY: AppBlocksDevTunnel (bit 26) + the widened civitai-cli
+	// allowedScopes (100663297) must be LIVE on prod auth (migration applied) BEFORE
+	// this ships — else the device request exceeds allowedScopes and login 400s
+	// (invalid_scope). Do NOT release this ahead of the civitai server change.
+	//
+	// What a login token can do: MINT an App-Blocks dev token (the mint gate needs
+	// AppBlocksSubmit), open an on-site dev tunnel (AppBlocksDevTunnel), and drive
+	// the read/estimate harness paths — cost preview / whatif, catalog browsing, app
+	// storage. It CANNOT run a real generation: the dev-token mint applies a uniform
+	// AIServicesWrite ceiling on the budgeted-spend scope, so a login-minted dev
+	// token has ai:write:budgeted STRIPPED (read/estimate only). Real-Buzz dev:live
+	// needs a personal API key with full scope (civitai.com/user/account), which
+	// carries AIServicesWrite.
+	DeviceScope = "100663297"
 
 	grantTypeDeviceCode   = "urn:ietf:params:oauth:grant-type:device_code"
 	grantTypeRefreshToken = "refresh_token"

--- a/internal/api/oauth_test.go
+++ b/internal/api/oauth_test.go
@@ -76,18 +76,20 @@ func TestStartDeviceParsesResponse(t *testing.T) {
 }
 
 // TestDeviceScopeCarriesRequiredBits pins the login scope contract: `civitai
-// login` must REQUEST exactly UserRead + AppBlocksSubmit — the civitai-cli
-// client's allowedScopes set. It must NOT request AIServicesWrite: the server's
-// device-flow validateScope is all-or-nothing, so asking for a scope the client
-// doesn't allow would REJECT the whole login. A granted token can still (a)
-// identify the user, (b) MINT an App-Blocks dev token (read/estimate; the mint
-// strips ai:write:budgeted without AIServicesWrite), and (c) submit via the
-// AppBlocksSubmit-gated routes. Real-Buzz dev:live needs a personal API key.
+// login` must REQUEST exactly UserRead + AppBlocksSubmit + AppBlocksDevTunnel —
+// the civitai-cli client's allowedScopes set. It must NOT request AIServicesWrite:
+// the server's device-flow validateScope is all-or-nothing, so asking for a scope
+// the client doesn't allow would REJECT the whole login. A granted token can still
+// (a) identify the user, (b) MINT an App-Blocks dev token (read/estimate; the mint
+// strips ai:write:budgeted without AIServicesWrite), (c) submit via the
+// AppBlocksSubmit-gated routes, and (d) open an on-site dev tunnel
+// (AppBlocksDevTunnel). Real-Buzz dev:live needs a personal API key.
 func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
 	const (
-		userRead        = 1 << 0  // 1
-		aiServicesWrite = 1 << 15 // 32768
-		appBlocksSubmit = 1 << 25 // 33554432
+		userRead           = 1 << 0  // 1
+		aiServicesWrite    = 1 << 15 // 32768
+		appBlocksSubmit    = 1 << 25 // 33554432
+		appBlocksDevTunnel = 1 << 26 // 67108864
 	)
 	got, err := strconv.Atoi(DeviceScope)
 	if err != nil {
@@ -99,6 +101,7 @@ func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
 	}{
 		{"UserRead", userRead},
 		{"AppBlocksSubmit", appBlocksSubmit},
+		{"AppBlocksDevTunnel", appBlocksDevTunnel},
 	} {
 		if got&c.bit == 0 {
 			t.Errorf("DeviceScope=%d is missing the %s bit (%d)", got, c.name, c.bit)
@@ -109,8 +112,8 @@ func TestDeviceScopeCarriesRequiredBits(t *testing.T) {
 	if got&aiServicesWrite != 0 {
 		t.Errorf("DeviceScope=%d unexpectedly includes the AIServicesWrite bit (%d) — would break login", got, aiServicesWrite)
 	}
-	if want := userRead | appBlocksSubmit; got != want {
-		t.Errorf("DeviceScope=%d, want exactly %d (UserRead|AppBlocksSubmit)", got, want)
+	if want := userRead | appBlocksSubmit | appBlocksDevTunnel; got != want {
+		t.Errorf("DeviceScope=%d, want exactly %d (UserRead|AppBlocksSubmit|AppBlocksDevTunnel)", got, want)
 	}
 }
 

--- a/internal/cmd/login_device_test.go
+++ b/internal/cmd/login_device_test.go
@@ -44,10 +44,10 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 				"token_type":    "Bearer",
 				"expires_in":    3600,
 				"refresh_token": "refresh-456",
-				// Echo the login scope the CLI requests (UserRead|AppBlocksSubmit
-				// = 33554433) so the persisted-scope assertion below reflects what
-				// `civitai login` obtains for the dev:live read/estimate paths.
-				"scope": "33554433",
+				// Echo the login scope the CLI requests
+				// (UserRead|AppBlocksSubmit|AppBlocksDevTunnel = 100663297) so the
+				// persisted-scope assertion below reflects what `civitai login` obtains.
+				"scope": "100663297",
 			})
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
@@ -101,7 +101,7 @@ func TestLoginDeviceFlowHappyPath(t *testing.T) {
 	if onDisk["auth_kind"] != "oauth" {
 		t.Errorf("auth_kind = %v, want oauth", onDisk["auth_kind"])
 	}
-	if onDisk["scope"] != "33554433" {
+	if onDisk["scope"] != "100663297" {
 		t.Errorf("scope = %v", onDisk["scope"])
 	}
 }
@@ -190,7 +190,7 @@ func loginDeviceServer(t *testing.T) (*httptest.Server, *string) {
 		case "/api/auth/oauth/device-token":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"access_token": "access-123", "token_type": "Bearer",
-				"expires_in": 3600, "refresh_token": "refresh-456", "scope": "33554433",
+				"expires_in": 3600, "refresh_token": "refresh-456", "scope": "100663297",
 			})
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)


### PR DESCRIPTION
## 🔴 DRAFT — DO NOT MERGE/RELEASE until the civitai server change is LIVE on prod
This is the CLI half of making `civitai app dev-tunnel` work over a plain `civitai login` (no full-scope personal API key). It **must not ship first**.

## What
Adds the new `AppBlocksDevTunnel` scope bit (`1<<26`) to the device-login `DeviceScope`:
`33554433` (UserRead|AppBlocksSubmit) → `100663297` (+AppBlocksDevTunnel).

## Why it's blocked
The auth hub clamps the requested device scope to the `civitai-cli` client's `allowedScopes`. Until the server PR (new scope bit + migration widening `allowedScopes` to `100663297`) is **deployed to prod**, a device request for `100663297` exceeds `allowedScopes` → the hub returns `invalid_scope` (400) → **`civitai login` breaks for everyone**.

## Release order
1. Merge + deploy the civitai server PR (adds `AppBlocksDevTunnel`, `.meta({requiredScope})` on the 3 dev-tunnel procs) **and apply the migration to prod**.
2. Verify a `civitai login` on the current CLI still works (allowedScopes widened, old scope still valid).
3. **Then** mark this ready, merge, release. Users re-`civitai login` to get a token with the new bit.

## Tests
`TestDeviceScopeCarriesRequiredBits` now pins UserRead|AppBlocksSubmit|**AppBlocksDevTunnel**, still forbids AIServicesWrite; device-login fixtures updated to the new granted scope. `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)