### PR TITLE
feat(devtunnel): wait for the public host to serve before printing the URL

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -40,6 +42,20 @@ const (
 	defaultDevTunnelEndpoint = "sish.civitai.com:2224"
 	// devTunnelEndpointEnv overrides the endpoint from the environment.
 	devTunnelEndpointEnv = "CIVITAI_DEV_TUNNEL_ENDPOINT"
+	// defaultReadyTimeout bounds the post-dial readiness wait. The PUBLIC host
+	// `dev-<16hex>.civit.ai` isn't reachable the instant the reverse tunnel binds —
+	// external-dns + Cloudflare propagation + Traefik router build take up to
+	// ~1–2 min. We poll until the server path is live (or this deadline), so the dev
+	// isn't handed a URL that NXDOMAINs/404s. Non-fatal on expiry (the host may
+	// still come up shortly) — override with --ready-timeout, skip with --no-wait.
+	defaultReadyTimeout = 120 * time.Second
+	// defaultReadyPollInterval is how often the readiness wait re-probes the public
+	// host. ~5s balances responsiveness against hammering CF/Traefik while a route
+	// is still being built.
+	defaultReadyPollInterval = 5 * time.Second
+	// probePublicTimeout bounds a single unauthenticated public-host GET so a hung
+	// connection (SYN blackhole during propagation) can't stall a poll iteration.
+	probePublicTimeout = 8 * time.Second
 )
 
 // tunnelAPI is the subset of the API client the session core needs (seam for a
@@ -64,19 +80,32 @@ type tunnelSessionDeps struct {
 	// not-running dev server fails fast with clear guidance instead of minting a
 	// rate-limited/reaper-tracked session that would only serve connection-refused.
 	probeLocal func(port int) error
-	keygen     func() (*devtunnel.EphemeralKey, error)
-	dialer     devtunnel.Dialer
-	blockID    string
-	port       int
-	endpoint   string
+	// probePublic checks whether the PUBLIC tunnel host is serving yet: it does an
+	// unauthenticated GET of https://<host>/ and reports ready per the classification
+	// in probePublicTunnel (HTTP 200/401/403 = the whole server path works — a naked
+	// no-token request is DENIED with 401 by the forwardAuth gate, which proves
+	// DNS→Traefik-router→gate are all up; 404/5xx/52x/DNS/refused = not up yet). Wired
+	// to probePublicTunnel in production; injected in tests. Nil disables the wait.
+	probePublic func(ctx context.Context, host string) (ready bool, detail string, err error)
+	keygen      func() (*devtunnel.EphemeralKey, error)
+	dialer      devtunnel.Dialer
+	blockID     string
+	port        int
+	endpoint    string
 	// baseURL is the configured Civitai origin; the mint response's URL must be
 	// same-origin as this (defense-in-depth against an attacker-influenced URL).
-	baseURL  string
-	idle     time.Duration
-	newTimer func(d time.Duration) devtunnel.Timer
-	signals  <-chan os.Signal
-	out      io.Writer
-	errw     io.Writer
+	baseURL string
+	idle    time.Duration
+	// readyTimeout bounds the post-dial readiness wait (default defaultReadyTimeout);
+	// readyPollInterval is the re-probe cadence (default defaultReadyPollInterval).
+	// noWait skips the wait entirely (print the URL immediately, as before).
+	readyTimeout      time.Duration
+	readyPollInterval time.Duration
+	noWait            bool
+	newTimer          func(d time.Duration) devtunnel.Timer
+	signals           <-chan os.Signal
+	out               io.Writer
+	errw              io.Writer
 }
 
 func newAppDevTunnelCmd() *cobra.Command {
@@ -84,6 +113,8 @@ func newAppDevTunnelCmd() *cobra.Command {
 	var port int
 	var endpoint string
 	var idle time.Duration
+	var readyTimeout time.Duration
+	var noWait bool
 
 	cmd := &cobra.Command{
 		Use:   "dev-tunnel [blockId]",
@@ -156,6 +187,9 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 			if idle <= 0 {
 				return fmt.Errorf("--idle-timeout must be positive (got %s)", idle)
 			}
+			if readyTimeout <= 0 {
+				return fmt.Errorf("--ready-timeout must be positive (got %s)", readyTimeout)
+			}
 
 			// Endpoint: flag > env > documented placeholder default.
 			ep := strings.TrimSpace(endpoint)
@@ -181,19 +215,23 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 			defer signal.Stop(sigCh)
 
 			return runTunnelSession(context.Background(), tunnelSessionDeps{
-				api:        client,
-				probeLocal: probeLocalDevServer,
-				keygen:     devtunnel.GenerateEphemeralKey,
-				dialer:     devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
-				blockID:    blockID,
-				port:       port,
-				endpoint:   ep,
-				baseURL:    cfg.BaseURL(),
-				idle:       idle,
-				newTimer:   devtunnel.NewRealTimer,
-				signals:    sigCh,
-				out:        cmd.OutOrStdout(),
-				errw:       cmd.ErrOrStderr(),
+				api:               client,
+				probeLocal:        probeLocalDevServer,
+				probePublic:       probePublicTunnel,
+				keygen:            devtunnel.GenerateEphemeralKey,
+				dialer:            devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
+				blockID:           blockID,
+				port:              port,
+				endpoint:          ep,
+				baseURL:           cfg.BaseURL(),
+				idle:              idle,
+				readyTimeout:      readyTimeout,
+				readyPollInterval: defaultReadyPollInterval,
+				noWait:            noWait,
+				newTimer:          devtunnel.NewRealTimer,
+				signals:           sigCh,
+				out:               cmd.OutOrStdout(),
+				errw:              cmd.ErrOrStderr(),
 			})
 		},
 	}
@@ -202,6 +240,8 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 	cmd.Flags().IntVar(&port, "port", defaultDevTunnelPort, "local dev-server port to tunnel (matches the scaffold's dev:tunnel)")
 	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+")")
 	cmd.Flags().DurationVar(&idle, "idle-timeout", defaultDevTunnelIdle, "tear the tunnel down after this much inactivity")
+	cmd.Flags().DurationVar(&readyTimeout, "ready-timeout", defaultReadyTimeout, "how long to wait for the public host to start serving before printing the URL anyway")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "skip the readiness wait and print the URL immediately (it may 404/NXDOMAIN for ~1–2 min while DNS/route propagate)")
 	return cmd
 }
 
@@ -271,8 +311,34 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 		return fmt.Errorf("open reverse tunnel to %s: %w", d.endpoint, err)
 	}
 
-	printTunnelReady(d.out, sess, d.port)
+	// The reverse tunnel is bound, but the PUBLIC host is not reachable yet —
+	// external-dns + Cloudflare + Traefik router readiness lag the bind by up to
+	// ~1–2 min. Wait for the server path to actually serve before telling the dev to
+	// open it, so they don't hit NXDOMAIN/404/502 on a too-early click. --no-wait
+	// skips this and prints the URL immediately (old behavior).
+	if d.noWait {
+		printTunnelReady(d.out, sess, d.port)
+	} else {
+		fmt.Fprintf(d.errw, "\nDev tunnel established — serving 127.0.0.1:%d as %s. Waiting for it to become reachable…\n", d.port, sess.Host)
+		ready, abortReason := waitForTunnelReachable(ctx, d, tunnel, sess.Host)
+		if abortReason != "" {
+			// The dev aborted (Ctrl-C / ctx) or the tunnel dropped DURING the wait —
+			// tear down now rather than fall into the idle loop.
+			_ = tunnel.Close()
+			stop(abortReason)
+			return nil
+		}
+		if ready {
+			printTunnelReadyConfirmed(d.out, sess, d.port)
+		} else {
+			// Readiness timeout is NON-fatal: the host may still come up shortly, so
+			// keep the tunnel and print the URL with a clear "not up yet" warning.
+			printTunnelReadyTimeout(d.out, sess, d.port, resolveReadyTimeout(d))
+		}
+	}
 
+	// Start the idle timer AFTER the readiness wait so the wait doesn't count
+	// against the idle-timeout budget.
 	idleTimer := d.newTimer(d.idle)
 	defer idleTimer.Stop()
 
@@ -361,6 +427,161 @@ func printTunnelReady(out io.Writer, sess *api.DevTunnelSession, port int) {
 	fmt.Fprintf(out, "      %s\n\n", sess.URL)
 	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on port %d.\n", port)
 	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
+}
+
+// printTunnelReadyConfirmed is the ready path: the public host answered healthy,
+// so lead with a ✓ confirmation then the standard "open this" block.
+func printTunnelReadyConfirmed(out io.Writer, sess *api.DevTunnelSession, port int) {
+	fmt.Fprintf(out, "\n✓ Ready — %s is reachable.\n", sess.Host)
+	printTunnelReady(out, sess, port)
+}
+
+// printTunnelReadyTimeout is the readiness-timeout path: the host did not answer
+// healthy within the deadline, but that is NON-fatal — DNS/Cloudflare/Traefik
+// propagation can still land shortly. Print the URL with a clear warning so the
+// dev knows to retry the browser in a moment rather than assume it's broken.
+func printTunnelReadyTimeout(out io.Writer, sess *api.DevTunnelSession, port int, waited time.Duration) {
+	fmt.Fprintf(out, "\n⚠ %s isn't resolving/serving yet (waited %s).\n", sess.Host, waited)
+	fmt.Fprintf(out, "  This is usually just DNS + Cloudflare + route propagation — it can take a minute.\n")
+	fmt.Fprintf(out, "  The tunnel is UP; open the URL and retry in a bit if it NXDOMAINs / 404s / 502s:\n\n")
+	fmt.Fprintf(out, "      %s\n\n", sess.URL)
+	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on port %d.\n", port)
+	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
+}
+
+// resolveReadyTimeout / resolveReadyPollInterval apply the documented defaults
+// when a dep leaves the value unset (zero), so a zero-value deps set (e.g. a
+// focused unit test) still behaves sanely.
+func resolveReadyTimeout(d tunnelSessionDeps) time.Duration {
+	if d.readyTimeout > 0 {
+		return d.readyTimeout
+	}
+	return defaultReadyTimeout
+}
+
+func resolveReadyPollInterval(d tunnelSessionDeps) time.Duration {
+	if d.readyPollInterval > 0 {
+		return d.readyPollInterval
+	}
+	return defaultReadyPollInterval
+}
+
+// waitForTunnelReachable polls the PUBLIC tunnel host until it starts serving
+// (d.probePublic reports ready) or the readiness deadline elapses, printing an
+// unobtrusive progress line to d.errw on each not-ready attempt. It probes
+// immediately, then every readyPollInterval.
+//
+// Returns:
+//   - (true, "")           the host became reachable — print the ready block.
+//   - (false, "")          the deadline elapsed (NON-fatal) — print the URL with a
+//     "not up yet" warning and keep the tunnel.
+//   - (false, <reason>)    the dev aborted (Ctrl-C / ctx canceled) or the tunnel
+//     dropped mid-wait — the caller tears the session down with <reason>.
+//
+// A nil d.probePublic disables the wait (returns ready immediately).
+func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel devtunnel.Tunnel, host string) (bool, string) {
+	if d.probePublic == nil {
+		return true, ""
+	}
+	interval := resolveReadyPollInterval(d)
+	deadline := time.NewTimer(resolveReadyTimeout(d))
+	defer deadline.Stop()
+	// Fire immediately for the first probe, then re-arm at `interval` after each
+	// not-ready result.
+	tick := time.NewTimer(0)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-d.signals:
+			return false, "interrupt"
+		case <-ctx.Done():
+			return false, "canceled"
+		case <-tunnel.Done():
+			return false, "tunnel closed"
+		case <-deadline.C:
+			return false, "" // timeout — non-fatal
+		case <-tick.C:
+			ready, detail, err := d.probePublic(ctx, host)
+			if ready {
+				return true, ""
+			}
+			if detail == "" {
+				if err != nil {
+					detail = err.Error()
+				} else {
+					detail = "not ready"
+				}
+			}
+			fmt.Fprintf(d.errw, "  … waiting for %s to come up (%s)\n", host, detail)
+			tick.Reset(interval)
+		}
+	}
+}
+
+// probePublicTunnel is the production probePublic: an UNAUTHENTICATED GET of
+// https://<host>/ (a fresh client that does NOT carry the CLI's credential), with
+// the response classified by classifyReadyStatus.
+//
+// WHY 401/403 mean healthy: a naked (un-embedded, no-token) request to the tunnel
+// host is DENIED by the forwardAuth gate with 401/403 precisely WHEN the whole
+// server path works — DNS resolved, Traefik built the router, and the forwardAuth
+// gate is reachable. 200 also = ready (the path serves). Everything else means the
+// path isn't up yet: 404 (Traefik has no route), 502/503/504 (backend/gate down),
+// Cloudflare origin errors 520–526, or a DNS/connection error.
+func probePublicTunnel(ctx context.Context, host string) (bool, string, error) {
+	// A dedicated client with NO auth transport — this is a public probe; it must
+	// not reuse the CLI credential. Redirect-following is fine (default).
+	client := &http.Client{Timeout: probePublicTimeout}
+	return probePublicURL(ctx, client, "https://"+host+"/")
+}
+
+// probePublicURL is the testable core of probePublicTunnel: GET rawURL with the
+// given client and classify. Split out so tests can point it at an httptest
+// server (real statuses) without needing a real https host.
+func probePublicURL(ctx context.Context, client *http.Client, rawURL string) (bool, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false, "bad-url", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// DNS failure, connection refused, timeout — the host/route/backend isn't up.
+		return false, classifyProbeErr(err), err
+	}
+	defer resp.Body.Close()
+	// Drain a little so the connection can be reused / closed cleanly.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return classifyReadyStatus(resp.StatusCode), fmt.Sprintf("http %d", resp.StatusCode), nil
+}
+
+// classifyReadyStatus maps an HTTP status to readiness: only 200/401/403 mean the
+// full server path is live (see probePublicTunnel). 404 (no route yet), 5xx, and
+// Cloudflare 520–526 are explicitly NOT ready.
+func classifyReadyStatus(code int) bool {
+	switch code {
+	case http.StatusOK, http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyProbeErr gives a short human tag for a transport-level probe failure,
+// for the progress line ("dns", "timeout", "unreachable").
+func classifyProbeErr(err error) string {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return "timeout"
+	}
+	return "unreachable"
 }
 
 // validateMintResponse asserts the server-returned session is well-formed before

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
@@ -12,6 +15,26 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/devtunnel"
 )
+
+// syncBuffer is a goroutine-safe io.Writer the concurrent runTunnelSession tests
+// use for stdout/stderr, so the test goroutine can read what the session goroutine
+// wrote without racing on a strings.Builder.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
 
 // ── test doubles ─────────────────────────────────────────────────────────────
 
@@ -182,17 +205,25 @@ func baseDeps(t *testing.T, apiStub *fakeTunnelAPI, dialer *fakeDialer, timer *f
 	return tunnelSessionDeps{
 		api:        apiStub,
 		probeLocal: func(int) error { return nil }, // no-op: local dev server "up"
-		keygen:     goodKeygen,
-		dialer:     dialer,
-		blockID:    "my-block",
-		port:       5186,
-		endpoint:   "sish.example:2224",
-		baseURL:    "https://civitai.com",
-		idle:       30 * time.Minute,
-		newTimer:   func(time.Duration) devtunnel.Timer { return timer },
-		signals:    sigs,
-		out:        &out,
-		errw:       &errw,
+		// probePublic left nil by default → the readiness wait treats the host as
+		// immediately reachable, so lifecycle tests that don't care about the wait are
+		// unaffected. Tests exercising the wait set it explicitly.
+		probePublic: nil,
+		keygen:      goodKeygen,
+		dialer:      dialer,
+		blockID:     "my-block",
+		port:        5186,
+		endpoint:    "sish.example:2224",
+		baseURL:     "https://civitai.com",
+		idle:        30 * time.Minute,
+		// Short readiness knobs so any wait-exercising test completes fast (the probe
+		// is injected and returns instantly — no real network).
+		readyTimeout:      100 * time.Millisecond,
+		readyPollInterval: time.Millisecond,
+		newTimer:          func(time.Duration) devtunnel.Timer { return timer },
+		signals:           sigs,
+		out:               &out,
+		errw:              &errw,
 	}
 }
 
@@ -688,5 +719,340 @@ func TestRunTunnelSessionRejectsMissingHostKey(t *testing.T) {
 	}
 	if apiStub.stopCount() != 1 || apiStub.stopCalls[0].sessionID != "bki_test" {
 		t.Errorf("a rejected mint must be revoked (avoid orphan), stop calls=%+v", apiStub.stopCalls)
+	}
+}
+
+// ── readiness-wait tests ─────────────────────────────────────────────────────
+
+const testTunnelHost = "dev-0123456789abcdef.civit.ai"
+
+// TestWaitForTunnelReachableReadyAfterRetries: the wait re-probes until the public
+// host reports ready (200/401/403), printing a progress line each not-ready
+// attempt, then returns (true, "").
+func TestWaitForTunnelReachableReadyAfterRetries(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var out, errw syncBuffer
+	deps.out = &out
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+
+	// waitForTunnelReachable runs synchronously in THIS goroutine, so a plain
+	// counter is race-free.
+	calls := 0
+	deps.probePublic = func(_ context.Context, host string) (bool, string, error) {
+		if host != testTunnelHost {
+			t.Errorf("probe got host %q, want %q", host, testTunnelHost)
+		}
+		calls++
+		if calls < 4 {
+			return false, "http 404", nil
+		}
+		return true, "http 401", nil
+	}
+
+	ready, abort := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost)
+	if !ready || abort != "" {
+		t.Fatalf("want (true, \"\"), got (%v, %q)", ready, abort)
+	}
+	if calls < 4 {
+		t.Fatalf("expected at least 4 probes (3 not-ready + 1 ready), got %d", calls)
+	}
+	if !strings.Contains(errw.String(), "waiting for "+testTunnelHost+" to come up (http 404)") {
+		t.Errorf("expected per-attempt progress on stderr:\n%s", errw.String())
+	}
+}
+
+// TestWaitForTunnelReachableAbortOnSignal: Ctrl-C during the wait returns
+// (false, "interrupt") so the caller tears the session down instead of proceeding.
+func TestWaitForTunnelReachableAbortOnSignal(t *testing.T) {
+	sigs := make(chan os.Signal, 1)
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), sigs)
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyPollInterval = 20 * time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return false, "http 502", nil // never ready
+	}
+
+	type res struct {
+		ready bool
+		abort string
+	}
+	resc := make(chan res, 1)
+	go func() {
+		r, a := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost)
+		resc <- res{r, a}
+	}()
+	sigs <- os.Interrupt
+
+	select {
+	case got := <-resc:
+		if got.ready || got.abort != "interrupt" {
+			t.Fatalf("want (false, \"interrupt\"), got (%v, %q)", got.ready, got.abort)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not abort on signal")
+	}
+}
+
+// TestWaitForTunnelReachableAbortOnTunnelClose: a tunnel that drops mid-wait ends
+// the wait with the "tunnel closed" reason.
+func TestWaitForTunnelReachableAbortOnTunnelClose(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyPollInterval = 20 * time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return false, "http 404", nil
+	}
+
+	tun := newFakeTunnel()
+	resc := make(chan string, 1)
+	go func() {
+		_, a := waitForTunnelReachable(context.Background(), deps, tun, testTunnelHost)
+		resc <- a
+	}()
+	close(tun.done)
+
+	select {
+	case a := <-resc:
+		if a != "tunnel closed" {
+			t.Fatalf("want abort reason \"tunnel closed\", got %q", a)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not end when the tunnel closed")
+	}
+}
+
+// TestWaitForTunnelReachableNilProbeSkips: a nil probePublic disables the wait
+// (returns ready immediately) — so lifecycle tests that don't wire a probe are
+// unaffected.
+func TestWaitForTunnelReachableNilProbeSkips(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	deps.probePublic = nil
+	ready, abort := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost)
+	if !ready || abort != "" {
+		t.Fatalf("nil probe should return (true, \"\"), got (%v, %q)", ready, abort)
+	}
+}
+
+// TestRunTunnelSessionReadyPrintsConfirmedURL: on the ready path runTunnelSession
+// prints the ✓ Ready confirmation + the /apps/dev URL (only after the wait
+// succeeds), with the "waiting…" progress on stderr.
+func TestRunTunnelSessionReadyPrintsConfirmedURL(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	timer := newFakeTimer()
+	sigs := make(chan os.Signal, 1)
+	var out, errw syncBuffer
+	deps := baseDeps(t, apiStub, dialer, timer, sigs)
+	deps.out = &out
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+	// Not-ready twice, then ready. Only the session goroutine touches `calls`.
+	calls := 0
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		calls++
+		if calls < 3 {
+			return false, "http 502", nil
+		}
+		return true, "http 401", nil
+	}
+
+	errc := runInBackground(deps)
+	if !waitForOutput(t, &out, "✓ Ready", errc) {
+		return
+	}
+	sigs <- os.Interrupt
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("runTunnelSession: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session did not exit after signal")
+	}
+	if !strings.Contains(out.String(), sampleSession().URL) {
+		t.Errorf("ready path must print the /apps/dev URL:\n%s", out.String())
+	}
+	if !strings.Contains(errw.String(), "Waiting for it to become reachable") {
+		t.Errorf("expected the 'established, waiting' status on stderr:\n%s", errw.String())
+	}
+}
+
+// TestRunTunnelSessionReadinessTimeoutNonFatal: when the host never becomes
+// reachable, the readiness deadline elapses, the WARNING + URL are printed, and
+// the tunnel is NOT torn down (it may still come up) — it stays alive in the idle
+// loop until an actual signal.
+func TestRunTunnelSessionReadinessTimeoutNonFatal(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	timer := newFakeTimer()
+	sigs := make(chan os.Signal, 1)
+	var out, errw syncBuffer
+	deps := baseDeps(t, apiStub, dialer, timer, sigs)
+	deps.out = &out
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 30 * time.Millisecond
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return false, "http 404", nil // never ready → deadline elapses
+	}
+
+	errc := runInBackground(deps)
+	if !waitForOutput(t, &out, "isn't resolving/serving yet", errc) {
+		return
+	}
+	// The readiness timeout is non-fatal: nothing torn down, session still alive.
+	if apiStub.stopCount() != 0 {
+		t.Errorf("readiness timeout must NOT tear the tunnel down; stop calls=%d", apiStub.stopCount())
+	}
+	if !strings.Contains(out.String(), sampleSession().URL) {
+		t.Errorf("timeout path must still print the URL:\n%s", out.String())
+	}
+	// Now really end it.
+	sigs <- os.Interrupt
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("runTunnelSession: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session did not exit after signal")
+	}
+	if !tunnel.closed || apiStub.stopCount() != 1 {
+		t.Errorf("expected exactly one teardown on the follow-up signal (closed=%v, stops=%d)", tunnel.closed, apiStub.stopCount())
+	}
+}
+
+// TestRunTunnelSessionNoWaitSkipsProbe: --no-wait prints the URL immediately and
+// NEVER calls probePublic.
+func TestRunTunnelSessionNoWaitSkipsProbe(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	timer := newFakeTimer()
+	sigs := make(chan os.Signal, 1)
+	var out syncBuffer
+	deps := baseDeps(t, apiStub, dialer, timer, sigs)
+	deps.out = &out
+	deps.noWait = true
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		t.Error("probePublic must NOT be called when --no-wait is set")
+		return false, "", nil
+	}
+
+	errc := runInBackground(deps)
+	sigs <- os.Interrupt
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("runTunnelSession: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session did not exit after signal")
+	}
+	if !strings.Contains(out.String(), sampleSession().URL) {
+		t.Errorf("--no-wait must print the URL immediately:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "✓ Ready") || strings.Contains(out.String(), "isn't resolving") {
+		t.Errorf("--no-wait must use the plain ready block (no wait outcome):\n%s", out.String())
+	}
+}
+
+// waitForOutput polls buf until it contains want, failing if the session exits
+// (via errc) first or the deadline passes. Returns true on success. Uses the
+// race-safe syncBuffer so reading buf while the session goroutine writes is safe.
+func waitForOutput(t *testing.T, buf *syncBuffer, want string, errc <-chan error) bool {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if strings.Contains(buf.String(), want) {
+			return true
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("output never contained %q:\n%s", want, buf.String())
+			return false
+		case err := <-errc:
+			t.Fatalf("session exited before printing %q (err=%v):\n%s", want, err, buf.String())
+			return false
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// TestClassifyReadyStatus: only 200/401/403 mean the full server path is live; a
+// naked no-token request being DENIED with 401/403 proves DNS→Traefik→forwardAuth
+// are all up. 404 (no route yet), 5xx, and Cloudflare 520–526 are NOT ready.
+func TestClassifyReadyStatus(t *testing.T) {
+	ready := []int{200, 401, 403}
+	notReady := []int{404, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 301, 400, 429}
+	for _, c := range ready {
+		if !classifyReadyStatus(c) {
+			t.Errorf("status %d should be READY", c)
+		}
+	}
+	for _, c := range notReady {
+		if classifyReadyStatus(c) {
+			t.Errorf("status %d should be NOT ready", c)
+		}
+	}
+}
+
+// TestProbePublicURLClassification: exercise probePublicURL against a real
+// httptest server returning each status — 200/401/403 → ready, others → not ready,
+// with a "http <code>" detail.
+func TestProbePublicURLClassification(t *testing.T) {
+	cases := []struct {
+		code  int
+		ready bool
+	}{
+		{200, true}, {401, true}, {403, true},
+		{404, false}, {500, false}, {502, false}, {503, false}, {504, false},
+		{520, false}, {526, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("http_%d", tc.code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+
+			ready, detail, err := probePublicURL(context.Background(), srv.Client(), srv.URL+"/")
+			if err != nil {
+				t.Fatalf("unexpected transport error for %d: %v", tc.code, err)
+			}
+			if ready != tc.ready {
+				t.Errorf("status %d: ready=%v, want %v", tc.code, ready, tc.ready)
+			}
+			if want := fmt.Sprintf("http %d", tc.code); detail != want {
+				t.Errorf("detail = %q, want %q", detail, want)
+			}
+		})
+	}
+}
+
+// TestProbePublicURLUnreachable: a GET against a closed port is a transport error
+// → not ready (mirrors DNS-failure/connection-refused during propagation).
+func TestProbePublicURLUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closedURL := srv.URL // capture, then close so the port refuses connections
+	srv.Close()
+
+	client := &http.Client{Timeout: time.Second}
+	ready, detail, err := probePublicURL(context.Background(), client, closedURL+"/")
+	if err == nil {
+		t.Fatal("expected a transport error against a closed port")
+	}
+	if ready {
+		t.Errorf("a connection-refused host must be NOT ready (detail %q)", detail)
 	}
 }


### PR DESCRIPTION
## What

`civitai app dev-tunnel` printed the "▶ Open this in your browser" block the instant the reverse SSH tunnel was dialed — but the PUBLIC host `dev-<16hex>.civit.ai` isn't reachable yet. external-dns + Cloudflare propagation + Traefik router readiness lag the bind by up to ~1–2 min, so the dev opened the URL too early and got NXDOMAIN / 404 / 502.

This adds a **readiness wait**: after the tunnel binds (and before the idle loop starts), poll the public host until the server path is actually serving, then print a ✓ "Ready" confirmation + the URL. Progress is shown on stderr while waiting.

## Health signal (the important part)

Poll `GET https://<host>/` with a **fresh, unauthenticated** client (does NOT reuse the CLI credential — it's a public probe), classified:

- **READY** — HTTP `200`/`401`/`403`. A naked (no-token) request is DENIED by the forwardAuth gate with **401/403** precisely *when the whole server path works* (DNS resolved → Traefik built the router → the gate is reachable). `200` also serves. So 401/403 = healthy.
- **NOT READY** (keep polling) — `404` (Traefik has no route yet), `502/503/504`, Cloudflare origin errors `520`–`526`, and any DNS/connection error. **404 is explicitly not ready** ("route not built").

## Flags & semantics

- `--ready-timeout` (default `120s`) bounds the wait; `--no-wait` skips it (prints the URL immediately, old behavior).
- Readiness **timeout is non-fatal**: still prints the URL with a clear "not up yet — retry in a bit" warning and **keeps the tunnel** (it may come up shortly).
- The wait selects on Ctrl-C / `ctx` / tunnel-drop so it can be aborted mid-wait (tears down cleanly).
- The idle timer starts **after** the wait, so the wait doesn't count against the idle-timeout budget.

## Tests

New tests cover: ready-after-retries, readiness-timeout non-fatal (no early teardown), `--no-wait` skips the probe entirely, abort-on-signal / abort-on-tunnel-close during the wait, the status classification (`200/401/403` ready vs `404/5xx/520-526` not ready) against an `httptest` server, and a closed-port (transport-error) case. Injected probe + short intervals via deps — no sleeps in the hot path. `make ci` green; race detector clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)