### PR TITLE
fix(dev-tunnel): --local-host + readiness verifies the local hop (fixes silent 502 when dev server isn't on loopback)

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -71,6 +71,13 @@ const (
 	// probePublicTimeout bounds a single unauthenticated public-host GET so a hung
 	// connection (SYN blackhole during propagation) can't stall a poll iteration.
 	probePublicTimeout = 8 * time.Second
+	// defaultLocalHost is the local dev-server host the tunnel reaches by default:
+	// "localhost" = loopback (127.0.0.1/::1), which PRESERVES the pre-flag behavior.
+	// The scaffold's `dev:tunnel` binds localhost, so most users need nothing.
+	defaultLocalHost = "localhost"
+	// defaultLocalHopNoticeInterval rate-limits the readiness wait's "tunnel up but
+	// local dev server unreachable" notice.
+	defaultLocalHopNoticeInterval = 15 * time.Second
 )
 
 // spinnerFrames is the braille animation cycle for the TTY readiness indicator.
@@ -93,11 +100,11 @@ type tunnelAPI interface {
 type tunnelSessionDeps struct {
 	api tunnelAPI
 	// probeLocal pre-flight-checks that the developer's local dev server is
-	// actually listening on 127.0.0.1:<port> BEFORE anything is minted server-side.
-	// A non-nil error aborts the session before keygen/StartDevTunnel, so a
-	// not-running dev server fails fast with clear guidance instead of minting a
-	// rate-limited/reaper-tracked session that would only serve connection-refused.
-	probeLocal func(port int) error
+	// actually listening on <localHost>:<port> BEFORE anything is minted
+	// server-side. A non-nil error aborts the session before keygen/StartDevTunnel,
+	// so a not-running dev server fails fast with clear guidance instead of minting
+	// a rate-limited/reaper-tracked session that would only serve connection-refused.
+	probeLocal func(host string, port int) error
 	// probePublic checks whether the PUBLIC tunnel host is serving yet: it does an
 	// unauthenticated GET of https://<host>/ and reports ready per the classification
 	// in probePublicTunnel (HTTP 200/401/403 = the whole server path works — a naked
@@ -105,11 +112,25 @@ type tunnelSessionDeps struct {
 	// DNS→Traefik-router→gate are all up; 404/5xx/52x/DNS/refused = not up yet). Wired
 	// to probePublicTunnel in production; injected in tests. Nil disables the wait.
 	probePublic func(ctx context.Context, host string) (ready bool, detail string, err error)
-	keygen      func() (*devtunnel.EphemeralKey, error)
-	dialer      devtunnel.Dialer
-	blockID     string
-	port        int
-	endpoint    string
+	// probeLocalHop checks whether a request can actually TRAVERSE the tunnel to the
+	// local dev server — the gate-only probePublic can't (a naked GET is denied 401
+	// by the forwardAuth gate before it ever reaches the backend). It sends a GET to
+	// the public host with a NON-entry Sec-Fetch-Dest, which the gate treats as a
+	// SUBRESOURCE and forwards to sish → the local server; a 502/503/504 means the
+	// tunnel is up but the local server is unreachable (returns false), any other
+	// status means the local hop works (returns true). Wired to probeLocalHopTunnel
+	// in production; injected in tests. Nil skips the local-hop check (gate-only
+	// readiness — used by lifecycle tests that don't exercise it).
+	probeLocalHop func(ctx context.Context, host string) (localReachable bool, detail string, err error)
+	keygen        func() (*devtunnel.EphemeralKey, error)
+	dialer        devtunnel.Dialer
+	blockID       string
+	port          int
+	// localHost is the resolved host the developer's dev server is bound to
+	// ("localhost" by default = loopback; e.g. 10.42.0.100 for a container). Used
+	// by BOTH the pre-flight probe and the live tunnel proxy so the two agree.
+	localHost string
+	endpoint  string
 	// baseURL is the configured Civitai origin; the mint response's URL must be
 	// same-origin as this (defense-in-depth against an attacker-influenced URL).
 	baseURL string
@@ -129,15 +150,21 @@ type tunnelSessionDeps struct {
 	nudgeAfter        time.Duration
 	spinnerInterval   time.Duration
 	quietInterval     time.Duration
-	newTimer          func(d time.Duration) devtunnel.Timer
-	signals           <-chan os.Signal
-	out               io.Writer
-	errw              io.Writer
+	// localHopNoticeInterval rate-limits the "tunnel up but local dev server
+	// unreachable" notice during the readiness wait (default
+	// defaultLocalHopNoticeInterval), so a stuck local hop is surfaced clearly and
+	// repeatedly without spamming a line per poll. Injectable so tests drive it fast.
+	localHopNoticeInterval time.Duration
+	newTimer               func(d time.Duration) devtunnel.Timer
+	signals                <-chan os.Signal
+	out                    io.Writer
+	errw                   io.Writer
 }
 
 func newAppDevTunnelCmd() *cobra.Command {
 	var blockFlag string
 	var port int
+	var localHost string
 	var endpoint string
 	var idle time.Duration
 	var readyTimeout time.Duration
@@ -177,6 +204,8 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
   civitai app dev-tunnel                 # blockId from block.manifest.json in the CWD
   civitai app dev-tunnel my-block
   civitai app dev-tunnel my-block --port 5173
+  # Dev server NOT on the CLI's loopback (a container/pod, VM, or bound interface):
+  civitai app dev-tunnel my-block --local-host 10.42.0.100
   civitai app dev-tunnel --block my-block --idle-timeout 15m`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -211,6 +240,12 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 			if port < 1 || port > 65535 {
 				return fmt.Errorf("invalid --port %d (must be 1-65535)", port)
 			}
+			// Resolve the local host: empty falls back to the loopback default so a
+			// `--local-host ""` can't accidentally break dialing.
+			lh := strings.TrimSpace(localHost)
+			if lh == "" {
+				lh = defaultLocalHost
+			}
 			if idle <= 0 {
 				return fmt.Errorf("--idle-timeout must be positive (got %s)", idle)
 			}
@@ -242,32 +277,36 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 			defer signal.Stop(sigCh)
 
 			return runTunnelSession(context.Background(), tunnelSessionDeps{
-				api:               client,
-				probeLocal:        probeLocalDevServer,
-				probePublic:       probePublicTunnel,
-				keygen:            devtunnel.GenerateEphemeralKey,
-				dialer:            devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
-				blockID:           blockID,
-				port:              port,
-				endpoint:          ep,
-				baseURL:           cfg.BaseURL(),
-				idle:              idle,
-				readyTimeout:      readyTimeout,
-				readyPollInterval: defaultReadyPollInterval,
-				noWait:            noWait,
-				nudgeAfter:        defaultNudgeAfter,
-				spinnerInterval:   defaultSpinnerInterval,
-				quietInterval:     defaultQuietInterval,
-				newTimer:          devtunnel.NewRealTimer,
-				signals:           sigCh,
-				out:               cmd.OutOrStdout(),
-				errw:              cmd.ErrOrStderr(),
+				api:                    client,
+				probeLocal:             probeLocalDevServer,
+				probePublic:            probePublicTunnel,
+				probeLocalHop:          probeLocalHopTunnel,
+				keygen:                 devtunnel.GenerateEphemeralKey,
+				dialer:                 devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
+				blockID:                blockID,
+				port:                   port,
+				localHost:              lh,
+				endpoint:               ep,
+				baseURL:                cfg.BaseURL(),
+				idle:                   idle,
+				readyTimeout:           readyTimeout,
+				readyPollInterval:      defaultReadyPollInterval,
+				noWait:                 noWait,
+				nudgeAfter:             defaultNudgeAfter,
+				spinnerInterval:        defaultSpinnerInterval,
+				quietInterval:          defaultQuietInterval,
+				localHopNoticeInterval: defaultLocalHopNoticeInterval,
+				newTimer:               devtunnel.NewRealTimer,
+				signals:                sigCh,
+				out:                    cmd.OutOrStdout(),
+				errw:                   cmd.ErrOrStderr(),
 			})
 		},
 	}
 
 	cmd.Flags().StringVar(&blockFlag, "block", "", "the blockId (app slug) to tunnel (or pass it positionally; defaults to the blockId in "+manifest.Filename+" in the CWD)")
 	cmd.Flags().IntVar(&port, "port", defaultDevTunnelPort, "local dev-server port to tunnel (matches the scaffold's dev:tunnel)")
+	cmd.Flags().StringVar(&localHost, "local-host", defaultLocalHost, "host your local dev server is bound to. Default `localhost` (loopback) — the scaffold's `dev:tunnel` binds localhost, so most users need nothing. Set this for a dev server NOT on the CLI's loopback: a container/pod (e.g. --local-host 10.42.0.100), a VM, or a specific bound interface")
 	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+")")
 	cmd.Flags().DurationVar(&idle, "idle-timeout", defaultDevTunnelIdle, "tear the tunnel down after this much inactivity")
 	cmd.Flags().DurationVar(&readyTimeout, "ready-timeout", defaultReadyTimeout, "cap the wait for the public host to start serving (0 = wait indefinitely until ready or Ctrl-C; a positive value warns + prints the URL anyway on expiry)")
@@ -285,7 +324,7 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	// Pre-flight FIRST: fail fast if the local dev server isn't listening, BEFORE
 	// minting anything server-side. Nothing to tear down yet — return directly.
 	if d.probeLocal != nil {
-		if err := d.probeLocal(d.port); err != nil {
+		if err := d.probeLocal(d.localHost, d.port); err != nil {
 			return err
 		}
 	}
@@ -331,6 +370,7 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 		Endpoint:         d.endpoint,
 		RemoteHost:       sess.Host,
 		LocalPort:        d.port,
+		LocalHost:        d.localHost,
 		Signer:           key.Signer,
 		SSHHostPublicKey: sess.SSHHostPublicKey,
 	})
@@ -347,9 +387,9 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	// open it, so they don't hit NXDOMAIN/404/502 on a too-early click. --no-wait
 	// skips this and prints the URL immediately (old behavior).
 	if d.noWait {
-		printTunnelReady(d.out, sess, d.port)
+		printTunnelReady(d.out, sess, d.localHost, d.port)
 	} else {
-		fmt.Fprintf(d.errw, "\nDev tunnel established — serving 127.0.0.1:%d as %s. Waiting for it to become reachable…\n", d.port, sess.Host)
+		fmt.Fprintf(d.errw, "\nDev tunnel established — serving %s:%d as %s. Waiting for it to become reachable…\n", localHostForDisplay(d.localHost), d.port, sess.Host)
 		ready, abortReason := waitForTunnelReachable(ctx, d, tunnel, sess.Host, sess.URL)
 		if abortReason != "" {
 			// The dev aborted (Ctrl-C / ctx) or the tunnel dropped DURING the wait —
@@ -359,12 +399,12 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 			return nil
 		}
 		if ready {
-			printTunnelReadyConfirmed(d.out, sess, d.port)
+			printTunnelReadyConfirmed(d.out, sess, d.localHost, d.port)
 		} else {
 			// A POSITIVE --ready-timeout cap elapsed (the default is indefinite, which
 			// never lands here). NON-fatal: the host may still come up shortly, so keep
 			// the tunnel and print the URL with a clear "not up yet" warning.
-			printTunnelReadyTimeout(d.out, sess, d.port, d.readyTimeout)
+			printTunnelReadyTimeout(d.out, sess, d.localHost, d.port, d.readyTimeout)
 		}
 	}
 
@@ -441,42 +481,62 @@ func enrichDevTunnelAuthError(ctx context.Context, d tunnelSessionDeps, err erro
 // actionable guidance. Run BEFORE the mint so a not-running dev server never
 // burns a rate-limited/reaper-tracked server session (which would only serve the
 // browser connection-refused).
-func probeLocalDevServer(port int) error {
-	conn, err := devtunnel.DialLocalDevServer(port, 2*time.Second)
+func probeLocalDevServer(host string, port int) error {
+	conn, err := devtunnel.DialLocalDevServer(host, port, 2*time.Second)
 	if err != nil {
-		return fmt.Errorf("no local dev server is listening on port %d (tried 127.0.0.1 and ::1) — start it first (e.g. `npm run dev:tunnel`), then re-run. (override the port with --port)", port)
+		return fmt.Errorf("no local dev server is listening on %s:%d (%s) — start it first (e.g. `npm run dev:tunnel`), then re-run. (override the port with --port, or the host with --local-host)",
+			localHostForDisplay(host), port, localDialTargets(host))
 	}
 	_ = conn.Close()
 	return nil
 }
 
+// localHostForDisplay renders the local host for user-facing messages: an
+// empty/"localhost" host shows as "localhost" (the loopback default).
+func localHostForDisplay(host string) string {
+	h := strings.TrimSpace(host)
+	if h == "" || strings.EqualFold(h, "localhost") {
+		return "localhost"
+	}
+	return h
+}
+
+// localDialTargets describes, for an error message, exactly what the dialer
+// tried: both loopback families for the loopback default, else the single host.
+func localDialTargets(host string) string {
+	if h := strings.TrimSpace(host); h == "" || strings.EqualFold(h, "localhost") {
+		return "tried 127.0.0.1 and ::1"
+	}
+	return "tried " + strings.TrimSpace(host)
+}
+
 // printTunnelReady prints the actionable "tunnel is up" block, with the
 // /apps/dev URL made prominent (it is the one thing the developer must open).
-func printTunnelReady(out io.Writer, sess *api.DevTunnelSession, port int) {
-	fmt.Fprintf(out, "\nDev tunnel ready — serving 127.0.0.1:%d as %s\n\n", port, sess.Host)
+func printTunnelReady(out io.Writer, sess *api.DevTunnelSession, localHost string, port int) {
+	fmt.Fprintf(out, "\nDev tunnel ready — serving %s:%d as %s\n\n", localHostForDisplay(localHost), port, sess.Host)
 	fmt.Fprintf(out, "  ▶ Open this in your browser (you must be logged in):\n\n")
 	fmt.Fprintf(out, "      %s\n\n", sess.URL)
-	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on port %d.\n", port)
+	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on %s:%d.\n", localHostForDisplay(localHost), port)
 	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
 }
 
 // printTunnelReadyConfirmed is the ready path: the public host answered healthy,
 // so lead with a ✓ confirmation then the standard "open this" block.
-func printTunnelReadyConfirmed(out io.Writer, sess *api.DevTunnelSession, port int) {
-	fmt.Fprintf(out, "\n✓ Ready — %s is reachable.\n", sess.Host)
-	printTunnelReady(out, sess, port)
+func printTunnelReadyConfirmed(out io.Writer, sess *api.DevTunnelSession, localHost string, port int) {
+	fmt.Fprintf(out, "\n✓ Ready — %s is reachable (local hop verified).\n", sess.Host)
+	printTunnelReady(out, sess, localHost, port)
 }
 
 // printTunnelReadyTimeout is the readiness-timeout path: the host did not answer
 // healthy within the deadline, but that is NON-fatal — DNS/Cloudflare/Traefik
 // propagation can still land shortly. Print the URL with a clear warning so the
 // dev knows to retry the browser in a moment rather than assume it's broken.
-func printTunnelReadyTimeout(out io.Writer, sess *api.DevTunnelSession, port int, waited time.Duration) {
+func printTunnelReadyTimeout(out io.Writer, sess *api.DevTunnelSession, localHost string, port int, waited time.Duration) {
 	fmt.Fprintf(out, "\n⚠ %s isn't resolving/serving yet (waited %s).\n", sess.Host, waited)
 	fmt.Fprintf(out, "  This is usually just DNS + Cloudflare + route propagation — it can take a minute.\n")
 	fmt.Fprintf(out, "  The tunnel is UP; open the URL and retry in a bit if it NXDOMAINs / 404s / 502s:\n\n")
 	fmt.Fprintf(out, "      %s\n\n", sess.URL)
-	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on port %d.\n", port)
+	fmt.Fprintf(out, "  Make sure your dev server is running (`npm run dev:tunnel`) on %s:%d.\n", localHostForDisplay(localHost), port)
 	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
 }
 
@@ -511,6 +571,13 @@ func resolveQuietInterval(d tunnelSessionDeps) time.Duration {
 		return d.quietInterval
 	}
 	return defaultQuietInterval
+}
+
+func resolveLocalHopNoticeInterval(d tunnelSessionDeps) time.Duration {
+	if d.localHopNoticeInterval > 0 {
+		return d.localHopNoticeInterval
+	}
+	return defaultLocalHopNoticeInterval
 }
 
 // writerIsTTY reports whether w is a terminal we can animate on — true only when
@@ -570,10 +637,22 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 	// A single reusable probe goroutine + buffered result channel. Only one probe is
 	// ever outstanding, so a cap-1 channel means the goroutine never blocks on send
 	// after we've returned (no goroutine leak).
+	//
+	// Each probe first checks the GATE (probePublic). If the gate is reachable AND a
+	// probeLocalHop is wired, it then checks the LOCAL HOP (a subresource-shaped
+	// request that the forwardAuth gate forwards to sish → the local dev server):
+	//   - gateReady=false                 → propagation not done; keep waiting.
+	//   - gateReady + localHopDone+localOK → the FULL path works → ready.
+	//   - gateReady + localHopDone+!localOK→ tunnel up but LOCAL server unreachable
+	//     (502/503/504): surface the clear notice, keep waiting (NOT ready).
+	//   - gateReady + !localHopDone        → local-hop probe errored transiently
+	//     (or no probeLocalHop wired → treated as OK): re-probe.
 	type probeResult struct {
-		ready  bool
-		detail string
-		err    error
+		gateReady    bool
+		localHopDone bool // the local-hop probe returned a definitive status (err==nil)
+		localOK      bool // the local hop responded non-bad-gateway
+		detail       string
+		err          error
 	}
 	resultCh := make(chan probeResult, 1)
 	var probeCancel context.CancelFunc
@@ -581,8 +660,19 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 		pctx, cancel := context.WithCancel(ctx)
 		probeCancel = cancel
 		go func() {
-			ready, detail, err := d.probePublic(pctx, host)
-			resultCh <- probeResult{ready, detail, err}
+			gateReady, detail, err := d.probePublic(pctx, host)
+			res := probeResult{gateReady: gateReady, detail: detail, err: err}
+			if gateReady && d.probeLocalHop != nil {
+				ok, ldetail, lerr := d.probeLocalHop(pctx, host)
+				if lerr == nil {
+					res.localHopDone = true
+					res.localOK = ok
+					res.detail = ldetail
+				}
+				// A local-hop transport error (lerr != nil) is left inconclusive
+				// (localHopDone=false) → re-probed, not reported as local-unreachable.
+			}
+			resultCh <- res
 		}()
 	}
 	cancelProbe := func() {
@@ -593,14 +683,25 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 	}
 
 	// Progress-indicator state (TTY only tracks lastLen so it can clear its line).
+	// localHopDown is set once the gate is reachable but the local hop 502s, so the
+	// indicator switches from "waiting for the host" to "waiting for your local dev
+	// server" — the actionable state.
 	frame := 0
 	lastLen := 0
+	localHopDown := false
+	localTarget := fmt.Sprintf("%s:%d", localHostForDisplay(d.localHost), d.port)
 	renderSpinner := func() {
 		if !tty {
 			return
 		}
-		line := fmt.Sprintf("%c Waiting for %s to come up… %s elapsed",
-			spinnerFrames[frame%len(spinnerFrames)], host, fmtMMSS(time.Since(start)))
+		var line string
+		if localHopDown {
+			line = fmt.Sprintf("%c Tunnel up — waiting for your local dev server on %s… %s elapsed",
+				spinnerFrames[frame%len(spinnerFrames)], localTarget, fmtMMSS(time.Since(start)))
+		} else {
+			line = fmt.Sprintf("%c Waiting for %s to come up… %s elapsed",
+				spinnerFrames[frame%len(spinnerFrames)], host, fmtMMSS(time.Since(start)))
+		}
 		fmt.Fprintf(d.errw, "\r%s", line)
 		lastLen = utf8.RuneCountInString(line)
 	}
@@ -608,6 +709,26 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 		if tty && lastLen > 0 {
 			fmt.Fprintf(d.errw, "\r%s\r", strings.Repeat(" ", lastLen))
 			lastLen = 0
+		}
+	}
+
+	// localUnreachableNotice prints the CLEAR, persistent "tunnel up but local dev
+	// server unreachable" guidance, rate-limited to at most every
+	// localHopNoticeInterval so a stuck local hop is surfaced repeatedly without
+	// one line per poll. On a TTY it clears the spinner line first, then repaints.
+	lastLocalNotice := time.Time{}
+	localNoticeEvery := resolveLocalHopNoticeInterval(d)
+	localUnreachableNotice := func() {
+		now := time.Now()
+		if !lastLocalNotice.IsZero() && now.Sub(lastLocalNotice) < localNoticeEvery {
+			return
+		}
+		lastLocalNotice = now
+		clearLine()
+		fmt.Fprintf(d.errw, "⚠ Tunnel is up, but your local dev server on %s is unreachable through the tunnel\n", localTarget)
+		fmt.Fprintf(d.errw, "  — is it running, and is --local-host correct? (currently %q)\n", localHostForDisplay(d.localHost))
+		if tty {
+			renderSpinner()
 		}
 	}
 
@@ -673,6 +794,8 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 			if tty {
 				frame++
 				renderSpinner()
+			} else if localHopDown {
+				fmt.Fprintf(d.errw, "  … tunnel up; still waiting for your local dev server on %s (%s)\n", localTarget, fmtMMSS(time.Since(start)))
 			} else {
 				fmt.Fprintf(d.errw, "  … still waiting for %s (%s)\n", host, fmtMMSS(time.Since(start)))
 			}
@@ -682,9 +805,24 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 			// on the completed ctx today, but leak-safe if a cancelable parent is ever
 			// threaded through runTunnelSession).
 			cancelProbe()
-			if res.ready {
+			// FULLY ready only when the gate is reachable AND the local hop is not a
+			// bad-gateway (or no local-hop probe is wired). This is the fix: gate-only
+			// readiness (200/401/403) declared "ready" while the local dev server was
+			// dead behind sish → the browser silently 502'd.
+			if res.gateReady && (d.probeLocalHop == nil || res.localOK) {
 				clearLine()
 				return true, ""
+			}
+			if res.gateReady && res.localHopDone && !res.localOK {
+				// Tunnel/gate up, but the local hop 502s — the local dev server is
+				// unreachable through the tunnel. Surface the clear, persistent notice
+				// and KEEP waiting (don't declare ready, don't hang silently).
+				localHopDown = true
+				localUnreachableNotice()
+			} else {
+				// Gate not up yet (or the local-hop probe was inconclusive) — back to
+				// the plain "waiting for the host" indicator.
+				localHopDown = false
 			}
 			// Not ready — re-probe after the poll interval. (The detail/err is folded
 			// into the indicator, not spammed per-attempt.)
@@ -729,6 +867,58 @@ func probePublicURL(ctx context.Context, client *http.Client, rawURL string) (bo
 	// Drain a little so the connection can be reused / closed cleanly.
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return classifyReadyStatus(resp.StatusCode), fmt.Sprintf("http %d", resp.StatusCode), nil
+}
+
+// probeLocalHopTunnel is the production probeLocalHop: it verifies a request can
+// actually TRAVERSE the tunnel to the local dev server, which the gate-only
+// probePublicTunnel cannot (a naked GET is denied 401 by the forwardAuth gate
+// BEFORE it reaches the backend — so gate-reachable ≠ local-server-reachable, the
+// silent-502 dogfood failure).
+//
+// HOW: it GETs https://<host>/ with a NON-entry Sec-Fetch-Dest ("image"). The
+// forwardAuth gate (dev-tunnel-gate.ts) classifies ENTRY dests
+// (document/iframe/frame/nested-document, or ABSENT) as token-required → 401, and
+// treats ANY OTHER Sec-Fetch-Dest as a SUBRESOURCE → allowed through to the
+// backend (sish → the local dev server). So the response status reflects the
+// LOCAL hop: 502/503/504 = tunnel up but local server unreachable (not ready);
+// any other status (200/404/…) = the local server responded (ready).
+func probeLocalHopTunnel(ctx context.Context, host string) (bool, string, error) {
+	client := &http.Client{Timeout: probePublicTimeout}
+	return probeLocalHopURL(ctx, client, "https://"+host+"/")
+}
+
+// probeLocalHopURL is the testable core of probeLocalHopTunnel: GET rawURL with a
+// subresource-shaped Sec-Fetch-Dest and classify per localHopReachable. Split out
+// so tests can point it at an httptest server (real statuses) without a real host.
+func probeLocalHopURL(ctx context.Context, client *http.Client, rawURL string) (bool, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false, "bad-url", err
+	}
+	// A non-entry Sec-Fetch-Dest makes the forwardAuth gate forward this to the
+	// backend as a SUBRESOURCE (no token needed) — so the status reflects the local
+	// hop, not the gate. Also mark it fetch-mode so it never looks like a navigation.
+	req.Header.Set("Sec-Fetch-Dest", "image")
+	req.Header.Set("Sec-Fetch-Mode", "no-cors")
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, classifyProbeErr(err), err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return localHopReachable(resp.StatusCode), fmt.Sprintf("http %d", resp.StatusCode), nil
+}
+
+// localHopReachable classifies a SUBRESOURCE-probe status: only the bad-gateway
+// family (502/503/504) means the tunnel is up but the local dev server is
+// unreachable; ANY other status means the local server responded (the hop works).
+func localHopReachable(code int) bool {
+	switch code {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return false
+	default:
+		return true
+	}
 }
 
 // classifyReadyStatus maps an HTTP status to readiness: only 200/401/403 mean the

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -204,7 +205,7 @@ func baseDeps(t *testing.T, apiStub *fakeTunnelAPI, dialer *fakeDialer, timer *f
 	var out, errw strings.Builder
 	return tunnelSessionDeps{
 		api:        apiStub,
-		probeLocal: func(int) error { return nil }, // no-op: local dev server "up"
+		probeLocal: func(string, int) error { return nil }, // no-op: local dev server "up"
 		// probePublic left nil by default → the readiness wait treats the host as
 		// immediately reachable, so lifecycle tests that don't care about the wait are
 		// unaffected. Tests exercising the wait set it explicitly.
@@ -637,7 +638,7 @@ func TestRunTunnelSessionProbeError(t *testing.T) {
 	dialer := &fakeDialer{tunnel: newFakeTunnel()}
 	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), make(chan os.Signal))
 	probeErr := errors.New("no local dev server is listening on 127.0.0.1:5186")
-	deps.probeLocal = func(port int) error {
+	deps.probeLocal = func(host string, port int) error {
 		if port != 5186 {
 			t.Errorf("probe got port %d, want the session port 5186", port)
 		}
@@ -1224,6 +1225,302 @@ func waitForOutput(t *testing.T, buf *syncBuffer, want string, errc <-chan error
 		default:
 			time.Sleep(time.Millisecond)
 		}
+	}
+}
+
+// ── --local-host + local-hop readiness tests ─────────────────────────────────
+
+// TestRunTunnelSessionThreadsLocalHost: a set localHost reaches BOTH the pre-flight
+// probe AND the tunnel proxy (the DialOptions), so the two agree on where the
+// local dev server lives.
+func TestRunTunnelSessionThreadsLocalHost(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	timer := newFakeTimer()
+	sigs := make(chan os.Signal, 1)
+
+	deps := baseDeps(t, apiStub, dialer, timer, sigs)
+	deps.localHost = "10.42.0.100"
+	var gotProbeHost string
+	deps.probeLocal = func(host string, port int) error {
+		gotProbeHost = host
+		if port != 5186 {
+			t.Errorf("probe port = %d, want 5186", port)
+		}
+		return nil
+	}
+
+	errc := runInBackground(deps)
+	sigs <- os.Interrupt
+	<-errc
+
+	if gotProbeHost != "10.42.0.100" {
+		t.Errorf("pre-flight probe got host %q, want the --local-host value", gotProbeHost)
+	}
+	if dialer.lastOpt.LocalHost != "10.42.0.100" {
+		t.Errorf("dial LocalHost = %q, want the --local-host value threaded to the proxy", dialer.lastOpt.LocalHost)
+	}
+}
+
+// TestRunTunnelSessionDefaultLocalHostViaCommand: the --local-host flag defaults to
+// "localhost" (loopback), preserving the pre-flag behavior, and threads that
+// default all the way to the dialer.
+func TestRunTunnelSessionDefaultLocalHostViaCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == startDevTunnelRoute {
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	// No --local-host given → the pre-flight probe must still pass against the
+	// loopback listener (default "localhost"), so we get PAST the probe to the
+	// (expected pre-GA) forbidden mint — never a "no local dev server" error.
+	_, _, err := run(t, "app", "dev-tunnel", "my-block", "--port", fmt.Sprint(port))
+	if err == nil {
+		t.Fatal("expected a forbidden mint error (flag dark)")
+	}
+	if strings.Contains(err.Error(), "no local dev server") {
+		t.Fatalf("default localhost probe must reach the loopback listener, got: %v", err)
+	}
+}
+
+// TestRunTunnelSessionLocalHostFlagPreflightUsesHost: an explicit --local-host that
+// points nowhere fails the pre-flight probe with a message naming the host + the
+// --local-host flag (so a wrong host is actionable), and NEVER mints.
+func TestRunTunnelSessionLocalHostFlagPreflightUsesHost(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+
+	// 192.0.2.1 is TEST-NET-1 (RFC 5737) — guaranteed unreachable, so the probe
+	// fails deterministically without minting. A short dial timeout keeps it fast
+	// (the production probe uses 2s).
+	_, _, err := run(t, "app", "dev-tunnel", "my-block", "--local-host", "192.0.2.1", "--port", "5186")
+	if err == nil {
+		t.Fatal("expected a pre-flight failure against an unreachable --local-host")
+	}
+	if !strings.Contains(err.Error(), "192.0.2.1") || !strings.Contains(err.Error(), "--local-host") {
+		t.Errorf("pre-flight error should name the host + --local-host: %v", err)
+	}
+}
+
+// TestLocalHopReachable: only the bad-gateway family (502/503/504) means the tunnel
+// is up but the local dev server is unreachable; every other status means the local
+// server responded (the hop works).
+func TestLocalHopReachable(t *testing.T) {
+	unreachable := []int{502, 503, 504}
+	reachable := []int{200, 201, 204, 301, 400, 401, 403, 404, 429, 500}
+	for _, c := range unreachable {
+		if localHopReachable(c) {
+			t.Errorf("status %d should mean LOCAL UNREACHABLE (bad gateway)", c)
+		}
+	}
+	for _, c := range reachable {
+		if !localHopReachable(c) {
+			t.Errorf("status %d should mean the local hop RESPONDED (reachable)", c)
+		}
+	}
+}
+
+// TestProbeLocalHopURLClassification: exercise probeLocalHopURL against a real
+// httptest server — 502/503/504 → not reachable, others → reachable — and assert
+// the subresource-shaped Sec-Fetch-Dest header is sent (so the gate forwards it to
+// the backend rather than demanding a token).
+func TestProbeLocalHopURLClassification(t *testing.T) {
+	cases := []struct {
+		code      int
+		reachable bool
+	}{
+		{200, true}, {404, true}, {401, true}, {403, true}, {500, true},
+		{502, false}, {503, false}, {504, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("http_%d", tc.code), func(t *testing.T) {
+			var gotDest string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotDest = r.Header.Get("Sec-Fetch-Dest")
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+
+			reachable, detail, err := probeLocalHopURL(context.Background(), srv.Client(), srv.URL+"/")
+			if err != nil {
+				t.Fatalf("unexpected transport error for %d: %v", tc.code, err)
+			}
+			if reachable != tc.reachable {
+				t.Errorf("status %d: reachable=%v, want %v", tc.code, reachable, tc.reachable)
+			}
+			if want := fmt.Sprintf("http %d", tc.code); detail != want {
+				t.Errorf("detail = %q, want %q", detail, want)
+			}
+			// The gate forwards NON-entry Sec-Fetch-Dest to the backend; "image" is a
+			// subresource dest (NOT document/iframe/frame/nested-document/absent).
+			if gotDest != "image" {
+				t.Errorf("local-hop probe must send a subresource Sec-Fetch-Dest (image), got %q", gotDest)
+			}
+		})
+	}
+}
+
+// TestProbeLocalHopURLUnreachable: a transport error (closed port) is returned as
+// an error (not a false "reachable") so the wait treats it as inconclusive, not as
+// a local-server-down signal.
+func TestProbeLocalHopURLUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+
+	client := &http.Client{Timeout: time.Second}
+	reachable, _, err := probeLocalHopURL(context.Background(), client, closedURL+"/")
+	if err == nil {
+		t.Fatal("expected a transport error against a closed port")
+	}
+	if reachable {
+		t.Error("a transport error must not report the local hop as reachable")
+	}
+}
+
+// TestWaitForTunnelReachableReadyRequiresLocalHop: with a probeLocalHop wired, the
+// wait declares ready ONLY when the gate is reachable AND the local hop is not a
+// bad-gateway — the core fix (gate-only readiness masked a dead local server).
+func TestWaitForTunnelReachableReadyRequiresLocalHop(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+	deps.localHost = "10.42.0.100"
+	deps.localHopNoticeInterval = time.Millisecond
+
+	// Gate is reachable from the first probe. The local hop 502s for the first few
+	// attempts (dev server not up), then responds — only THEN is the wait ready.
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return true, "http 401", nil // gate always up
+	}
+	var mu sync.Mutex
+	localCalls := 0
+	deps.probeLocalHop = func(context.Context, string) (bool, string, error) {
+		mu.Lock()
+		localCalls++
+		n := localCalls
+		mu.Unlock()
+		if n < 3 {
+			return false, "http 502", nil // tunnel up, local server down
+		}
+		return true, "http 404", nil // local server now responds
+	}
+
+	ready, abort := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost, testTunnelURL)
+	if !ready || abort != "" {
+		t.Fatalf("want (true, \"\") once the local hop responds, got (%v, %q)", ready, abort)
+	}
+	mu.Lock()
+	got := localCalls
+	mu.Unlock()
+	if got < 3 {
+		t.Fatalf("expected the wait to re-probe the local hop until it responded, got %d local probes", got)
+	}
+	// The clear local-unreachable guidance was surfaced while the hop was 502-ing.
+	if !strings.Contains(errw.String(), "local dev server on 10.42.0.100:5186 is unreachable") {
+		t.Errorf("expected the clear local-unreachable notice naming host:port:\n%s", errw.String())
+	}
+	if !strings.Contains(errw.String(), "--local-host") {
+		t.Errorf("the notice must reference --local-host:\n%s", errw.String())
+	}
+}
+
+// TestWaitForTunnelReachableLocalHopDownKeepsWaiting: gate reachable but the local
+// hop 502s forever → the wait must NOT declare ready and must NOT return the
+// positive-cap (false, "") until the deadline; it keeps waiting, surfacing the
+// notice, until an abort. Proven by an indefinite wait that we abort by signal.
+func TestWaitForTunnelReachableLocalHopDownKeepsWaiting(t *testing.T) {
+	sigs := make(chan os.Signal, 1)
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), sigs)
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyTimeout = 0 // indefinite
+	deps.readyPollInterval = time.Millisecond
+	deps.quietInterval = time.Hour
+	deps.localHopNoticeInterval = time.Millisecond
+	deps.localHost = "10.42.0.100"
+
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return true, "http 401", nil // gate up
+	}
+	var mu sync.Mutex
+	localProbes := 0
+	deps.probeLocalHop = func(context.Context, string) (bool, string, error) {
+		mu.Lock()
+		localProbes++
+		mu.Unlock()
+		return false, "http 502", nil // local server never comes up
+	}
+
+	type res struct {
+		ready bool
+		abort string
+	}
+	resc := make(chan res, 1)
+	go func() {
+		r, a := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost, testTunnelURL)
+		resc <- res{r, a}
+	}()
+
+	// It must NOT return while the local hop is down.
+	select {
+	case got := <-resc:
+		t.Fatalf("wait returned while the local hop was still down: (%v, %q)", got.ready, got.abort)
+	case <-time.After(60 * time.Millisecond):
+	}
+	mu.Lock()
+	if localProbes < 2 {
+		t.Errorf("expected repeated local-hop probes, got %d", localProbes)
+	}
+	mu.Unlock()
+	// The clear notice was surfaced (persistent).
+	if !strings.Contains(errw.String(), "is unreachable through the tunnel") {
+		t.Errorf("expected the persistent local-unreachable notice:\n%s", errw.String())
+	}
+
+	// Abort proves it was still alive and responsive.
+	sigs <- os.Interrupt
+	select {
+	case got := <-resc:
+		if got.ready || got.abort != "interrupt" {
+			t.Fatalf("want (false, \"interrupt\"), got (%v, %q)", got.ready, got.abort)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not abort on signal while the local hop was down")
+	}
+}
+
+// TestWaitForTunnelReachableNilLocalHopIsGateOnly: a nil probeLocalHop preserves
+// the old gate-only readiness (so lifecycle tests that don't wire it are
+// unaffected) — gate reachable → ready immediately.
+func TestWaitForTunnelReachableNilLocalHopIsGateOnly(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 5 * time.Second
+	deps.probeLocalHop = nil // gate-only
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return true, "http 401", nil
+	}
+	ready, abort := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost, testTunnelURL)
+	if !ready || abort != "" {
+		t.Fatalf("nil probeLocalHop should be gate-only ready, got (%v, %q)", ready, abort)
 	}
 }
 

--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -61,21 +61,40 @@ const localDialTimeout = 3 * time.Second
 // IPv4 is tried first (still the common bind), IPv6 second.
 var loopbackHosts = []string{"127.0.0.1", "::1"}
 
-// DialLocalDevServer connects to the developer's local dev server on `port`,
-// trying each loopback family in turn with a per-attempt timeout, and returns
-// the first successful connection. Shared by the pre-flight probe (which closes
-// the returned conn) and the live tunnel proxy (which uses it) so the two always
-// agree on whether the dev server is reachable.
-func DialLocalDevServer(port int, timeout time.Duration) (net.Conn, error) {
-	var lastErr error
-	for _, host := range loopbackHosts {
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout)
-		if err == nil {
-			return conn, nil
+// isLoopbackHost reports whether `host` should use the both-loopback-families
+// behavior: an empty host or the literal "localhost" (the scaffold's
+// `dev:tunnel` binds `localhost`). Any explicit address/hostname is dialed as-is.
+func isLoopbackHost(host string) bool {
+	h := strings.TrimSpace(host)
+	return h == "" || strings.EqualFold(h, "localhost")
+}
+
+// DialLocalDevServer connects to the developer's local dev server on `host:port`.
+//
+//   - host "" or "localhost" (the SAFE default) → the loopback behavior: try each
+//     family in turn (127.0.0.1 then ::1) with a per-attempt timeout and return
+//     the first successful connection. A `--host localhost` dev server binds only
+//     ONE family (`::1` on a dual-stack box), so both must be tried.
+//   - any other host (e.g. a container/pod-netns IP like 10.42.0.100, a VM, or a
+//     specific bound interface) → dial EXACTLY that host:port (single target; the
+//     both-families logic is loopback-specific).
+//
+// Shared by the pre-flight probe (which closes the returned conn) and the live
+// tunnel proxy (which uses it) so the two always agree on whether the dev server
+// is reachable.
+func DialLocalDevServer(host string, port int, timeout time.Duration) (net.Conn, error) {
+	if isLoopbackHost(host) {
+		var lastErr error
+		for _, lh := range loopbackHosts {
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort(lh, strconv.Itoa(port)), timeout)
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
 		}
-		lastErr = err
+		return nil, lastErr
 	}
-	return nil, lastErr
+	return net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout)
 }
 
 // sshDialer is the production Dialer: an in-process `ssh -R` via
@@ -166,6 +185,7 @@ func (d *sshDialer) Dial(ctx context.Context, opts DialOptions) (Tunnel, error) 
 		done:      make(chan struct{}),
 		activity:  make(chan struct{}, 1),
 		log:       d.log,
+		localHost: opts.LocalHost,
 		localPort: opts.LocalPort,
 	}
 	go t.serve()
@@ -180,9 +200,22 @@ type sshTunnel struct {
 	done      chan struct{}
 	activity  chan struct{}
 	log       io.Writer
+	localHost string
 	localPort int
 	closeOnce sync.Once
+
+	// localErrMu guards lastLocalErr so the per-connection proxy path can
+	// rate-limit the "local dev server unreachable" notice: a broken local server
+	// makes the browser retry many subresources, which would otherwise flood the
+	// log and scroll the guidance off-screen. We emit it at most once per
+	// localErrLogEvery.
+	localErrMu   sync.Mutex
+	lastLocalErr time.Time
 }
+
+// localErrLogEvery rate-limits the proxy's local-unreachable notice (see
+// localErrMu) so a retrying browser doesn't flood stderr.
+const localErrLogEvery = 5 * time.Second
 
 func (t *sshTunnel) Done() <-chan struct{}     { return t.done }
 func (t *sshTunnel) Activity() <-chan struct{} { return t.activity }
@@ -216,12 +249,13 @@ func (t *sshTunnel) serve() {
 }
 
 // proxy bridges one forwarded connection to the local dev server on
-// 127.0.0.1/::1:<localPort> (whichever loopback family it is bound to).
+// <localHost>:<localPort> (loopback both-families when localHost is
+// empty/"localhost", else the exact host).
 func (t *sshTunnel) proxy(remote net.Conn) {
 	defer remote.Close()
-	local, err := DialLocalDevServer(t.localPort, localDialTimeout)
+	local, err := DialLocalDevServer(t.localHost, t.localPort, localDialTimeout)
 	if err != nil {
-		t.logf("  tunnel: local dev server on port %d unreachable (%v) — is your dev server running (`npm run dev:tunnel`)?\n", t.localPort, err)
+		t.logLocalUnreachable(err)
 		return
 	}
 	defer local.Close()
@@ -231,6 +265,39 @@ func (t *sshTunnel) proxy(remote net.Conn) {
 	go func() { defer wg.Done(); _, _ = io.Copy(local, remote); _ = closeWrite(local) }()
 	go func() { defer wg.Done(); _, _ = io.Copy(remote, local); _ = closeWrite(remote) }()
 	wg.Wait()
+}
+
+// displayLocalHost renders the local host for user-facing messages: an
+// empty/"localhost" host is shown as "localhost" (the loopback default).
+func displayLocalHost(host string) string {
+	if isLoopbackHost(host) {
+		return "localhost"
+	}
+	return host
+}
+
+// logLocalUnreachable emits the prominent, rate-limited notice that the tunnel is
+// up but the local dev server can't be reached. It names the resolved
+// --local-host so a wrong host (the silent-502 dogfood failure: dev server on a
+// container IP, not loopback) is obvious. Rate-limited via localErrMu so a
+// retrying browser doesn't scroll it off-screen.
+func (t *sshTunnel) logLocalUnreachable(err error) {
+	if t.log == nil {
+		return
+	}
+	t.localErrMu.Lock()
+	now := time.Now()
+	if !t.lastLocalErr.IsZero() && now.Sub(t.lastLocalErr) < localErrLogEvery {
+		t.localErrMu.Unlock()
+		return
+	}
+	t.lastLocalErr = now
+	t.localErrMu.Unlock()
+
+	host := displayLocalHost(t.localHost)
+	t.logf("\n  ⚠ tunnel: local dev server on port %d unreachable at %s:%d (%v)\n"+
+		"    → is your dev server running (`npm run dev:tunnel`), and is --local-host %q correct?\n\n",
+		t.localPort, host, t.localPort, err, host)
 }
 
 // closeWrite half-closes the write side when supported (TCP), so the peer sees

--- a/internal/devtunnel/ssh_dialer_test.go
+++ b/internal/devtunnel/ssh_dialer_test.go
@@ -355,10 +355,14 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 	defer ch.Close()
 
 	// The proxy dial to the dead local port fails; the channel closes. Poll the
-	// log for the guidance line.
+	// log for the guidance line — it must name the port AND the --local-host so a
+	// wrong host is obvious (the silent-502 dogfood failure).
 	deadline := time.After(2 * time.Second)
 	for {
 		if strings.Contains(logbuf.String(), fmt.Sprintf("on port %d unreachable", deadPort)) {
+			if !strings.Contains(logbuf.String(), "--local-host") {
+				t.Errorf("unreachable notice must reference --local-host, got %q", logbuf.String())
+			}
 			return
 		}
 		select {
@@ -371,40 +375,148 @@ func TestSSHDialerLocalDevDown(t *testing.T) {
 	}
 }
 
+// TestSSHDialerProxyHonorsLocalHost proves the live proxy dials the configured
+// LocalHost (not just loopback): with an explicit LocalHost that points at the
+// echo server's address, an inbound forwarded connection round-trips. This is the
+// fix for the silent-502 dogfood failure — a dev server not on the CLI's loopback
+// (e.g. a container IP) is now reachable through the tunnel.
+func TestSSHDialerProxyHonorsLocalHost(t *testing.T) {
+	localPort, stopEcho := echoServer(t) // binds 127.0.0.1
+	defer stopEcho()
+
+	fs := newForwardServer(t)
+	defer fs.close()
+
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const host = "dev-0123456789abcdef.civit.ai"
+
+	d := NewSSHDialer(io.Discard)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Explicit LocalHost "127.0.0.1" — the non-loopback code path (exact single
+	// target), pointed at where the echo server actually listens.
+	tunnel, err := d.Dial(ctx, DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: localPort, LocalHost: "127.0.0.1", Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer tunnel.Close()
+
+	sconn := <-fs.sconnCh
+	<-fs.forwardReady
+	ch := fs.pushConnection(t, sconn, subdomainLabel(host), uint32(remoteBindPort))
+	defer ch.Close()
+
+	msg := "GET /apps/dev HTTP/1.1\r\n\r\n"
+	if _, err := ch.Write([]byte(msg)); err != nil {
+		t.Fatalf("write to forwarded channel: %v", err)
+	}
+	buf := make([]byte, len(msg))
+	_ = ch.CloseWrite()
+	if _, err := io.ReadFull(ch, buf); err != nil {
+		t.Fatalf("read echo back through the tunnel (explicit LocalHost): %v", err)
+	}
+	if got := string(buf); !strings.HasPrefix(got, "GET /apps/dev") {
+		t.Errorf("proxied round-trip via explicit LocalHost mismatch: got %q", got)
+	}
+}
+
+// TestSSHDialerProxyLocalHostUnreachableNamesHost proves a wrong/unreachable
+// LocalHost surfaces the host in the guidance line (so the dev sees WHICH host
+// the proxy tried and can correct --local-host).
+func TestSSHDialerProxyLocalHostUnreachableNamesHost(t *testing.T) {
+	// A closed port on an explicit loopback host.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadPort := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	fs := newForwardServer(t)
+	defer fs.close()
+	key, _ := GenerateEphemeralKey()
+	const host = "dev-0123456789abcdef.civit.ai"
+
+	var logbuf syncBuffer
+	d := NewSSHDialer(&logbuf)
+	tunnel, err := d.Dial(context.Background(), DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: deadPort, LocalHost: "127.0.0.1", Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer tunnel.Close()
+
+	sconn := <-fs.sconnCh
+	<-fs.forwardReady
+	ch := fs.pushConnection(t, sconn, subdomainLabel(host), uint32(remoteBindPort))
+	defer ch.Close()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		got := logbuf.String()
+		if strings.Contains(got, fmt.Sprintf("on port %d unreachable", deadPort)) {
+			if !strings.Contains(got, "127.0.0.1") {
+				t.Errorf("unreachable notice must name the tried host 127.0.0.1, got %q", got)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Errorf("expected an unreachable-local-dev log line naming the host, got %q", got)
+			return
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
 // TestDialLocalDevServerBothFamilies proves the loopback dialer reaches a dev
 // server bound to EITHER family. The IPv6-only case is the real regression: a
 // `--host localhost` dev server binds `::1` only on a dual-stack box, and the
 // old 127.0.0.1-hardcoded dialer/probe falsely reported it unreachable.
 func TestDialLocalDevServerBothFamilies(t *testing.T) {
-	t.Run("ipv4", func(t *testing.T) {
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
+	// The loopback-default cases run for BOTH host values that select loopback
+	// behavior: "" (unset) and "localhost". Both must try both families.
+	for _, loopbackHost := range []string{"", "localhost"} {
+		loopbackHost := loopbackHost
+		name := "host-empty"
+		if loopbackHost != "" {
+			name = "host-" + loopbackHost
 		}
-		defer ln.Close()
-		port := ln.Addr().(*net.TCPAddr).Port
-		conn, err := DialLocalDevServer(port, 2*time.Second)
-		if err != nil {
-			t.Fatalf("expected to reach the IPv4 dev server on port %d: %v", port, err)
-		}
-		_ = conn.Close()
-	})
+		t.Run(name, func(t *testing.T) {
+			t.Run("ipv4", func(t *testing.T) {
+				ln, err := net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer ln.Close()
+				port := ln.Addr().(*net.TCPAddr).Port
+				conn, err := DialLocalDevServer(loopbackHost, port, 2*time.Second)
+				if err != nil {
+					t.Fatalf("expected to reach the IPv4 dev server on port %d: %v", port, err)
+				}
+				_ = conn.Close()
+			})
 
-	t.Run("ipv6", func(t *testing.T) {
-		ln, err := net.Listen("tcp", "[::1]:0")
-		if err != nil {
-			t.Skipf("IPv6 loopback unavailable on this host: %v", err)
-		}
-		defer ln.Close()
-		port := ln.Addr().(*net.TCPAddr).Port
-		// Regression guard: on the old code this returned "connection refused"
-		// because it only ever dialed 127.0.0.1.
-		conn, err := DialLocalDevServer(port, 2*time.Second)
-		if err != nil {
-			t.Fatalf("expected to reach the IPv6-only dev server on port %d (this is the localhost→::1 fix): %v", port, err)
-		}
-		_ = conn.Close()
-	})
+			t.Run("ipv6", func(t *testing.T) {
+				ln, err := net.Listen("tcp", "[::1]:0")
+				if err != nil {
+					t.Skipf("IPv6 loopback unavailable on this host: %v", err)
+				}
+				defer ln.Close()
+				port := ln.Addr().(*net.TCPAddr).Port
+				// Regression guard: on the old code this returned "connection refused"
+				// because it only ever dialed 127.0.0.1.
+				conn, err := DialLocalDevServer(loopbackHost, port, 2*time.Second)
+				if err != nil {
+					t.Fatalf("expected to reach the IPv6-only dev server on port %d (this is the localhost→::1 fix): %v", port, err)
+				}
+				_ = conn.Close()
+			})
+		})
+	}
 
 	t.Run("nothing-listening", func(t *testing.T) {
 		// A port that is (almost certainly) closed: bind then immediately free.
@@ -414,9 +526,60 @@ func TestDialLocalDevServerBothFamilies(t *testing.T) {
 		}
 		deadPort := ln.Addr().(*net.TCPAddr).Port
 		_ = ln.Close()
-		if conn, err := DialLocalDevServer(deadPort, 500*time.Millisecond); err == nil {
+		if conn, err := DialLocalDevServer("localhost", deadPort, 500*time.Millisecond); err == nil {
 			_ = conn.Close()
 			t.Fatalf("expected an error dialing the closed port %d", deadPort)
+		}
+	})
+}
+
+// TestDialLocalDevServerSpecificHost proves the non-loopback path: a specific
+// host (the container/pod-netns / VM / bound-interface case, e.g. 10.42.0.100)
+// is dialed EXACTLY as given — reaching a server bound to 127.0.0.1 ONLY when the
+// caller asks for 127.0.0.1, and erroring when nothing listens there.
+func TestDialLocalDevServerSpecificHost(t *testing.T) {
+	t.Run("reaches-explicit-127.0.0.1", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+		port := ln.Addr().(*net.TCPAddr).Port
+		conn, err := DialLocalDevServer("127.0.0.1", port, 2*time.Second)
+		if err != nil {
+			t.Fatalf("expected to reach the explicit-host dev server on 127.0.0.1:%d: %v", port, err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("explicit-ipv4-does-not-fall-back-to-ipv6", func(t *testing.T) {
+		// Bind ONLY ::1, then ask for 127.0.0.1 explicitly. Unlike the loopback
+		// default (which tries both families), an explicit 127.0.0.1 must NOT reach
+		// an IPv6-only server — it is a single, exact target.
+		ln, err := net.Listen("tcp", "[::1]:0")
+		if err != nil {
+			t.Skipf("IPv6 loopback unavailable on this host: %v", err)
+		}
+		defer ln.Close()
+		port := ln.Addr().(*net.TCPAddr).Port
+		if conn, err := DialLocalDevServer("127.0.0.1", port, 500*time.Millisecond); err == nil {
+			_ = conn.Close()
+			t.Fatalf("explicit 127.0.0.1 must NOT reach an IPv6-only server on port %d", port)
+		}
+	})
+
+	t.Run("unreachable-host-errors", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		deadPort := ln.Addr().(*net.TCPAddr).Port
+		_ = ln.Close()
+		// A specific host with nothing listening is a hard error (no both-families
+		// masking).
+		if conn, err := DialLocalDevServer("127.0.0.1", deadPort, 500*time.Millisecond); err == nil {
+			_ = conn.Close()
+			t.Fatalf("expected an error dialing the closed 127.0.0.1:%d", deadPort)
 		}
 	})
 }

--- a/internal/devtunnel/tunnel.go
+++ b/internal/devtunnel/tunnel.go
@@ -16,6 +16,14 @@ type DialOptions struct {
 	RemoteHost string
 	// LocalPort is the developer's running dev server port on 127.0.0.1.
 	LocalPort int
+	// LocalHost is the host the developer's dev server is bound to. Empty or
+	// "localhost" means loopback (the SAFE default: try 127.0.0.1 then ::1); any
+	// other value (e.g. a container/VPN IP like 10.42.0.100, or a specific bound
+	// interface) is dialed EXACTLY as given. This lets the tunnel reach a dev
+	// server that is NOT on the CLI's loopback (a container/pod netns, a VM, a
+	// specific interface) — the silent-502 case where sish has the tunnel but the
+	// proxy can't reach the local server.
+	LocalHost string
 	// Signer is the ephemeral private key authenticating the `ssh -R` bind.
 	Signer ssh.Signer
 	// SSHHostPublicKey is the sish endpoint's OpenSSH host public-key line


### PR DESCRIPTION
## The dogfood failure

A dev tunnel returned **502 for every request** even though sish had the tunnel registered. Root cause: the user's dev server was reachable at `10.42.0.100:5186` — a container/pod netns (`10.42.0.0/16`), *not* loopback — and the CLI:

1. **Only ever dialed loopback.** `DialLocalDevServer` hardcoded `127.0.0.1`/`::1`, and there was no flag to target another host. So the proxy couldn't reach the local server → 502.
2. **Only probed the public gate for readiness.** A naked `GET` is denied **401** by the forwardAuth gate, which `classifyReadyStatus` treats as "ready". That proves DNS→Traefik→gate are up, but never that a request can *traverse the tunnel to the local server*. So the CLI declared ready while the local hop was dead, and the failure only showed up as a browser 502.

## Fix 1 — `--local-host` flag

Default `"localhost"` (loopback — **preserves today's behavior**; the scaffold's `dev:tunnel` binds localhost, so most users need nothing). Threaded through the pre-flight probe, the tunnel proxy (`DialOptions.LocalHost` → `sshTunnel.localHost`), and a new `DialLocalDevServer(host, port, timeout)` signature:

- host `""`/`"localhost"` → keep the both-loopback-families dial (`127.0.0.1` then `::1`).
- any other host (e.g. `10.42.0.100`, a VM, a bound interface) → dial that exact target.

```
civitai app dev-tunnel --local-host 10.42.0.100
```

## Fix 2 — readiness verifies the LOCAL hop, and fails loudly

Adds a **local-hop probe**: a `GET` to the public host with a **non-entry `Sec-Fetch-Dest: image`** header. The gate (`dev-tunnel-gate.ts`) classifies entry dests (`document`/`iframe`/`frame`/`nested-document`/absent) as token-required (401) and treats any other dest as a **subresource → allowed through to sish → the local server**. So the status reflects the local hop:

- `502`/`503`/`504` → tunnel up but **local server unreachable** → NOT ready.
- any other status (200/404/…) → the local server responded → hop works.

Full readiness now requires **gate reachable AND local hop not bad-gateway**. While the hop 502s, the wait surfaces a clear, rate-limited notice — `Tunnel is up, but your local dev server on <host>:<port> is unreachable through the tunnel — is it running, and is --local-host correct?` — and **keeps waiting** (preserving the indefinite-wait / nudge / snappy-Ctrl-C / non-fatal-timeout semantics). The mid-session proxy error also now names `--local-host` and is rate-limited so it doesn't scroll past under the spinner.

## Testing

Both probes are injected (`probePublic` + new `probeLocalHop`) so the whole path is drivable on non-TTY writers with no real network. Added coverage:

- `DialLocalDevServer`: `""`/`localhost` try both families (existing behavior preserved); an explicit host dials exactly that (and does *not* fall back to the other family); unreachable → error.
- proxy honors `LocalHost` (round-trips) and names the tried host in the unreachable notice.
- `--local-host` flag: default `localhost`; a set value threads to both the pre-flight probe and the dialer.
- local-hop classification (`localHopReachable` + `probeLocalHopURL`, incl. the subresource header) and the readiness combinations: gate+hop OK → ready; gate OK + hop 502 → not ready, emits the notice, keeps waiting; nil `probeLocalHop` → gate-only (backward compat).

Gates: `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...`, `go test -race ./internal/cmd/... ./internal/devtunnel/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)