### PR TITLE
fix(devtunnel): accept forwarded-tcpip channels directly (fixes 502 — tunnel never delivered)

### DIFF
--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -167,41 +169,108 @@ func (d *sshDialer) Dial(ctx context.Context, opts DialOptions) (Tunnel, error) 
 	}
 	client := ssh.NewClient(sshConn, chans, reqs)
 
-	// Bind the SUBDOMAIN LABEL, not the full host: sish appends its own domain to
-	// the requested subdomain, so requesting the full `dev-<16hex>.civit.ai`
-	// double-appends to `dev-<16hex>.civit.ai.civit.ai` and the browser's real
+	// Register OUR OWN handler for inbound forwarded-tcpip channels BEFORE asking
+	// sish to forward, so no early channel is missed.
+	//
+	// WHY NOT client.Listen: x/crypto's client.Listen installs a forwardList
+	// handler that, for every inbound `forwarded-tcpip` channel, first calls
+	// parseTCPAddr(payload.OriginAddr, payload.OriginPort) — which runs
+	// netip.ParseAddr on OriginAddr and REJECTS the channel with
+	// "cannot parse IP address" if it is not an IP literal (x/crypto tcpip.go).
+	// sish sets OriginAddr to the tunnel HOSTNAME (`dev-<16hex>`), not an IP — so
+	// x/crypto rejects EVERY channel before it ever reaches the forward match.
+	// Accept() therefore never fires, the proxy never runs, and sish returns 502.
+	//
+	// CONFIRMED LIVE (PR): with a live sish tunnel, sish stamps the channel
+	// Addr="dev-<16hex>" Port=80 (which DOES match our `<label>:80` bind — so the
+	// address match is NOT the problem), but OriginAddr="dev-<16hex>" — a hostname,
+	// not an IP — which is exactly what parseTCPAddr rejects. Stock CLI → 502 on
+	// every real request; this handler → 200 (see PR evidence).
+	//
+	// Since we only ever request a SINGLE reverse forward, EVERY inbound
+	// forwarded-tcpip channel on this connection is unambiguously ours — accept
+	// them ALL, without inspecting the Addr/Port/Origin sish stamps on them.
+	newChans := client.HandleChannelOpen("forwarded-tcpip")
+	if newChans == nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("forwarded-tcpip channel handler already registered")
+	}
+
+	// Request the reverse forward ourselves. Bind the SUBDOMAIN LABEL, not the
+	// full host: sish appends its own domain to the requested subdomain, so
+	// requesting the full `dev-<16hex>.civit.ai` double-appends to
+	// `dev-<16hex>.civit.ai.civit.ai` and the browser's real
 	// `Host: dev-<16hex>.civit.ai` request 404s. See subdomainLabel. opts.RemoteHost
 	// stays the full host for logging / the ready-URL / upstream validation.
-	bindAddr := fmt.Sprintf("%s:%d", subdomainLabel(opts.RemoteHost), remoteBindPort)
-	listener, err := client.Listen("tcp", bindAddr)
+	bindLabel := subdomainLabel(opts.RemoteHost)
+	req := tcpipForwardRequest{BindAddr: bindLabel, BindPort: remoteBindPort}
+	ok, _, err := client.SendRequest("tcpip-forward", true, ssh.Marshal(&req))
 	if err != nil {
 		_ = client.Close()
-		return nil, fmt.Errorf("request reverse forward for %s: %w", bindAddr, err)
+		return nil, fmt.Errorf("request reverse forward for %s:%d: %w", bindLabel, remoteBindPort, err)
+	}
+	if !ok {
+		_ = client.Close()
+		return nil, fmt.Errorf("reverse forward for %s:%d denied by sish", bindLabel, remoteBindPort)
 	}
 
 	t := &sshTunnel{
 		client:    client,
-		listener:  listener,
+		newChans:  newChans,
+		bindLabel: bindLabel,
 		done:      make(chan struct{}),
 		activity:  make(chan struct{}, 1),
 		log:       d.log,
 		localHost: opts.LocalHost,
 		localPort: opts.LocalPort,
+		debug:     os.Getenv(devTunnelDebugEnv) != "",
 	}
 	go t.serve()
 	return t, nil
 }
 
+// tcpipForwardRequest is the RFC 4254 §7.1 `tcpip-forward` global-request
+// payload (string bind address, uint32 bind port). Marshalled with ssh.Marshal,
+// which emits the fields in declaration order — matching the wire format.
+type tcpipForwardRequest struct {
+	BindAddr string
+	BindPort uint32
+}
+
+// forwardedTCPPayload is the RFC 4254 §7.2 `forwarded-tcpip` channel-open
+// payload sish sends for each inbound connection. We parse it only for the
+// diagnostic log (see devTunnelDebugEnv) — the proxy accepts the channel
+// regardless of what these fields say, because our single reverse forward owns
+// every forwarded-tcpip channel on this connection. OriginAddr is the field that
+// broke stock delivery: sish sets it to the tunnel hostname (not an IP), which
+// x/crypto's built-in handler rejects via netip.ParseAddr.
+type forwardedTCPPayload struct {
+	Addr       string
+	Port       uint32
+	OriginAddr string
+	OriginPort uint32
+}
+
+// devTunnelDebugEnv, when set to any non-empty value, makes the tunnel log the
+// exact (Addr:Port / OriginAddr:OriginPort) sish stamps on each inbound
+// forwarded-tcpip channel — the evidence for WHY x/crypto's built-in
+// client.Listen handler rejected it (a non-IP OriginAddr → "cannot parse IP
+// address"), the root cause of the historical 502s. Off by default; zero cost
+// when unset.
+const devTunnelDebugEnv = "CIVITAI_DEVTUNNEL_DEBUG"
+
 // sshTunnel is a live reverse tunnel from the sish endpoint to the local dev
 // server.
 type sshTunnel struct {
 	client    *ssh.Client
-	listener  net.Listener
+	newChans  <-chan ssh.NewChannel
+	bindLabel string
 	done      chan struct{}
 	activity  chan struct{}
 	log       io.Writer
 	localHost string
 	localPort int
+	debug     bool
 	closeOnce sync.Once
 
 	// localErrMu guards lastLocalErr so the per-connection proxy path can
@@ -227,31 +296,47 @@ func (t *sshTunnel) logf(format string, a ...any) {
 	fmt.Fprintf(t.log, format, a...)
 }
 
-// serve accepts forwarded connections until the listener closes, proxying each
-// to the local dev server. It closes done on exit so the command's select loop
-// learns the tunnel terminated.
+// serve accepts inbound forwarded-tcpip channels until the connection drops (the
+// channel stream closes) or Close tears it down, proxying each to the local dev
+// server. It accepts EVERY channel unconditionally: our single reverse forward
+// owns them all, so we deliberately do NOT strict-match the (Addr:Port) sish
+// stamps on the channel — that strict match (x/crypto's client.Listen) is
+// exactly what broke delivery and 502'd. It closes done on exit so the command's
+// select loop learns the tunnel terminated.
 func (t *sshTunnel) serve() {
 	defer close(t.done)
-	for {
-		remote, err := t.listener.Accept()
-		if err != nil {
-			// Listener closed (teardown) or the SSH connection dropped.
-			return
+	for newCh := range t.newChans {
+		if t.debug {
+			var p forwardedTCPPayload
+			if err := ssh.Unmarshal(newCh.ExtraData(), &p); err == nil {
+				_, originErr := netip.ParseAddr(p.OriginAddr)
+				t.logf("  [debug] forwarded-tcpip: sish stamped Addr=%q Port=%d OriginAddr=%q OriginPort=%d (we bound %q:%d) — accepting; x/crypto client.Listen would have REJECTED it because OriginAddr is not an IP: %v\n",
+					p.Addr, p.Port, p.OriginAddr, p.OriginPort, t.bindLabel, remoteBindPort, originErr != nil)
+			} else {
+				t.logf("  [debug] forwarded-tcpip: could not parse ExtraData (%v); accepting anyway\n", err)
+			}
 		}
+		ch, reqs, err := newCh.Accept()
+		if err != nil {
+			// The connection is going away; the range will end on the next close.
+			continue
+		}
+		go ssh.DiscardRequests(reqs)
 		// Best-effort, coalesced activity signal (drop if the buffer is full — one
 		// pending signal is enough to reset the idle timer).
 		select {
 		case t.activity <- struct{}{}:
 		default:
 		}
-		go t.proxy(remote)
+		go t.proxy(ch)
 	}
 }
 
-// proxy bridges one forwarded connection to the local dev server on
+// proxy bridges one forwarded channel to the local dev server on
 // <localHost>:<localPort> (loopback both-families when localHost is
-// empty/"localhost", else the exact host).
-func (t *sshTunnel) proxy(remote net.Conn) {
+// empty/"localhost", else the exact host). remote is an ssh.Channel (an
+// io.ReadWriteCloser whose CloseWrite half-closes the SSH channel).
+func (t *sshTunnel) proxy(remote io.ReadWriteCloser) {
 	defer remote.Close()
 	local, err := DialLocalDevServer(t.localHost, t.localPort, localDialTimeout)
 	if err != nil {
@@ -302,18 +387,21 @@ func (t *sshTunnel) logLocalUnreachable(err error) {
 
 // closeWrite half-closes the write side when supported (TCP), so the peer sees
 // EOF and the copy unwinds; otherwise a no-op.
-func closeWrite(c net.Conn) error {
+func closeWrite(c io.ReadWriteCloser) error {
 	if cw, ok := c.(interface{ CloseWrite() error }); ok {
 		return cw.CloseWrite()
 	}
 	return nil
 }
 
-// Close tears the tunnel down (idempotent): closing the listener unblocks
-// serve, and closing the client drops the SSH connection.
+// Close tears the tunnel down (idempotent): closing the client drops the SSH
+// connection, which closes the forwarded-tcpip channel stream and unblocks
+// serve's range. A best-effort cancel-tcpip-forward lets sish drop the vhost
+// promptly instead of waiting for the connection teardown.
 func (t *sshTunnel) Close() error {
 	t.closeOnce.Do(func() {
-		_ = t.listener.Close()
+		req := tcpipForwardRequest{BindAddr: t.bindLabel, BindPort: remoteBindPort}
+		_, _, _ = t.client.SendRequest("cancel-tcpip-forward", false, ssh.Marshal(&req))
 		_ = t.client.Close()
 	})
 	return nil

--- a/internal/devtunnel/ssh_dialer_test.go
+++ b/internal/devtunnel/ssh_dialer_test.go
@@ -193,6 +193,89 @@ func (fs *forwardServer) pushConnection(t *testing.T, sconn *ssh.ServerConn, hos
 	return ch
 }
 
+// pushConnectionWithOrigin is pushConnection with control over the OriginAddr /
+// OriginPort of the forwarded-tcpip payload. sish stamps OriginAddr with the
+// tunnel HOSTNAME (not an IP), which is exactly the shape x/crypto's built-in
+// client.Listen handler rejects (netip.ParseAddr fails → "cannot parse IP
+// address" → channel rejected → 502). This lets the regression test reproduce
+// that real-world channel and assert our handler proxies it anyway.
+func (fs *forwardServer) pushConnectionWithOrigin(t *testing.T, sconn *ssh.ServerConn, addr string, port uint32, originAddr string, originPort uint32) ssh.Channel {
+	t.Helper()
+	payload := ssh.Marshal(struct {
+		Addr       string
+		Port       uint32
+		OriginAddr string
+		OriginPort uint32
+	}{addr, port, originAddr, originPort})
+	ch, reqs, err := sconn.OpenChannel("forwarded-tcpip", payload)
+	if err != nil {
+		t.Fatalf("open forwarded-tcpip: %v", err)
+	}
+	go ssh.DiscardRequests(reqs)
+	return ch
+}
+
+// TestSSHDialerProxiesNonIPOriginAddr is the regression guard for the CONFIRMED
+// delivery bug: sish opens each forwarded-tcpip channel with OriginAddr set to
+// the tunnel HOSTNAME (`dev-<16hex>`, NOT an IP) — and, defensively, an Addr that
+// need not equal the exact `<label>:80` we registered. x/crypto's built-in
+// client.Listen handler runs netip.ParseAddr(OriginAddr) and REJECTS every such
+// channel ("cannot parse IP address"), so Accept() never fires and sish 502s
+// (verified live against the real sish: stock CLI → 502, this handler → 200).
+// Our dialer accepts ALL forwarded-tcpip channels regardless of Addr/Origin, so
+// the inbound connection must still round-trip to the local dev server.
+func TestSSHDialerProxiesNonIPOriginAddr(t *testing.T) {
+	localPort, stopEcho := echoServer(t)
+	defer stopEcho()
+
+	fs := newForwardServer(t)
+	defer fs.close()
+
+	key, err := GenerateEphemeralKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const host = "dev-0123456789abcdef.civit.ai"
+
+	d := NewSSHDialer(io.Discard)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tunnel, err := d.Dial(ctx, DialOptions{Endpoint: fs.addr(), RemoteHost: host, LocalPort: localPort, Signer: key.Signer, SSHHostPublicKey: fs.hostAuthorizedKey()})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer tunnel.Close()
+
+	sconn := <-fs.sconnCh
+	<-fs.forwardReady
+
+	// Reproduce EXACTLY what live sish sends: a non-IP OriginAddr (the tunnel
+	// hostname). Also stamp a MISMATCHED Addr (the full host, not the bound label)
+	// to prove we don't strict-match the address either. Both would make
+	// client.Listen reject the channel.
+	ch := fs.pushConnectionWithOrigin(t, sconn, host, uint32(remoteBindPort), subdomainLabel(host), uint32(remoteBindPort))
+	defer ch.Close()
+
+	msg := "GET /@vite/client HTTP/1.1\r\n\r\n"
+	if _, err := ch.Write([]byte(msg)); err != nil {
+		t.Fatalf("write to forwarded channel: %v", err)
+	}
+	buf := make([]byte, len(msg))
+	_ = ch.CloseWrite()
+	if _, err := io.ReadFull(ch, buf); err != nil {
+		t.Fatalf("read echo back through the tunnel (non-IP OriginAddr must still proxy): %v", err)
+	}
+	if got := string(buf); !strings.HasPrefix(got, "GET /@vite/client") {
+		t.Errorf("proxied round-trip mismatch for non-IP-origin channel: got %q", got)
+	}
+
+	select {
+	case <-tunnel.Activity():
+	case <-time.After(time.Second):
+		t.Error("expected an Activity signal for the inbound connection")
+	}
+}
+
 // TestSSHDialerReverseForwardProxies is the real dialer end-to-end against an
 // in-process SSH forward server + a local echo server: it proves Dial binds the
 // reverse forward, an inbound forwarded connection is proxied to the local dev


### PR DESCRIPTION
## The bug

`civitai app dev-tunnel` established the reverse tunnel and sish logged `forwarding started`, but **every real request returned 502** and the local dev server (vite) received nothing. This never worked end-to-end.

## Confirmed root cause (with live evidence)

The prime hypothesis (Addr/Port mismatch from the label-bind) was **refuted** by the actual channel payload. The real cause:

sish opens each inbound `forwarded-tcpip` channel with **`OriginAddr` set to the tunnel HOSTNAME (`dev-<16hex>`), not an IP literal**. x/crypto/ssh v0.45.0's built-in reverse-forward handler (installed by `client.Listen`) runs `parseTCPAddr(payload.OriginAddr, …)` → `netip.ParseAddr`, which fails on a non-IP string and **rejects every channel** with `cannot parse IP address` — *before* the forward is ever matched. `Accept()` never fires, the proxy never runs, sish 502s.

Live instrumented capture (debug hook, against production sish):

```
forwarded-tcpip: sish stamped Addr="dev-c8f4dd3160a51adf" Port=80
  OriginAddr="dev-c8f4dd3160a51adf" OriginPort=80  (we bound "dev-c8f4dd3160a51adf":80)
```

`Addr:Port` == our `<label>:80` bind (so the address match was **not** the problem); `OriginAddr` is a hostname, which is what x/crypto rejects.

## Fix

Stop using `client.Listen`. Send the `tcpip-forward` global request ourselves (still binding the subdomain **label** — preserves the #90 vhost fix) and register `client.HandleChannelOpen("forwarded-tcpip")`, accepting **every** inbound channel unconditionally (our single reverse forward owns them all), proxying each to the local dev server via the existing `DialLocalDevServer`. Teardown sends `cancel-tcpip-forward` then closes the client (ends serve's range).

Preserves: label-bind vhost fix, idle `Activity` signal, `Done()`/teardown, `--local-host`, and the local-hop readiness probe.

## End-to-end proof (same block, same vite, only the CLI differs)

Laptop tunnel → prod sish → `curl -H "Sec-Fetch-Dest: image"` from a host that resolves the dev DNS:

| Request | Stock v0.1.50 (`client.Listen`) | This build (`HandleChannelOpen`) |
|---|---|---|
| naked `GET /` | 401 (gate) | 401 (gate) |
| `GET /@vite/client` (subresource) | **502** | **200** — vite's actual client JS |
| `GET /` (subresource) | **502** | **200** |
| `GET /src/main.tsx` | — | **200** |

vite served the 200s (returned its dev client module), confirming HTTP reached the local dev server.

## Tests + gates

- New regression test `TestSSHDialerProxiesNonIPOriginAddr`: pushes a `forwarded-tcpip` channel with a **non-IP OriginAddr** (+ a mismatched Addr) and asserts it still round-trips to the local dev server + fires Activity — the shape stock `client.Listen` rejects.
- Existing dev-tunnel tests stay green.

```
go build ./...     # ok
go vet ./...       # ok
gofmt -l .         # clean
go test ./...      # all ok
go test -race ./internal/devtunnel/... ./internal/cmd/...  # ok
```

A `CIVITAI_DEVTUNNEL_DEBUG=1` env var logs the exact Addr/OriginAddr sish stamps on each channel (diagnostic, zero cost when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
