### PR TITLE
fix(dev-tunnel): resolve readiness probe via DoH so a premature NXDOMAIN doesn't poison the resolver (30-min hang / browser render fail)

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -20,6 +20,7 @@ import (
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/internal/devtunnel"
+	"github.com/civitai/cli/internal/dnsprobe"
 	"github.com/civitai/cli/internal/manifest"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -78,6 +79,13 @@ const (
 	// defaultLocalHopNoticeInterval rate-limits the readiness wait's "tunnel up but
 	// local dev server unreachable" notice.
 	defaultLocalHopNoticeInterval = 15 * time.Second
+	// defaultDNSPendingGrace is how long the readiness wait shows the generic
+	// "waiting for the host" indicator before switching to the DNS-specific
+	// "waiting for DNS to publish for <host>…" line, once DoH reports the record
+	// isn't published yet. A short grace avoids flipping the message on the very
+	// first probe (the record is expected to be missing for the first second or
+	// two right after mint).
+	defaultDNSPendingGrace = 5 * time.Second
 )
 
 // spinnerFrames is the braille animation cycle for the TTY readiness indicator.
@@ -155,10 +163,15 @@ type tunnelSessionDeps struct {
 	// defaultLocalHopNoticeInterval), so a stuck local hop is surfaced clearly and
 	// repeatedly without spamming a line per poll. Injectable so tests drive it fast.
 	localHopNoticeInterval time.Duration
-	newTimer               func(d time.Duration) devtunnel.Timer
-	signals                <-chan os.Signal
-	out                    io.Writer
-	errw                   io.Writer
+	// dnsPendingGrace is how long the wait shows the generic indicator before
+	// switching to the "waiting for DNS to publish" line once DoH reports the host
+	// isn't published yet (default defaultDNSPendingGrace). Injectable so tests
+	// drive it fast.
+	dnsPendingGrace time.Duration
+	newTimer        func(d time.Duration) devtunnel.Timer
+	signals         <-chan os.Signal
+	out             io.Writer
+	errw            io.Writer
 }
 
 func newAppDevTunnelCmd() *cobra.Command {
@@ -296,6 +309,7 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 				spinnerInterval:        defaultSpinnerInterval,
 				quietInterval:          defaultQuietInterval,
 				localHopNoticeInterval: defaultLocalHopNoticeInterval,
+				dnsPendingGrace:        defaultDNSPendingGrace,
 				newTimer:               devtunnel.NewRealTimer,
 				signals:                sigCh,
 				out:                    cmd.OutOrStdout(),
@@ -580,6 +594,13 @@ func resolveLocalHopNoticeInterval(d tunnelSessionDeps) time.Duration {
 	return defaultLocalHopNoticeInterval
 }
 
+func resolveDNSPendingGrace(d tunnelSessionDeps) time.Duration {
+	if d.dnsPendingGrace > 0 {
+		return d.dnsPendingGrace
+	}
+	return defaultDNSPendingGrace
+}
+
 // writerIsTTY reports whether w is a terminal we can animate on — true only when
 // w is an *os.File whose fd is a TTY. A bytes.Buffer / syncBuffer (tests) or a
 // pipe (CI) is NOT a TTY, so it takes the quiet non-animated path.
@@ -689,16 +710,28 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 	frame := 0
 	lastLen := 0
 	localHopDown := false
+	// dnsPending is set once DoH AUTHORITATIVELY reports the tunnel host isn't
+	// published yet (external-dns + Cloudflare haven't propagated the record). It
+	// switches the indicator to the DNS-specific line — but only after a short
+	// grace period, so a single first-probe NXDOMAIN doesn't flip the message
+	// instantly.
+	dnsPending := false
+	dnsGrace := resolveDNSPendingGrace(d)
+	showDNSPending := func() bool { return dnsPending && time.Since(start) >= dnsGrace }
 	localTarget := fmt.Sprintf("%s:%d", localHostForDisplay(d.localHost), d.port)
 	renderSpinner := func() {
 		if !tty {
 			return
 		}
 		var line string
-		if localHopDown {
+		switch {
+		case localHopDown:
 			line = fmt.Sprintf("%c Tunnel up — waiting for your local dev server on %s… %s elapsed",
 				spinnerFrames[frame%len(spinnerFrames)], localTarget, fmtMMSS(time.Since(start)))
-		} else {
+		case showDNSPending():
+			line = fmt.Sprintf("%c Waiting for DNS to publish for %s (external-dns + Cloudflare, usually <1 min)… %s elapsed",
+				spinnerFrames[frame%len(spinnerFrames)], host, fmtMMSS(time.Since(start)))
+		default:
 			line = fmt.Sprintf("%c Waiting for %s to come up… %s elapsed",
 				spinnerFrames[frame%len(spinnerFrames)], host, fmtMMSS(time.Since(start)))
 		}
@@ -791,12 +824,15 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 			fmt.Fprintf(d.errw, "      %s\n\n", tunnelURL)
 			renderSpinner()
 		case <-ui.C:
-			if tty {
+			switch {
+			case tty:
 				frame++
 				renderSpinner()
-			} else if localHopDown {
+			case localHopDown:
 				fmt.Fprintf(d.errw, "  … tunnel up; still waiting for your local dev server on %s (%s)\n", localTarget, fmtMMSS(time.Since(start)))
-			} else {
+			case showDNSPending():
+				fmt.Fprintf(d.errw, "  … waiting for DNS to publish for %s (external-dns + Cloudflare, usually <1 min) (%s)\n", host, fmtMMSS(time.Since(start)))
+			default:
 				fmt.Fprintf(d.errw, "  … still waiting for %s (%s)\n", host, fmtMMSS(time.Since(start)))
 			}
 		case res := <-resultCh:
@@ -818,11 +854,15 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 				// unreachable through the tunnel. Surface the clear, persistent notice
 				// and KEEP waiting (don't declare ready, don't hang silently).
 				localHopDown = true
+				dnsPending = false
 				localUnreachableNotice()
 			} else {
 				// Gate not up yet (or the local-hop probe was inconclusive) — back to
-				// the plain "waiting for the host" indicator.
+				// the plain "waiting for the host" indicator. If DoH reports the record
+				// isn't published yet, switch to the DNS-specific indicator (after the
+				// grace period) so "DNS not up" reads differently from "route not built".
 				localHopDown = false
+				dnsPending = isDNSPending(res.detail, res.err)
 			}
 			// Not ready — re-probe after the poll interval. (The detail/err is folded
 			// into the indicator, not spammed per-attempt.)
@@ -833,9 +873,37 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 	}
 }
 
+// devTunnelResolver is the DoH resolver the readiness probes use to resolve the
+// ephemeral tunnel host. It is a package var so tests can inject a fake DoH
+// endpoint; production uses Cloudflare DoH JSON.
+var devTunnelResolver dnsprobe.Resolver = dnsprobe.DefaultResolver
+
+// dnsPendingDetail is the probe `detail` reported when DoH AUTHORITATIVELY says
+// the tunnel host is not published yet (NXDOMAIN / no address answer) — DISTINCT
+// from a transient "dns" transport error. The readiness wait keys off this (or the
+// dnsprobe.ErrNotPublished sentinel) to show the "waiting for DNS to publish" line
+// instead of the generic "still waiting".
+const dnsPendingDetail = "dns-pending"
+
+// probeHTTPClientForHost builds the probe HTTP client for host, resolving host via
+// DNS-over-HTTPS to Cloudflare (NOT the OS resolver). This is the crux of the fix:
+// a premature GET of the just-minted `dev-<16hex>.civit.ai` used to resolve via the
+// OS resolver, which NXDOMAIN-negative-caches the not-yet-published record for up to
+// the civit.ai SOA minimum TTL (1800s, CF-unlowerable) — hanging the CLI for ~30 min
+// AND poisoning the OS cache so the browser can't later resolve the now-live host.
+// Resolving over DoH sees the record the moment CF has it and NEVER poisons the OS
+// negative cache. On an authoritative not-published result it returns
+// dnsprobe.ErrNotPublished; if DoH itself fails it falls back to the OS resolver so
+// behavior is never worse than before.
+func probeHTTPClientForHost(ctx context.Context, host string) (*http.Client, error) {
+	return dnsprobe.DialClient(ctx, devTunnelResolver, host, probePublicTimeout)
+}
+
 // probePublicTunnel is the production probePublic: an UNAUTHENTICATED GET of
 // https://<host>/ (a fresh client that does NOT carry the CLI's credential), with
-// the response classified by classifyReadyStatus.
+// the response classified by classifyReadyStatus. The host is resolved via DoH
+// (see probeHTTPClientForHost) so the OS resolver is never queried for the
+// not-yet-published host.
 //
 // WHY 401/403 mean healthy: a naked (un-embedded, no-token) request to the tunnel
 // host is DENIED by the forwardAuth gate with 401/403 precisely WHEN the whole
@@ -844,9 +912,18 @@ func waitForTunnelReachable(ctx context.Context, d tunnelSessionDeps, tunnel dev
 // path isn't up yet: 404 (Traefik has no route), 502/503/504 (backend/gate down),
 // Cloudflare origin errors 520–526, or a DNS/connection error.
 func probePublicTunnel(ctx context.Context, host string) (bool, string, error) {
-	// A dedicated client with NO auth transport — this is a public probe; it must
-	// not reuse the CLI credential. Redirect-following is fine (default).
-	client := &http.Client{Timeout: probePublicTimeout}
+	client, err := probeHTTPClientForHost(ctx, host)
+	if err != nil {
+		if errors.Is(err, dnsprobe.ErrNotPublished) {
+			// DoH says the record isn't published yet — the expected state right after
+			// mint. Report the DISTINCT dns-pending signal (not a hard error) so the
+			// wait keeps polling and shows the DNS-specific message.
+			return false, dnsPendingDetail, err
+		}
+		// Should not happen (DialClient falls back to the OS resolver on transient DoH
+		// failure), but be defensive: treat an unexpected resolver error as not-ready.
+		return false, "dns", err
+	}
 	return probePublicURL(ctx, client, "https://"+host+"/")
 }
 
@@ -883,7 +960,16 @@ func probePublicURL(ctx context.Context, client *http.Client, rawURL string) (bo
 // LOCAL hop: 502/503/504 = tunnel up but local server unreachable (not ready);
 // any other status (200/404/…) = the local server responded (ready).
 func probeLocalHopTunnel(ctx context.Context, host string) (bool, string, error) {
-	client := &http.Client{Timeout: probePublicTimeout}
+	// Resolve via DoH too (the gate probe already proved the host resolves, but
+	// keeping the local-hop probe off the OS resolver means NEITHER probe can poison
+	// the OS negative cache). A transient DoH failure falls back to the OS resolver.
+	client, err := probeHTTPClientForHost(ctx, host)
+	if err != nil {
+		// Inconclusive (e.g. a transient not-published between gate-ready and this
+		// probe) — report not-reachable-yet so the caller re-probes rather than
+		// declaring the local hop down.
+		return false, classifyProbeErr(err), err
+	}
 	return probeLocalHopURL(ctx, client, "https://"+host+"/")
 }
 
@@ -931,6 +1017,14 @@ func classifyReadyStatus(code int) bool {
 	default:
 		return false
 	}
+}
+
+// isDNSPending reports whether a probe result means "DNS isn't published yet"
+// (DoH returned NXDOMAIN / no address answer) as opposed to any other not-ready
+// reason. It accepts EITHER the dnsPendingDetail marker (so injected test probes
+// need not import the sentinel) OR the dnsprobe.ErrNotPublished sentinel.
+func isDNSPending(detail string, err error) bool {
+	return detail == dnsPendingDetail || errors.Is(err, dnsprobe.ErrNotPublished)
 }
 
 // classifyProbeErr gives a short human tag for a transport-level probe failure,

--- a/internal/cmd/app_dev_tunnel_doh_test.go
+++ b/internal/cmd/app_dev_tunnel_doh_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/civitai/cli/internal/dnsprobe"
+)
+
+// fakeDoHResolver is an injectable dnsprobe.Resolver for the probe tests.
+type fakeDoHResolver struct {
+	addrs []netip.Addr
+	err   error
+}
+
+func (f fakeDoHResolver) Resolve(context.Context, string) ([]netip.Addr, error) {
+	return f.addrs, f.err
+}
+
+// withResolver swaps the package devTunnelResolver for the duration of a test.
+func withResolver(t *testing.T, r dnsprobe.Resolver) {
+	t.Helper()
+	prev := devTunnelResolver
+	devTunnelResolver = r
+	t.Cleanup(func() { devTunnelResolver = prev })
+}
+
+// TestProbePublicTunnelDNSPending: when DoH authoritatively reports the tunnel host
+// isn't published yet, probePublicTunnel reports the DISTINCT dns-pending signal
+// (not-ready + dnsPendingDetail + the ErrNotPublished sentinel), NOT a hard error.
+func TestProbePublicTunnelDNSPending(t *testing.T) {
+	withResolver(t, fakeDoHResolver{err: fmt.Errorf("x: %w", dnsprobe.ErrNotPublished)})
+
+	ready, detail, err := probePublicTunnel(context.Background(), testTunnelHost)
+	if ready {
+		t.Fatal("a not-yet-published host must be NOT ready")
+	}
+	if detail != dnsPendingDetail {
+		t.Fatalf("detail = %q, want %q", detail, dnsPendingDetail)
+	}
+	if !errors.Is(err, dnsprobe.ErrNotPublished) {
+		t.Fatalf("err should carry ErrNotPublished, got %v", err)
+	}
+}
+
+// TestIsDNSPending: the mapping helper accepts either the detail marker or the
+// sentinel error, and rejects other not-ready reasons.
+func TestIsDNSPending(t *testing.T) {
+	if !isDNSPending(dnsPendingDetail, nil) {
+		t.Error("dnsPendingDetail should be DNS-pending")
+	}
+	if !isDNSPending("", fmt.Errorf("wrap: %w", dnsprobe.ErrNotPublished)) {
+		t.Error("ErrNotPublished sentinel should be DNS-pending")
+	}
+	if isDNSPending("http 404", nil) {
+		t.Error("a 404 (route not built) is NOT DNS-pending")
+	}
+	if isDNSPending("unreachable", errors.New("connection refused")) {
+		t.Error("a connection error is NOT DNS-pending")
+	}
+}
+
+// TestWaitForTunnelReachableDNSPendingLine: when the gate probe reports the
+// dns-pending state, the non-TTY heartbeat surfaces the DNS-specific line
+// ("waiting for DNS to publish for <host>") rather than the generic "still
+// waiting" — then, once DoH resolves, the wait completes ready.
+func TestWaitForTunnelReachableDNSPendingLine(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var errw syncBuffer
+	deps.errw = &errw // syncBuffer → non-TTY path
+	deps.readyPollInterval = 2 * time.Millisecond
+	deps.readyTimeout = 0 // indefinite
+	deps.quietInterval = 3 * time.Millisecond
+	deps.dnsPendingGrace = time.Millisecond // show the DNS line almost immediately
+
+	release := make(chan struct{})
+	deps.probePublic = func(_ context.Context, _ string) (bool, string, error) {
+		select {
+		case <-release:
+			return true, "http 401", nil
+		default:
+			// DoH says not published yet.
+			return false, dnsPendingDetail, fmt.Errorf("x: %w", dnsprobe.ErrNotPublished)
+		}
+	}
+
+	resc := make(chan bool, 1)
+	go func() {
+		ready, _ := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost, testTunnelURL)
+		resc <- ready
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for !strings.Contains(errw.String(), "waiting for DNS to publish for "+testTunnelHost) {
+		select {
+		case <-deadline:
+			t.Fatalf("no DNS-pending line appeared:\n%s", errw.String())
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	// It must be the DNS-specific line, not the generic one.
+	if strings.Contains(errw.String(), "still waiting for "+testTunnelHost) {
+		t.Errorf("should show the DNS-specific line, not the generic 'still waiting':\n%s", errw.String())
+	}
+
+	close(release)
+	select {
+	case ready := <-resc:
+		if !ready {
+			t.Fatal("wait should end ready once DoH resolves")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not finish after the host published")
+	}
+}
+
+// TestWaitForTunnelReachableDNSPendingIsNotFatal: the dns-pending result (a
+// not-ready + ErrNotPublished error) must NOT abort the wait — it keeps polling.
+// Distinct from a real abort (Ctrl-C / tunnel close). Here a positive readyTimeout
+// caps it non-fatally, proving dns-pending alone never returns an abort reason.
+func TestWaitForTunnelReachableDNSPendingIsNotFatal(t *testing.T) {
+	deps := baseDeps(t, &fakeTunnelAPI{}, &fakeDialer{}, newFakeTimer(), make(chan os.Signal))
+	var errw syncBuffer
+	deps.errw = &errw
+	deps.readyPollInterval = time.Millisecond
+	deps.readyTimeout = 40 * time.Millisecond // positive cap → non-fatal expiry
+	deps.dnsPendingGrace = time.Millisecond
+
+	deps.probePublic = func(context.Context, string) (bool, string, error) {
+		return false, dnsPendingDetail, fmt.Errorf("x: %w", dnsprobe.ErrNotPublished)
+	}
+
+	ready, abort := waitForTunnelReachable(context.Background(), deps, newFakeTunnel(), testTunnelHost, testTunnelURL)
+	if ready {
+		t.Fatal("never-published host should not be ready")
+	}
+	if abort != "" {
+		t.Fatalf("dns-pending must be non-fatal (no abort), got abort=%q", abort)
+	}
+}

--- a/internal/dnsprobe/doh.go
+++ b/internal/dnsprobe/doh.go
@@ -1,0 +1,258 @@
+// Package dnsprobe resolves a hostname via DNS-over-HTTPS (DoH) to Cloudflare,
+// bypassing the OS/local resolver, and builds an *http.Client that dials the
+// DoH-resolved IP for that host.
+//
+// WHY this exists: the dev-tunnel readiness probe GETs the freshly-minted
+// ephemeral host `dev-<16hex>.civit.ai` the instant the reverse tunnel binds —
+// BEFORE external-dns + Cloudflare have published the record. The OS resolver's
+// first lookup returns NXDOMAIN and NEGATIVE-CACHES it for up to the civit.ai
+// zone's SOA minimum TTL (1800s / 30 min, which Cloudflare does not let us
+// lower). That poisons the OS cache with two consequences:
+//  1. the CLI keeps seeing the cached NXDOMAIN and hangs "still waiting…" for up
+//     to 30 min even after the record goes live, and
+//  2. worse, the SAME poisoned OS-resolver cache breaks the user's BROWSER — when
+//     they open civitai.com/apps/dev/<blockId>, the iframe host `dev-*.civit.ai`
+//     won't resolve, so the app "doesn't render".
+//
+// Resolving the probe over DoH (a) lets the CLI see the record as soon as
+// Cloudflare has it (no local negative cache) and (b) CRUCIALLY never asks the OS
+// resolver about the not-yet-published host, so the OS negative cache is never
+// poisoned and the browser's later first query resolves cleanly.
+//
+// If DoH itself fails (e.g. 443 to Cloudflare is blocked), the client falls back
+// to the OS resolver so behavior is never worse than today.
+package dnsprobe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"time"
+)
+
+// ErrNotPublished is returned by a Resolver (via errors.Is) when the DoH server
+// AUTHORITATIVELY reports the name does not exist yet (NXDOMAIN) or resolved with
+// no A/AAAA answer — the "DNS hasn't propagated yet" signal. It is DISTINCT from
+// a transient DoH failure (network error, non-200, unparseable body), which is
+// returned as an ordinary error and triggers the OS-resolver fallback.
+var ErrNotPublished = errors.New("dns record not published yet")
+
+// DefaultDoHEndpoint is Cloudflare's DoH JSON endpoint (RFC 8484 JSON form).
+const DefaultDoHEndpoint = "https://cloudflare-dns.com/dns-query"
+
+// defaultDoHTimeout bounds a single DoH lookup so a hung Cloudflare request can't
+// stall a readiness poll.
+const defaultDoHTimeout = 5 * time.Second
+
+// Resolver resolves a hostname to IP addresses. Implementations MUST return
+// ErrNotPublished for an authoritative not-found (NXDOMAIN / no address answer)
+// and any OTHER error for a transient failure (so the caller can fall back to the
+// OS resolver only on transient failures, never masking a real NXDOMAIN).
+type Resolver interface {
+	Resolve(ctx context.Context, host string) ([]netip.Addr, error)
+}
+
+// DoHResolver resolves via a DNS-over-HTTPS JSON endpoint (Cloudflare by default).
+type DoHResolver struct {
+	// Endpoint is the DoH JSON URL. Empty → DefaultDoHEndpoint.
+	Endpoint string
+	// Client is the HTTP client used for the DoH request. Nil → a client with
+	// defaultDoHTimeout. NOTE: this client resolves the DoH ENDPOINT host
+	// (cloudflare-dns.com — a stable, long-published record) via the OS resolver;
+	// only the EPHEMERAL tunnel host is resolved over DoH. That is intentional and
+	// safe: the OS negative cache is only ever poisoned by a query for the
+	// not-yet-published host, which we never send to it.
+	Client *http.Client
+}
+
+// DefaultResolver is the production resolver: Cloudflare DoH JSON.
+var DefaultResolver Resolver = &DoHResolver{}
+
+// dohJSONResponse is the subset of the Cloudflare DoH JSON response we read.
+// Status is the DNS RCODE (0 = NOERROR, 3 = NXDOMAIN). Answer holds the records.
+type dohJSONResponse struct {
+	Status int `json:"Status"`
+	Answer []struct {
+		Name string `json:"name"`
+		Type int    `json:"type"` // RR type: 1 = A, 28 = AAAA, 5 = CNAME
+		TTL  int    `json:"TTL"`
+		Data string `json:"data"`
+	} `json:"Answer"`
+}
+
+const (
+	rcodeNXDOMAIN = 3
+	rrTypeA       = 1
+	rrTypeAAAA    = 28
+)
+
+// Resolve queries the DoH endpoint for A then (if none) AAAA records of host and
+// returns the resolved addresses. An authoritative not-found (NXDOMAIN, or
+// NOERROR with no address answer) is reported as ErrNotPublished; any transport
+// or protocol failure is returned as an ordinary (transient) error.
+func (r *DoHResolver) Resolve(ctx context.Context, host string) ([]netip.Addr, error) {
+	host = strings.TrimSuffix(strings.TrimSpace(host), ".")
+	if host == "" {
+		return nil, errors.New("dnsprobe: empty host")
+	}
+
+	// Query A first (CF-proxied dev hosts always have an A record); if the name
+	// exists but has no A, try AAAA before concluding "not published".
+	addrs, nxA, err := r.query(ctx, host, "A")
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) > 0 {
+		return addrs, nil
+	}
+	// No A answer. Try AAAA — but if the A query already said NXDOMAIN the name
+	// definitively doesn't exist, so skip the extra round-trip.
+	if !nxA {
+		aaaa, _, aerr := r.query(ctx, host, "AAAA")
+		if aerr == nil && len(aaaa) > 0 {
+			return aaaa, nil
+		}
+	}
+	// Name is NXDOMAIN, or NOERROR/NODATA with no address record yet → not
+	// published (from the readiness probe's point of view).
+	return nil, fmt.Errorf("%s: %w", host, ErrNotPublished)
+}
+
+// query performs one DoH JSON lookup and returns the address answers (of the
+// matching family), whether the response was NXDOMAIN, and a transient error.
+func (r *DoHResolver) query(ctx context.Context, host, qtype string) (addrs []netip.Addr, nxdomain bool, err error) {
+	endpoint := r.Endpoint
+	if endpoint == "" {
+		endpoint = DefaultDoHEndpoint
+	}
+	client := r.Client
+	if client == nil {
+		client = &http.Client{Timeout: defaultDoHTimeout}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	q := req.URL.Query()
+	q.Set("name", host)
+	q.Set("type", qtype)
+	req.URL.RawQuery = q.Encode()
+	// The JSON DoH form is selected by the Accept header.
+	req.Header.Set("Accept", "application/dns-json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, false, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("dnsprobe: DoH %s returned HTTP %d", endpoint, resp.StatusCode)
+	}
+	var parsed dohJSONResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, false, fmt.Errorf("dnsprobe: parse DoH response: %w", err)
+	}
+	if parsed.Status == rcodeNXDOMAIN {
+		return nil, true, nil
+	}
+	want := rrTypeA
+	if qtype == "AAAA" {
+		want = rrTypeAAAA
+	}
+	for _, a := range parsed.Answer {
+		if a.Type != want {
+			continue // skip CNAME/other RRs in the chain
+		}
+		if ip, perr := netip.ParseAddr(strings.TrimSpace(a.Data)); perr == nil {
+			addrs = append(addrs, ip)
+		}
+	}
+	return addrs, false, nil
+}
+
+// DialClient resolves host via the given Resolver and returns an *http.Client to
+// probe it with, dialing the DoH-resolved IP for host (TLS SNI + the Host header
+// are preserved automatically because the request URL still names host — only the
+// dial TARGET is overridden). The returned client's requests therefore NEVER
+// touch the OS resolver for host.
+//
+// Behavior:
+//   - resolver reports ErrNotPublished  → returns (nil, ErrNotPublished): the
+//     caller treats it as the "DNS not up yet" not-ready state.
+//   - resolver returns a transient error → FALLS BACK to a plain client that uses
+//     the OS resolver (returns (client, nil)) so we are never worse than today.
+//   - resolver succeeds                  → returns a client pinned to the resolved
+//     IP for host.
+//
+// timeout bounds the returned client's own requests.
+func DialClient(ctx context.Context, r Resolver, host string, timeout time.Duration) (*http.Client, error) {
+	if r == nil {
+		r = DefaultResolver
+	}
+	addrs, err := r.Resolve(ctx, host)
+	if err != nil {
+		if errors.Is(err, ErrNotPublished) {
+			// Authoritative NXDOMAIN/no-answer — surface it so the probe can report
+			// the distinct DNS-pending state (and, importantly, we never asked the OS
+			// resolver, so its negative cache stays clean for the browser).
+			return nil, err
+		}
+		// Transient DoH failure (443 blocked, timeout, bad body): fall back to the OS
+		// resolver so the probe still works — never worse than before this change.
+		return osResolverClient(timeout), nil
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("%s: %w", host, ErrNotPublished)
+	}
+	return pinnedClient(host, addrs, timeout), nil
+}
+
+// osResolverClient is a plain client that resolves via the OS resolver (the
+// fallback when DoH is unavailable).
+func osResolverClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}
+
+// pinnedClient returns an *http.Client whose transport dials the given resolved
+// address(es) whenever the request targets host, and otherwise dials normally.
+// Only the dial target is overridden — TLS ServerName and the Host header still
+// carry host, so certificate validation and virtual-host routing are unchanged.
+func pinnedClient(host string, addrs []netip.Addr, timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{Timeout: timeout}
+	// Pre-render the pinned IP once; prefer the first (an A record for a
+	// CF-proxied host is a stable anycast VIP).
+	pinned := addrs[0].String()
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(dctx context.Context, network, addr string) (net.Conn, error) {
+			reqHost, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				// No port? dial as given (shouldn't happen for http/https).
+				return dialer.DialContext(dctx, network, addr)
+			}
+			if strings.EqualFold(reqHost, host) {
+				return dialer.DialContext(dctx, network, net.JoinHostPort(pinned, port))
+			}
+			// A redirect to a different host — resolve it normally.
+			return dialer.DialContext(dctx, network, addr)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   timeout,
+		ExpectContinueTimeout: time.Second,
+	}
+	return &http.Client{Timeout: timeout, Transport: transport}
+}

--- a/internal/dnsprobe/doh.go
+++ b/internal/dnsprobe/doh.go
@@ -115,12 +115,19 @@ func (r *DoHResolver) Resolve(ctx context.Context, host string) ([]netip.Addr, e
 	// definitively doesn't exist, so skip the extra round-trip.
 	if !nxA {
 		aaaa, _, aerr := r.query(ctx, host, "AAAA")
-		if aerr == nil && len(aaaa) > 0 {
+		if aerr != nil {
+			// A returned clean NODATA but the AAAA follow-up failed TRANSIENTLY — we
+			// can't authoritatively conclude "not published" (there might be an AAAA we
+			// couldn't fetch). Propagate the transient error so the caller takes the
+			// fallback path rather than mis-classifying a blip as authoritative NXDOMAIN.
+			return nil, aerr
+		}
+		if len(aaaa) > 0 {
 			return aaaa, nil
 		}
 	}
-	// Name is NXDOMAIN, or NOERROR/NODATA with no address record yet → not
-	// published (from the readiness probe's point of view).
+	// Clean NXDOMAIN, or clean NOERROR/NODATA on BOTH A and AAAA with no address
+	// record yet → authoritatively not published (from the readiness probe's POV).
 	return nil, fmt.Errorf("%s: %w", host, ErrNotPublished)
 }
 
@@ -200,7 +207,7 @@ func DialClient(ctx context.Context, r Resolver, host string, timeout time.Durat
 	if r == nil {
 		r = DefaultResolver
 	}
-	addrs, err := r.Resolve(ctx, host)
+	addrs, err := resolveWithRetry(ctx, r, host)
 	if err != nil {
 		if errors.Is(err, ErrNotPublished) {
 			// Authoritative NXDOMAIN/no-answer — surface it so the probe can report
@@ -208,14 +215,42 @@ func DialClient(ctx context.Context, r Resolver, host string, timeout time.Durat
 			// resolver, so its negative cache stays clean for the browser).
 			return nil, err
 		}
-		// Transient DoH failure (443 blocked, timeout, bad body): fall back to the OS
-		// resolver so the probe still works — never worse than before this change.
+		// A transient DoH failure PERSISTED across the retry (443 blocked, timeout,
+		// bad body): fall back to the OS resolver so the probe still works — never
+		// worse than before this change. This is the LAST resort.
 		return osResolverClient(timeout), nil
 	}
 	if len(addrs) == 0 {
 		return nil, fmt.Errorf("%s: %w", host, ErrNotPublished)
 	}
 	return pinnedClient(host, addrs, timeout), nil
+}
+
+// dohRetryBackoff is the short pause between the first DoH resolve and its single
+// retry (bounded by the caller's ctx). Kept small so a lone hiccup on
+// cloudflare-dns.com is smoothed over without materially slowing a readiness poll.
+const dohRetryBackoff = 150 * time.Millisecond
+
+// resolveWithRetry resolves host, retrying ONCE on a TRANSIENT failure before
+// giving up. A transient blip on cloudflare-dns.com must NOT immediately trigger
+// the OS-resolver fallback — that fallback re-poisons the OS negative cache for
+// the unpublished host, the exact failure this package prevents. An authoritative
+// ErrNotPublished is returned immediately and NEVER retried (a real NXDOMAIN must
+// not fall back). A canceled ctx aborts the backoff promptly.
+func resolveWithRetry(ctx context.Context, r Resolver, host string) ([]netip.Addr, error) {
+	addrs, err := r.Resolve(ctx, host)
+	if err == nil || errors.Is(err, ErrNotPublished) {
+		return addrs, err
+	}
+	// First attempt failed transiently — pause briefly (interruptibly) then retry once.
+	timer := time.NewTimer(dohRetryBackoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return nil, err // keep the original transient error; caller falls back
+	case <-timer.C:
+	}
+	return r.Resolve(ctx, host)
 }
 
 // osResolverClient is a plain client that resolves via the OS resolver (the

--- a/internal/dnsprobe/doh_test.go
+++ b/internal/dnsprobe/doh_test.go
@@ -1,0 +1,191 @@
+package dnsprobe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// dohHandler returns an httptest handler that answers the Cloudflare DoH JSON API:
+// for name==liveName it returns an A record (ip); NXDOMAIN for nxName; and an empty
+// NOERROR answer otherwise. It asserts the request carries Accept: application/dns-json.
+func dohHandler(t *testing.T, liveName, ip, nxName string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/dns-json" {
+			t.Errorf("Accept = %q, want application/dns-json", got)
+		}
+		name := strings.TrimSuffix(r.URL.Query().Get("name"), ".")
+		qtype := r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/dns-json")
+		switch {
+		case name == liveName && qtype == "A":
+			fmt.Fprintf(w, `{"Status":0,"Answer":[{"name":%q,"type":5,"TTL":60,"data":"cname.example."},{"name":%q,"type":1,"TTL":60,"data":%q}]}`, name, name, ip)
+		case name == nxName:
+			// NXDOMAIN
+			fmt.Fprint(w, `{"Status":3,"Answer":[]}`)
+		default:
+			// NOERROR / NODATA (no address answer)
+			fmt.Fprint(w, `{"Status":0,"Answer":[]}`)
+		}
+	}
+}
+
+func TestDoHResolverAAnswer(t *testing.T) {
+	srv := httptest.NewServer(dohHandler(t, "dev-0123456789abcdef.civit.ai", "203.0.113.7", "nope.civit.ai"))
+	defer srv.Close()
+
+	r := &DoHResolver{Endpoint: srv.URL, Client: srv.Client()}
+	addrs, err := r.Resolve(context.Background(), "dev-0123456789abcdef.civit.ai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addrs) != 1 || addrs[0].String() != "203.0.113.7" {
+		t.Fatalf("addrs = %v, want [203.0.113.7]", addrs)
+	}
+}
+
+func TestDoHResolverNXDOMAIN(t *testing.T) {
+	srv := httptest.NewServer(dohHandler(t, "live.civit.ai", "203.0.113.7", "dev-deadbeefdeadbeef.civit.ai"))
+	defer srv.Close()
+
+	r := &DoHResolver{Endpoint: srv.URL, Client: srv.Client()}
+	_, err := r.Resolve(context.Background(), "dev-deadbeefdeadbeef.civit.ai")
+	if !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("NXDOMAIN should map to ErrNotPublished, got %v", err)
+	}
+}
+
+func TestDoHResolverEmptyAnswerIsNotPublished(t *testing.T) {
+	// A name that returns NOERROR but no A/AAAA answer (NODATA) — treated as
+	// not-published from the readiness probe's point of view.
+	srv := httptest.NewServer(dohHandler(t, "live.civit.ai", "203.0.113.7", "nx.civit.ai"))
+	defer srv.Close()
+
+	r := &DoHResolver{Endpoint: srv.URL, Client: srv.Client()}
+	_, err := r.Resolve(context.Background(), "empty.civit.ai")
+	if !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("empty answer should map to ErrNotPublished, got %v", err)
+	}
+}
+
+func TestDoHResolverNon200IsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	r := &DoHResolver{Endpoint: srv.URL, Client: srv.Client()}
+	_, err := r.Resolve(context.Background(), "dev-0123456789abcdef.civit.ai")
+	if err == nil {
+		t.Fatal("expected a transient error on non-200 DoH response")
+	}
+	if errors.Is(err, ErrNotPublished) {
+		t.Fatalf("a 502 from the DoH endpoint must NOT be classified as not-published (it's transient): %v", err)
+	}
+}
+
+// stubResolver is an injectable Resolver for DialClient tests.
+type stubResolver struct {
+	addrs []netip.Addr
+	err   error
+}
+
+func (s stubResolver) Resolve(context.Context, string) ([]netip.Addr, error) {
+	return s.addrs, s.err
+}
+
+// TestDialClientDialsResolvedIP: DialClient's client must dial the DoH-resolved IP
+// for the host while preserving the Host header (no OS resolution of the host).
+func TestDialClientDialsResolvedIP(t *testing.T) {
+	var gotHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL) // http://127.0.0.1:PORT
+	port := u.Port()
+
+	// Resolver claims the (never-DNS-registered) host resolves to 127.0.0.1 — the
+	// httptest server's address — so if the client actually dials the resolved IP,
+	// the request reaches the server even though "tunnel.example" has no DNS record.
+	r := stubResolver{addrs: []netip.Addr{netip.MustParseAddr("127.0.0.1")}}
+	client, err := DialClient(context.Background(), r, "tunnel.example", 3*time.Second)
+	if err != nil {
+		t.Fatalf("DialClient error: %v", err)
+	}
+	target := fmt.Sprintf("http://tunnel.example:%s/", port)
+	resp, err := client.Get(target)
+	if err != nil {
+		t.Fatalf("GET via pinned client failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if want := "tunnel.example:" + port; gotHost != want {
+		t.Fatalf("server saw Host %q, want %q (Host header must be preserved)", gotHost, want)
+	}
+}
+
+// TestDialClientNotPublished: an authoritative not-found is surfaced as
+// ErrNotPublished with no client (the caller treats it as the DNS-pending state).
+func TestDialClientNotPublished(t *testing.T) {
+	r := stubResolver{err: fmt.Errorf("x: %w", ErrNotPublished)}
+	client, err := DialClient(context.Background(), r, "tunnel.example", time.Second)
+	if !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("want ErrNotPublished, got err=%v", err)
+	}
+	if client != nil {
+		t.Fatalf("want nil client on not-published, got %v", client)
+	}
+}
+
+// TestDialClientEmptyAddrsNotPublished: a success with no addresses is also
+// not-published.
+func TestDialClientEmptyAddrsNotPublished(t *testing.T) {
+	r := stubResolver{addrs: nil, err: nil}
+	client, err := DialClient(context.Background(), r, "tunnel.example", time.Second)
+	if !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("want ErrNotPublished on empty addrs, got err=%v", err)
+	}
+	if client != nil {
+		t.Fatalf("want nil client, got %v", client)
+	}
+}
+
+// TestDialClientFallsBackOnTransientDoHFailure: a transient DoH error (e.g. 443 to
+// Cloudflare blocked) falls back to an OS-resolver client so behavior is never
+// worse than before — DialClient returns a usable client and no error.
+func TestDialClientFallsBackOnTransientDoHFailure(t *testing.T) {
+	r := stubResolver{err: errors.New("doh unreachable: connection refused")}
+	client, err := DialClient(context.Background(), r, "tunnel.example", time.Second)
+	if err != nil {
+		t.Fatalf("transient DoH failure must fall back, not error; got %v", err)
+	}
+	if client == nil {
+		t.Fatal("want a fallback (OS-resolver) client, got nil")
+	}
+	// The fallback client must reach a normal host via the OS resolver.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	resp, gerr := client.Get(srv.URL + "/")
+	if gerr != nil {
+		t.Fatalf("fallback client GET failed: %v", gerr)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fallback status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/dnsprobe/doh_test.go
+++ b/internal/dnsprobe/doh_test.go
@@ -189,3 +189,134 @@ func TestDialClientFallsBackOnTransientDoHFailure(t *testing.T) {
 		t.Fatalf("fallback status = %d, want 200", resp.StatusCode)
 	}
 }
+
+// TestDoHResolverANODATAWithAAAATransientIsTransient: when A returns a CLEAN
+// NODATA (NOERROR, no A records — not NXDOMAIN) and the AAAA follow-up fails
+// TRANSIENTLY, Resolve must propagate the transient error, NOT conclude
+// ErrNotPublished. Only a clean NODATA/NXDOMAIN on BOTH families is authoritative.
+func TestDoHResolverANODATAWithAAAATransientIsTransient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("type") {
+		case "A":
+			// Clean NOERROR / NODATA — the name exists but has no A record (yet).
+			w.Header().Set("Content-Type", "application/dns-json")
+			fmt.Fprint(w, `{"Status":0,"Answer":[]}`)
+		default: // AAAA
+			// Transient failure (e.g. Cloudflare 502).
+			w.WriteHeader(http.StatusBadGateway)
+		}
+	}))
+	defer srv.Close()
+
+	r := &DoHResolver{Endpoint: srv.URL, Client: srv.Client()}
+	_, err := r.Resolve(context.Background(), "dev-0123456789abcdef.civit.ai")
+	if err == nil {
+		t.Fatal("expected a transient error when the AAAA follow-up fails")
+	}
+	if errors.Is(err, ErrNotPublished) {
+		t.Fatalf("A-NODATA + transient-AAAA must NOT be authoritative not-published: %v", err)
+	}
+}
+
+// scriptedResolver returns queued results in order (one per Resolve call) and
+// counts calls — so a test can model "first attempt transient, second succeeds".
+type scriptedResolver struct {
+	steps []struct {
+		addrs []netip.Addr
+		err   error
+	}
+	calls int
+}
+
+func (s *scriptedResolver) Resolve(context.Context, string) ([]netip.Addr, error) {
+	i := s.calls
+	s.calls++
+	if i >= len(s.steps) {
+		i = len(s.steps) - 1 // repeat the last step for any extra calls
+	}
+	return s.steps[i].addrs, s.steps[i].err
+}
+
+// TestDialClientRetriesTransientThenSucceeds: a lone transient DoH hiccup must NOT
+// trigger the OS-resolver fallback (which would re-poison the negative cache) — one
+// retry is attempted, and when it succeeds DialClient returns a PINNED client
+// (dials the resolved IP; a fallback client would fail to OS-resolve tunnel.example).
+func TestDialClientRetriesTransientThenSucceeds(t *testing.T) {
+	var gotHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	port := u.Port()
+
+	r := &scriptedResolver{steps: []struct {
+		addrs []netip.Addr
+		err   error
+	}{
+		{nil, errors.New("doh timeout")},                      // first attempt: transient
+		{[]netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil}, // retry: success
+	}}
+
+	client, err := DialClient(context.Background(), r, "tunnel.example", 3*time.Second)
+	if err != nil {
+		t.Fatalf("DialClient error: %v", err)
+	}
+	if r.calls != 2 {
+		t.Fatalf("expected exactly one retry (2 resolve calls), got %d", r.calls)
+	}
+	resp, gerr := client.Get(fmt.Sprintf("http://tunnel.example:%s/", port))
+	if gerr != nil {
+		t.Fatalf("GET via pinned client failed (should be pinned, not OS-fallback): %v", gerr)
+	}
+	resp.Body.Close()
+	if want := "tunnel.example:" + port; gotHost != want {
+		t.Fatalf("server saw Host %q, want %q — client was not pinned to the resolved IP", gotHost, want)
+	}
+}
+
+// TestDialClientRetriesThenFallsBack: when BOTH the first attempt and the retry
+// fail transiently, DialClient falls back to the OS resolver (last resort) — and
+// it retried exactly once (2 resolve calls) before doing so.
+func TestDialClientRetriesThenFallsBack(t *testing.T) {
+	r := &scriptedResolver{steps: []struct {
+		addrs []netip.Addr
+		err   error
+	}{
+		{nil, errors.New("doh timeout #1")},
+		{nil, errors.New("doh timeout #2")},
+	}}
+
+	client, err := DialClient(context.Background(), r, "tunnel.example", time.Second)
+	if err != nil {
+		t.Fatalf("persistent transient failure must fall back, not error; got %v", err)
+	}
+	if client == nil {
+		t.Fatal("want a fallback (OS-resolver) client, got nil")
+	}
+	if r.calls != 2 {
+		t.Fatalf("expected exactly one retry before fallback (2 resolve calls), got %d", r.calls)
+	}
+}
+
+// TestDialClientNotPublishedIsNotRetried: an authoritative NXDOMAIN must be
+// returned immediately (no retry, no fallback) — the whole point of the fix.
+func TestDialClientNotPublishedIsNotRetried(t *testing.T) {
+	r := &scriptedResolver{steps: []struct {
+		addrs []netip.Addr
+		err   error
+	}{
+		{nil, fmt.Errorf("x: %w", ErrNotPublished)},
+	}}
+	client, err := DialClient(context.Background(), r, "tunnel.example", time.Second)
+	if !errors.Is(err, ErrNotPublished) {
+		t.Fatalf("want ErrNotPublished, got err=%v", err)
+	}
+	if client != nil {
+		t.Fatalf("want nil client (no fallback) on authoritative NXDOMAIN, got %v", client)
+	}
+	if r.calls != 1 {
+		t.Fatalf("ErrNotPublished must NOT be retried; got %d resolve calls", r.calls)
+	}
+}


### PR DESCRIPTION
## Problem (root-caused, confirmed live)

`civitai app dev-tunnel` mints an ephemeral `dev-<16hex>.civit.ai` tunnel host, then its readiness probes immediately GET `https://<host>/` using Go's default HTTP client — which resolves via the **OS/local resolver**. But external-dns + Cloudflare haven't published the record yet at that instant, so the probe's first lookup returns **NXDOMAIN**, and the local resolver **negative-caches** it for up to the civit.ai zone's SOA minimum TTL (**1800s / 30 min** — and Cloudflare does not allow lowering it). Consequences:

1. The CLI hangs `still waiting…` for up to 30 min even after the record goes live (the probe keeps getting the cached NXDOMAIN).
2. Worse: the poisoned OS-resolver cache also breaks the **browser** on the same machine — when the user opens `civitai.com/apps/dev/<blockId>`, the iframe host `dev-*.civit.ai` won't resolve → the app "doesn't render".

Verified on the affected machine: `dig <host>` via the local `127.0.0.1` resolver returns blank while `dig @1.1.1.1 <host>` resolves fine; the SOA min TTL is 1800.

## Fix — resolve the readiness probes via DoH (bypass the OS resolver)

New `internal/dnsprobe` package resolves a hostname via **DNS-over-HTTPS to Cloudflare** (JSON API: `GET https://cloudflare-dns.com/dns-query?name=<host>&type=A`, `Accept: application/dns-json`) and builds an `*http.Client` whose `Transport.DialContext` dials the DoH-resolved `<ip>:443` for `<host>` — TLS `ServerName` and the `Host` header are preserved (only the dial target is overridden).

Both dev-tunnel probes (`probePublicTunnel` gate probe and `probeLocalHopTunnel` local-hop probe) now use this client, so **neither touches the OS resolver** for the not-yet-published host. This:

- **(a)** lets the CLI see the record as soon as Cloudflare has it — no local negative cache, no 30-min hang; and
- **(b)** CRUCIALLY never poisons the OS resolver's negative cache, so the browser's later first query for the now-live record resolves and the app renders.

### Fallback
If DoH itself fails (e.g. 443 to Cloudflare is blocked), `dnsprobe.DialClient` falls back to the OS resolver — behavior is never worse than today. Only an **authoritative** NXDOMAIN/no-answer is treated as "not published yet"; a transient DoH failure (network / non-200 / unparseable) is not, and triggers the fallback.

### Better DNS-pending UX
When DoH returns NXDOMAIN/no-answer, the probe reports a **distinct** `dns-pending` not-ready state (vs a transport error). After a short grace period the readiness wait shows:

```
waiting for DNS to publish for <host> (external-dns + Cloudflare, usually <1 min)…
```

instead of the generic `still waiting`, distinguishing "DNS not up yet" from "tunnel/gate not ready".

### Preserved
Gate readiness classification (200/401/403), local-hop classification (Sec-Fetch-Dest subresource; 502/503/504 = local unreachable), indefinite wait, one-time nudge, snappy Ctrl-C, `--local-host`, the non-fatal `--ready-timeout` cap, and the non-TTY heartbeat. **DoH resolution is only for the probes' own HTTP requests** — the tunnel's SSH connection and the local dial are unchanged.

## Tests
- **`internal/dnsprobe`**: DoH JSON parse against an `httptest` server — A-record answer → IP; NXDOMAIN (Status 3) → `ErrNotPublished`; NOERROR/NODATA (empty answer) → `ErrNotPublished`; non-200 → transient error (NOT not-published). `DialClient` dials the DoH-resolved IP with the `Host` header preserved; not-published → `ErrNotPublished` with no client; transient DoH failure → OS-resolver fallback client.
- **`internal/cmd`**: `probePublicTunnel` maps a not-published DoH result → the `dns-pending` signal (not a hard error); the readiness wait surfaces the DNS-specific line and treats dns-pending as **non-fatal** (keeps waiting). All existing dev-tunnel / readiness tests stay green; the injected-probe deps kept everything testable on non-TTY buffers with no real network/DNS.

Gates: `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...`, and `go test -race ./internal/cmd/... ./internal/devtunnel/... ./internal/dnsprobe/...` all pass. The DoH JSON endpoint was reachable from the dev environment and returns exactly the parsed shape (verified live: A-records parse; a bogus name → NXDOMAIN → `ErrNotPublished`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
