### PR TITLE
fix(scaffold): dev server sends Access-Control-Allow-Origin so the null-origin dev-tunnel iframe can load ES modules

### DIFF
--- a/internal/scaffold/templates/page-money/src/dev-embed.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-embed.test.ts.tmpl
@@ -18,6 +18,14 @@ describe('dev-tunnel embeddability', () => {
     expect(csp).toContain(PROD_PARENT_ORIGIN); // https://civitai.com
   });
 
+  it('sets Access-Control-Allow-Origin:* so the null-origin sandboxed iframe can load ES modules', () => {
+    // The dev-tunnel embeds this server in App Blocks' PageBlockHost iframe,
+    // which is sandboxed with a null origin. Its ES-module fetches are CORS-
+    // blocked without ACAO, matching how prod app-blocks serve their modules.
+    const headers = devServerSecurityHeaders();
+    expect(headers['Access-Control-Allow-Origin']).toBe('*');
+  });
+
   it('does NOT set X-Frame-Options (would block the cross-origin embed)', () => {
     const headers = devServerSecurityHeaders();
     const keys = Object.keys(headers).map((k) => k.toLowerCase());

--- a/internal/scaffold/templates/page-money/src/dev-embed.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-embed.ts.tmpl
@@ -32,15 +32,32 @@ export const DEV_ALLOWED_HOSTS: string[] = ['localhost', DEV_TUNNEL_HOST_SUFFIX]
 
 /**
  * Response headers that make the dev server iframe-embeddable from the prod
- * parent. We set a `frame-ancestors` CSP scoped to civitai.com (+ self for the
- * plain local harness) and, critically, DO NOT set `X-Frame-Options` — an
- * `X-Frame-Options: DENY/SAMEORIGIN` would block the cross-origin embed
- * regardless of the CSP. (Vite sets no XFO by default; this documents + asserts
- * that invariant.)
+ * parent. Two headers, both DEV-ONLY:
+ *
+ * 1. `frame-ancestors` CSP scoped to civitai.com (+ self for the plain local
+ *    harness) so civitai.com may EMBED the dev server. Critically we DO NOT set
+ *    `X-Frame-Options` — an `X-Frame-Options: DENY/SAMEORIGIN` would block the
+ *    cross-origin embed regardless of the CSP. (Vite sets no XFO by default;
+ *    this documents + asserts that invariant.)
+ *
+ * 2. `Access-Control-Allow-Origin: *` so the ES modules load. The dev-tunnel
+ *    embeds this server inside App Blocks' `PageBlockHost` iframe, which is
+ *    sandboxed with a NULL origin. When that null-origin document fetches the
+ *    dev server's ES modules (`/src/main.tsx`, `/@vite/client`, …) the browser
+ *    applies CORS; without an `Access-Control-Allow-Origin` header it blocks
+ *    every module script ("from origin 'null' has been blocked by CORS policy").
+ *    `*` matches how PRODUCTION app-blocks are served (their module scripts
+ *    carry `access-control-allow-origin: *`), so the tunneled dev build behaves
+ *    like prod. This is safe here: the dev server is reachable only through the
+ *    authenticated dev-tunnel gate and is a local dev server; module-script
+ *    fetches are non-credentialed, so `*` (not a specific origin) is correct.
+ *    Like all `server.*` options this applies only to `vite dev`, never to a
+ *    `vite build` production bundle.
  */
 export function devServerSecurityHeaders(): Record<string, string> {
   return {
     'Content-Security-Policy': `frame-ancestors 'self' ${PROD_PARENT_ORIGIN}`,
+    'Access-Control-Allow-Origin': '*',
   };
 }
 


### PR DESCRIPTION
## Root cause (null-origin CORS)

`civitai app dev-tunnel` serves the author's **local** vite dev server into the production App Blocks `PageBlockHost` iframe — which is **sandboxed with a null origin**. The scaffold's `devServerSecurityHeaders()` (in `internal/scaffold/templates/page-money/src/dev-embed.ts.tmpl`) returned only a `Content-Security-Policy: frame-ancestors 'self' https://civitai.com` header. That lets civitai.com *embed* the dev server, but omits `Access-Control-Allow-Origin`. So when the null-origin iframe loads the dev server's ES modules (`/src/main.tsx`, `/@vite/client`, …) the browser CORS-blocks them:

> Access to script at 'https://dev-<hex>.civit.ai/src/main.tsx' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

## Fix

Add `'Access-Control-Allow-Origin': '*'` to `devServerSecurityHeaders()` (alongside the existing frame-ancestors CSP). Verified live: patching a real app's copy made `/src/main.tsx` + `/@vite/client` serve `access-control-allow-origin: *` through the tunnel, and the app then rendered in the prod host.

## Prod parity

Production app-blocks already serve their module scripts with `access-control-allow-origin: *` (verified on notepad.civit.ai). The tunneled dev build now matches that serving posture.

## Security rationale

`ACAO: *` on the dev server is safe here: the dev server is reachable **only through the authenticated dev-tunnel gate** and is a **local dev server**, and it matches the prod app-block serving posture. Module-script fetches are non-credentialed, so `*` (not a specific origin) is correct. **DEV-ONLY** — `server.*` options apply to `vite dev`, never to a production `vite build`.

## Scope

- Only **page-money** ships `dev:tunnel` + `devServerSecurityHeaders`; **page-vite** and **static** have no dev-tunnel/header helper and are untouched.
- `dev-embed.test.ts.tmpl` gains an assertion that `Access-Control-Allow-Origin: *` is present; the frame-ancestors assertion is kept intact.

## Gates

- `go build ./...`, `go vet ./...` — clean; `gofmt -l .` — empty; `go test ./...` — all pass.
- Replicated the CI `template-page-money` job locally: scaffold page-money → `npm install` → `npm run typecheck` (0) → `npm test` (**122 passed**, incl. the new dev-tunnel assertion).

## Follow-up

HMR-over-tunnel is a separate known follow-up (not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)