### PR TITLE
feat(ui): sweep remaining commands onto internal/ui + per-stream color + adaptive colors

### DIFF
--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -14,6 +14,7 @@ import (
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/internal/manifest"
 	"github.com/civitai/cli/internal/scaffold"
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -70,10 +71,12 @@ func tokenCanSpend(jwt string) bool {
 //   - credential can't spend + personal key → that key lacks AI Services.
 //
 // It's a pure function (canSpend from whoami, authKind from config) so the
-// branch logic is unit-testable without a network round-trip.
-func readOnlyTokenWarning(canSpend bool, authKind, slug string) string {
-	const header = "\n⚠  This token is READ-ONLY (no `ai:write:budgeted` scope) — " +
-		"`npm run dev:live` will NOT spend Buzz or generate; Generate dead-ends silently."
+// branch logic is unit-testable without a network round-trip. The header glyph +
+// color are resolved against sty's writer (the command's stderr) so color
+// follows that stream independently of stdout.
+func readOnlyTokenWarning(sty ui.Styler, canSpend bool, authKind, slug string) string {
+	header := "\n" + sty.Warn("This token is READ-ONLY (no `ai:write:budgeted` scope) — "+
+		"`npm run dev:live` will NOT spend Buzz or generate; Generate dead-ends silently.")
 	remint := "     civitai app dev-token " + slug + " --env >> .env.development.local   # re-mint, then restart dev:live"
 
 	switch {
@@ -182,7 +185,7 @@ never commit it; re-mint when it expires.`,
 				if id, whoErr := client.WhoAmI(context.Background()); whoErr == nil {
 					canSpend = id.CanSpendBuzz()
 				}
-				fmt.Fprintln(errOut, readOnlyTokenWarning(canSpend, cfg.AuthKind(), slug))
+				fmt.Fprintln(errOut, readOnlyTokenWarning(ui.For(errOut), canSpend, cfg.AuthKind(), slug))
 			}
 			return nil
 		},
@@ -227,9 +230,9 @@ func mintDevTokenWithRename(ctx context.Context, client *api.Client, errOut io.W
 		if serr := manifest.SetBlockID(dir, newSlug); serr != nil {
 			return "", slug, fmt.Errorf("could not update %s with the renamed slug %q: %w", manifest.Filename, newSlug, serr)
 		}
-		fmt.Fprintf(errOut,
-			"Slug %q is registered to another account — renamed to %q for your app (%s updated).\n",
-			slug, newSlug, manifest.Filename)
+		fmt.Fprintln(errOut, ui.For(errOut).Warn(fmt.Sprintf(
+			"Slug %q is registered to another account — renamed to %q for your app (%s updated).",
+			slug, newSlug, manifest.Filename)))
 		slug = newSlug
 	}
 }

--- a/internal/cmd/app_dev_token_warn_test.go
+++ b/internal/cmd/app_dev_token_warn_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
 )
 
 // makeJWT builds a syntactically-valid JWT whose payload carries the given
@@ -130,7 +132,7 @@ func TestReadOnlyTokenWarning(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := readOnlyTokenWarning(tc.canSpend, tc.authKind, "my-block")
+			got := readOnlyTokenWarning(ui.For(io.Discard), tc.canSpend, tc.authKind, "my-block")
 			if !strings.Contains(got, "READ-ONLY") {
 				t.Errorf("missing READ-ONLY header; got:\n%s", got)
 			}

--- a/internal/cmd/app_pull.go
+++ b/internal/cmd/app_pull.go
@@ -11,6 +11,7 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -160,15 +161,15 @@ func runAppPull(cmd *cobra.Command, fetch cloneInfoFetcher, app string, args []s
 		if err := gitRunner("", "-C", dir, "merge", "--ff-only", "FETCH_HEAD"); err != nil {
 			return fmt.Errorf("git merge --ff-only failed: %w", err)
 		}
-		fmt.Fprintf(out, "Synced %s.\n", info.Slug)
+		fmt.Fprintln(out, ui.Success(fmt.Sprintf("Synced %s.", info.Slug)))
 		// On the sync path the tokened URL is passed explicitly to `git fetch` and is
 		// NOT written to .git/config — so there's nothing to scrub from disk. The only
 		// exposure is the transient one: the token appeared in the git fetch child
 		// process's arguments while the fetch ran.
-		fmt.Fprintln(errOut,
-			"\n⚠  The fetch URL embedded your access token in the git command line — it was "+
+		fmt.Fprintf(errOut, "\n%s\n", ui.For(errOut).Warn(
+			"The fetch URL embedded your access token in the git command line — it was "+
 				"briefly visible to other local processes (via `ps` / /proc/<pid>/cmdline) "+
-				"while syncing. It was NOT persisted to .git/config.")
+				"while syncing. It was NOT persisted to .git/config."))
 		return nil
 	}
 
@@ -178,11 +179,11 @@ func runAppPull(cmd *cobra.Command, fetch cloneInfoFetcher, app string, args []s
 	if err := gitRunner("", "clone", "--", info.CloneURL, dir); err != nil {
 		return fmt.Errorf("git clone failed: %w", err)
 	}
-	fmt.Fprintf(out, "Cloned %s into %s.\n", info.Slug, dir)
+	fmt.Fprintln(out, ui.Success(fmt.Sprintf("Cloned %s into %s.", info.Slug, dir)))
 	// On the clone path git persists the tokened remote URL to .git/config, so the
 	// token now lives on disk. Surface the config-persistence caveat + the remedy.
-	fmt.Fprintln(errOut,
-		"\n⚠  The clone URL embeds your access token. git stored it in .git/config — "+
-			"do not commit or share it. To drop it: `git -C "+dir+" remote set-url origin "+info.HTTPURL+"`.")
+	fmt.Fprintf(errOut, "\n%s\n", ui.For(errOut).Warn(
+		"The clone URL embeds your access token. git stored it in .git/config — "+
+			"do not commit or share it. To drop it: `git -C "+dir+" remote set-url origin "+info.HTTPURL+"`."))
 	return nil
 }

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +80,7 @@ and deployed (deployState 'live').`,
 				return writeJSON(out, map[string]any{"submissions": subs})
 			}
 			if len(subs) == 0 {
-				fmt.Fprintln(out, "No submissions yet — run `civitai app submit` to create one.")
+				fmt.Fprintf(out, "No submissions yet — run %s to create one.\n", ui.Code("civitai app submit"))
 				return nil
 			}
 			printSubmissionTable(out, subs)
@@ -139,7 +140,7 @@ func printSubmissionDetail(w io.Writer, s *api.Submission) {
 		fmt.Fprintf(w, "\nApproval notes:\n  %s\n", *s.ApprovalNotes)
 	}
 	if s.LiveURL != nil && *s.LiveURL != "" {
-		fmt.Fprintf(w, "\nLive at: %s\n", *s.LiveURL)
+		fmt.Fprintf(w, "\nLive at: %s\n", ui.URL(*s.LiveURL))
 	} else {
 		fmt.Fprintf(w, "\nNot live yet — %s.civit.ai only serves after the app is approved and deployed (deployState 'live').\n", s.BlockID)
 	}

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -62,9 +62,10 @@ Defaults to the current directory.`,
 					return err
 				}
 				if !res.OK() {
-					fmt.Fprintln(cmd.ErrOrStderr(), ui.ErrorMsg(fmt.Sprintf("validation failed (%d error(s)) — fix before submitting, or pass --skip-validate:", len(res.Errors))))
+					errw := cmd.ErrOrStderr()
+					fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("validation failed (%d error(s)) — fix before submitting, or pass --skip-validate:", len(res.Errors))))
 					for _, e := range res.Errors {
-						fmt.Fprintf(cmd.ErrOrStderr(), "  - %s\n", e)
+						fmt.Fprintf(errw, "  - %s\n", e)
 					}
 					return fmt.Errorf("validation failed")
 				}

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/civitai/cli/internal/ui"
 	"github.com/civitai/cli/internal/validate"
 	"github.com/spf13/cobra"
 )
@@ -81,9 +82,10 @@ Defaults to the current directory.`,
 				return nil
 			}
 
-			// Hard errors always fail.
+			// Hard errors always fail. Style the header against stderr (per-stream
+			// color) so a colored stderr while stdout is piped still works.
 			if !res.OK() {
-				fmt.Fprintf(errw, "%d validation error(s) in %s:\n", len(res.Errors), dir)
+				fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("%d validation error(s) in %s:", len(res.Errors), dir)))
 				for _, e := range res.Errors {
 					fmt.Fprintf(errw, "  - %s\n", e)
 				}
@@ -98,11 +100,11 @@ Defaults to the current directory.`,
 				if strict {
 					return fmt.Errorf("validation failed: %d warning(s) with --strict", len(res.Warnings))
 				}
-				fmt.Fprintf(out, "OK (with %d warning(s)) — %s is valid\n", len(res.Warnings), dir)
+				fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s is valid (with %d warning(s))", dir, len(res.Warnings))))
 				return nil
 			}
 
-			fmt.Fprintf(out, "OK — %s is valid\n", dir)
+			fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s is valid", dir)))
 			return nil
 		},
 	}
@@ -146,8 +148,8 @@ func printWarnings(w io.Writer, res validate.Result) {
 	if !res.HasWarnings() {
 		return
 	}
-	fmt.Fprintf(w, "%d warning(s):\n", len(res.Warnings))
+	fmt.Fprintln(w, ui.For(w).Warn(fmt.Sprintf("%d warning(s):", len(res.Warnings))))
 	for _, warn := range res.Warnings {
-		fmt.Fprintf(w, "  ! %s\n", warn)
+		fmt.Fprintf(w, "  - %s\n", warn)
 	}
 }

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -8,6 +8,7 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +63,7 @@ Pass the publish-request id as a positional argument or via --id (find it with
 			if err := client.WithdrawRequest(ctx, id); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "✓ Withdrew %s\n", id)
+			fmt.Fprintln(cmd.OutOrStdout(), ui.Success(fmt.Sprintf("Withdrew %s", id)))
 			return nil
 		},
 	}

--- a/internal/cmd/buzz.go
+++ b/internal/cmd/buzz.go
@@ -8,6 +8,7 @@ import (
 	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +52,8 @@ how to switch to a personal key.`,
 				if errors.Is(err, api.ErrBuzzScope) {
 					// Actionable guidance + a non-zero exit (a 403 is a real,
 					// fixable failure, not "balance is zero").
-					fmt.Fprintln(cmd.ErrOrStderr(), buzzScopeHint)
+					errw := cmd.ErrOrStderr()
+					fmt.Fprintln(errw, ui.For(errw).Warn(buzzScopeHint))
 					return fmt.Errorf("credential can't read Buzz balance")
 				}
 				return err
@@ -68,7 +70,7 @@ how to switch to a personal key.`,
 				})
 			}
 
-			fmt.Fprintln(out, "Buzz balance:")
+			fmt.Fprintln(out, ui.Bold("Buzz balance:"))
 			fmt.Fprintf(out, "  Blue:   %d\n", acct.Blue)
 			fmt.Fprintf(out, "  Green:  %d\n", acct.Green)
 			fmt.Fprintf(out, "  Yellow: %d\n", acct.Yellow)

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -234,8 +234,8 @@ func TestAppValidateWarningsExitZero(t *testing.T) {
 	if !strings.Contains(errOut, "warning(s)") {
 		t.Errorf("stderr should list warnings: %s", errOut)
 	}
-	if !strings.Contains(out, "OK (with") {
-		t.Errorf("stdout should report OK-with-warnings: %s", out)
+	if !strings.Contains(out, "is valid") || !strings.Contains(out, "warning(s)") {
+		t.Errorf("stdout should report valid-with-warnings: %s", out)
 	}
 }
 

--- a/internal/cmd/update_notice.go
+++ b/internal/cmd/update_notice.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -137,15 +138,13 @@ func maybeNotifyUpdate(errW io.Writer, cmdName string, noFlag bool) {
 }
 
 // printDim writes s as a dim line to w, framed by a leading newline so it
-// visually separates from the command's own output. ANSI dim is only emitted
-// when w is the real terminal (we already gate on stderr being a TTY before
-// calling, but keep the escape minimal and safe).
+// visually separates from the command's own output. Color is resolved against w
+// itself (the command's stderr) via the shared ui layer — so ANSI is emitted
+// only when w is a real terminal, and NO_COLOR/--no-color suppress it. We
+// already gate on stderr being a TTY before calling, but routing through ui
+// keeps the escape handling in one place.
 func printDim(w io.Writer, s string) {
-	const (
-		dim   = "\033[2m"
-		reset = "\033[0m"
-	)
-	_, _ = io.WriteString(w, "\n"+dim+s+reset+"\n")
+	_, _ = io.WriteString(w, "\n"+ui.For(w).Dim(s)+"\n")
 }
 
 // spawnDetachedRefresh launches `civitai __update-check` as a detached

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/civitai/cli/internal/ui"
 	"github.com/minio/selfupdate"
 	"github.com/spf13/cobra"
 )
@@ -171,7 +172,7 @@ func runUpgrade(out io.Writer, force, noUpdateCheck bool) error {
 
 	// Already up to date? (current >= latest). --force overrides.
 	if !force && compareVersions(version, latest) >= 0 && isParseableVersion(version) {
-		fmt.Fprintf(out, "civitai is already up to date (%s).\n", version)
+		fmt.Fprintln(out, ui.Success(fmt.Sprintf("civitai is already up to date (%s).", version)))
 		return nil
 	}
 
@@ -188,8 +189,8 @@ func runUpgrade(out io.Writer, force, noUpdateCheck bool) error {
 
 	// Homebrew delegation (unless --force).
 	if !force && isHomebrewPath(resolved) {
-		fmt.Fprintln(out, "civitai was installed via Homebrew. Upgrade with:")
-		fmt.Fprintln(out, "  brew upgrade civitai/tap/civitai")
+		fmt.Fprintln(out, ui.Info("civitai was installed via Homebrew. Upgrade with:"))
+		fmt.Fprintf(out, "  %s\n", ui.Code("brew upgrade civitai/tap/civitai"))
 		return nil
 	}
 
@@ -258,7 +259,7 @@ func runUpgrade(out io.Writer, force, noUpdateCheck bool) error {
 		return fmt.Errorf("install update: %w", err)
 	}
 
-	fmt.Fprintf(out, "Upgraded civitai %s → %s.\n", version, latest)
+	fmt.Fprintln(out, ui.Success(fmt.Sprintf("Upgraded civitai %s → %s.", version, latest)))
 	return nil
 }
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/civitai/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -76,8 +77,8 @@ token. Skip it with --no-update-check or by setting CIVITAI_NO_UPDATE_CHECK.`,
 			// tagged go-install): release/Homebrew builds (or being online)
 			// carry the full commit + date.
 			if rCommit == "none" || rDate == "unknown" {
-				fmt.Fprintln(out, "  note:   build metadata is unavailable for this build;")
-				fmt.Fprintln(out, "          release/Homebrew builds (or running a tagged install online) carry the full commit + date.")
+				fmt.Fprintln(out, ui.Dim("  note:   build metadata is unavailable for this build;"))
+				fmt.Fprintln(out, ui.Dim("          release/Homebrew builds (or running a tagged install online) carry the full commit + date."))
 			}
 
 			if !disabled {

--- a/internal/ui/CONVENTION.md
+++ b/internal/ui/CONVENTION.md
@@ -94,16 +94,21 @@ escape. Re-assert this whenever you add a helper.
 - The cmd test package's `TestMain` forces `stdinIsTTY` OFF by default; opt back
   in per-test with a stubbed prompt.
 
-## Deferred to PR 2 (known limitations, intentionally not fixed in PR 1)
+## Per-stream color + adaptive colors (implemented in PR 2)
 
-- **Per-stream color resolution.** `ui.Configure` auto-detects color against a
-  single writer (stdout). Helpers written to *stderr* therefore inherit stdout's
-  TTY decision — e.g. `civitai whoami > file` (stdout redirected, stderr still a
-  TTY) disables color for a stderr status line too. Acceptable for now (the
-  invariant "piping disables ANSI" still holds); PR 2 can thread per-stream
-  enablement if a command needs colored stderr while stdout is piped.
-- **`lipgloss.AdaptiveColor` for contrast-sensitive styles.** The palette uses
-  fixed ANSI256 colors. On terminals whose background clashes (e.g. the cyan
-  `URL` / pink spinner on a light theme) contrast may be poor. PR 2 can switch
-  the contrast-sensitive styles (URL, spinner, maybe Dim) to `AdaptiveColor`
-  (light/dark variants) once we decide the light-mode palette.
+- **Per-stream color resolution.** The force overrides (`--no-color`/`NO_COLOR`,
+  `--color`/`CLICOLOR_FORCE`, `TERM=dumb`) are absolute and stream-independent;
+  the AUTO case is resolved **per-writer**. `ui.Configure` records the mode + the
+  bare-helper default writer (stdout); `ui.EnabledFor(w)` answers a specific
+  stream's enablement. The bare helpers (`ui.Success`, …) resolve against stdout;
+  a `ui.Printer` or `ui.For(w)` **Styler** resolves against the writer it renders
+  to. So `civitai app validate > file` on a TTY stderr gets a plain stdout and a
+  colored stderr. When a status line goes to **stderr**, bind `ui.For(errw)` (or
+  `ui.NewPrinter(errw)`) instead of the bare helper so color follows that stream.
+- **`lipgloss.AdaptiveColor` for contrast-sensitive styles.** The two genuinely
+  contrast-sensitive styles — `URL` (underlined cyan) and the spinner accent
+  (pink) — use `lipgloss.AdaptiveColor{Light, Dark}` so they stay legible on both
+  light and dark backgrounds. The `Dark` variant matches the historical fixed
+  color, and the `io.Discard` renderer resolves adaptive colors deterministically
+  (dark), so golden tests stay stable. `Dim`/`Bold`/`Success`/`Warn`/`ErrorMsg`/
+  `Code` keep their fixed profile (they read fine on both).

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -7,6 +7,12 @@
 //     PersistentPreRunE, via Configure. Precedence (highest first):
 //     --no-color / NO_COLOR (force OFF) > --color / CLICOLOR_FORCE (force ON) >
 //     auto (ON only when the target writer is a real TTY and TERM != "dumb").
+//   - The force overrides are ABSOLUTE and stream-independent. The auto case is
+//     resolved PER-WRITER: color is enabled for exactly the streams that are a
+//     real terminal. So a piped stdout with a still-TTY stderr yields plain
+//     stdout AND colored stderr — the bare helpers render against stdout (the
+//     configured default writer), a Printer/Styler renders against the writer it
+//     is bound to. See EnabledFor.
 //   - The styled-string helpers (Success, Warn, ErrorMsg, Info, Bold, Dim, URL,
 //     Code) RETURN strings so call sites keep using fmt.Fprintf and output stays
 //     composable + testable. When color is disabled every helper returns PLAIN
@@ -34,69 +40,158 @@ import (
 
 // Options configures color enablement. The flag bools come from the root
 // command's persistent --no-color / --color flags; Writer is the destination
-// status output is written to (used for the auto TTY check). The NO_COLOR /
-// CLICOLOR_FORCE / TERM environment variables are consulted by Configure itself.
+// the BARE helpers resolve their auto color against (typically stdout). The
+// NO_COLOR / CLICOLOR_FORCE / TERM environment variables are consulted by
+// Configure itself.
 type Options struct {
 	// NoColor is the resolved --no-color flag (force color OFF).
 	NoColor bool
 	// ForceColor is the resolved --color flag (force color ON even off a TTY).
 	ForceColor bool
-	// Writer is where status output goes; the auto path enables color only when
-	// this is a real terminal. Typically os.Stderr.
+	// Writer is where the bare helpers' output goes; the auto path enables their
+	// color only when this is a real terminal. Typically os.Stdout. A Printer or
+	// Styler bound to a different stream resolves auto against THAT stream.
 	Writer io.Writer
 }
 
-var (
-	mu      sync.RWMutex
-	enabled bool
+// colorMode is the resolved, stream-independent part of the color decision. The
+// force cases are absolute; modeAuto defers to the specific writer's TTY-ness.
+type colorMode int
 
-	styleSuccess lipgloss.Style
-	styleWarn    lipgloss.Style
-	styleError   lipgloss.Style
-	styleInfo    lipgloss.Style
-	styleBold    lipgloss.Style
-	styleDim     lipgloss.Style
-	styleURL     lipgloss.Style
-	styleCode    lipgloss.Style
-	spinnerStyle lipgloss.Style
+const (
+	// modeOff forces color off (default until Configure runs — the safe plain
+	// default so any helper called pre-configuration never leaks ANSI).
+	modeOff colorMode = iota
+	// modeOn forces color on regardless of the writer.
+	modeOn
+	// modeAuto enables color per-writer: on for a real TTY, off otherwise.
+	modeAuto
+)
+
+var (
+	mu sync.RWMutex
+	// mode is the resolved force/auto decision (stream-independent).
+	mode colorMode
+	// defaultWriter is what the bare package-level helpers resolve auto against
+	// (the configured Writer — stdout). nil means os.Stdout.
+	defaultWriter io.Writer
+)
+
+// isTerminal reports whether w is a real terminal we may color/animate on. It is
+// a package var so tests can simulate a TTY stream without a real terminal.
+var isTerminal = func(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok && f != nil {
+		return term.IsTerminal(int(f.Fd()))
+	}
+	return false
+}
+
+// styleSet is one fully-built palette (either the plain Ascii set or the colored
+// ANSI256 set). Both are built once at init and are immutable thereafter, so the
+// per-writer decision is a cheap pick between the two.
+type styleSet struct {
+	success lipgloss.Style
+	warn    lipgloss.Style
+	err     lipgloss.Style
+	info    lipgloss.Style
+	bold    lipgloss.Style
+	dim     lipgloss.Style
+	url     lipgloss.Style
+	code    lipgloss.Style
+	spinner lipgloss.Style
+}
+
+var (
+	plainStyles styleSet
+	colorStyles styleSet
 )
 
 func init() {
-	// Default to DISABLED (plain) until Configure runs, so any helper called
-	// before configuration never leaks ANSI. Build the plain style set.
-	rebuildStyles(false)
+	// Build BOTH palettes once. Enablement is now decided per-writer at render
+	// time (stylesFor), so both must always be available.
+	plainStyles = buildStyles(false)
+	colorStyles = buildStyles(true)
 }
 
-// Configure resolves color enablement from opts + environment and (re)builds the
-// style set. Call it once, early (the root PersistentPreRunE). Precedence:
+// buildStyles constructs a palette. When off, a renderer pinned to the Ascii
+// profile guarantees Render() emits zero ANSI; when on, ANSI256 gives a
+// deterministic, widely-supported palette (so golden tests of enabled output are
+// stable). The two contrast-sensitive styles (URL, spinner) use AdaptiveColor so
+// they stay legible on both light and dark terminal backgrounds; the Dark
+// variant matches the historical fixed color, and lipgloss resolves adaptive
+// colors deterministically here (the io.Discard renderer reports a dark
+// background) so golden tests remain stable.
+func buildStyles(on bool) styleSet {
+	r := lipgloss.NewRenderer(io.Discard)
+	if on {
+		r.SetColorProfile(termenv.ANSI256)
+	} else {
+		r.SetColorProfile(termenv.Ascii)
+	}
+	return styleSet{
+		success: r.NewStyle().Foreground(lipgloss.Color("42")),  // green
+		warn:    r.NewStyle().Foreground(lipgloss.Color("214")), // amber
+		err:     r.NewStyle().Foreground(lipgloss.Color("203")), // red
+		info:    r.NewStyle().Foreground(lipgloss.Color("39")),  // blue
+		bold:    r.NewStyle().Bold(true),
+		dim:     r.NewStyle().Faint(true),
+		// URL: underlined cyan on dark, a deeper blue on light (256-color 25) so
+		// it doesn't wash out on a white background.
+		url: r.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "25", Dark: "45"}).Underline(true),
+		// Code: magenta-ish — fixed is fine (reads on both).
+		code: r.NewStyle().Foreground(lipgloss.Color("170")),
+		// Spinner accent: pink on dark, a stronger magenta (162) on light.
+		spinner: r.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "162", Dark: "205"}),
+	}
+}
+
+// Configure resolves the color mode from opts + environment and records the
+// bare-helper default writer. Call it once, early (the root PersistentPreRunE).
+// Precedence:
 //
 //	--no-color / NO_COLOR      → OFF  (highest)
 //	--color   / CLICOLOR_FORCE → ON
-//	auto: TTY writer && TERM != "dumb"
+//	auto: per-writer TTY (TERM != "dumb")
 func Configure(o Options) {
-	on := resolveEnabled(o)
+	m := resolveMode(o)
+	w := o.Writer
 	mu.Lock()
 	defer mu.Unlock()
-	enabled = on
-	rebuildStyles(on)
+	mode = m
+	defaultWriter = w
 }
 
-// resolveEnabled applies the documented precedence. Split out (pure-ish, reads
-// env) so it is unit-testable via t.Setenv + a non-TTY Writer.
-func resolveEnabled(o Options) bool {
+// resolveMode applies the documented precedence for the stream-independent part
+// of the decision. Split out (pure-ish, reads env) so it is unit-testable via
+// t.Setenv.
+func resolveMode(o Options) colorMode {
 	// Force OFF wins over everything.
 	if o.NoColor || envSet("NO_COLOR") {
-		return false
+		return modeOff
 	}
 	// Force ON next.
 	if o.ForceColor || envTrue("CLICOLOR_FORCE") {
-		return true
+		return modeOn
 	}
-	// Auto: only on a real terminal with a capable TERM.
+	// A dumb terminal can't render our styling — treat as forced off.
 	if os.Getenv("TERM") == "dumb" {
-		return false
+		return modeOff
 	}
-	return isTerminal(o.Writer)
+	return modeAuto
+}
+
+// resolveEnabled resolves the full decision (mode + the writer's TTY-ness) for
+// o.Writer. Retained as the single-writer convenience used by the precedence
+// tests; the runtime path uses EnabledFor.
+func resolveEnabled(o Options) bool {
+	switch resolveMode(o) {
+	case modeOff:
+		return false
+	case modeOn:
+		return true
+	default:
+		return isTerminal(o.Writer)
+	}
 }
 
 // envSet reports whether name is present and non-empty (the NO_COLOR contract:
@@ -112,106 +207,121 @@ func envTrue(name string) bool {
 	return ok && v != "" && v != "0"
 }
 
-// isTerminal reports whether w is a real terminal we may color/animate on.
-func isTerminal(w io.Writer) bool {
-	if f, ok := w.(*os.File); ok && f != nil {
-		return term.IsTerminal(int(f.Fd()))
+// EnabledFor reports whether styled (colored) output is enabled for the specific
+// writer w. The force modes are absolute; in auto mode the answer is w's
+// TTY-ness — so color follows each stream independently (piped stdout off, TTY
+// stderr on).
+func EnabledFor(w io.Writer) bool {
+	mu.RLock()
+	m := mode
+	mu.RUnlock()
+	switch m {
+	case modeOff:
+		return false
+	case modeOn:
+		return true
+	default:
+		return isTerminal(w)
 	}
-	return false
 }
 
-// rebuildStyles constructs the style set for the given enablement. When off, a
-// renderer pinned to the Ascii profile guarantees Render() emits zero ANSI; when
-// on, ANSI256 gives a deterministic, widely-supported palette (so golden tests
-// of the enabled output are stable).
-func rebuildStyles(on bool) {
-	r := lipgloss.NewRenderer(io.Discard)
-	if on {
-		r.SetColorProfile(termenv.ANSI256)
-	} else {
-		r.SetColorProfile(termenv.Ascii)
+// Enabled reports whether styled output is on for the configured default writer
+// (stdout). Prefer EnabledFor(w) when the destination stream matters.
+func Enabled() bool { return EnabledFor(curDefaultWriter()) }
+
+// curDefaultWriter returns the writer the bare helpers resolve against.
+func curDefaultWriter() io.Writer {
+	mu.RLock()
+	w := defaultWriter
+	mu.RUnlock()
+	if w == nil {
+		return os.Stdout
 	}
-	styleSuccess = r.NewStyle().Foreground(lipgloss.Color("42")) // green
-	styleWarn = r.NewStyle().Foreground(lipgloss.Color("214"))   // amber
-	styleError = r.NewStyle().Foreground(lipgloss.Color("203"))  // red
-	styleInfo = r.NewStyle().Foreground(lipgloss.Color("39"))    // blue
-	styleBold = r.NewStyle().Bold(true)
-	styleDim = r.NewStyle().Faint(true)
-	styleURL = r.NewStyle().Foreground(lipgloss.Color("45")).Underline(true) // cyan
-	styleCode = r.NewStyle().Foreground(lipgloss.Color("170"))               // magenta-ish
-	spinnerStyle = r.NewStyle().Foreground(lipgloss.Color("205"))            // pink
+	return w
 }
 
-// Enabled reports whether styled (colored) output is on.
-func Enabled() bool {
-	mu.RLock()
-	defer mu.RUnlock()
-	return enabled
+// stylesFor picks the palette for w's resolved enablement.
+func stylesFor(w io.Writer) styleSet {
+	if EnabledFor(w) {
+		return colorStyles
+	}
+	return plainStyles
 }
 
-// ── styled-string helpers (return strings; plain when disabled) ──────────────
+// ── Styler: writer-bound styled-string rendering ─────────────────────────────
 
-// Success renders a "✓ <s>" success line in green (glyph kept when disabled).
-func Success(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleSuccess.Render("✓ " + s)
-}
+// Styler renders styled strings resolved against a SPECIFIC writer's color
+// enablement. Use it (via For) at stderr call sites where the bare helpers —
+// which resolve against stdout — would mis-decide (e.g. colored stderr while
+// stdout is piped). The methods mirror the package-level helpers.
+type Styler struct{ w io.Writer }
 
-// Warn renders a "⚠ <s>" warning line in amber.
-func Warn(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleWarn.Render("⚠ " + s)
-}
+// For returns a Styler bound to w.
+func For(w io.Writer) Styler { return Styler{w: w} }
 
-// ErrorMsg renders a "✗ <s>" error line in red.
-func ErrorMsg(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleError.Render("✗ " + s)
-}
+func (s Styler) set() styleSet { return stylesFor(s.w) }
+
+// Success renders a "✓ <str>" success line in green (glyph kept when disabled).
+func (s Styler) Success(str string) string { return s.set().success.Render("✓ " + str) }
+
+// Warn renders a "⚠ <str>" warning line in amber.
+func (s Styler) Warn(str string) string { return s.set().warn.Render("⚠ " + str) }
+
+// ErrorMsg renders a "✗ <str>" error line in red.
+func (s Styler) ErrorMsg(str string) string { return s.set().err.Render("✗ " + str) }
 
 // Info renders an informational line in blue (no glyph).
-func Info(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleInfo.Render(s)
-}
+func (s Styler) Info(str string) string { return s.set().info.Render(str) }
 
-// Bold renders s bold.
-func Bold(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleBold.Render(s)
-}
+// Bold renders str bold.
+func (s Styler) Bold(str string) string { return s.set().bold.Render(str) }
 
-// Dim renders s faint/dim.
-func Dim(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleDim.Render(s)
-}
+// Dim renders str faint/dim.
+func (s Styler) Dim(str string) string { return s.set().dim.Render(str) }
 
-// URL renders a URL in underlined cyan (the one thing a user must click).
-func URL(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleURL.Render(s)
-}
+// URL renders a URL in underlined cyan/blue.
+func (s Styler) URL(str string) string { return s.set().url.Render(str) }
 
 // Code renders inline code / a literal command.
-func Code(s string) string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return styleCode.Render(s)
-}
+func (s Styler) Code(str string) string { return s.set().code.Render(str) }
+
+// ── styled-string helpers (return strings; plain when disabled) ──────────────
+//
+// These resolve against the configured default writer (stdout). For output
+// written to a different stream (stderr), bind a Styler with For(w) so color
+// follows that stream.
+
+// Success renders a "✓ <s>" success line in green (glyph kept when disabled).
+func Success(s string) string { return For(curDefaultWriter()).Success(s) }
+
+// Warn renders a "⚠ <s>" warning line in amber.
+func Warn(s string) string { return For(curDefaultWriter()).Warn(s) }
+
+// ErrorMsg renders a "✗ <s>" error line in red.
+func ErrorMsg(s string) string { return For(curDefaultWriter()).ErrorMsg(s) }
+
+// Info renders an informational line in blue (no glyph).
+func Info(s string) string { return For(curDefaultWriter()).Info(s) }
+
+// Bold renders s bold.
+func Bold(s string) string { return For(curDefaultWriter()).Bold(s) }
+
+// Dim renders s faint/dim.
+func Dim(s string) string { return For(curDefaultWriter()).Dim(s) }
+
+// URL renders a URL in underlined cyan (the one thing a user must click).
+func URL(s string) string { return For(curDefaultWriter()).URL(s) }
+
+// Code renders inline code / a literal command.
+func Code(s string) string { return For(curDefaultWriter()).Code(s) }
 
 // ── Printer: an ergonomic writer-bound wrapper ───────────────────────────────
 
 // Printer binds an io.Writer so call sites can emit styled lines without
 // threading the writer through every helper. Each method writes ONE line
-// (newline-terminated). Nil-safe: a zero Printer writes to os.Stdout.
+// (newline-terminated) and resolves color against the BOUND writer, so a Printer
+// over stderr colors independently of stdout. Nil-safe: a zero Printer writes to
+// os.Stdout.
 type Printer struct {
 	w io.Writer
 }
@@ -226,37 +336,40 @@ func (p *Printer) writer() io.Writer {
 	return p.w
 }
 
+// styler returns a Styler bound to the Printer's writer (per-stream color).
+func (p *Printer) styler() Styler { return For(p.writer()) }
+
 // Successf writes a styled success line.
 func (p *Printer) Successf(format string, a ...any) {
-	fmt.Fprintln(p.writer(), Success(fmt.Sprintf(format, a...)))
+	fmt.Fprintln(p.writer(), p.styler().Success(fmt.Sprintf(format, a...)))
 }
 
 // Warnf writes a styled warning line.
 func (p *Printer) Warnf(format string, a ...any) {
-	fmt.Fprintln(p.writer(), Warn(fmt.Sprintf(format, a...)))
+	fmt.Fprintln(p.writer(), p.styler().Warn(fmt.Sprintf(format, a...)))
 }
 
 // Errorf writes a styled error line.
 func (p *Printer) Errorf(format string, a ...any) {
-	fmt.Fprintln(p.writer(), ErrorMsg(fmt.Sprintf(format, a...)))
+	fmt.Fprintln(p.writer(), p.styler().ErrorMsg(fmt.Sprintf(format, a...)))
 }
 
 // Infof writes a styled info line.
 func (p *Printer) Infof(format string, a ...any) {
-	fmt.Fprintln(p.writer(), Info(fmt.Sprintf(format, a...)))
+	fmt.Fprintln(p.writer(), p.styler().Info(fmt.Sprintf(format, a...)))
 }
 
 // ── spinner ──────────────────────────────────────────────────────────────────
 
 // Spinner returns a bubbles spinner model pre-styled to match the CLI's accent.
 // Callers embed it in their own bubbletea models (e.g. the dev-tunnel wait);
-// simple "spin while doing X" sites should use WithSpinner instead.
+// simple "spin while doing X" sites should use WithSpinner instead. The accent
+// is resolved against the default writer (stdout) — the spinner only animates on
+// a TTY, and --no-color forces it plain.
 func Spinner() spinner.Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	mu.RLock()
-	s.Style = spinnerStyle
-	mu.RUnlock()
+	s.Style = stylesFor(curDefaultWriter()).spinner
 	return s
 }
 

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -173,4 +174,138 @@ func TestWithSpinnerNonTTYSuccess(t *testing.T) {
 	if buf.String() != "Working…\n" {
 		t.Errorf("output = %q", buf.String())
 	}
+}
+
+// ── per-stream color resolution (PR 2) ───────────────────────────────────────
+
+// ttyBuf is a writer we can force isTerminal to treat as a real TTY, so
+// per-stream tests can simulate "stdout piped, stderr a terminal" without an
+// actual pty.
+type ttyBuf struct{ bytes.Buffer }
+
+// withFakeTTY overrides the isTerminal seam so that exactly the given writers
+// report as terminals, restoring the real check afterward.
+func withFakeTTY(t *testing.T, ttys ...io.Writer) {
+	t.Helper()
+	orig := isTerminal
+	t.Cleanup(func() { isTerminal = orig })
+	isTerminal = func(w io.Writer) bool {
+		for _, x := range ttys {
+			if x == w {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// TestPerStreamAuto is the headline PR-2 case: with AUTO color (no force
+// flags/env), a piped stdout stays plain while a TTY stderr is colored. The bare
+// helpers resolve against stdout (the configured default writer); a Styler bound
+// to stderr resolves against stderr.
+func TestPerStreamAuto(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("CLICOLOR_FORCE", "")
+	t.Setenv("TERM", "xterm")
+
+	var stdout bytes.Buffer // piped (non-TTY)
+	var stderr ttyBuf       // a real terminal
+	withFakeTTY(t, &stderr)
+
+	// Auto mode, default writer = stdout (piped).
+	Configure(Options{Writer: &stdout})
+	defer disable(t)
+
+	if EnabledFor(&stdout) {
+		t.Error("stdout is piped — EnabledFor(stdout) must be false in auto mode")
+	}
+	if !EnabledFor(&stderr) {
+		t.Error("stderr is a TTY — EnabledFor(stderr) must be true in auto mode")
+	}
+
+	// Bare helper → stdout decision → PLAIN.
+	if got := Warn("careful"); strings.Contains(got, esc) {
+		t.Errorf("bare Warn (stdout-resolved) must be plain when stdout is piped: %q", got)
+	}
+	// Styler over stderr → stderr decision → COLORED.
+	if got := For(&stderr).Warn("careful"); !strings.Contains(got, esc) {
+		t.Errorf("For(stderr).Warn must be colored when stderr is a TTY: %q", got)
+	}
+	// A Printer bound to stderr writes colored; to stdout writes plain.
+	var eb ttyBuf
+	withFakeTTY(t, &eb)
+	Configure(Options{Writer: &stdout})
+	NewPrinter(&eb).Errorf("boom")
+	if !strings.Contains(eb.String(), esc) {
+		t.Errorf("Printer(stderr-TTY).Errorf must be colored: %q", eb.String())
+	}
+	var ob bytes.Buffer
+	NewPrinter(&ob).Errorf("boom")
+	if strings.Contains(ob.String(), esc) {
+		t.Errorf("Printer(stdout-pipe).Errorf must be plain: %q", ob.String())
+	}
+}
+
+// TestPerStreamNoColorBothPlain: --no-color forces BOTH streams plain, even the
+// TTY one (force OFF is absolute).
+func TestPerStreamNoColorBothPlain(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr ttyBuf
+	withFakeTTY(t, &stderr)
+	Configure(Options{NoColor: true, Writer: &stdout})
+	defer disable(t)
+
+	if EnabledFor(&stdout) || EnabledFor(&stderr) {
+		t.Error("--no-color must disable color for every stream, TTY or not")
+	}
+	if strings.Contains(For(&stderr).Warn("x"), esc) {
+		t.Errorf("--no-color must keep even a TTY stderr plain")
+	}
+}
+
+// TestPerStreamForceColorBothColored: --color forces BOTH streams colored, even
+// a piped one (force ON is absolute).
+func TestPerStreamForceColorBothColored(t *testing.T) {
+	var stdout bytes.Buffer // piped
+	var stderr bytes.Buffer // piped
+	Configure(Options{ForceColor: true, Writer: &stdout})
+	defer disable(t)
+
+	if !EnabledFor(&stdout) || !EnabledFor(&stderr) {
+		t.Error("--color must enable color for every stream, piped or not")
+	}
+	if !strings.Contains(For(&stderr).Warn("x"), esc) {
+		t.Errorf("--color must color even a piped stderr")
+	}
+}
+
+// TestAdaptiveStylesColoredDeterministic: the two AdaptiveColor styles (URL,
+// spinner) still emit ANSI when enabled and resolve deterministically (same
+// bytes every call) so golden assertions stay stable.
+func TestAdaptiveStylesColoredDeterministic(t *testing.T) {
+	enable(t)
+	defer disable(t)
+	a := URL("https://civitai.com")
+	b := URL("https://civitai.com")
+	if !strings.Contains(a, esc) {
+		t.Errorf("URL should emit ANSI when enabled: %q", a)
+	}
+	if a != b {
+		t.Errorf("AdaptiveColor URL must render deterministically: %q vs %q", a, b)
+	}
+	// Deterministic Dark variant (256-color 45) is picked (the io.Discard
+	// renderer reports a dark background), so golden assertions stay stable.
+	if !strings.Contains(a, "38;5;45") {
+		t.Errorf("URL should resolve to the deterministic dark cyan (38;5;45): %q", a)
+	}
+	// The text survives (lipgloss splits underlined runs per-rune, so assert the
+	// characters are present in order rather than as one contiguous run).
+	for _, ch := range "https://civitai.com" {
+		if !strings.ContainsRune(a, ch) {
+			t.Errorf("URL dropped character %q: %q", ch, a)
+		}
+	}
+	// Spinner accent style is non-empty/renderable (adaptive) and plain when off.
+	sp := Spinner()
+	_ = sp // constructing it must not panic; style resolution happened.
 }


### PR DESCRIPTION
PR 2 of the CLI output modernization. PR 1 built `internal/ui` and converted a representative handful; this sweeps the remaining commands onto the helpers and implements the two deferred follow-ups.

## Part A — command sweep
Converted the human status/success/warn/error lines (matching `login`/`whoami`/`app submit`) in: **app status, app validate, app withdraw, app dev-token, app pull, buzz, version, upgrade**, and replaced the hand-rolled `\033[2m` dim escapes in `update_notice.go` with `ui.Dim`.

- **`completion`** emits only shell-eval'd script (no human text) — left untouched.
- **`app dev-tunnel`** was already converted — left untouched.
- **Invariant held:** every `--json` / structured path returns BEFORE any `ui.*` call, so machine-readable output stays raw (zero ANSI). No exit codes, flags, or parseable columns changed — only free-text human lines restyled (tabwriter tables left unstyled).

## Part B.1 — per-stream color resolution
The force overrides (`--no-color`/`NO_COLOR`, `--color`/`CLICOLOR_FORCE`, `TERM=dumb`) stay **absolute and stream-independent**; only the AUTO case is now resolved **per-writer**. `ui.Configure` records the mode + the bare-helper default writer (stdout); `ui.EnabledFor(w)` answers a specific stream. Bare helpers resolve against stdout; a `ui.Printer` or the new `ui.For(w)` **Styler** resolves against the stream it renders to. So a piped stdout + TTY stderr → plain stdout, colored stderr. Stderr status lines (submit/validate errors, pull/dev-token/buzz warnings, the update notice) now bind `ui.For(errw)`.

## Part B.2 — AdaptiveColor
The two genuinely contrast-sensitive styles — `URL` and the spinner accent — use `lipgloss.AdaptiveColor{Light, Dark}` so they read on light and dark backgrounds. The `Dark` variant matches the historical fixed color, and the `io.Discard` renderer resolves adaptive colors deterministically (dark) so golden tests stay stable. `Dim`/`Bold`/`Success`/`Warn`/`ErrorMsg`/`Code` keep fixed colors.

Removed the two PR-2 TODOs from `CONVENTION.md`.

## Tests / gates
- `go build ./...`, `go vet ./...`, `gofmt -s -l .` (empty), `go test ./...`, `go test -race ./internal/cmd/... ./internal/ui/...` — all green.
- New `ui` tests: stdout-pipe + stderr-TTY (auto) → plain stdout / colored stderr; `--no-color` → both plain; `--color` → both colored; adaptive URL colored + deterministic. Preserves the disabled→plain golden guarantee.
- Replicated the CI `template-page-money` job locally: scaffold → `npm install` → `typecheck` → `test` (122 passed) → `build` → `app validate` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
