### PR TITLE
fix(scaffold): route Vite HMR over the dev-tunnel (wss:443) so live-reload works in the tunneled iframe

### DIFF
--- a/internal/scaffold/dev_embed_render_test.go
+++ b/internal/scaffold/dev_embed_render_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,10 +78,11 @@ func TestPageMoneyEmitsEmbeddableDevServer(t *testing.T) {
 // server's own `ws://localhost:5186` — which the browser inside the tunneled
 // iframe can't reach, so live-reload silently fails on the tunnel. The wiring is:
 // the `dev:tunnel` script sets CIVITAI_DEV_TUNNEL_HMR=1, and vite.config reads it
-// to conditionally emit `server.hmr = { clientPort: 443, protocol: 'wss' }` with
+// to conditionally emit `server.ws = { clientPort: 443, protocol: 'wss' }` with
 // `host` LEFT UNSET (so the client derives the runtime-minted tunnel host from
 // location.hostname). Plain dev/dev:harness/dev:live must NOT force wss:443 (that
-// breaks local HMR) — hence the env gate.
+// breaks local HMR) — hence the env gate. (Vite 8.1 renamed the websocket options
+// from `server.hmr` to `server.ws`; the scaffold pins vite ^8.0.0 → 8.1.x+.)
 func TestPageMoneyDevTunnelRoutesHmrOverTunnel(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := Render(PageMoney, dir, Data{Slug: "my-block", Name: "My Block"}); err != nil {
@@ -103,21 +105,88 @@ func TestPageMoneyDevTunnelRoutesHmrOverTunnel(t *testing.T) {
 	}
 
 	// 2. vite.config gates the tunnel HMR block on that env var and, when set,
-	//    emits clientPort:443 + wss — WITHOUT hardcoding an `hmr.host` (the tunnel
-	//    host is minted at runtime; the client must fall back to location.hostname).
+	//    emits clientPort:443 + wss on `server.ws` — WITHOUT hardcoding a `ws.host`
+	//    (the tunnel host is minted at runtime; the client must fall back to
+	//    location.hostname).
 	viteCfg := read("vite.config.ts")
 	if !strings.Contains(viteCfg, "CIVITAI_DEV_TUNNEL_HMR") {
 		t.Errorf("vite.config.ts should gate tunnel HMR on CIVITAI_DEV_TUNNEL_HMR:\n%s", viteCfg)
 	}
 	if !strings.Contains(viteCfg, "clientPort: 443") {
-		t.Errorf("vite.config.ts should set hmr.clientPort: 443 for the tunnel")
+		t.Errorf("vite.config.ts should set ws.clientPort: 443 for the tunnel")
 	}
 	if !strings.Contains(viteCfg, "protocol: 'wss'") {
-		t.Errorf("vite.config.ts should set hmr.protocol: 'wss' for the tunnel")
+		t.Errorf("vite.config.ts should set ws.protocol: 'wss' for the tunnel")
+	}
+	// Vite 8.1 renamed the websocket options from `server.hmr` to `server.ws`; the
+	// scaffold pins vite ^8.0.0 (→ 8.1.x+) where `server.hmr`'s ws options are
+	// deprecated aliases. The tunnel block must use the current `ws:` key.
+	if !strings.Contains(viteCfg, "ws: { clientPort: 443, protocol: 'wss' }") {
+		t.Errorf("vite.config.ts should route tunnel HMR via `server.ws` (Vite 8.1), not the deprecated `server.hmr` ws options:\n%s", viteCfg)
 	}
 	// The client MUST derive the (runtime-minted) tunnel host from location.hostname
-	// — a hardcoded `hmr: { host: ... }` would pin the wrong host and break render.
-	if strings.Contains(viteCfg, "hmr: { host:") || strings.Contains(viteCfg, "hmr:{host:") {
-		t.Errorf("vite.config.ts must NOT hardcode hmr.host (tunnel host is runtime-minted):\n%s", viteCfg)
+	// — a hardcoded `ws: { host: ... }` would pin the wrong host and break render.
+	if strings.Contains(viteCfg, "ws: { host:") || strings.Contains(viteCfg, "ws:{host:") {
+		t.Errorf("vite.config.ts must NOT hardcode ws.host (tunnel host is runtime-minted):\n%s", viteCfg)
+	}
+}
+
+// TestPageMoneyPlainDevKeepsLocalHmr locks in the "gated OFF" side of the tunnel
+// HMR wiring: ONLY `dev:tunnel` may carry CIVITAI_DEV_TUNNEL_HMR. If the flag
+// leaked into plain `dev` / `dev:harness` / `dev:live` — or into ANY committed
+// `.env` file that `loadEnv(mode, cwd, ”)` reads (it applies `.env*` to EVERY
+// mode, plain dev included) — Vite would force wss:443 for local dev too and
+// silently break local ws HMR (the browser can't reach `wss://localhost:443`).
+// This is the counterpart to TestPageMoneyDevTunnelRoutesHmrOverTunnel, which
+// asserts the flag IS present on `dev:tunnel`.
+func TestPageMoneyPlainDevKeepsLocalHmr(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Render(PageMoney, dir, Data{Slug: "my-block", Name: "My Block"}); err != nil {
+		t.Fatalf("render page-money: %v", err)
+	}
+
+	read := func(rel string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return string(b)
+	}
+
+	const gate = "CIVITAI_DEV_TUNNEL_HMR"
+
+	// Parse scripts so we assert PER-SCRIPT — the flag legitimately lives on
+	// `dev:tunnel`, so a whole-file grep can't distinguish a leak from the intended
+	// use. Only the three plain-dev scripts must be clean.
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal([]byte(read("package.json")), &pkg); err != nil {
+		t.Fatalf("parse package.json: %v", err)
+	}
+	// Control assertion: dev:tunnel DOES carry the gate (proves the negative checks
+	// below aren't passing simply because the flag was dropped everywhere).
+	if !strings.Contains(pkg.Scripts["dev:tunnel"], gate) {
+		t.Errorf("dev:tunnel script should set %s (control):\n%q", gate, pkg.Scripts["dev:tunnel"])
+	}
+	for _, name := range []string{"dev", "dev:harness", "dev:live"} {
+		script, ok := pkg.Scripts[name]
+		if !ok {
+			t.Errorf("package.json missing expected %q script", name)
+			continue
+		}
+		if strings.Contains(script, gate) {
+			t.Errorf("plain %q script must NOT set %s (would force wss:443 → break local HMR):\n%q", name, gate, script)
+		}
+	}
+
+	// The gate must NOT appear in ANY committed .env file — loadEnv(mode, cwd, '')
+	// applies .env* to EVERY mode incl. plain dev, so a leak here would break local
+	// HMR for dev/dev:harness/dev:live regardless of the per-script gate above.
+	for _, envFile := range []string{".env.development", ".env.production", ".env.example"} {
+		if body := read(envFile); strings.Contains(body, gate) {
+			t.Errorf("%s must NOT contain %s (loadEnv applies it to plain dev too):\n%s", envFile, gate, body)
+		}
 	}
 }

--- a/internal/scaffold/dev_embed_render_test.go
+++ b/internal/scaffold/dev_embed_render_test.go
@@ -71,3 +71,53 @@ func TestPageMoneyEmitsEmbeddableDevServer(t *testing.T) {
 		t.Errorf("scaffold should ship src/dev-embed.test.ts: %v", err)
 	}
 }
+
+// TestPageMoneyDevTunnelRoutesHmrOverTunnel asserts the scaffold routes Vite HMR
+// over the reverse tunnel (`wss://dev-<hex>.civit.ai:443`) instead of the dev
+// server's own `ws://localhost:5186` — which the browser inside the tunneled
+// iframe can't reach, so live-reload silently fails on the tunnel. The wiring is:
+// the `dev:tunnel` script sets CIVITAI_DEV_TUNNEL_HMR=1, and vite.config reads it
+// to conditionally emit `server.hmr = { clientPort: 443, protocol: 'wss' }` with
+// `host` LEFT UNSET (so the client derives the runtime-minted tunnel host from
+// location.hostname). Plain dev/dev:harness/dev:live must NOT force wss:443 (that
+// breaks local HMR) — hence the env gate.
+func TestPageMoneyDevTunnelRoutesHmrOverTunnel(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Render(PageMoney, dir, Data{Slug: "my-block", Name: "My Block"}); err != nil {
+		t.Fatalf("render page-money: %v", err)
+	}
+
+	read := func(rel string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return string(b)
+	}
+
+	// 1. dev:tunnel sets the HMR gate env var (so config knows it's tunneling).
+	pkg := read("package.json")
+	if !strings.Contains(pkg, "CIVITAI_DEV_TUNNEL_HMR=1") {
+		t.Errorf("dev:tunnel script should set CIVITAI_DEV_TUNNEL_HMR=1:\n%s", pkg)
+	}
+
+	// 2. vite.config gates the tunnel HMR block on that env var and, when set,
+	//    emits clientPort:443 + wss — WITHOUT hardcoding an `hmr.host` (the tunnel
+	//    host is minted at runtime; the client must fall back to location.hostname).
+	viteCfg := read("vite.config.ts")
+	if !strings.Contains(viteCfg, "CIVITAI_DEV_TUNNEL_HMR") {
+		t.Errorf("vite.config.ts should gate tunnel HMR on CIVITAI_DEV_TUNNEL_HMR:\n%s", viteCfg)
+	}
+	if !strings.Contains(viteCfg, "clientPort: 443") {
+		t.Errorf("vite.config.ts should set hmr.clientPort: 443 for the tunnel")
+	}
+	if !strings.Contains(viteCfg, "protocol: 'wss'") {
+		t.Errorf("vite.config.ts should set hmr.protocol: 'wss' for the tunnel")
+	}
+	// The client MUST derive the (runtime-minted) tunnel host from location.hostname
+	// — a hardcoded `hmr: { host: ... }` would pin the wrong host and break render.
+	if strings.Contains(viteCfg, "hmr: { host:") || strings.Contains(viteCfg, "hmr:{host:") {
+		t.Errorf("vite.config.ts must NOT hardcode hmr.host (tunnel host is runtime-minted):\n%s", viteCfg)
+	}
+}

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -10,7 +10,7 @@
     "dev": "vite",
     "dev:harness": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=mock vite --host localhost --port 5186",
     "dev:live": "VITE_DEV_HARNESS=true VITE_HARNESS_MODE=live vite --host localhost --port 5186",
-    "dev:tunnel": "vite --host localhost --port 5186 --strictPort",
+    "dev:tunnel": "CIVITAI_DEV_TUNNEL_HMR=1 vite --host localhost --port 5186 --strictPort",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",

--- a/internal/scaffold/templates/page-money/src/dev-embed.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/dev-embed.test.ts.tmpl
@@ -26,6 +26,16 @@ describe('dev-tunnel embeddability', () => {
     expect(headers['Access-Control-Allow-Origin']).toBe('*');
   });
 
+  it('does NOT restrict connect-src, so the tunnel HMR wss socket is allowed', () => {
+    // `civitai app dev-tunnel` routes Vite HMR over `wss://<tunnel-host>/`. A
+    // `connect-src` CSP directive on the dev server would block that socket; the
+    // dev CSP is frame-ancestors-only. This guards a future CSP tightening from
+    // silently breaking tunnel live-reload.
+    const csp = devServerSecurityHeaders()['Content-Security-Policy'];
+    expect(csp).not.toContain('connect-src');
+    expect(csp).not.toContain('default-src');
+  });
+
   it('does NOT set X-Frame-Options (would block the cross-origin embed)', () => {
     const headers = devServerSecurityHeaders();
     const keys = Object.keys(headers).map((k) => k.toLowerCase());

--- a/internal/scaffold/templates/page-money/vite.config.ts.tmpl
+++ b/internal/scaffold/templates/page-money/vite.config.ts.tmpl
@@ -21,6 +21,21 @@ export default defineConfig(({ mode }) => {
   const hostKey = env.CIVITAI_HOST_KEY;
   const proxyTarget = env.VITE_LIVE_HOST_ORIGIN || 'https://civitai.com';
 
+  // `civitai app dev-tunnel` runs `dev:tunnel`, which sets CIVITAI_DEV_TUNNEL_HMR=1
+  // (see package.json). When tunneling, Vite's injected `@vite/client` must open
+  // its HMR socket over the PUBLIC tunnel host (`wss://dev-<16hex>.civit.ai:443`),
+  // NOT the dev server's own `ws://localhost:5186` — which the browser INSIDE the
+  // `dev-<hex>.civit.ai` iframe cannot reach (that's why HMR silently fails on the
+  // tunnel while a manual hard-reload still works). Setting `clientPort: 443` +
+  // `protocol: 'wss'` while LEAVING `hmr.host` UNSET makes the client derive the
+  // host from `location.hostname` — which, inside the tunneled iframe, IS the
+  // `dev-<hex>.civit.ai` host, and is minted at runtime AFTER Vite starts so it
+  // can't be hardcoded here. For plain `dev` / `dev:harness` / `dev:live` (flag
+  // unset) HMR stays at its DEFAULT local ws — forcing wss:443 there would BREAK
+  // local live-reload. Deterministic env gate, not a host heuristic.
+  const tunnelHmr =
+    env.CIVITAI_DEV_TUNNEL_HMR === '1' || env.CIVITAI_DEV_TUNNEL_HMR === 'true';
+
   return {
   base: '/',
   // civitaiSetupPlugin is `apply: 'serve'` (dev-only) — it powers the dev:live
@@ -48,6 +63,9 @@ export default defineConfig(({ mode }) => {
     // See src/dev-embed.ts (single source of truth + tests).
     allowedHosts: DEV_ALLOWED_HOSTS,
     headers: devServerSecurityHeaders(),
+    // Route HMR over the tunnel ONLY when `dev:tunnel` set the gate flag (see
+    // `tunnelHmr` above). Spread-in so plain dev leaves `server.hmr` at default.
+    ...(tunnelHmr ? { hmr: { clientPort: 443, protocol: 'wss' } } : {}),
     // dev:live backend proxy. In live mode the SDK's createLiveHost fetches
     // /api/... with `backendBaseUrl: ''` (see src/dev-transport.ts) so the
     // browser hits THIS dev server SAME-ORIGIN — no cross-origin preflight (N1).

--- a/internal/scaffold/templates/page-money/vite.config.ts.tmpl
+++ b/internal/scaffold/templates/page-money/vite.config.ts.tmpl
@@ -26,13 +26,16 @@ export default defineConfig(({ mode }) => {
   // its HMR socket over the PUBLIC tunnel host (`wss://dev-<16hex>.civit.ai:443`),
   // NOT the dev server's own `ws://localhost:5186` — which the browser INSIDE the
   // `dev-<hex>.civit.ai` iframe cannot reach (that's why HMR silently fails on the
-  // tunnel while a manual hard-reload still works). Setting `clientPort: 443` +
-  // `protocol: 'wss'` while LEAVING `hmr.host` UNSET makes the client derive the
-  // host from `location.hostname` — which, inside the tunneled iframe, IS the
-  // `dev-<hex>.civit.ai` host, and is minted at runtime AFTER Vite starts so it
-  // can't be hardcoded here. For plain `dev` / `dev:harness` / `dev:live` (flag
-  // unset) HMR stays at its DEFAULT local ws — forcing wss:443 there would BREAK
-  // local live-reload. Deterministic env gate, not a host heuristic.
+  // tunnel while a manual hard-reload still works). The websocket knobs live on
+  // `server.ws` (Vite 8.1 renamed the old `server.hmr` websocket options —
+  // `clientPort`/`protocol`/`host`/… — to `server.ws`; the `server.hmr` aliases
+  // are deprecated). Setting `clientPort: 443` + `protocol: 'wss'` while LEAVING
+  // `ws.host` UNSET makes the client derive the host from `location.hostname` —
+  // which, inside the tunneled iframe, IS the `dev-<hex>.civit.ai` host, and is
+  // minted at runtime AFTER Vite starts so it can't be hardcoded here. For plain
+  // `dev` / `dev:harness` / `dev:live` (flag unset) HMR stays at its DEFAULT local
+  // ws — forcing wss:443 there would BREAK local live-reload. Deterministic env
+  // gate, not a host heuristic.
   const tunnelHmr =
     env.CIVITAI_DEV_TUNNEL_HMR === '1' || env.CIVITAI_DEV_TUNNEL_HMR === 'true';
 
@@ -64,8 +67,8 @@ export default defineConfig(({ mode }) => {
     allowedHosts: DEV_ALLOWED_HOSTS,
     headers: devServerSecurityHeaders(),
     // Route HMR over the tunnel ONLY when `dev:tunnel` set the gate flag (see
-    // `tunnelHmr` above). Spread-in so plain dev leaves `server.hmr` at default.
-    ...(tunnelHmr ? { hmr: { clientPort: 443, protocol: 'wss' } } : {}),
+    // `tunnelHmr` above). Spread-in so plain dev leaves `server.ws` at default.
+    ...(tunnelHmr ? { ws: { clientPort: 443, protocol: 'wss' } } : {}),
     // dev:live backend proxy. In live mode the SDK's createLiveHost fetches
     // /api/... with `backendBaseUrl: ''` (see src/dev-transport.ts) so the
     // browser hits THIS dev server SAME-ORIGIN — no cross-origin preflight (N1).


### PR DESCRIPTION
## Problem

App Blocks authors run their block locally and `civitai app dev-tunnel <id>` exposes it as `dev-<16hex>.civit.ai`, iframed by `https://civitai.com/apps/dev/<id>`. The app **renders** end-to-end, but **HMR does not flow** — a local edit does not auto-reload (a manual hard-reload does).

## Root cause

The page-money scaffold's `vite.config.ts` sets no `server.hmr`, so Vite's injected `@vite/client` defaults its HMR socket to the dev server's own host/port → `ws://localhost:5186`, which the browser **inside** the `dev-<hex>.civit.ai` iframe cannot reach. HMR must instead go over the tunnel: `wss://<tunnel-host>:443/`.

Constraint: the tunnel host is minted at runtime (after Vite starts) and changes every run, so it can't be hardcoded. With `server.hmr.host` unset, Vite's client falls back to `location.hostname` — which inside the iframe IS `dev-<hex>.civit.ai`.

## Fix

- `dev:tunnel` script sets `CIVITAI_DEV_TUNNEL_HMR=1`.
- `vite.config.ts` reads it (via the existing `loadEnv(mode, cwd, '')` at config time) and, only when set, emits `server.hmr = { clientPort: 443, protocol: 'wss' }` — `host` left unset. Plain `dev`/`dev:harness`/`dev:live` keep default local ws HMR (forcing wss:443 there would break local live-reload).

Deterministic env gate, not a host heuristic.

## Coverage

- `dev_embed_render_test.go`: new `TestPageMoneyDevTunnelRoutesHmrOverTunnel` — asserts `dev:tunnel` sets the flag, config gates on it, emits `clientPort: 443` + `protocol: 'wss'`, and does NOT hardcode `hmr.host`.
- `src/dev-embed.test.ts`: asserts the dev CSP has no `connect-src`/`default-src` that would block the HMR wss (guards a future CSP tightening).

`go test ./...` green, `go vet ./...` clean, `gofmt` clean.

## Not verified

Actual live-reload requires a real moderator browser walk on the author's laptop (the auth path uses an invisible Turnstile that blocks headless automation). Verified: config renders correctly, all tests pass. The companion gate change (civitai repo) makes the ws upgrade pass deterministically at the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)