### PR TITLE
feat(app): center dev-tunnel in create next-steps + fill tunnel startup silence

### DIFF
--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -60,21 +60,28 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	if !strings.Contains(stdout, "1. cd ") || !strings.Contains(stdout, "npm install") {
 		t.Errorf("create should print a numbered cd+install step:\n%s", stdout)
 	}
-	// Harness-aware next steps (page-money needs the mock host).
-	if !strings.Contains(stdout, "dev:harness") {
-		t.Errorf("create should print dev:harness next step:\n%s", stdout)
+	// The DEV TUNNEL is the highlighted prod-fidelity preview path.
+	if !strings.Contains(stdout, "civitai app dev-tunnel") {
+		t.Errorf("create should highlight the dev-tunnel preview step:\n%s", stdout)
 	}
-	// The mock-vs-live clarification must survive (a placeholder Generate
-	// result is the mock, not a bug).
-	if !strings.Contains(stdout, "MOCK") {
-		t.Errorf("create should flag dev:harness as a MOCK host:\n%s", stdout)
-	}
-	if !strings.Contains(stdout, "dev:live") {
-		t.Errorf("create should point at dev:live for a real generation:\n%s", stdout)
-	}
-	// Validate is folded into the submit step.
-	if !strings.Contains(stdout, "civitai app submit") {
+	// submit must precede the tunnel (the tunnel resolves the app server-side, so
+	// it must be registered first).
+	iSubmit := strings.Index(stdout, "civitai app submit")
+	iTunnel := strings.Index(stdout, "civitai app dev-tunnel")
+	if iSubmit < 0 {
 		t.Errorf("create should print the submit next step:\n%s", stdout)
+	}
+	if iSubmit >= 0 && iTunnel >= 0 && iSubmit > iTunnel {
+		t.Errorf("submit must be sequenced BEFORE the dev-tunnel step (register first):\n%s", stdout)
+	}
+	// The harness remains as the single-line offline/mock fallback tip.
+	if !strings.Contains(stdout, "dev:harness") {
+		t.Errorf("create should keep the dev:harness fallback tip:\n%s", stdout)
+	}
+	// The trimmed message drops the old multi-line Buzz/OAuth/personal-key
+	// paragraph (dev:live now lives in dev-token/README, not the scaffold banner).
+	if strings.Contains(stdout, "dev:live") {
+		t.Errorf("create next steps should NOT re-bloat with the dev:live Buzz paragraph:\n%s", stdout)
 	}
 
 	assertScaffoldValid(t, dest)

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -343,6 +343,18 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 		}
 	}
 
+	// Immediate feedback: the mint round-trip + SSH dial below take a few seconds
+	// with NOTHING printed otherwise, so the terminal looks hung. Emit a status line
+	// the instant the session starts. Written to errw (status stream) as a single
+	// plain line so the TTY and non-TTY paths are identical + greppable — we
+	// deliberately do NOT wrap the mint+dial in an animated bubbletea spinner here:
+	// runTunnelSession has an active signal.Notify(d.signals), and a default
+	// bubbletea program (without WithoutSignalHandler) would race that handler for
+	// the SIGINT/SIGTERM during this pre-serving phase. The reachability wait below
+	// already animates the longer wait (waitTunnelTTY) with the signal-safe watcher
+	// design.
+	fmt.Fprintf(d.errw, "%s\n", ui.Dim(fmt.Sprintf("Establishing dev tunnel for %s… (minting session + opening SSH tunnel)", d.blockID)))
+
 	key, err := d.keygen()
 	if err != nil {
 		return fmt.Errorf("generate ephemeral tunnel key: %w", err)
@@ -530,7 +542,6 @@ func printTunnelReady(out io.Writer, sess *api.DevTunnelSession, localHost strin
 	fmt.Fprintf(out, "\nDev tunnel ready — serving %s:%d as %s\n\n", localHostForDisplay(localHost), port, ui.Bold(sess.Host))
 	fmt.Fprintf(out, "  ▶ Open this in your browser (you must be logged in):\n\n")
 	fmt.Fprintf(out, "      %s\n\n", ui.URL(sess.URL))
-	fmt.Fprintf(out, "  Make sure your dev server is running (%s) on %s:%d.\n", ui.Code("npm run dev:tunnel"), localHostForDisplay(localHost), port)
 	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
 }
 
@@ -550,7 +561,6 @@ func printTunnelReadyTimeout(out io.Writer, sess *api.DevTunnelSession, localHos
 	fmt.Fprintf(out, "  This is usually just DNS + Cloudflare + route propagation — it can take a minute.\n")
 	fmt.Fprintf(out, "  The tunnel is UP; open the URL and retry in a bit if it NXDOMAINs / 404s / 502s:\n\n")
 	fmt.Fprintf(out, "      %s\n\n", ui.URL(sess.URL))
-	fmt.Fprintf(out, "  Make sure your dev server is running (%s) on %s:%d.\n", ui.Code("npm run dev:tunnel"), localHostForDisplay(localHost), port)
 	fmt.Fprintf(out, "  Press Ctrl-C to tear the tunnel down.\n\n")
 }
 

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -1119,6 +1119,16 @@ func TestRunTunnelSessionReadyPrintsConfirmedURL(t *testing.T) {
 	if !strings.Contains(errw.String(), "Waiting for it to become reachable") {
 		t.Errorf("expected the 'established, waiting' status on stderr:\n%s", errw.String())
 	}
+	// Change 2: the immediate startup status fills the previously-silent mint+dial
+	// window (printed BEFORE keygen/mint, so the terminal never looks hung).
+	if !strings.Contains(errw.String(), "Establishing dev tunnel for my-block") {
+		t.Errorf("expected the immediate 'establishing' status on stderr:\n%s", errw.String())
+	}
+	// Change 3: the redundant "Make sure your dev server is running" line is gone —
+	// probeLocal already guaranteed the dev server was listening before the mint.
+	if strings.Contains(out.String(), "Make sure your dev server is running") {
+		t.Errorf("ready block must NOT print the redundant dev-server-running noise:\n%s", out.String())
+	}
 }
 
 // TestRunTunnelSessionReadinessTimeoutNonFatal: when the host never becomes
@@ -1151,6 +1161,10 @@ func TestRunTunnelSessionReadinessTimeoutNonFatal(t *testing.T) {
 	if !strings.Contains(out.String(), "isn't resolving/serving yet") {
 		t.Errorf("timeout path must print the warning:\n%s", out.String())
 	}
+	// Change 3: the timeout block also drops the redundant dev-server-running noise.
+	if strings.Contains(out.String(), "Make sure your dev server is running") {
+		t.Errorf("timeout block must NOT print the redundant dev-server-running noise:\n%s", out.String())
+	}
 	// The readiness timeout is non-fatal: nothing torn down, session still alive.
 	if apiStub.stopCount() != 0 {
 		t.Errorf("readiness timeout must NOT tear the tunnel down; stop calls=%d", apiStub.stopCount())
@@ -1178,9 +1192,10 @@ func TestRunTunnelSessionNoWaitSkipsProbe(t *testing.T) {
 	dialer := &fakeDialer{tunnel: tunnel}
 	timer := newFakeTimer()
 	sigs := make(chan os.Signal, 1)
-	var out syncBuffer
+	var out, errw syncBuffer
 	deps := baseDeps(t, apiStub, dialer, timer, sigs)
 	deps.out = &out
+	deps.errw = &errw
 	deps.noWait = true
 	deps.probePublic = func(context.Context, string) (bool, string, error) {
 		t.Error("probePublic must NOT be called when --no-wait is set")
@@ -1202,6 +1217,15 @@ func TestRunTunnelSessionNoWaitSkipsProbe(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "✓ Ready") || strings.Contains(out.String(), "isn't resolving") {
 		t.Errorf("--no-wait must use the plain ready block (no wait outcome):\n%s", out.String())
+	}
+	// Change 2: even on --no-wait (which pre-probes then skips the reachability
+	// wait), the immediate startup status still fills the mint+dial window.
+	if !strings.Contains(errw.String(), "Establishing dev tunnel for my-block") {
+		t.Errorf("--no-wait must still print the immediate 'establishing' status:\n%s", errw.String())
+	}
+	// Change 3: the plain ready block drops the redundant dev-server-running noise.
+	if strings.Contains(out.String(), "Make sure your dev server is running") {
+		t.Errorf("--no-wait ready block must NOT print the redundant dev-server-running noise:\n%s", out.String())
 	}
 }
 

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -188,17 +188,19 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 	fmt.Fprintln(out, "\n"+ui.Bold("Next steps:"))
 	switch {
 	case tmpl.NeedsHarness():
-		// SDK/page-money apps render blank under plain `dev` (no host) — the
-		// dev loop needs the mock host via `dev:harness`. Keep the mock-vs-live
-		// distinction as a clearly-separate tip so a placeholder "Generate"
-		// result isn't mistaken for a broken real generation.
+		// SDK/page-money apps preview best via the DEV TUNNEL — your LOCAL code
+		// rendered INSIDE the real Civitai host (real session/Buzz/pickers),
+		// prod-fidelity. The tunnel resolves the app server-side, so it must be
+		// registered first: `civitai app submit` creates the (pending) app row that
+		// `civitai app dev-tunnel` then resolves — hence submit precedes the tunnel.
+		// dev-tunnel is cohort-gated, so the harness tip is the offline/mock
+		// fallback for quick iteration (or authors not yet in the cohort).
 		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
-		fmt.Fprintln(out, "  2. npm run dev:harness      # preview locally — MOCK host, no real Buzz")
-		fmt.Fprintln(out, "  3. civitai app submit       # validate + submit for review")
+		fmt.Fprintln(out, "  2. civitai app submit      # validate + register (required before a dev tunnel)")
+		fmt.Fprintln(out, "  3. npm run dev:tunnel      # in another terminal: serve your app for the tunnel")
+		fmt.Fprintln(out, "  4. civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
 		fmt.Fprintln(out)
-		fmt.Fprintln(out, "  Real generation (spends real Buzz)? npm run dev:live needs a full-scope personal API")
-		fmt.Fprintln(out, "  key: create at https://civitai.com/user/account, then `civitai login --token <key>`.")
-		fmt.Fprintln(out, "  An OAuth `civitai login` can submit/withdraw but cannot spend Buzz (check `civitai whoami`).")
+		fmt.Fprintln(out, "  Quick offline iteration, or not in the tunnel cohort? npm run dev:harness (mock host, no Buzz).")
 	case tmpl == scaffold.PageVite:
 		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev              # preview locally")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -143,9 +143,13 @@ func TestAppInitPageMoneyTemplate(t *testing.T) {
 			t.Errorf("page-money should scaffold %s: %v", f, err)
 		}
 	}
-	// Next steps must use dev:harness (plain `dev` renders blank without a host).
+	// Next steps center the dev-tunnel (prod-fidelity preview) and keep dev:harness
+	// as the offline/mock fallback tip. Plain `dev` renders blank without a host.
+	if !strings.Contains(out, "civitai app dev-tunnel") {
+		t.Errorf("page-money next steps should highlight the dev-tunnel: %s", out)
+	}
 	if !strings.Contains(out, "npm run dev:harness") {
-		t.Errorf("page-money next steps should mention dev:harness: %s", out)
+		t.Errorf("page-money next steps should keep the dev:harness fallback: %s", out)
 	}
 	if strings.Contains(out, "npm run dev\n") {
 		t.Errorf("page-money next steps should NOT suggest plain `npm run dev`: %s", out)


### PR DESCRIPTION
Four related dev-tunnel DX polish changes, all off \`main\` (not stacked on #105).

## Change 1 — \`app create\`/\`app init\` next-steps center the dev-tunnel
The page-money/SDK "Next steps" now lead with the dev-tunnel prod-fidelity preview (your LOCAL code rendered inside the real Civitai host) and drop the old multi-line Buzz/OAuth/personal-key paragraph (that guidance already lives in \`dev-tunnel --help\`, \`dev-token\`, and the whoami/403 enrichment).

**Correctness gate:** a fresh scaffolded \`block.manifest.json\` DOES carry a non-empty \`blockId\` (= the slug), but \`blocks.startDevTunnel\` resolves the app server-side via \`resolveDevPageBlockForAuthor\` (owned \`appBlock\` row, any status). A brand-new never-submitted app has no such row → NOT_FOUND. So \`civitai app submit\` (which registers the app as pending) is sequenced BEFORE the tunnel step. \`dev:harness\` stays as a one-line offline/mock fallback (the tunnel is cohort-gated).

New sequence:
\`\`\`
  1. cd <dir> && npm install
  2. civitai app submit      # validate + register (required before a dev tunnel)
  3. npm run dev:tunnel      # in another terminal: serve your app for the tunnel
  4. civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity

  Quick offline iteration, or not in the tunnel cohort? npm run dev:harness (mock host, no Buzz).
\`\`\`

## Change 2 — fill the silent mint+dial window
\`dev-tunnel\` now prints \`Establishing dev tunnel for <blockId>…\` the instant the session starts (after the local pre-flight, before keygen/mint/dial), so the terminal no longer looks hung during the network mint + SSH handshake. Single plain line on stderr → TTY and non-TTY identical. Intentionally NOT an animated \`ui.WithSpinner\` here: it would race the active \`signal.Notify(d.signals)\` for SIGINT/SIGTERM during the pre-serving phase (the reachability wait below already animates the longer wait with the signal-safe watcher design).

## Change 3 — drop the "Make sure your dev server is running" noise
Removed from both \`printTunnelReady\` and \`printTunnelReadyTimeout\`. \`probeLocal\` is a fail-fast pre-flight before minting on every production path (\`RunE\` wires \`probeLocal: probeLocalDevServer\`, and \`--no-wait\` pre-probes too), so the dev server is guaranteed to have been listening by the time these print. The genuine "tunnel up but local hop now failing" case is still handled by the rate-limited local-hop notice.

## Change 4 — create→tunnel auto-detect (no code change)
Confirmed: the scaffolded manifest's \`blockId\` is non-empty, so \`dev-tunnel\` with no args auto-detects it (no required-error). The real gate is server-side registration — an unsubmitted app hits NOT_FOUND, which Change 1's submit-first sequencing makes coherent. No bug found.

## Verification
- \`gofmt -l .\` → empty
- \`go vet ./...\` → clean
- \`go test ./...\` → all pass
- Rendered the actual \`app create\` output to confirm shape.

**Not verified (needs a manual run):** the live interactive tunnel (mod/cohort account + invisible-Turnstile browser). The output shape + wiring are unit-tested; the real end-to-end tunnel was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)