### PR TITLE
fix(dev-tunnel): name the subdomain in the readiness-wait message

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -415,7 +415,7 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	if d.noWait {
 		printTunnelReady(d.out, sess, d.localHost, d.port)
 	} else {
-		fmt.Fprintf(d.errw, "\nDev tunnel established — serving %s:%d as %s. Waiting for it to become reachable…\n", localHostForDisplay(d.localHost), d.port, sess.Host)
+		fmt.Fprintf(d.errw, "\nDev tunnel established — serving %s:%d as %s. Waiting for %s…\n", localHostForDisplay(d.localHost), d.port, sess.Host, sess.Host)
 		ready, abortReason := waitForTunnelReachable(ctx, d, tunnel, sess.Host, sess.URL)
 		if abortReason != "" {
 			// The dev aborted (Ctrl-C / ctx) or the tunnel dropped DURING the wait —
@@ -1000,7 +1000,7 @@ func (m *tunnelWaitModel) View() string {
 	case m.dnsPending && time.Since(m.start) >= m.dnsGrace:
 		return fmt.Sprintf("%s Waiting for DNS to publish for %s (external-dns + Cloudflare, usually <1 min)… %s elapsed", m.sp.View(), m.host, elapsed)
 	default:
-		return fmt.Sprintf("%s Waiting for %s to come up… %s elapsed", m.sp.View(), m.host, elapsed)
+		return fmt.Sprintf("%s Waiting for %s… %s elapsed", m.sp.View(), m.host, elapsed)
 	}
 }
 

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -1116,8 +1116,8 @@ func TestRunTunnelSessionReadyPrintsConfirmedURL(t *testing.T) {
 	if !strings.Contains(out.String(), sampleSession().URL) {
 		t.Errorf("ready path must print the /apps/dev URL:\n%s", out.String())
 	}
-	if !strings.Contains(errw.String(), "Waiting for it to become reachable") {
-		t.Errorf("expected the 'established, waiting' status on stderr:\n%s", errw.String())
+	if !strings.Contains(errw.String(), "Waiting for "+sampleSession().Host) {
+		t.Errorf("expected the 'established, waiting for <subdomain>' status on stderr:\n%s", errw.String())
 	}
 	// Change 2: the immediate startup status fills the previously-silent mint+dial
 	// window (printed BEFORE keygen/mint, so the terminal never looks hung).


### PR DESCRIPTION
The dev-tunnel readiness-wait messaging now names the tunnel host instead of the generic "Waiting for it to become reachable…".

- `internal/cmd/app_dev_tunnel.go` line ~418 (non-`--no-wait` path): `Waiting for it to become reachable…` → `Waiting for <sess.Host>…` (e.g. `Waiting for dev-<hex>.civit.ai…`). The `established — serving …` prefix is unchanged.
- `View()` spinner line (~1003): `Waiting for %s to come up…` → `Waiting for %s…` (host, `m.host`). The DNS-publish line is unchanged (still references the host).

Copy-only; no control-flow, timing, or readiness-logic changes. Test assertion updated to check the host appears in the wait line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)