### PR TITLE
fix(dev-tunnel): clearer 401 (login) + 404 (register-first) errors

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1127,11 +1127,20 @@ func devTunnelError(status int, raw []byte) error {
 	}
 	switch status {
 	case http.StatusUnauthorized:
-		return fmt.Errorf("not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)", msg)
+		// A 401 here is always a missing/expired/invalid credential; the server
+		// message on this path is the origin-gate string ("Please use the public
+		// API instead"), which is misleading to a CLI user. Drop it — the only
+		// action is `civitai login`.
+		return fmt.Errorf("not logged in (401) — run `civitai login` (or set CIVITAI_TOKEN)")
 	case http.StatusForbidden:
 		return &DevTunnelForbiddenError{ServerMsg: msg, InsufficientScope: isInsufficientScopeMsg(msg)}
 	case http.StatusNotFound:
-		return fmt.Errorf("app not found (404): %s — check the blockId with `civitai app status` (you can only tunnel your OWN app)", msg)
+		// blocks.startDevTunnel resolves the app via an owned appBlock row of ANY
+		// status; a brand-new app (just `civitai app create`d) has no server-side
+		// row yet → NOT_FOUND. Lead with the new-app path (register with `civitai
+		// app submit`, which POSTs submit-version to create the pending row the
+		// tunnel then resolves), then the wrong-slug/not-yours case.
+		return fmt.Errorf("app not registered to your account (404): %s — if it's a new app, register it first with `civitai app submit`; otherwise verify the blockId with `civitai app status` (you can only tunnel your OWN app)", msg)
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
 	case http.StatusServiceUnavailable:

--- a/internal/api/dev_tunnel_test.go
+++ b/internal/api/dev_tunnel_test.go
@@ -153,7 +153,7 @@ func TestStartDevTunnelErrorMapping(t *testing.T) {
 		want   string
 	}{
 		{http.StatusForbidden, "not available"},
-		{http.StatusNotFound, "app not found"},
+		{http.StatusNotFound, "app not registered"},
 		{http.StatusUnauthorized, "not logged in"},
 		{http.StatusServiceUnavailable, "unavailable (503)"},
 	}
@@ -173,6 +173,56 @@ func TestStartDevTunnelErrorMapping(t *testing.T) {
 		if !strings.Contains(err.Error(), tc.want) {
 			t.Errorf("status %d: error %q should contain %q", tc.status, err.Error(), tc.want)
 		}
+	}
+}
+
+// TestStartDevTunnel401DropsServerMessage: on this path a 401 is always a
+// missing/expired/invalid credential, and the server's tRPC message is the
+// misleading origin-gate string ("Please use the public API instead"). The
+// mapped error must NOT echo it — it should just tell the user to log in.
+func TestStartDevTunnel401DropsServerMessage(t *testing.T) {
+	const serverMsg = "Please use the public API instead"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": serverMsg}},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "tok", "")
+	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if strings.Contains(err.Error(), serverMsg) {
+		t.Errorf("401 error %q should NOT echo the server message %q", err.Error(), serverMsg)
+	}
+	if !strings.Contains(err.Error(), "civitai login") {
+		t.Errorf("401 error %q should tell the user to run `civitai login`", err.Error())
+	}
+}
+
+// TestStartDevTunnel404MentionsRegister: a 404 is the common new-app case (an
+// app just `civitai app create`d has no server-side row yet), so the error must
+// lead the user to register it with `civitai app submit`.
+func TestStartDevTunnel404MentionsRegister(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"json": map[string]any{"message": "not found"}},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "tok", "")
+	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "civitai app submit") {
+		t.Errorf("404 error %q should mention `civitai app submit`", err.Error())
+	}
+	if !strings.Contains(err.Error(), "civitai app status") {
+		t.Errorf("404 error %q should still mention `civitai app status` for the not-yours case", err.Error())
 	}
 }
 


### PR DESCRIPTION
Two user-facing error-message fixes in `devTunnelError` (`internal/api/api.go`), mapping non-200 `blocks.startDevTunnel` responses.

## Fix 1 — 401 no longer echoes the misleading server text
On this path a 401 is always a missing/expired/invalid credential, and the server's tRPC message is the origin-gate string "Please use the public API instead" — meaningless to a CLI user. Dropped the `%s` server-message interpolation; kept the `(401)` code.

- Before: ``not logged in (401): %s — run `civitai login` (or set CIVITAI_TOKEN)``
- After: ``not logged in (401) — run `civitai login` (or set CIVITAI_TOKEN)``

## Fix 2 — 404 leads with the new-app register-first case
`blocks.startDevTunnel` resolves the app via an owned `appBlock` row of ANY status. A brand-new app (just `civitai app create`d) has no server-side row yet → NOT_FOUND. The old text pointed at "wrong slug / not yours," the wrong diagnosis for the common new-app case. `civitai app submit` (POST `/api/v1/blocks/submit-version`) creates the pending row the tunnel then resolves — verified via the flow + the `app_init.go` comment.

- Before: ``app not found (404): %s — check the blockId with `civitai app status` (you can only tunnel your OWN app)``
- After: ``app not registered to your account (404): %s — if it's a new app, register it first with `civitai app submit`; otherwise verify the blockId with `civitai app status` (you can only tunnel your OWN app)``

Did not thread `blockID` into the message (KISS — the wording already covers both cases clearly).

## Tests
Updated `TestStartDevTunnelErrorMapping` (404 substring `app not found` → `app not registered`) and added `TestStartDevTunnel401DropsServerMessage` (asserts the 401 does NOT echo the server msg + tells the user to `civitai login`) and `TestStartDevTunnel404MentionsRegister` (asserts `civitai app submit` + still mentions `civitai app status`).

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)