### PR TITLE
feat(cli): dev-tunnel passes local manifest scopes as declaredScopes

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -930,7 +930,7 @@ func devTokenError(status int, raw []byte) error {
 // The `civitai app dev-tunnel` command drives three tRPC procedures on the
 // `blocks` router (civitai/civitai src/server/routers/blocks.router.ts):
 //
-//   - blocks.startDevTunnel  (mutation) input  { blockId, sshPublicKey }
+//   - blocks.startDevTunnel  (mutation) input  { blockId, sshPublicKey, declaredScopes? }
 //                                      result { sessionId, host, url, expiresAt, spendCapBuzz }
 //   - blocks.stopDevTunnel   (mutation) input  { sessionId? , blockId? } (one required)
 //                                      result { ok, stopped }
@@ -981,18 +981,24 @@ type DevTunnelSession struct {
 // so the command layer is testable without a live server.
 type DevTunnelController interface {
 	// StartDevTunnel mints a tunnel credential + host for blockId, binding it to
-	// the caller's ephemeral SSH public key. Returns the assigned host + the
-	// /apps/dev URL the developer opens.
-	StartDevTunnel(ctx context.Context, blockID, sshPublicKey string) (*DevTunnelSession, error)
+	// the caller's ephemeral SSH public key. declaredScopes carries the LOCAL
+	// manifest's `scopes` so the server can grant them to an UNSUBMITTED app's
+	// tunnel token (empty = read-only). Returns the assigned host + the /apps/dev
+	// URL the developer opens.
+	StartDevTunnel(ctx context.Context, blockID, sshPublicKey string, declaredScopes []string) (*DevTunnelSession, error)
 	// StopDevTunnel revokes the caller's tunnel by sessionId (preferred) or, when
 	// sessionId is empty, by blockId. Returns whether a session was torn down.
 	StopDevTunnel(ctx context.Context, sessionID, blockID string) (bool, error)
 }
 
-// startDevTunnelInput mirrors the blocks.startDevTunnel zod input.
+// startDevTunnelInput mirrors the blocks.startDevTunnel zod input. DeclaredScopes
+// is `omitempty` so an empty/absent local manifest sends nothing — matching the
+// server's `.optional()` and keeping the request identical to the pre-scopes
+// shape (an old server ignores the extra field).
 type startDevTunnelInput struct {
-	BlockID      string `json:"blockId"`
-	SSHPublicKey string `json:"sshPublicKey"`
+	BlockID        string   `json:"blockId"`
+	SSHPublicKey   string   `json:"sshPublicKey"`
+	DeclaredScopes []string `json:"declaredScopes,omitempty"`
 }
 
 // stopDevTunnelInput mirrors the blocks.stopDevTunnel zod input (one of the two
@@ -1004,8 +1010,8 @@ type stopDevTunnelInput struct {
 
 // StartDevTunnel POSTs blocks.startDevTunnel and returns the minted session. The
 // OAuth access token is refreshed transparently on a 401.
-func (c *Client) StartDevTunnel(ctx context.Context, blockID, sshPublicKey string) (*DevTunnelSession, error) {
-	body, err := json.Marshal(map[string]any{"json": startDevTunnelInput{BlockID: blockID, SSHPublicKey: sshPublicKey}})
+func (c *Client) StartDevTunnel(ctx context.Context, blockID, sshPublicKey string, declaredScopes []string) (*DevTunnelSession, error) {
+	body, err := json.Marshal(map[string]any{"json": startDevTunnelInput{BlockID: blockID, SSHPublicKey: sshPublicKey, DeclaredScopes: declaredScopes}})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/dev_tunnel_test.go
+++ b/internal/api/dev_tunnel_test.go
@@ -36,7 +36,7 @@ func TestStartDevTunnelRequestResponse(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok-1", "")
-	sess, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 AAAAKEY")
+	sess, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 AAAAKEY", nil)
 	if err != nil {
 		t.Fatalf("StartDevTunnel: %v", err)
 	}
@@ -60,6 +60,11 @@ func TestStartDevTunnelRequestResponse(t *testing.T) {
 	if wire.JSON.BlockID != "my-block" || wire.JSON.SSHPublicKey != "ssh-ed25519 AAAAKEY" {
 		t.Errorf("input = %+v, want blockId=my-block + the pubkey", wire.JSON)
 	}
+	// No scopes passed → declaredScopes is OMITTED entirely (omitempty), keeping
+	// the wire shape identical to the pre-scopes request an old server expects.
+	if strings.Contains(gotBody, "declaredScopes") {
+		t.Errorf("empty scopes must omit the declaredScopes key: %s", gotBody)
+	}
 	// Decoded result.
 	if sess.SessionID != "bki_abc" || sess.Host != "dev-0123456789abcdef.civit.ai" {
 		t.Errorf("session = %+v", sess)
@@ -73,6 +78,49 @@ func TestStartDevTunnelRequestResponse(t *testing.T) {
 	// R1: the sish host public key the CLI pins is decoded from the mint response.
 	if sess.SSHHostPublicKey != "ssh-ed25519 AAAAHOSTKEY" {
 		t.Errorf("sshHostPublicKey = %q, want the pinned host key line", sess.SSHHostPublicKey)
+	}
+}
+
+// TestStartDevTunnelDeclaredScopes: when the caller passes the local manifest's
+// scopes they are serialized as a `declaredScopes` string array under the tRPC
+// `json` key — this is what lets the server grant them to an UNSUBMITTED app's
+// tunnel token.
+func TestStartDevTunnelDeclaredScopes(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		gotBody = string(raw)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{"json": map[string]any{
+				"sessionId":        "bki_abc",
+				"host":             "dev-0123456789abcdef.civit.ai",
+				"url":              "https://civitai.com/apps/dev/my-block",
+				"expiresAt":        1893456000,
+				"sshHostPublicKey": "ssh-ed25519 AAAAHOSTKEY",
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok-1", "")
+	scopes := []string{"ai:write:budgeted", "user:read:self"}
+	if _, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 AAAAKEY", scopes); err != nil {
+		t.Fatalf("StartDevTunnel: %v", err)
+	}
+	var wire struct {
+		JSON startDevTunnelInput `json:"json"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &wire); err != nil {
+		t.Fatalf("request body not {json:...}: %v (%s)", err, gotBody)
+	}
+	if len(wire.JSON.DeclaredScopes) != 2 ||
+		wire.JSON.DeclaredScopes[0] != "ai:write:budgeted" ||
+		wire.JSON.DeclaredScopes[1] != "user:read:self" {
+		t.Errorf("declaredScopes = %#v, want the two manifest scopes in order", wire.JSON.DeclaredScopes)
+	}
+	// It rides under the tRPC `json` envelope (not top-level).
+	if !strings.Contains(gotBody, `"declaredScopes":["ai:write:budgeted","user:read:self"]`) {
+		t.Errorf("declaredScopes should serialize as a string array under json: %s", gotBody)
 	}
 }
 
@@ -165,7 +213,7 @@ func TestStartDevTunnelErrorMapping(t *testing.T) {
 			})
 		}))
 		c := New(srv.URL, "tok", "")
-		_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+		_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K", nil)
 		srv.Close()
 		if err == nil {
 			t.Fatalf("status %d: expected error", tc.status)
@@ -190,7 +238,7 @@ func TestStartDevTunnel401DropsServerMessage(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K", nil)
 	if err == nil {
 		t.Fatal("expected error on 401")
 	}
@@ -216,7 +264,7 @@ func TestStartDevTunnel404SlugTakenOrInvalid(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+	_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K", nil)
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -258,7 +306,7 @@ func TestStartDevTunnelForbiddenClassifiesScope(t *testing.T) {
 			}))
 			defer srv.Close()
 			c := New(srv.URL, "tok", "")
-			_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K")
+			_, err := c.StartDevTunnel(context.Background(), "my-block", "ssh-ed25519 K", nil)
 			var forbidden *DevTunnelForbiddenError
 			if !errors.As(err, &forbidden) {
 				t.Fatalf("403 should map to *DevTunnelForbiddenError, got %v", err)

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -178,6 +179,59 @@ type tunnelSessionDeps struct {
 	errw            io.Writer
 }
 
+// maxDeclaredScopes / maxDeclaredScopeLen mirror the server's zod bound on
+// blocks.startDevTunnel's declaredScopes input
+// (z.array(z.string().min(1).max(64)).max(32)). Enforcing them CLIENT-side means
+// an oversized/garbage local manifest degrades to the valid subset instead of
+// being rejected with an opaque BAD_REQUEST — preserving the CLI's promise that a
+// malformed manifest never blocks tunneling.
+const (
+	maxDeclaredScopes   = 32
+	maxDeclaredScopeLen = 64
+)
+
+// boundDeclaredScopes filters the local manifest scopes down to what the server
+// will accept: drop empty/whitespace-only entries and any over maxDeclaredScopeLen
+// chars, dedupe (preserving first-seen order), and cap at maxDeclaredScopes. Returns
+// nil when nothing valid remains so the request omits declaredScopes entirely.
+func boundDeclaredScopes(scopes []string) []string {
+	if len(scopes) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(scopes))
+	out := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		if strings.TrimSpace(s) == "" || len(s) > maxDeclaredScopeLen {
+			continue // empty/whitespace-only or too long → the server would reject it
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+		if len(out) == maxDeclaredScopes {
+			break // at the cap — extras are silently dropped, not sent
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// sanitizeScopeForDisplay strips non-printable/control runes from a scope before
+// it is echoed to the dev's terminal, so a crafted manifest can't inject ANSI /
+// control sequences into their session. Display-only — the value SENT to the
+// server is unchanged (the server sanitizes independently).
+func sanitizeScopeForDisplay(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, s)
+}
+
 func newAppDevTunnelCmd() *cobra.Command {
 	var blockFlag string
 	var port int
@@ -295,8 +349,11 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 			// unreadable/malformed manifest (or one with no scopes) sends nothing — the
 			// tunnel still works, just read-only for spend. This is NON-fatal even when
 			// the blockId was given explicitly (flag/positional), so a bare directory
-			// never blocks tunneling.
-			declaredScopes := manifest.LoadScopes(".")
+			// never blocks tunneling. boundDeclaredScopes enforces the server's zod
+			// bound CLIENT-side so an oversized/garbage scopes array degrades to the
+			// valid subset instead of 400ing the mint (keeping that "never blocks"
+			// promise).
+			declaredScopes := boundDeclaredScopes(manifest.LoadScopes("."))
 
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
@@ -372,9 +429,15 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	// Transparency: surface exactly which scopes the tunnel is requesting (a
 	// spend-consent signal, and it catches manifest typos before a click). Only
 	// when the local manifest declares any — an empty set is read-only and needs
-	// no notice.
+	// no notice. Sanitize for DISPLAY so a crafted manifest can't inject ANSI/
+	// control sequences into the dev's terminal (the value SENT to the server is
+	// unchanged — the server sanitizes independently).
 	if len(d.declaredScopes) > 0 {
-		fmt.Fprintf(d.errw, "%s\n", ui.Dim(fmt.Sprintf("Declaring scopes: %s", strings.Join(d.declaredScopes, ", "))))
+		display := make([]string, len(d.declaredScopes))
+		for i, s := range d.declaredScopes {
+			display[i] = sanitizeScopeForDisplay(s)
+		}
+		fmt.Fprintf(d.errw, "%s\n", ui.Dim(fmt.Sprintf("Declaring scopes: %s", strings.Join(display, ", "))))
 	}
 
 	key, err := d.keygen()

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -94,7 +94,7 @@ const (
 // tunnelAPI is the subset of the API client the session core needs (seam for a
 // mock in tests).
 type tunnelAPI interface {
-	StartDevTunnel(ctx context.Context, blockID, sshPublicKey string) (*api.DevTunnelSession, error)
+	StartDevTunnel(ctx context.Context, blockID, sshPublicKey string, declaredScopes []string) (*api.DevTunnelSession, error)
 	StopDevTunnel(ctx context.Context, sessionID, blockID string) (bool, error)
 	// WhoAmI resolves the signed-in identity — used to enrich a 403 mint refusal
 	// with which account the CLI is authenticated as (the usual cause is being
@@ -133,7 +133,11 @@ type tunnelSessionDeps struct {
 	keygen        func() (*devtunnel.EphemeralKey, error)
 	dialer        devtunnel.Dialer
 	blockID       string
-	port          int
+	// declaredScopes are the LOCAL manifest's `scopes`, forwarded to
+	// StartDevTunnel so the server can grant them to an UNSUBMITTED app's tunnel
+	// token. Empty/nil = read-only (no spend) — never fatal.
+	declaredScopes []string
+	port           int
 	// localHost is the resolved host the developer's dev server is bound to
 	// ("localhost" by default = loopback; e.g. 10.42.0.100 for a container). Used
 	// by BOTH the pre-flight probe and the live tunnel proxy so the two agree.
@@ -285,6 +289,15 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
 
+			// Read the LOCAL manifest scopes (from the CWD — the dev runs this from
+			// their App project dir) so the server can grant them to the tunnel token
+			// of an UNSUBMITTED app (no submit needed). Degrade gracefully: a missing/
+			// unreadable/malformed manifest (or one with no scopes) sends nothing — the
+			// tunnel still works, just read-only for spend. This is NON-fatal even when
+			// the blockId was given explicitly (flag/positional), so a bare directory
+			// never blocks tunneling.
+			declaredScopes := manifest.LoadScopes(".")
+
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 			defer signal.Stop(sigCh)
@@ -297,6 +310,7 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 				keygen:                 devtunnel.GenerateEphemeralKey,
 				dialer:                 devtunnel.NewSSHDialer(cmd.ErrOrStderr()),
 				blockID:                blockID,
+				declaredScopes:         declaredScopes,
 				port:                   port,
 				localHost:              lh,
 				endpoint:               ep,
@@ -355,12 +369,20 @@ func runTunnelSession(ctx context.Context, d tunnelSessionDeps) error {
 	// design.
 	fmt.Fprintf(d.errw, "%s\n", ui.Dim(fmt.Sprintf("Establishing dev tunnel for %s… (minting session + opening SSH tunnel)", d.blockID)))
 
+	// Transparency: surface exactly which scopes the tunnel is requesting (a
+	// spend-consent signal, and it catches manifest typos before a click). Only
+	// when the local manifest declares any — an empty set is read-only and needs
+	// no notice.
+	if len(d.declaredScopes) > 0 {
+		fmt.Fprintf(d.errw, "%s\n", ui.Dim(fmt.Sprintf("Declaring scopes: %s", strings.Join(d.declaredScopes, ", "))))
+	}
+
 	key, err := d.keygen()
 	if err != nil {
 		return fmt.Errorf("generate ephemeral tunnel key: %w", err)
 	}
 
-	sess, err := d.api.StartDevTunnel(ctx, d.blockID, key.AuthorizedKey)
+	sess, err := d.api.StartDevTunnel(ctx, d.blockID, key.AuthorizedKey, d.declaredScopes)
 	if err != nil {
 		// A 403 mint refusal is the common "wrong account" case — enrich it with
 		// the signed-in identity + how to switch accounts. This runs on the

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -107,6 +107,102 @@ func TestAppDevTunnelBlockIdFromManifest(t *testing.T) {
 	}
 }
 
+// TestAppDevTunnelDeclaresManifestScopes: run from an App project dir whose
+// block.manifest.json declares `scopes`, and the full cobra path (RunE →
+// manifest.LoadScopes → api client) carries them to the mint request as
+// declaredScopes AND prints the transparency line. This is what lets the server
+// grant those scopes to an unsubmitted app's tunnel token.
+func TestAppDevTunnelDeclaresManifestScopes(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == startDevTunnelRoute {
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
+	}))
+	defer srv.Close()
+
+	// App project dir with a manifest that declares scopes.
+	dir := t.TempDir()
+	const m = `{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "demo",
+  "version": "0.1.0",
+  "name": "Demo",
+  "type": "block",
+  "scopes": ["ai:write:budgeted", "user:read:self"],
+  "page": { "path": "/", "title": "Demo" }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(m), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	_, errOut, _ := run(t, "app", "dev-tunnel", "--port", fmt.Sprint(port))
+
+	// The manifest scopes serialized into the mint request under the tRPC json key.
+	if !strings.Contains(gotBody, `"declaredScopes":["ai:write:budgeted","user:read:self"]`) {
+		t.Errorf("start body should carry the manifest scopes as declaredScopes: %s", gotBody)
+	}
+	// The dev is shown what the tunnel is requesting (spend-consent transparency).
+	if !strings.Contains(errOut, "Declaring scopes: ai:write:budgeted, user:read:self") {
+		t.Errorf("expected the 'Declaring scopes' transparency line on stderr, got: %s", errOut)
+	}
+}
+
+// TestAppDevTunnelNoManifestScopesOmitsField: an explicit blockId with NO
+// manifest in the CWD is non-fatal (the tunnel still works) and the request
+// omits declaredScopes entirely — read-only, and wire-identical to an old client.
+func TestAppDevTunnelNoManifestScopesOmitsField(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == startDevTunnelRoute {
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
+	}))
+	defer srv.Close()
+
+	// A bare dir with NO manifest — the explicit blockId must still tunnel.
+	chdir(t, t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	_, errOut, err := run(t, "app", "dev-tunnel", "my-block", "--port", fmt.Sprint(port))
+	// A missing manifest is NON-fatal — the only failure is the (expected) dark mint.
+	if err != nil && strings.Contains(err.Error(), "blockId is required") {
+		t.Fatalf("an explicit blockId must not require a manifest: %v", err)
+	}
+	if !strings.Contains(gotBody, `"blockId":"my-block"`) {
+		t.Errorf("start body should carry the explicit blockId: %s", gotBody)
+	}
+	if strings.Contains(gotBody, "declaredScopes") {
+		t.Errorf("no manifest scopes must omit declaredScopes: %s", gotBody)
+	}
+	if strings.Contains(errOut, "Declaring scopes") {
+		t.Errorf("no scopes must not print a declaration line: %s", errOut)
+	}
+}
+
 // TestAppDevTunnelBlockFlagWinsOverPositionalWithWarning: passing BOTH --block
 // and a DIFFERENT positional blockId warns on stderr that --block wins, and the
 // resolved blockId (carried to the mint request) is the --block value.

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -161,6 +161,92 @@ func TestAppDevTunnelDeclaresManifestScopes(t *testing.T) {
 	}
 }
 
+// TestAppDevTunnelBoundsOversizedManifestScopes: a manifest whose scopes exceed
+// the server's zod bound (>32 entries, a duplicate, and a >64-char garbage entry)
+// must NOT 400 the tunnel — the CLI bounds them client-side and degrades to the
+// valid subset (the tunnel still starts). Guards the "a malformed manifest never
+// blocks tunneling" promise.
+func TestAppDevTunnelBoundsOversizedManifestScopes(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == startDevTunnelRoute {
+			raw, _ := io.ReadAll(r.Body)
+			gotBody = string(raw)
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": "Dev tunnels are not available"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "tester", "id": 7})
+	}))
+	defer srv.Close()
+
+	// 34 distinct valid scopes (> the 32 cap) + a duplicate of the first + one
+	// >64-char garbage entry.
+	valid := make([]string, 34)
+	for i := range valid {
+		valid[i] = fmt.Sprintf("scope:%02d", i)
+	}
+	scopes := append([]string{}, valid...)
+	scopes = append(scopes, valid[0])                 // duplicate
+	scopes = append(scopes, strings.Repeat("x", 100)) // > 64 chars
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	m := fmt.Sprintf(`{
+  "$schema": "https://civitai.com/schemas/app-block/v1.json",
+  "blockId": "demo",
+  "version": "0.1.0",
+  "name": "Demo",
+  "type": "block",
+  "scopes": %s,
+  "page": { "path": "/", "title": "Demo" }
+}`, scopesJSON)
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(m), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	port := listenLocal(t)
+	_, _, runErr := run(t, "app", "dev-tunnel", "--port", fmt.Sprint(port))
+	// The oversized manifest must not block the tunnel — the only failure is the
+	// (expected, dark) forbidden mint, never a validation abort.
+	if runErr != nil && strings.Contains(runErr.Error(), "blockId is required") {
+		t.Fatalf("oversized scopes must not block the tunnel: %v", runErr)
+	}
+
+	var wire struct {
+		JSON struct {
+			DeclaredScopes []string `json:"declaredScopes"`
+		} `json:"json"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &wire); err != nil {
+		t.Fatalf("request body not {json:...}: %v (%s)", err, gotBody)
+	}
+	sent := wire.JSON.DeclaredScopes
+	if len(sent) != 32 {
+		t.Errorf("declaredScopes should be capped at 32, got %d: %v", len(sent), sent)
+	}
+	seen := map[string]bool{}
+	for _, s := range sent {
+		if len(s) > 64 {
+			t.Errorf("an over-64-char scope leaked through: %q", s)
+		}
+		if seen[s] {
+			t.Errorf("a duplicate scope leaked through: %q", s)
+		}
+		seen[s] = true
+	}
+}
+
 // TestAppDevTunnelNoManifestScopesOmitsField: an explicit blockId with NO
 // manifest in the CWD is non-fatal (the tunnel still works) and the request
 // omits declaredScopes entirely — read-only, and wire-identical to an old client.

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -441,6 +442,66 @@ func TestRunTunnelSessionNoScopesNoDeclaration(t *testing.T) {
 	}
 	if strings.Contains(errw.String(), "Declaring scopes") {
 		t.Errorf("no scopes must NOT print a declaration line:\n%s", errw.String())
+	}
+}
+
+// TestBoundDeclaredScopes: the client-side bound mirrors the server's zod input
+// (z.array(z.string().min(1).max(64)).max(32)) so an oversized/garbage manifest
+// degrades to the valid subset instead of 400ing the mint.
+func TestBoundDeclaredScopes(t *testing.T) {
+	long := strings.Repeat("a", maxDeclaredScopeLen+1) // > limit → dropped
+	ok64 := strings.Repeat("b", maxDeclaredScopeLen)   // exactly the limit → kept
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"drops empty and whitespace-only", []string{"ai:write:budgeted", "", "   ", "\t"}, []string{"ai:write:budgeted"}},
+		{"drops over-long, keeps exactly-64", []string{long, ok64}, []string{ok64}},
+		{"dedupes preserving first-seen order", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"all invalid degrades to nil", []string{"", "   ", long}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := boundDeclaredScopes(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("boundDeclaredScopes(%#v) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// Over-count degrades to the FIRST maxDeclaredScopes, in order.
+	over := make([]string, maxDeclaredScopes+5)
+	for i := range over {
+		over[i] = fmt.Sprintf("scope-%d", i)
+	}
+	got := boundDeclaredScopes(over)
+	if len(got) != maxDeclaredScopes {
+		t.Fatalf("over-count should cap at %d, got %d", maxDeclaredScopes, len(got))
+	}
+	if got[0] != "scope-0" || got[maxDeclaredScopes-1] != fmt.Sprintf("scope-%d", maxDeclaredScopes-1) {
+		t.Errorf("cap should keep the first %d in order, got %q…%q", maxDeclaredScopes, got[0], got[len(got)-1])
+	}
+}
+
+// TestSanitizeScopeForDisplay: control/ANSI sequences are stripped from the
+// terminal echo (a crafted manifest can't inject escapes into the dev's session),
+// while ordinary printable scope characters survive untouched.
+func TestSanitizeScopeForDisplay(t *testing.T) {
+	// An embedded ESC[31m ANSI sequence + a bare control char.
+	in := "ai:\x1b[31mwrite\x1b[0m:budg\x07eted"
+	got := sanitizeScopeForDisplay(in)
+	if strings.ContainsRune(got, '\x1b') || strings.ContainsRune(got, '\x07') {
+		t.Errorf("control chars must be stripped, got %q", got)
+	}
+	// The printable payload (minus the control bytes) is preserved.
+	if got != "ai:[31mwrite[0m:budgeted" {
+		t.Errorf("printable characters must survive, got %q", got)
+	}
+	// A clean scope is unchanged.
+	if s := "ai:write:budgeted"; sanitizeScopeForDisplay(s) != s {
+		t.Errorf("clean scope should be unchanged, got %q", sanitizeScopeForDisplay(s))
 	}
 }
 

--- a/internal/cmd/app_dev_tunnel_test.go
+++ b/internal/cmd/app_dev_tunnel_test.go
@@ -45,7 +45,10 @@ type fakeTunnelAPI struct {
 
 	startResult *api.DevTunnelSession
 	startErr    error
-	startCalls  []struct{ blockID, pubKey string }
+	startCalls  []struct {
+		blockID, pubKey string
+		declaredScopes  []string
+	}
 
 	stopErr   error
 	stopCalls []struct{ sessionID, blockID string }
@@ -74,10 +77,13 @@ func (f *fakeTunnelAPI) whoamiCount() int {
 	return f.whoamiCall
 }
 
-func (f *fakeTunnelAPI) StartDevTunnel(_ context.Context, blockID, pubKey string) (*api.DevTunnelSession, error) {
+func (f *fakeTunnelAPI) StartDevTunnel(_ context.Context, blockID, pubKey string, declaredScopes []string) (*api.DevTunnelSession, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.startCalls = append(f.startCalls, struct{ blockID, pubKey string }{blockID, pubKey})
+	f.startCalls = append(f.startCalls, struct {
+		blockID, pubKey string
+		declaredScopes  []string
+	}{blockID, pubKey, declaredScopes})
 	if f.startErr != nil {
 		return nil, f.startErr
 	}
@@ -364,6 +370,77 @@ func TestRunTunnelSessionSignalTeardown(t *testing.T) {
 	// The /apps/dev URL was printed prominently.
 	if !strings.Contains(out.String(), "https://civitai.com/apps/dev/my-block") {
 		t.Errorf("stdout should print the /apps/dev URL:\n%s", out.String())
+	}
+}
+
+// TestRunTunnelSessionForwardsDeclaredScopes: the local manifest scopes carried
+// on deps are (a) forwarded verbatim to StartDevTunnel — so the server can grant
+// them to an unsubmitted app's token — and (b) surfaced to the dev as a
+// transparency line before the tunnel starts.
+func TestRunTunnelSessionForwardsDeclaredScopes(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	sigs := make(chan os.Signal, 1)
+
+	var errw strings.Builder
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), sigs)
+	deps.errw = &errw
+	deps.declaredScopes = []string{"ai:write:budgeted", "user:read:self"}
+
+	errc := runInBackground(deps)
+	sigs <- os.Interrupt
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("runTunnelSession: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTunnelSession did not return after signal")
+	}
+
+	if len(apiStub.startCalls) != 1 {
+		t.Fatalf("start calls = %+v", apiStub.startCalls)
+	}
+	got := apiStub.startCalls[0].declaredScopes
+	if len(got) != 2 || got[0] != "ai:write:budgeted" || got[1] != "user:read:self" {
+		t.Errorf("StartDevTunnel declaredScopes = %#v, want the manifest scopes", got)
+	}
+	// The transparency line names the scopes so the dev sees what's requested.
+	if !strings.Contains(errw.String(), "Declaring scopes: ai:write:budgeted, user:read:self") {
+		t.Errorf("expected a 'Declaring scopes' transparency line on stderr:\n%s", errw.String())
+	}
+}
+
+// TestRunTunnelSessionNoScopesNoDeclaration: with no manifest scopes, nothing is
+// forwarded (nil/empty) and no transparency line is printed — the read-only path.
+func TestRunTunnelSessionNoScopesNoDeclaration(t *testing.T) {
+	apiStub := &fakeTunnelAPI{startResult: sampleSession()}
+	tunnel := newFakeTunnel()
+	dialer := &fakeDialer{tunnel: tunnel}
+	sigs := make(chan os.Signal, 1)
+
+	var errw strings.Builder
+	deps := baseDeps(t, apiStub, dialer, newFakeTimer(), sigs)
+	deps.errw = &errw
+	// declaredScopes intentionally unset (nil).
+
+	errc := runInBackground(deps)
+	sigs <- os.Interrupt
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("runTunnelSession: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTunnelSession did not return after signal")
+	}
+
+	if len(apiStub.startCalls) != 1 || len(apiStub.startCalls[0].declaredScopes) != 0 {
+		t.Errorf("no manifest scopes → StartDevTunnel must get empty scopes, got %+v", apiStub.startCalls)
+	}
+	if strings.Contains(errw.String(), "Declaring scopes") {
+		t.Errorf("no scopes must NOT print a declaration line:\n%s", errw.String())
 	}
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -34,10 +34,10 @@ type Manifest struct {
 
 // LoadScopes reads the `scopes` array from the manifest in dir, degrading
 // gracefully: a missing manifest, an unreadable file, or malformed JSON all
-// return nil (no scopes) with no error. This is used by `civitai app dev-token`
-// to send the dev's LOCAL manifest scopes for the server's no-row mint path —
-// the slug arg still identifies a registered app even when the manifest is
-// absent, so a read failure must never block minting.
+// return nil (no scopes) with no error. It is used by `civitai app dev-tunnel`
+// (and `civitai app dev-token`) to send the dev's LOCAL manifest scopes for the
+// server's no-row mint path — the slug arg still identifies a registered app even
+// when the manifest is absent, so a read failure must never block minting.
 func LoadScopes(dir string) []string {
 	raw, err := os.ReadFile(Path(dir))
 	if err != nil {


### PR DESCRIPTION
## What

`civitai app dev-tunnel <slug>` now reads the local `block.manifest.json` `scopes` and forwards them to the server's `blocks.startDevTunnel` mutation as a new optional `declaredScopes` string array.

## Why

This enables **unsubmitted-app spend testing**: with the manifest's requested scopes declared at tunnel-mint time, the server can grant them to an UNSUBMITTED app's dev-tunnel token, so a developer can exercise spend flows (e.g. `ai:write:budgeted`) locally before ever running `civitai app submit`. The grant is **server-side gated** — the token only receives the scopes the server chooses to grant; the CLI merely declares the manifest's intent.

## Changes

- **`internal/api/api.go`** — `StartDevTunnel` gains a `declaredScopes []string` param; `startDevTunnelInput` gains `DeclaredScopes []string` with `json:"declaredScopes,omitempty"`. Empty/absent scopes send nothing, keeping the wire shape identical to the pre-scopes request, so an **old server ignores the extra field** (backward compatible).
- **`internal/cmd/app_dev_tunnel.go`** — loads scopes from the CWD manifest via `manifest.LoadScopes(".")` (degrades gracefully; **non-fatal** even for an explicitly provided blockId — a bare directory still tunnels, just read-only for spend), forwards them to the mint call, and prints a `Declaring scopes: …` transparency line so the dev sees exactly what the tunnel is requesting (spend-consent signal + catches manifest typos). No scopes → no line.

## Tests

- `internal/api/dev_tunnel_test.go` — `declaredScopes` serializes correctly when set; **omitted** when empty.
- `internal/cmd/app_dev_tunnel_test.go` — scopes on deps are forwarded verbatim to `StartDevTunnel` and surfaced in the transparency line; no-scopes path forwards empty + prints nothing.
- `internal/cmd/app_dev_tunnel_cmd_test.go` — full cobra path: a manifest declaring `scopes` lands them in the mint request body + prints the line; a missing manifest with an explicit blockId is non-fatal and omits the field. blockId precedence (`--block` > positional > manifest) unchanged.

`go build ./...`, `go vet ./internal/...`, and `go test ./internal/...` all pass; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)