### PR TITLE
feat(cli): allow apps:storage:shared:* in the manifest schema

### DIFF
--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -64,7 +64,9 @@
           "block:settings:write",
           "social:tip:self",
           "apps:storage:read",
-          "apps:storage:write"
+          "apps:storage:write",
+          "apps:storage:shared:read",
+          "apps:storage:shared:write"
         ]
       }
     },


### PR DESCRIPTION
Syncs the CLI's vendored manifest schema with the canonical one (companion: civitai#3022) so `civitai app validate` accepts `apps:storage:shared:read/write` — the scopes the shared-storage platform requires. Without this, an app can't declare shared storage.

⚠️ **Merge + release AFTER civitai#3022 deploys** — the canonical drift-check (`scripts/check-canonical-schema.sh`) compares the vendored copy to the live `civitai.com/schemas/app-block/v1.json`, so this must not lead the canonical update. Needs a CLI release (v0.1.59) for authors to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)