### PR TITLE
feat(cli): sync manifest `category` field (civitai#3089)

### DIFF
--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -117,6 +117,37 @@ func TestValidateRejectsBadScope(t *testing.T) {
 	}`, "scopes")
 }
 
+// --- marketplace category (optional; enforced by the vendored schema enum,
+// mirroring the server's BlockManifestValidator category check ~L312) ---
+
+func TestValidateAcceptsValidCategory(t *testing.T) {
+	// A manifest declaring a known marketplace category validates.
+	mustAccept(t, "valid category", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "category": "generation",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+func TestValidateRejectsUnknownCategory(t *testing.T) {
+	// An out-of-taxonomy category fails with a clear, field-keyed error.
+	mustReject(t, "unknown category", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "category": "bananas",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "category")
+}
+
+func TestValidateAcceptsMissingCategory(t *testing.T) {
+	// category is optional — a manifest omitting it validates (baseGood has none).
+	res := validateManifest(t, baseGood)
+	if !res.OK() {
+		t.Fatalf("manifest without category should validate, got: %v", res.Errors)
+	}
+}
+
 func TestValidateRejectsBadContentRating(t *testing.T) {
 	mustReject(t, "bad contentRating", `{
 		"blockId": "ok-block", "version": "0.1.0", "name": "X",

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -38,6 +38,19 @@
       "description": "Content rating of the app surface.",
       "enum": ["g", "pg", "pg13", "r", "x"]
     },
+    "category": {
+      "type": "string",
+      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories — this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
+      "enum": [
+        "generation",
+        "games",
+        "utility",
+        "discovery",
+        "moderation",
+        "analytics",
+        "other"
+      ]
+    },
     "renderMode": {
       "type": "string",
       "description": "How the block renders. Defaults to \"iframe\". \"inline\"/\"hybrid\" require a verified/internal trust tier (server-assigned), so authors should leave this as iframe.",


### PR DESCRIPTION
## What

Sync the vendored manifest schema with the canonical one so `civitai app validate` accepts (and taxonomy-validates) the new OPTIONAL top-level `category` field added in **civitai#3089** (merged to civitai `main`).

- **Schema** (`schema/app-block.manifest.schema.json`): add the `category` property — `type: string`, `enum` = the marketplace taxonomy `generation, games, utility, discovery, moderation, analytics, other` (in that order), with the description copied **verbatim** from the canonical `public/schemas/app-block/v1.json`. Verified byte-consistent with `main` via normalized `jq -S` diff.
- **Validator**: no Go change needed. The CLI enforces field-level enums purely through the vendored JSON Schema — there is **no separate Go scope/field allowlist** (the `scopes` enum is schema-only; `internal/validate/semantic.go` only ports the cross-field / tier-gated rules the schema *can't* express). This mirrors **cli#113** (the `apps:storage:shared:*` scope sync), which was schema-only. So the schema sync alone gives `civitai app validate` the category check.
- **Tests** (`internal/validate/validate_test.go`): valid category passes; unknown category fails with a clear field-keyed error (`/category: value must be one of 'generation', ...`), mirroring the server's `BlockManifestValidator` category rule (`block-manifest-validator.service.ts` ~L312); missing category passes (it's optional).

## Test results

`go test ./...` — all packages PASS (validate, cmd, api, manifest, scaffold, …).

## ⚠️ Blocked on civitai#3089 deploy — do NOT merge yet

The `schema-drift` CI check (`scripts/check-canonical-schema.sh`) compares the vendored schema against the **live** canonical URL `https://civitai.com/schemas/app-block/v1.json`. **civitai#3089 is merged to `main` but NOT yet deployed to dp-prod**, so the live canonical does not yet serve `category` (confirmed: 0 occurrences live right now). **The drift-check WILL FAIL until #3089 deploys — that is EXPECTED, not a problem with this PR.**

Do not work around it. Once #3089 is live in dp-prod, re-run the drift check → it will pass → merge → cut a release. This mirrors the exact `civitai#3022 → cli#113 → v0.1.59` sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
