### PR TITLE
fix(app submit): make the no-token fallback clearly 'not submitted' + point at /apps/my-submissions

### DIFF
--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -180,12 +180,18 @@ func printMoneyPathNote(out io.Writer, m *manifest.Manifest) {
 
 func printManualNextSteps(cmd *cobra.Command, cfg *config.Config, m *manifest.Manifest, zipPath string) {
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "\nNo token configured, so the bundle was written but not uploaded.")
+	base := strings.TrimRight(cfg.BaseURL(), "/")
+	// Lead with an unmistakable NOT-submitted banner: no token means the bundle
+	// was written locally but never reached the server, so no review started.
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, ui.Warn("NOT SUBMITTED — no token configured, so the bundle was written locally but never uploaded to Civitai."))
+	fmt.Fprintln(out, "No moderator review has started. To actually submit it, do ONE of:")
 	fmt.Fprintln(out, "\n  1) Authenticate, then re-run to upload directly:")
 	fmt.Fprintln(out, "     civitai login          # browser device login")
 	fmt.Fprintln(out, "     civitai app submit")
+	fmt.Fprintf(out, "     %s/apps/my-submissions   # your submissions appear here once uploaded\n", base)
 	fmt.Fprintf(out, "\n  2) Or upload %s via the web UI:\n", filepath.Base(zipPath))
-	fmt.Fprintf(out, "     %s/apps/submit\n", cfg.BaseURL())
+	fmt.Fprintf(out, "     %s/apps/submit\n", base)
 	fmt.Fprintln(out, "     (requires an invite while Apps is in invite-only beta).")
 	printMoneyPathNote(out, m)
 }

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -65,11 +65,22 @@ func TestAppSubmitFallbackPrintsManualSteps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("submit fallback: %v\n%s", err, stdout)
 	}
-	if !strings.Contains(stdout, "No token configured") || !strings.Contains(stdout, "/apps/submit") {
-		t.Errorf("fallback should print manual next steps: %s", stdout)
+	if !strings.Contains(stdout, "NOT SUBMITTED") || !strings.Contains(stdout, "never uploaded") {
+		t.Errorf("fallback must clearly read as not-submitted: %s", stdout)
+	}
+	if !strings.Contains(stdout, "/apps/submit") {
+		t.Errorf("fallback should keep the web-UI upload option: %s", stdout)
 	}
 	if !strings.Contains(stdout, "civitai login") {
 		t.Errorf("fallback should point at `civitai login`: %s", stdout)
+	}
+	// The dev believed they'd submitted with no token; point them at where a
+	// successful submit will actually show up (mirrors the happy path's link).
+	if !strings.Contains(stdout, "/apps/my-submissions") {
+		t.Errorf("fallback should point at /apps/my-submissions: %s", stdout)
+	}
+	if !strings.Contains(stdout, "invite-only beta") {
+		t.Errorf("fallback should keep the invite-only beta note: %s", stdout)
 	}
 }
 


### PR DESCRIPTION
## Problem

A dev asked *"I submitted the app, where do I find it?"* — but no publish request ever reached the server. They ran `civitai app submit` **without a valid token**, which falls to the manual-next-steps fallback: it writes a local `.zip` and prints guidance. They saw the success-styled `✓ Wrote canonical bundle` line and the old, easy-to-skim headline (`No token configured, so the bundle was written but not uploaded`) and believed they'd submitted. Only a local `.zip` existed.

## Fix (fallback / no-token path only)

- Lead with an amber `ui.Warn` **"NOT SUBMITTED — …never uploaded to Civitai."** banner + "No moderator review has started" so it's unmistakable nothing reached the server.
- Add a pointer to `<base>/apps/my-submissions` — where a *successful* submit shows up — mirroring the happy path's Track-it link (`# your submissions appear here once uploaded`).
- Keep the accurate "written locally but never uploaded" fact, the `civitai login` + re-run path, the web-UI upload option, and the invite-only-beta note. Trim a trailing slash off the base URL.

The **happy path** (`doUpload`) already printed the publish-request id, the per-app `<slug>.civit.ai` deploy URL, and the `/apps/my-submissions` link — it is **left untouched**.

### Before
```
No token configured, so the bundle was written but not uploaded.

  1) Authenticate, then re-run to upload directly:
     civitai login          # browser device login
     civitai app submit

  2) Or upload demo-block-0.1.0.zip via the web UI:
     https://civitai.com/apps/submit
     (requires an invite while Apps is in invite-only beta).
```

### After
```
⚠ NOT SUBMITTED — no token configured, so the bundle was written locally but never uploaded to Civitai.
No moderator review has started. To actually submit it, do ONE of:

  1) Authenticate, then re-run to upload directly:
     civitai login          # browser device login
     civitai app submit
     https://civitai.com/apps/my-submissions   # your submissions appear here once uploaded

  2) Or upload demo-block-0.1.0.zip via the web UI:
     https://civitai.com/apps/submit
     (requires an invite while Apps is in invite-only beta).
```

## Tests

Adjusted `TestAppSubmitFallbackPrintsManualSteps` to assert the clearer not-submitted wording (`NOT SUBMITTED`, `never uploaded`) and the `/apps/my-submissions` pointer, while keeping the web-UI-upload, `civitai login`, and invite-only-beta assertions. `go build ./...` clean; `go test ./internal/cmd/... ./internal/ui/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)