### PR TITLE
fix(schema): sync collections:* scopes into the vendored app-block schema

### DIFF
--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -79,7 +79,10 @@
           "apps:storage:read",
           "apps:storage:write",
           "apps:storage:shared:read",
-          "apps:storage:shared:write"
+          "apps:storage:shared:write",
+          "collections:read:self",
+          "collections:write:self",
+          "collections:read:private"
         ]
       }
     },


### PR DESCRIPTION
## What

Sync the CLI's vendored App-Block manifest schema with the canonical server schema to add the three `collections:*` block scopes:

- `collections:read:self`
- `collections:write:self`
- `collections:read:private`

## Why (the drift)

The canonical, server-published schema at `https://civitai.com/schemas/app-block/v1.json` added these scopes in civitai#3103 (now deployed), but the CLI's vendored copy (`schema/app-block.manifest.schema.json`, `go:embed`ed for offline validation) was behind. Two consequences:

1. `civitai app validate` / `civitai app submit` **rejected** any manifest declaring a collections scope — `value must be one of 'models:read:self', …, 'apps:storage:shared:write'` (the new scopes weren't in the enum).
2. `scripts/check-canonical-schema.sh` — which fetches the LIVE canonical URL and diffs it against the vendored copy — was **failing** (red drift-check).

## The change

Adds the three scopes to the manifest schema's `scopes` enum, in **canonical order** (matching `BLOCK_SCOPE_TO_OAUTH_BIT` in `src/shared/constants/block-scope.constants.ts`). This is the exact same lockstep as the earlier `apps:storage:shared:*` sync (#113) — one JSON-schema file. Validation is purely JSON-schema-driven (`go:embed`), so there is no separate Go-side scope allowlist to update, and no test pins the full scope set.

## Verification

- `scripts/check-canonical-schema.sh` → `OK: vendored schema matches the canonical` (the vendored copy now byte-matches the live URL, only the 3 collections scopes differed).
- `go build ./...` → clean.
- `go test ./...` → all packages green.
- Built the binary and ran `civitai app validate` against a manifest declaring all three collections scopes → **passes** (`✓ is valid`). A bogus `collections:bogus:nope` still fails, and the error now lists all three collections scopes in the enum.

## Release

Needs a release after merge for authors to use it — releases are a manual goreleaser draft the maintainer publishes; this PR does not cut one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
