### PR TITLE
fix(scaffold): bump @civitai/* template pins to current + add pins-vs-published guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,28 @@ jobs:
       - name: check canonical schema
         run: ./scripts/check-canonical-schema.sh
 
+  # Rot-guard: assert each scaffold template's `@civitai/*` pin still ADMITS the
+  # version npm currently publishes as `latest`. A pre-1.0 caret (`^0.24.0`)
+  # locks the minor, so a pin that falls behind npm silently ships apps that are
+  # born stale — and `npm install` won't catch it (it resolves the caret to the
+  # newest version the stale range still admits). This is the network half of
+  # the scaffold guard; it's env-gated so the default `go test ./...` stays
+  # offline, and it SKIPS (never false-fails) when npm is unreachable.
+  pins-vs-published:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: check scaffold pins vs npm latest
+        env:
+          CIVITAI_CHECK_PUBLISHED_PINS: "1"
+        run: go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -v
+
   # Rot-guard: scaffold the page-money template and run its JS toolchain against
   # the PUBLISHED SDK (@civitai/blocks-react). Catches a template that renders
   # but no longer installs / typechecks / tests / builds after an SDK bump — the

--- a/internal/scaffold/pins_guard_test.go
+++ b/internal/scaffold/pins_guard_test.go
@@ -1,0 +1,210 @@
+package scaffold
+
+// Pins-vs-published rot-guard.
+//
+// Every scaffolded App is born pinning the `@civitai/*` packages the templates
+// declare. Because those pins use a caret (`^0.24.0`) and the SDK is pre-1.0,
+// the caret LOCKS THE MINOR — `^0.18.0` will never install `0.24.0`. So a
+// template whose pins fall behind npm silently ships apps that are born stale,
+// peer-mismatched, and missing whatever the newer minors added. The
+// `template-page-money` CI job (npm install → typecheck → build) does NOT catch
+// this: `npm install` happily resolves the caret to the newest version it
+// ADMITS, so a stale `^0.18.0` installs a green-but-old `0.18.x`.
+//
+// This guard closes that gap: it reads each template's `@civitai/*` pin and
+// asserts the caret range still ADMITS the version npm currently publishes as
+// `latest`. When it doesn't, it fails loud with the stale pin, the current
+// published version, and the one-line fix.
+//
+// It is network-gated: it only runs when CIVITAI_CHECK_PUBLISHED_PINS=1 (a
+// dedicated CI job sets it), so the default `go test ./...` stays offline. When
+// enabled but npm is unreachable it SKIPS (never a false failure).
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// civitaiPinRe extracts `"@civitai/<pkg>": "<pin>"` pairs from a rendered or raw
+// package.json(.tmpl). The pin lines carry no template placeholders, so a raw
+// scan of the .tmpl is exact.
+var civitaiPinRe = regexp.MustCompile(`"(@civitai/[a-z0-9-]+)"\s*:\s*"([^"]+)"`)
+
+func TestScaffoldPinsSatisfyPublished(t *testing.T) {
+	if os.Getenv("CIVITAI_CHECK_PUBLISHED_PINS") != "1" {
+		t.Skip("network guard; set CIVITAI_CHECK_PUBLISHED_PINS=1 to run (CI does)")
+	}
+
+	pins := collectCivitaiPins(t)
+	if len(pins) == 0 {
+		t.Fatal("no @civitai/* pins found in any template package.json.tmpl — the extractor is broken")
+	}
+
+	// De-dupe the published lookups across templates.
+	latest := map[string]string{}
+	for _, p := range pins {
+		if _, ok := latest[p.pkg]; ok {
+			continue
+		}
+		v, err := fetchNpmLatest(p.pkg)
+		if err != nil {
+			t.Skipf("npm unreachable for %s (%v) — skipping, not failing", p.pkg, err)
+		}
+		latest[p.pkg] = v
+	}
+
+	for _, p := range pins {
+		published := latest[p.pkg]
+		ok, err := caretAdmits(p.pin, published)
+		if err != nil {
+			t.Fatalf("%s: cannot evaluate pin %q against published %q: %v", p.file, p.pin, published, err)
+		}
+		if !ok {
+			t.Errorf(
+				"STALE SCAFFOLD PIN — every app created from this template is born stale.\n"+
+					"  template: %s\n"+
+					"  package:  %s\n"+
+					"  pinned:   %s   (does NOT admit the published version — pre-1.0 caret locks the minor)\n"+
+					"  published:%s   (npmjs.org/%s latest)\n"+
+					"  fix:      set the pin to \"^%s\" and update the matching assertion in scaffold_test.go",
+				p.file, p.pkg, p.pin, published, p.pkg, published,
+			)
+		}
+	}
+}
+
+type civitaiPin struct {
+	file string // template-relative path of the package.json.tmpl
+	pkg  string // e.g. @civitai/app-sdk
+	pin  string // e.g. ^0.24.0
+}
+
+// collectCivitaiPins walks the embedded templates for every package.json.tmpl
+// and extracts its @civitai/* pins.
+func collectCivitaiPins(t *testing.T) []civitaiPin {
+	t.Helper()
+	var out []civitaiPin
+	err := fs.WalkDir(templatesFS, "templates", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "package.json.tmpl" {
+			return nil
+		}
+		raw, err := templatesFS.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		for _, m := range civitaiPinRe.FindAllStringSubmatch(string(raw), -1) {
+			out = append(out, civitaiPin{file: p, pkg: m[1], pin: m[2]})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking templates: %v", err)
+	}
+	return out
+}
+
+// fetchNpmLatest returns the `version` npm publishes as `latest` for pkg.
+func fetchNpmLatest(pkg string) (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	url := "https://registry.npmjs.org/" + pkg + "/latest"
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Version == "" {
+		return "", fmt.Errorf("GET %s: empty version", url)
+	}
+	return body.Version, nil
+}
+
+// caretAdmits reports whether a caret range `^X.Y.Z` admits the concrete
+// version `published` (stable X.Y.Z), following npm's pre-1.0 semantics:
+//   - ^X.Y.Z, X>0    → [X.Y.Z, (X+1).0.0)
+//   - ^0.Y.Z, Y>0    → [0.Y.Z, 0.(Y+1).0)
+//   - ^0.0.Z         → [0.0.Z, 0.0.(Z+1))
+//
+// A bare (caret-less) pin must equal the published version.
+func caretAdmits(pin, published string) (bool, error) {
+	pubMaj, pubMin, pubPat, err := parseSemver(published)
+	if err != nil {
+		return false, fmt.Errorf("published %q: %w", published, err)
+	}
+
+	caret := strings.HasPrefix(pin, "^")
+	base := strings.TrimPrefix(pin, "^")
+	lo0, lo1, lo2, err := parseSemver(base)
+	if err != nil {
+		return false, fmt.Errorf("pin %q: %w", pin, err)
+	}
+
+	if !caret {
+		return lo0 == pubMaj && lo1 == pubMin && lo2 == pubPat, nil
+	}
+
+	// published must be >= lower bound.
+	if cmpSemver(pubMaj, pubMin, pubPat, lo0, lo1, lo2) < 0 {
+		return false, nil
+	}
+	// and < the caret's upper bound.
+	var hi0, hi1, hi2 int
+	switch {
+	case lo0 > 0:
+		hi0, hi1, hi2 = lo0+1, 0, 0
+	case lo1 > 0:
+		hi0, hi1, hi2 = 0, lo1+1, 0
+	default:
+		hi0, hi1, hi2 = 0, 0, lo2+1
+	}
+	return cmpSemver(pubMaj, pubMin, pubPat, hi0, hi1, hi2) < 0, nil
+}
+
+func parseSemver(v string) (int, int, int, error) {
+	// Drop any prerelease/build metadata; `latest` is stable but be defensive.
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, fmt.Errorf("not X.Y.Z: %q", v)
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("non-numeric component in %q: %w", v, err)
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], nil
+}
+
+func cmpSemver(a0, a1, a2, b0, b1, b2 int) int {
+	if a0 != b0 {
+		return a0 - b0
+	}
+	if a1 != b1 {
+		return a1 - b1
+	}
+	return a2 - b2
+}

--- a/internal/scaffold/pins_guard_test.go
+++ b/internal/scaffold/pins_guard_test.go
@@ -22,6 +22,7 @@ package scaffold
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -32,6 +33,11 @@ import (
 	"testing"
 	"time"
 )
+
+// errPkgNotFound is returned by fetchNpmLatest when npm answers 404/410 — the
+// package genuinely does not exist (vs a transient/connectivity failure). The
+// guard hard-fails on this and skips on everything else.
+var errPkgNotFound = errors.New("package not found on npm")
 
 // civitaiPinRe extracts `"@civitai/<pkg>": "<pin>"` pairs from a rendered or raw
 // package.json(.tmpl). The pin lines carry no template placeholders, so a raw
@@ -50,18 +56,39 @@ func TestScaffoldPinsSatisfyPublished(t *testing.T) {
 
 	// De-dupe the published lookups across templates.
 	latest := map[string]string{}
+	notFound := map[string]bool{} // packages npm returned 404/410 for
 	for _, p := range pins {
-		if _, ok := latest[p.pkg]; ok {
+		if _, ok := latest[p.pkg]; ok || notFound[p.pkg] {
 			continue
 		}
 		v, err := fetchNpmLatest(p.pkg)
-		if err != nil {
+		switch {
+		case errors.Is(err, errPkgNotFound):
+			// The package genuinely does not exist on npm — a renamed/
+			// unpublished/typo'd pin. This is a REAL drift, not "can't tell
+			// right now", so fail loud (don't skip).
+			notFound[p.pkg] = true
+			t.Errorf(
+				"NONEXISTENT PACKAGE — a template pins a package npm does not publish.\n"+
+					"  template: %s\n"+
+					"  package:  %s   (not found on npm — renamed, unpublished, or a typo in the pin?)\n"+
+					"  fix:      correct the @civitai/* package name in the template's package.json.tmpl",
+				p.file, p.pkg,
+			)
+		case err != nil:
+			// Transient/connectivity failure (DNS/timeout/connection-refused,
+			// or a 5xx / 429 rate-limit) — we can't tell right now, so skip
+			// rather than false-fail.
 			t.Skipf("npm unreachable for %s (%v) — skipping, not failing", p.pkg, err)
+		default:
+			latest[p.pkg] = v
 		}
-		latest[p.pkg] = v
 	}
 
 	for _, p := range pins {
+		if notFound[p.pkg] {
+			continue // already reported as a nonexistent package
+		}
 		published := latest[p.pkg]
 		ok, err := caretAdmits(p.pin, published)
 		if err != nil {
@@ -123,6 +150,12 @@ func fetchNpmLatest(pkg string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+	// 404/410 = the package genuinely doesn't exist → a real drift/typo the
+	// guard must fail on. Any other non-200 (5xx, 429 rate-limit, …) is a
+	// "can't tell right now" that the caller skips on.
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		return "", fmt.Errorf("GET %s: %s: %w", url, resp.Status, errPkgNotFound)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("GET %s: %s", url, resp.Status)
 	}
@@ -179,6 +212,9 @@ func caretAdmits(pin, published string) (bool, error) {
 	return cmpSemver(pubMaj, pubMin, pubPat, hi0, hi1, hi2) < 0, nil
 }
 
+// parseSemver parses a concrete X.Y.Z. Only caret (`^X.Y.Z`) and exact pins are
+// supported (all the templates use); a `~`/`>=`/`x` operator will fail loud
+// here, which is the right behavior — a red CI prompting a guard update.
 func parseSemver(v string) (int, int, int, error) {
 	// Drop any prerelease/build metadata; `latest` is stable but be defensive.
 	if i := strings.IndexAny(v, "-+"); i >= 0 {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -118,12 +118,14 @@ func TestRenderPageMoney(t *testing.T) {
 	pkg := readFile(t, filepath.Join(dest, "package.json"))
 	mustContain(t, pkg, `"@civitai/blocks-react"`)
 	// Per-account Buzz (useBuzzBalance / body.accountType / snapshot.spentAccountType)
-	// needs @civitai/blocks-react@0.18.0 (createMockHost now answers GET_BUZZ_BALANCE
+	// needs @civitai/blocks-react@0.18.0+ (createMockHost answers GET_BUZZ_BALANCE
 	// from the `buzzBalance` option AND stamps spentAccountType on succeeded
 	// snapshots natively — so the scaffold no longer ships a mock balance shim) +
-	// @civitai/app-sdk@0.14.0.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.18.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.14.0"`)
+	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
+	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
+	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.29.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.24.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -111,7 +111,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.14.0` + `@civitai/blocks-react@^0.17.0` (already pinned in
+`@civitai/app-sdk@^0.24.0` + `@civitai/blocks-react@^0.29.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.14.0",
-    "@civitai/blocks-react": "^0.18.0",
+    "@civitai/app-sdk": "^0.24.0",
+    "@civitai/blocks-react": "^0.29.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Why

The `page-money` scaffold pinned `@civitai/app-sdk@^0.14.0` + `@civitai/blocks-react@^0.18.0`, but npm publishes **`@civitai/app-sdk@0.24.0`** / **`@civitai/blocks-react@0.29.0`**. The SDK is pre-1.0, so a caret **locks the minor** (`^0.18.0` can never install `0.24.0`) — every scaffolded app was born 6–11 minors stale, peer-mismatched, and missing later APIs.

The existing `template-page-money` CI job (scaffold → `npm install` → typecheck → build) does **not** catch this: `npm install` resolves the stale caret to the newest version it still *admits* — a green-but-old `0.18.x`. Staleness was silent.

## Pin changes

| Template | Package | Before | After |
|---|---|---|---|
| `page-money/package.json.tmpl` | `@civitai/app-sdk` | `^0.14.0` | `^0.24.0` |
| `page-money/package.json.tmpl` | `@civitai/blocks-react` | `^0.18.0` | `^0.29.0` |

`^0.24.0` ↔ `^0.29.0` is the current published pairing — `blocks-react@0.29.0`'s `peerDependencies` require `@civitai/app-sdk: ^0.24.0`, so they're consistent. `page-vite` and `static` templates carry no `@civitai/*` deps (nothing to bump). No OAuth template exists in this repo. The README claim + the two `scaffold_test.go` assertions were bumped in lockstep.

## Proof a freshly-scaffolded app installs + builds against the new pins

Scaffolded `page-money` to a temp dir with the built CLI, then ran its own toolchain (verbatim):

```
$ npm ls @civitai/app-sdk @civitai/blocks-react
├── @civitai/app-sdk@0.24.0
└─┬ @civitai/blocks-react@0.29.0
  └── @civitai/app-sdk@0.24.0 deduped        # no peer-dep conflict

$ npm run typecheck
> tsc -p tsconfig.json --noEmit             # clean, no output

$ npm test
 Test Files  10 passed (10)
      Tests  123 passed (123)

$ npm run build
dist/assets/index-DuB_LVUc.js   248.09 kB │ gzip: 75.10 kB
✓ built in 84ms
```

`npm install` completed with **no peer-dep error**. **No template code changes were needed** for the SDK bump — the scaffold's code compiles and tests green against `app-sdk@0.24` / `blocks-react@0.29` as-is.

## The pins-vs-published CI guard

New `TestScaffoldPinsSatisfyPublished` (`internal/scaffold/pins_guard_test.go`):

- Walks the embedded templates for every `package.json.tmpl`, extracts each `@civitai/*` pin.
- Fetches `https://registry.npmjs.org/<pkg>/latest` → `.version`.
- Asserts the caret range still **admits** the published version (correct pre-1.0 caret semantics: `^0.Y.Z` → `[0.Y.Z, 0.(Y+1).0)`).
- On a stale pin, fails **loud** with the stale pin, the current published version, and the one-line fix.
- **Network-gated** behind `CIVITAI_CHECK_PUBLISHED_PINS=1` so the default `go test ./...` stays offline; **skips (never false-fails)** when npm is unreachable.

Wired into CI as a dedicated `pins-vs-published` job (`.github/workflows/ci.yml`) that sets the env and runs the guard.

Verified both directions locally:

```
# passes against current npm
--- PASS: TestScaffoldPinsSatisfyPublished (0.47s)

# deliberately reverting app-sdk to ^0.18.0 → fails loud:
STALE SCAFFOLD PIN — every app created from this template is born stale.
  template: templates/page-money/package.json.tmpl
  package:  @civitai/app-sdk
  pinned:   ^0.18.0   (does NOT admit the published version — pre-1.0 caret locks the minor)
  published:0.24.0   (npmjs.org/@civitai/app-sdk latest)
  fix:      set the pin to "^0.24.0" and update the matching assertion in scaffold_test.go
```

Full offline suite: `go build ./...`, `go vet ./...`, `gofmt -s -l` clean, `go test ./...` all pass (the guard skips offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
