### PR TITLE
feat(ci): scaffold-currency guard — anti-pattern + latest-SDK build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,63 @@ jobs:
       - name: validate
         working-directory: ./_ci-page-money
         run: go run ../cmd/civitai app validate
+
+  # Scaffold-currency guard — the "born-broken app" gate. Two rot-classes that
+  # pins-vs-published + template-page-money both MISS:
+  #
+  #   (a) ANTI-PATTERN gate — scaffold the SDK template, then scan the generated
+  #       source for a curated denylist of dead/superseded platform surfaces
+  #       (the REMOVED /api/v1/blocks/buzz route, the superseded shared-storage
+  #       REST route, the deprecated @civitai/blocks-cli). A scaffold can compile
+  #       and pass the pins guard yet still fetch a route that 404s at runtime —
+  #       exactly how playable-collections shipped 3 broken features. The denylist
+  #       is precise: it does NOT flag legitimately-REST unbridged endpoints
+  #       (catalog /models, /images; the /me viewer read; the /dev-token mint).
+  #       Logic + fixtures live in internal/antipattern (offline table test); this
+  #       runs it against the real `civitai app init` output.
+  #
+  #   (b) LATEST-SDK build — install the ACTUAL newest published @civitai/app-sdk
+  #       + @civitai/blocks-react (not the pinned caret npm resolves to) and
+  #       re-typecheck + re-build. pins-vs-published catches "the pin can't admit
+  #       latest"; THIS catches "the template code breaks against latest" (a
+  #       removed/renamed SDK export). Network-dependent — a transient npm outage
+  #       can false-fail; re-run.
+  scaffold-currency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: scaffold page-money
+        run: go run ./cmd/civitai app init "CI Currency Block" --dir ./_ci-currency --template page-money
+
+      # (a) Anti-pattern gate on the scaffolded app.
+      - name: anti-pattern scan (scaffolded app)
+        env:
+          CIVITAI_ANTIPATTERN_SCAN_DIR: ./_ci-currency
+        run: go test ./internal/antipattern -run TestScanDirFromEnv -count=1 -v
+
+      # (b) Build against the LATEST published SDK, not just the pinned caret.
+      - name: install (pinned)
+        working-directory: ./_ci-currency
+        run: npm install --no-audit --no-fund
+
+      - name: install @latest SDK
+        working-directory: ./_ci-currency
+        run: npm install --no-audit --no-fund @civitai/app-sdk@latest @civitai/blocks-react@latest
+
+      - name: typecheck against latest SDK
+        working-directory: ./_ci-currency
+        run: npm run typecheck
+
+      - name: build against latest SDK
+        working-directory: ./_ci-currency
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,17 @@ jobs:
           node-version: "22"
 
       - name: scaffold page-money
-        run: go run ./cmd/civitai app init "CI Currency Block" --dir ./_ci-currency --template page-money
+        run: go run ./cmd/civitai app init "CI Currency Block" --dir "$GITHUB_WORKSPACE/_ci-currency" --template page-money
 
       # (a) Anti-pattern gate on the scaffolded app.
+      #     CIVITAI_ANTIPATTERN_SCAN_DIR MUST be ABSOLUTE: `go test` runs the test
+      #     binary with its CWD set to the package dir (internal/antipattern), not
+      #     the repo root, so a relative `./_ci-currency` would resolve under the
+      #     package dir and lstat-fail. github.workspace anchors it to where the
+      #     scaffold step wrote the app.
       - name: anti-pattern scan (scaffolded app)
         env:
-          CIVITAI_ANTIPATTERN_SCAN_DIR: ./_ci-currency
+          CIVITAI_ANTIPATTERN_SCAN_DIR: ${{ github.workspace }}/_ci-currency
         run: go test ./internal/antipattern -run TestScanDirFromEnv -count=1 -v
 
       # (b) Build against the LATEST published SDK, not just the pinned caret.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,15 @@ jobs:
   #       + @civitai/blocks-react (not the pinned caret npm resolves to) and
   #       re-typecheck + re-build. pins-vs-published catches "the pin can't admit
   #       latest"; THIS catches "the template code breaks against latest" (a
-  #       removed/renamed SDK export). Network-dependent — a transient npm outage
-  #       can false-fail; re-run.
+  #       removed/renamed SDK export). Network-dependent, so it mirrors the
+  #       pins-vs-published SKIP-on-unreachable contract: a reachability PROBE
+  #       gates the install/typecheck/build steps — an npm outage (network / DNS /
+  #       5xx / 429) SKIPS them (job stays green, indistinguishable-from-real is
+  #       avoided) while a reachable registry runs them and FAILS on a genuine
+  #       code-breaks-against-latest signal. (A peer-dep incompat where the pin
+  #       can't admit latest is already caught by pins-vs-published, so treating an
+  #       install failure under a REACHABLE registry as real is correct.) The
+  #       offline anti-pattern scan is hermetic and always runs.
   scaffold-currency:
     runs-on: ubuntu-latest
     steps:
@@ -155,18 +162,41 @@ jobs:
         run: go test ./internal/antipattern -run TestScanDirFromEnv -count=1 -v
 
       # (b) Build against the LATEST published SDK, not just the pinned caret.
+      #     Probe npm first; if the registry is unreachable (network/DNS/5xx/429)
+      #     the build steps SKIP so a transient outage can't red the job (mirrors
+      #     the pins-vs-published skip-on-unreachable contract). A 200 on the
+      #     /latest metadata means "reachable" — a real SDK break then fails at
+      #     typecheck/build, not here.
+      - name: probe npm reachability
+        id: npmprobe
+        run: |
+          code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+            https://registry.npmjs.org/@civitai/app-sdk/latest 2>/dev/null) || code=000
+          [ -z "$code" ] && code=000
+          if [ "$code" = "200" ]; then
+            echo "reachable=true" >> "$GITHUB_OUTPUT"
+            echo "npm registry reachable (HTTP $code) — running the latest-SDK build check"
+          else
+            echo "reachable=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=scaffold-currency::skipped latest-SDK build check — npm registry unreachable (HTTP $code); not a real failure, re-run later"
+          fi
+
       - name: install (pinned)
+        if: steps.npmprobe.outputs.reachable == 'true'
         working-directory: ./_ci-currency
         run: npm install --no-audit --no-fund
 
       - name: install @latest SDK
+        if: steps.npmprobe.outputs.reachable == 'true'
         working-directory: ./_ci-currency
         run: npm install --no-audit --no-fund @civitai/app-sdk@latest @civitai/blocks-react@latest
 
       - name: typecheck against latest SDK
+        if: steps.npmprobe.outputs.reachable == 'true'
         working-directory: ./_ci-currency
         run: npm run typecheck
 
       - name: build against latest SDK
+        if: steps.npmprobe.outputs.reachable == 'true'
         working-directory: ./_ci-currency
         run: npm run build

--- a/internal/antipattern/antipattern.go
+++ b/internal/antipattern/antipattern.go
@@ -1,0 +1,203 @@
+// Package antipattern is the scaffold-currency "born-broken app" gate.
+//
+// The pins-vs-published guard (internal/scaffold, PR #118) catches a template
+// whose `@civitai/*` PIN has fallen behind npm. It does NOT catch a scaffold
+// whose CODE still calls a dead/superseded platform endpoint — a template that
+// compiles and installs cleanly yet ships an app that is broken the moment a
+// user runs it. That is the gap this package closes.
+//
+// THE MOTIVATING FAILURE (playable-collections, 2026-07): an app fell 9 SDK
+// minors behind with THREE broken features because its scaffold used REST
+// endpoints the platform had SUPERSEDED with host-mediated SDK hooks:
+//   - it fetched `/api/v1/blocks/buzz` — a route that was REMOVED (buzz is now
+//     read through the host bridge behind `useBuzzBalance()`), so every buzz
+//     read 404'd.
+//   - it wrote shared state by POSTing `/api/v1/blocks/shared-storage/*` with a
+//     hand-rolled (and wrong) payload shape, instead of the host-mediated
+//     shared-storage bridge — so shared writes silently mismatched the contract.
+//
+// The doctrine (App Blocks "bridge-first"): a browser App block does NOT talk to
+// civitai's REST API directly for any surface that has a PAGE-HOST BRIDGE. The
+// host (which holds the real user session) mediates those via postMessage, and
+// the SDK exposes them as hooks. The authoritative inventory of bridged surfaces
+// is civitai's `src/components/AppBlocks/hostHandlerParity.ts` INVENTORY: buzz
+// reads, viewer, workflows (submit/estimate/poll/cancel), pickers, app storage,
+// shared storage, image upload, wildcard packs. A direct `fetch()` to the REST
+// route BEHIND one of those bridges is the anti-pattern.
+//
+// PRECISION — this is a small CURATED denylist, NOT a blanket "no /api/v1/blocks".
+// Several `/api/v1/blocks/*` routes are legitimately REST and have NO bridge:
+//   - `/api/v1/blocks/models`, `/api/v1/blocks/images` — public high-volume
+//     catalog reads (there is no host bridge; the scaffolds fetch these).
+//   - `/api/v1/blocks/dev-token` — the headless dev-token mint (a CLI/dev path,
+//     not a runtime block surface).
+//   - `/api/v1/blocks/me` — the viewer self-read; its `useViewer()` bridge
+//     successor exists but the route STAYS LIVE until the hook publishes and
+//     consumers migrate, and the page-money scaffold uses it in its dev harness.
+//
+// Flagging any of those would false-fail a correct scaffold, so they are
+// deliberately absent from the denylist. We only flag routes that are REMOVED or
+// whose bridge has fully superseded the REST shape (buzz, shared-storage).
+package antipattern
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Rule is one curated anti-pattern: a regexp that, when it matches a line of a
+// scaffolded app's source, means the scaffold is using a dead/discouraged
+// platform surface. Each rule carries the concrete replacement so the failure
+// message tells the author exactly what to use instead.
+type Rule struct {
+	// ID is a short stable identifier used in messages and tests.
+	ID string
+	// What is a human phrase naming the offending pattern.
+	What string
+	// Pattern matches the offending token on a single line.
+	Pattern *regexp.Regexp
+	// Replacement is the concrete thing to use instead (a hook / the Go CLI).
+	Replacement string
+}
+
+// Rules is the curated denylist. Keep it SMALL and PRECISE — every entry must be
+// a surface the platform has REMOVED or fully superseded with a host bridge, and
+// must NOT match a legitimately-REST endpoint (see the package doc). Each entry
+// links to its replacement hook.
+func Rules() []Rule {
+	return []Rule{
+		{
+			// REMOVED route. Buzz balance is read through the page-host bridge
+			// (GET_BUZZ_BALANCE in hostHandlerParity.ts) exposed as a hook; the
+			// REST route no longer exists, so a scaffold that fetches it 404s.
+			// The terminating char class keeps this to the whole `/buzz` path
+			// segment (won't match a hypothetical `/buzz-*` sibling), and we scan
+			// line-by-line so `$` anchors end-of-line.
+			ID:          "buzz-rest",
+			What:        "fetch of the REMOVED /api/v1/blocks/buzz REST route",
+			Pattern:     regexp.MustCompile("/api/v1/blocks/buzz(?:[/?'\"\\x60\\s),;]|$)"),
+			Replacement: "read buzz through the host bridge — useBuzzBalance() / useBuzzWorkflow() from @civitai/blocks-react (the /api/v1/blocks/buzz route was REMOVED)",
+		},
+		{
+			// SUPERSEDED route. Cross-user/app-global storage is host-mediated
+			// via the SHARED_* bridges (SHARED_APPEND / SHARED_GET_COUNT /
+			// SHARED_VOTE / … in hostHandlerParity.ts). The REST route is the
+			// exact "wrong payload shape" trap the playable-collections app hit.
+			ID:          "shared-storage-rest",
+			What:        "direct fetch of the superseded /api/v1/blocks/shared-storage REST route",
+			Pattern:     regexp.MustCompile("/api/v1/blocks/shared-storage"),
+			Replacement: "use the host-mediated shared-storage hooks from @civitai/blocks-react (the SHARED_APPEND / SHARED_GET_COUNT / SHARED_VOTE bridges), not the REST route — the REST payload shape is superseded",
+		},
+		{
+			// DEPRECATED tool. The npm `@civitai/blocks-cli` package is retired in
+			// favour of this Go CLI; a scaffold that references it teaches authors
+			// a dead workflow.
+			ID:          "deprecated-blocks-cli",
+			What:        "reference to the deprecated @civitai/blocks-cli npm package",
+			Pattern:     regexp.MustCompile("@civitai/blocks-cli"),
+			Replacement: "use the Go civitai CLI (`civitai app <init|dev|submit>`); the @civitai/blocks-cli npm package is deprecated",
+		},
+	}
+}
+
+// Finding is a single rule match at a location in the scanned tree.
+type Finding struct {
+	File string // path relative to the scanned root
+	Line int    // 1-based line number
+	Text string // the trimmed source line
+	Rule Rule
+}
+
+// scannedExts are the source extensions we grep. Anything else (images, lock
+// files, fonts) is skipped. package.json / README are included so a dead pin or
+// a documented dead workflow is caught too.
+var scannedExts = map[string]bool{
+	".ts": true, ".tsx": true, ".js": true, ".jsx": true,
+	".mjs": true, ".cjs": true, ".json": true,
+	".html": true, ".htm": true, ".css": true,
+	".md": true, ".txt": true,
+}
+
+// skipDirs are directory names never descended into (build output, deps, vcs).
+var skipDirs = map[string]bool{
+	"node_modules": true, ".git": true, "dist": true, "build": true,
+	"coverage": true, "out": true, ".vite": true, ".next": true,
+}
+
+// ScanDir walks dir and returns every anti-pattern Finding in its source files,
+// sorted by file then line. A clean tree returns nil, nil.
+func ScanDir(dir string) ([]Finding, error) {
+	rules := Rules()
+	var findings []Finding
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !scannedExts[strings.ToLower(filepath.Ext(d.Name()))] {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			rel = path
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			for _, r := range rules {
+				if r.Pattern.MatchString(line) {
+					findings = append(findings, Finding{
+						File: rel,
+						Line: i + 1,
+						Text: strings.TrimSpace(line),
+						Rule: r,
+					})
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Rule.ID < findings[j].Rule.ID
+	})
+	return findings, nil
+}
+
+// Format renders findings as a human-readable, CI-friendly report. Empty
+// findings returns "".
+func Format(findings []Finding) string {
+	if len(findings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "scaffold-currency: %d anti-pattern(s) found in the scaffolded app:\n\n", len(findings))
+	for _, f := range findings {
+		fmt.Fprintf(&b, "  %s:%d — %s [%s]\n", f.File, f.Line, f.Rule.What, f.Rule.ID)
+		fmt.Fprintf(&b, "      line: %s\n", f.Text)
+		fmt.Fprintf(&b, "      fix:  %s\n\n", f.Rule.Replacement)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/antipattern/antipattern.go
+++ b/internal/antipattern/antipattern.go
@@ -96,10 +96,13 @@ func Rules() []Rule {
 		{
 			// DEPRECATED tool. The npm `@civitai/blocks-cli` package is retired in
 			// favour of this Go CLI; a scaffold that references it teaches authors
-			// a dead workflow.
+			// a dead workflow. The trailing boundary keeps this to the EXACT
+			// package name — a version suffix (`@1.2.3`), a subpath (`/bin`), a
+			// quote, or end-of-line terminates it — so a hypothetical sibling like
+			// `@civitai/blocks-client` is NOT false-flagged.
 			ID:          "deprecated-blocks-cli",
 			What:        "reference to the deprecated @civitai/blocks-cli npm package",
-			Pattern:     regexp.MustCompile("@civitai/blocks-cli"),
+			Pattern:     regexp.MustCompile("@civitai/blocks-cli(?:[@/'\"\\x60\\s),;]|$)"),
 			Replacement: "use the Go civitai CLI (`civitai app <init|dev|submit>`); the @civitai/blocks-cli npm package is deprecated",
 		},
 	}

--- a/internal/antipattern/antipattern_test.go
+++ b/internal/antipattern/antipattern_test.go
@@ -1,0 +1,143 @@
+package antipattern
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScanDir is the two-directional correctness proof for the anti-pattern
+// gate: a fixture that uses a dead/superseded surface FAILS (naming the file,
+// pattern, and replacement), a clean fixture PASSES, and — critically — a
+// fixture full of legitimately-REST endpoints that have no bridge does NOT
+// false-flag.
+func TestScanDir(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string
+		wantRule  string // "" means expect zero findings
+		wantFile  string // substring the offending file path must contain
+		wantInMsg string // substring the formatted message / replacement must contain
+	}{
+		{
+			name: "clean scaffold passes",
+			dir:  "clean",
+		},
+		{
+			name: "legit unbridged REST routes are not flagged",
+			dir:  "legit-rest",
+		},
+		{
+			name: "node_modules is not descended into",
+			dir:  "skips-deps",
+		},
+		{
+			name:      "removed buzz REST route fails",
+			dir:       "buzz-rest",
+			wantRule:  "buzz-rest",
+			wantFile:  "buzz.ts",
+			wantInMsg: "useBuzzBalance",
+		},
+		{
+			name:      "superseded shared-storage REST route fails",
+			dir:       "shared-storage-rest",
+			wantRule:  "shared-storage-rest",
+			wantFile:  "store.ts",
+			wantInMsg: "SHARED_APPEND",
+		},
+		{
+			name:      "deprecated blocks-cli reference fails",
+			dir:       "blocks-cli",
+			wantRule:  "deprecated-blocks-cli",
+			wantFile:  "README.md",
+			wantInMsg: "civitai app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := ScanDir(filepath.Join("testdata", tt.dir))
+			if err != nil {
+				t.Fatalf("ScanDir(%s): %v", tt.dir, err)
+			}
+
+			if tt.wantRule == "" {
+				if len(findings) != 0 {
+					t.Fatalf("expected a clean scan, got %d finding(s):\n%s", len(findings), Format(findings))
+				}
+				return
+			}
+
+			if len(findings) == 0 {
+				t.Fatalf("expected rule %q to fire, got zero findings", tt.wantRule)
+			}
+			// The offending finding must exist with the right rule + file.
+			var hit *Finding
+			for i := range findings {
+				if findings[i].Rule.ID == tt.wantRule {
+					hit = &findings[i]
+					break
+				}
+			}
+			if hit == nil {
+				t.Fatalf("expected rule %q, got findings:\n%s", tt.wantRule, Format(findings))
+			}
+			if !strings.Contains(hit.File, tt.wantFile) {
+				t.Errorf("finding file = %q, want it to contain %q", hit.File, tt.wantFile)
+			}
+			if hit.Line == 0 {
+				t.Errorf("finding has no line number")
+			}
+			if hit.Rule.Replacement == "" {
+				t.Errorf("finding rule %q has an empty Replacement — the message must tell the author what to use instead", hit.Rule.ID)
+			}
+			// The formatted report must name the file, the pattern, and the fix.
+			msg := Format(findings)
+			for _, want := range []string{hit.File, tt.wantInMsg, tt.wantRule} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Format() output missing %q; got:\n%s", want, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestLegitRoutesNeverMatchAnyRule is a focused regression guard: the exact
+// unbridged routes the real scaffolds rely on must never match ANY rule, so the
+// gate can never false-fail a correct scaffold.
+func TestLegitRoutesNeverMatchAnyRule(t *testing.T) {
+	legit := []string{
+		"await fetch('/api/v1/blocks/models?limit=20')",
+		"await fetch('/api/v1/blocks/images')",
+		"fetch(`${base}/api/v1/blocks/me`)",
+		"fetch(`${origin}/api/v1/blocks/dev-token`, { method: 'POST' })",
+		"fetch(`${base}/api/trpc/buzz.getBuzzAccount`)",
+	}
+	for _, r := range Rules() {
+		for _, line := range legit {
+			if r.Pattern.MatchString(line) {
+				t.Errorf("rule %q FALSE-FLAGGED a legit line:\n  rule:    %s\n  matched: %s", r.ID, r.Pattern, line)
+			}
+		}
+	}
+}
+
+// TestScanDirFromEnv is the CI entrypoint. The scaffold-currency job scaffolds a
+// template to disk, sets CIVITAI_ANTIPATTERN_SCAN_DIR to it, and runs this test;
+// any finding fails the job. It SKIPS when the env var is unset so the default
+// `go test ./...` stays hermetic.
+func TestScanDirFromEnv(t *testing.T) {
+	dir := os.Getenv("CIVITAI_ANTIPATTERN_SCAN_DIR")
+	if dir == "" {
+		t.Skip("set CIVITAI_ANTIPATTERN_SCAN_DIR=<scaffolded app dir> to scan it (the CI scaffold-currency job does)")
+	}
+	findings, err := ScanDir(dir)
+	if err != nil {
+		t.Fatalf("scanning %s: %v", dir, err)
+	}
+	if len(findings) > 0 {
+		t.Fatalf("%s", Format(findings))
+	}
+	t.Logf("scaffold-currency: no anti-patterns found in %s", dir)
+}

--- a/internal/antipattern/antipattern_test.go
+++ b/internal/antipattern/antipattern_test.go
@@ -123,6 +123,42 @@ func TestLegitRoutesNeverMatchAnyRule(t *testing.T) {
 	}
 }
 
+// TestBlocksCliBoundary guards the deprecated-blocks-cli rule against matching a
+// wider package name: `@civitai/blocks-cli` (and a versioned/subpath form) must
+// fire, but a hypothetical sibling `@civitai/blocks-client` must NOT.
+func TestBlocksCliBoundary(t *testing.T) {
+	var rule Rule
+	for _, r := range Rules() {
+		if r.ID == "deprecated-blocks-cli" {
+			rule = r
+		}
+	}
+	if rule.Pattern == nil {
+		t.Fatal("deprecated-blocks-cli rule not found")
+	}
+
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{`import x from '@civitai/blocks-cli';`, true},
+		{`npx @civitai/blocks-cli submit`, true},
+		{`"@civitai/blocks-cli": "^1.2.3"`, true},
+		{`npm i @civitai/blocks-cli@1.2.3`, true},
+		{`require('@civitai/blocks-cli/bin')`, true},
+		{`@civitai/blocks-cli`, true}, // bare, end-of-line
+		// Must NOT false-flag a wider package name.
+		{`import x from '@civitai/blocks-client';`, false},
+		{`"@civitai/blocks-client": "^1.0.0"`, false},
+		{`@civitai/blocks-client-utils`, false},
+	}
+	for _, c := range cases {
+		if got := rule.Pattern.MatchString(c.line); got != c.want {
+			t.Errorf("match(%q) = %v, want %v (pattern %s)", c.line, got, c.want, rule.Pattern)
+		}
+	}
+}
+
 // TestScanDirFromEnv is the CI entrypoint. The scaffold-currency job scaffolds a
 // template to disk, sets CIVITAI_ANTIPATTERN_SCAN_DIR to it, and runs this test;
 // any finding fails the job. It SKIPS when the env var is unset so the default

--- a/internal/antipattern/testdata/blocks-cli/README.md
+++ b/internal/antipattern/testdata/blocks-cli/README.md
@@ -1,0 +1,10 @@
+# Example App
+
+To publish this app, run:
+
+```sh
+npx @civitai/blocks-cli submit
+```
+
+<!-- ANTI-PATTERN: the @civitai/blocks-cli npm package is deprecated; the app
+should be published with the Go civitai CLI (`civitai app submit`). -->

--- a/internal/antipattern/testdata/buzz-rest/src/buzz.ts
+++ b/internal/antipattern/testdata/buzz-rest/src/buzz.ts
@@ -1,0 +1,9 @@
+// ANTI-PATTERN: fetches the REMOVED /api/v1/blocks/buzz REST route instead of
+// reading buzz through the host bridge (useBuzzBalance()). This is the exact
+// dead-endpoint that broke playable-collections.
+export async function getBuzz(base: string, token: string) {
+  const res = await fetch(`${base}/api/v1/blocks/buzz`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return res.json();
+}

--- a/internal/antipattern/testdata/clean/src/App.tsx
+++ b/internal/antipattern/testdata/clean/src/App.tsx
@@ -1,0 +1,14 @@
+import { useBuzzBalance } from '@civitai/blocks-react';
+
+// A clean scaffold: buzz is read through the host bridge hook, and the only
+// direct REST calls are to unbridged catalog / dev-token routes.
+export function App() {
+  const { balance } = useBuzzBalance();
+  return balance;
+}
+
+async function loadCatalog() {
+  // Legit: public catalog read, no host bridge.
+  const res = await fetch('/api/v1/blocks/models?limit=20');
+  return res.json();
+}

--- a/internal/antipattern/testdata/legit-rest/src/catalog.ts
+++ b/internal/antipattern/testdata/legit-rest/src/catalog.ts
@@ -1,0 +1,21 @@
+// Every fetch here targets a legitimately-REST endpoint that has NO host bridge.
+// None of these may be flagged — flagging them would false-fail a correct app.
+
+export async function models() {
+  return fetch('/api/v1/blocks/models?limit=20'); // public catalog read
+}
+
+export async function images() {
+  return fetch('/api/v1/blocks/images'); // public catalog read
+}
+
+export async function viewer(base: string, token: string) {
+  // Viewer self-read: the useViewer() bridge exists but this route stays live
+  // until the hook publishes and consumers migrate; scaffolds use it in dev.
+  return fetch(`${base}/api/v1/blocks/me`, { headers: { authorization: `Bearer ${token}` } });
+}
+
+export async function devToken(base: string) {
+  // Headless dev-token mint — a CLI/dev path, not a runtime block surface.
+  return fetch(`${base}/api/v1/blocks/dev-token`, { method: 'POST' });
+}

--- a/internal/antipattern/testdata/shared-storage-rest/src/store.ts
+++ b/internal/antipattern/testdata/shared-storage-rest/src/store.ts
@@ -1,0 +1,9 @@
+// ANTI-PATTERN: writes shared state by POSTing the superseded shared-storage
+// REST route with a hand-rolled payload, instead of the host-mediated
+// SHARED_APPEND bridge. This is the "wrong payload shape" trap.
+export async function vote(base: string, key: string) {
+  return fetch(`${base}/api/v1/blocks/shared-storage/increment`, {
+    method: 'POST',
+    body: JSON.stringify({ key, delta: 1 }),
+  });
+}

--- a/internal/antipattern/testdata/skips-deps/node_modules/dead-dep/index.js
+++ b/internal/antipattern/testdata/skips-deps/node_modules/dead-dep/index.js
@@ -1,0 +1,3 @@
+// A dependency inside node_modules that uses the dead route. The scanner must
+// NOT descend into node_modules — this file must be invisible to ScanDir.
+fetch('/api/v1/blocks/buzz');

--- a/internal/antipattern/testdata/skips-deps/src/app.ts
+++ b/internal/antipattern/testdata/skips-deps/src/app.ts
@@ -1,0 +1,3 @@
+// Clean app source; the only dead-route use lives under node_modules/, which
+// ScanDir must skip.
+export const ok = true;

--- a/internal/scaffold/antipattern_scan_test.go
+++ b/internal/scaffold/antipattern_scan_test.go
@@ -1,0 +1,33 @@
+package scaffold
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/civitai/cli/internal/antipattern"
+)
+
+// TestScaffoldedTemplatesHaveNoAntipatterns renders EVERY template to disk and
+// asserts the scaffold-currency anti-pattern gate finds nothing. This is the
+// offline half of the gate (runs in the default `go test ./...`): it proves the
+// SHIPPED templates never teach a dead/superseded platform surface, and it fires
+// the moment a future template edit reintroduces one — before it reaches an
+// author. The network-dependent scaffold-of-record scan runs in CI against the
+// `civitai app init` output; this covers all templates hermetically.
+func TestScaffoldedTemplatesHaveNoAntipatterns(t *testing.T) {
+	for _, tmpl := range AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), string(tmpl))
+			if _, err := Render(tmpl, dest, Data{Slug: "sample-block", Name: "Sample Block"}); err != nil {
+				t.Fatalf("render %s: %v", tmpl, err)
+			}
+			findings, err := antipattern.ScanDir(dest)
+			if err != nil {
+				t.Fatalf("scan %s: %v", tmpl, err)
+			}
+			if len(findings) > 0 {
+				t.Fatalf("template %q ships an anti-pattern:\n%s", tmpl, antipattern.Format(findings))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why — the motivating failure

The **playable-collections** app fell **9 SDK minors behind with 3 broken features** because its scaffold used REST endpoints the platform had **superseded with host-mediated hooks**:
- it fetched `/api/v1/blocks/buzz` — a route that was **REMOVED** (buzz is now read through the host bridge behind `useBuzzBalance()`), so every buzz read 404'd;
- it wrote shared state by POSTing `/api/v1/blocks/shared-storage/*` with a hand-rolled, **wrong payload shape**, instead of the host-mediated shared-storage bridge.

The pins-vs-published guard (#118) catches a stale **pin**; it does **not** catch a scaffold whose **code** calls a dead endpoint or breaks against the current SDK. This PR closes that gap.

## What this adds

### 1. Anti-pattern gate — `internal/antipattern`
A pure-Go scanner (`ScanDir`) greps a scaffolded app's source against a **small, curated, precise** denylist (not a blanket "no `/api/v1/blocks`"). Each entry links to its replacement, and the failure message names file + line + pattern + fix.

| Rule | Pattern | Why | Replacement |
|---|---|---|---|
| `buzz-rest` | `/api/v1/blocks/buzz` | **REMOVED** route (buzz is host-mediated: `GET_BUZZ_BALANCE` in `hostHandlerParity.ts`) | `useBuzzBalance()` / `useBuzzWorkflow()` from `@civitai/blocks-react` |
| `shared-storage-rest` | `/api/v1/blocks/shared-storage` | **SUPERSEDED** by the `SHARED_*` bridges — the exact "wrong payload shape" trap | the host-mediated shared-storage hooks (`SHARED_APPEND` / `SHARED_GET_COUNT` / `SHARED_VOTE` bridges) |
| `deprecated-blocks-cli` | `@civitai/blocks-cli` | **DEPRECATED** npm CLI | the Go `civitai` CLI (`civitai app <init\|dev\|submit>`) |

**Precision — deliberately NOT flagged** (would false-fail a correct scaffold; verified against the real templates + `hostHandlerParity.ts` inventory): `/api/v1/blocks/models` and `/api/v1/blocks/images` (public high-volume catalog reads, no bridge), `/api/v1/blocks/dev-token` (headless dev-token mint), and `/api/v1/blocks/me` (viewer self-read — the `useViewer()` bridge exists but the route stays live until the hook publishes and the page-money scaffold uses it in its dev harness). The denylist targets only **removed** or **fully-superseded** REST shapes.

### 2. Latest-SDK build — currency, not just the pin
The `scaffold-currency` CI job installs the **actual newest published** `@civitai/app-sdk@latest` + `@civitai/blocks-react@latest` (not the caret npm resolves to) and re-typechecks + re-builds. #118 catches "the pin can't admit latest"; this catches "the template **code** breaks against latest" (a removed/renamed SDK export).

### 3. Coverage across templates
Only **page-money** uses the SDK (`page-vite` and `static` ship no `@civitai/*` and no `fetch`/blocks code), so the latest-SDK build applies to page-money. The anti-pattern gate applies to **all** templates: an offline test (`internal/scaffold`, runs in `go test ./...`) renders every template and asserts zero findings, so the shipped templates can never regress into teaching a dead surface.

## Tests
- **`internal/antipattern` table test** — both directions: buzz-rest / shared-storage / blocks-cli fixtures each **FAIL** naming file+pattern+replacement; a `clean` fixture and a `legit-rest` fixture (models/images/me/dev-token) **PASS** (no false-flag); a `skips-deps` fixture proves `node_modules/` is never descended into. Plus a focused guard that the exact legit routes never match any rule.
- **`internal/scaffold` render-and-scan test** — every rendered template is anti-pattern-clean (offline).
- Offline `go test ./...`, `go vet ./...`, `gofmt -s -l`, `go build ./...` all clean.

## Verbatim proof (injected-fail, run locally)

Scaffold a real app, scan clean, then inject `/api/v1/blocks/buzz`:

```
=== CLEAN scaffold scan (PASS) ===
    antipattern_test.go:142: scaffold-currency: no anti-patterns found in .../_ci-e2e
--- PASS: TestScanDirFromEnv (0.00s)

=== after injecting fetch(`${base}/api/v1/blocks/buzz`) (FAIL) ===
    antipattern_test.go:140: scaffold-currency: 1 anti-pattern(s) found in the scaffolded app:

      src/bad-buzz.ts:2 — fetch of the REMOVED /api/v1/blocks/buzz REST route [buzz-rest]
          line: return fetch(`${base}/api/v1/blocks/buzz`, { headers: { authorization: `Bearer ${token}` } });
          fix:  read buzz through the host bridge — useBuzzBalance() / useBuzzWorkflow() from @civitai/blocks-react (the /api/v1/blocks/buzz route was REMOVED)
--- FAIL: TestScanDirFromEnv (0.00s)

=== after removing the injected file (PASS) ===
ok  github.com/civitai/cli/internal/antipattern
```

Latest-SDK step confirmed against the current published SDK (app-sdk `0.24.1`, blocks-react `0.29.0` — both admitted by the #118 pins): `npm install @latest` → `typecheck` → `build` all **OK**. And it fails as intended on a removed export:

```
src/removed-export.ts(1,10): error TS2305: Module '"@civitai/blocks-react"' has no exported member 'useRemovedInNewSdk'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)