### PR TITLE
feat(validate): re-vendor tightened manifest schema + friendly buildCommand-allowlist check

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -15,6 +16,18 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
+
+// buildCommandRe is the allowlist of permitted build invocations, kept in
+// lockstep with BUILD_COMMAND_RE in the server's block-manifest-validator
+// (src/server/services/block-manifest-validator.service.ts). It admits only
+// "npm/pnpm/yarn run <script>", "vite build", and "npx vite build" — a
+// defense-in-depth guard against shell injection via buildCommand. The vendored
+// JSON Schema carries the same `pattern`; this Go copy exists only to emit a
+// clear, actionable message instead of a raw regex-mismatch error.
+var buildCommandRe = regexp.MustCompile(`^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$`)
+
+// buildCommandMaxLength mirrors BUILD_COMMAND_MAX_LENGTH on the server.
+const buildCommandMaxLength = 128
 
 // printer renders jsonschema ErrorKind messages. It must be non-nil — the
 // library's LocalizedString implementations dereference it.
@@ -140,9 +153,23 @@ func serverOwnedFieldChecks(generic any) []string {
 
 func buildCoherence(dir string, m *manifest.Manifest) []string {
 	var errs []string
-	hasBuild := strings.TrimSpace(m.BuildCommand) != ""
+	build := strings.TrimSpace(m.BuildCommand)
+	hasBuild := build != ""
 	out := strings.TrimSpace(m.OutputDir)
 	hasOut := out != ""
+
+	// buildCommand must be one of the allowlisted invocations (defense in depth
+	// against shell injection). The vendored JSON Schema also enforces the same
+	// pattern + max length, but its error ("does not match pattern ^(?:...)$")
+	// is opaque — emit a clear, actionable message instead. Mirrors the server's
+	// BUILD_COMMAND_RE / BUILD_COMMAND_MAX_LENGTH exactly.
+	if hasBuild {
+		if len(build) > buildCommandMaxLength {
+			errs = append(errs, fmt.Sprintf("buildCommand is too long (%d chars) — it must be at most %d characters", len(build), buildCommandMaxLength))
+		} else if !buildCommandRe.MatchString(build) {
+			errs = append(errs, fmt.Sprintf("buildCommand %q is not an allowed build invocation — use \"npm run <script>\", \"pnpm run <script>\", \"yarn run <script>\", \"vite build\", or \"npx vite build\"", build))
+		}
+	}
 
 	switch {
 	case hasBuild && !hasOut:

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -384,4 +385,48 @@ func TestValidateRejectsOutputDirTraversal(t *testing.T) {
 		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"},
 		"buildCommand": "npm run build", "outputDir": "../../escape"
 	}`, "path traversal")
+}
+
+// --- 🔴 buildCommand allowlist (mirrors server BUILD_COMMAND_RE /
+// BUILD_COMMAND_MAX_LENGTH; a friendly Go message on top of the schema pattern) ---
+
+// buildManifest wraps a buildCommand + valid outputDir (buildCommand requires
+// outputDir) in an otherwise-good manifest.
+func buildManifest(buildCommand string) string {
+	return `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [],
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"},
+		"buildCommand": ` + strconv.Quote(buildCommand) + `, "outputDir": "dist"
+	}`
+}
+
+func TestValidateAcceptsAllowlistedBuildCommands(t *testing.T) {
+	for _, bc := range []string{
+		"npm run build",
+		"pnpm run build",
+		"yarn run test:e2e",
+		"vite build",
+		"npx vite build",
+	} {
+		mustAccept(t, "buildCommand "+bc, buildManifest(bc))
+	}
+}
+
+func TestValidateRejectsNonAllowlistedBuildCommands(t *testing.T) {
+	for _, bc := range []string{
+		"make all",
+		"npm run build && rm -rf /",
+		"bash -c x",
+		"vite build --watch",
+	} {
+		mustReject(t, "buildCommand "+bc, buildManifest(bc), "not an allowed build invocation")
+	}
+}
+
+func TestValidateRejectsOverlongBuildCommand(t *testing.T) {
+	// A valid-shaped but >128-char buildCommand (long script name) is rejected
+	// with the length message, mirroring the server's max length.
+	long := "npm run " + strings.Repeat("a", 130)
+	mustReject(t, "overlong buildCommand", buildManifest(long), "too long")
 }

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -93,16 +93,22 @@
     },
     "buildCommand": {
       "type": "string",
-      "description": "Config-as-code: command the platform runs to build the static bundle (e.g. \"npm run build\"). Omit for no-build (static) apps. When set, outputDir must also be set.",
+      "description": "Config-as-code: command the platform runs to build the static bundle. Must be one of an allowlisted set of build invocations (defense-in-depth against shell injection): \"npm run <script>\", \"pnpm run <script>\", \"yarn run <script>\" (where <script> is a package.json script name), \"vite build\", or \"npx vite build\". Omit for no-build (static) apps. When set, outputDir must also be set. The pattern and max length are kept in lockstep with BUILD_COMMAND_RE / BUILD_COMMAND_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality).",
       "minLength": 1,
-      "maxLength": 256
+      "maxLength": 128,
+      "pattern": "^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$"
     },
     "outputDir": {
       "type": "string",
-      "description": "Config-as-code: directory (relative to the project root) the buildCommand emits static files into (e.g. \"dist\"). Required when buildCommand is set.",
+      "description": "Config-as-code: directory (relative to the project root) the buildCommand emits static files into (e.g. \"dist\"). Must be a safe relative path \u2014 no leading \"/\", no \"..\" path traversal, no backslash separators, and no Windows drive prefix (e.g. C:). Required when buildCommand is set. Kept in lockstep with the outputDir checks in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). (The server additionally rejects a NUL byte; that impossible-in-a-manifest case is intentionally omitted here for RE2 regex portability.)",
       "minLength": 1,
       "maxLength": 256,
-      "pattern": "^[^/].*"
+      "allOf": [
+        { "$comment": "no leading '/' (absolute path)", "not": { "pattern": "^/" } },
+        { "$comment": "no backslash separators (Windows / '\\..' traversal)", "not": { "pattern": "\\\\" } },
+        { "$comment": "no '..' path-traversal segment", "not": { "pattern": "(^|/)\\.\\.(/|$)" } },
+        { "$comment": "no Windows drive prefix (e.g. C:)", "not": { "pattern": "^[A-Za-z]:" } }
+      ]
     },
     "publicSettingsKeys": {
       "type": "array",


### PR DESCRIPTION
## What

Re-vendors the embedded App Block manifest schema (`schema/app-block.manifest.schema.json`, consumed via `//go:embed` and compiled/evaluated by santhosh-tekuri/jsonschema/v6) with the pre-verified canonical bytes from the companion `civitai` PR, and adds a friendly Go semantic check for `buildCommand`.

### Schema re-vendor
Only the `buildCommand` and `outputDir` blocks changed vs the prior embedded copy (byte-identical to the canonical source across the three repos that share it — not hand-edited):
- **`buildCommand`**: adds an allowlist `pattern` (`^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$`) and tightens `maxLength` 256 → 128 — defense-in-depth against shell injection.
- **`outputDir`**: replaces the single `^[^/].*` pattern with stricter traversal rules (no leading `/`, no `..` segment, no backslash separators, no Windows drive prefix).

All new regexes are RE2-compatible (no lookahead) — a green `go test` confirms the schema compiles under the Go RE2 engine.

### Friendly `buildCommand` check
Extends `buildCoherence` in `internal/validate/validate.go` so a bad `buildCommand` yields a clear, actionable message instead of a raw regex-mismatch error — mirroring the existing precedent where `outputDir` already gets a friendly Go message on top of the schema. The allowlist regex is compiled once at package scope (`regexp.MustCompile`) and matches the server's `BUILD_COMMAND_RE` / `BUILD_COMMAND_MAX_LENGTH` (128) exactly. No existing checks were removed.

## Tests
Added to `internal/validate/validate_test.go` (following the existing `mustAccept`/`mustReject` helpers):
- **accept**: `npm run build`, `pnpm run build`, `yarn run test:e2e`, `vite build`, `npx vite build`
- **reject**: `make all`, `npm run build && rm -rf /`, `bash -c x`, `vite build --watch`, and an over-128-char buildCommand

`go build ./...` and `go test ./...` both pass.

## ⚠️ Sequencing

Merge only **AFTER** the companion `civitai` canonical-schema PR deploys to the live https://civitai.com/schemas/app-block/v1.json — until then the `schema-drift` CI job compares this embedded copy against the still-old live URL and will (expectedly) fail. That failure self-heals once the live schema carries the new bytes; it is not a required check for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)