### PR TITLE
chore(scaffold): bump @civitai pins to admit published 0.25.0 / 0.30.0

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -124,8 +124,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.29.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.24.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.30.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.25.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -111,7 +111,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.24.0` + `@civitai/blocks-react@^0.29.0` (already pinned in
+`@civitai/app-sdk@^0.25.0` + `@civitai/blocks-react@^0.30.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.24.0",
-    "@civitai/blocks-react": "^0.29.0",
+    "@civitai/app-sdk": "^0.25.0",
+    "@civitai/blocks-react": "^0.30.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
`pins-vs-published` (`TestScaffoldPinsSatisfyPublished`) is failing on `main` and on every open PR: the scaffold `page-money` template pins `@civitai/app-sdk` `^0.24.0` and `@civitai/blocks-react` `^0.29.0`, but those packages have since published **0.25.0** / **0.30.0**. A pre-1.0 caret locks the minor (`^0.24.0` = `>=0.24.0 <0.25.0`), so the pins no longer admit the published versions.

Bumps both pins one minor in lockstep across the three places that carry them:
- `internal/scaffold/templates/page-money/package.json.tmpl`
- `internal/scaffold/templates/page-money/README.md.tmpl`
- `internal/scaffold/scaffold_test.go` (the exact-string assertions)

Verified locally: `CIVITAI_CHECK_PUBLISHED_PINS=1 go test ./internal/scaffold/ -run TestScaffoldPinsSatisfyPublished` passes; `go build ./...` + `go test ./internal/scaffold/...` green.

Unblocks #120 (its `pins-vs-published` failure is this drift, not the schema change) once that PR is rebased on this.