### PR TITLE
chore(schema): re-vendor canonical manifest schema (scopeJustifications, #3195)

### DIFF
--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -86,6 +86,15 @@
         ]
       }
     },
+    "scopeJustifications": {
+      "type": "object",
+      "description": "OPTIONAL per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. Backward-compatible — omit it and the manifest stays valid; `scopes` is unchanged. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. NOTE: this captures the developer's STATED rationale only; the platform does not verify the claims.",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
     "minApiVersion": {
       "type": "string",
       "description": "Minimum App SDK API version the block targets (informational).",


### PR DESCRIPTION
civitai #3195 added the optional `scopeJustifications` field to the canonical `public/schemas/app-block/v1.json` (per-scope mod-review rationale) but didn't re-vendor this byte-mirror, so `schema-drift` / `check-canonical-schema` went red against the live URL.

Byte-copies the new canonical (sha `fb863095`) — the only change is the added optional `scopeJustifications` block (+9 lines). `go test ./internal/validate/...` passes (schema compiles under RE2 + validates); the Go `Manifest` struct ignores the unknown field, and `civitai app validate` now enforces the field's semantics via the embedded schema. No behavior change for manifests that omit it (backward-compatible).