### PR TITLE
feat(validate): reject scopeJustifications keys that aren't declared scopes

### DIFF
--- a/internal/validate/semantic.go
+++ b/internal/validate/semantic.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -85,6 +86,44 @@ func semanticChecks(generic any) []string {
 		errs = append(errs, sandboxChecks(iframe)...)
 	}
 
+	// scopeJustifications keys must be a subset of the declared scopes
+	// (validator: justifications for scopes the block doesn't request are
+	// rejected). The JSON Schema type-gates the map + its values but cannot
+	// express the keys⊆scopes cross-field rule.
+	errs = append(errs, scopeJustificationChecks(m)...)
+
+	return errs
+}
+
+// scopeJustificationChecks enforces that every key in scopeJustifications is a
+// scope the manifest actually declares in scopes[] — mirroring the server, which
+// rejects justifications for scopes the block doesn't request. The vendored JSON
+// Schema already covers the value shape (non-empty string ≤500 chars); this adds
+// ONLY the keys⊆scopes rule the schema cannot express. Absent map or empty map
+// yields no error (backward-compatible). Scope names are canonical lowercase, so
+// the comparison is an exact match with no case-folding (mirroring the server).
+func scopeJustificationChecks(generic map[string]any) []string {
+	just, ok := generic["scopeJustifications"].(map[string]any)
+	if !ok || len(just) == 0 {
+		// Absent, wrong-typed (schema-handled), or empty → nothing to check.
+		return nil
+	}
+	scopes := stringSet(generic["scopes"])
+
+	// Iterate sorted keys so error order is deterministic.
+	keys := make([]string, 0, len(just))
+	for k := range just {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var errs []string
+	for _, key := range keys {
+		if _, declared := scopes[key]; !declared {
+			errs = append(errs, fmt.Sprintf(
+				"scopeJustifications key %q is not one of the manifest's declared scopes", key))
+		}
+	}
 	return errs
 }
 

--- a/internal/validate/semantic_test.go
+++ b/internal/validate/semantic_test.go
@@ -43,6 +43,107 @@ func TestIframeRequiredFieldsBadTypes(t *testing.T) {
 	}
 }
 
+func TestScopeJustificationChecks(t *testing.T) {
+	cases := []struct {
+		name    string
+		generic map[string]any
+		want    []string
+	}{
+		{
+			name: "key present in scopes → no error (control)",
+			generic: map[string]any{
+				"scopes":              []any{"user:read:self"},
+				"scopeJustifications": map[string]any{"user:read:self": "needed to greet the user"},
+			},
+			want: nil,
+		},
+		{
+			name: "key not in scopes → specific error naming the key",
+			generic: map[string]any{
+				"scopes":              []any{"user:read:self"},
+				"scopeJustifications": map[string]any{"buzz:read:self": "why I want buzz"},
+			},
+			want: []string{
+				`scopeJustifications key "buzz:read:self" is not one of the manifest's declared scopes`,
+			},
+		},
+		{
+			name: "multiple unknown keys → one error each",
+			generic: map[string]any{
+				"scopes": []any{"user:read:self"},
+				"scopeJustifications": map[string]any{
+					"buzz:read:self":     "a",
+					"media:read:owned":   "b",
+					"apps:storage:write": "c",
+				},
+			},
+			want: []string{
+				`scopeJustifications key "apps:storage:write" is not one of the manifest's declared scopes`,
+				`scopeJustifications key "buzz:read:self" is not one of the manifest's declared scopes`,
+				`scopeJustifications key "media:read:owned" is not one of the manifest's declared scopes`,
+			},
+		},
+		{
+			name: "mix of known and unknown → only unknown errors",
+			generic: map[string]any{
+				"scopes": []any{"user:read:self", "buzz:read:self"},
+				"scopeJustifications": map[string]any{
+					"user:read:self":   "known-ok",
+					"media:read:owned": "unknown",
+				},
+			},
+			want: []string{
+				`scopeJustifications key "media:read:owned" is not one of the manifest's declared scopes`,
+			},
+		},
+		{
+			name:    "scopeJustifications absent → no error",
+			generic: map[string]any{"scopes": []any{"user:read:self"}},
+			want:    nil,
+		},
+		{
+			name: "empty scopeJustifications map → no error",
+			generic: map[string]any{
+				"scopes":              []any{"user:read:self"},
+				"scopeJustifications": map[string]any{},
+			},
+			want: nil,
+		},
+		{
+			name: "case matters — exact match only, no case-fold",
+			generic: map[string]any{
+				"scopes":              []any{"user:read:self"},
+				"scopeJustifications": map[string]any{"User:Read:Self": "wrong case"},
+			},
+			want: []string{
+				`scopeJustifications key "User:Read:Self" is not one of the manifest's declared scopes`,
+			},
+		},
+		{
+			name: "wrong-typed scopeJustifications (schema-handled) → no error",
+			generic: map[string]any{
+				"scopes":              []any{"user:read:self"},
+				"scopeJustifications": "not-an-object",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scopeJustificationChecks(tc.generic)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d errors %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("error[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestSandboxChecksNonStringIgnored(t *testing.T) {
 	if errs := sandboxChecks(map[string]any{"sandbox": 123}); errs != nil {
 		t.Errorf("non-string sandbox is schema-handled, got %v", errs)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -149,6 +149,30 @@ func TestValidateAcceptsMissingCategory(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsUnknownScopeJustificationKey(t *testing.T) {
+	// End-to-end through the semantic path: an otherwise-valid manifest that
+	// justifies a scope it does not declare must be rejected, matching the
+	// server rule that justifications for un-requested scopes are rejected.
+	mustReject(t, "unknown scopeJustifications key", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": ["user:read:self"],
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"},
+		"scopeJustifications": {"buzz:read:self": "I would like buzz"}
+	}`, `scopeJustifications key "buzz:read:self"`)
+}
+
+func TestValidateAcceptsDeclaredScopeJustification(t *testing.T) {
+	// Control: justifying a scope that IS declared passes end-to-end.
+	mustAccept(t, "declared scopeJustifications key", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": ["user:read:self"],
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"},
+		"scopeJustifications": {"user:read:self": "needed to greet the signed-in user"}
+	}`)
+}
+
 func TestValidateRejectsBadContentRating(t *testing.T) {
 	mustReject(t, "bad contentRating", `{
 		"blockId": "ok-block", "version": "0.1.0", "name": "X",


### PR DESCRIPTION
## What

`civitai app validate` now rejects a `scopeJustifications` key that isn't one of the manifest's declared `scopes[]`, matching the server-side rule (justifications for scopes the app doesn't request are rejected). Devs fail fast locally instead of only being rejected on submit.

## Why

civitai #3195 added the optional `scopeJustifications` manifest field (a map of `scope-id → rationale`, shown to moderators), and the CLI re-vendored the JSON Schema (#123) so it already validates each justification **value** (non-empty string, ≤500 chars). But one rule can't be expressed in JSON Schema and was **not** enforced locally: **every `scopeJustifications` key must be a scope actually declared in `scopes[]`.** The server enforces this imperatively; the CLI didn't — so a manifest that justified an un-requested scope passed `civitai app validate` locally and was only rejected on submit. This closes that gap.

## The change

- New `scopeJustificationChecks(generic map[string]any) []string` helper in `internal/validate/semantic.go`, in the same style as `iframeRequiredFields` / `sandboxChecks`, wired into `semanticChecks`.
- Reads `scopes` (`[]any` of strings, via the existing `stringSet` helper) and `scopeJustifications` (`map[string]any`) defensively — absent/wrong-typed is tolerated (the JSON Schema already type-gates), no panics.
- For each key not present in `scopes`, appends `scopeJustifications key %q is not one of the manifest's declared scopes`.
- Exact lowercase match, **no case-fold** — scopes are canonical lowercase, mirroring the server.
- Does **not** duplicate the value length/type check (the vendored schema owns that). Only the keys⊆scopes rule.
- Absent `scopeJustifications` → no error; empty `{}` → no error (backward-compatible).

## Tests

Table-driven unit tests (`internal/validate/semantic_test.go`) — control (declared key OK), unknown key → specific error naming the key, multiple unknown keys → one error each, mix of known/unknown, absent, empty map, exact-case (no case-fold), wrong-typed map. Plus end-to-end tests through `Dir()` (`internal/validate/validate_test.go`): an otherwise-valid manifest with an undeclared justification key is rejected; the declared-key control accepts.

```
$ make ci   # tidy vet test build
go vet ./...        # clean
go test ./...       # all packages ok (internal/validate ok)
go build ...        # ok
```

Confirmed the end-to-end test **fails** with the check unwired (`expected rejection, got valid`) and passes once restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
