### PR TITLE
ci: automate re-vendoring the embedded manifest schema from the canonical

### DIFF
--- a/.github/workflows/revendor-canonical-schema.yml
+++ b/.github/workflows/revendor-canonical-schema.yml
@@ -1,0 +1,90 @@
+# Auto-re-vendor the go:embedded block-manifest schema from the canonical one
+# published at https://civitai.com/schemas/app-block/v1.json.
+#
+# The CLI embeds a mirror of the platform's canonical schema for offline
+# `civitai app validate`. Every canonical change (a new field, a tightened rule)
+# turns `check-canonical-schema` red until a human re-vendors the mirror. This
+# job runs the re-vendor script, validates the result IN THIS JOB, and opens a
+# PR when the schema changed — so the hand-resync never recurs. Sibling of the
+# `bump-scaffold-pins` workflow (the pin-drift automation).
+name: revendor-canonical-schema
+
+on:
+  schedule:
+    # Weekly, Mondays 07:37 UTC — offset from bump-scaffold-pins (07:17) so the
+    # two automations don't open PRs in the same minute. Cron literal quoted so
+    # the `*` isn't parsed as a YAML alias.
+    - cron: "37 7 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  revendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: re-vendor embedded schema from the live canonical
+        run: ./scripts/revendor-canonical-schema.sh
+
+      # Only validate + open a PR when the re-vendor actually changed the file —
+      # a no-op run (already in sync) skips everything downstream.
+      - name: detect changes
+        id: changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "embedded schema already current — nothing to do"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Prove the re-vendored schema compiles under the CLI's jsonschema engine
+      # AND the bundled example manifests still validate against it. An added
+      # REQUIRED field or an otherwise-breaking change fails here → no PR opens
+      # (a human handles the incompatible change); an additive/optional change
+      # validates cleanly → the PR opens.
+      - name: validate — schema compiles + examples validate
+        if: steps.changed.outputs.changed == 'true'
+        run: go test ./internal/validate/...
+
+      - name: open PR if schema changed
+        if: steps.changed.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        with:
+          # Shared scoped automation token (Contents + Pull requests: RW on this
+          # repo only) — the same secret bump-scaffold-pins uses, because the
+          # civitai org disallows the default GITHUB_TOKEN from creating PRs.
+          # A PR opened with it also triggers the repo's normal CI.
+          token: ${{ secrets.BUMP_SCAFFOLD_PINS_TOKEN }}
+          branch: automation/revendor-canonical-schema
+          delete-branch: true
+          commit-message: "chore(schema): re-vendor embedded manifest schema from canonical"
+          title: "chore(schema): re-vendor embedded manifest schema from canonical"
+          body: |
+            Automated by the `revendor-canonical-schema` workflow
+            (`scripts/revendor-canonical-schema.sh`).
+
+            The canonical block-manifest schema published at
+            https://civitai.com/schemas/app-block/v1.json changed, so the CLI's
+            go:embedded mirror (`schema/app-block.manifest.schema.json`) drifted
+            and `check-canonical-schema` would go red. This PR re-vendors the
+            embedded copy from the canonical.
+
+            Validated in the job before opening: the re-vendored schema compiles
+            under the CLI's jsonschema engine and the bundled example manifests
+            still validate against it (`go test ./internal/validate/...`).
+
+            **Reviewer heads-up:** this bot only re-vendors the schema *bytes*.
+            If the canonical change added a field with author-facing semantics
+            (e.g. a new manifest key), consider whether `internal/validate/` (the
+            Go semantic checks / friendly messages) should track it too — that
+            part is a deliberate human call.

--- a/.github/workflows/revendor-canonical-schema.yml
+++ b/.github/workflows/revendor-canonical-schema.yml
@@ -54,7 +54,10 @@ jobs:
       # validates cleanly → the PR opens.
       - name: validate — schema compiles + examples validate
         if: steps.changed.outputs.changed == 'true'
-        run: go test ./internal/validate/...
+        # Full suite so the ROOT-package examples test (examples_test.go —
+        # `TestExampleManifestsValidateClean`, which validates the shipped
+        # examples/*.block.manifest.json) runs too, not just internal/validate.
+        run: go test ./...
 
       - name: open PR if schema changed
         if: steps.changed.outputs.changed == 'true'
@@ -81,7 +84,7 @@ jobs:
 
             Validated in the job before opening: the re-vendored schema compiles
             under the CLI's jsonschema engine and the bundled example manifests
-            still validate against it (`go test ./internal/validate/...`).
+            still validate against it (`go test ./...`).
 
             **Reviewer heads-up:** this bot only re-vendors the schema *bytes*.
             If the canonical change added a field with author-facing semantics

--- a/scripts/revendor-canonical-schema.sh
+++ b/scripts/revendor-canonical-schema.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Auto-re-vendor: overwrite the embedded block-manifest schema with the canonical
+# one published at https://civitai.com/schemas/app-block/v1.json, IF they differ.
+#
+# The CLI go:embeds schema/app-block.manifest.schema.json for offline `civitai
+# app validate`; that copy is a vendored mirror of the platform's canonical
+# schema, and `check-canonical-schema.sh` fails CI when it drifts. This script is
+# the auto-fix that keeps the mirror in sync so a canonical change never needs a
+# hand-resync (the scheduled `revendor-canonical-schema` workflow runs it and
+# opens a PR when anything changed).
+#
+# Comparison is normalized (jq -S) — same as the drift guard — so insignificant
+# key-ordering/whitespace differences don't trigger a needless re-vendor; any
+# real content difference does.
+#
+# Fetch contract (mirrors the pins guard): a transient failure (network / DNS /
+# timeout / 5xx / 429) is a SKIP (exit 0, no change) — don't fail the scheduled
+# job or open a broken PR on a blip. A 404/410 means the canonical URL moved — a
+# real contract break — so fail loud.
+set -euo pipefail
+
+CANONICAL_URL="${CANONICAL_URL:-https://civitai.com/schemas/app-block/v1.json}"
+VENDORED="$(cd "$(dirname "$0")/.." && pwd)/schema/app-block.manifest.schema.json"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+code="$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 30 "$CANONICAL_URL" || echo 000)"
+case "$code" in
+  200) ;;
+  404 | 410)
+    echo "ERROR: canonical schema $CANONICAL_URL returned HTTP $code — did the canonical URL move?" >&2
+    exit 1
+    ;;
+  *)
+    echo "canonical schema $CANONICAL_URL unreachable (HTTP $code) — skipping re-vendor (transient)" >&2
+    exit 0
+    ;;
+esac
+
+if ! jq empty "$tmp" >/dev/null 2>&1; then
+  echo "ERROR: canonical schema at $CANONICAL_URL is not valid JSON — skipping" >&2
+  exit 1
+fi
+
+if diff -q <(jq -S . "$VENDORED") <(jq -S . "$tmp") >/dev/null 2>&1; then
+  echo "embedded schema already matches the canonical — nothing to do"
+  exit 0
+fi
+
+cp "$tmp" "$VENDORED"
+echo "re-vendored $VENDORED from $CANONICAL_URL"

--- a/scripts/revendor-canonical-schema.sh
+++ b/scripts/revendor-canonical-schema.sh
@@ -38,8 +38,11 @@ case "$code" in
     ;;
 esac
 
-if ! jq empty "$tmp" >/dev/null 2>&1; then
-  echo "ERROR: canonical schema at $CANONICAL_URL is not valid JSON — skipping" >&2
+# Reject an empty/whitespace or non-object 200 body BEFORE the cp — `jq empty`
+# alone exits 0 on a 0-byte file, which would overwrite the embedded schema with
+# an empty file (a CDN/edge quirk shouldn't be able to blank the mirror).
+if [ ! -s "$tmp" ] || ! jq -e 'type == "object"' "$tmp" >/dev/null 2>&1; then
+  echo "ERROR: canonical schema at $CANONICAL_URL is empty or not a JSON object — refusing to re-vendor" >&2
   exit 1
 fi
 


### PR DESCRIPTION
The schema-drift twin of the pin-drift automation (`bump-scaffold-pins`). Every canonical schema change (e.g. #3195's `scopeJustifications`) turns `check-canonical-schema` red until a human re-vendors the go:embedded mirror (`schema/app-block.manifest.schema.json`) — we hand-did this twice this cycle.

- **`scripts/revendor-canonical-schema.sh`** — fetch the canonical from `https://civitai.com/schemas/app-block/v1.json`, `jq -S` compare to the embedded copy (same normalization the drift guard uses), overwrite on real drift. Fetch contract mirrors the pins guard: transient failure (network/DNS/5xx/429) → **skip** (exit 0); 404/410 (canonical moved) → **fail loud**. Idempotent.
- **`.github/workflows/revendor-canonical-schema.yml`** — weekly (offset from `bump-scaffold-pins`) + `workflow_dispatch`. Runs the script; if the schema changed, validates in-job (`go test ./internal/validate/...` — schema compiles under the jsonschema engine + bundled examples still validate; an incompatible change fails here → no PR), then opens a PR via the shared scoped token (`BUMP_SCAFFOLD_PINS_TOKEN`).

Verified locally: the script is an idempotent no-op while the mirror is in sync; shellcheck clean; YAML valid. The PR body flags that a semantic canonical addition may still warrant a human `internal/validate/` change — the bot only re-vendors the bytes.

Follow-up: the same automation for the app-starters SDK mirror (JS).