### PR TITLE
feat(cli): add read subcommands (models/model-versions/images/tags/creators/users)

### DIFF
--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// ImageStats is the reaction/comment stats block on an image item.
+type ImageStats struct {
+	LikeCount    int `json:"likeCount"`
+	HeartCount   int `json:"heartCount"`
+	LaughCount   int `json:"laughCount"`
+	CryCount     int `json:"cryCount"`
+	CommentCount int `json:"commentCount"`
+}
+
+// ImageItem is the subset of a `GET /api/v1/images` item the CLI renders. The
+// full item (meta, tags, hash, baseModel) is preserved for --json via Raw.
+type ImageItem struct {
+	ID        int        `json:"id"`
+	URL       string     `json:"url"`
+	Width     int        `json:"width"`
+	Height    int        `json:"height"`
+	NSFWLevel string     `json:"nsfwLevel"`
+	Type      string     `json:"type"`
+	PostID    *int       `json:"postId"`
+	Username  string     `json:"username"`
+	Stats     ImageStats `json:"stats"`
+}
+
+// ImageSearchResult bundles the parsed items + pagination metadata with the raw
+// response body (for --json passthrough).
+type ImageSearchResult struct {
+	Items    []ImageItem `json:"items"`
+	Metadata Metadata    `json:"metadata"`
+	Raw      []byte      `json:"-"`
+}
+
+// SearchImages calls GET /api/v1/images with the given query params.
+func (c *Client) SearchImages(ctx context.Context, q url.Values) (*ImageSearchResult, error) {
+	var res ImageSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/images", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}

--- a/internal/api/model_versions.go
+++ b/internal/api/model_versions.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// ModelVersionFile is the subset of a model-version file the CLI lists.
+type ModelVersionFile struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	SizeKB float64 `json:"sizeKB"`
+}
+
+// ModelVersionModel is the embedded parent-model summary on a version detail.
+type ModelVersionModel struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	NSFW bool   `json:"nsfw"`
+}
+
+// ModelVersionStats is the version-level stats block.
+type ModelVersionStats struct {
+	DownloadCount int `json:"downloadCount"`
+	ThumbsUpCount int `json:"thumbsUpCount"`
+}
+
+// ModelVersionDetail is the subset of `GET /api/v1/model-versions/{id}` (and
+// `/by-hash/{hash}`) the CLI renders. The full body (images, all files with
+// hashes) is preserved for --json via the raw bytes the getter returns.
+type ModelVersionDetail struct {
+	ID           int                `json:"id"`
+	ModelID      int                `json:"modelId"`
+	Name         string             `json:"name"`
+	BaseModel    string             `json:"baseModel"`
+	AIR          string             `json:"air"`
+	DownloadURL  string             `json:"downloadUrl"`
+	TrainedWords []string           `json:"trainedWords"`
+	Model        *ModelVersionModel `json:"model"`
+	Files        []ModelVersionFile `json:"files"`
+	Stats        ModelVersionStats  `json:"stats"`
+}
+
+// GetModelVersion calls GET /api/v1/model-versions/{id}.
+func (c *Client) GetModelVersion(ctx context.Context, id string) (*ModelVersionDetail, []byte, error) {
+	var v ModelVersionDetail
+	raw, err := c.getInto(ctx, "/api/v1/model-versions/"+url.PathEscape(id), nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &v, raw, nil
+}
+
+// GetModelVersionByHash calls GET /api/v1/model-versions/by-hash/{hash}. The
+// server upper-cases the hash server-side; any file-hash type (AutoV2, SHA256,
+// …) is accepted.
+func (c *Client) GetModelVersionByHash(ctx context.Context, hash string) (*ModelVersionDetail, []byte, error) {
+	var v ModelVersionDetail
+	raw, err := c.getInto(ctx, "/api/v1/model-versions/by-hash/"+url.PathEscape(hash), nil, &v)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &v, raw, nil
+}

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// Creator is the minimal creator view the model endpoints embed.
+type Creator struct {
+	Username string `json:"username"`
+}
+
+// ModelStats is the AllTime stats block the model list/detail endpoints embed.
+type ModelStats struct {
+	DownloadCount int `json:"downloadCount"`
+	ThumbsUpCount int `json:"thumbsUpCount"`
+	CommentCount  int `json:"commentCount"`
+}
+
+// ModelListItem is the subset of a `GET /api/v1/models` item the CLI renders in
+// its compact list. The full item (versions, files, images, license flags) is
+// preserved for --json via the result's Raw bytes.
+type ModelListItem struct {
+	ID      int        `json:"id"`
+	Name    string     `json:"name"`
+	Type    string     `json:"type"`
+	NSFW    bool       `json:"nsfw"`
+	Creator *Creator   `json:"creator"`
+	Stats   ModelStats `json:"stats"`
+}
+
+// ModelVersionSummary is the per-version summary shown under a model detail.
+type ModelVersionSummary struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	BaseModel string `json:"baseModel"`
+}
+
+// ModelDetail is the subset of `GET /api/v1/models/{id}` the CLI renders.
+type ModelDetail struct {
+	ID            int                   `json:"id"`
+	Name          string                `json:"name"`
+	Type          string                `json:"type"`
+	NSFW          bool                  `json:"nsfw"`
+	Creator       *Creator              `json:"creator"`
+	Tags          []string              `json:"tags"`
+	Stats         ModelStats            `json:"stats"`
+	ModelVersions []ModelVersionSummary `json:"modelVersions"`
+}
+
+// ModelSearchResult bundles the parsed items + pagination metadata with the raw
+// response body (for --json passthrough).
+type ModelSearchResult struct {
+	Items    []ModelListItem `json:"items"`
+	Metadata Metadata        `json:"metadata"`
+	Raw      []byte          `json:"-"`
+}
+
+// SearchModels calls GET /api/v1/models with the given query params.
+func (c *Client) SearchModels(ctx context.Context, q url.Values) (*ModelSearchResult, error) {
+	var res ModelSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/models", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// GetModel calls GET /api/v1/models/{id}. Returns the parsed detail and the raw
+// body (for --json).
+func (c *Client) GetModel(ctx context.Context, id string) (*ModelDetail, []byte, error) {
+	var m ModelDetail
+	raw, err := c.getInto(ctx, "/api/v1/models/"+url.PathEscape(id), nil, &m)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &m, raw, nil
+}

--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Reader is the read surface of the public Civitai REST API (`/api/v1/**`).
+//
+// These are all public GET endpoints: they accept the CLI's bearer token when
+// one is configured (a personal API key or an OAuth device-login access token,
+// refreshed transparently on a 401) but also work fully anonymously, since the
+// public read routes do not enforce scope. Build the Client with an empty token
+// (api.New(base, "", "")) to force anonymous requests.
+type Reader interface {
+	SearchModels(ctx context.Context, q url.Values) (*ModelSearchResult, error)
+	GetModel(ctx context.Context, id string) (*ModelDetail, []byte, error)
+	GetModelVersion(ctx context.Context, id string) (*ModelVersionDetail, []byte, error)
+	GetModelVersionByHash(ctx context.Context, hash string) (*ModelVersionDetail, []byte, error)
+	SearchImages(ctx context.Context, q url.Values) (*ImageSearchResult, error)
+	SearchTags(ctx context.Context, q url.Values) (*TagSearchResult, error)
+	SearchCreators(ctx context.Context, q url.Values) (*CreatorSearchResult, error)
+	SearchUsers(ctx context.Context, q url.Values) (*UserSearchResult, error)
+}
+
+// Metadata is the pagination envelope the list endpoints return under
+// `metadata`. Not every endpoint sets every field: the cursor-paged feeds
+// (models/images) set nextCursor/nextPage (+ currentPage/pageSize when
+// page-paged), while the tRPC-backed lists (tags/creators) set the classic
+// totalItems/currentPage/pageSize/totalPages + nextPage/prevPage.
+//
+// nextCursor is left as RawMessage because the server emits it as a string, a
+// number, or a date depending on the endpoint's sort key; CursorString renders
+// it as a plain string for the user to feed back via --cursor.
+type Metadata struct {
+	NextCursor  json.RawMessage `json:"nextCursor,omitempty"`
+	NextPage    string          `json:"nextPage,omitempty"`
+	PrevPage    string          `json:"prevPage,omitempty"`
+	CurrentPage *int            `json:"currentPage,omitempty"`
+	PageSize    *int            `json:"pageSize,omitempty"`
+	TotalItems  *int            `json:"totalItems,omitempty"`
+	TotalPages  *int            `json:"totalPages,omitempty"`
+}
+
+// CursorString renders nextCursor as a bare string (unquoting a JSON string
+// value) for display + re-use via --cursor. Returns "" when there is no cursor.
+func (m Metadata) CursorString() string {
+	raw := strings.TrimSpace(string(m.NextCursor))
+	if raw == "" || raw == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(m.NextCursor, &s); err == nil {
+		return s
+	}
+	return raw
+}
+
+// getRaw performs a public GET against path with the query q, returning the
+// status code and raw body. The token (if any) is attached by authedDo and a
+// non-empty token is refreshed once on a 401; an empty token sends no
+// Authorization header (anonymous). A non-2xx status is turned into a clear
+// error by the caller via readError.
+func (c *Client) getRaw(ctx context.Context, path string, q url.Values) (int, []byte, error) {
+	full := c.BaseURL + path
+	if enc := q.Encode(); enc != "" {
+		full += "?" + enc
+	}
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	}
+	return c.authedDo(ctx, build)
+}
+
+// getInto GETs path+q, and on a 2xx unmarshals the body into out (when non-nil)
+// and returns the raw body (for --json). A non-2xx returns a readError.
+func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any) ([]byte, error) {
+	status, raw, err := c.getRaw(ctx, path, q)
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status >= 300 {
+		return nil, readError(status, raw)
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return nil, fmt.Errorf("unexpected response from %s (status %d): %s", path, status, snippet(raw))
+		}
+	}
+	return raw, nil
+}
+
+// readError turns a non-2xx read response into a clear, actionable error,
+// surfacing the API's own error body ({"error": ...} or {"message": ...})
+// rather than a Go struct dump.
+func readError(status int, raw []byte) error {
+	msg := strings.TrimSpace(string(raw))
+	var wrapped struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if json.Unmarshal(raw, &wrapped) == nil {
+		if len(wrapped.Error) > 0 {
+			// error may be a string or a nested object (zod issue list).
+			var s string
+			if json.Unmarshal(wrapped.Error, &s) == nil && s != "" {
+				msg = s
+			} else {
+				msg = strings.TrimSpace(string(wrapped.Error))
+			}
+		} else if wrapped.Message != "" {
+			msg = wrapped.Message
+		}
+	}
+	msg = snippet([]byte(msg))
+	switch status {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized (401): %s — your token may be expired; run `civitai login` (these endpoints also work without a token)", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("not found (404): %s", msg)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limited (429): %s — for deep paging use --cursor instead of --page", msg)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("service unavailable (503): %s — the search backend is briefly overloaded; retry shortly", msg)
+	default:
+		return fmt.Errorf("server returned %d: %s", status, msg)
+	}
+}
+
+// snippet bounds an error/body string so a huge response can't flood the
+// terminal.
+func snippet(raw []byte) string {
+	s := strings.TrimSpace(string(raw))
+	const max = 500
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}

--- a/internal/api/read_test.go
+++ b/internal/api/read_test.go
@@ -1,0 +1,232 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestServer records the last request path + query and returns body for any
+// GET.
+func newTestServer(t *testing.T, body string) (*httptest.Server, *string, *url.Values, *string) {
+	t.Helper()
+	var gotPath string
+	var gotQuery url.Values
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &gotPath, &gotQuery, &gotAuth
+}
+
+func TestSearchModelsBuildsRequestAndParses(t *testing.T) {
+	const body = `{
+	  "items": [
+	    {"id": 1, "name": "Pony", "type": "Checkpoint", "nsfw": false,
+	     "creator": {"username": "bob"},
+	     "stats": {"downloadCount": 10, "thumbsUpCount": 3, "commentCount": 2}}
+	  ],
+	  "metadata": {"nextCursor": "abc123", "nextPage": "https://x/y?cursor=abc123"}
+	}`
+	srv, gotPath, gotQuery, gotAuth := newTestServer(t, body)
+
+	c := New(srv.URL, "tok-1", "")
+	q := url.Values{}
+	q.Set("query", "pony")
+	q.Set("limit", "5")
+	q.Set("types", "Checkpoint")
+	res, err := c.SearchModels(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchModels: %v", err)
+	}
+	if *gotPath != "/api/v1/models" {
+		t.Errorf("path = %q, want /api/v1/models", *gotPath)
+	}
+	if gotQuery.Get("query") != "pony" || gotQuery.Get("limit") != "5" || gotQuery.Get("types") != "Checkpoint" {
+		t.Errorf("query params not passed through: %v", *gotQuery)
+	}
+	if *gotAuth != "Bearer tok-1" {
+		t.Errorf("auth = %q, want Bearer tok-1", *gotAuth)
+	}
+	if len(res.Items) != 1 || res.Items[0].ID != 1 || res.Items[0].Creator.Username != "bob" {
+		t.Errorf("parsed items wrong: %+v", res.Items)
+	}
+	if res.Items[0].Stats.DownloadCount != 10 {
+		t.Errorf("stats not parsed: %+v", res.Items[0].Stats)
+	}
+	if got := res.Metadata.CursorString(); got != "abc123" {
+		t.Errorf("CursorString = %q, want abc123", got)
+	}
+	if len(res.Raw) == 0 {
+		t.Error("Raw body should be preserved for --json")
+	}
+}
+
+func TestSearchModelsAnonymousSendsNoAuthHeader(t *testing.T) {
+	srv, _, _, gotAuth := newTestServer(t, `{"items":[],"metadata":{}}`)
+	// Empty token => anonymous.
+	c := New(srv.URL, "", "")
+	if _, err := c.SearchModels(context.Background(), url.Values{}); err != nil {
+		t.Fatalf("SearchModels: %v", err)
+	}
+	if *gotAuth != "" {
+		t.Errorf("anonymous request should send no Authorization header, got %q", *gotAuth)
+	}
+}
+
+func TestGetModelParsesDetail(t *testing.T) {
+	const body = `{"id": 42, "name": "M", "type": "LORA", "nsfw": true,
+	  "creator": {"username": "alice"}, "tags": ["anime","style"],
+	  "stats": {"downloadCount": 5, "thumbsUpCount": 1, "commentCount": 0},
+	  "modelVersions": [{"id": 100, "name": "v1", "baseModel": "SDXL 1.0"}]}`
+	srv, gotPath, _, _ := newTestServer(t, body)
+
+	c := New(srv.URL, "", "")
+	m, raw, err := c.GetModel(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	if *gotPath != "/api/v1/models/42" {
+		t.Errorf("path = %q, want /api/v1/models/42", *gotPath)
+	}
+	if m.ID != 42 || len(m.ModelVersions) != 1 || m.ModelVersions[0].BaseModel != "SDXL 1.0" {
+		t.Errorf("parsed detail wrong: %+v", m)
+	}
+	if len(m.Tags) != 2 {
+		t.Errorf("tags not parsed: %v", m.Tags)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should be returned")
+	}
+}
+
+func TestGetModelVersionByHashUppercasePath(t *testing.T) {
+	srv, gotPath, _, _ := newTestServer(t, `{"id": 7, "modelId": 3, "name": "v", "baseModel": "SD 1.5"}`)
+	c := New(srv.URL, "", "")
+	v, _, err := c.GetModelVersionByHash(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("GetModelVersionByHash: %v", err)
+	}
+	if *gotPath != "/api/v1/model-versions/by-hash/abc123" {
+		t.Errorf("path = %q", *gotPath)
+	}
+	if v.ID != 7 || v.ModelID != 3 {
+		t.Errorf("parsed version wrong: %+v", v)
+	}
+}
+
+func TestSearchImagesPassesFiltersAndParses(t *testing.T) {
+	const body = `{"items":[{"id":9,"url":"https://img/1.png","width":512,"height":768,
+	  "nsfwLevel":"None","type":"image","postId":55,"username":"u",
+	  "stats":{"likeCount":2,"heartCount":4,"commentCount":1}}],
+	  "metadata":{"nextCursor":123}}`
+	srv, gotPath, gotQuery, _ := newTestServer(t, body)
+	c := New(srv.URL, "", "")
+	q := url.Values{}
+	q.Set("modelId", "4384")
+	q.Set("limit", "1")
+	res, err := c.SearchImages(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchImages: %v", err)
+	}
+	if *gotPath != "/api/v1/images" {
+		t.Errorf("path = %q", *gotPath)
+	}
+	if gotQuery.Get("modelId") != "4384" {
+		t.Errorf("modelId not passed: %v", *gotQuery)
+	}
+	if len(res.Items) != 1 || res.Items[0].Username != "u" || res.Items[0].Stats.HeartCount != 4 {
+		t.Errorf("parsed image wrong: %+v", res.Items)
+	}
+	// nextCursor came in as a NUMBER — CursorString must still render it.
+	if got := res.Metadata.CursorString(); got != "123" {
+		t.Errorf("numeric cursor CursorString = %q, want 123", got)
+	}
+}
+
+func TestSearchTagsAndCreators(t *testing.T) {
+	srvT, pathT, _, _ := newTestServer(t, `{"items":[{"name":"anime","link":"https://x/models?tag=anime"}],"metadata":{"totalItems":1}}`)
+	c := New(srvT.URL, "", "")
+	tags, err := c.SearchTags(context.Background(), url.Values{})
+	if err != nil {
+		t.Fatalf("SearchTags: %v", err)
+	}
+	if *pathT != "/api/v1/tags" || len(tags.Items) != 1 || tags.Items[0].Name != "anime" {
+		t.Errorf("tags wrong: path=%q items=%+v", *pathT, tags.Items)
+	}
+	if tags.Metadata.TotalItems == nil || *tags.Metadata.TotalItems != 1 {
+		t.Errorf("tags metadata.totalItems not parsed: %+v", tags.Metadata)
+	}
+
+	srvC, pathC, _, _ := newTestServer(t, `{"items":[{"username":"artist","modelCount":12,"link":"l"}],"metadata":{}}`)
+	c2 := New(srvC.URL, "", "")
+	cr, err := c2.SearchCreators(context.Background(), url.Values{})
+	if err != nil {
+		t.Fatalf("SearchCreators: %v", err)
+	}
+	if *pathC != "/api/v1/creators" || len(cr.Items) != 1 || cr.Items[0].ModelCount != 12 {
+		t.Errorf("creators wrong: path=%q items=%+v", *pathC, cr.Items)
+	}
+}
+
+func TestSearchUsersPath(t *testing.T) {
+	srv, gotPath, gotQuery, _ := newTestServer(t, `{"items":[{"id":5,"username":"bob","image":"i"}]}`)
+	c := New(srv.URL, "", "")
+	q := url.Values{}
+	q.Set("query", "bob")
+	res, err := c.SearchUsers(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+	if *gotPath != "/api/v1/users" || gotQuery.Get("query") != "bob" {
+		t.Errorf("users request wrong: path=%q q=%v", *gotPath, *gotQuery)
+	}
+	if len(res.Items) != 1 || res.Items[0].ID != 5 {
+		t.Errorf("users parse wrong: %+v", res.Items)
+	}
+}
+
+func TestReadErrorSurfacesBody(t *testing.T) {
+	cases := []struct {
+		status int
+		body   string
+		want   string
+	}{
+		{http.StatusNotFound, `{"error":"No model with id 999"}`, "not found (404): No model with id 999"},
+		{http.StatusUnauthorized, `{"error":"Unauthorized"}`, "unauthorized (401)"},
+		{http.StatusTooManyRequests, `{"error":"too many pages"}`, "rate limited (429)"},
+		{http.StatusServiceUnavailable, `{"error":"overloaded"}`, "service unavailable (503)"},
+		{http.StatusBadRequest, `{"message":"bad param"}`, "server returned 400: bad param"},
+	}
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			_, _ = w.Write([]byte(tc.body))
+		}))
+		c := New(srv.URL, "", "")
+		_, _, err := c.GetModel(context.Background(), "999")
+		srv.Close()
+		if err == nil {
+			t.Errorf("status %d: expected error", tc.status)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("status %d: error %q should contain %q", tc.status, err, tc.want)
+		}
+	}
+}
+
+func TestCursorStringEmpty(t *testing.T) {
+	var m Metadata
+	if got := m.CursorString(); got != "" {
+		t.Errorf("empty metadata CursorString = %q, want empty", got)
+	}
+}

--- a/internal/api/tags_creators_users.go
+++ b/internal/api/tags_creators_users.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// TagItem is a `GET /api/v1/tags` item: the tag name + a convenience link to
+// the models filtered by it.
+type TagItem struct {
+	Name string `json:"name"`
+	Link string `json:"link"`
+}
+
+// TagSearchResult bundles parsed tags + metadata with the raw body.
+type TagSearchResult struct {
+	Items    []TagItem `json:"items"`
+	Metadata Metadata  `json:"metadata"`
+	Raw      []byte    `json:"-"`
+}
+
+// SearchTags calls GET /api/v1/tags.
+func (c *Client) SearchTags(ctx context.Context, q url.Values) (*TagSearchResult, error) {
+	var res TagSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/tags", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// CreatorItem is a `GET /api/v1/creators` item.
+type CreatorItem struct {
+	Username   string `json:"username"`
+	ModelCount int    `json:"modelCount"`
+	Link       string `json:"link"`
+}
+
+// CreatorSearchResult bundles parsed creators + metadata with the raw body.
+type CreatorSearchResult struct {
+	Items    []CreatorItem `json:"items"`
+	Metadata Metadata      `json:"metadata"`
+	Raw      []byte        `json:"-"`
+}
+
+// SearchCreators calls GET /api/v1/creators.
+func (c *Client) SearchCreators(ctx context.Context, q url.Values) (*CreatorSearchResult, error) {
+	var res CreatorSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/creators", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// UserItem is the subset of a `GET /api/v1/users` search item the CLI renders.
+// The public users search returns basic identity fields; richer fields
+// (status/avatar) are only included for internal system requests.
+type UserItem struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Image    string `json:"image"`
+}
+
+// UserSearchResult bundles parsed users with the raw body. The public users
+// endpoint returns only `{ items }` (no pagination metadata).
+type UserSearchResult struct {
+	Items []UserItem `json:"items"`
+	Raw   []byte     `json:"-"`
+}
+
+// SearchUsers calls GET /api/v1/users — the public user search. This is the
+// only public users read route: the per-id `/api/v1/users/{userId}` route is an
+// internal webhook (POST + system token) and is NOT usable by the CLI, so
+// `civitai users get` resolves a user through this search (by ?query= for a
+// name, or ?ids= for a numeric id).
+func (c *Client) SearchUsers(ctx context.Context, q url.Values) (*UserSearchResult, error) {
+	var res UserSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/users", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}

--- a/internal/cmd/creators.go
+++ b/internal/cmd/creators.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const creatorsLimitMax = 200
+
+func newCreatorsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "creators",
+		Short: "Search creators on Civitai",
+		Long: `Read-only access to Civitai creators via the public REST API
+(GET /api/v1/creators). Works anonymously.`,
+		Example: `  civitai creators search --query artist --limit 10`,
+	}
+	cmd.AddCommand(newCreatorsSearchCmd())
+	return cmd
+}
+
+func newCreatorsSearchCmd() *cobra.Command {
+	var (
+		query       string
+		limit, page int
+	)
+	cmd := &cobra.Command{
+		Use:     "search",
+		Short:   "Search creators (GET /api/v1/creators)",
+		Example: `  civitai creators search --query artist --limit 10`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, creatorsLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "query", query)
+			addIfPositive(q, "limit", limit)
+			addIfPositive(q, "page", page)
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchCreators(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printCreatorList(cmd, res.Items)
+			printPageFooter(cmd, "civitai creators search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "text search query")
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page")
+	cmd.Flags().IntVar(&page, "page", 0, "page number")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printCreatorList(cmd *cobra.Command, items []api.CreatorItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No creators found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "USERNAME\tMODELS\tLINK")
+	for _, c := range items {
+		fmt.Fprintf(tw, "%s\t%d\t%s\n", orDash(c.Username), c.ModelCount, c.Link)
+	}
+	_ = tw.Flush()
+}

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const imagesLimitMax = 200
+
+func newImagesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Search images on Civitai",
+		Long: `Read-only access to Civitai images via the public REST API
+(GET /api/v1/images). Works anonymously.`,
+		Example: `  civitai images search --limit 5
+  civitai images search --model-id 4384 --sort "Most Reactions"`,
+	}
+	cmd.AddCommand(newImagesSearchCmd())
+	return cmd
+}
+
+func newImagesSearchCmd() *cobra.Command {
+	var (
+		username, sort, period, cursor               string
+		postID, modelID, modelVersionID, limit, page int
+		nsfw                                         bool
+	)
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search images (GET /api/v1/images)",
+		Long: `Search images via GET /api/v1/images.
+
+Pagination: use --page for shallow paging or --cursor for deep paging (the API
+caps page*limit at 1000). The next cursor is printed after the results.`,
+		Example: `  civitai images search --limit 5
+  civitai images search --model-version-id 128713 --sort Newest
+  civitai images search --username some-user --cursor <cursor>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, imagesLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "username", username)
+			addIfSet(q, "sort", sort)
+			addIfSet(q, "period", period)
+			addIfSet(q, "cursor", cursor)
+			addIfPositive(q, "postId", postID)
+			addIfPositive(q, "modelId", modelID)
+			addIfPositive(q, "modelVersionId", modelVersionID)
+			addIfPositive(q, "limit", limit)
+			addIfPositive(q, "page", page)
+			if cmd.Flags().Changed("nsfw") {
+				q.Set("nsfw", strconv.FormatBool(nsfw))
+			}
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchImages(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printImageList(cmd, res.Items)
+			printPageFooter(cmd, "civitai images search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-200)")
+	cmd.Flags().IntVar(&page, "page", 0, "page number (shallow paging; prefer --cursor)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	cmd.Flags().IntVar(&postID, "post-id", 0, "filter by post id")
+	cmd.Flags().IntVar(&modelID, "model-id", 0, "filter by model id")
+	cmd.Flags().IntVar(&modelVersionID, "model-version-id", 0, "filter by model version id")
+	cmd.Flags().StringVar(&username, "username", "", "filter by uploader username")
+	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order (\"Most Reactions\", \"Most Comments\", Newest)")
+	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printImageList(cmd *cobra.Command, items []api.ImageItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No images found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tUPLOADER\tSIZE\tNSFW\tHEARTS\tCOMMENTS\tURL")
+	for _, im := range items {
+		fmt.Fprintf(tw, "%d\t%s\t%dx%d\t%s\t%d\t%d\t%s\n",
+			im.ID, orDash(im.Username), im.Width, im.Height, orDash(im.NSFWLevel),
+			im.Stats.HeartCount, im.Stats.CommentCount, im.URL)
+	}
+	_ = tw.Flush()
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func newModelVersionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "model-versions",
+		Short:   "Inspect model versions on Civitai",
+		Aliases: []string{"model-version", "mv"},
+		Long: `Read-only access to Civitai model versions via the public REST API. Look up a
+version by its id or by a file hash (AutoV2, SHA256, …). Works anonymously.`,
+		Example: `  civitai model-versions get 128713
+  civitai model-versions by-hash 5D8D26E2A6`,
+	}
+	cmd.AddCommand(newModelVersionsGetCmd())
+	cmd.AddCommand(newModelVersionsByHashCmd())
+	return cmd
+}
+
+func newModelVersionsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <id>",
+		Short:   "Get a model version by id (GET /api/v1/model-versions/{id})",
+		Example: `  civitai model-versions get 128713`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			if _, err := strconv.Atoi(args[0]); err != nil {
+				return fmt.Errorf("model version id must be an integer, got %q", args[0])
+			}
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			v, raw, err := client.GetModelVersion(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printModelVersionDetail(cmd, v)
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func newModelVersionsByHashCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "by-hash <hash>",
+		Short:   "Get a model version by file hash (GET /api/v1/model-versions/by-hash/{hash})",
+		Long:    `Look up a model version by any of its file hashes (AutoV1, AutoV2, SHA256, CRC32, BLAKE3). The hash is matched case-insensitively.`,
+		Example: `  civitai model-versions by-hash 5D8D26E2A6`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			v, raw, err := client.GetModelVersionByHash(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printModelVersionDetail(cmd, v)
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printModelVersionDetail(cmd *cobra.Command, v *api.ModelVersionDetail) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "%s (version id %d, model id %d)\n", v.Name, v.ID, v.ModelID)
+	if v.Model != nil {
+		fmt.Fprintf(out, "  model:     %s (%s)\n", v.Model.Name, v.Model.Type)
+	}
+	fmt.Fprintf(out, "  baseModel: %s\n", v.BaseModel)
+	if v.AIR != "" {
+		fmt.Fprintf(out, "  air:       %s\n", v.AIR)
+	}
+	fmt.Fprintf(out, "  downloads: %d   thumbsUp: %d\n", v.Stats.DownloadCount, v.Stats.ThumbsUpCount)
+	if len(v.TrainedWords) > 0 {
+		fmt.Fprintf(out, "  triggers:  %s\n", joinTags(v.TrainedWords))
+	}
+	if v.DownloadURL != "" {
+		fmt.Fprintf(out, "  download:  %s\n", v.DownloadURL)
+	}
+	if len(v.Files) > 0 {
+		fmt.Fprintf(out, "  files (%d):\n", len(v.Files))
+		tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+		for _, f := range v.Files {
+			fmt.Fprintf(tw, "    %s\t%s\t%.1f MB\n", f.Name, f.Type, f.SizeKB/1024)
+		}
+		_ = tw.Flush()
+	}
+}

--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const modelsLimitMax = 100
+
+func newModelsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "Search and inspect models on Civitai",
+		Long: `Read-only access to Civitai models via the public REST API
+(GET /api/v1/models). These commands work anonymously; if you are logged in
+(civitai login) your token is sent automatically.`,
+		Example: `  civitai models search --query "pony" --limit 5
+  civitai models get 4384`,
+	}
+	cmd.AddCommand(newModelsSearchCmd())
+	cmd.AddCommand(newModelsGetCmd())
+	return cmd
+}
+
+func newModelsSearchCmd() *cobra.Command {
+	var (
+		query, tag, username, typ, sort, period, cursor string
+		nsfw                                            bool
+		limit, page                                     int
+	)
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search models (GET /api/v1/models)",
+		Long: `Search models via GET /api/v1/models.
+
+Pagination: use --page for shallow paging, or --cursor for deep paging (the API
+caps page*limit at 1000 and otherwise returns 429 — prefer --cursor). The next
+cursor is printed after the results.`,
+		Example: `  civitai models search --query "pony" --limit 5
+  civitai models search --type LORA --sort "Most Downloaded" --period Month
+  civitai models search --username some-creator --cursor <cursor>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, modelsLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "query", query)
+			addIfSet(q, "tag", tag)
+			addIfSet(q, "username", username)
+			addIfSet(q, "types", typ) // API query param is `types`
+			addIfSet(q, "sort", sort)
+			addIfSet(q, "period", period)
+			addIfSet(q, "cursor", cursor)
+			addIfPositive(q, "limit", limit)
+			addIfPositive(q, "page", page)
+			if cmd.Flags().Changed("nsfw") {
+				q.Set("nsfw", strconv.FormatBool(nsfw))
+			}
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchModels(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printModelList(cmd, res.Items)
+			printPageFooter(cmd, "civitai models search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "text search query")
+	cmd.Flags().StringVar(&tag, "tag", "", "filter by tag name")
+	cmd.Flags().StringVar(&username, "username", "", "filter by creator username")
+	cmd.Flags().StringVar(&typ, "type", "", "filter by model type (e.g. Checkpoint, LORA, TextualInversion)")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order (e.g. \"Highest Rated\", \"Most Downloaded\", Newest)")
+	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
+	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().IntVar(&page, "page", 0, "page number (shallow paging; prefer --cursor for deep paging)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func newModelsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a model by id (GET /api/v1/models/{id})",
+		Example: `  civitai models get 4384
+  civitai models get 4384 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			if _, err := strconv.Atoi(args[0]); err != nil {
+				return fmt.Errorf("model id must be a positive integer, got %q", args[0])
+			}
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			m, raw, err := client.GetModel(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printModelDetail(cmd, m)
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printModelList(cmd *cobra.Command, items []api.ModelListItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No models found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tCREATOR\tDOWNLOADS\tTHUMBSUP")
+	for _, m := range items {
+		creator := "-"
+		if m.Creator != nil && m.Creator.Username != "" {
+			creator = m.Creator.Username
+		}
+		name := m.Name
+		if m.NSFW {
+			name += " [nsfw]"
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%d\t%d\n", m.ID, name, m.Type, creator, m.Stats.DownloadCount, m.Stats.ThumbsUpCount)
+	}
+	_ = tw.Flush()
+}
+
+func printModelDetail(cmd *cobra.Command, m *api.ModelDetail) {
+	out := cmd.OutOrStdout()
+	creator := "-"
+	if m.Creator != nil && m.Creator.Username != "" {
+		creator = m.Creator.Username
+	}
+	fmt.Fprintf(out, "%s (id %d)\n", m.Name, m.ID)
+	fmt.Fprintf(out, "  type:      %s\n", m.Type)
+	fmt.Fprintf(out, "  creator:   %s\n", creator)
+	fmt.Fprintf(out, "  nsfw:      %t\n", m.NSFW)
+	fmt.Fprintf(out, "  downloads: %d   thumbsUp: %d   comments: %d\n", m.Stats.DownloadCount, m.Stats.ThumbsUpCount, m.Stats.CommentCount)
+	if len(m.Tags) > 0 {
+		fmt.Fprintf(out, "  tags:      %s\n", joinTags(m.Tags))
+	}
+	fmt.Fprintf(out, "  versions (%d):\n", len(m.ModelVersions))
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	for _, v := range m.ModelVersions {
+		fmt.Fprintf(tw, "    %d\t%s\t%s\n", v.ID, v.Name, v.BaseModel)
+	}
+	_ = tw.Flush()
+}
+
+func joinTags(tags []string) string {
+	const max = 12
+	if len(tags) <= max {
+		return strings.Join(tags, ", ")
+	}
+	return strings.Join(tags[:max], ", ") + fmt.Sprintf(", … (+%d)", len(tags)-max)
+}

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// readOpts are the flags shared by every read subcommand.
+type readOpts struct {
+	json bool
+	anon bool
+}
+
+// bindReadFlags attaches the shared --json / --anon flags to a read subcommand.
+func bindReadFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
+	cmd.Flags().Bool("anon", false, "force an anonymous request (ignore any stored login token)")
+}
+
+// readFlags reads the shared --json / --anon flag values off cmd.
+func readFlags(cmd *cobra.Command) *readOpts {
+	j, _ := cmd.Flags().GetBool("json")
+	a, _ := cmd.Flags().GetBool("anon")
+	return &readOpts{json: j, anon: a}
+}
+
+// newReader builds an api.Client for the public read endpoints. It sends the
+// stored login token when present (OAuth device-login or personal key, both
+// refreshed transparently) unless --anon is set, and works fully anonymously
+// when no token is configured — the public read routes don't require auth.
+func newReader(o *readOpts) (*api.Client, string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, "", err
+	}
+	if o.anon {
+		return api.New(cfg.BaseURL(), "", ""), cfg.BaseURL(), nil
+	}
+	return api.NewWithSource(cfg.BaseURL(), auth.New(cfg), ""), cfg.BaseURL(), nil
+}
+
+// emitJSON pretty-prints the raw API body (falling back to the raw bytes if it
+// is not valid JSON) and reports whether output was handled.
+func emitJSON(cmd *cobra.Command, raw []byte) error {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		buf.Reset()
+		buf.Write(raw)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), strings.TrimRight(buf.String(), "\n"))
+	return nil
+}
+
+// checkLimit validates a --limit against an endpoint's documented maximum. A
+// zero limit means "server default" and is always allowed.
+func checkLimit(limit, max int) error {
+	if limit < 0 || limit > max {
+		return fmt.Errorf("--limit must be between 1 and %d for this endpoint", max)
+	}
+	return nil
+}
+
+// addIfPositive sets key=v on q when v > 0.
+func addIfPositive(q interface{ Set(string, string) }, key string, v int) {
+	if v > 0 {
+		q.Set(key, strconv.Itoa(v))
+	}
+}
+
+// addIfSet sets key=v on q when v is non-empty.
+func addIfSet(q interface{ Set(string, string) }, key, v string) {
+	if v != "" {
+		q.Set(key, v)
+	}
+}
+
+// printPageFooter prints a compact pagination footer + a hint for fetching the
+// next page, when the endpoint returned enough to page.
+func printPageFooter(cmd *cobra.Command, cmdPath string, m api.Metadata) {
+	out := cmd.OutOrStdout()
+	var parts []string
+	if m.TotalItems != nil {
+		parts = append(parts, fmt.Sprintf("total items: %d", *m.TotalItems))
+	}
+	if m.CurrentPage != nil {
+		p := fmt.Sprintf("page %d", *m.CurrentPage)
+		if m.TotalPages != nil {
+			p += fmt.Sprintf("/%d", *m.TotalPages)
+		}
+		parts = append(parts, p)
+	}
+	cursor := m.CursorString()
+	if cursor != "" {
+		parts = append(parts, "next cursor: "+cursor)
+	}
+	if len(parts) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "\n%s\n", strings.Join(parts, "  ·  "))
+	switch {
+	case cursor != "":
+		fmt.Fprintf(out, "next page: %s --cursor %s\n", cmdPath, cursor)
+	case m.CurrentPage != nil && (m.TotalPages == nil || *m.CurrentPage < *m.TotalPages):
+		fmt.Fprintf(out, "next page: %s --page %d\n", cmdPath, *m.CurrentPage+1)
+	}
+}

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -137,6 +137,27 @@ func TestUsersGetNumericUsesIds(t *testing.T) {
 	}
 }
 
+func TestUsersGetNoExactMatchErrors(t *testing.T) {
+	// A name query returning only FUZZY neighbours (no exact username) must
+	// ERROR, not confidently print the top fuzzy hit as "the" user.
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[{"id":5,"username":"bob"},{"id":6,"username":"bobby"}]}`))
+	})
+	out, _, err := run(t, "users", "get", "bo")
+	if err == nil {
+		t.Fatalf("expected an error for a name with no exact match; got output:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "no user found with exact username") {
+		t.Errorf("error should explain no-exact-match, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "bob") {
+		t.Errorf("error should list the closest candidates, got: %v", err)
+	}
+	if strings.Contains(out, "id 5") {
+		t.Errorf("must NOT print a fuzzy user as the answer:\n%s", out)
+	}
+}
+
 func TestTagsSearchWiring(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/tags" {

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// setupReadServer points the CLI at a local server via CIVITAI_BASE_URL and
+// clears any real token so command tests are hermetic + anonymous.
+func setupReadServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+}
+
+func TestReadCommandsRegistered(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help: %v", err)
+	}
+	for _, want := range []string{"models", "model-versions", "images", "tags", "creators", "users"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("root help missing read command %q\n%s", want, out)
+		}
+	}
+}
+
+func TestModelsSearchHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/models" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "pony" {
+			t.Errorf("query not passed: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":1,"name":"Pony","type":"Checkpoint",
+		  "creator":{"username":"bob"},"stats":{"downloadCount":10,"thumbsUpCount":3}}],
+		  "metadata":{"nextCursor":"c1"}}`))
+	})
+	out, _, err := run(t, "models", "search", "--query", "pony", "--limit", "1")
+	if err != nil {
+		t.Fatalf("models search: %v", err)
+	}
+	if !strings.Contains(out, "Pony") || !strings.Contains(out, "bob") {
+		t.Errorf("human output missing fields: %s", out)
+	}
+	if !strings.Contains(out, "next cursor: c1") {
+		t.Errorf("footer should show next cursor: %s", out)
+	}
+}
+
+func TestModelsSearchJSONPassthrough(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	out, _, err := run(t, "models", "search", "--json")
+	if err != nil {
+		t.Fatalf("models search --json: %v", err)
+	}
+	if !strings.Contains(out, `"items"`) || !strings.Contains(out, `"metadata"`) {
+		t.Errorf("--json should print raw API JSON: %s", out)
+	}
+}
+
+func TestModelsSearchLimitValidation(t *testing.T) {
+	_, _, err := run(t, "models", "search", "--limit", "101")
+	if err == nil {
+		t.Fatal("expected error for --limit > 100")
+	}
+	if !strings.Contains(err.Error(), "1 and 100") {
+		t.Errorf("error should name the max: %v", err)
+	}
+}
+
+func TestImagesSearchLimitValidation(t *testing.T) {
+	_, _, err := run(t, "images", "search", "--limit", "201")
+	if err == nil {
+		t.Fatal("expected error for --limit > 200")
+	}
+	if !strings.Contains(err.Error(), "1 and 200") {
+		t.Errorf("error should name the max: %v", err)
+	}
+}
+
+func TestModelsGetRejectsNonNumericId(t *testing.T) {
+	_, _, err := run(t, "models", "get", "abc")
+	if err == nil {
+		t.Fatal("expected error for non-numeric model id")
+	}
+}
+
+func TestModelsGetSurfacesServerError(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"No model with id 999"}`))
+	})
+	_, _, err := run(t, "models", "get", "999")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "No model with id 999") {
+		t.Errorf("error should surface API body: %v", err)
+	}
+}
+
+func TestUsersGetResolvesByQuery(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/users" || r.URL.Query().Get("query") != "bob" {
+			t.Errorf("unexpected users request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":5,"username":"bob"},{"id":6,"username":"bobby"}]}`))
+	})
+	out, _, err := run(t, "users", "get", "bob")
+	if err != nil {
+		t.Fatalf("users get: %v", err)
+	}
+	if !strings.Contains(out, "bob (id 5)") {
+		t.Errorf("should pick exact username match: %s", out)
+	}
+}
+
+func TestUsersGetNumericUsesIds(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("ids") != "5" {
+			t.Errorf("numeric arg should use ?ids=: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":5,"username":"bob"}]}`))
+	})
+	if _, _, err := run(t, "users", "get", "5"); err != nil {
+		t.Fatalf("users get 5: %v", err)
+	}
+}
+
+func TestTagsSearchWiring(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/tags" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"items":[{"name":"anime","link":"l"}],"metadata":{}}`))
+	})
+	out, _, err := run(t, "tags", "search", "--query", "anime")
+	if err != nil {
+		t.Fatalf("tags search: %v", err)
+	}
+	if !strings.Contains(out, "anime") {
+		t.Errorf("tags output missing name: %s", out)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -249,5 +249,13 @@ Get started:
 	root.AddCommand(newCompletionCmd())
 	root.AddCommand(newUpdateCheckCmd())
 
+	// Read subcommands — public REST API (`/api/v1/**`) browsing.
+	root.AddCommand(newModelsCmd())
+	root.AddCommand(newModelVersionsCmd())
+	root.AddCommand(newImagesCmd())
+	root.AddCommand(newTagsCmd())
+	root.AddCommand(newCreatorsCmd())
+	root.AddCommand(newUsersCmd())
+
 	return root
 }

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const tagsLimitMax = 200
+
+func newTagsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tags",
+		Short: "Search model tags on Civitai",
+		Long: `Read-only access to Civitai model tags via the public REST API
+(GET /api/v1/tags). Works anonymously.`,
+		Example: `  civitai tags search --query anime --limit 10`,
+	}
+	cmd.AddCommand(newTagsSearchCmd())
+	return cmd
+}
+
+func newTagsSearchCmd() *cobra.Command {
+	var (
+		query       string
+		limit, page int
+	)
+	cmd := &cobra.Command{
+		Use:     "search",
+		Short:   "Search tags (GET /api/v1/tags)",
+		Example: `  civitai tags search --query anime --limit 10`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, tagsLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "query", query)
+			addIfPositive(q, "limit", limit)
+			addIfPositive(q, "page", page)
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchTags(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printTagList(cmd, res.Items)
+			printPageFooter(cmd, "civitai tags search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "text search query")
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page")
+	cmd.Flags().IntVar(&page, "page", 0, "page number")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printTagList(cmd *cobra.Command, items []api.TagItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No tags found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tLINK")
+	for _, t := range items {
+		fmt.Fprintf(tw, "%s\t%s\n", t.Name, t.Link)
+	}
+	_ = tw.Flush()
+}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -66,15 +66,27 @@ is selected when present).`,
 			if len(res.Items) == 0 {
 				return fmt.Errorf("no user found for %q", arg)
 			}
-			// Prefer an exact username match for a name query; otherwise the first
-			// result (a numeric id lookup returns exactly the requested user).
+			// A numeric id lookup returns exactly the requested user. A NAME query
+			// hits the search endpoint, which returns ≤5 FUZZY neighbours — so we
+			// require an exact (case-insensitive) username match and refuse to
+			// present a fuzzy top-hit as "the" user. Otherwise a typo'd or
+			// non-existent name (which still returns plausible neighbours) would
+			// confidently print the WRONG person.
 			match := res.Items[0]
 			if !numeric {
+				found := false
 				for _, u := range res.Items {
 					if strings.EqualFold(u.Username, arg) {
-						match = u
+						match, found = u, true
 						break
 					}
+				}
+				if !found {
+					names := make([]string, 0, len(res.Items))
+					for _, u := range res.Items {
+						names = append(names, orDash(u.Username))
+					}
+					return fmt.Errorf("no user found with exact username %q; closest matches: %s (use the numeric id for an exact lookup)", arg, strings.Join(names, ", "))
 				}
 			}
 			printUser(cmd, match)

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func newUsersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Look up users on Civitai",
+		Long: `Read-only access to Civitai users via the public REST API.
+
+NOTE: the public users route is the search endpoint GET /api/v1/users (keyed by
+?query= or ?ids=). The per-id route /api/v1/users/{userId} is an INTERNAL
+webhook (POST + system token) and is NOT usable by the CLI, so "users get"
+resolves a user through the public search. Works anonymously.`,
+		Example: `  civitai users get some-username
+  civitai users get 5`,
+	}
+	cmd.AddCommand(newUsersGetCmd())
+	return cmd
+}
+
+func newUsersGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <username-or-id>",
+		Short: "Look up a user by username or id (public search: GET /api/v1/users)",
+		Long: `Look up a user by username or numeric id via the public user search
+(GET /api/v1/users). A numeric argument is matched via ?ids=; anything else via
+?query= (returning the best-matching users, from which an exact username match
+is selected when present).`,
+		Example: `  civitai users get some-username
+  civitai users get 5 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			arg := args[0]
+			q := url.Values{}
+			numeric := false
+			if _, err := strconv.Atoi(arg); err == nil {
+				q.Set("ids", arg)
+				numeric = true
+			} else {
+				q.Set("query", arg)
+			}
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchUsers(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			if len(res.Items) == 0 {
+				return fmt.Errorf("no user found for %q", arg)
+			}
+			// Prefer an exact username match for a name query; otherwise the first
+			// result (a numeric id lookup returns exactly the requested user).
+			match := res.Items[0]
+			if !numeric {
+				for _, u := range res.Items {
+					if strings.EqualFold(u.Username, arg) {
+						match = u
+						break
+					}
+				}
+			}
+			printUser(cmd, match)
+			if !numeric && len(res.Items) > 1 {
+				fmt.Fprintf(cmd.OutOrStdout(), "\nother matches:\n")
+				tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+				for _, u := range res.Items {
+					if u.ID == match.ID {
+						continue
+					}
+					fmt.Fprintf(tw, "  %d\t%s\n", u.ID, orDash(u.Username))
+				}
+				_ = tw.Flush()
+			}
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printUser(cmd *cobra.Command, u api.UserItem) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "%s (id %d)\n", orDash(u.Username), u.ID)
+	if u.Image != "" {
+		fmt.Fprintf(out, "  image: %s\n", u.Image)
+	}
+}


### PR DESCRIPTION
## Phase 1: read subcommands over the public REST API

Adds read-only browsing of the public Civitai REST API (`/api/v1/**`) to the CLI.

### Command tree

```
civitai models search        GET /api/v1/models
civitai models get <id>      GET /api/v1/models/{id}
civitai model-versions get <id>          GET /api/v1/model-versions/{id}
civitai model-versions by-hash <hash>    GET /api/v1/model-versions/by-hash/{hash}
civitai images search        GET /api/v1/images
civitai tags search          GET /api/v1/tags
civitai creators search      GET /api/v1/creators
civitai users get <username-or-id>       GET /api/v1/users  (public search)
```

### Auth — works logged-in OR anonymous

All commands reuse the existing `api.Client` + `TokenSource`. They send the stored
login token when present (OAuth device-login **or** personal API key, both refreshed
transparently on a 401) and work **fully anonymously** when no token is configured,
because the public read routes don't enforce scope. `--anon` forces an anonymous
request; a 401 surfaces a "run `civitai login`" hint but the public endpoints still
work without one.

### Design

- **Output:** human-readable + aligned by default (matches the `whoami` / `buzz` style),
  with `--json` printing the **raw API response** for scripting.
- **Pagination:** `--page` (shallow) / `--cursor` (deep) passed through; the response's
  `nextCursor` / `nextPage` is printed with a ready-to-run next-page hint.
- **Limits:** client-side caps validated (models ≤100, images ≤200) with a clear error.
- **Errors:** non-2xx surfaces the API's own error body + status, not a Go struct dump.
- Client methods live in `internal/api/` next to the existing ones; commands under
  `internal/cmd/`.

### Verified live (with the existing OAuth login session)

```
$ civitai models search --query "pony" --limit 3
ID      NAME                           TYPE              CREATOR        DOWNLOADS  THUMBSUP
257749  Pony Diffusion V6 XL           Checkpoint        PurpleSmartAI  1029467    76299
372465  Pony Realism                   Checkpoint        ZyloO          554729     32213
332646  Pony PDXL Negative Embeddings  TextualInversion  Zovya          226758     14093
next cursor: 3

$ civitai models get 4384
DreamShaper (id 4384)
  type:      Checkpoint
  creator:   Lykon
  downloads: 1650251   thumbsUp: 58027 ...
  versions (31): ...

$ civitai model-versions by-hash 879DB523C3
8 (version id 128713, model id 4384)  ...
```

`images search`, `tags search`, `creators search`, `model-versions get`, `users get`,
and `--json` were all exercised live as well. (The two Meilisearch-backed paths —
`models search` and `users search` — intermittently returned a live upstream 503,
which the CLI surfaces cleanly with a retry hint.)

### Response shapes — verified against source

Structs were matched to the **actual civitai handlers/services**, not guessed:
`src/pages/api/v1/{models/index.ts,models/[id].ts,model-versions/[id].ts,model-versions/by-hash/[hash].ts,images/index.ts,tags.ts,creators.ts,users/*}`
and the services they call (`model-search.service.ts`, `image-search.service.ts`,
`model.service.ts` `getStatsForModel`) + the `{ items, metadata }` envelope.

**Note on `users get`:** the per-id route `GET /api/v1/users/{userId}` is an internal
**webhook** (POST + system token) and is **not usable by the CLI**, so `users get`
resolves a user through the public search `GET /api/v1/users` (`?query=` for a name,
`?ids=` for a numeric id, selecting an exact username match when present).

### Deferred

Articles, collections, and workflows have **no public REST endpoints** and are out of
scope here — they need separate API-side work.

### Tests

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` all clean. New unit tests
(`internal/api/read_test.go`) cover request URL/param building, parsing into the structs,
the anonymous no-auth-header path, numeric-vs-string cursor rendering, limit validation,
and error-body surfacing via `httptest`. Command wiring tests (`internal/cmd/read_cmd_test.go`)
cover registration, human + `--json` output, limit validation, and error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
