### PR TITLE
feat(cli): add articles + collections read subcommands

### DIFF
--- a/internal/api/articles.go
+++ b/internal/api/articles.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// ArticleUser is the minimal author view the article endpoints embed. The list
+// and detail payloads both nest the author under `user` (the models endpoints
+// use `creator` instead); only id + username are rendered, the rest (image,
+// cosmetics, profilePicture) is preserved for --json via the raw body.
+type ArticleUser struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+}
+
+// ArticleTag is a tag attached to an article (`tags[]` on both list + detail).
+type ArticleTag struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// ArticleStats is the per-article stats block the LIST endpoint embeds
+// (`GET /api/v1/articles`). Note the detail endpoint uses different, AllTime-
+// suffixed keys — see ArticleDetailStats.
+type ArticleStats struct {
+	FavoriteCount  int `json:"favoriteCount"`
+	CollectedCount int `json:"collectedCount"`
+	CommentCount   int `json:"commentCount"`
+	LikeCount      int `json:"likeCount"`
+	ViewCount      int `json:"viewCount"`
+}
+
+// ArticleListItem is the subset of a `GET /api/v1/articles` item the CLI renders
+// in its compact list. The full item (coverImage, cosmetics, content flags) is
+// preserved for --json via the result's Raw bytes.
+type ArticleListItem struct {
+	ID          int          `json:"id"`
+	Title       string       `json:"title"`
+	NSFWLevel   int          `json:"nsfwLevel"`
+	PublishedAt string       `json:"publishedAt"`
+	User        *ArticleUser `json:"user"`
+	Tags        []ArticleTag `json:"tags"`
+	Stats       ArticleStats `json:"stats"`
+}
+
+// ArticleDetailStats is the stats block `GET /api/v1/articles/{id}` embeds. The
+// detail endpoint returns AllTime-suffixed counters (from the ArticleStat table)
+// — distinct from the list endpoint's ArticleStats keys.
+type ArticleDetailStats struct {
+	ViewCountAllTime      int `json:"viewCountAllTime"`
+	CommentCountAllTime   int `json:"commentCountAllTime"`
+	LikeCountAllTime      int `json:"likeCountAllTime"`
+	HeartCountAllTime     int `json:"heartCountAllTime"`
+	FavoriteCountAllTime  int `json:"favoriteCountAllTime"`
+	CollectedCountAllTime int `json:"collectedCountAllTime"`
+}
+
+// ArticleDetail is the subset of `GET /api/v1/articles/{id}` the CLI renders.
+// The endpoint also returns the full article body (content/contentJson),
+// attachments, and coverImage — all preserved for --json via the raw body.
+type ArticleDetail struct {
+	ID          int                 `json:"id"`
+	Title       string              `json:"title"`
+	NSFWLevel   int                 `json:"nsfwLevel"`
+	PublishedAt string              `json:"publishedAt"`
+	User        *ArticleUser        `json:"user"`
+	Tags        []ArticleTag        `json:"tags"`
+	Stats       *ArticleDetailStats `json:"stats"`
+}
+
+// ArticleSearchResult bundles the parsed items + pagination metadata with the
+// raw response body (for --json passthrough).
+type ArticleSearchResult struct {
+	Items    []ArticleListItem `json:"items"`
+	Metadata Metadata          `json:"metadata"`
+	Raw      []byte            `json:"-"`
+}
+
+// SearchArticles calls GET /api/v1/articles with the given query params.
+func (c *Client) SearchArticles(ctx context.Context, q url.Values) (*ArticleSearchResult, error) {
+	var res ArticleSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/articles", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// GetArticle calls GET /api/v1/articles/{id}. Returns the parsed detail and the
+// raw body (for --json).
+func (c *Client) GetArticle(ctx context.Context, id string) (*ArticleDetail, []byte, error) {
+	var a ArticleDetail
+	raw, err := c.getInto(ctx, "/api/v1/articles/"+url.PathEscape(id), nil, &a)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &a, raw, nil
+}

--- a/internal/api/articles_collections_test.go
+++ b/internal/api/articles_collections_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSearchArticlesBuildsRequestAndParses(t *testing.T) {
+	const body = `{
+	  "items": [
+	    {"id": 7, "title": "My Workflow", "nsfwLevel": 1, "publishedAt": "2026-07-01T12:00:00.000Z",
+	     "user": {"id": 3, "username": "bob"},
+	     "tags": [{"id": 5, "name": "comfyui"}, {"id": 8, "name": "workflow"}],
+	     "stats": {"favoriteCount": 4, "collectedCount": 2, "commentCount": 1, "likeCount": 9, "viewCount": 100}}
+	  ],
+	  "metadata": {"nextCursor": "1719835200|7", "nextPage": "https://x/y?cursor=1719835200%7C7"}
+	}`
+	srv, gotPath, gotQuery, gotAuth := newTestServer(t, body)
+
+	c := New(srv.URL, "tok-1", "")
+	q := url.Values{}
+	q.Set("query", "workflow")
+	q.Set("limit", "5")
+	q.Set("tags", "5,8")
+	q.Set("sort", "Most Reactions")
+	res, err := c.SearchArticles(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchArticles: %v", err)
+	}
+	if *gotPath != "/api/v1/articles" {
+		t.Errorf("path = %q, want /api/v1/articles", *gotPath)
+	}
+	if gotQuery.Get("query") != "workflow" || gotQuery.Get("limit") != "5" ||
+		gotQuery.Get("tags") != "5,8" || gotQuery.Get("sort") != "Most Reactions" {
+		t.Errorf("query params not passed through: %v", *gotQuery)
+	}
+	if *gotAuth != "Bearer tok-1" {
+		t.Errorf("auth = %q, want Bearer tok-1", *gotAuth)
+	}
+	if len(res.Items) != 1 || res.Items[0].ID != 7 || res.Items[0].User.Username != "bob" {
+		t.Errorf("parsed items wrong: %+v", res.Items)
+	}
+	if res.Items[0].Stats.LikeCount != 9 || res.Items[0].Stats.CommentCount != 1 {
+		t.Errorf("stats not parsed: %+v", res.Items[0].Stats)
+	}
+	if len(res.Items[0].Tags) != 2 || res.Items[0].Tags[0].Name != "comfyui" {
+		t.Errorf("tags not parsed: %+v", res.Items[0].Tags)
+	}
+	// Article cursor is the opaque "<v>|<id>" string — must round-trip verbatim.
+	if got := res.Metadata.CursorString(); got != "1719835200|7" {
+		t.Errorf("CursorString = %q, want 1719835200|7", got)
+	}
+	if len(res.Raw) == 0 {
+		t.Error("Raw body should be preserved for --json")
+	}
+}
+
+func TestSearchArticlesAnonymousSendsNoAuthHeader(t *testing.T) {
+	srv, _, _, gotAuth := newTestServer(t, `{"items":[],"metadata":{}}`)
+	c := New(srv.URL, "", "") // empty token => anonymous
+	if _, err := c.SearchArticles(context.Background(), url.Values{}); err != nil {
+		t.Fatalf("SearchArticles: %v", err)
+	}
+	if *gotAuth != "" {
+		t.Errorf("anonymous request should send no Authorization header, got %q", *gotAuth)
+	}
+}
+
+func TestGetArticleParsesDetail(t *testing.T) {
+	// Detail stats use the AllTime-suffixed keys (distinct from the list shape).
+	const body = `{"id": 42, "title": "Deep Dive", "nsfwLevel": 1,
+	  "publishedAt": "2026-06-15T09:30:00.000Z",
+	  "user": {"id": 11, "username": "alice"},
+	  "tags": [{"id": 1, "name": "tutorial"}],
+	  "stats": {"viewCountAllTime": 500, "commentCountAllTime": 12, "likeCountAllTime": 40,
+	            "heartCountAllTime": 5, "favoriteCountAllTime": 7, "collectedCountAllTime": 3}}`
+	srv, gotPath, _, _ := newTestServer(t, body)
+
+	c := New(srv.URL, "", "")
+	a, raw, err := c.GetArticle(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("GetArticle: %v", err)
+	}
+	if *gotPath != "/api/v1/articles/42" {
+		t.Errorf("path = %q, want /api/v1/articles/42", *gotPath)
+	}
+	if a.ID != 42 || a.Title != "Deep Dive" || a.User.Username != "alice" {
+		t.Errorf("parsed detail wrong: %+v", a)
+	}
+	if a.Stats == nil || a.Stats.ViewCountAllTime != 500 || a.Stats.FavoriteCountAllTime != 7 {
+		t.Errorf("detail stats not parsed: %+v", a.Stats)
+	}
+	if len(a.Tags) != 1 || a.Tags[0].Name != "tutorial" {
+		t.Errorf("tags not parsed: %v", a.Tags)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should be returned")
+	}
+}
+
+func TestSearchCollectionsBuildsRequestAndParses(t *testing.T) {
+	// Collections nextCursor is NUMERIC — CursorString must still render it.
+	const body = `{
+	  "items": [
+	    {"id": 3, "name": "Favorites", "description": "my faves", "type": "Model",
+	     "nsfwLevel": 1, "read": "Public", "isPublic": true, "itemCount": 25,
+	     "coverImageUrl": "https://img/cover.jpg", "user": {"id": 9, "username": "carol"}}
+	  ],
+	  "metadata": {"nextCursor": 3, "nextPage": "https://x/y?cursor=3"}
+	}`
+	srv, gotPath, gotQuery, _ := newTestServer(t, body)
+
+	c := New(srv.URL, "", "")
+	q := url.Values{}
+	q.Set("query", "fav")
+	q.Set("limit", "3")
+	q.Set("sort", "Newest")
+	res, err := c.SearchCollections(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchCollections: %v", err)
+	}
+	if *gotPath != "/api/v1/collections" {
+		t.Errorf("path = %q, want /api/v1/collections", *gotPath)
+	}
+	if gotQuery.Get("query") != "fav" || gotQuery.Get("limit") != "3" || gotQuery.Get("sort") != "Newest" {
+		t.Errorf("query params not passed through: %v", *gotQuery)
+	}
+	if len(res.Items) != 1 || res.Items[0].ID != 3 || res.Items[0].Name != "Favorites" {
+		t.Errorf("parsed items wrong: %+v", res.Items)
+	}
+	if res.Items[0].ItemCount != 25 || !res.Items[0].IsPublic || res.Items[0].User.Username != "carol" {
+		t.Errorf("collection fields not parsed: %+v", res.Items[0])
+	}
+	if got := res.Metadata.CursorString(); got != "3" {
+		t.Errorf("numeric cursor CursorString = %q, want 3", got)
+	}
+	if len(res.Raw) == 0 {
+		t.Error("Raw body should be preserved for --json")
+	}
+}
+
+func TestGetCollectionParsesDetail(t *testing.T) {
+	// Detail drops itemCount but adds tags[]; user.id may be null.
+	const body = `{"id": 88, "name": "Anime Picks", "description": null, "type": "Image",
+	  "nsfwLevel": null, "read": "Public", "isPublic": true,
+	  "coverImageUrl": null, "user": {"id": null, "username": "dave"},
+	  "tags": [{"id": 2, "name": "anime"}, {"id": 4, "name": "style"}]}`
+	srv, gotPath, _, _ := newTestServer(t, body)
+
+	c := New(srv.URL, "", "")
+	col, raw, err := c.GetCollection(context.Background(), "88")
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if *gotPath != "/api/v1/collections/88" {
+		t.Errorf("path = %q, want /api/v1/collections/88", *gotPath)
+	}
+	if col.ID != 88 || col.Name != "Anime Picks" || !col.IsPublic {
+		t.Errorf("parsed detail wrong: %+v", col)
+	}
+	if col.Description != "" || col.NSFWLevel != nil {
+		t.Errorf("null fields should decode to zero/nil: %+v", col)
+	}
+	if col.User == nil || col.User.ID != nil || col.User.Username != "dave" {
+		t.Errorf("null user id should be nil: %+v", col.User)
+	}
+	if len(col.Tags) != 2 || col.Tags[1].Name != "style" {
+		t.Errorf("tags not parsed: %v", col.Tags)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should be returned")
+	}
+}
+
+func TestArticlesCollectionsSurfaceReadErrors(t *testing.T) {
+	// 404 on both detail endpoints surfaces the API error body via readError.
+	for _, tc := range []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"article", func(c *Client) error { _, _, err := c.GetArticle(context.Background(), "999"); return err }},
+		{"collection", func(c *Client) error { _, _, err := c.GetCollection(context.Background(), "999"); return err }},
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"No ` + tc.name + ` with id 999"}`))
+		}))
+		c := New(srv.URL, "", "")
+		err := tc.call(c)
+		srv.Close()
+		if err == nil {
+			t.Errorf("%s: expected error", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "not found (404)") ||
+			!strings.Contains(err.Error(), "No "+tc.name+" with id 999") {
+			t.Errorf("%s: error should surface 404 body: %v", tc.name, err)
+		}
+	}
+}

--- a/internal/api/collections.go
+++ b/internal/api/collections.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"net/url"
+)
+
+// CollectionUser is the minimal owner view the collection endpoints embed. Both
+// id and username can be null server-side, so id is a pointer and username is
+// left as its zero value ("") when absent.
+type CollectionUser struct {
+	ID       *int   `json:"id"`
+	Username string `json:"username"`
+}
+
+// CollectionTag is a tag attached to a collection (detail-only `tags[]`).
+type CollectionTag struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// CollectionListItem is a `GET /api/v1/collections` item. The endpoint projects
+// a fixed public shape (no cross-user fields); coverImageUrl is a ready-to-use
+// edge URL (or null). itemCount is the count of ACCEPTED items.
+type CollectionListItem struct {
+	ID            int             `json:"id"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description"`
+	Type          string          `json:"type"`
+	NSFWLevel     *int            `json:"nsfwLevel"`
+	Read          string          `json:"read"`
+	IsPublic      bool            `json:"isPublic"`
+	ItemCount     int             `json:"itemCount"`
+	CoverImageURL string          `json:"coverImageUrl"`
+	User          *CollectionUser `json:"user"`
+}
+
+// CollectionDetail is the subset of `GET /api/v1/collections/{id}` the CLI
+// renders. The detail shape drops itemCount but adds tags[].
+type CollectionDetail struct {
+	ID            int             `json:"id"`
+	Name          string          `json:"name"`
+	Description   string          `json:"description"`
+	Type          string          `json:"type"`
+	NSFWLevel     *int            `json:"nsfwLevel"`
+	Read          string          `json:"read"`
+	IsPublic      bool            `json:"isPublic"`
+	CoverImageURL string          `json:"coverImageUrl"`
+	User          *CollectionUser `json:"user"`
+	Tags          []CollectionTag `json:"tags"`
+}
+
+// CollectionSearchResult bundles the parsed items + pagination metadata with the
+// raw response body (for --json passthrough).
+type CollectionSearchResult struct {
+	Items    []CollectionListItem `json:"items"`
+	Metadata Metadata             `json:"metadata"`
+	Raw      []byte               `json:"-"`
+}
+
+// SearchCollections calls GET /api/v1/collections with the given query params.
+func (c *Client) SearchCollections(ctx context.Context, q url.Values) (*CollectionSearchResult, error) {
+	var res CollectionSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/collections", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// GetCollection calls GET /api/v1/collections/{id}. Returns the parsed detail
+// and the raw body (for --json).
+func (c *Client) GetCollection(ctx context.Context, id string) (*CollectionDetail, []byte, error) {
+	var col CollectionDetail
+	raw, err := c.getInto(ctx, "/api/v1/collections/"+url.PathEscape(id), nil, &col)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &col, raw, nil
+}

--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -25,6 +25,10 @@ type Reader interface {
 	SearchTags(ctx context.Context, q url.Values) (*TagSearchResult, error)
 	SearchCreators(ctx context.Context, q url.Values) (*CreatorSearchResult, error)
 	SearchUsers(ctx context.Context, q url.Values) (*UserSearchResult, error)
+	SearchArticles(ctx context.Context, q url.Values) (*ArticleSearchResult, error)
+	GetArticle(ctx context.Context, id string) (*ArticleDetail, []byte, error)
+	SearchCollections(ctx context.Context, q url.Values) (*CollectionSearchResult, error)
+	GetCollection(ctx context.Context, id string) (*CollectionDetail, []byte, error)
 }
 
 // Metadata is the pagination envelope the list endpoints return under

--- a/internal/cmd/articles.go
+++ b/internal/cmd/articles.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const articlesLimitMax = 100
+
+func newArticlesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "articles",
+		Short: "Search and inspect articles on Civitai",
+		Long: `Read-only access to Civitai articles via the public REST API
+(GET /api/v1/articles). These endpoints are public and work anonymously; if you
+are logged in (civitai login) your token is sent automatically.`,
+		Example: `  civitai articles search --query "workflow" --limit 5
+  civitai articles get 1234`,
+	}
+	cmd.AddCommand(newArticlesSearchCmd())
+	cmd.AddCommand(newArticlesGetCmd())
+	return cmd
+}
+
+func newArticlesSearchCmd() *cobra.Command {
+	var (
+		query, tags, username, sort, cursor string
+		nsfw                                bool
+		limit                               int
+	)
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search articles (GET /api/v1/articles)",
+		Long: `Search articles via GET /api/v1/articles.
+
+Pagination is cursor-based (the article feed uses a keyset cursor — there is no
+--page). The next cursor is printed after the results; pass it back via --cursor.`,
+		Example: `  civitai articles search --query "comfyui" --limit 5
+  civitai articles search --sort "Most Reactions" --nsfw
+  civitai articles search --username some-creator --cursor <cursor>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, articlesLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "query", query)
+			addIfSet(q, "tags", tags) // comma-delimited tag ids
+			addIfSet(q, "username", username)
+			addIfSet(q, "sort", sort)
+			addIfSet(q, "cursor", cursor)
+			addIfPositive(q, "limit", limit)
+			if cmd.Flags().Changed("nsfw") {
+				q.Set("nsfw", strconv.FormatBool(nsfw))
+			}
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchArticles(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printArticleList(cmd, res.Items)
+			printPageFooter(cmd, "civitai articles search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "text search query (matches the article title)")
+	cmd.Flags().StringVar(&tags, "tags", "", "filter by tag ids (comma-separated, e.g. 5,12)")
+	cmd.Flags().StringVar(&username, "username", "", "filter by author username")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order (Newest, \"Recently Updated\", \"Most Reactions\", \"Most Comments\", \"Most Bookmarks\", \"Most Collected\")")
+	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func newArticlesGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an article by id (GET /api/v1/articles/{id})",
+		Example: `  civitai articles get 1234
+  civitai articles get 1234 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			if n, err := strconv.Atoi(args[0]); err != nil || n <= 0 {
+				return fmt.Errorf("article id must be a positive integer, got %q", args[0])
+			}
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			a, raw, err := client.GetArticle(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printArticleDetail(cmd, a)
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printArticleList(cmd *cobra.Command, items []api.ArticleListItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No articles found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTITLE\tAUTHOR\tPUBLISHED\tREACTIONS\tCOMMENTS")
+	for _, a := range items {
+		author := "-"
+		if a.User != nil && a.User.Username != "" {
+			author = a.User.Username
+		}
+		title := a.Title
+		if a.NSFWLevel > 1 {
+			title += " [nsfw]"
+		}
+		reactions := a.Stats.LikeCount + a.Stats.FavoriteCount
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%d\t%d\n", a.ID, title, author, dashIfEmpty(shortDate(a.PublishedAt)), reactions, a.Stats.CommentCount)
+	}
+	_ = tw.Flush()
+}
+
+func printArticleDetail(cmd *cobra.Command, a *api.ArticleDetail) {
+	out := cmd.OutOrStdout()
+	author := "-"
+	if a.User != nil && a.User.Username != "" {
+		author = a.User.Username
+	}
+	fmt.Fprintf(out, "%s (id %d)\n", a.Title, a.ID)
+	fmt.Fprintf(out, "  author:    %s\n", author)
+	fmt.Fprintf(out, "  published: %s\n", dashIfEmpty(shortDate(a.PublishedAt)))
+	fmt.Fprintf(out, "  nsfwLevel: %d\n", a.NSFWLevel)
+	if a.Stats != nil {
+		fmt.Fprintf(out, "  views: %d   likes: %d   favorites: %d   comments: %d   collected: %d\n",
+			a.Stats.ViewCountAllTime, a.Stats.LikeCountAllTime, a.Stats.FavoriteCountAllTime,
+			a.Stats.CommentCountAllTime, a.Stats.CollectedCountAllTime)
+	}
+	if len(a.Tags) > 0 {
+		fmt.Fprintf(out, "  tags:      %s\n", joinArticleTags(a.Tags))
+	}
+}
+
+func joinArticleTags(tags []api.ArticleTag) string {
+	const max = 12
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+	if len(names) <= max {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:max], ", ") + fmt.Sprintf(", … (+%d)", len(names)-max)
+}

--- a/internal/cmd/articles_collections_cmd_test.go
+++ b/internal/cmd/articles_collections_cmd_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestArticlesCollectionsRegistered(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help: %v", err)
+	}
+	for _, want := range []string{"articles", "collections"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("root help missing read command %q\n%s", want, out)
+		}
+	}
+}
+
+func TestArticlesSearchHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/articles" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "comfyui" {
+			t.Errorf("query not passed: %v", r.URL.Query())
+		}
+		if r.URL.Query().Get("tags") != "5,8" {
+			t.Errorf("tags not passed: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":7,"title":"My Workflow","nsfwLevel":1,
+		  "publishedAt":"2026-07-01T12:00:00.000Z","user":{"id":3,"username":"bob"},
+		  "tags":[{"id":5,"name":"comfyui"}],
+		  "stats":{"favoriteCount":4,"commentCount":1,"likeCount":9,"viewCount":100}}],
+		  "metadata":{"nextCursor":"1719835200|7"}}`))
+	})
+	out, _, err := run(t, "articles", "search", "--query", "comfyui", "--tags", "5,8", "--limit", "1")
+	if err != nil {
+		t.Fatalf("articles search: %v", err)
+	}
+	if !strings.Contains(out, "My Workflow") || !strings.Contains(out, "bob") {
+		t.Errorf("human output missing fields: %s", out)
+	}
+	if !strings.Contains(out, "next cursor: 1719835200|7") {
+		t.Errorf("footer should show next cursor: %s", out)
+	}
+}
+
+func TestArticlesSearchJSONPassthrough(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	out, _, err := run(t, "articles", "search", "--json")
+	if err != nil {
+		t.Fatalf("articles search --json: %v", err)
+	}
+	if !strings.Contains(out, `"items"`) || !strings.Contains(out, `"metadata"`) {
+		t.Errorf("--json should print raw API JSON: %s", out)
+	}
+}
+
+func TestArticlesSearchLimitValidation(t *testing.T) {
+	_, _, err := run(t, "articles", "search", "--limit", "101")
+	if err == nil {
+		t.Fatal("expected error for --limit > 100")
+	}
+	if !strings.Contains(err.Error(), "1 and 100") {
+		t.Errorf("error should name the max: %v", err)
+	}
+}
+
+func TestArticlesGetRejectsNonNumericId(t *testing.T) {
+	if _, _, err := run(t, "articles", "get", "abc"); err == nil {
+		t.Fatal("expected error for non-numeric article id")
+	}
+}
+
+func TestArticlesGetSurfacesServerError(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"No article with id 999"}`))
+	})
+	_, _, err := run(t, "articles", "get", "999")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "No article with id 999") {
+		t.Errorf("error should surface API body: %v", err)
+	}
+}
+
+func TestArticlesGetHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/articles/42" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":42,"title":"Deep Dive","nsfwLevel":1,
+		  "publishedAt":"2026-06-15T09:30:00.000Z","user":{"id":11,"username":"alice"},
+		  "tags":[{"id":1,"name":"tutorial"}],
+		  "stats":{"viewCountAllTime":500,"likeCountAllTime":40,"favoriteCountAllTime":7,
+		           "commentCountAllTime":12,"collectedCountAllTime":3}}`))
+	})
+	out, _, err := run(t, "articles", "get", "42")
+	if err != nil {
+		t.Fatalf("articles get: %v", err)
+	}
+	if !strings.Contains(out, "Deep Dive (id 42)") || !strings.Contains(out, "alice") {
+		t.Errorf("detail output missing fields: %s", out)
+	}
+	if !strings.Contains(out, "views: 500") {
+		t.Errorf("detail output missing AllTime stats: %s", out)
+	}
+}
+
+func TestCollectionsSearchHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/collections" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "anime" {
+			t.Errorf("query not passed: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":3,"name":"Anime Picks","type":"Image",
+		  "read":"Public","isPublic":true,"itemCount":25,
+		  "user":{"id":9,"username":"carol"}}],
+		  "metadata":{"nextCursor":3}}`))
+	})
+	out, _, err := run(t, "collections", "search", "--query", "anime", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search: %v", err)
+	}
+	if !strings.Contains(out, "Anime Picks") || !strings.Contains(out, "carol") {
+		t.Errorf("human output missing fields: %s", out)
+	}
+	// Numeric cursor must still render in the footer.
+	if !strings.Contains(out, "next cursor: 3") {
+		t.Errorf("footer should show numeric next cursor: %s", out)
+	}
+}
+
+func TestCollectionsSearchJSONPassthrough(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	out, _, err := run(t, "collections", "search", "--json")
+	if err != nil {
+		t.Fatalf("collections search --json: %v", err)
+	}
+	if !strings.Contains(out, `"items"`) {
+		t.Errorf("--json should print raw API JSON: %s", out)
+	}
+}
+
+func TestCollectionsSearchLimitValidation(t *testing.T) {
+	_, _, err := run(t, "collections", "search", "--limit", "101")
+	if err == nil {
+		t.Fatal("expected error for --limit > 100")
+	}
+	if !strings.Contains(err.Error(), "1 and 100") {
+		t.Errorf("error should name the max: %v", err)
+	}
+}
+
+func TestCollectionsGetRejectsNonNumericId(t *testing.T) {
+	if _, _, err := run(t, "collections", "get", "abc"); err == nil {
+		t.Fatal("expected error for non-numeric collection id")
+	}
+}
+
+func TestCollectionsGetHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/collections/88" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":88,"name":"Favorites","description":"my faves",
+		  "type":"Model","read":"Public","isPublic":true,
+		  "user":{"id":9,"username":"dave"},"tags":[{"id":2,"name":"anime"}]}`))
+	})
+	out, _, err := run(t, "collections", "get", "88")
+	if err != nil {
+		t.Fatalf("collections get: %v", err)
+	}
+	if !strings.Contains(out, "Favorites (id 88)") || !strings.Contains(out, "dave") {
+		t.Errorf("detail output missing fields: %s", out)
+	}
+	if !strings.Contains(out, "anime") {
+		t.Errorf("detail output missing tags: %s", out)
+	}
+}

--- a/internal/cmd/collections.go
+++ b/internal/cmd/collections.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+const collectionsLimitMax = 100
+
+func newCollectionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "collections",
+		Short: "Search and inspect collections on Civitai",
+		Long: `Read-only access to Civitai collections via the public REST API
+(GET /api/v1/collections). These endpoints are public and work anonymously; if
+you are logged in (civitai login) your token is sent automatically. Only public
+collections are discoverable.`,
+		Example: `  civitai collections search --query "favorites" --limit 5
+  civitai collections get 1234`,
+	}
+	cmd.AddCommand(newCollectionsSearchCmd())
+	cmd.AddCommand(newCollectionsGetCmd())
+	return cmd
+}
+
+func newCollectionsSearchCmd() *cobra.Command {
+	var (
+		query, sort, cursor string
+		nsfw                bool
+		limit               int
+	)
+	cmd := &cobra.Command{
+		Use:   "search",
+		Short: "Search collections (GET /api/v1/collections)",
+		Long: `Search public collections via GET /api/v1/collections.
+
+Pagination is cursor-based (a keyset cursor on the collection id — there is no
+--page). The next cursor is printed after the results; pass it back via --cursor.
+Cursor paging is only supported for the default (Newest) sort.`,
+		Example: `  civitai collections search --query "anime" --limit 5
+  civitai collections search --sort Newest --cursor <cursor>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, collectionsLimitMax); err != nil {
+				return err
+			}
+			o := readFlags(cmd)
+			q := url.Values{}
+			addIfSet(q, "query", query)
+			addIfSet(q, "sort", sort)
+			addIfSet(q, "cursor", cursor)
+			addIfPositive(q, "limit", limit)
+			if cmd.Flags().Changed("nsfw") {
+				q.Set("nsfw", strconv.FormatBool(nsfw))
+			}
+
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchCollections(context.Background(), q)
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, res.Raw)
+			}
+			printCollectionList(cmd, res.Items)
+			printPageFooter(cmd, "civitai collections search", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "text search query (matches the collection name)")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order (Newest, \"Most Followers\")")
+	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
+	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response (Newest sort only)")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func newCollectionsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a collection by id (GET /api/v1/collections/{id})",
+		Example: `  civitai collections get 1234
+  civitai collections get 1234 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			if n, err := strconv.Atoi(args[0]); err != nil || n <= 0 {
+				return fmt.Errorf("collection id must be a positive integer, got %q", args[0])
+			}
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			col, raw, err := client.GetCollection(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printCollectionDetail(cmd, col)
+			return nil
+		},
+	}
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func printCollectionList(cmd *cobra.Command, items []api.CollectionListItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No collections found.")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tOWNER\tITEMS")
+	for _, c := range items {
+		owner := "-"
+		if c.User != nil && c.User.Username != "" {
+			owner = c.User.Username
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%d\n", c.ID, c.Name, dashIfEmpty(c.Type), owner, c.ItemCount)
+	}
+	_ = tw.Flush()
+}
+
+func printCollectionDetail(cmd *cobra.Command, c *api.CollectionDetail) {
+	out := cmd.OutOrStdout()
+	owner := "-"
+	if c.User != nil && c.User.Username != "" {
+		owner = c.User.Username
+	}
+	fmt.Fprintf(out, "%s (id %d)\n", c.Name, c.ID)
+	fmt.Fprintf(out, "  owner:  %s\n", owner)
+	fmt.Fprintf(out, "  type:   %s\n", dashIfEmpty(c.Type))
+	fmt.Fprintf(out, "  read:   %s\n", dashIfEmpty(c.Read))
+	fmt.Fprintf(out, "  public: %t\n", c.IsPublic)
+	if c.Description != "" {
+		fmt.Fprintf(out, "  about:  %s\n", truncate(c.Description, 200))
+	}
+	if len(c.Tags) > 0 {
+		fmt.Fprintf(out, "  tags:   %s\n", joinCollectionTags(c.Tags))
+	}
+}
+
+func joinCollectionTags(tags []api.CollectionTag) string {
+	const max = 12
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+	if len(names) <= max {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:max], ", ") + fmt.Sprintf(", … (+%d)", len(names)-max)
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -256,6 +256,8 @@ Get started:
 	root.AddCommand(newTagsCmd())
 	root.AddCommand(newCreatorsCmd())
 	root.AddCommand(newUsersCmd())
+	root.AddCommand(newArticlesCmd())
+	root.AddCommand(newCollectionsCmd())
 
 	return root
 }


### PR DESCRIPTION
## Summary

Adds `civitai articles` and `civitai collections` read subcommands (each with `search` + `get`) to the CLI, mirroring the `models`/`images`/`model-versions`/`tags`/`creators`/`users` read commands added in #127 and **reusing the same shared read scaffold** (no new plumbing):

- `internal/api/read.go` — `getInto`/`getRaw`/`readError`/`Metadata` + `json.RawMessage` cursor handling
- `internal/cmd/read.go` — `readFlags`/`newReader`/`emitJSON`/`checkLimit`/`printPageFooter` + shared `--json`/`--anon` flags

### Command tree
```
civitai articles     search   -> GET /api/v1/articles
                     get <id> -> GET /api/v1/articles/{id}
civitai collections  search   -> GET /api/v1/collections
                     get <id> -> GET /api/v1/collections/{id}
```

Client methods live in `internal/api/{articles,collections}.go`; command files in `internal/cmd/{articles,collections}.go`; registered in `internal/cmd/root.go` alongside the existing read commands.

### Auth
These endpoints are **public + edge-cached** (they shipped as fully anonymous, `{ items, metadata }` envelope like models). The commands send the login token when present but **work fully anonymously** — reuse `api.Client` + `TokenSource` + `--anon`. Errors go through the shared `readError` path (surfaces the API `{error}`/`{message}` body).

## Shapes / params verified against civitai source
Verified against `src/pages/api/v1/{articles,collections}/{index,[id]}.ts` (zod schemas + response projections) and the underlying services (`article.service.ts` `getArticles`/`getArticleById`, `collection.service.ts`), not guessed:

**articles search** params: `limit` (1–100, capped client-side), `cursor` (opaque `"<v>|<id>"` string), `query`, `tags` (comma-delimited tag ids), `username`, `sort` (ArticleSort), `nsfw`. Cursor is a keyset cursor — **no `--page`** (matches the schema). Envelope `{ items, metadata:{ nextCursor(string), nextPage } }`.
**articles get**: id coerced to a positive int4. Detail stats use the **AllTime-suffixed** keys (`viewCountAllTime`, …) — distinct from the list endpoint's `viewCount`/`likeCount`/… keys; modeled as separate structs.

**collections search** params: `limit` (1–100), `cursor` (**numeric** keyset on collection id), `query`, `sort` (CollectionSort: `Newest`/`Most Followers`), `nsfw`. No `username`/`tags`/`page`. Envelope `{ items, metadata:{ nextCursor(number), nextPage } }`. The list item shape is fully projected in source (`id`/`name`/`description`/`type`/`nsfwLevel`/`read`/`isPublic`/`itemCount`/`coverImageUrl`/`user{id,username}`).
**collections get**: detail drops `itemCount`, adds `tags[]`; `user.id` can be null (modeled `*int`).

The article/collection cursors differ (string `"v|id"` vs numeric) — both round-trip through `read.go`'s `json.RawMessage` cursor handling, no float64 loss. Human view models a readable subset; **`--json` dumps the raw body** so un-modeled fields (e.g. `nsfwLevel: 29`, `coverImage`, article `content`) are never lost.

## Live smoke test (prod, anonymous — no login)
```
$ civitai articles search --limit 3 --anon
ID     TITLE                                   AUTHOR        PUBLISHED   REACTIONS  COMMENTS
32682  V67 Buzz Giveaway Winners Announcement  angelomaiota  2026-07-17  3          1
32680  Promptyx Version 1.6                    angelomaiota  2026-07-17  4          1
32677  最新 optim ｢QPOLA｣ 公開 / Latest optim  muooon        2026-07-17  1          0
next cursor: 1784248294.488|32676
next page: civitai articles search --cursor 1784248294.488|32676

$ civitai articles get 32680 --anon
Promptyx Version 1.6 (id 32680)
  author:    angelomaiota
  published: 2026-07-17
  nsfwLevel: 1
  views: 106   likes: 4   favorites: 0   comments: 1   collected: 2
  tags:      news

$ civitai collections search --limit 3 --anon
ID        NAME           TYPE  OWNER               ITEMS
17307017  Lightsabers    Post  GlitchTheGreat9447  0
17306890  Kaito Onogi    Post  AkiraFudosBelt      1
17306884  Lovely Ladies  Post  AnonAImous_Art      4
next cursor: 17306702

$ civitai collections get 17306890 --anon
Kaito Onogi (id 17306890)
  owner:  AkiraFudosBelt
  type:   Post
  read:   Public
  public: true
  about:  Kaito Onogi from Tsurune
```

## Tests
- `internal/api/articles_collections_test.go` — httptest (no live calls): param building, envelope parse, string vs numeric cursor handling, null-field decoding, 404 error surfacing.
- `internal/cmd/articles_collections_cmd_test.go` — registration, human + `--json` output, limit validation, non-numeric id rejection, server-error path.
- `go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
