### PR TITLE
feat(download): `civitai download` + `--base-model` filter; surface on-site-gen trap; fix stale update-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,11 @@ also takes `--json` to print the **raw API JSON response** for scripting.
 
 | Command | What it does | Notable flags |
 | --- | --- | --- |
-| `civitai models search` | Search models (`GET /api/v1/models`) | `--query`, `--tag`, `--username`, `--type`, `--sort`, `--period`, `--nsfw`; paging `--limit` (≤100), `--page`, `--cursor` |
+| `civitai models search` | Search models (`GET /api/v1/models`) | `--query`, `--tag`, `--username`, `--type`, `--base-model` (repeatable), `--sort`, `--period`, `--nsfw`; paging `--limit` (≤100), `--page`, `--cursor` |
 | `civitai models get <id>` | Get one model by id | `--json`, `--anon` |
 | `civitai model-versions get <id>` | Get a model version by id (alias `mv`) | `--json`, `--anon` |
 | `civitai model-versions by-hash <hash>` | Look up a model version by file hash (AutoV2, SHA256, …) | `--json`, `--anon` |
+| `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--no-verify`, `--force`, `--allow-nonmodel`, `--anon` |
 | `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
 | `civitai tags search` | Search model tags | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai creators search` | Search creators | `--query`; paging `--limit` (≤200), `--page` |
@@ -283,6 +284,48 @@ civitai model-versions by-hash 5D8D26E2A6
 civitai articles get 32680
 civitai images search --model-id 4384 --sort "Most Reactions" --json   # raw JSON for scripting
 ```
+
+**Filtering by base model.** `--base-model` is repeatable and maps to the REST
+`baseModels` filter (an OR across the values). It's the key discovery filter for
+things `--type` can't separate — e.g. video checkpoints all share
+`--type Checkpoint` and are distinguished only by base model:
+
+```bash
+civitai models search --type Checkpoint --base-model "Wan Video 2.2 T2V-A14B"
+civitai models search --base-model Pony --base-model Illustrious --limit 20
+```
+
+**On-site-generation marker.** In the human (non-`--json`) output of
+`models get` and `model-versions get`, a version whose **primary file is not
+model weights** (`type != "Model"` — e.g. an on-site-generation registration that
+ships a training-data ZIP instead of the weights) is tagged
+`[training data — no downloadable weights]` so you can spot the trap before
+trying to download it. `--json` output is an unchanged raw passthrough.
+
+## Download model files
+
+`civitai download` fetches the file(s) of a model **version**. Identify the
+version deterministically by its numeric **version id**, or resolve a model's
+default (primary/latest) published version with `--model`:
+
+```bash
+civitai download 128713                       # the version's primary file → ./<server-name>
+civitai download --model 4384                 # resolve model 4384's default version, then download it
+civitai download 128713 --out ./dreamshaper.safetensors
+civitai download 128713 --file vae --out-dir ./models   # pick a file; write into a dir
+civitai download 128713 --all --out-dir ./models        # every file in the version
+```
+
+Behavior:
+
+- **Identifier** — exactly one of the positional `<version-id>` or `--model <model-id>` is required (no numeric-ambiguity guessing).
+- **File selection** — defaults to the version's **primary** file. `--file <name>` selects one file (exact name, else a unique case-insensitive substring; ambiguous/none errors and lists the files). `--all` downloads every file.
+- **Output** — `--out <path>` sets an exact target path (single file only). `--out-dir <dir>` writes server-named files into a directory (works with `--all`). Parent directories are created as needed. Default is the server-provided filename in the current directory.
+- **Streaming + atomicity** — the body streams to `<target>.part` and is renamed into place only on success, so an interrupted run never leaves a truncated final file. Large files (10+ GB) are never buffered in memory. TTY-aware progress is printed to **stderr**. The Civitai download URL 302-redirects to signed storage; the CLI follows it.
+- **Auth** — your stored login token (`civitai login`) or `CIVITAI_API_KEY` is used automatically; gated / early-access files need it (a 401/403 gives an actionable message). Public files download anonymously (`--anon` forces no token).
+- **Integrity (default on)** — the streamed bytes are verified against the file's `SHA256`; a mismatch deletes the `.part` and fails. `--no-verify` skips it; a file with no published SHA256 downloads with a warning (not a hard failure).
+- **Idempotency** — an already-present target (that verifies, or with `--no-verify`) is skipped with a note; `--force` re-downloads.
+- **On-site-generation guard** — a version whose selected file is **not model weights** (`type != "Model"`, e.g. a training-data ZIP) is **refused by default**; pass `--allow-nonmodel` to download it anyway.
 
 ## Validate fidelity
 

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"net/http"
+)
+
+// Downloader streams a file's bytes from a (possibly redirecting) URL. Behind an
+// interface so the command layer stays testable without a live server.
+type Downloader interface {
+	// DownloadFile issues an authenticated GET to fileURL and returns the open
+	// HTTP response for streaming. The CALLER owns resp.Body and MUST close it.
+	// Redirects are followed automatically; the Civitai `/api/download` route
+	// 302s to signed object storage on a DIFFERENT host, and Go's default client
+	// strips the Authorization header on a cross-host redirect (exactly what we
+	// want — the signed URL needs no bearer). A 401 with a refreshable token
+	// source is retried once after a transparent refresh.
+	DownloadFile(ctx context.Context, fileURL string) (*http.Response, error)
+}
+
+// downloadHTTPClient returns an *http.Client tuned for large streamed downloads:
+// NO overall timeout (a 10+ GB file legitimately runs for a long time; the
+// caller's context governs cancellation instead), reusing the shared client's
+// Transport, and the DEFAULT redirect policy (follow up to 10 hops, stripping
+// the Authorization header on a cross-host redirect).
+func (c *Client) downloadHTTPClient() *http.Client {
+	var transport http.RoundTripper
+	if c.HTTP != nil {
+		transport = c.HTTP.Transport
+	}
+	return &http.Client{Transport: transport}
+}
+
+// DownloadFile implements Downloader. See the interface doc for the contract.
+func (c *Client) DownloadFile(ctx context.Context, fileURL string) (*http.Response, error) {
+	hc := c.downloadHTTPClient()
+	token, err := c.Tokens.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.doDownload(ctx, hc, fileURL, token)
+	if err != nil {
+		return nil, err
+	}
+	// One transparent refresh + retry on a 401 (OAuth access token expired).
+	// A non-refreshable (personal-key) source returns ErrNoRefresh and we keep
+	// the 401 response for the caller to map to actionable guidance.
+	if resp.StatusCode == http.StatusUnauthorized {
+		if newTok, rerr := c.Tokens.Refresh(ctx); rerr == nil && newTok != "" {
+			_ = resp.Body.Close()
+			return c.doDownload(ctx, hc, fileURL, newTok)
+		}
+	}
+	return resp, nil
+}
+
+// doDownload builds + issues a single GET with the given bearer token (attached
+// only when non-empty, so anonymous downloads send no Authorization header).
+func (c *Client) doDownload(ctx context.Context, hc *http.Client, fileURL, token string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return hc.Do(req)
+}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -3,6 +3,9 @@ package api
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 )
 
 // Downloader streams a file's bytes from a (possibly redirecting) URL. Behind an
@@ -18,17 +21,50 @@ type Downloader interface {
 	DownloadFile(ctx context.Context, fileURL string) (*http.Response, error)
 }
 
+// downloadResponseHeaderTimeout bounds how long the download client waits for a
+// server to send response HEADERS after the connection is accepted. There is
+// deliberately NO overall client Timeout (a large file legitimately streams for
+// a long time), so without this a server that accepts the connection then never
+// responds would hang the download forever. Body streaming remains governed by
+// the caller's (SIGINT-bound) context.
+const downloadResponseHeaderTimeout = 30 * time.Second
+
 // downloadHTTPClient returns an *http.Client tuned for large streamed downloads:
 // NO overall timeout (a 10+ GB file legitimately runs for a long time; the
-// caller's context governs cancellation instead), reusing the shared client's
-// Transport, and the DEFAULT redirect policy (follow up to 10 hops, stripping
-// the Authorization header on a cross-host redirect).
+// caller's context governs cancellation instead), a ResponseHeaderTimeout so a
+// silent server can't hang forever, and the DEFAULT redirect policy (follow up
+// to 10 hops, stripping the Authorization header on a cross-host redirect).
 func (c *Client) downloadHTTPClient() *http.Client {
-	var transport http.RoundTripper
+	var base http.RoundTripper
 	if c.HTTP != nil {
-		transport = c.HTTP.Transport
+		base = c.HTTP.Transport
 	}
-	return &http.Client{Transport: transport}
+	return &http.Client{Transport: downloadTransport(base, downloadResponseHeaderTimeout)}
+}
+
+// downloadTransport returns a RoundTripper carrying a ResponseHeaderTimeout. When
+// base is an *http.Transport (or nil, meaning the shared default) it is CLONED —
+// never mutated — before the timeout is set, so shared transport state is left
+// untouched. A non-*http.Transport base (e.g. a test round-tripper) is returned
+// as-is (it governs its own timeouts).
+func downloadTransport(base http.RoundTripper, headerTimeout time.Duration) http.RoundTripper {
+	var src *http.Transport
+	switch t := base.(type) {
+	case *http.Transport:
+		src = t
+	case nil:
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			src = dt
+		}
+	default:
+		return base
+	}
+	if src == nil {
+		return base
+	}
+	clone := src.Clone()
+	clone.ResponseHeaderTimeout = headerTimeout
+	return clone
 }
 
 // DownloadFile implements Downloader. See the interface doc for the contract.
@@ -54,15 +90,48 @@ func (c *Client) DownloadFile(ctx context.Context, fileURL string) (*http.Respon
 	return resp, nil
 }
 
-// doDownload builds + issues a single GET with the given bearer token (attached
-// only when non-empty, so anonymous downloads send no Authorization header).
+// doDownload builds + issues a single GET. The bearer token is attached ONLY
+// when non-empty AND the destination is a trusted host+scheme (see
+// isTrustedDownloadHost): f.DownloadURL is SERVER-SUPPLIED, so a hostile value
+// must never be able to exfiltrate the token to an arbitrary host. An off-domain
+// or non-https URL (e.g. a signed object-storage redirect target) is fetched
+// WITHOUT the Authorization header — it needs none.
 func (c *Client) doDownload(ctx context.Context, hc *http.Client, fileURL, token string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	if token != "" {
+	if token != "" && isTrustedDownloadHost(fileURL, c.BaseURL) {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	return hc.Do(req)
+}
+
+// isTrustedDownloadHost reports whether the bearer token may be attached to a GET
+// for fileURL. The token is attached only when EITHER:
+//   - fileURL is https AND its host is civitai.com or a *.civitai.com subdomain
+//     (an exact dotted-suffix match, so "evilcivitai.com" and
+//     "civitai.com.evil.com" are both rejected — never a naive substring test),
+//     OR
+//   - fileURL is same-scheme + same-host as the configured API base URL (the
+//     endpoint the user explicitly pointed the CLI at — trusted by definition;
+//     this also lets a self-hosted / test API authenticate its own downloads).
+//
+// An off-domain signed-storage redirect target matches neither and is fetched
+// without the token, matching Go's own cross-host Authorization stripping.
+func isTrustedDownloadHost(fileURL, baseURL string) bool {
+	u, err := url.Parse(fileURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := u.Hostname() // strips any :port
+	if u.Scheme == "https" && (host == "civitai.com" || strings.HasSuffix(host, ".civitai.com")) {
+		return true
+	}
+	if b, berr := url.Parse(baseURL); berr == nil && b.Host != "" {
+		if u.Scheme == b.Scheme && u.Host == b.Host {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/download_auth_test.go
+++ b/internal/api/download_auth_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestIsTrustedDownloadHost is the security gate for attaching the bearer token:
+// only https civitai.com (+ subdomains) or the exact configured API origin are
+// trusted; a hostile/off-domain URL is not.
+func TestIsTrustedDownloadHost(t *testing.T) {
+	const base = "https://civitai.com"
+	cases := []struct {
+		fileURL string
+		baseURL string
+		want    bool
+	}{
+		// civitai domain over https.
+		{"https://civitai.com/api/download/models/1", base, true},
+		{"https://models.civitai.com/blob", base, true},
+		{"https://a.b.civitai.com/blob", base, true},
+		// Look-alike / substring attacks must be rejected.
+		{"https://evilcivitai.com/steal", base, false},
+		{"https://civitai.com.evil.com/steal", base, false},
+		{"https://notcivitai.com/steal", base, false},
+		// Right host, wrong scheme (would leak the token over cleartext).
+		{"http://civitai.com/api/download/models/1", base, false},
+		// Off-domain signed-storage target (the redirect destination).
+		{"https://signed-storage.example.com/blob?sig=abc", base, false},
+		// Same-origin as the configured API endpoint is trusted (self-host / test).
+		{"http://127.0.0.1:8080/dl", "http://127.0.0.1:8080", true},
+		{"http://127.0.0.1:8080/dl", "http://127.0.0.1:9999", false}, // different port
+		{"http://127.0.0.1:8080/dl", "https://127.0.0.1:8080", false}, // different scheme
+		// Garbage.
+		{"://nope", base, false},
+		{"", base, false},
+	}
+	for _, tc := range cases {
+		if got := isTrustedDownloadHost(tc.fileURL, tc.baseURL); got != tc.want {
+			t.Errorf("isTrustedDownloadHost(%q, %q) = %v, want %v", tc.fileURL, tc.baseURL, got, tc.want)
+		}
+	}
+}
+
+// TestDownloadFileSkipsAuthForUntrustedHost proves the token is NOT sent to an
+// off-domain download host even when one is configured — the exfiltration
+// defense. The BaseURL is the trusted civitai.com API, but the download URL is a
+// different (local, off-domain) host, so no Authorization must reach it.
+func TestDownloadFileSkipsAuthForUntrustedHost(t *testing.T) {
+	const body = "SIGNED-STORAGE-BYTES"
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := New("https://civitai.com", "secret-token", "") // trusted API base, but...
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/signed-blob")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body = %q, want %q (download must still succeed without auth)", got, body)
+	}
+	if gotAuth != "" {
+		t.Errorf("token leaked to untrusted host: Authorization = %q, want none", gotAuth)
+	}
+}
+
+// TestDownloadTransportSetsResponseHeaderTimeout proves the download client
+// carries a ResponseHeaderTimeout and does so on a CLONE (the shared default
+// transport is never mutated).
+func TestDownloadTransportSetsResponseHeaderTimeout(t *testing.T) {
+	tr := downloadTransport(nil, downloadResponseHeaderTimeout)
+	ht, ok := tr.(*http.Transport)
+	if !ok {
+		t.Fatalf("downloadTransport(nil) = %T, want *http.Transport", tr)
+	}
+	if ht.ResponseHeaderTimeout != downloadResponseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", ht.ResponseHeaderTimeout, downloadResponseHeaderTimeout)
+	}
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok && dt.ResponseHeaderTimeout != 0 {
+		t.Errorf("DefaultTransport was mutated: ResponseHeaderTimeout = %v (must clone, not mutate)", dt.ResponseHeaderTimeout)
+	}
+}
+
+// TestDownloadTransportHeaderTimeoutFires proves a server that accepts the
+// connection but never sends headers is aborted by the ResponseHeaderTimeout
+// rather than hanging. Uses a short timeout for a fast, non-flaky test.
+func TestDownloadTransportHeaderTimeoutFires(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(3 * time.Second): // well beyond the client's header timeout
+		case <-r.Context().Done():
+		}
+		_, _ = io.WriteString(w, "too late")
+	}))
+	defer srv.Close()
+
+	hc := &http.Client{Transport: downloadTransport(nil, 50*time.Millisecond)}
+	resp, err := hc.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected a ResponseHeaderTimeout error, got a response")
+	}
+}

--- a/internal/api/download_auth_test.go
+++ b/internal/api/download_auth_test.go
@@ -33,7 +33,7 @@ func TestIsTrustedDownloadHost(t *testing.T) {
 		{"https://signed-storage.example.com/blob?sig=abc", base, false},
 		// Same-origin as the configured API endpoint is trusted (self-host / test).
 		{"http://127.0.0.1:8080/dl", "http://127.0.0.1:8080", true},
-		{"http://127.0.0.1:8080/dl", "http://127.0.0.1:9999", false}, // different port
+		{"http://127.0.0.1:8080/dl", "http://127.0.0.1:9999", false},  // different port
 		{"http://127.0.0.1:8080/dl", "https://127.0.0.1:8080", false}, // different scheme
 		// Garbage.
 		{"://nope", base, false},

--- a/internal/api/download_test.go
+++ b/internal/api/download_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDownloadFileSendsBearerAndStreams(t *testing.T) {
+	const body = "MODEL-WEIGHTS-BYTES"
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok-xyz", "")
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/file")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("streamed body = %q, want %q", got, body)
+	}
+	if gotAuth != "Bearer tok-xyz" {
+		t.Errorf("Authorization = %q, want Bearer tok-xyz", gotAuth)
+	}
+}
+
+func TestDownloadFileAnonymousSendsNoAuth(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, "x")
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "", "") // empty token => anonymous
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/file")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	resp.Body.Close()
+	if gotAuth != "" {
+		t.Errorf("anonymous download sent Authorization %q, want none", gotAuth)
+	}
+}
+
+func TestDownloadFileFollowsRedirect(t *testing.T) {
+	const body = "REDIRECTED-STORAGE-BYTES"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/download" {
+			http.Redirect(w, r, "/storage/blob", http.StatusFound) // 302
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/api/download")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after following redirect", resp.StatusCode)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body after redirect = %q, want %q", got, body)
+	}
+}
+
+// refreshOnceSource is a TokenSource that returns badTok first and, once
+// Refresh is called, returns goodTok thereafter.
+type refreshOnceSource struct {
+	badTok, goodTok string
+	refreshed       bool
+}
+
+func (s *refreshOnceSource) Token(context.Context) (string, error) {
+	if s.refreshed {
+		return s.goodTok, nil
+	}
+	return s.badTok, nil
+}
+func (s *refreshOnceSource) Refresh(context.Context) (string, error) {
+	s.refreshed = true
+	return s.goodTok, nil
+}
+
+func TestDownloadFileRefreshesOn401(t *testing.T) {
+	const body = "AFTER-REFRESH"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer good" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewWithSource(srv.URL, &refreshOnceSource{badTok: "bad", goodTok: "good"}, "")
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/file")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after refresh+retry", resp.StatusCode)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+}
+
+func TestDownloadFileKeeps401WhenNotRefreshable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "nope")
+	}))
+	defer srv.Close()
+
+	// StaticToken can't refresh → the 401 is returned to the caller.
+	c := New(srv.URL, "personal-key", "")
+	resp, err := c.DownloadFile(context.Background(), srv.URL+"/file")
+	if err != nil {
+		t.Fatalf("DownloadFile: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 preserved for a non-refreshable source", resp.StatusCode)
+	}
+}
+
+func TestPrimaryFile(t *testing.T) {
+	files := []ModelVersionFile{
+		{Name: "a.safetensors", Type: "Model", Primary: false},
+		{Name: "b.safetensors", Type: "Model", Primary: true},
+	}
+	if pf := PrimaryFile(files); pf == nil || pf.Name != "b.safetensors" {
+		t.Errorf("PrimaryFile picked %+v, want the primary-flagged file", pf)
+	}
+	// No primary flag => first file.
+	nofl := []ModelVersionFile{{Name: "first"}, {Name: "second"}}
+	if pf := PrimaryFile(nofl); pf == nil || pf.Name != "first" {
+		t.Errorf("PrimaryFile fallback = %+v, want first", pf)
+	}
+	if PrimaryFile(nil) != nil {
+		t.Error("PrimaryFile(nil) should be nil")
+	}
+}
+
+func TestIsModelWeights(t *testing.T) {
+	if !(&ModelVersionFile{Type: "Model"}).IsModelWeights() {
+		t.Error(`type "Model" should be weights`)
+	}
+	for _, ty := range []string{"Training Data", "Config", "VAE", ""} {
+		if (&ModelVersionFile{Type: ty}).IsModelWeights() {
+			t.Errorf("type %q should NOT be weights", ty)
+		}
+	}
+}
+
+// Guard: the file struct still decodes the live-verified field names.
+func TestModelVersionFileDecodesLiveFields(t *testing.T) {
+	const raw = `{"id":93211,"name":"dreamshaper_8.safetensors","type":"Model","sizeKB":2082642.47,"primary":true,"downloadUrl":"https://civitai.com/api/download/models/128713","hashes":{"SHA256":"879DB523","AutoV2":"879DB523C3"}}`
+	var f ModelVersionFile
+	if err := json.Unmarshal([]byte(raw), &f); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if f.ID != 93211 || f.Name != "dreamshaper_8.safetensors" || f.Type != "Model" || !f.Primary {
+		t.Errorf("decoded file wrong: %+v", f)
+	}
+	if !strings.Contains(f.DownloadURL, "/api/download/models/128713") {
+		t.Errorf("downloadUrl = %q", f.DownloadURL)
+	}
+	if f.Hashes.SHA256 != "879DB523" {
+		t.Errorf("hashes.SHA256 = %q", f.Hashes.SHA256)
+	}
+}

--- a/internal/api/model_versions.go
+++ b/internal/api/model_versions.go
@@ -5,11 +5,57 @@ import (
 	"net/url"
 )
 
-// ModelVersionFile is the subset of a model-version file the CLI lists.
+// FileHashes is the per-file hash set the API returns under `files[].hashes`.
+// The keys are UPPER-cased algorithm names on the wire (AutoV1, AutoV2, SHA256,
+// CRC32, BLAKE3); SHA256 is the one `download` verifies against.
+type FileHashes struct {
+	AutoV1 string `json:"AutoV1,omitempty"`
+	AutoV2 string `json:"AutoV2,omitempty"`
+	SHA256 string `json:"SHA256,omitempty"`
+	CRC32  string `json:"CRC32,omitempty"`
+	BLAKE3 string `json:"BLAKE3,omitempty"`
+}
+
+// ModelVersionFile is the subset of a model-version `files[]` entry the CLI
+// lists and downloads. ID/Primary/DownloadURL/Hashes are carried (beyond the
+// display-only Name/Type/SizeKB) because `download` selects + fetches + verifies
+// individual files. Field names track the live API EXACTLY (verified against
+// GET /api/v1/model-versions/{id}: id, name, type, sizeKB, primary, downloadUrl,
+// hashes{SHA256,…}).
 type ModelVersionFile struct {
-	Name   string  `json:"name"`
-	Type   string  `json:"type"`
-	SizeKB float64 `json:"sizeKB"`
+	ID          int        `json:"id"`
+	Name        string     `json:"name"`
+	Type        string     `json:"type"`
+	SizeKB      float64    `json:"sizeKB"`
+	Primary     bool       `json:"primary"`
+	DownloadURL string     `json:"downloadUrl"`
+	Hashes      FileHashes `json:"hashes"`
+}
+
+// ModelFileType is the `type` value of the main model-weights file. A file whose
+// type is anything else (e.g. "Training Data", "Config", "VAE") is NOT the
+// downloadable weights — the on-site-generation / component-file trap `download`
+// guards against by default.
+const ModelFileType = "Model"
+
+// IsModelWeights reports whether the file is the main model-weights file
+// (type == "Model"), as opposed to training data / config / a component file.
+func (f *ModelVersionFile) IsModelWeights() bool { return f.Type == ModelFileType }
+
+// PrimaryFile returns the primary file of a version's file list (the one flagged
+// `primary: true`), falling back to the first file when none is flagged. Returns
+// nil for an empty list. This is the file `download` fetches by default and the
+// one the list/detail renderers inspect for the on-site-gen marker.
+func PrimaryFile(files []ModelVersionFile) *ModelVersionFile {
+	if len(files) == 0 {
+		return nil
+	}
+	for i := range files {
+		if files[i].Primary {
+			return &files[i]
+		}
+	}
+	return &files[0]
 }
 
 // ModelVersionModel is the embedded parent-model summary on a version detail.

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -30,10 +30,15 @@ type ModelListItem struct {
 }
 
 // ModelVersionSummary is the per-version summary shown under a model detail.
+// Files is carried so the detail renderer can flag a version whose primary file
+// is not model weights (the on-site-gen / training-data trap) and so `download
+// --model` can resolve + inspect the model's default version. The full
+// GET /api/v1/models/{id} response embeds each version's files[].
 type ModelVersionSummary struct {
-	ID        int    `json:"id"`
-	Name      string `json:"name"`
-	BaseModel string `json:"baseModel"`
+	ID        int                `json:"id"`
+	Name      string             `json:"name"`
+	BaseModel string             `json:"baseModel"`
+	Files     []ModelVersionFile `json:"files"`
 }
 
 // ModelDetail is the subset of `GET /api/v1/models/{id}` the CLI renders.

--- a/internal/cmd/base_model_marker_test.go
+++ b/internal/cmd/base_model_marker_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestModelsSearchBaseModelRepeatedEncoding proves --base-model is repeatable and
+// encodes as repeated `baseModels=` query keys (the array form the API's
+// string|string[] union parses as `baseModel IN (...)`).
+func TestModelsSearchBaseModelRepeatedEncoding(t *testing.T) {
+	var got []string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()["baseModels"]
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "models", "search", "--base-model", "Pony", "--base-model", "Illustrious"); err != nil {
+		t.Fatalf("models search --base-model: %v", err)
+	}
+	if len(got) != 2 || got[0] != "Pony" || got[1] != "Illustrious" {
+		t.Errorf("baseModels query = %v, want [Pony Illustrious] as repeated keys", got)
+	}
+}
+
+func TestModelsSearchBaseModelSingle(t *testing.T) {
+	var got []string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()["baseModels"]
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	// A base model with a space (e.g. video checkpoints) must round-trip intact.
+	if _, _, err := run(t, "models", "search", "--base-model", "Wan Video 2.2 T2V-A14B"); err != nil {
+		t.Fatalf("models search --base-model: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Wan Video 2.2 T2V-A14B" {
+		t.Errorf("baseModels = %v, want the single spaced value", got)
+	}
+}
+
+// TestModelVersionGetMarksTrainingData asserts the on-site-gen marker renders in
+// the human `model-versions get` output when the primary file is not weights.
+func TestModelVersionGetMarksTrainingData(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1,"modelId":2,"name":"clean-name","baseModel":"SD 1.5",
+		  "files":[{"id":9,"name":"training.zip","type":"Training Data","primary":true,"sizeKB":18000}]}`))
+	})
+	out, _, err := run(t, "model-versions", "get", "1")
+	if err != nil {
+		t.Fatalf("model-versions get: %v", err)
+	}
+	if !strings.Contains(out, "training data — no downloadable weights") {
+		t.Errorf("training-data version should carry the marker: %s", out)
+	}
+}
+
+// TestModelVersionGetNoMarkerForWeights asserts a normal weights version is NOT
+// tagged.
+func TestModelVersionGetNoMarkerForWeights(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1,"modelId":2,"name":"v","baseModel":"SD 1.5",
+		  "files":[{"id":9,"name":"model.safetensors","type":"Model","primary":true,"sizeKB":2000000}]}`))
+	})
+	out, _, err := run(t, "model-versions", "get", "1")
+	if err != nil {
+		t.Fatalf("model-versions get: %v", err)
+	}
+	if strings.Contains(out, "no downloadable weights") {
+		t.Errorf("a normal weights version must NOT be tagged: %s", out)
+	}
+}
+
+// TestModelGetMarksTrainingDataVersion asserts the marker also shows in the
+// `models get` version list.
+func TestModelGetMarksTrainingDataVersion(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":2,"name":"M","type":"Checkpoint",
+		  "modelVersions":[{"id":10,"name":"weights","baseModel":"SD 1.5","files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true}]},
+		                   {"id":11,"name":"onsite","baseModel":"SD 1.5","files":[{"id":2,"name":"t.zip","type":"Training Data","primary":true}]}]}`))
+	})
+	out, _, err := run(t, "models", "get", "2")
+	if err != nil {
+		t.Fatalf("models get: %v", err)
+	}
+	if !strings.Contains(out, "training data — no downloadable weights") {
+		t.Errorf("models get should tag the on-site-gen version: %s", out)
+	}
+}
+
+// TestModelVersionGetJSONUnchanged asserts --json is a raw passthrough (no marker
+// injected).
+func TestModelVersionGetJSONUnchanged(t *testing.T) {
+	const raw = `{"id":1,"modelId":2,"name":"clean","baseModel":"SD 1.5","files":[{"id":9,"name":"t.zip","type":"Training Data","primary":true}]}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(raw))
+	})
+	out, _, err := run(t, "model-versions", "get", "1", "--json")
+	if err != nil {
+		t.Fatalf("model-versions get --json: %v", err)
+	}
+	if strings.Contains(out, "no downloadable weights") {
+		t.Errorf("--json output must NOT carry the human marker: %s", out)
+	}
+	if !strings.Contains(out, `"Training Data"`) {
+		t.Errorf("--json should pass the raw body through: %s", out)
+	}
+}
+
+// TestDecideNoticeForcesRefreshWhenAheadOfCache proves the stale-cache guard: a
+// cache pinning a "latest" OLDER than the running version (the draft-window
+// artifact) forces a refresh even while the cache is otherwise fresh, and never
+// shows a notice.
+func TestDecideNoticeForcesRefreshWhenAheadOfCache(t *testing.T) {
+	now := time.Now()
+	c := updateCache{
+		LastCheck:     now.Add(-1 * time.Hour), // fresh (< 24h)
+		LatestVersion: "v0.1.61",               // stale: older than what we run
+	}
+	d := decideNotice(c, "v0.1.62", now)
+	if d.show {
+		t.Errorf("must not show a notice when ahead of the cached latest: %+v", d)
+	}
+	if !d.refresh {
+		t.Error("a cache pinning an older 'latest' than the running version must force a refresh")
+	}
+}
+
+// TestDecideNoticeNoNoticeWhenCurrentEqualsLatest guards the >= case.
+func TestDecideNoticeNoNoticeWhenCurrentEqualsLatest(t *testing.T) {
+	now := time.Now()
+	c := updateCache{LastCheck: now, LatestVersion: "v0.1.62"}
+	if d := decideNotice(c, "v0.1.62", now); d.show {
+		t.Errorf("equal current/latest must not notify: %+v", d)
+	}
+}
+
+// TestDecideNoticeShowsWhenBehind keeps the positive path covered.
+func TestDecideNoticeShowsWhenBehind(t *testing.T) {
+	now := time.Now()
+	c := updateCache{LastCheck: now, LatestVersion: "v0.1.62"}
+	d := decideNotice(c, "v0.1.60", now)
+	if !d.show {
+		t.Errorf("a genuinely behind version should notify: %+v", d)
+	}
+	if !strings.Contains(d.notice, "v0.1.62") {
+		t.Errorf("notice should name the latest: %q", d.notice)
+	}
+}

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -1,0 +1,456 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// downloadOpts holds the resolved flag values for `civitai download`.
+type downloadOpts struct {
+	modelID       string // --model (mutually exclusive with the positional version id)
+	file          string // --file: select one file by name (exact | unique substring)
+	all           bool   // --all: download every file in the version
+	out           string // --out: target path (single-file only)
+	outDir        string // --out-dir: directory for server-named files
+	noVerify      bool   // --no-verify: skip SHA256 verification
+	force         bool   // --force: re-download even if the target already exists
+	allowNonModel bool   // --allow-nonmodel: permit non-"Model" files (training data, etc.)
+	anon          bool   // --anon: force an anonymous request
+}
+
+func newDownloadCmd() *cobra.Command {
+	o := &downloadOpts{}
+	cmd := &cobra.Command{
+		Use:   "download [version-id]",
+		Short: "Download a model version's file(s)",
+		Long: `Download the file(s) of a model VERSION from Civitai.
+
+Identify the version deterministically by its numeric version id:
+
+  civitai download 128713
+
+…or resolve a model's default (primary/latest) published version with --model:
+
+  civitai download --model 4384
+
+By default the version's PRIMARY file is downloaded into the current directory
+under its server-provided name. Use --file to pick a specific file, or --all to
+download every file. Downloads stream to "<target>.part" and are renamed into
+place only on success, so an interrupted run never leaves a truncated final file.
+
+Authentication: your stored login token (civitai login) or CIVITAI_API_KEY is
+used automatically; gated / early-access files need it. Public files download
+anonymously.
+
+Integrity: the streamed bytes are verified against the file's SHA256 by default
+(--no-verify to skip; a file with no published SHA256 is downloaded with a
+warning). A hash mismatch deletes the partial file and fails.
+
+On-site-generation guard: a version whose selected file is not model weights
+(type != "Model", e.g. a training-data ZIP) is refused by default — pass
+--allow-nonmodel to download it anyway.`,
+		Example: `  civitai download 128713
+  civitai download --model 4384 --out ./dreamshaper.safetensors
+  civitai download 128713 --file vae --out-dir ./models
+  civitai download 128713 --all --out-dir ./models`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDownload(cmd, args, o)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&o.modelID, "model", "", "resolve+download a MODEL's default (primary/latest) version instead of a version id")
+	f.StringVar(&o.file, "file", "", "select a specific file by name (exact match, else a unique case-insensitive substring)")
+	f.BoolVar(&o.all, "all", false, "download every file in the version")
+	f.StringVar(&o.out, "out", "", "target file path (single-file only; mutually exclusive with --all/--out-dir)")
+	f.StringVar(&o.outDir, "out-dir", "", "directory to write server-named file(s) into (created if needed)")
+	f.BoolVar(&o.noVerify, "no-verify", false, "skip SHA256 verification of the downloaded bytes")
+	f.BoolVar(&o.force, "force", false, "re-download even if the target file already exists")
+	f.BoolVar(&o.allowNonModel, "allow-nonmodel", false, "allow downloading a non-\"Model\" file (training data, config, etc.)")
+	f.BoolVar(&o.anon, "anon", false, "force an anonymous request (ignore any stored login token)")
+	return cmd
+}
+
+func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
+	// ── resolve the target version id (exactly one of positional / --model) ──
+	var positional string
+	if len(args) == 1 {
+		positional = strings.TrimSpace(args[0])
+	}
+	if positional != "" && o.modelID != "" {
+		return fmt.Errorf("provide EITHER a version id or --model <model-id>, not both")
+	}
+	if positional == "" && o.modelID == "" {
+		return fmt.Errorf("provide a model-version id (civitai download <version-id>) or --model <model-id>")
+	}
+
+	// ── validate flag combinations up front ──
+	if o.all && o.file != "" {
+		return fmt.Errorf("--all and --file are mutually exclusive")
+	}
+	if o.out != "" && o.outDir != "" {
+		return fmt.Errorf("--out (a file path) and --out-dir (a directory) are mutually exclusive")
+	}
+	if o.out != "" && o.all {
+		return fmt.Errorf("--out sets a single file path and can't be combined with --all — use --out-dir")
+	}
+
+	client, _, err := newReader(&readOpts{anon: o.anon})
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	versionID, err := resolveVersionID(ctx, client, positional, o.modelID)
+	if err != nil {
+		return err
+	}
+
+	v, _, err := client.GetModelVersion(ctx, versionID)
+	if err != nil {
+		return err
+	}
+
+	selected, err := selectFiles(v.Files, o)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	errW := cmd.ErrOrStderr()
+
+	downloaded := 0
+	for i := range selected {
+		f := selected[i]
+		// on-site-gen / component-file guard.
+		if !f.IsModelWeights() && !o.allowNonModel {
+			if o.all {
+				// In --all mode, don't abort the whole run for a bundled
+				// non-weights file — skip it with a clear note.
+				fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf(
+					"skipping %q (type %q, not model weights) — pass --allow-nonmodel to include it", f.Name, f.Type)))
+				continue
+			}
+			return fmt.Errorf("%q is %q, not model weights — this is likely an on-site-generation / training-data registration, not downloadable weights.\n"+
+				"Re-run with --allow-nonmodel if you really want this file", f.Name, f.Type)
+		}
+
+		target := targetPath(f, o)
+		skipped, err := downloadOne(ctx, client, out, errW, f, target, o)
+		if err != nil {
+			return err
+		}
+		if !skipped {
+			downloaded++
+		}
+	}
+
+	if downloaded == 0 && o.all {
+		// Everything was skipped (all files non-weights, or all already present).
+		fmt.Fprintln(errW, ui.For(errW).Warn("no model-weights files were downloaded (all files were non-model or already present)"))
+	}
+	return nil
+}
+
+// resolveVersionID returns the version id to download: the positional id verbatim
+// (validated numeric), or the primary/latest published version of --model.
+func resolveVersionID(ctx context.Context, client api.Reader, positional, modelID string) (string, error) {
+	if positional != "" {
+		if _, err := strconv.Atoi(positional); err != nil {
+			return "", fmt.Errorf("model-version id must be an integer, got %q", positional)
+		}
+		return positional, nil
+	}
+	if _, err := strconv.Atoi(modelID); err != nil {
+		return "", fmt.Errorf("--model id must be an integer, got %q", modelID)
+	}
+	m, _, err := client.GetModel(ctx, modelID)
+	if err != nil {
+		return "", err
+	}
+	if len(m.ModelVersions) == 0 {
+		return "", fmt.Errorf("model %s has no published versions to download", modelID)
+	}
+	// The API returns modelVersions with the default/latest first.
+	return strconv.Itoa(m.ModelVersions[0].ID), nil
+}
+
+// selectFiles resolves which file(s) of a version to download from the flags:
+// --all → every file; --file → one file by exact name or a unique
+// case-insensitive substring; default → the primary file (or the first file when
+// none is flagged primary).
+func selectFiles(files []api.ModelVersionFile, o *downloadOpts) ([]api.ModelVersionFile, error) {
+	if len(files) == 0 {
+		return nil, fmt.Errorf("this version has no downloadable files")
+	}
+	if o.all {
+		return files, nil
+	}
+	if o.file != "" {
+		return selectOneFile(files, o.file)
+	}
+	primary := api.PrimaryFile(files)
+	return []api.ModelVersionFile{*primary}, nil
+}
+
+// selectOneFile picks a single file by name: an exact (case-insensitive) name
+// match wins; otherwise a UNIQUE case-insensitive substring match; ambiguous or
+// no match is an error that lists the available files.
+func selectOneFile(files []api.ModelVersionFile, want string) ([]api.ModelVersionFile, error) {
+	// Exact (case-insensitive) name match first.
+	for i := range files {
+		if strings.EqualFold(files[i].Name, want) {
+			return []api.ModelVersionFile{files[i]}, nil
+		}
+	}
+	// Unique case-insensitive substring match.
+	var matches []api.ModelVersionFile
+	lw := strings.ToLower(want)
+	for i := range files {
+		if strings.Contains(strings.ToLower(files[i].Name), lw) {
+			matches = append(matches, files[i])
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[:1], nil
+	case 0:
+		return nil, fmt.Errorf("no file matches %q. Available files:\n%s", want, formatFileList(files))
+	default:
+		return nil, fmt.Errorf("%q is ambiguous — it matches %d files. Be more specific:\n%s", want, len(matches), formatFileList(matches))
+	}
+}
+
+// formatFileList renders a compact "  - name (type, size)" list for errors.
+func formatFileList(files []api.ModelVersionFile) string {
+	var b strings.Builder
+	for i := range files {
+		f := files[i]
+		fmt.Fprintf(&b, "  - %s (%s, %s)\n", f.Name, f.Type, humanBytes(int64(f.SizeKB*1024)))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// targetPath computes the on-disk destination for a file given the flags:
+// --out (verbatim path), else --out-dir/<server-name>, else ./<server-name>.
+func targetPath(f api.ModelVersionFile, o *downloadOpts) string {
+	if o.out != "" {
+		return o.out
+	}
+	if o.outDir != "" {
+		return filepath.Join(o.outDir, f.Name)
+	}
+	return f.Name
+}
+
+// downloadOne downloads a single file to target, streaming to "<target>.part"
+// and renaming on success. Returns skipped=true when an already-present target
+// satisfied the idempotency check. Verification (SHA256, default on) deletes the
+// partial file and errors on mismatch.
+func downloadOne(ctx context.Context, dl api.Downloader, out, errW io.Writer, f api.ModelVersionFile, target string, o *downloadOpts) (skipped bool, err error) {
+	sha := strings.TrimSpace(f.Hashes.SHA256)
+	verify := !o.noVerify && sha != ""
+	if !o.noVerify && sha == "" {
+		fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf("%s: no SHA256 published — skipping integrity verification", f.Name)))
+	}
+
+	// Idempotency: skip an already-present target unless --force. When verifying
+	// and a hash is known, only skip on a confirmed match; without a hash (or
+	// --no-verify) a present file is trusted.
+	if !o.force {
+		if info, statErr := os.Stat(target); statErr == nil && !info.IsDir() {
+			if !verify {
+				fmt.Fprintf(out, "already present: %s\n", target)
+				return true, nil
+			}
+			match, verr := fileSHA256Matches(target, sha)
+			if verr == nil && match {
+				fmt.Fprintf(out, "already present (SHA256 verified): %s\n", target)
+				return true, nil
+			}
+			// Present but wrong/unverifiable → re-download.
+		}
+	}
+
+	if dir := filepath.Dir(target); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return false, fmt.Errorf("create output directory %s: %w", dir, err)
+		}
+	}
+
+	resp, err := dl.DownloadFile(ctx, f.DownloadURL)
+	if err != nil {
+		return false, fmt.Errorf("download %s: %w", f.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if err := downloadStatusError(resp.StatusCode, f.Name); err != nil {
+		return false, err
+	}
+
+	partPath := target + ".part"
+	partFile, err := os.Create(partPath)
+	if err != nil {
+		return false, fmt.Errorf("create %s: %w", partPath, err)
+	}
+	// Best-effort cleanup of the partial file on any failure before rename.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = partFile.Close()
+			_ = os.Remove(partPath)
+		}
+	}()
+
+	total := resp.ContentLength
+	if total <= 0 && f.SizeKB > 0 {
+		total = int64(f.SizeKB * 1024)
+	}
+	pw := newProgressWriter(errW, f.Name, total)
+
+	hasher := sha256.New()
+	writers := []io.Writer{partFile, pw}
+	if verify {
+		writers = append(writers, hasher)
+	}
+	if _, err := io.Copy(io.MultiWriter(writers...), resp.Body); err != nil {
+		return false, fmt.Errorf("streaming %s: %w", f.Name, err)
+	}
+	pw.done()
+	if err := partFile.Close(); err != nil {
+		return false, fmt.Errorf("finalize %s: %w", partPath, err)
+	}
+
+	if verify {
+		got := hex.EncodeToString(hasher.Sum(nil))
+		if !strings.EqualFold(got, sha) {
+			// Delete the corrupt partial; the defer would also remove it, but be
+			// explicit so the failure message is honest about the state on disk.
+			_ = os.Remove(partPath)
+			cleanup = false
+			return false, fmt.Errorf("SHA256 mismatch for %s — expected %s, got %s (deleted the partial download)", f.Name, strings.ToLower(sha), got)
+		}
+	}
+
+	if err := os.Rename(partPath, target); err != nil {
+		return false, fmt.Errorf("install %s: %w", target, err)
+	}
+	cleanup = false
+
+	note := ""
+	if verify {
+		note = "  (SHA256 verified)"
+	}
+	fmt.Fprintf(out, "Saved %s (%s)%s\n", target, humanBytes(pw.written), note)
+	return false, nil
+}
+
+// downloadStatusError maps a non-2xx download response to an actionable error.
+func downloadStatusError(status int, name string) error {
+	switch {
+	case status >= 200 && status < 300:
+		return nil
+	case status == http.StatusUnauthorized:
+		return fmt.Errorf("downloading %s requires authentication (401) — run `civitai login` (or set CIVITAI_API_KEY)", name)
+	case status == http.StatusForbidden:
+		return fmt.Errorf("access to %s is forbidden (403) — it may be early-access or otherwise gated for your account", name)
+	case status == http.StatusNotFound:
+		return fmt.Errorf("download URL for %s returned 404 — the file may have been removed", name)
+	default:
+		return fmt.Errorf("download of %s failed (HTTP %d)", name, status)
+	}
+}
+
+// fileSHA256Matches streams path and reports whether its SHA256 equals want
+// (case-insensitive).
+func fileSHA256Matches(path, want string) (bool, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer fh.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, fh); err != nil {
+		return false, err
+	}
+	return strings.EqualFold(hex.EncodeToString(h.Sum(nil)), want), nil
+}
+
+// ── progress ─────────────────────────────────────────────────────────────────
+
+// progressWriter counts streamed bytes and renders progress to a writer
+// (stderr). On a TTY it draws a throttled, carriage-return-updated line; off a
+// TTY it prints an occasional plain line so long downloads still show life
+// without flooding a log.
+type progressWriter struct {
+	w         io.Writer
+	name      string
+	total     int64 // expected size; 0 = unknown
+	written   int64
+	tty       bool
+	start     time.Time
+	lastPrint time.Time
+}
+
+func newProgressWriter(w io.Writer, name string, total int64) *progressWriter {
+	return &progressWriter{w: w, name: name, total: total, tty: ui.IsTTY(w), start: time.Now()}
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.written += int64(n)
+	now := time.Now()
+	if p.tty {
+		if now.Sub(p.lastPrint) >= 100*time.Millisecond {
+			p.lastPrint = now
+			fmt.Fprint(p.w, "\r"+p.line())
+		}
+	} else if now.Sub(p.lastPrint) >= 5*time.Second {
+		p.lastPrint = now
+		fmt.Fprintln(p.w, p.line())
+	}
+	return n, nil
+}
+
+// done finishes the progress display (clears/terminates the TTY line).
+func (p *progressWriter) done() {
+	if p.tty {
+		fmt.Fprint(p.w, "\r"+p.line()+"\n")
+	}
+}
+
+func (p *progressWriter) line() string {
+	if p.total > 0 {
+		pct := float64(p.written) / float64(p.total) * 100
+		return fmt.Sprintf("  %s  %s / %s (%.0f%%)", p.name, humanBytes(p.written), humanBytes(p.total), pct)
+	}
+	return fmt.Sprintf("  %s  %s", p.name, humanBytes(p.written))
+}
+
+// humanBytes renders a byte count in binary units (KiB/MiB/GiB…), abbreviated
+// as KB/MB/GB for brevity.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -112,7 +113,12 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	if err != nil {
 		return err
 	}
-	ctx := context.Background()
+	// Cancel the whole download on Ctrl-C (SIGINT): the signal-bound context is
+	// threaded into every request + io.Copy, so an interrupted transfer unblocks
+	// with a cancellation error and downloadOne's cleanup defer removes the
+	// partial ".part" file rather than leaving it behind.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 
 	versionID, err := resolveVersionID(ctx, client, positional, o.modelID)
 	if err != nil {
@@ -148,7 +154,10 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 				"Re-run with --allow-nonmodel if you really want this file", f.Name, f.Type)
 		}
 
-		target := targetPath(f, o)
+		target, err := targetPath(f, o)
+		if err != nil {
+			return err
+		}
 		skipped, err := downloadOne(ctx, client, out, errW, f, target, o)
 		if err != nil {
 			return err
@@ -246,14 +255,27 @@ func formatFileList(files []api.ModelVersionFile) string {
 
 // targetPath computes the on-disk destination for a file given the flags:
 // --out (verbatim path), else --out-dir/<server-name>, else ./<server-name>.
-func targetPath(f api.ModelVersionFile, o *downloadOpts) string {
+//
+// For the two server-named cases (default and --out-dir) the API-supplied
+// f.Name is reduced to its bare basename with filepath.Base BEFORE joining, so a
+// hostile name like "/home/user/.bashrc" or "../../etc/foo" can never write
+// outside the current directory / outside --out-dir (path-traversal / arbitrary
+// write). --out is the user's OWN explicit target and is used verbatim (they may
+// legitimately pass a relative or absolute path). A basename that degenerates to
+// ".", "/", or ".." (empty or all-slashes server name) is unusable and errors
+// rather than writing to a junk path.
+func targetPath(f api.ModelVersionFile, o *downloadOpts) (string, error) {
 	if o.out != "" {
-		return o.out
+		return o.out, nil
+	}
+	base := filepath.Base(f.Name)
+	if base == "." || base == ".." || base == string(filepath.Separator) || base == "/" {
+		return "", fmt.Errorf("server returned an unusable filename %q; pass --out to set the output path", f.Name)
 	}
 	if o.outDir != "" {
-		return filepath.Join(o.outDir, f.Name)
+		return filepath.Join(o.outDir, base), nil
 	}
-	return f.Name
+	return base, nil
 }
 
 // downloadOne downloads a single file to target, streaming to "<target>.part"
@@ -302,6 +324,12 @@ func downloadOne(ctx context.Context, dl api.Downloader, out, errW io.Writer, f 
 	}
 
 	partPath := target + ".part"
+	// Self-heal a stale ".part" left by a previously aborted run: we don't resume,
+	// so remove it before starting a fresh transfer (os.Create truncates too, but
+	// be explicit).
+	if _, statErr := os.Stat(partPath); statErr == nil {
+		_ = os.Remove(partPath)
+	}
 	partFile, err := os.Create(partPath)
 	if err != nil {
 		return false, fmt.Errorf("create %s: %w", partPath, err)

--- a/internal/cmd/download_cancel_test.go
+++ b/internal/cmd/download_cancel_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// TestDownloadOneCancelCleansPart proves a context cancellation mid-transfer
+// (what SIGINT triggers via signal.NotifyContext) unblocks the streaming copy
+// with an error and leaves NO .part (and no final file) behind — the cleanup
+// defer fires on the cancelled io.Copy.
+func TestDownloadOneCancelCleansPart(t *testing.T) {
+	streaming := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Promise a large body, send a first chunk, flush, then block until the
+		// client cancels (its ctx cancellation closes the connection -> r.Context()
+		// is Done here), so the client's io.Copy is stuck mid-stream when we cancel.
+		w.Header().Set("Content-Length", "1000000")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "partial-bytes")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		close(streaming)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "m.safetensors")
+	dl := api.New(srv.URL, "", "")
+	f := api.ModelVersionFile{Name: "m.safetensors", Type: "Model", DownloadURL: srv.URL + "/dl"}
+	o := &downloadOpts{noVerify: true}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := downloadOne(ctx, dl, io.Discard, io.Discard, f, target, o)
+		errc <- err
+	}()
+
+	<-streaming // the transfer has started and is now blocked
+	cancel()    // simulate Ctrl-C
+
+	err := <-errc
+	if err == nil {
+		t.Fatal("expected a cancellation error from the interrupted download")
+	}
+	if _, e := os.Stat(target + ".part"); !os.IsNotExist(e) {
+		t.Errorf(".part should be removed on cancel; stat err = %v", e)
+	}
+	if _, e := os.Stat(target); !os.IsNotExist(e) {
+		t.Errorf("no final file should exist on cancel; stat err = %v", e)
+	}
+}

--- a/internal/cmd/download_cmd_test.go
+++ b/internal/cmd/download_cmd_test.go
@@ -1,0 +1,438 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// dlFile describes a file the fake API version exposes.
+type dlFile struct {
+	id      int
+	name    string
+	typ     string
+	primary bool
+	body    string // bytes served at the download URL
+	withSHA bool   // include a correct hashes.SHA256 in the JSON
+	badSHA  bool   // include a WRONG hashes.SHA256 (mismatch test)
+}
+
+func sha256hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// dlServer wires a fake Civitai API + download storage for the download command.
+// modelVersions/{id} and models/{id} both surface the same file set; each file's
+// downloadUrl points back at this server (optionally via a one-hop redirect).
+type dlServer struct {
+	srv      *httptest.Server
+	lastAuth string
+	dlHits   int
+}
+
+func newDLServer(t *testing.T, redirect bool, files []dlFile) *dlServer {
+	t.Helper()
+	d := &dlServer{}
+	var base string
+
+	filesJSON := func() string {
+		var parts []string
+		for _, f := range files {
+			hashes := ""
+			switch {
+			case f.badSHA:
+				hashes = `,"hashes":{"SHA256":"` + strings.Repeat("0", 64) + `"}`
+			case f.withSHA:
+				hashes = `,"hashes":{"SHA256":"` + sha256hex(f.body) + `"}`
+			}
+			parts = append(parts, fmt.Sprintf(
+				`{"id":%d,"name":%q,"type":%q,"sizeKB":%f,"primary":%t,"downloadUrl":"%s/dl/%s"%s}`,
+				f.id, f.name, f.typ, float64(len(f.body))/1024, f.primary, base, f.name, hashes))
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"id":128713,"modelId":4384,"name":"v","baseModel":"SD 1.5","files":%s}`, filesJSON())
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"id":4384,"name":"M","type":"Checkpoint","modelVersions":[{"id":128713,"name":"v","baseModel":"SD 1.5","files":%s}]}`, filesJSON())
+	})
+	serve := func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Path[strings.LastIndexByte(r.URL.Path, '/')+1:]
+		for _, f := range files {
+			if f.name == name {
+				_, _ = w.Write([]byte(f.body))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) {
+		d.dlHits++
+		d.lastAuth = r.Header.Get("Authorization")
+		if redirect {
+			http.Redirect(w, r, base+"/store"+r.URL.Path[len("/dl"):], http.StatusFound)
+			return
+		}
+		serve(w, r)
+	})
+	mux.HandleFunc("/store/", serve)
+
+	d.srv = httptest.NewServer(mux)
+	base = d.srv.URL
+	t.Cleanup(d.srv.Close)
+	return d
+}
+
+// setupDownloadEnv points the CLI at d and gives it a fresh temp config + cwd.
+// token != "" configures CIVITAI_TOKEN so downloads authenticate.
+func setupDownloadEnv(t *testing.T, d *dlServer, token string) {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("CIVITAI_TOKEN", token)
+	t.Setenv("CIVITAI_BASE_URL", d.srv.URL)
+	chdir(t, t.TempDir())
+}
+
+func TestDownloadVersionIDPrimaryDefault(t *testing.T) {
+	const body = "PRIMARY-MODEL-WEIGHTS"
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: body, withSHA: true},
+		{id: 2, name: "extra.vae.pt", typ: "VAE", body: "vae"},
+	})
+	setupDownloadEnv(t, d, "")
+	out, _, err := run(t, "download", "128713")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	got, rerr := os.ReadFile("model.safetensors")
+	if rerr != nil {
+		t.Fatalf("primary file not written: %v", rerr)
+	}
+	if string(got) != body {
+		t.Errorf("content = %q, want %q", got, body)
+	}
+	if _, err := os.Stat("extra.vae.pt"); err == nil {
+		t.Error("only the primary file should be downloaded by default")
+	}
+	if !strings.Contains(out, "Saved model.safetensors") || !strings.Contains(out, "SHA256 verified") {
+		t.Errorf("output should confirm save + verify: %s", out)
+	}
+	if _, err := os.Stat("model.safetensors.part"); err == nil {
+		t.Error(".part file should be renamed away on success")
+	}
+}
+
+func TestDownloadModelResolvesDefaultVersion(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	if _, _, err := run(t, "download", "--model", "4384"); err != nil {
+		t.Fatalf("download --model: %v", err)
+	}
+	if _, err := os.Stat("m.safetensors"); err != nil {
+		t.Errorf("--model should resolve + download the default version's file: %v", err)
+	}
+}
+
+func TestDownloadRejectsBothIdAndModel(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{{id: 1, name: "m", typ: "Model", primary: true, body: "x"}})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713", "--model", "4384")
+	if err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
+func TestDownloadRequiresAnIdentifier(t *testing.T) {
+	d := newDLServer(t, false, nil)
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download")
+	if err == nil || !strings.Contains(err.Error(), "version id") {
+		t.Fatalf("expected missing-identifier error, got %v", err)
+	}
+}
+
+func TestDownloadFileSelectExactAndSubstring(t *testing.T) {
+	files := []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "w"},
+		{id: 2, name: "config.yaml", typ: "Config", body: "cfg"},
+	}
+	// Exact (case-insensitive) name.
+	d := newDLServer(t, false, files)
+	setupDownloadEnv(t, d, "")
+	if _, _, err := run(t, "download", "128713", "--file", "MODEL.SAFETENSORS", "--allow-nonmodel"); err != nil {
+		t.Fatalf("exact --file: %v", err)
+	}
+	if _, err := os.Stat("model.safetensors"); err != nil {
+		t.Errorf("exact match should download model.safetensors: %v", err)
+	}
+
+	// Unique substring.
+	d2 := newDLServer(t, false, files)
+	setupDownloadEnv(t, d2, "")
+	if _, _, err := run(t, "download", "128713", "--file", "config", "--allow-nonmodel"); err != nil {
+		t.Fatalf("substring --file: %v", err)
+	}
+	if _, err := os.Stat("config.yaml"); err != nil {
+		t.Errorf("substring match should download config.yaml: %v", err)
+	}
+}
+
+func TestDownloadFileAmbiguousErrors(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "model-a.safetensors", typ: "Model", primary: true, body: "a"},
+		{id: 2, name: "model-b.safetensors", typ: "Model", body: "b"},
+	})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713", "--file", "safetensors")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "model-a.safetensors") {
+		t.Errorf("ambiguity error should list candidates: %v", err)
+	}
+}
+
+func TestDownloadFileNoMatchErrors(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "a"}})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713", "--file", "nope")
+	if err == nil || !strings.Contains(err.Error(), "no file matches") {
+		t.Fatalf("expected no-match error, got %v", err)
+	}
+}
+
+func TestDownloadAll(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+		{id: 2, name: "vae.pt", typ: "VAE", body: "vae", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	dir := t.TempDir()
+	if _, _, err := run(t, "download", "128713", "--all", "--allow-nonmodel", "--out-dir", dir); err != nil {
+		t.Fatalf("download --all: %v", err)
+	}
+	for _, name := range []string{"model.safetensors", "vae.pt"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("--all should write %s: %v", name, err)
+		}
+	}
+}
+
+func TestDownloadAllSkipsNonModelWithoutOverride(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+		{id: 2, name: "training.zip", typ: "Training Data", body: "trainingdata"},
+	})
+	setupDownloadEnv(t, d, "")
+	dir := t.TempDir()
+	_, errOut, err := run(t, "download", "128713", "--all", "--out-dir", dir)
+	if err != nil {
+		t.Fatalf("download --all: %v", err)
+	}
+	if _, e := os.Stat(filepath.Join(dir, "model.safetensors")); e != nil {
+		t.Errorf("--all should still fetch the weights: %v", e)
+	}
+	if _, e := os.Stat(filepath.Join(dir, "training.zip")); e == nil {
+		t.Error("--all must skip the non-model training file without --allow-nonmodel")
+	}
+	if !strings.Contains(errOut, "skipping") {
+		t.Errorf("stderr should note the skipped non-model file: %s", errOut)
+	}
+}
+
+func TestDownloadSHA256Verifies(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "good-weights", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	out, _, err := run(t, "download", "128713")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if !strings.Contains(out, "SHA256 verified") {
+		t.Errorf("should report verification: %s", out)
+	}
+}
+
+func TestDownloadSHA256MismatchDeletesPartAndErrors(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "some-bytes", badSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713")
+	if err == nil || !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Fatalf("expected SHA256 mismatch error, got %v", err)
+	}
+	if _, e := os.Stat("m.safetensors.part"); e == nil {
+		t.Error("mismatch must delete the .part file")
+	}
+	if _, e := os.Stat("m.safetensors"); e == nil {
+		t.Error("mismatch must not leave a final file")
+	}
+}
+
+func TestDownloadMissingHashWarnsAndSkipsVerify(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "bytes"}, // no withSHA
+	})
+	setupDownloadEnv(t, d, "")
+	out, errOut, err := run(t, "download", "128713")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if _, e := os.Stat("m.safetensors"); e != nil {
+		t.Errorf("file should still download without a hash: %v", e)
+	}
+	if !strings.Contains(errOut, "no SHA256 published") {
+		t.Errorf("should warn about the missing hash: %s", errOut)
+	}
+	if strings.Contains(out, "SHA256 verified") {
+		t.Errorf("should NOT claim verification when no hash exists: %s", out)
+	}
+}
+
+func TestDownloadNonModelRefusedByDefault(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
+	})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713")
+	if err == nil || !strings.Contains(err.Error(), "not model weights") {
+		t.Fatalf("expected on-site-gen refusal, got %v", err)
+	}
+	if _, e := os.Stat("training.zip"); e == nil {
+		t.Error("refused download must not write the file")
+	}
+}
+
+func TestDownloadNonModelAllowedWithOverride(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
+	})
+	setupDownloadEnv(t, d, "")
+	if _, _, err := run(t, "download", "128713", "--allow-nonmodel"); err != nil {
+		t.Fatalf("download --allow-nonmodel: %v", err)
+	}
+	if _, e := os.Stat("training.zip"); e != nil {
+		t.Errorf("--allow-nonmodel should permit the download: %v", e)
+	}
+}
+
+func TestDownloadOutPath(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	target := filepath.Join(t.TempDir(), "nested", "custom-name.safetensors")
+	if _, _, err := run(t, "download", "128713", "--out", target); err != nil {
+		t.Fatalf("download --out: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("--out should create the target (and parent dirs): %v", err)
+	}
+}
+
+func TestDownloadOutRejectedWithAll(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{{id: 1, name: "m", typ: "Model", primary: true, body: "x"}})
+	setupDownloadEnv(t, d, "")
+	_, _, err := run(t, "download", "128713", "--all", "--out", "x")
+	if err == nil || !strings.Contains(err.Error(), "--out") {
+		t.Fatalf("expected --out/--all conflict, got %v", err)
+	}
+}
+
+func TestDownloadFollowsRedirect(t *testing.T) {
+	const body = "STORAGE-BYTES"
+	d := newDLServer(t, true, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: body, withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	if _, _, err := run(t, "download", "128713"); err != nil {
+		t.Fatalf("download with redirect: %v", err)
+	}
+	got, err := os.ReadFile("m.safetensors")
+	if err != nil || string(got) != body {
+		t.Errorf("redirected download content = %q (err %v), want %q", got, err, body)
+	}
+}
+
+func TestDownloadSendsAuthWhenTokenConfigured(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "w", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "my-key")
+	if _, _, err := run(t, "download", "128713"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if d.lastAuth != "Bearer my-key" {
+		t.Errorf("download Authorization = %q, want Bearer my-key", d.lastAuth)
+	}
+}
+
+func TestDownloadSkipsWhenPresentUnlessForce(t *testing.T) {
+	const body = "weights-body"
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: body, withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+	// First download.
+	if _, _, err := run(t, "download", "128713"); err != nil {
+		t.Fatalf("first download: %v", err)
+	}
+	hits := d.dlHits
+	// Second run: present + SHA matches => skip (no new download hit).
+	out, _, err := run(t, "download", "128713")
+	if err != nil {
+		t.Fatalf("second download: %v", err)
+	}
+	if !strings.Contains(out, "already present") {
+		t.Errorf("second run should skip: %s", out)
+	}
+	if d.dlHits != hits {
+		t.Errorf("skip should not re-fetch: hits %d -> %d", hits, d.dlHits)
+	}
+	// --force re-downloads.
+	if _, _, err := run(t, "download", "128713", "--force"); err != nil {
+		t.Fatalf("force download: %v", err)
+	}
+	if d.dlHits != hits+1 {
+		t.Errorf("--force should re-fetch: hits=%d want %d", d.dlHits, hits+1)
+	}
+}
+
+func TestDownload401ActionableError(t *testing.T) {
+	// A server that 401s the download route.
+	var base string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"id":128713,"modelId":4384,"name":"v","baseModel":"SD 1.5","files":[{"id":1,"name":"gated.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"%s/dl/gated"}]}`, base)
+	})
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) })
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	defer srv.Close()
+
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+
+	_, _, err := run(t, "download", "128713")
+	if err == nil || !strings.Contains(err.Error(), "requires authentication") {
+		t.Fatalf("expected actionable 401 error, got %v", err)
+	}
+}

--- a/internal/cmd/download_sanitize_test.go
+++ b/internal/cmd/download_sanitize_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// TestTargetPathSanitizesServerName proves the API-supplied file name is reduced
+// to a bare basename in the two server-named modes (default + --out-dir), so a
+// hostile name can never escape the intended directory. --out is used verbatim.
+func TestTargetPathSanitizesServerName(t *testing.T) {
+	cases := []struct {
+		name    string // server-supplied f.Name
+		want    string // expected basename
+		wantErr bool
+	}{
+		{"../../etc/passwd", "passwd", false},
+		{"/abs/path/x", "x", false},
+		{"a/b/c.safetensors", "c.safetensors", false},
+		{"model.safetensors", "model.safetensors", false},
+		{"..", "", true},
+		{"", "", true},
+		{"/", "", true},
+		{"///", "", true},
+	}
+	const outDir = "/tmp/models"
+	for _, tc := range cases {
+		f := api.ModelVersionFile{Name: tc.name}
+
+		// Default mode: resolves to a bare basename in cwd.
+		got, err := targetPath(f, &downloadOpts{})
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("default %q: expected an error, got path %q", tc.name, got)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("default %q: unexpected error: %v", tc.name, err)
+			} else if got != tc.want {
+				t.Errorf("default %q -> %q, want basename %q", tc.name, got, tc.want)
+			}
+			// A resolved default path must be a single path element (no separators).
+			if err == nil && strings.ContainsRune(got, filepath.Separator) {
+				t.Errorf("default %q escaped cwd: %q contains a separator", tc.name, got)
+			}
+		}
+
+		// --out-dir mode: resolves strictly inside outDir.
+		gotDir, errDir := targetPath(f, &downloadOpts{outDir: outDir})
+		if tc.wantErr {
+			if errDir == nil {
+				t.Errorf("out-dir %q: expected an error, got path %q", tc.name, gotDir)
+			}
+			continue
+		}
+		if errDir != nil {
+			t.Errorf("out-dir %q: unexpected error: %v", tc.name, errDir)
+			continue
+		}
+		if want := filepath.Join(outDir, tc.want); gotDir != want {
+			t.Errorf("out-dir %q -> %q, want %q", tc.name, gotDir, want)
+		}
+		// The resolved path must stay within outDir (no traversal escape).
+		clean := filepath.Clean(gotDir)
+		if clean != filepath.Clean(outDir) && !strings.HasPrefix(clean, filepath.Clean(outDir)+string(filepath.Separator)) {
+			t.Errorf("out-dir %q escaped: resolved %q is outside %q", tc.name, clean, outDir)
+		}
+	}
+}
+
+// TestTargetPathOutIsVerbatim proves --out (the user's OWN explicit target) is
+// NOT sanitized — a relative or absolute path is honored as given.
+func TestTargetPathOutIsVerbatim(t *testing.T) {
+	f := api.ModelVersionFile{Name: "server-name.safetensors"}
+	for _, out := range []string{
+		"../../my/explicit/path.safetensors",
+		"/abs/target.safetensors",
+		"rel/name.safetensors",
+	} {
+		got, err := targetPath(f, &downloadOpts{out: out})
+		if err != nil {
+			t.Errorf("--out %q: unexpected error: %v", out, err)
+		}
+		if got != out {
+			t.Errorf("--out %q -> %q, want it verbatim", out, got)
+		}
+	}
+}
+
+// TestDownloadSanitizesHostileServerName is the end-to-end guard: a version whose
+// files[].name is "../../evil.txt" must land as evil.txt INSIDE the --out-dir,
+// never escape it.
+func TestDownloadSanitizesHostileServerName(t *testing.T) {
+	const body = "pwned-bytes"
+	var base string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"id":128713,"modelId":4384,"name":"v","baseModel":"SD 1.5","files":[{"id":1,"name":"../../evil.txt","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"%s/dl/blob","hashes":{"SHA256":"%s"}}]}`, base, sha256hex(body))
+	})
+	// Serve the bytes at a CLEAN path (independent of the hostile file name).
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) { _, _ = io.WriteString(w, body) })
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	defer srv.Close()
+
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	dir := t.TempDir()
+	chdir(t, t.TempDir())
+
+	if _, _, err := run(t, "download", "128713", "--out-dir", dir); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+
+	// Lands as dir/evil.txt.
+	saved := filepath.Join(dir, "evil.txt")
+	got, err := os.ReadFile(saved)
+	if err != nil {
+		t.Fatalf("sanitized file should be %s: %v", saved, err)
+	}
+	if string(got) != body {
+		t.Errorf("content = %q, want %q", got, body)
+	}
+	// Must NOT have escaped two levels up.
+	escaped := filepath.Clean(filepath.Join(dir, "..", "..", "evil.txt"))
+	if _, err := os.Stat(escaped); err == nil {
+		t.Errorf("hostile name escaped the target dir: %s exists", escaped)
+	}
+}

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -85,7 +85,11 @@ func newModelVersionsByHashCmd() *cobra.Command {
 
 func printModelVersionDetail(cmd *cobra.Command, v *api.ModelVersionDetail) {
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "%s (version id %d, model id %d)\n", v.Name, v.ID, v.ModelID)
+	header := fmt.Sprintf("%s (version id %d, model id %d)", v.Name, v.ID, v.ModelID)
+	if mk := nonModelFileMarker(v.Files); mk != "" {
+		header += " " + mk
+	}
+	fmt.Fprintln(out, header)
 	if v.Model != nil {
 		fmt.Fprintf(out, "  model:     %s (%s)\n", v.Model.Name, v.Model.Type)
 	}

--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -32,6 +32,7 @@ func newModelsCmd() *cobra.Command {
 func newModelsSearchCmd() *cobra.Command {
 	var (
 		query, tag, username, typ, sort, period, cursor string
+		baseModels                                      []string
 		nsfw                                            bool
 		limit, page                                     int
 	)
@@ -57,6 +58,14 @@ cursor is printed after the results.`,
 			addIfSet(q, "tag", tag)
 			addIfSet(q, "username", username)
 			addIfSet(q, "types", typ) // API query param is `types`
+			// baseModels is a repeatable filter → repeated `baseModels=` query
+			// keys, which the API's zod union (string | string[]) parses as an
+			// array (baseModel IN (...), i.e. OR across the given values).
+			for _, bm := range baseModels {
+				if bm != "" {
+					q.Add("baseModels", bm)
+				}
+			}
 			addIfSet(q, "sort", sort)
 			addIfSet(q, "period", period)
 			addIfSet(q, "cursor", cursor)
@@ -86,6 +95,7 @@ cursor is printed after the results.`,
 	cmd.Flags().StringVar(&tag, "tag", "", "filter by tag name")
 	cmd.Flags().StringVar(&username, "username", "", "filter by creator username")
 	cmd.Flags().StringVar(&typ, "type", "", "filter by model type (e.g. Checkpoint, LORA, TextualInversion)")
+	cmd.Flags().StringSliceVar(&baseModels, "base-model", nil, "filter by base model; repeatable (e.g. --base-model Pony --base-model \"Illustrious\"). Distinguishes video checkpoints (\"Wan Video 2.2 T2V-A14B\") that all share --type Checkpoint")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (e.g. \"Highest Rated\", \"Most Downloaded\", Newest)")
 	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
@@ -166,7 +176,11 @@ func printModelDetail(cmd *cobra.Command, m *api.ModelDetail) {
 	fmt.Fprintf(out, "  versions (%d):\n", len(m.ModelVersions))
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
 	for _, v := range m.ModelVersions {
-		fmt.Fprintf(tw, "    %d\t%s\t%s\n", v.ID, v.Name, v.BaseModel)
+		marker := nonModelFileMarker(v.Files)
+		if marker != "" {
+			marker = "  " + marker
+		}
+		fmt.Fprintf(tw, "    %d\t%s\t%s%s\n", v.ID, v.Name, v.BaseModel, marker)
 	}
 	_ = tw.Flush()
 }

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -59,6 +59,21 @@ func emitJSON(cmd *cobra.Command, raw []byte) error {
 	return nil
 }
 
+// nonModelFileMarker returns a short human tag when a version's PRIMARY file is
+// not model weights (type != "Model") — the on-site-generation / training-data
+// trap where a clean-named version ships e.g. a training ZIP instead of
+// downloadable weights. Returns "" for a normal weights version (or no files).
+func nonModelFileMarker(files []api.ModelVersionFile) string {
+	pf := api.PrimaryFile(files)
+	if pf == nil || pf.IsModelWeights() {
+		return ""
+	}
+	if strings.EqualFold(pf.Type, "Training Data") {
+		return "[training data — no downloadable weights]"
+	}
+	return fmt.Sprintf("[%s — not model weights]", strings.ToLower(pf.Type))
+}
+
 // checkLimit validates a --limit against an endpoint's documented maximum. A
 // zero limit means "server default" and is always allowed.
 func checkLimit(limit, max int) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -252,6 +252,7 @@ Get started:
 	// Read subcommands — public REST API (`/api/v1/**`) browsing.
 	root.AddCommand(newModelsCmd())
 	root.AddCommand(newModelVersionsCmd())
+	root.AddCommand(newDownloadCmd())
 	root.AddCommand(newImagesCmd())
 	root.AddCommand(newTagsCmd())
 	root.AddCommand(newCreatorsCmd())

--- a/internal/cmd/update_cache.go
+++ b/internal/cmd/update_cache.go
@@ -118,6 +118,15 @@ func decideNotice(c updateCache, current string, now time.Time) noticeDecision {
 	if !isParseableVersion(current) {
 		return d
 	}
+	// Guard against a STALE cache pinning an older "latest" than what we're
+	// actually running (the draft-window artifact: /releases/latest briefly
+	// returned the prior tag, so a fresh install cached a "latest" OLDER than
+	// itself). If we're ahead of the cached latest, the cache is definitionally
+	// stale — force a refresh now instead of waiting out the TTL. Never show a
+	// notice in this case (compareVersions != -1 already suppresses it below).
+	if compareVersions(current, c.LatestVersion) == 1 {
+		d.refresh = true
+	}
 	if compareVersions(current, c.LatestVersion) != -1 {
 		return d // up to date or ahead.
 	}

--- a/internal/cmd/update_check.go
+++ b/internal/cmd/update_check.go
@@ -79,10 +79,15 @@ func printUpdateNotice(w io.Writer, current string) {
 		// ONLY path that may honestly claim the user is up to date.
 		fmt.Fprintln(w, "\nYou're on the latest version.")
 	default:
-		// current > latest (dev/pre-release build ahead of the newest release):
-		// don't claim "on the latest version" — say nothing actionable, just
-		// surface the latest release informationally and honestly.
-		fmt.Fprintf(w, "\nLatest release: %s — https://github.com/civitai/cli/releases/latest\n", latest)
+		// current > latest: we are AT OR AHEAD of the newest published release,
+		// so there is nothing to update to — show NO notice. This is exactly the
+		// symptom the dogfood hit: right after v0.1.62 was cut, GitHub's
+		// /releases/latest (which EXCLUDES drafts) still returned v0.1.61, so a
+		// v0.1.62 machine compared as "ahead" and the old code printed a
+		// misleading "Latest release: v0.1.61" line that read like the user was
+		// behind. When current >= latest we stay silent (never a false "behind"
+		// nag, never a false "on the latest" claim for a dev build ahead).
+		return
 	}
 }
 

--- a/internal/cmd/update_check_test.go
+++ b/internal/cmd/update_check_test.go
@@ -202,14 +202,19 @@ func TestPrintUpdateNotice_CurrentAhead(t *testing.T) {
 	if strings.Contains(out, "newer version is available") {
 		t.Errorf("should not prompt upgrade when current is ahead: %s", out)
 	}
-	// When ahead (a dev/pre-release build newer than the latest release), we must
-	// NOT claim "You're on the latest version." — that would be a false claim.
+	// When ahead (a dev/pre-release build newer than the latest release, OR the
+	// draft-window artifact where /releases/latest momentarily returns the prior
+	// tag), we must NOT claim "You're on the latest version." AND must NOT print
+	// a misleading "Latest release: <older>" line that reads like the user is
+	// behind. current >= latest ⇒ NO notice at all.
 	if strings.Contains(out, "You're on the latest version") {
 		t.Errorf("should not claim 'on the latest version' when current is ahead: %s", out)
 	}
-	// Instead it surfaces the latest release informationally and honestly.
-	if !strings.Contains(out, "Latest release: v0.1.9") {
-		t.Errorf("ahead build should surface the latest release informationally: %s", out)
+	if strings.Contains(out, "Latest release") {
+		t.Errorf("ahead build must not surface an older 'Latest release' line (reads as behind): %s", out)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("current >= latest should produce NO update notice, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
## What & why

A blind-dogfood found the CLI is great at *discovery* but can't *assemble*: no download verb, no base-model filter, the clean-named "training-zip" trap, and a version-check that reported `Latest release: v0.1.61` while running `v0.1.62`. This PR closes all four.

## Feature 1 — `civitai download` (the missing verb)

- **Deterministic identifier:** positional `download <version-id>` = a model-VERSION id; `--model <model-id>` (mutually exclusive) resolves the model's default (primary/latest) published version. Exactly one required — no numeric-ambiguity guessing.
- **Multi-file:** default = the version's **primary** file; `--file <name>` selects one (exact, else unique case-insensitive substring; ambiguous/none errors and lists the files); `--all` downloads every file.
- **Output:** `--out <path>` (single file only), `--out-dir <dir>` (server-named files into a dir, works with `--all`), default = server name in cwd; parent dirs created.
- **Mechanics:** streams to `<target>.part` → renames on success (never a truncated final file); follows the `/api/download` → signed-storage 302 (Go strips `Authorization` cross-host); TTY-aware progress to **stderr**; large files streamed, never buffered.
- **Auth:** uses the configured token source automatically (login token or `CIVITAI_API_KEY`); 401/403 → actionable "run `civitai login`" / "early-access or gated" message; `--anon` forces no token.
- **SHA256 verify (default on):** mismatch deletes the `.part` and exits non-zero with both hashes; `--no-verify` skips; **no published SHA256 → warn + skip verify (not a hard fail)**.
- **Idempotency:** present target that verifies (or `--no-verify`) is skipped; `--force` re-downloads.
- **On-site-gen guard (papercut #3):** a selected file whose `type != "Model"` (e.g. a training-data ZIP masquerading as the ~18 MB "version") is **refused by default**; `--allow-nonmodel` overrides. `--all` skips bundled non-model files with a warning rather than aborting the whole run.

## Feature 2 — `models search --base-model` (papercut #2)

Repeatable `StringSliceVar` → REST `baseModels` param. **Verified against the live API and the civitai source** (`model.schema.ts`: `baseModels: z.union([z.string(), z.string().array()])`; service does `mv."baseModel" IN (…)`) — repeated `baseModels=` keys are OR semantics. This is the key discovery filter for video checkpoints, which all share `--type Checkpoint` and differ only by base model (`"Wan Video 2.2 T2V-A14B"`).

## Papercut #3b — surface the trap in list/detail output

`models get` / `model-versions get` human output tags a version whose **primary file is not weights** with `[training data — no downloadable weights]`. `--json` is an unchanged raw passthrough.

## Papercut #5 — stale update-check, root-caused

The symptom was the GitHub `/releases/latest` **draft-exclusion artifact**: while `v0.1.62`'s release was a draft, that endpoint returned `v0.1.61`, so a `v0.1.62` machine compared as "ahead" and the old code printed a misleading `Latest release: v0.1.61` line. **Confirmed resolved at the source** — the endpoint now returns `v0.1.62`. Fixed the compare-guard to be robust regardless: **`current >= latest` now shows NO notice** (was the misleading older-"Latest release" line), and `decideNotice` **force-refreshes the cache when it pins a "latest" older than the running version**, so a stale pre-publish record can't linger through its TTL.

## What I verified live

- `baseModels` param exists, accepts repeated keys, and applies OR semantics (23 Illustrious + 8 Pony versions for `baseModels=Pony&baseModels=Illustrious`).
- Version-detail file fields: `id`, `name`, `type`, `sizeKB`, `primary`, `downloadUrl`, `hashes.SHA256` (+ AutoV1/AutoV2/CRC32/BLAKE3).
- A real 24 KB download end-to-end: streamed with progress, **SHA256 matched the API's published hash**, `.part` renamed away, idempotent skip on re-run, and `--model`+`--out` created nested dirs.
- The update-check endpoint now returns `v0.1.62` (draft published), so the original symptom no longer reproduces; the compare-guard is hardened anyway.

## Test coverage

httptest-server, table-driven, matching the repo's style:
- **download:** version-id path, `--model` resolution, primary default, `--file` exact/substring/ambiguous/no-match, `--all`, `--all` skips non-model, SHA256 verify pass + mismatch (deletes `.part` + errors), missing-hash warn+skip, non-`Model` refusal + `--allow-nonmodel`, `--out`/`--out-dir` (dir creation), `--out`+`--all` conflict, redirect follow, `Authorization` sent when a token is configured, anonymous sends none, 401 refresh + non-refreshable 401 preserved, skip-if-present + `--force`, actionable 401.
- **--base-model:** repeated-key encoding + single spaced value.
- **marker:** rendered in `models get` + `model-versions get`, absent for weights, `--json` unchanged.
- **update-check:** `current >= latest` → no notice; stale-cache force-refresh; behind still notifies.

`go build ./... && go test ./... && go vet ./...` all green (also `-race`). The branch-protection required checks `pins-vs-published` + `scaffold-currency` are unrelated to this diff.

## Follow-up

The developer.civitai.com CLI guide (`site/guide/cli.md`, civitai-developer-docs) needs a follow-up documenting `download` + `--base-model` — **not touched here** (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
