### PR TITLE
fix(download): drop non-weights refusal, let any model type's file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ also takes `--json` to print the **raw API JSON response** for scripting.
 | `civitai models get <id>` | Get one model by id | `--json`, `--anon` |
 | `civitai model-versions get <id>` | Get a model version by id (alias `mv`) | `--json`, `--anon` |
 | `civitai model-versions by-hash <hash>` | Look up a model version by file hash (AutoV2, SHA256, …) | `--json`, `--anon` |
-| `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--no-verify`, `--force`, `--allow-nonmodel`, `--anon` |
+| `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--no-verify`, `--force`, `--anon` |
 | `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
 | `civitai tags search` | Search model tags | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai creators search` | Search creators | `--query`; paging `--limit` (≤200), `--page` |
@@ -295,22 +295,23 @@ civitai models search --type Checkpoint --base-model "Wan Video 2.2 T2V-A14B"
 civitai models search --base-model Pony --base-model Illustrious --limit 20
 ```
 
-**On-site-generation marker.** In the human (non-`--json`) output of
+**Non-weights file marker.** In the human (non-`--json`) output of
 `models get` and `model-versions get`, a version whose **primary file is not
-model weights** (`type != "Model"` — e.g. an on-site-generation registration that
-ships a training-data ZIP instead of the weights) is tagged
-`[training data — no downloadable weights]` so you can spot the trap before
-trying to download it. `--json` output is an unchanged raw passthrough.
+model weights** (`type != "Model"`) is tagged with its actual file type — e.g.
+`[Archive]` (a "Workflows" model's downloadable deliverable), `[Training Data]`,
+or `[Other]` — so you can see at a glance that the version's file isn't weights.
+It's purely informational: any file type still downloads. `--json` output is an
+unchanged raw passthrough.
 
 ## Download model files
 
 `civitai download` fetches the file(s) of a model **version**. Identify the
 version deterministically by its numeric **version id**, or resolve a model's
-default (primary/latest) published version with `--model`:
+default (first) published version with `--model`:
 
 ```bash
 civitai download 128713                       # the version's primary file → ./<server-name>
-civitai download --model 4384                 # resolve model 4384's default weights version, then download it
+civitai download --model 4384                 # resolve model 4384's default version, then download its primary file
 civitai download --model 4384 --dry-run       # print the plan (files, sizes, hashes, targets) — download nothing
 civitai download 128713 --out ./dreamshaper.safetensors
 civitai download 128713 --file vae --out-dir ./models   # pick a file; write into a dir
@@ -320,8 +321,8 @@ civitai download 128713 --all --out-dir ./models        # every file in the vers
 Behavior:
 
 - **Identifier** — exactly one of the positional `<version-id>` or `--model <model-id>` is required (no numeric-ambiguity guessing).
-- **`--model` picks downloadable weights** — a model's default (latest) version can be a training-data / on-site-generation registration whose primary file is **not** model weights. `--model` skips those and resolves to the newest version whose primary file **is** downloadable weights (noting the skip on stderr); if no version has weights it errors clearly. Naming a non-weights version by its explicit `<version-id>` is unchanged — it still hits the `--allow-nonmodel` guard.
-- **`--dry-run`** — resolve the version + selected file(s) and print the plan (each file's name, size, SHA256, resolved target path, and whether authentication will be required) then exit `0`, transferring nothing and creating no file (not even a `.part`). Works with `--file`, `--all`, `--model`, `--out`, and `--out-dir`. A non-weights file shows as *would be refused* in the plan rather than aborting it.
+- **`--model` resolves the default version** — the model's default (first published) version; its primary file is downloaded regardless of file type. Any model type works, including a `type: Workflows` model whose deliverable is a downloadable `Archive`.
+- **`--dry-run`** — resolve the version + selected file(s) and print the plan (each file's name, size, SHA256, resolved target path, and whether authentication will be required) then exit `0`, transferring nothing and creating no file (not even a `.part`). Works with `--file`, `--all`, `--model`, `--out`, and `--out-dir`.
 - **File selection** — defaults to the version's **primary** file. `--file <name>` selects one file (exact name, else a unique case-insensitive substring; ambiguous/none errors and lists the files). `--all` downloads every file.
 - **Output** — `--out <path>` sets an exact target path (single file only). `--out-dir <dir>` writes server-named files into a directory (works with `--all`). Parent directories are created as needed. Default is the server-provided filename in the current directory.
 - **Streaming + atomicity** — the body streams to `<target>.part` and is renamed into place only on success, so an interrupted run never leaves a truncated final file. Large files (10+ GB) are never buffered in memory. TTY-aware progress is printed to **stderr**. The Civitai download URL 302-redirects to signed storage; the CLI follows it.
@@ -329,7 +330,7 @@ Behavior:
 - **Transient-failure retry (reads)** — the read endpoints (search / model / version / images / tags / creators / users / articles / collections) retry a transient `502`/`503`/`504` or network error a few times with exponential backoff (with jitter), noting each retry on stderr. A `429` is retried **only** when it carries a `Retry-After` header (a genuine throttle, honored up to a cap); a `429` **without** `Retry-After` is Civitai's deterministic deep-paging limit and is surfaced immediately with the hint to use `--cursor` instead of `--page`. The download **stream** is not retried mid-transfer.
 - **Integrity (default on)** — the streamed bytes are verified against the file's `SHA256`; a mismatch deletes the `.part` and fails. `--no-verify` skips it; a file with no published SHA256 downloads with a warning (not a hard failure).
 - **Idempotency** — an already-present target (that verifies, or with `--no-verify`) is skipped with a note; `--force` re-downloads.
-- **On-site-generation guard** — a version whose selected file is **not model weights** (`type != "Model"`, e.g. a training-data ZIP) is **refused by default**; pass `--allow-nonmodel` to download it anyway.
+- **Any file type downloads** — the selected/primary file is downloaded whatever its `type` (`Model` weights, a `type: Workflows` model's `Archive`, training data, or other artifacts). The human `models get` / `model-versions get` output tags a non-weights primary file with its type (e.g. `[Archive]`) purely for information; it never blocks a download.
 
 ## Validate fidelity
 

--- a/internal/api/model_versions.go
+++ b/internal/api/model_versions.go
@@ -33,19 +33,20 @@ type ModelVersionFile struct {
 }
 
 // ModelFileType is the `type` value of the main model-weights file. A file whose
-// type is anything else (e.g. "Training Data", "Config", "VAE") is NOT the
-// downloadable weights — the on-site-generation / component-file trap `download`
-// guards against by default.
+// type is anything else (e.g. "Archive", "Training Data", "Config", "VAE") is not
+// weights but a different deliverable — the renderers tag it with an
+// informational type marker; `download` fetches any type regardless.
 const ModelFileType = "Model"
 
 // IsModelWeights reports whether the file is the main model-weights file
-// (type == "Model"), as opposed to training data / config / a component file.
+// (type == "Model"), as opposed to an archive / training data / config / a
+// component file. Used only for the informational non-weights marker.
 func (f *ModelVersionFile) IsModelWeights() bool { return f.Type == ModelFileType }
 
 // PrimaryFile returns the primary file of a version's file list (the one flagged
 // `primary: true`), falling back to the first file when none is flagged. Returns
 // nil for an empty list. This is the file `download` fetches by default and the
-// one the list/detail renderers inspect for the on-site-gen marker.
+// one the list/detail renderers inspect for the non-weights marker.
 func PrimaryFile(files []ModelVersionFile) *ModelVersionFile {
 	if len(files) == 0 {
 		return nil

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -30,9 +30,8 @@ type ModelListItem struct {
 }
 
 // ModelVersionSummary is the per-version summary shown under a model detail.
-// Files is carried so the detail renderer can flag a version whose primary file
-// is not model weights (the on-site-gen / training-data trap) and so `download
-// --model` can resolve + inspect the model's default version. The full
+// Files is carried so the detail renderer can tag a version whose primary file
+// is not model weights with its file type (an informational marker). The full
 // GET /api/v1/models/{id} response embeds each version's files[].
 type ModelVersionSummary struct {
 	ID        int                `json:"id"`

--- a/internal/cmd/base_model_marker_test.go
+++ b/internal/cmd/base_model_marker_test.go
@@ -39,9 +39,30 @@ func TestModelsSearchBaseModelSingle(t *testing.T) {
 	}
 }
 
-// TestModelVersionGetMarksTrainingData asserts the on-site-gen marker renders in
-// the human `model-versions get` output when the primary file is not weights.
-func TestModelVersionGetMarksTrainingData(t *testing.T) {
+// TestModelVersionGetMarksNonWeightsType asserts the informational marker renders
+// the ACTUAL file type in the human `model-versions get` output when the primary
+// file is not weights — here an Archive (e.g. a "Workflows" model), tagged
+// [Archive] rather than any "no downloadable weights" claim.
+func TestModelVersionGetMarksNonWeightsType(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1,"modelId":2,"name":"clean-name","baseModel":"SD 1.5",
+		  "files":[{"id":9,"name":"workflow.zip","type":"Archive","primary":true,"sizeKB":18000}]}`))
+	})
+	out, _, err := run(t, "model-versions", "get", "1")
+	if err != nil {
+		t.Fatalf("model-versions get: %v", err)
+	}
+	if !strings.Contains(out, "[Archive]") {
+		t.Errorf("non-weights version should carry the accurate [Archive] marker: %s", out)
+	}
+	if strings.Contains(out, "no downloadable weights") {
+		t.Errorf("marker must NOT falsely claim there are no downloadable weights: %s", out)
+	}
+}
+
+// TestModelVersionGetMarksTrainingDataType asserts a Training Data primary file
+// is tagged with its verbatim type.
+func TestModelVersionGetMarksTrainingDataType(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"id":1,"modelId":2,"name":"clean-name","baseModel":"SD 1.5",
 		  "files":[{"id":9,"name":"training.zip","type":"Training Data","primary":true,"sizeKB":18000}]}`))
@@ -50,8 +71,8 @@ func TestModelVersionGetMarksTrainingData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("model-versions get: %v", err)
 	}
-	if !strings.Contains(out, "training data — no downloadable weights") {
-		t.Errorf("training-data version should carry the marker: %s", out)
+	if !strings.Contains(out, "[Training Data]") {
+		t.Errorf("training-data version should carry the [Training Data] marker: %s", out)
 	}
 }
 
@@ -66,14 +87,14 @@ func TestModelVersionGetNoMarkerForWeights(t *testing.T) {
 	if err != nil {
 		t.Fatalf("model-versions get: %v", err)
 	}
-	if strings.Contains(out, "no downloadable weights") {
-		t.Errorf("a normal weights version must NOT be tagged: %s", out)
+	if strings.Contains(out, "[") {
+		t.Errorf("a normal weights version must NOT be tagged with a type marker: %s", out)
 	}
 }
 
-// TestModelGetMarksTrainingDataVersion asserts the marker also shows in the
-// `models get` version list.
-func TestModelGetMarksTrainingDataVersion(t *testing.T) {
+// TestModelGetMarksNonWeightsVersion asserts the marker also shows the accurate
+// type in the `models get` version list.
+func TestModelGetMarksNonWeightsVersion(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"id":2,"name":"M","type":"Checkpoint",
 		  "modelVersions":[{"id":10,"name":"weights","baseModel":"SD 1.5","files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true}]},
@@ -83,8 +104,8 @@ func TestModelGetMarksTrainingDataVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("models get: %v", err)
 	}
-	if !strings.Contains(out, "training data — no downloadable weights") {
-		t.Errorf("models get should tag the on-site-gen version: %s", out)
+	if !strings.Contains(out, "[Training Data]") {
+		t.Errorf("models get should tag the non-weights version with its type: %s", out)
 	}
 }
 
@@ -99,7 +120,7 @@ func TestModelVersionGetJSONUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("model-versions get --json: %v", err)
 	}
-	if strings.Contains(out, "no downloadable weights") {
+	if strings.Contains(out, "[Training Data]") {
 		t.Errorf("--json output must NOT carry the human marker: %s", out)
 	}
 	if !strings.Contains(out, `"Training Data"`) {

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -21,16 +21,15 @@ import (
 
 // downloadOpts holds the resolved flag values for `civitai download`.
 type downloadOpts struct {
-	modelID       string // --model (mutually exclusive with the positional version id)
-	file          string // --file: select one file by name (exact | unique substring)
-	all           bool   // --all: download every file in the version
-	out           string // --out: target path (single-file only)
-	outDir        string // --out-dir: directory for server-named files
-	noVerify      bool   // --no-verify: skip SHA256 verification
-	force         bool   // --force: re-download even if the target already exists
-	allowNonModel bool   // --allow-nonmodel: permit non-"Model" files (training data, etc.)
-	anon          bool   // --anon: force an anonymous request
-	dryRun        bool   // --dry-run: print the resolved plan and exit without transferring
+	modelID  string // --model (mutually exclusive with the positional version id)
+	file     string // --file: select one file by name (exact | unique substring)
+	all      bool   // --all: download every file in the version
+	out      string // --out: target path (single-file only)
+	outDir   string // --out-dir: directory for server-named files
+	noVerify bool   // --no-verify: skip SHA256 verification
+	force    bool   // --force: re-download even if the target already exists
+	anon     bool   // --anon: force an anonymous request
+	dryRun   bool   // --dry-run: print the resolved plan and exit without transferring
 }
 
 func newDownloadCmd() *cobra.Command {
@@ -44,9 +43,7 @@ Identify the version deterministically by its numeric version id:
 
   civitai download 128713
 
-…or resolve a model's default published version with --model (which skips
-non-weights registrations — training-data / on-site-generation versions — and
-picks the newest version with downloadable weights):
+…or resolve a model's default (first published) version with --model:
 
   civitai download --model 4384
 
@@ -54,9 +51,11 @@ Use --dry-run to print the resolved plan (files, sizes, SHA256, target paths,
 and whether auth is required) without transferring anything.
 
 By default the version's PRIMARY file is downloaded into the current directory
-under its server-provided name. Use --file to pick a specific file, or --all to
-download every file. Downloads stream to "<target>.part" and are renamed into
-place only on success, so an interrupted run never leaves a truncated final file.
+under its server-provided name. Any file type downloads — model weights, but
+also non-weights deliverables like a "Workflows" model's Archive, training data,
+or other artifacts. Use --file to pick a specific file, or --all to download
+every file. Downloads stream to "<target>.part" and are renamed into place only
+on success, so an interrupted run never leaves a truncated final file.
 
 Authentication: your stored login token (civitai login) or CIVITAI_API_KEY is
 used automatically; gated / early-access files need it. Public files download
@@ -64,11 +63,7 @@ anonymously.
 
 Integrity: the streamed bytes are verified against the file's SHA256 by default
 (--no-verify to skip; a file with no published SHA256 is downloaded with a
-warning). A hash mismatch deletes the partial file and fails.
-
-On-site-generation guard: a version whose selected file is not model weights
-(type != "Model", e.g. a training-data ZIP) is refused by default — pass
---allow-nonmodel to download it anyway.`,
+warning). A hash mismatch deletes the partial file and fails.`,
 		Example: `  civitai download 128713
   civitai download --model 4384 --out ./dreamshaper.safetensors
   civitai download 128713 --file vae --out-dir ./models
@@ -79,14 +74,13 @@ On-site-generation guard: a version whose selected file is not model weights
 		},
 	}
 	f := cmd.Flags()
-	f.StringVar(&o.modelID, "model", "", "resolve+download a MODEL's default (primary/latest) version instead of a version id")
+	f.StringVar(&o.modelID, "model", "", "resolve+download a MODEL's default (first published) version instead of a version id")
 	f.StringVar(&o.file, "file", "", "select a specific file by name (exact match, else a unique case-insensitive substring)")
 	f.BoolVar(&o.all, "all", false, "download every file in the version")
 	f.StringVar(&o.out, "out", "", "target file path (single-file only; mutually exclusive with --all/--out-dir)")
 	f.StringVar(&o.outDir, "out-dir", "", "directory to write server-named file(s) into (created if needed)")
 	f.BoolVar(&o.noVerify, "no-verify", false, "skip SHA256 verification of the downloaded bytes")
 	f.BoolVar(&o.force, "force", false, "re-download even if the target file already exists")
-	f.BoolVar(&o.allowNonModel, "allow-nonmodel", false, "allow downloading a non-\"Model\" file (training data, config, etc.)")
 	f.BoolVar(&o.anon, "anon", false, "force an anonymous request (ignore any stored login token)")
 	f.BoolVar(&o.dryRun, "dry-run", false, "print the resolved download plan (files, sizes, hashes, targets) and exit without downloading anything")
 	return cmd
@@ -130,7 +124,7 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	out := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
 
-	versionID, err := resolveVersionID(ctx, client, positional, o.modelID, errW)
+	versionID, err := resolveVersionID(ctx, client, positional, o.modelID)
 	if err != nil {
 		return err
 	}
@@ -146,8 +140,7 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	}
 
 	// --dry-run: print the resolved plan and exit 0, transferring nothing and
-	// creating no file (not even a ".part"). The non-weights refusal is shown in
-	// the plan rather than aborting it, so the whole plan is always visible.
+	// creating no file (not even a ".part").
 	if o.dryRun {
 		return printDownloadPlan(out, selected, o, baseURL)
 	}
@@ -155,19 +148,6 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	downloaded := 0
 	for i := range selected {
 		f := selected[i]
-		// on-site-gen / component-file guard.
-		if !f.IsModelWeights() && !o.allowNonModel {
-			if o.all {
-				// In --all mode, don't abort the whole run for a bundled
-				// non-weights file — skip it with a clear note.
-				fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf(
-					"skipping %q (type %q, not model weights) — pass --allow-nonmodel to include it", f.Name, f.Type)))
-				continue
-			}
-			return fmt.Errorf("%q is %q, not model weights — this is likely an on-site-generation / training-data registration, not downloadable weights.\n"+
-				"Re-run with --allow-nonmodel if you really want this file", f.Name, f.Type)
-		}
-
 		target, err := targetPath(f, o)
 		if err != nil {
 			return err
@@ -182,25 +162,20 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	}
 
 	if downloaded == 0 && o.all {
-		// Everything was skipped (all files non-weights, or all already present).
-		fmt.Fprintln(errW, ui.For(errW).Warn("no model-weights files were downloaded (all files were non-model or already present)"))
+		// Everything was already present on disk.
+		fmt.Fprintln(errW, ui.For(errW).Warn("no files were downloaded (all were already present)"))
 	}
 	return nil
 }
 
 // resolveVersionID returns the version id to download: the positional id verbatim
-// (validated numeric), or a downloadable-weights version of --model.
+// (validated numeric), or the default (first published) version of --model.
 //
-// For --model, the API returns modelVersions default/latest-first, but that
-// default can be a training-data / on-site-generation registration whose primary
-// file is not model weights (downloading it errors on a ZIP). So instead of
-// blindly taking modelVersions[0], this picks the FIRST version whose primary
-// file IS downloadable weights, skipping non-weights versions and noting the skip
-// on stderr. If the models endpoint embeds no per-version file info at all, it
-// can't distinguish and falls back to the prior [0] behavior. Naming a non-weights
-// version by its explicit positional id is unchanged — it still hits the
-// --allow-nonmodel guard in the download loop.
-func resolveVersionID(ctx context.Context, client api.Reader, positional, modelID string, errW io.Writer) (string, error) {
+// For --model, the API returns modelVersions default/latest-first, so the model's
+// default version is modelVersions[0]. Its primary file is downloaded regardless
+// of file type — a "Workflows" model's Archive, training data, or plain weights
+// all download the same way.
+func resolveVersionID(ctx context.Context, client api.Reader, positional, modelID string) (string, error) {
 	if positional != "" {
 		if _, err := strconv.Atoi(positional); err != nil {
 			return "", fmt.Errorf("model-version id must be an integer, got %q", positional)
@@ -217,39 +192,12 @@ func resolveVersionID(ctx context.Context, client api.Reader, positional, modelI
 	if len(m.ModelVersions) == 0 {
 		return "", fmt.Errorf("model %s has no published versions to download", modelID)
 	}
-	// Pick the first version whose primary file is downloadable weights.
-	sawFiles := false
-	for i := range m.ModelVersions {
-		v := m.ModelVersions[i]
-		pf := api.PrimaryFile(v.Files)
-		if pf == nil {
-			continue
-		}
-		sawFiles = true
-		if pf.IsModelWeights() {
-			if i != 0 {
-				defType := "non-weights"
-				if dpf := api.PrimaryFile(m.ModelVersions[0].Files); dpf != nil && dpf.Type != "" {
-					defType = strings.ToLower(dpf.Type)
-				}
-				fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf(
-					"model default is a %s registration; using version %d %q with downloadable weights", defType, v.ID, v.Name)))
-			}
-			return strconv.Itoa(v.ID), nil
-		}
-	}
-	if !sawFiles {
-		// No per-version file info embedded — can't distinguish; preserve the
-		// prior behavior of taking the default/latest version.
-		return strconv.Itoa(m.ModelVersions[0].ID), nil
-	}
-	return "", fmt.Errorf("model %s has no version with downloadable weights — every published version is a non-\"Model\" registration (e.g. training data / on-site generation). Inspect the versions with `civitai model %s` and pass a specific version id", modelID, modelID)
+	return strconv.Itoa(m.ModelVersions[0].ID), nil
 }
 
 // printDownloadPlan renders the --dry-run plan: for each selected file its name,
 // size, SHA256, resolved target path, and whether authentication will be
-// required — then whether it would be downloaded or refused as non-weights. It
-// writes NOTHING to disk.
+// required. It writes NOTHING to disk.
 func printDownloadPlan(out io.Writer, files []api.ModelVersionFile, o *downloadOpts, baseURL string) error {
 	fmt.Fprintf(out, "Dry run — planning %d file(s); nothing will be downloaded.\n", len(files))
 	for i := range files {
@@ -271,11 +219,7 @@ func printDownloadPlan(out io.Writer, files []api.ModelVersionFile, o *downloadO
 		} else {
 			fmt.Fprintf(out, "  auth:   not required\n")
 		}
-		if !f.IsModelWeights() && !o.allowNonModel {
-			fmt.Fprintf(out, "  status: WOULD BE REFUSED — %q, not model weights; pass --allow-nonmodel to include it\n", f.Type)
-		} else {
-			fmt.Fprintf(out, "  status: would download\n")
-		}
+		fmt.Fprintf(out, "  status: would download\n")
 	}
 	return nil
 }

--- a/internal/cmd/download_cmd_test.go
+++ b/internal/cmd/download_cmd_test.go
@@ -172,17 +172,18 @@ func TestDownloadFileSelectExactAndSubstring(t *testing.T) {
 	// Exact (case-insensitive) name.
 	d := newDLServer(t, false, files)
 	setupDownloadEnv(t, d, "")
-	if _, _, err := run(t, "download", "128713", "--file", "MODEL.SAFETENSORS", "--allow-nonmodel"); err != nil {
+	if _, _, err := run(t, "download", "128713", "--file", "MODEL.SAFETENSORS"); err != nil {
 		t.Fatalf("exact --file: %v", err)
 	}
 	if _, err := os.Stat("model.safetensors"); err != nil {
 		t.Errorf("exact match should download model.safetensors: %v", err)
 	}
 
-	// Unique substring.
+	// Unique substring — selects the non-"Model" config file, which now downloads
+	// with no flag.
 	d2 := newDLServer(t, false, files)
 	setupDownloadEnv(t, d2, "")
-	if _, _, err := run(t, "download", "128713", "--file", "config", "--allow-nonmodel"); err != nil {
+	if _, _, err := run(t, "download", "128713", "--file", "config"); err != nil {
 		t.Fatalf("substring --file: %v", err)
 	}
 	if _, err := os.Stat("config.yaml"); err != nil {
@@ -221,7 +222,7 @@ func TestDownloadAll(t *testing.T) {
 	})
 	setupDownloadEnv(t, d, "")
 	dir := t.TempDir()
-	if _, _, err := run(t, "download", "128713", "--all", "--allow-nonmodel", "--out-dir", dir); err != nil {
+	if _, _, err := run(t, "download", "128713", "--all", "--out-dir", dir); err != nil {
 		t.Fatalf("download --all: %v", err)
 	}
 	for _, name := range []string{"model.safetensors", "vae.pt"} {
@@ -231,7 +232,9 @@ func TestDownloadAll(t *testing.T) {
 	}
 }
 
-func TestDownloadAllSkipsNonModelWithoutOverride(t *testing.T) {
+// --all now downloads EVERY file regardless of type — the weights AND the
+// non-"Model" file — with no skip and no override flag.
+func TestDownloadAllDownloadsEveryFileType(t *testing.T) {
 	d := newDLServer(t, false, []dlFile{
 		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
 		{id: 2, name: "training.zip", typ: "Training Data", body: "trainingdata"},
@@ -243,13 +246,13 @@ func TestDownloadAllSkipsNonModelWithoutOverride(t *testing.T) {
 		t.Fatalf("download --all: %v", err)
 	}
 	if _, e := os.Stat(filepath.Join(dir, "model.safetensors")); e != nil {
-		t.Errorf("--all should still fetch the weights: %v", e)
+		t.Errorf("--all should fetch the weights: %v", e)
 	}
-	if _, e := os.Stat(filepath.Join(dir, "training.zip")); e == nil {
-		t.Error("--all must skip the non-model training file without --allow-nonmodel")
+	if _, e := os.Stat(filepath.Join(dir, "training.zip")); e != nil {
+		t.Errorf("--all should now fetch the non-model training file too: %v", e)
 	}
-	if !strings.Contains(errOut, "skipping") {
-		t.Errorf("stderr should note the skipped non-model file: %s", errOut)
+	if strings.Contains(errOut, "not model weights") {
+		t.Errorf("stderr must NOT note a non-weights skip anymore: %s", errOut)
 	}
 }
 
@@ -304,30 +307,41 @@ func TestDownloadMissingHashWarnsAndSkipsVerify(t *testing.T) {
 	}
 }
 
-func TestDownloadNonModelRefusedByDefault(t *testing.T) {
+// Repro (a): a version whose PRIMARY file is a non-"Model" Archive — as a
+// "Workflows" model registers — downloads with NO flag and NO refusal.
+func TestDownloadArchivePrimaryDownloads(t *testing.T) {
+	const body = "WORKFLOW-ARCHIVE-BYTES"
 	d := newDLServer(t, false, []dlFile{
-		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
+		{id: 1, name: "workflow.zip", typ: "Archive", primary: true, body: body, withSHA: true},
 	})
 	setupDownloadEnv(t, d, "")
-	_, _, err := run(t, "download", "128713")
-	if err == nil || !strings.Contains(err.Error(), "not model weights") {
-		t.Fatalf("expected on-site-gen refusal, got %v", err)
+	out, _, err := run(t, "download", "3083777")
+	if err != nil {
+		t.Fatalf("an Archive primary file should download with no flag, got %v", err)
 	}
-	if _, e := os.Stat("training.zip"); e == nil {
-		t.Error("refused download must not write the file")
+	got, rerr := os.ReadFile("workflow.zip")
+	if rerr != nil {
+		t.Fatalf("Archive file not written: %v", rerr)
+	}
+	if string(got) != body {
+		t.Errorf("content = %q, want %q", got, body)
+	}
+	if !strings.Contains(out, "Saved workflow.zip") {
+		t.Errorf("output should confirm the save: %s", out)
 	}
 }
 
-func TestDownloadNonModelAllowedWithOverride(t *testing.T) {
+// A non-"Model" Training Data primary file also downloads with no flag.
+func TestDownloadTrainingDataPrimaryDownloads(t *testing.T) {
 	d := newDLServer(t, false, []dlFile{
 		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
 	})
 	setupDownloadEnv(t, d, "")
-	if _, _, err := run(t, "download", "128713", "--allow-nonmodel"); err != nil {
-		t.Fatalf("download --allow-nonmodel: %v", err)
+	if _, _, err := run(t, "download", "128713"); err != nil {
+		t.Fatalf("a Training Data file should download with no flag, got %v", err)
 	}
 	if _, e := os.Stat("training.zip"); e != nil {
-		t.Errorf("--allow-nonmodel should permit the download: %v", e)
+		t.Errorf("the training file should be written: %v", e)
 	}
 }
 

--- a/internal/cmd/download_dryrun_test.go
+++ b/internal/cmd/download_dryrun_test.go
@@ -45,7 +45,7 @@ func TestDownloadDryRunPrintsPlanWritesNothing(t *testing.T) {
 	}
 }
 
-func TestDownloadDryRunAllShowsRefusalWithoutError(t *testing.T) {
+func TestDownloadDryRunAllPlansEveryFileNoRefusal(t *testing.T) {
 	d := newDLServer(t, false, []dlFile{
 		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "w", withSHA: true},
 		{id: 2, name: "training.zip", typ: "Training Data", body: "trainingdata"},
@@ -55,13 +55,17 @@ func TestDownloadDryRunAllShowsRefusalWithoutError(t *testing.T) {
 
 	out, _, err := run(t, "download", "128713", "--all", "--out-dir", dir, "--dry-run")
 	if err != nil {
-		t.Fatalf("dry-run --all should exit 0 even with a non-weights file, got %v", err)
+		t.Fatalf("dry-run --all should exit 0, got %v", err)
 	}
 	if !strings.Contains(out, "model.safetensors") || !strings.Contains(out, "training.zip") {
 		t.Errorf("plan should list every selected file:\n%s", out)
 	}
-	if !strings.Contains(out, "WOULD BE REFUSED") {
-		t.Errorf("the non-weights file should show as refused in the plan:\n%s", out)
+	// The non-weights file is no longer refused — every file plans as downloadable.
+	if strings.Contains(out, "WOULD BE REFUSED") {
+		t.Errorf("no file should be refused in the plan anymore:\n%s", out)
+	}
+	if strings.Count(out, "would download") != 2 {
+		t.Errorf("both files should plan as would-download:\n%s", out)
 	}
 	if !dirIsEmpty(t, dir) {
 		t.Error("dry-run --all must write nothing to the out-dir")
@@ -92,22 +96,25 @@ func TestDownloadDryRunModel(t *testing.T) {
 	}
 }
 
-func TestDownloadDryRunSingleNonWeightsShowsRefusalNotError(t *testing.T) {
-	// A single non-weights primary in dry-run: the plan shows the refusal but the
-	// command still exits 0 (it never claims it downloaded it).
+func TestDownloadDryRunArchivePlansDownloadNoRefusal(t *testing.T) {
+	// Repro (a), dry-run form: a single non-weights primary — a "Workflows" model's
+	// Archive — plans as a normal download with no refusal line, and writes nothing.
 	d := newDLServer(t, false, []dlFile{
-		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
+		{id: 1, name: "workflow.zip", typ: "Archive", primary: true, body: "workflowbytes"},
 	})
 	setupDownloadEnv(t, d, "")
 
-	out, _, err := run(t, "download", "128713", "--dry-run")
+	out, _, err := run(t, "download", "3083777", "--dry-run")
 	if err != nil {
-		t.Fatalf("dry-run of a non-weights file should not error the plan, got %v", err)
+		t.Fatalf("dry-run of an Archive file should not error, got %v", err)
 	}
-	if !strings.Contains(out, "WOULD BE REFUSED") {
-		t.Errorf("plan should show the non-weights refusal:\n%s", out)
+	if strings.Contains(out, "WOULD BE REFUSED") {
+		t.Errorf("an Archive file must NOT be refused in the plan anymore:\n%s", out)
 	}
-	if _, e := os.Stat("training.zip"); e == nil {
+	if !strings.Contains(out, "would download") {
+		t.Errorf("the Archive file should plan as would-download:\n%s", out)
+	}
+	if _, e := os.Stat("workflow.zip"); e == nil {
 		t.Error("dry-run must not write the file")
 	}
 }

--- a/internal/cmd/download_model_weights_test.go
+++ b/internal/cmd/download_model_weights_test.go
@@ -65,30 +65,50 @@ func setupMVEnv(t *testing.T, m *mvServer) {
 	chdir(t, t.TempDir())
 }
 
-func TestModelResolvesSkipsNonWeightsDefault(t *testing.T) {
-	// Default (versions[0]) is training-data; a later version has weights.
+// --model resolves the model's DEFAULT (first) version regardless of file type —
+// even when that default's primary file is a non-"Model" Archive — and downloads
+// it with no skip and no error.
+func TestModelResolvesDefaultVersionEvenWhenNonWeights(t *testing.T) {
+	// Default (versions[0]) is a non-weights Archive; a later version has weights.
 	m := newMVServer(t, 4384, []mvVer{
-		{id: 900, name: "training-registration", ftype: "Training Data"},
+		{id: 900, name: "workflow-registration", ftype: "Archive"},
 		{id: 800, name: "v1.0-weights", ftype: "Model"},
 	})
 	setupMVEnv(t, m)
 
 	_, errOut, err := run(t, "download", "--model", "4384")
 	if err != nil {
-		t.Fatalf("download --model should resolve to the weights version: %v", err)
+		t.Fatalf("download --model should resolve the default version, got %v", err)
 	}
-	// It must have fetched version 800 (the weights one), not 900.
-	if !strings.HasSuffix(m.fetchedVerURL, "/800") {
-		t.Errorf("expected version 800 to be downloaded, fetched %q", m.fetchedVerURL)
+	// It must have fetched the DEFAULT version 900, not the later weights one.
+	if !strings.HasSuffix(m.fetchedVerURL, "/900") {
+		t.Errorf("expected the default version 900 to be downloaded, fetched %q", m.fetchedVerURL)
 	}
-	if !strings.Contains(errOut, "800") || !strings.Contains(errOut, "downloadable weights") {
-		t.Errorf("stderr should note the skip + chosen version: %s", errOut)
-	}
-	if !strings.Contains(errOut, "training data") {
-		t.Errorf("stderr note should name the default's type: %s", errOut)
+	if strings.Contains(errOut, "downloadable weights") {
+		t.Errorf("no weights-skip note should be printed anymore: %s", errOut)
 	}
 }
 
+// Repro (b): every version's primary file is non-"Model" — --model still resolves
+// the default version and downloads it, no error.
+func TestModelAllNonWeightsResolvesDefault(t *testing.T) {
+	m := newMVServer(t, 4384, []mvVer{
+		{id: 900, name: "workflows", ftype: "Archive"},
+		{id: 901, name: "training", ftype: "Training Data"},
+	})
+	setupMVEnv(t, m)
+
+	_, _, err := run(t, "download", "--model", "4384")
+	if err != nil {
+		t.Fatalf("--model with all-non-weights versions should resolve the default, got %v", err)
+	}
+	if !strings.HasSuffix(m.fetchedVerURL, "/900") {
+		t.Errorf("expected the default version 900 to be downloaded, fetched %q", m.fetchedVerURL)
+	}
+}
+
+// Repro (c): when the default version already IS weights, --model resolves it with
+// no note.
 func TestModelDefaultAlreadyWeightsNoNote(t *testing.T) {
 	m := newMVServer(t, 4384, []mvVer{
 		{id: 800, name: "v1.0-weights", ftype: "Model"},
@@ -108,31 +128,16 @@ func TestModelDefaultAlreadyWeightsNoNote(t *testing.T) {
 	}
 }
 
-func TestModelAllNonWeightsErrors(t *testing.T) {
-	m := newMVServer(t, 4384, []mvVer{
-		{id: 900, name: "training", ftype: "Training Data"},
-		{id: 901, name: "onsite-gen", ftype: "Archive"},
-	})
-	setupMVEnv(t, m)
-
-	_, _, err := run(t, "download", "--model", "4384")
-	if err == nil || !strings.Contains(err.Error(), "no version with downloadable weights") {
-		t.Fatalf("expected a clear no-weights error, got %v", err)
-	}
-}
-
-// The explicit positional non-weights path is unchanged: it still refuses via the
-// --allow-nonmodel guard (resolveVersionID does not touch it).
-func TestExplicitPositionalNonWeightsStillRefuses(t *testing.T) {
+// The explicit positional non-weights path now downloads the file (no refusal).
+func TestExplicitPositionalNonWeightsDownloads(t *testing.T) {
 	d := newDLServer(t, false, []dlFile{
 		{id: 1, name: "training.zip", typ: "Training Data", primary: true, body: "trainingdata"},
 	})
 	setupDownloadEnv(t, d, "")
-	_, _, err := run(t, "download", "128713")
-	if err == nil || !strings.Contains(err.Error(), "not model weights") {
-		t.Fatalf("explicit positional non-weights should still be refused, got %v", err)
+	if _, _, err := run(t, "download", "128713"); err != nil {
+		t.Fatalf("explicit positional non-weights should download, got %v", err)
 	}
-	if _, e := os.Stat("training.zip"); e == nil {
-		t.Error("refused positional download must not write the file")
+	if _, e := os.Stat("training.zip"); e != nil {
+		t.Errorf("positional non-weights download must write the file: %v", e)
 	}
 }

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -59,19 +59,22 @@ func emitJSON(cmd *cobra.Command, raw []byte) error {
 	return nil
 }
 
-// nonModelFileMarker returns a short human tag when a version's PRIMARY file is
-// not model weights (type != "Model") — the on-site-generation / training-data
-// trap where a clean-named version ships e.g. a training ZIP instead of
-// downloadable weights. Returns "" for a normal weights version (or no files).
+// nonModelFileMarker returns a short human tag naming a version's PRIMARY file
+// type when it is NOT model weights (type != "Model") — e.g. a "Workflows"
+// model's [Archive], a [Training Data] registration, or [Other]. It's purely
+// informational: any file type downloads, so this only flags "this version's
+// primary file isn't weights" without claiming it can't be downloaded. Returns
+// "" for a normal weights version (or no files).
 func nonModelFileMarker(files []api.ModelVersionFile) string {
 	pf := api.PrimaryFile(files)
 	if pf == nil || pf.IsModelWeights() {
 		return ""
 	}
-	if strings.EqualFold(pf.Type, "Training Data") {
-		return "[training data — no downloadable weights]"
+	typ := strings.TrimSpace(pf.Type)
+	if typ == "" {
+		typ = "Other"
 	}
-	return fmt.Sprintf("[%s — not model weights]", strings.ToLower(pf.Type))
+	return "[" + typ + "]"
 }
 
 // checkLimit validates a --limit against an endpoint's documented maximum. A


### PR DESCRIPTION
## What & why

The training-data-trap protection (added in v0.1.63/64) over-fires on legitimate non-weight model **types**. A `type: Workflows` model's deliverable IS a downloadable `Archive`, but the CLI refused it by default and `--model` even claimed there were no downloadable weights.

Repro (both fixed here, verified via `--dry-run`, which needs no auth):

- `civitai download 3083777 --dry-run` previously printed `status: WOULD BE REFUSED — "Archive", not model weights; pass --allow-nonmodel`. Now it plans the download normally (`status: would download`).
- `civitai download --model 2426853 --dry-run` previously **errored** `model … has no version with downloadable weights …` (model 2426853 is `type: Workflows`; every version's file is `type: Archive`). Now it resolves the default version and plans its Archive file.

Per the maintainer's decision: **drop the refusal/skip entirely, keep only an accurate informational marker, let any file download.**

## Removals

- **Download hard-refusal** of non-`"Model"` files (`runDownload` loop + the `printDownloadPlan` `WOULD BE REFUSED` branch).
- **`--allow-nonmodel` flag** entirely (brand-new; now pointless — a dead flag is worse than removing it).
- **`--model` weights-skip** — `resolveVersionID` now picks the model's default (first) version and downloads its primary file; the `IsModelWeights()` skip loop, the stderr skip-note, and the "no version with downloadable weights" error are gone.

## Kept, reworded

The `models get` / `model-versions get` human marker now renders the **accurate file type** — `[Archive]`, `[Training Data]`, `[Other]` — instead of the misleading hardcoded "training data — no downloadable weights". It's purely informational; any file type downloads. `--json` output is byte-unchanged. `IsModelWeights()` / `PrimaryFile()` are retained (still used by the marker + primary-file selection).

## Tests

Converted the tests the old behavior owned (refusal, `--allow-nonmodel`, `--model` weights-skip, dry-run refusal rows) to assert the new behavior, and added coverage: a positional `Archive`/`Training Data` primary downloads with no flag; `--model` resolves the default version even when every version is non-weights; the default-is-weights path still works; the marker renders the accurate `[<fileType>]` and is absent for a `Model` file; `--json` unchanged. Retry / dry-run / auth-error / path-traversal / host-gate tests still pass. `go build`/`vet`/`test`/`-race`/`gofmt -s` all green.

Follow-up (separate repo, not touched here): the developer.civitai.com CLI guide references the removed refusal/`--allow-nonmodel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)