### PR TITLE
chore(scaffold): bump SDK pins (app-sdk 0.26, blocks-react 0.33)

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -124,8 +124,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.32.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.25.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.33.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.26.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -111,7 +111,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.25.0` + `@civitai/blocks-react@^0.32.0` (already pinned in
+`@civitai/app-sdk@^0.26.0` + `@civitai/blocks-react@^0.33.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.25.0",
-    "@civitai/blocks-react": "^0.32.0",
+    "@civitai/app-sdk": "^0.26.0",
+    "@civitai/blocks-react": "^0.33.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
New `@civitai/app-sdk@0.26.0` and `@civitai/blocks-react@0.33.0` minors were published. Pre-1.0 caret locks the minor, so the scaffold template pins (`^0.25.0`/`^0.32.0`) no longer admit them and `pins-vs-published` was failing on every open cli PR. Ran `go run ./internal/scaffold/cmd/bump-pins`; guard test green locally. Unblocks #133 and #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)