### PR TITLE
fix(api): read full response body — 1 MiB cap truncated JSON responses >1 MiB

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -340,6 +340,11 @@ type Client struct {
 	// Stderr receives the one-line transient-retry notices on read GETs; nil
 	// defaults to os.Stderr. Tests point it at a buffer to assert the notice.
 	Stderr io.Writer
+	// MaxResponseBody overrides the per-response body read cap (see
+	// maxResponseBody) when > 0. It bounds memory against a pathological body;
+	// a real civitai JSON page is far below the default. Tests set a small value
+	// to exercise the over-cap guard without allocating 64 MiB.
+	MaxResponseBody int64
 }
 
 // New builds a Client with sane defaults from a static token (personal API key
@@ -406,7 +411,10 @@ func (c *Client) doOnceWith(httpClient *http.Client, build func() (*http.Request
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, err := c.readBody(resp.Body)
+	if err != nil {
+		return resp.StatusCode, raw, err
+	}
 	return resp.StatusCode, raw, nil
 }
 

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -210,8 +210,8 @@ func (c *OAuthClient) resolveEndpoints(ctx context.Context) (*oauthEndpoints, er
 		return c.endpoints, nil
 	}
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if resp.StatusCode != http.StatusOK {
+	raw, err := readResponseBody(resp.Body, maxResponseBody)
+	if err != nil || resp.StatusCode != http.StatusOK {
 		c.endpoints = fallback()
 		return c.endpoints, nil
 	}
@@ -558,7 +558,10 @@ func (c *OAuthClient) postForm(ctx context.Context, rawURL string, form url.Valu
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, err := readResponseBody(resp.Body, maxResponseBody)
+	if err != nil {
+		return resp.StatusCode, raw, err
+	}
 	return resp.StatusCode, raw, nil
 }
 

--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -135,6 +136,45 @@ func readError(status int, raw []byte) error {
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
+}
+
+// maxResponseBody bounds how many bytes of a single HTTP response body the
+// client reads into memory. It is deliberately far above any real Civitai JSON
+// page — a `models search --limit 100` page tops out at a few MB — so a genuine
+// API response is NEVER truncated, while a pathological/runaway body still can't
+// exhaust memory. The previous 1 MiB cap silently truncated any response over
+// ~1 MiB mid-JSON (e.g. `models search --limit 20`, ~1.04 MiB), so json.Unmarshal
+// failed with a misleading "unexpected response (status 200)".
+const maxResponseBody = 64 << 20 // 64 MiB
+
+// maxBody returns the effective per-response body cap: the Client override when
+// set (tests use a small value), else maxResponseBody.
+func (c *Client) maxBody() int64 {
+	if c.MaxResponseBody > 0 {
+		return c.MaxResponseBody
+	}
+	return maxResponseBody
+}
+
+// readBody reads an entire HTTP response body, bounded by the client's cap.
+func (c *Client) readBody(body io.Reader) ([]byte, error) {
+	return readResponseBody(body, c.maxBody())
+}
+
+// readResponseBody reads an entire HTTP response body, bounded by limit. It
+// reads one byte past the cap so it can DETECT an over-limit body and return a
+// clear error instead of silently handing truncated bytes to json.Unmarshal —
+// a silent truncation is exactly what caused the 1 MiB-cap bug. Under the cap it
+// returns the full body (never truncating a real response).
+func readResponseBody(body io.Reader, limit int64) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return raw, err
+	}
+	if int64(len(raw)) > limit {
+		return raw[:limit], fmt.Errorf("response body exceeded %d MiB limit", limit>>20)
+	}
+	return raw, nil
 }
 
 // snippet bounds an error/body string so a huge response can't flood the

--- a/internal/api/read_bodycap_test.go
+++ b/internal/api/read_bodycap_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// buildModelsPayload builds a valid `{"items":[…],"metadata":{}}` JSON body of
+// at least minBytes, returning the payload and the exact item count so a test
+// can assert the full body was read + parsed (no truncation). Each item carries
+// a fixed filler so the body grows deterministically.
+func buildModelsPayload(minBytes int) (string, int) {
+	var b strings.Builder
+	b.WriteString(`{"items":[`)
+	filler := strings.Repeat("a", 512)
+	n := 0
+	for b.Len() < minBytes {
+		if n > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%d,"name":"%s","type":"LORA"}`, n, filler)
+		n++
+	}
+	b.WriteString(`],"metadata":{}}`)
+	return b.String(), n
+}
+
+// serveBody returns an httptest server that writes body (as JSON) for any GET.
+func serveBody(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSearchModelsReadsBodyOver1MiB is the regression test for the client-side
+// 1 MiB read cap. Before the fix the read path used
+// io.ReadAll(io.LimitReader(resp.Body, 1<<20)), which truncated any response
+// over 1 MiB mid-JSON, so json.Unmarshal failed with a misleading
+// "unexpected response from /api/v1/models (status 200)". This exercises the
+// real read seam (SearchModels → getInto) against a ~1.5 MiB valid body and
+// asserts the FULL body is read + parsed (every item present).
+func TestSearchModelsReadsBodyOver1MiB(t *testing.T) {
+	body, want := buildModelsPayload(1500000) // ~1.5 MiB, > 1<<20
+	if len(body) <= 1<<20 {
+		t.Fatalf("test payload not larger than 1 MiB: %d bytes", len(body))
+	}
+	srv := serveBody(t, body)
+
+	c := New(srv.URL, "tok", "")
+	res, err := c.SearchModels(context.Background(), url.Values{})
+	if err != nil {
+		t.Fatalf("SearchModels on a >1MiB body: %v", err)
+	}
+	if len(res.Items) != want {
+		t.Errorf("parsed %d items, want %d — body was truncated", len(res.Items), want)
+	}
+	if len(res.Raw) != len(body) {
+		t.Errorf("Raw body = %d bytes, want the full %d bytes", len(res.Raw), len(body))
+	}
+	// Last item must be present + intact (truncation drops the tail first).
+	if res.Items[want-1].ID != want-1 {
+		t.Errorf("last item id = %d, want %d", res.Items[want-1].ID, want-1)
+	}
+}
+
+// TestSearchModelsBoundaryAroundOneMiB checks a body just under and just over
+// the old 1 MiB cap both parse fully.
+func TestSearchModelsBoundaryAroundOneMiB(t *testing.T) {
+	cases := []struct {
+		name    string
+		minSize int
+	}{
+		{"justUnder1MiB", 1<<20 - 20000},
+		{"justOver1MiB", 1<<20 + 20000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, want := buildModelsPayload(tc.minSize)
+			srv := serveBody(t, body)
+			c := New(srv.URL, "", "")
+			res, err := c.SearchModels(context.Background(), url.Values{})
+			if err != nil {
+				t.Fatalf("SearchModels (%d bytes): %v", len(body), err)
+			}
+			if len(res.Items) != want {
+				t.Errorf("parsed %d items, want %d (body %d bytes)", len(res.Items), want, len(body))
+			}
+		})
+	}
+}
+
+// TestReadBodyOverCapReturnsError asserts a body at/over the effective cap
+// yields a clear error rather than silently handing truncated bytes to the
+// parser. A small Client.MaxResponseBody override stands in for the 64 MiB
+// default so the test needn't allocate 64 MiB.
+func TestReadBodyOverCapReturnsError(t *testing.T) {
+	const capBytes = 4096
+	body, _ := buildModelsPayload(capBytes * 4) // comfortably over the cap
+	srv := serveBody(t, body)
+
+	c := New(srv.URL, "", "")
+	c.MaxResponseBody = capBytes
+	_, err := c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("expected an over-cap error, got nil (silent truncation)")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("error = %q, want it to mention the body exceeded the limit", err)
+	}
+}
+
+// TestReadBodyUnderCapReturnsFullBody asserts a body at/under the cap is read in
+// full (no off-by-one truncation at the boundary).
+func TestReadBodyUnderCapReturnsFullBody(t *testing.T) {
+	body := strings.Repeat("x", 1000)
+	cases := []struct {
+		name  string
+		limit int64
+	}{
+		{"underCap", 2000},
+		{"exactlyCap", 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := readResponseBody(strings.NewReader(body), tc.limit)
+			if err != nil {
+				t.Fatalf("readResponseBody: %v", err)
+			}
+			if len(raw) != len(body) {
+				t.Errorf("read %d bytes, want %d", len(raw), len(body))
+			}
+		})
+	}
+}
+
+// TestReadResponseBodyOverLimitError unit-tests the helper directly: a body one
+// byte over the limit errors and does not silently truncate.
+func TestReadResponseBodyOverLimitError(t *testing.T) {
+	body := strings.Repeat("x", 1025)
+	_, err := readResponseBody(strings.NewReader(body), 1024)
+	if err == nil {
+		t.Fatal("expected an over-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("error = %q, want 'exceeded'", err)
+	}
+}

--- a/internal/api/retry.go
+++ b/internal/api/retry.go
@@ -266,6 +266,9 @@ func (c *Client) doOnceHdr(build func() (*http.Request, error), token string) (i
 		return 0, nil, nil, err
 	}
 	defer resp.Body.Close()
-	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, err := c.readBody(resp.Body)
+	if err != nil {
+		return resp.StatusCode, resp.Header, raw, err
+	}
 	return resp.StatusCode, resp.Header, raw, nil
 }


### PR DESCRIPTION
## The bug (🔴 confirmed, reproducible)

The read path read the HTTP response body through `io.ReadAll(io.LimitReader(resp.Body, 1<<20))`, **capping it at 1 MiB**. Any read-endpoint response over 1 MiB was truncated mid-JSON, so `json.Unmarshal` failed and the user saw:

```
Error: unexpected response from /api/v1/models (status 200): …
```

Confirmed boundary against the **live** API:
- `models search --type LORA --limit 17` (0.86 MiB) → **works**
- `models search --type LORA --limit 20` (1.04 MiB) and up → **FAIL**

The raw API returns valid, deterministic JSON (~2.2 MB at `--limit 40`, ~4.4 MB at `--limit 100`) — this was purely a **client-side read cap**. It broke ordinary browsing: `--limit 50`, `--type LORA`, `images search`, models with many versions, etc. **Latent since the read path shipped.**

## The fix

- One shared constant `maxResponseBody = 64 << 20` (64 MiB — far above any real civitai JSON page, still memory-bounded), used uniformly at every response-read site:
  - `internal/api/retry.go` `doOnceHdr` — the read GET seam (`getRaw → getWithRetry → authedDoHdr → doOnceHdr`). **Primary fix.**
  - `internal/api/api.go` `doOnceWith` — Apps-surface authed calls (WhoAmI/buzz/`ListSubmissions`/cloneinfo) + mutations; `ListSubmissions` can also exceed 1 MiB.
  - `internal/api/oauth.go` (discovery + token) — tiny bodies, changed for consistency with the shared constant.
- A shared `readResponseBody` helper reads **one byte past** the cap so an at/over-limit body returns a clear `response body exceeded NN MiB limit` error **instead of silently handing truncated bytes to the parser** — a silent truncation is exactly what caused this bug. The cap is overridable via `Client.MaxResponseBody` for tests.
- Download stream path (`internal/api/download.go`, `io.Copy`) is unchanged (already unbounded/correct). `snippet()`/`readError` still bound displayed error bodies to 500 chars.

## Tests

- **Regression:** `TestSearchModelsReadsBodyOver1MiB` drives `SearchModels` against a ~1.5 MiB valid body via httptest and asserts every item parses + `Raw` is the full body. **Fails before the fix** with the exact `unexpected response (status 200)` symptom (verified).
- Boundary tests just under / just over 1 MiB both succeed.
- Over-cap guard: a body over the (small, test-injected) cap yields the clear error, not silent truncation. Under/at-cap reads return the full body.
- All existing tests green (retry / auth / download / oauth / path-traversal / host-gate).

## Verification

`go build ./... && go vet ./... && go test -count=1 ./...` all green; `go test -race ./internal/api/... ./internal/cmd/...` green; `gofmt -s -l .` clean. Built the binary and ran `models search --type LORA --limit 40` against the live API → **40 items**, no error (`--limit 100` → 4.36 MB body, parses clean).
