### PR TITLE
fix(cli): two-path root --help + guard --all same-name overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ civitai download 128713                       # the version's primary file → .
 civitai download --model 4384                 # resolve model 4384's default version, then download its primary file
 civitai download --model 4384 --dry-run       # print the plan (files, sizes, hashes, targets) — download nothing
 civitai download 128713 --out ./dreamshaper.safetensors
-civitai download 128713 --file vae --out-dir ./models   # pick a file; write into a dir
+civitai download 128713 --file vae --out-dir ./models   # pick a file by name; write into a dir
+civitai download 691639 --file 1234567                  # pick one of two same-named files by its file id
 civitai download 128713 --all --out-dir ./models        # every file in the version
 civitai download 128713 --all --layout comfyui --root ~/ComfyUI   # route each file to its type folder
 civitai download 128713 --layout a1111 --for-base "SDXL 1.0"      # A1111 layout + base-model compat warning
@@ -397,7 +398,8 @@ Behavior:
 - **Identifier** — exactly one of the positional `<version-id>` or `--model <model-id>` is required (no numeric-ambiguity guessing).
 - **`--model` resolves the default version** — the model's default (first published) version; its primary file is downloaded regardless of file type. Any model type works, including a `type: Workflows` model whose deliverable is a downloadable `Archive`.
 - **`--dry-run`** — resolve the version + selected file(s) and print the plan (each file's name, size, SHA256, resolved target path, and whether authentication will be required) then exit `0`, transferring nothing and creating no file (not even a `.part`). Works with `--file`, `--all`, `--model`, `--out`, `--out-dir`, and `--layout`/`--root` (the plan shows the routed target paths).
-- **File selection** — defaults to the version's **primary** file. `--file <name>` selects one file (exact name, else a unique case-insensitive substring; ambiguous/none errors and lists the files). `--all` downloads every file.
+- **File selection** — defaults to the version's **primary** file. `--file` selects one file by **numeric file id** (the version's `files[].id`) or by **name** (exact, else a unique case-insensitive substring; ambiguous/none errors and lists the candidate files with their ids). `--all` downloads every file.
+- **Same-named files (no silent overwrite)** — a version can ship two files that share a name (e.g. Flux Dev's fp16 **and** fp8, both `flux_dev.safetensors`). Selecting that shared name with `--file` is **ambiguous** and errors, listing both files with their ids — pass the **numeric id** to pick exactly one (`--file 1234567`; the id is shown by `--dry-run` and in the error). `--all` **refuses** to run when two selected files would resolve to the **same on-disk path** (which would silently clobber one) — it fails *before* transferring anything, lists the colliding files with their ids/sizes, and tells you to pick one with `--file <id>` (or write them to separate paths). No download ever silently overwrites another.
 - **Output** — `--out <path>` sets an exact target path (single file only). `--out-dir <dir>` writes server-named files into a directory (works with `--all`). Parent directories are created as needed. Default is the server-provided filename in the current directory.
 - **Type-aware folder routing (`--layout`)** — `--layout <a1111|comfyui>` writes each file into the correct subfolder for that app, keyed by the file/model **type**, under `--root <dir>` (default `.`). This fixes the footgun where `--all --out-dir X` dumps a **bundled VAE into the checkpoint folder** and pollutes the model dropdown: with `--layout`, the checkpoint lands in the checkpoints folder and the VAE in the VAE folder. `--layout` is mutually exclusive with `--out`/`--out-dir`; `--root` only applies with `--layout`. An unmapped type (Poses, Wildcards, Archive, …) is written to `--root` with a stderr note rather than silently misplaced. The routed folder maps:
 

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -64,6 +64,14 @@ or other artifacts. Use --file to pick a specific file, or --all to download
 every file. Downloads stream to "<target>.part" and are renamed into place only
 on success, so an interrupted run never leaves a truncated final file.
 
+Selecting one of two same-named files: a version can ship two files with the
+SAME name (e.g. an fp16 and an fp8 both named flux_dev.safetensors). --file
+accepts a numeric FILE ID (the version's files[].id) as well as a name, so you
+can pick exactly one — the ids are shown by --dry-run and in the error you get
+if a name is ambiguous. --all refuses to run when two selected files would
+resolve to the same on-disk path (which would silently overwrite one), listing
+the colliding files with their ids so you can --file <id> the one you want.
+
 Authentication: downloading ANY model file requires authentication — run
 'civitai login' (Civitai requires a token even for public files; a 336 KB public
 embedding 401s just like a gated checkpoint). Your stored login token or
@@ -91,6 +99,7 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 		Example: `  civitai download 128713
   civitai download --model 4384 --out ./dreamshaper.safetensors
   civitai download 128713 --file vae --out-dir ./models
+  civitai download 691639 --file 1234567          # pick one of two same-named files by id
   civitai download 128713 --all --out-dir ./models
   civitai download 128713 --all --layout comfyui --root ~/ComfyUI
   civitai download 128713 --layout a1111 --for-base "SDXL 1.0"`,
@@ -101,8 +110,8 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 	}
 	f := cmd.Flags()
 	f.StringVar(&o.modelID, "model", "", "resolve+download a MODEL's default (first published) version instead of a version id")
-	f.StringVar(&o.file, "file", "", "select a specific file by name (exact match, else a unique case-insensitive substring)")
-	f.BoolVar(&o.all, "all", false, "download every file in the version")
+	f.StringVar(&o.file, "file", "", "select one file by numeric file id, or by name (exact, else a unique case-insensitive substring); use the id to pick one of two same-named files")
+	f.BoolVar(&o.all, "all", false, "download every file in the version (refuses if two files would overwrite the same path — pick one with --file <id>)")
 	f.StringVar(&o.out, "out", "", "target file path (single-file only; mutually exclusive with --all/--out-dir)")
 	f.StringVar(&o.outDir, "out-dir", "", "directory to write server-named file(s) into (created if needed)")
 	f.StringVar(&o.layout, "layout", "", "route each file into its type's subfolder for an app (a1111|comfyui); mutually exclusive with --out/--out-dir")
@@ -184,6 +193,16 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	selected, err := selectFiles(v.Files, o)
 	if err != nil {
 		return err
+	}
+
+	// Guard against a silent same-target overwrite BEFORE any transfer (and before
+	// the --dry-run plan): when multiple files are selected, two resolving to the
+	// same on-disk path would clobber each other (data loss). Fail-safe here so no
+	// bytes ever move for an unsafe plan.
+	if len(selected) > 1 {
+		if err := checkTargetCollisions(selected, o); err != nil {
+			return err
+		}
 	}
 
 	// Always surface the version's base model, and (with --for-base) warn on a
@@ -318,17 +337,43 @@ func selectFiles(files []api.ModelVersionFile, o *downloadOpts) ([]api.ModelVers
 	return []api.ModelVersionFile{*primary}, nil
 }
 
-// selectOneFile picks a single file by name: an exact (case-insensitive) name
-// match wins; otherwise a UNIQUE case-insensitive substring match; ambiguous or
-// no match is an error that lists the available files.
+// selectOneFile picks a single file for --file. Resolution order:
+//
+//  1. Numeric file id — an all-digits `want` that equals a file's `id` selects
+//     exactly that file. This is the unambiguous way to pick ONE of two files
+//     that share a name (a version can ship, e.g., an fp16 and an fp8 both named
+//     flux_dev.safetensors): copy the numeric id shown in the collision error or
+//     the --dry-run plan. Tried first so an id always wins; a real filename is
+//     practically never bare digits.
+//  2. Exact (case-insensitive) name — one match wins. TWO+ files can legitimately
+//     share a name, so that's ambiguous: error and tell the user to pick by id.
+//  3. A UNIQUE case-insensitive substring match.
+//
+// Ambiguous or no match is an error that lists the candidate files with their ids.
 func selectOneFile(files []api.ModelVersionFile, want string) ([]api.ModelVersionFile, error) {
-	// Exact (case-insensitive) name match first.
-	for i := range files {
-		if strings.EqualFold(files[i].Name, want) {
-			return []api.ModelVersionFile{files[i]}, nil
+	// (1) Numeric file-id selection.
+	if id, err := strconv.Atoi(strings.TrimSpace(want)); err == nil {
+		for i := range files {
+			if files[i].ID == id {
+				return []api.ModelVersionFile{files[i]}, nil
+			}
 		}
 	}
-	// Unique case-insensitive substring match.
+	// (2) Exact (case-insensitive) name match — collect ALL, since a name can be
+	// shared by more than one file.
+	var exact []api.ModelVersionFile
+	for i := range files {
+		if strings.EqualFold(files[i].Name, want) {
+			exact = append(exact, files[i])
+		}
+	}
+	if len(exact) == 1 {
+		return exact[:1], nil
+	}
+	if len(exact) > 1 {
+		return nil, fmt.Errorf("%q matches %d files that share this name — select one by its numeric file id with --file <id>:\n%s", want, len(exact), formatFileList(exact))
+	}
+	// (3) Unique case-insensitive substring match.
 	var matches []api.ModelVersionFile
 	lw := strings.ToLower(want)
 	for i := range files {
@@ -342,18 +387,68 @@ func selectOneFile(files []api.ModelVersionFile, want string) ([]api.ModelVersio
 	case 0:
 		return nil, fmt.Errorf("no file matches %q. Available files:\n%s", want, formatFileList(files))
 	default:
-		return nil, fmt.Errorf("%q is ambiguous — it matches %d files. Be more specific:\n%s", want, len(matches), formatFileList(matches))
+		return nil, fmt.Errorf("%q is ambiguous — it matches %d files. Be more specific (or use --file <id>):\n%s", want, len(matches), formatFileList(matches))
 	}
 }
 
-// formatFileList renders a compact "  - name (type, size)" list for errors.
+// formatFileList renders a compact "  - [id N] name (type, size)" list for
+// errors. The id is included so the user can copy it into --file <id> to
+// disambiguate same-named files.
 func formatFileList(files []api.ModelVersionFile) string {
 	var b strings.Builder
 	for i := range files {
 		f := files[i]
-		fmt.Fprintf(&b, "  - %s (%s, %s)\n", safeTerm(f.Name), safeTerm(f.Type), humanBytes(int64(f.SizeKB*1024)))
+		fmt.Fprintf(&b, "  - [id %d] %s (%s, %s)\n", f.ID, safeTerm(f.Name), safeTerm(dashIfEmpty(f.Type)), humanBytes(int64(f.SizeKB*1024)))
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// checkTargetCollisions guards against a silent same-target overwrite: when more
+// than one file is selected (--all, or --layout/--out-dir routing several files),
+// two files that resolve to the SAME on-disk path would clobber each other —
+// the second download overwrites the first with no warning and one file is lost.
+// This bit Flux Dev version 691639, which ships an fp16 (22.2 GB) and an fp8
+// (15.9 GB) file BOTH named flux_dev.safetensors → --all planned both to
+// ./flux_dev.safetensors.
+//
+// It returns a fail-safe error listing every colliding group (with each file's
+// numeric id + size to distinguish them) BEFORE anything is transferred, so no
+// data is ever lost to a silent overwrite. Per-file targetPath errors are left
+// for the normal per-file path to surface.
+func checkTargetCollisions(files []api.ModelVersionFile, o *downloadOpts) error {
+	byTarget := make(map[string][]api.ModelVersionFile)
+	var order []string
+	for i := range files {
+		target, _, err := targetPath(files[i], o)
+		if err != nil {
+			// An unusable target for this file is reported later per-file; don't
+			// mask it with a collision error here.
+			continue
+		}
+		if _, seen := byTarget[target]; !seen {
+			order = append(order, target)
+		}
+		byTarget[target] = append(byTarget[target], files[i])
+	}
+
+	var b strings.Builder
+	groups := 0
+	for _, target := range order {
+		grp := byTarget[target]
+		if len(grp) < 2 {
+			continue
+		}
+		groups++
+		fmt.Fprintf(&b, "  %s  ← %d files:\n", target, len(grp))
+		for i := range grp {
+			f := grp[i]
+			fmt.Fprintf(&b, "      - [id %d] %s (%s, %s)\n", f.ID, f.Name, dashIfEmpty(f.Type), humanBytes(int64(f.SizeKB*1024)))
+		}
+	}
+	if groups == 0 {
+		return nil
+	}
+	return fmt.Errorf("refusing to download: %d set(s) of files would be written to the same path and silently overwrite each other:\n%s\nPick ONE with --file <id> (the numeric file id shown above), or download them separately to distinct paths (e.g. one at a time with --out <path>).", groups, strings.TrimRight(b.String(), "\n"))
 }
 
 // targetPath computes the on-disk destination for a file given the flags:

--- a/internal/cmd/download_collision_test.go
+++ b/internal/cmd/download_collision_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// collisionServer is a fake API whose download URLs are keyed by FILE ID (not by
+// name), so a version can expose two files that share a name yet serve DISTINCT
+// bytes — the exact shape of Flux Dev v691639 (fp16 + fp8 both named
+// flux_dev.safetensors). The shared newDLServer serves by name and can't model
+// that, so the collision + id-disambiguation tests use this.
+type collisionServer struct {
+	srv    *httptest.Server
+	dlHits int
+}
+
+func newCollisionServer(t *testing.T, versionID int, files []dlFile) *collisionServer {
+	t.Helper()
+	c := &collisionServer{}
+	var base string
+	byID := make(map[int]dlFile, len(files))
+	for _, f := range files {
+		byID[f.id] = f
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		var parts []string
+		for _, f := range files {
+			hashes := ""
+			if f.withSHA {
+				hashes = `,"hashes":{"SHA256":"` + sha256hex(f.body) + `"}`
+			}
+			parts = append(parts, fmt.Sprintf(
+				`{"id":%d,"name":%q,"type":%q,"sizeKB":%f,"primary":%t,"downloadUrl":"%s/dl/%d"%s}`,
+				f.id, f.name, f.typ, float64(len(f.body))/1024, f.primary, base, f.id, hashes))
+		}
+		fmt.Fprintf(w, `{"id":%d,"modelId":618692,"name":"v","baseModel":"Flux.1 D","model":{"name":"Flux","type":"Checkpoint"},"files":[%s]}`,
+			versionID, strings.Join(parts, ","))
+	})
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) {
+		c.dlHits++
+		idStr := r.URL.Path[strings.LastIndexByte(r.URL.Path, '/')+1:]
+		id, _ := strconv.Atoi(idStr)
+		if f, ok := byID[id]; ok {
+			_, _ = w.Write([]byte(f.body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	c.srv = httptest.NewServer(mux)
+	base = c.srv.URL
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func setupCollisionEnv(t *testing.T, c *collisionServer, token string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", token)
+	t.Setenv("CIVITAI_BASE_URL", c.srv.URL)
+	chdir(t, t.TempDir())
+}
+
+// sameName is the two-same-named-files fixture (fp16 + fp8, distinct ids/bytes).
+func sameNameFiles() []dlFile {
+	return []dlFile{
+		{id: 691640, name: "flux_dev.safetensors", typ: "Model", primary: true, body: "FP16-TWENTYTWO-GB-BODY", withSHA: true},
+		{id: 691641, name: "flux_dev.safetensors", typ: "Model", body: "FP8-SIXTEEN-GB-BODY", withSHA: true},
+	}
+}
+
+// TestDownloadAllSameNameCollisionErrorsNoClobber is the core data-loss repro:
+// --all on a version with two same-named files must FAIL before any transfer,
+// name both colliding files with their ids, and write NOTHING (no clobber).
+func TestDownloadAllSameNameCollisionErrorsNoClobber(t *testing.T) {
+	c := newCollisionServer(t, 691639, sameNameFiles())
+	setupCollisionEnv(t, c, "tok")
+	dir := t.TempDir()
+
+	_, _, err := run(t, "download", "691639", "--all", "--out-dir", dir)
+	if err == nil {
+		t.Fatal("expected a collision error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"same path", "691640", "691641", "--file"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("collision error should contain %q:\n%s", want, msg)
+		}
+	}
+	// Nothing was written and nothing was fetched — no silent overwrite happened.
+	if !dirIsEmpty(t, dir) {
+		t.Error("collision must write NOTHING to the out-dir (no clobber)")
+	}
+	if c.dlHits != 0 {
+		t.Errorf("collision must be detected before any transfer (dlHits=%d)", c.dlHits)
+	}
+}
+
+// TestDownloadDryRunSameNameCollisionErrors proves the guard fires in --dry-run
+// too (fail-safe before the plan), so a preview surfaces the unsafe plan.
+func TestDownloadDryRunSameNameCollisionErrors(t *testing.T) {
+	c := newCollisionServer(t, 691639, sameNameFiles())
+	setupCollisionEnv(t, c, "tok")
+	dir := t.TempDir()
+
+	_, _, err := run(t, "download", "691639", "--all", "--out-dir", dir, "--dry-run")
+	if err == nil || !strings.Contains(err.Error(), "same path") {
+		t.Fatalf("dry-run should also refuse a colliding plan, got %v", err)
+	}
+	if c.dlHits != 0 {
+		t.Errorf("dry-run collision must fetch nothing (dlHits=%d)", c.dlHits)
+	}
+}
+
+// TestDownloadLayoutSameNameCollisionErrors proves the guard also covers
+// --layout routing (two Model files route to the same checkpoints folder under
+// the same name → same target path).
+func TestDownloadLayoutSameNameCollisionErrors(t *testing.T) {
+	c := newCollisionServer(t, 691639, sameNameFiles())
+	setupCollisionEnv(t, c, "tok")
+	root := t.TempDir()
+
+	_, _, err := run(t, "download", "691639", "--all", "--layout", "comfyui", "--root", root)
+	if err == nil || !strings.Contains(err.Error(), "same path") {
+		t.Fatalf("--layout routing two same-named files into one folder should collide, got %v", err)
+	}
+	if c.dlHits != 0 {
+		t.Errorf("collision must be caught before transfer (dlHits=%d)", c.dlHits)
+	}
+}
+
+// TestDownloadFileByIDSelectsOneOfTwoSameNamed proves --file <id> downloads
+// EXACTLY the requested one of two same-named files, with the correct bytes.
+func TestDownloadFileByIDSelectsOneOfTwoSameNamed(t *testing.T) {
+	allowPrivateDownloadHostsInTest(t)
+	files := sameNameFiles()
+	for _, tc := range []struct {
+		id   int
+		body string
+	}{
+		{files[0].id, files[0].body},
+		{files[1].id, files[1].body},
+	} {
+		t.Run(strconv.Itoa(tc.id), func(t *testing.T) {
+			c := newCollisionServer(t, 691639, files)
+			setupCollisionEnv(t, c, "tok")
+			if _, _, err := run(t, "download", "691639", "--file", strconv.Itoa(tc.id)); err != nil {
+				t.Fatalf("--file %d: %v", tc.id, err)
+			}
+			got, rerr := os.ReadFile("flux_dev.safetensors")
+			if rerr != nil {
+				t.Fatalf("selected file not written: %v", rerr)
+			}
+			if string(got) != tc.body {
+				t.Errorf("--file %d downloaded wrong bytes: got %q, want %q", tc.id, got, tc.body)
+			}
+		})
+	}
+}
+
+// TestDownloadFileByNameAmbiguousWhenSameNamed proves that selecting the shared
+// NAME (rather than an id) no longer silently picks the first file — it errors
+// and points at --file <id>, listing both ids.
+func TestDownloadFileByNameAmbiguousWhenSameNamed(t *testing.T) {
+	c := newCollisionServer(t, 691639, sameNameFiles())
+	setupCollisionEnv(t, c, "tok")
+
+	_, _, err := run(t, "download", "691639", "--file", "flux_dev.safetensors")
+	if err == nil {
+		t.Fatal("selecting two same-named files by name should be ambiguous, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"share this name", "--file <id>", "691640", "691641"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ambiguous-name error should contain %q:\n%s", want, msg)
+		}
+	}
+	if c.dlHits != 0 {
+		t.Errorf("ambiguous selection must not fetch (dlHits=%d)", c.dlHits)
+	}
+	if _, e := os.Stat("flux_dev.safetensors"); e == nil {
+		t.Error("ambiguous selection must not write a file (no silent first-match download)")
+	}
+}
+
+// TestDownloadDistinctNameAllStillWorks proves the guard doesn't regress the
+// normal case: a version with DISTINCT-named files still downloads all of them.
+func TestDownloadDistinctNameAllStillWorks(t *testing.T) {
+	allowPrivateDownloadHostsInTest(t)
+	c := newCollisionServer(t, 128713, []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+		{id: 2, name: "vae.pt", typ: "VAE", body: "vae", withSHA: true},
+	})
+	setupCollisionEnv(t, c, "tok")
+	dir := t.TempDir()
+
+	if _, _, err := run(t, "download", "128713", "--all", "--out-dir", dir); err != nil {
+		t.Fatalf("distinct-name --all should still work: %v", err)
+	}
+	for name, want := range map[string]string{"model.safetensors": "weights", "vae.pt": "vae"} {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Errorf("--all should write %s: %v", name, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestDownloadDistinctNameDryRunShowsBothTargets proves --dry-run --all on
+// distinct-named files plans BOTH targets and transfers nothing (the guard is a
+// no-op here).
+func TestDownloadDistinctNameDryRunShowsBothTargets(t *testing.T) {
+	c := newCollisionServer(t, 128713, []dlFile{
+		{id: 1, name: "model.safetensors", typ: "Model", primary: true, body: "w", withSHA: true},
+		{id: 2, name: "vae.pt", typ: "VAE", body: "v", withSHA: true},
+	})
+	setupCollisionEnv(t, c, "tok")
+	dir := t.TempDir()
+
+	out, _, err := run(t, "download", "128713", "--all", "--out-dir", dir, "--dry-run")
+	if err != nil {
+		t.Fatalf("distinct-name dry-run --all: %v", err)
+	}
+	for _, name := range []string{"model.safetensors", "vae.pt"} {
+		if !strings.Contains(out, filepath.Join(dir, name)) {
+			t.Errorf("plan should show target for %s:\n%s", name, out)
+		}
+	}
+	if c.dlHits != 0 {
+		t.Errorf("dry-run must transfer nothing (dlHits=%d)", c.dlHits)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -174,21 +174,34 @@ func NewRootCmd() *cobra.Command {
 	colorViper := viper.New()
 	root := &cobra.Command{
 		Use:   "civitai",
-		Short: "Civitai CLI — author and ship Apps",
+		Short: "Civitai CLI — browse & download models, and build Apps",
 		Long: `civitai is the command-line interface for Civitai (https://civitai.com).
 
-Its first feature group is Apps authoring — Apps are small,
-sandboxed web apps that run inside Civitai surfaces. The CLI scaffolds a
-correct project, validates it against the platform contract, and packages it
-for submission, so you don't have to hand-format a ZIP.
+It does two things from one static binary:
+
+  • Browse & download the public catalog — search models, list images and
+    articles, and fetch model files. Reading is anonymous; downloading a
+    model file needs a token (civitai login). --layout routes each file into
+    the right folder for ComfyUI / A1111.
+  • Build & submit Apps — small, sandboxed web apps that run inside Civitai
+    surfaces. Scaffold a correct project, validate it against the platform
+    contract, and package it for submission.
 
 Get started:
 
+  # Browse & download
+  civitai models search --query "pony" --limit 5
+  civitai download 128713 --layout comfyui --root ~/ComfyUI
+
+  # Build an App
   civitai login                    store your API token
   civitai app create my-app        scaffold a ready-to-build App
-  civitai app validate             check the manifest before you submit
   civitai app submit               package + submit for review`,
-		Example: `  # First time: authenticate, then scaffold and submit an app.
+		Example: `  # Browse & download the public catalog (no account needed to read).
+  civitai models search --query "dreamshaper" --limit 5
+  civitai download 128713 --layout comfyui --root ~/ComfyUI
+
+  # Build & ship an App.
   civitai login
   civitai app create my-first-app
   cd my-first-app

--- a/internal/cmd/root_help_test.go
+++ b/internal/cmd/root_help_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRootHelpPresentsBothPaths proves the root command foregrounds BOTH the
+// browse/download path and the Apps path (dogfood: the README #138 now leads
+// with browse/download, but the binary's root help still presented the CLI as
+// Apps-only). Short + Long + Example must name both, and the browse examples
+// must use REAL subcommands.
+func TestRootHelpPresentsBothPaths(t *testing.T) {
+	cmd := NewRootCmd()
+	short := strings.ToLower(cmd.Short)
+	blob := cmd.Short + "\n" + cmd.Long + "\n" + cmd.Example
+	low := strings.ToLower(blob)
+
+	// Short must name both paths — browse/download AND Apps.
+	if !strings.Contains(short, "download") && !strings.Contains(short, "browse") {
+		t.Errorf("root Short should mention browse/download, got %q", cmd.Short)
+	}
+	if !strings.Contains(short, "app") {
+		t.Errorf("root Short should still mention Apps, got %q", cmd.Short)
+	}
+
+	// Long + Example must present both paths.
+	for _, want := range []string{"browse", "download", "app"} {
+		if !strings.Contains(low, want) {
+			t.Errorf("root help should mention %q:\n%s", want, blob)
+		}
+	}
+
+	// The browse/download examples must use REAL subcommand invocations.
+	for _, want := range []string{"civitai models search", "civitai download"} {
+		if !strings.Contains(blob, want) {
+			t.Errorf("root help should show a real browse/download example %q:\n%s", want, blob)
+		}
+	}
+	// …and still an app example.
+	if !strings.Contains(blob, "civitai app create") {
+		t.Errorf("root help should still show an app example (civitai app create):\n%s", blob)
+	}
+}
+
+// TestRootHelpExamplesResolveToRealCommands proves the commands named in the
+// root help (models search, download, app create) actually exist in the tree —
+// so the examples can't drift into naming a command that isn't wired up.
+func TestRootHelpExamplesResolveToRealCommands(t *testing.T) {
+	root := NewRootCmd()
+	cases := [][]string{
+		{"models", "search"},
+		{"download"},
+		{"app", "create"},
+	}
+	for _, path := range cases {
+		c, _, err := root.Find(path)
+		if err != nil {
+			t.Errorf("root help example command %v does not resolve: %v", path, err)
+			continue
+		}
+		if c.Name() != path[len(path)-1] {
+			t.Errorf("root help example %v resolved to %q, want %q", path, c.Name(), path[len(path)-1])
+		}
+	}
+}


### PR DESCRIPTION
Two dogfood-surfaced fixes to the `civitai` CLI, based directly on `main`.

## Fix 1 — root `--help` led with Apps only
README #138 now foregrounds browse/download, but the binary's root command still presented the CLI as Apps-only. Reworded `internal/cmd/root.go`:
- `Short`: `Civitai CLI — author and ship Apps` → **`Civitai CLI — browse & download models, and build Apps`**.
- `Long` / `Example`: now present **both paths** — (a) browse & download the public catalog (`civitai models search …`, `civitai download … --layout comfyui`), and (b) build & submit Apps (`civitai login` → `app create` → `app validate` → `app submit`). Examples use real subcommands/flags (verified against each command's `--help`).

## Fix 2 — `--all` silently overwrote same-name files (data loss)
Confirmed via Flux: model version **691639** ships two files BOTH named `flux_dev.safetensors` (fp16 22.2 GB + fp8 15.9 GB). `civitai download <id> --all` planned both to the same target path → the second silently clobbered the first, and `--file <name>` matched both (silently picking the first).

**Collision behavior chosen: fail-safe error (not auto-suffix).** Auto-suffixing changes the filename the loader expects; erroring is safer. `checkTargetCollisions()` runs when >1 file is selected (`--all`, or `--layout`/`--out-dir` routing several files), *before* any transfer **and** before the `--dry-run` plan. If two selected files resolve to the same on-disk path it errors, listing each colliding file with its numeric **id** + size, and tells the user to pick one with `--file <id>`. No download ever silently overwrites another.

**`--file` disambiguation mechanism: numeric file id.** `--file` now accepts a numeric **file id** (`files[].id`) as an alternative to a name — chosen over `--file-index` because the collision error and `--dry-run` plan already surface the ids, so the user copies the id straight from the message. Selecting the shared **name** is now ambiguous and errors (was: silently returned the first exact match), pointing at `--file <id>`. Distinct-name and single-file behavior is unchanged.

## Test coverage (table-driven, httptest, deterministic)
- `root_help_test.go`:
  - `TestRootHelpPresentsBothPaths` — `Short`/`Long`/`Example` mention browse/download AND Apps; browse examples use `civitai models search` + `civitai download`; still shows `civitai app create`.
  - `TestRootHelpExamplesResolveToRealCommands` — `models search`, `download`, `app create` resolve in the command tree.
- `download_collision_test.go` (dedicated id-serving httptest server so two same-named files serve distinct bytes):
  - `TestDownloadAllSameNameCollisionErrorsNoClobber` — `--all` errors before transfer, names both ids, out-dir empty, `dlHits==0` (real httptest interaction proving no clobber).
  - `TestDownloadDryRunSameNameCollisionErrors` — guard fires in `--dry-run` too, fetches nothing.
  - `TestDownloadLayoutSameNameCollisionErrors` — guard also covers `--layout` routing.
  - `TestDownloadFileByIDSelectsOneOfTwoSameNamed` (table: id1/id2) — `--file <id>` downloads exactly that file with correct bytes.
  - `TestDownloadFileByNameAmbiguousWhenSameNamed` — shared-name select errors (no silent first-match), lists both ids.
  - `TestDownloadDistinctNameAllStillWorks` — distinct-named `--all` still downloads all correctly.
  - `TestDownloadDistinctNameDryRunShowsBothTargets` — dry-run plans both distinct targets, transfers nothing.

`go build ./... && go vet ./... && go test -count=1 ./... && go test -race ./internal/cmd/... ./internal/api/...` all green; `gofmt -s -l .` clean. README + `--help` updated for the id disambiguation and collision behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)