### PR TITLE
fix(nix): update stale vendorHash + add flake-build CI guard

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,37 @@
+name: flake
+
+# Builds the Nix flake so a stale vendorHash (or a flake that no longer
+# evaluates/builds) fails CI instead of silently shipping a broken
+# `nix run github:civitai/cli`. vendorHash drifts whenever go.mod/go.sum change,
+# so this runs on those + the flake files. To fix a failure: set vendorHash to
+# lib.fakeHash in flake.nix, run `nix build`, and copy the `got:` value.
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+      - flake.nix
+      - flake.lock
+      - .github/workflows/flake.yml
+  push:
+    branches: [main]
+    paths:
+      - go.mod
+      - go.sum
+      - flake.nix
+      - flake.lock
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: nix build .#default (validates vendorHash + build)
+        run: nix build .#default
+      - name: run the built binary
+        run: ./result/bin/civitai version

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
           # Computed from go.sum (this module is not vendored). To recompute
           # after a go.mod/go.sum change: set this to `lib.fakeHash`, run
           # `nix build`, and copy the `got: sha256-…` value from the error.
-          vendorHash = "sha256-tOrwJxtpwKWfY4ACZYFilGWulS9UdHP58M2O5NgS09E=";
+          vendorHash = "sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=";
 
           # The module root is `package cli` (a library that embeds the schema);
           # the executable lives in ./cmd/civitai (package main). Build only it.


### PR DESCRIPTION
The pinned vendorHash was from v0.1.65; go.mod changed since (x/net/html added
in the htmlrender rewrite + security-PR dep bumps), so `nix build`/`nix run
github:civitai/cli` failed with a vendorHash mismatch from ~v0.1.67 on. Update
to the current go.sum's hash and add a flake CI job so it can't silently drift
again on the next go.mod change.
