### PR TITLE
fix(login): close --token stray-positional footgun; pin the arg matrix with tests

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -65,6 +65,14 @@ account with ` + "`civitai whoami`" + `.)`,
 		// pflag parse the space-separated form `login --token <value>` as a single
 		// positional arg. Accept exactly one positional ONLY when --token was given,
 		// to preserve that form; login otherwise takes no positional args.
+		//
+		// Combined with SetInterspersed(false) below, this is position-aware: a
+		// positional can ONLY be recovered as the token value when it FOLLOWS
+		// --token. A positional BEFORE --token (e.g. `login foo --token`) halts
+		// flag parsing, so --token is never marked Changed and this guard falls
+		// through to NoArgs, rejecting the stray positional — closing the footgun
+		// where `login foo --token` used to store `foo` as the token. See the
+		// SetInterspersed call for the full rationale.
 		Args: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("token") && len(args) <= 1 {
 				return nil
@@ -109,6 +117,30 @@ account with ` + "`civitai whoami`" + `.)`,
 	cmd.Flags().StringVar(&tokenFlag, "token", "", "store a personal API key instead of the browser device login (pass with no value to print where to create one)")
 	// Allow `civitai login --token` with no argument; the sentinel is detected in RunE.
 	cmd.Flags().Lookup("token").NoOptDefVal = tokenFlagNoValue
+	// Non-interspersed parsing makes the positional-recovery of the space form
+	// (`login --token <key>`) POSITION-AWARE, which closes the audit footgun.
+	//
+	// The problem: with NoOptDefVal set, `login --token <key>` and
+	// `login <stray> --token` are otherwise INDISTINGUISHABLE after parsing —
+	// both leave --token marked Changed with a single positional, so the stray
+	// value would be stored as the token (overwriting a good credential with
+	// garbage). NoOptDefVal is nonetheless required: it's what lets bare
+	// `--token` mean "print the mint deeplink" AND what stops pflag from
+	// swallowing a following flag as the value (so `login --token --bogus`
+	// correctly errors "unknown flag" instead of storing "--bogus").
+	//
+	// With interspersed=false, pflag stops treating tokens as flags at the FIRST
+	// positional. So a positional BEFORE --token (`login foo --token`) halts
+	// parsing: --token is left as a positional, never marked Changed, and the
+	// Args guard rejects the stray arg via NoArgs — nothing is stored. A
+	// positional AFTER --token (`login --token key`) still parses as the one
+	// allowed positional and is recovered as the value in RunE. This makes the
+	// whole matrix unambiguous WITHOUT scanning raw os.Args. (Trade-off: global
+	// flags must precede the space-form value, e.g. `login --no-color --token
+	// key`, not `login --token key --no-color`; the `--token=key` form has no
+	// such constraint. Combining --token with the device-only --no-browser is
+	// nonsensical anyway.)
+	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "do not attempt to open a browser for device login")
 	return cmd
 }

--- a/internal/cmd/login_token_deeplink_test.go
+++ b/internal/cmd/login_token_deeplink_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -79,5 +83,172 @@ func TestLoginTokenWithValueStillStores(t *testing.T) {
 	raw, _ := os.ReadFile(filepath.Join(dir, "civitai", "config.yaml"))
 	if !strings.Contains(string(raw), "abc123") {
 		t.Errorf("personal key should be persisted: %s", raw)
+	}
+}
+
+// TestLoginArgMatrix pins the FULL `login`/`--token` argument-handling contract
+// (one subtest per spec row), closing the audit footgun where a stray positional
+// before a bare `--token` (`login foo --token`) was stored as the token,
+// overwriting a good credential with garbage.
+//
+// The fix is structural: `--token` keeps NoOptDefVal (so bare `--token` prints
+// the mint deeplink and a following flag isn't swallowed as the value) and the
+// login command parses NON-interspersed, so a positional only binds as the token
+// value when it FOLLOWS `--token`. A positional before it halts flag parsing,
+// leaving `--token` unchanged so the NoArgs guard rejects the stray arg.
+//
+// Each row asserts: exit/err, whether a config was written (and its contents +
+// 0600 perms for the store rows), whether the OAuth device flow made a network
+// call, that the browser opener is never reached on a non-device row, and that
+// no token/stray value leaks to stdout/stderr or (for strays) into a config.
+func TestLoginArgMatrix(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+
+		wantErr      bool   // command should exit non-zero
+		wantConfig   bool   // a config file should exist afterward
+		wantStored   string // config must contain this token AND it must NOT be echoed to stdout
+		wantDeeplink bool   // stdout should print the mint deeplink + re-run guidance
+		wantDevice   bool   // the OAuth device flow must make a network call
+
+		// stray must never appear in stdout/stderr and must never be persisted to a
+		// config file (the garbage-credential footgun + secret-hygiene guard).
+		stray string
+	}{
+		// Row 1: `login` (bare) → device/browser flow (here the device-init fails
+		// fast so the flow errors deterministically without polling).
+		{name: "bare login runs device flow", args: []string{"login", "--no-browser"},
+			wantErr: true, wantDevice: true},
+		// Row 2: `login --token <key>` (space) → store.
+		{name: "space form stores the key", args: []string{"login", "--token", "key-space"},
+			wantConfig: true, wantStored: "key-space"},
+		// Row 3: `login --token=<key>` (equals) → store.
+		{name: "equals form stores the key", args: []string{"login", "--token=key-equals"},
+			wantConfig: true, wantStored: "key-equals"},
+		// Row 4: `login --token` (bare flag) → mint deeplink, no config, no network.
+		{name: "bare --token prints deeplink", args: []string{"login", "--token"},
+			wantDeeplink: true},
+		// Row 5: `login --token=` (empty equals) → mint deeplink.
+		{name: "empty equals prints deeplink", args: []string{"login", "--token="},
+			wantDeeplink: true},
+		// Row 6: `login foo` → stray positional rejected.
+		{name: "stray positional rejected", args: []string{"login", "foo"},
+			wantErr: true, stray: "foo"},
+		// Row 7 (FOOTGUN): `login foo --token` → MUST NOT store foo as the token.
+		// Chosen outcome: a clear error (the stray positional halts parsing, so
+		// --token is never set and NoArgs rejects the stray) — nothing is stored.
+		{name: "footgun stray positional then bare --token errors", args: []string{"login", "foo", "--token"},
+			wantErr: true, stray: "foo"},
+		// Row 8: `login foo --token bar` → stray positional, store nothing.
+		{name: "stray positional then --token value errors", args: []string{"login", "foo", "--token", "bar"},
+			wantErr: true, stray: "foo"},
+		// Row 9: `login --token bar foo` → stray positional after the value, error.
+		{name: "extra positional after value errors", args: []string{"login", "--token", "bar", "foo"},
+			wantErr: true, stray: "bar"},
+		// Row 10: `login --token a b` → two positionals, error.
+		{name: "two positionals error", args: []string{"login", "--token", "a", "b"},
+			wantErr: true, stray: "a"},
+		// Row 11: `login --token --someUnknownFlag` → unknown flag, NOT swallowed
+		// as the token value.
+		{name: "unknown flag not swallowed as value", args: []string{"login", "--token", "--someUnknownFlag"},
+			wantErr: true, stray: "--someUnknownFlag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			t.Setenv("CIVITAI_TOKEN", "")
+
+			// An OAuth server that records every hit and fails device-init fast, so
+			// the ONLY thing that reaches it is the actual device flow (row 1) — and
+			// even then without polling. Any hit on a token/deeplink/error row means
+			// the device flow was wrongly entered.
+			var hits int32
+			var base string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				if r.URL.Path == "/.well-known/openid-configuration" {
+					writeLoginDiscovery(w, base)
+					return
+				}
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid_client"})
+			}))
+			defer srv.Close()
+			base = srv.URL
+			t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+			// The browser opener must never be reached for a non-device row; on the
+			// device row device-init fails before any open, so it's never reached
+			// either. Any call is a bug.
+			prev := browserOpener
+			browserOpener = func(string) error {
+				t.Error("browser opener must not be called")
+				return nil
+			}
+			defer func() { browserOpener = prev }()
+
+			out, errOut, err := run(t, tt.args...)
+
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected a non-zero exit\nstdout:%s\nstderr:%s", out, errOut)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v\nstdout:%s\nstderr:%s", err, out, errOut)
+			}
+
+			cfgPath := filepath.Join(dir, "civitai", "config.yaml")
+			fi, statErr := os.Stat(cfgPath)
+			cfgExists := statErr == nil
+			if tt.wantConfig && !cfgExists {
+				t.Errorf("expected a config file at %s", cfgPath)
+			}
+			if !tt.wantConfig && cfgExists {
+				t.Errorf("no config should be written for %v", tt.args)
+			}
+
+			if tt.wantStored != "" {
+				raw, _ := os.ReadFile(cfgPath)
+				if !strings.Contains(string(raw), tt.wantStored) {
+					t.Errorf("config should persist the key %q: %s", tt.wantStored, raw)
+				}
+				// The credential file must be owner-only.
+				if cfgExists && fi.Mode().Perm() != 0o600 {
+					t.Errorf("config perms = %v, want 0600", fi.Mode().Perm())
+				}
+				// A stored credential must never be echoed back to the terminal.
+				if strings.Contains(out, tt.wantStored) || strings.Contains(errOut, tt.wantStored) {
+					t.Errorf("stored key %q must not be printed:\nstdout:%s\nstderr:%s", tt.wantStored, out, errOut)
+				}
+			}
+
+			if tt.wantDeeplink {
+				if !strings.Contains(out, accountAPIKeysURL) {
+					t.Errorf("expected the mint deeplink %q:\n%s", accountAPIKeysURL, out)
+				}
+				if !strings.Contains(out, "civitai login --token <key>") {
+					t.Errorf("expected re-run guidance:\n%s", out)
+				}
+			}
+
+			gotDevice := atomic.LoadInt32(&hits) > 0
+			if gotDevice != tt.wantDevice {
+				t.Errorf("device flow attempted = %v, want %v (hits=%d)", gotDevice, tt.wantDevice, atomic.LoadInt32(&hits))
+			}
+
+			if tt.stray != "" {
+				if strings.Contains(out, tt.stray) || strings.Contains(errOut, tt.stray) {
+					t.Errorf("stray value %q leaked to output:\nstdout:%s\nstderr:%s", tt.stray, out, errOut)
+				}
+				if cfgExists {
+					raw, _ := os.ReadFile(cfgPath)
+					if strings.Contains(string(raw), tt.stray) {
+						t.Errorf("stray value %q must never be persisted: %s", tt.stray, raw)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fast-follow to #144. Pins the `login` `--token` argument-handling contract with tests and closes a low-harm footgun the audit found.

## The footgun (closed)

`--token` used `NoOptDefVal` (so bare `--token` is valid → prints the mint deeplink) plus "recover the value from a positional when `--token` is set" logic for the space form `login --token <key>`. Because `NoOptDefVal` makes pflag treat the space-form value as a positional, `login foo --token` and `login --token foo` are **indistinguishable after parsing** — both leave `--token` marked `Changed` with a single positional. So `login foo --token` stored the stray `foo` as the token, **overwriting a valid credential with garbage**. The Args-rejection cases were also untested.

## Mechanism chosen: (B) position-aware — via `SetInterspersed(false)`

I kept the shipped structure (mechanism B, position-aware recovery) rather than redesigning to a plain string flag (A), because A **regresses** the `login --token --someUnknownFlag` row: a plain pflag string flag *swallows* the following `--someUnknownFlag` as the token value (verified empirically) instead of erroring "unknown flag". `NoOptDefVal` is what prevents that swallow and what makes bare `--token` mean "print the deeplink" — so it has to stay.

Rather than scan raw `os.Args` for order (fragile, and `os.Args` doesn't reflect cobra's `SetArgs` in tests), I made recovery position-aware with **one structural line**: `cmd.Flags().SetInterspersed(false)`. Non-interspersed parsing stops treating tokens as flags at the first positional:

- positional **after** `--token` (`login --token key`) → parses as the one allowed positional → recovered as the value.
- positional **before** `--token` (`login foo --token`) → halts flag parsing, so `--token` is never marked `Changed`; the existing `NoArgs` guard rejects the stray arg → **nothing stored**.

No raw-arg scanning, and every currently-working row is preserved (including the real "unknown flag" error). Trade-off: global flags must precede the space-form value (`login --no-color --token key`, not `login --token key --no-color`); the `--token=key` form has no such constraint, and combining `--token` with the device-only `--no-browser` is nonsensical anyway.

## `login foo --token` outcome

**Clear error** (`unknown command "foo" for "civitai login"`, rc 1), nothing stored. The stray positional halts parsing so `--token` is never set and `NoArgs` rejects the stray.

## Behavior matrix now pinned by `TestLoginArgMatrix` (one subtest per row)

| Invocation | Result | Pinned |
|---|---|---|
| `login` (bare) | device/browser flow | yes |
| `login --token <key>` | store (0600), rc 0 | yes |
| `login --token=<key>` | store, rc 0 | yes |
| `login --token` | mint deeplink, no config, no network, rc 0 | yes |
| `login --token=` | mint deeplink, rc 0 | yes |
| `login foo` | error, store nothing | yes |
| `login foo --token` (**footgun**) | **error, `foo` NOT stored** | yes |
| `login foo --token bar` | error, store nothing | yes |
| `login --token bar foo` | error, store nothing | yes |
| `login --token a b` | error, store nothing | yes |
| `login --token --someUnknownFlag` | **error unknown flag** (not swallowed) | yes |

Each subtest asserts: exit/err, config presence + contents + **0600 perms** (store rows), whether the OAuth device flow made a network call, that the browser opener is never reached on non-device rows, and that no token/stray value leaks to stdout/stderr or into a config (explicitly incl. the footgun row not persisting `foo`).

## Gates

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./internal/cmd/...` all green; `gofmt -s -l .` clean. Built binary spot-checked on the footgun (error, no config), bare `--token` (deeplink, rc 0), `--token=`/space store (0600, key persisted), unknown-flag (rc 1, not swallowed), and stray positional (rc 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
