### PR TITLE
feat(images): add --base-model (+ --type/--tags) to `images search`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ also takes `--json` to print the **raw API JSON response** for scripting.
 | `civitai model-versions get <id>` | Get a model version by id (alias `mv`) | `--json`, `--anon` |
 | `civitai model-versions by-hash <hash>` | Look up a model version by file hash (AutoV2, SHA256, …) | `--json`, `--anon` |
 | `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--layout`, `--root`, `--for-base`, `--no-verify`, `--force`, `--anon` |
-| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
+| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--base-model` (repeatable), `--type` (image/video/audio), `--tags` (tag ids), `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
 | `civitai tags search` | Search model tags | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai creators search` | Search creators | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai users get <username-or-id>` | Look up a user via public search (a number = exact id; a name = exact-username match, else it lists close matches) | `--json`, `--anon` |
@@ -355,11 +355,15 @@ civitai images search --model-id 4384 --sort "Most Reactions" --json   # raw JSO
 **Filtering by base model.** `--base-model` is repeatable and maps to the REST
 `baseModels` filter (an OR across the values). It's the key discovery filter for
 things `--type` can't separate — e.g. video checkpoints all share
-`--type Checkpoint` and are distinguished only by base model:
+`--type Checkpoint` and are distinguished only by base model. It works on both
+`models search` and `images search`:
 
 ```bash
 civitai models search --type Checkpoint --base-model "Wan Video 2.2 T2V-A14B"
 civitai models search --base-model Pony --base-model Illustrious --limit 20
+# images too — find recent-popular images generated with a given base model:
+civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
+civitai images search --type video --sort "Most Reactions"   # videos only
 ```
 
 **Non-weights file marker.** In the human (non-`--json`) output of

--- a/internal/cmd/base_model_marker_test.go
+++ b/internal/cmd/base_model_marker_test.go
@@ -39,6 +39,63 @@ func TestModelsSearchBaseModelSingle(t *testing.T) {
 	}
 }
 
+// TestImagesSearchBaseModelRepeatedEncoding proves `images search --base-model`
+// is repeatable and encodes as repeated `baseModels=` query keys — the same
+// array form the /api/v1/images zod string|string[] union OR-combines.
+func TestImagesSearchBaseModelRepeatedEncoding(t *testing.T) {
+	var got []string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/images" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		got = r.URL.Query()["baseModels"]
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "images", "search", "--base-model", "Krea 2", "--base-model", "Flux.1 D"); err != nil {
+		t.Fatalf("images search --base-model: %v", err)
+	}
+	if len(got) != 2 || got[0] != "Krea 2" || got[1] != "Flux.1 D" {
+		t.Errorf("baseModels query = %v, want [Krea 2, Flux.1 D] as repeated keys", got)
+	}
+}
+
+// TestImagesSearchBaseModelSingle asserts a single spaced base model round-trips
+// intact as one `baseModels=` key.
+func TestImagesSearchBaseModelSingle(t *testing.T) {
+	var got []string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()["baseModels"]
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "images", "search", "--base-model", "Krea 2"); err != nil {
+		t.Fatalf("images search --base-model: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Krea 2" {
+		t.Errorf("baseModels = %v, want the single spaced value", got)
+	}
+}
+
+// TestImagesSearchTypeAndTagsWiring proves the confirmed --type (image|video|
+// audio enum) and --tags (comma-separated tag ids) filters map to the `type`
+// and `tags` query params.
+func TestImagesSearchTypeAndTagsWiring(t *testing.T) {
+	var gotType, gotTags string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotType = r.URL.Query().Get("type")
+		gotTags = r.URL.Query().Get("tags")
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "images", "search", "--type", "video", "--tags", "4,111"); err != nil {
+		t.Fatalf("images search --type --tags: %v", err)
+	}
+	if gotType != "video" {
+		t.Errorf("type query = %q, want video", gotType)
+	}
+	if gotTags != "4,111" {
+		t.Errorf("tags query = %q, want 4,111", gotTags)
+	}
+}
+
 // TestModelVersionGetMarksNonWeightsType asserts the informational marker renders
 // the ACTUAL file type in the human `model-versions get` output when the primary
 // file is not weights — here an Archive (e.g. a "Workflows" model), tagged

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -20,7 +20,8 @@ func newImagesCmd() *cobra.Command {
 		Long: `Read-only access to Civitai images via the public REST API
 (GET /api/v1/images). Works anonymously.`,
 		Example: `  civitai images search --limit 5
-  civitai images search --model-id 4384 --sort "Most Reactions"`,
+  civitai images search --model-id 4384 --sort "Most Reactions"
+  civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week`,
 	}
 	cmd.AddCommand(newImagesSearchCmd())
 	return cmd
@@ -28,7 +29,8 @@ func newImagesCmd() *cobra.Command {
 
 func newImagesSearchCmd() *cobra.Command {
 	var (
-		username, sort, period, cursor               string
+		username, sort, period, cursor, typ, tags    string
+		baseModels                                   []string
 		postID, modelID, modelVersionID, limit, page int
 		nsfw                                         bool
 	)
@@ -41,6 +43,8 @@ Pagination: use --page for shallow paging or --cursor for deep paging (the API
 caps page*limit at 1000). The next cursor is printed after the results.`,
 		Example: `  civitai images search --limit 5
   civitai images search --model-version-id 128713 --sort Newest
+  civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
+  civitai images search --type video --sort "Most Reactions"
   civitai images search --username some-user --cursor <cursor>`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,9 +54,19 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			o := readFlags(cmd)
 			q := url.Values{}
 			addIfSet(q, "username", username)
+			addIfSet(q, "type", typ)  // image | video | audio
+			addIfSet(q, "tags", tags) // comma-delimited tag ids
 			addIfSet(q, "sort", sort)
 			addIfSet(q, "period", period)
 			addIfSet(q, "cursor", cursor)
+			// baseModels is a repeatable filter → repeated `baseModels=` query
+			// keys, which the API's zod union (string | string[]) parses as an
+			// array (baseModel IN (...), i.e. OR across the given values).
+			for _, bm := range baseModels {
+				if bm != "" {
+					q.Add("baseModels", bm)
+				}
+			}
 			addIfPositive(q, "postId", postID)
 			addIfPositive(q, "modelId", modelID)
 			addIfPositive(q, "modelVersionId", modelVersionID)
@@ -85,6 +99,9 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().IntVar(&modelID, "model-id", 0, "filter by model id")
 	cmd.Flags().IntVar(&modelVersionID, "model-version-id", 0, "filter by model version id")
 	cmd.Flags().StringVar(&username, "username", "", "filter by uploader username")
+	cmd.Flags().StringSliceVar(&baseModels, "base-model", nil, "filter by base model; repeatable (e.g. --base-model \"Krea 2\" --base-model Flux). The API OR-combines the given values")
+	cmd.Flags().StringVar(&typ, "type", "", "filter by media type (image, video, audio)")
+	cmd.Flags().StringVar(&tags, "tags", "", "filter by tag ids (comma-separated, e.g. 4,111)")
 	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (\"Most Reactions\", \"Most Comments\", Newest)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")


### PR DESCRIPTION
## Gap

`GET /api/v1/images` respects a `baseModels` query param — `?baseModels=Krea%202&sort=Most%20Reactions&period=Week` returns recent-popular Krea2 images, and a nonsense value returns a `ZodError` — but `civitai images search` exposed **no** base-model filter (its flags were `--sort/--period/--limit/--page/--cursor/--nsfw/--post-id/--model-id/--model-version-id/--username`). This mirrors the `--base-model` flag already on `models search`.

## Change

Added to `images search` (all mapped through the existing `url.Values` passthrough to `SearchImages`):

| Flag | Query param | Notes |
|---|---|---|
| `--base-model` (repeatable, `StringSliceVar`) | `baseModels` (repeated keys) | Exactly mirrors `models search --base-model`; API OR-combines the values |
| `--type` | `type` | Strict API enum `image`/`video`/`audio` |
| `--tags` | `tags` | Comma-separated tag ids (mirrors `articles search --tags`) |

All three were **empirically confirmed** against the live API before being added (nonsense value → `ZodError`/0 items; real value filters).

## Audit — other read search commands × `baseModels` support

Each endpoint was probed with a nonsense `baseModels` value (full results ⇒ ignored; error/0 ⇒ respected):

| Endpoint | `baseModels` supported? | Confirmed how | Action |
|---|---|---|---|
| `/api/v1/models` | yes | (already exposed) | — (pre-existing `--base-model`) |
| `/api/v1/images` | **yes** | nonsense → `ZodError` listing valid enum; `Krea 2` → filtered results | **added `--base-model`** |
| `/api/v1/tags` | no | nonsense → full 5 results (ignored) | none |
| `/api/v1/creators` | no | nonsense → full 5 results (ignored) | none |
| `/api/v1/articles` | no | nonsense → full 5 results (ignored) | none |
| `/api/v1/collections` | no | nonsense → full 5 results (ignored) | none |

Additional high-value filters the `images` CLI omitted (also confirmed respected):

| Param | Confirmed how | Action |
|---|---|---|
| `type` | nonsense → `ZodError` (enum image/video/audio); `type=video` → all-video results | **added `--type`** |
| `tags` | nonsense id `999999999` → 0 items; real id `4` → results (a name errors "expected number") | **added `--tags`** |

## Tests

- `TestImagesSearchBaseModelRepeatedEncoding` — `--base-model A --base-model B` → both `baseModels=` keys present.
- `TestImagesSearchBaseModelSingle` — a single spaced value (`Krea 2`) round-trips as one key.
- `TestImagesSearchTypeAndTagsWiring` — `--type`/`--tags` map to the `type`/`tags` query params.

All assert against the captured `r.URL.Query()` via the existing httptest read-server harness.

## Gates

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./internal/cmd/... ./internal/api/...`, `gofmt -s -l .` — all clean. README + `--help`/examples updated.

Built-binary spot-check: `civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week --limit 5` returns 5 Krea2 images; a nonsense `--base-model` surfaces the API `ZodError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)