### PR TITLE
fix(images): polish images search — drop unusable --tags, add BASE MODEL column, warn on --model-id+--sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ also takes `--json` to print the **raw API JSON response** for scripting.
 | `civitai model-versions get <id>` | Get a model version by id (alias `mv`) | `--json`, `--anon` |
 | `civitai model-versions by-hash <hash>` | Look up a model version by file hash (AutoV2, SHA256, …) | `--json`, `--anon` |
 | `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--layout`, `--root`, `--for-base`, `--no-verify`, `--force`, `--anon` |
-| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--base-model` (repeatable), `--type` (image/video/audio), `--tags` (tag ids), `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
+| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--base-model` (repeatable), `--type` (image/video/audio), `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
 | `civitai tags search` | Search model tags | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai creators search` | Search creators | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai users get <username-or-id>` | Look up a user via public search (a number = exact id; a name = exact-username match, else it lists close matches) | `--json`, `--anon` |
@@ -365,6 +365,16 @@ civitai models search --base-model Pony --base-model Illustrious --limit 20
 civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
 civitai images search --type video --sort "Most Reactions"   # videos only
 ```
+
+The human table includes a `BASE MODEL` column (the base model each image was
+generated with, when the API reports one; `-` when it doesn't), so you can see
+the ecosystem at a glance without dropping to `--json`.
+
+**`--sort` is ignored with `--model-id`.** The REST API returns images for a
+given `modelId` in its own default order regardless of `sort`, so
+`images search --model-id <id> --sort …` prints a one-line note on stderr and the
+results are NOT re-sorted. (`--model-version-id` is unaffected — it honours
+`--sort`.)
 
 **Non-weights file marker.** In the human (non-`--json`) output of
 `models get` and `model-versions get`, a version whose **primary file is not

--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -25,6 +25,7 @@ type ImageItem struct {
 	Type      string     `json:"type"`
 	PostID    *int       `json:"postId"`
 	Username  string     `json:"username"`
+	BaseModel string     `json:"baseModel"`
 	Stats     ImageStats `json:"stats"`
 }
 

--- a/internal/cmd/base_model_marker_test.go
+++ b/internal/cmd/base_model_marker_test.go
@@ -75,24 +75,28 @@ func TestImagesSearchBaseModelSingle(t *testing.T) {
 	}
 }
 
-// TestImagesSearchTypeAndTagsWiring proves the confirmed --type (image|video|
-// audio enum) and --tags (comma-separated tag ids) filters map to the `type`
-// and `tags` query params.
-func TestImagesSearchTypeAndTagsWiring(t *testing.T) {
-	var gotType, gotTags string
+// TestImagesSearchTypeWiring proves the confirmed --type (image|video|audio
+// enum) filter maps to the `type` query param.
+func TestImagesSearchTypeWiring(t *testing.T) {
+	var gotType string
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotType = r.URL.Query().Get("type")
-		gotTags = r.URL.Query().Get("tags")
 		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
 	})
-	if _, _, err := run(t, "images", "search", "--type", "video", "--tags", "4,111"); err != nil {
-		t.Fatalf("images search --type --tags: %v", err)
+	if _, _, err := run(t, "images", "search", "--type", "video"); err != nil {
+		t.Fatalf("images search --type: %v", err)
 	}
 	if gotType != "video" {
 		t.Errorf("type query = %q, want video", gotType)
 	}
-	if gotTags != "4,111" {
-		t.Errorf("tags query = %q, want 4,111", gotTags)
+}
+
+// TestImagesSearchNoTagsFlag guards that the unusable --tags flag (needed
+// numeric tag ids the /api/v1/tags endpoint can't surface) is gone: it must be
+// unknown, and no `tags` query param is ever sent.
+func TestImagesSearchNoTagsFlag(t *testing.T) {
+	if _, _, err := run(t, "images", "search", "--tags", "4,111"); err == nil {
+		t.Fatal("--tags should be removed (unknown flag), got no error")
 	}
 }
 

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -29,7 +29,7 @@ func newImagesCmd() *cobra.Command {
 
 func newImagesSearchCmd() *cobra.Command {
 	var (
-		username, sort, period, cursor, typ, tags    string
+		username, sort, period, cursor, typ          string
 		baseModels                                   []string
 		postID, modelID, modelVersionID, limit, page int
 		nsfw                                         bool
@@ -51,11 +51,18 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			if err := checkLimit(limit, imagesLimitMax); err != nil {
 				return err
 			}
+			// The API silently ignores `sort` when `modelId` is set (results come
+			// back in the API's default order regardless), so warn rather than
+			// let the user believe their --sort took effect. Note: --model-version-id
+			// does NOT share this quirk — it honours --sort — so it's excluded here.
+			if cmd.Flags().Changed("model-id") && cmd.Flags().Changed("sort") {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"note: the API ignores --sort when --model-id is set; results are returned in the API's default order.")
+			}
 			o := readFlags(cmd)
 			q := url.Values{}
 			addIfSet(q, "username", username)
-			addIfSet(q, "type", typ)  // image | video | audio
-			addIfSet(q, "tags", tags) // comma-delimited tag ids
+			addIfSet(q, "type", typ) // image | video | audio
 			addIfSet(q, "sort", sort)
 			addIfSet(q, "period", period)
 			addIfSet(q, "cursor", cursor)
@@ -101,7 +108,6 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().StringVar(&username, "username", "", "filter by uploader username")
 	cmd.Flags().StringSliceVar(&baseModels, "base-model", nil, "filter by base model; repeatable (e.g. --base-model \"Krea 2\" --base-model Flux). The API OR-combines the given values")
 	cmd.Flags().StringVar(&typ, "type", "", "filter by media type (image, video, audio)")
-	cmd.Flags().StringVar(&tags, "tags", "", "filter by tag ids (comma-separated, e.g. 4,111)")
 	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (\"Most Reactions\", \"Most Comments\", Newest)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
@@ -116,10 +122,11 @@ func printImageList(cmd *cobra.Command, items []api.ImageItem) {
 		return
 	}
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tUPLOADER\tSIZE\tNSFW\tHEARTS\tCOMMENTS\tURL")
+	fmt.Fprintln(tw, "ID\tUPLOADER\tBASE MODEL\tSIZE\tNSFW\tHEARTS\tCOMMENTS\tURL")
 	for _, im := range items {
-		fmt.Fprintf(tw, "%d\t%s\t%dx%d\t%s\t%d\t%d\t%s\n",
-			im.ID, orDash(safeTerm(im.Username)), im.Width, im.Height, orDash(safeTerm(im.NSFWLevel)),
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%dx%d\t%s\t%d\t%d\t%s\n",
+			im.ID, orDash(safeTerm(im.Username)), orDash(truncate(safeTerm(im.BaseModel), 24)),
+			im.Width, im.Height, orDash(safeTerm(im.NSFWLevel)),
 			im.Stats.HeartCount, im.Stats.CommentCount, safeTerm(im.URL))
 	}
 	_ = tw.Flush()

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -158,6 +158,141 @@ func TestUsersGetNoExactMatchErrors(t *testing.T) {
 	}
 }
 
+// TestImagesSearchBaseModelColumn asserts the human table surfaces a BASE MODEL
+// column, populated from the API's per-image `baseModel` string, with an empty
+// value rendered as `-`.
+func TestImagesSearchBaseModelColumn(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":10,"height":20,"nsfwLevel":"None","username":"alice","baseModel":"Krea 2","stats":{}},
+		  {"id":2,"url":"https://img/2","width":30,"height":40,"nsfwLevel":"None","username":"bob","baseModel":"","stats":{}}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "search")
+	if err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if !strings.Contains(out, "BASE MODEL") {
+		t.Errorf("table should have a BASE MODEL header: %s", out)
+	}
+	if !strings.Contains(out, "Krea 2") {
+		t.Errorf("populated baseModel should render: %s", out)
+	}
+	// The empty-baseModel row (id 2) must show a dash for its base model.
+	var id2Line string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "2 ") {
+			id2Line = line
+		}
+	}
+	if id2Line == "" {
+		t.Fatalf("could not find the id-2 row: %s", out)
+	}
+	if !strings.Contains(id2Line, "-") {
+		t.Errorf("empty baseModel should render as '-': %q", id2Line)
+	}
+}
+
+// TestImagesSearchBaseModelSanitized asserts a server-controlled baseModel with
+// terminal control characters is routed through safeTerm before printing.
+func TestImagesSearchBaseModelSanitized(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// A real ANSI escape (ESC 0x1b, JSON-escaped) in a server string; safeTerm strips it.
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":10,"height":20,"nsfwLevel":"None","username":"alice","baseModel":"Krea\u001b[31m2","stats":{}}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "search")
+	if err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("baseModel escape byte should be stripped by safeTerm: %q", out)
+	}
+	// The visible text survives (only the ESC control byte is removed).
+	if !strings.Contains(out, "Krea") || !strings.Contains(out, "[31m2") {
+		t.Errorf("printable baseModel text should survive sanitizing: %q", out)
+	}
+}
+
+// TestImagesSearchJSONUnchangedByBaseModel asserts --json stays a raw
+// passthrough — the baseModel column rendering must not touch machine output.
+func TestImagesSearchJSONUnchangedByBaseModel(t *testing.T) {
+	const raw = `{"items":[{"id":1,"baseModel":"Krea 2","url":"u"}],"metadata":{}}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(raw))
+	})
+	out, _, err := run(t, "images", "search", "--json")
+	if err != nil {
+		t.Fatalf("images search --json: %v", err)
+	}
+	if strings.Contains(out, "BASE MODEL") {
+		t.Errorf("--json must not carry the human table header: %s", out)
+	}
+	if !strings.Contains(out, `"baseModel"`) {
+		t.Errorf("--json should pass the raw body through: %s", out)
+	}
+}
+
+// TestImagesSearchModelIDSortWarns asserts that combining --model-id with --sort
+// prints the "ignored sort" note on STDERR (not stdout, so --json/stdout stay
+// clean), while --model-id alone and --sort alone stay silent.
+func TestImagesSearchModelIDSortWarns(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	}
+	const wantNote = "the API ignores --sort when --model-id is set"
+
+	// Both set → note on stderr, nothing on stdout.
+	setupReadServer(t, handler)
+	stdout, stderr, err := run(t, "images", "search", "--model-id", "123", "--sort", "Most Reactions")
+	if err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if !strings.Contains(stderr, wantNote) {
+		t.Errorf("expected the sort-ignored note on stderr, got: %q", stderr)
+	}
+	if strings.Contains(stdout, wantNote) {
+		t.Errorf("the note must not pollute stdout: %q", stdout)
+	}
+
+	// --model-id alone → no note.
+	setupReadServer(t, handler)
+	if _, stderr, err := run(t, "images", "search", "--model-id", "123"); err != nil {
+		t.Fatalf("images search --model-id: %v", err)
+	} else if strings.Contains(stderr, wantNote) {
+		t.Errorf("--model-id alone must not warn: %q", stderr)
+	}
+
+	// --sort alone → no note.
+	setupReadServer(t, handler)
+	if _, stderr, err := run(t, "images", "search", "--sort", "Most Reactions"); err != nil {
+		t.Fatalf("images search --sort: %v", err)
+	} else if strings.Contains(stderr, wantNote) {
+		t.Errorf("--sort alone must not warn: %q", stderr)
+	}
+
+	// --model-version-id + --sort → no note (that combo honours sort).
+	setupReadServer(t, handler)
+	if _, stderr, err := run(t, "images", "search", "--model-version-id", "128713", "--sort", "Most Reactions"); err != nil {
+		t.Fatalf("images search --model-version-id --sort: %v", err)
+	} else if strings.Contains(stderr, wantNote) {
+		t.Errorf("--model-version-id honours --sort; must not warn: %q", stderr)
+	}
+}
+
+// TestRootHelpMentionsImagesSearch guards Fix 4: the top-level help's examples
+// surface image browsing as first-class.
+func TestRootHelpMentionsImagesSearch(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help: %v", err)
+	}
+	if !strings.Contains(out, "images search") {
+		t.Errorf("root help should include an `images search` example: %s", out)
+	}
+}
+
 func TestTagsSearchWiring(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/tags" {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -191,6 +191,7 @@ Get started:
 
   # Browse & download
   civitai models search --query "pony" --limit 5
+  civitai images search --sort "Most Reactions" --period Week
   civitai download 128713 --layout comfyui --root ~/ComfyUI
 
   # Build an App
@@ -199,6 +200,7 @@ Get started:
   civitai app submit               package + submit for review`,
 		Example: `  # Browse & download the public catalog (no account needed to read).
   civitai models search --query "dreamshaper" --limit 5
+  civitai images search --sort "Most Reactions" --period Week
   civitai download 128713 --layout comfyui --root ~/ComfyUI
 
   # Build & ship an App.


### PR DESCRIPTION
Four small `images search` / help-polish fixes surfaced by a blind dogfood.

### 1. Remove the unusable `--tags` flag
`--tags` (added in #146) takes numeric tag *ids*, but the only tag-discovery endpoint (`/api/v1/tags`) returns just `{name, link}` — no id — so there is no CLI-discoverable way to produce a valid value. Removed the flag, its `tags` query-param mapping, and its README/`--help` mention. `--base-model` and `--type` (both usable) stay.

### 2. Add a `BASE MODEL` column to the table
The API returns a `baseModel` string per image (~72% populated). Surfaced it in the human table so users see the ecosystem without dropping to `--json`. Routed through `safeTerm` (server-controlled string), truncated at 24 chars, empty → `-`. `--json` output is byte-unchanged (raw passthrough).

### 3. Warn when `--model-id` and `--sort` are both set
`GET /api/v1/images?modelId=X` **ignores `sort`** (verified live: Most Reactions vs Newest return identical order), so `--model-id X --sort "Most Reactions"` silently returns unsorted results. Now prints a one-line **stderr** note (non-blocking, doesn't corrupt `--json`/stdout). Verified `--model-version-id` does **not** share the quirk (it honours `sort`), so it's excluded from the condition.

### 4. Add an image example to the top-level `--help`
The root "Get started" / Example was model/app-centric. Added `civitai images search --sort "Most Reactions" --period Week` so image browsing reads as first-class.

### Testing
- `--tags` removed → unknown-flag guard test; `--type` wiring kept in its own test.
- BASE MODEL column: populated value renders, empty → `-`, control-char `baseModel` sanitized (safeTerm), `--json` unchanged.
- `--model-id`+`--sort` → note on stderr; `--model-id` alone / `--sort` alone / `--model-version-id`+`--sort` → no note.
- Root `--help` mentions `images search`.

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./internal/cmd/... ./internal/api/...`, and `gofmt -s -l .` all clean. Built the binary and spot-checked against the live API: BASE MODEL column visible, warning fires on `--model-id`+`--sort`, no `--tags` in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)