### PR TITLE
feat(images): add opt-in --meta flag to `images search`

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ also takes `--json` to print the **raw API JSON response** for scripting.
 | `civitai model-versions get <id>` | Get a model version by id (alias `mv`) | `--json`, `--anon` |
 | `civitai model-versions by-hash <hash>` | Look up a model version by file hash (AutoV2, SHA256, …) | `--json`, `--anon` |
 | `civitai download <version-id>` | Download a model version's file(s) | `--model`, `--file`, `--all`, `--out`, `--out-dir`, `--layout`, `--root`, `--for-base`, `--no-verify`, `--force`, `--anon` |
-| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--base-model` (repeatable), `--type` (image/video/audio), `--sort`, `--period`, `--nsfw`; paging `--limit` (≤200), `--page`, `--cursor` |
+| `civitai images search` | Search images (`GET /api/v1/images`) | `--model-id`, `--model-version-id`, `--post-id`, `--username`, `--base-model` (repeatable), `--type` (image/video/audio), `--sort`, `--period`, `--nsfw`, `--meta` (include generation metadata); paging `--limit` (≤200), `--page`, `--cursor` |
 | `civitai tags search` | Search model tags | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai creators search` | Search creators | `--query`; paging `--limit` (≤200), `--page` |
 | `civitai users get <username-or-id>` | Look up a user via public search (a number = exact id; a name = exact-username match, else it lists close matches) | `--json`, `--anon` |
@@ -364,6 +364,19 @@ civitai models search --base-model Pony --base-model Illustrious --limit 20
 # images too — find recent-popular images generated with a given base model:
 civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
 civitai images search --type video --sort "Most Reactions"   # videos only
+```
+
+**Generation metadata (`--meta`).** By default the image list is a compact table
+without generation data (matching the API, which omits `meta` unless asked). Add
+`--meta` to include each image's prompt, sampler, cfg, steps, seed, and model —
+rendered as an indented detail block per image (the table can't hold a prompt).
+Images whose uploader chose to hide their generation data show
+`meta: (hidden by uploader)`. With `--json`, `--meta` adds the raw `meta` object
+to each item.
+
+```bash
+civitai images search --nsfw --sort "Most Reactions" --period Month --meta
+civitai images search --model-version-id 128713 --meta --json | jq '.items[].meta'
 ```
 
 The human table includes a `BASE MODEL` column (the base model each image was

--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/url"
+	"strings"
 )
 
 // ImageStats is the reaction/comment stats block on an image item.
@@ -17,41 +19,101 @@ type ImageStats struct {
 
 // ImageMeta is the generation metadata attached to an image when it is requested
 // with `withMeta=true` (and `flatMeta=true`, which forces the flat shape on every
-// query route so this can be parsed uniformly). It is nil on the item when the
-// API returns `meta: null` — either because meta was not requested or because the
-// uploader chose to hide their generation data.
+// query route so this can be parsed uniformly).
 //
-// Numeric fields use json.Number because the API values are attacker-influenced
-// and can be large or float (seeds routinely exceed int32, e.g.
-// 557589798350441; cfgScale is a float) — a tolerant type keeps a surprising
-// value from failing the whole parse.
+// The numeric-ish fields (cfgScale/steps/seed) are json.RawMessage rather than a
+// concrete number: the values are generator-supplied and freeform — a seed can
+// exceed int32 (e.g. 557589798350441), cfgScale can be a float, and a field can
+// occasionally arrive as an empty string, a non-numeric string, a bool, or an
+// array. Capturing the raw bytes means one surprising field can never fail the
+// decode; render them with CfgScaleString/StepsString/SeedString.
 type ImageMeta struct {
-	Prompt         string      `json:"prompt"`
-	NegativePrompt string      `json:"negativePrompt"`
-	Sampler        string      `json:"sampler"`
-	CfgScale       json.Number `json:"cfgScale"`
-	Steps          json.Number `json:"steps"`
-	Seed           json.Number `json:"seed"`
-	Model          string      `json:"Model"` // capitalized in the API payload
+	Prompt         string          `json:"prompt"`
+	NegativePrompt string          `json:"negativePrompt"`
+	Sampler        string          `json:"sampler"`
+	CfgScale       json.RawMessage `json:"cfgScale"`
+	Steps          json.RawMessage `json:"steps"`
+	Seed           json.RawMessage `json:"seed"`
+	Model          string          `json:"Model"` // capitalized in the API payload
 }
 
+// CfgScaleString renders the cfgScale for display (empty when absent).
+func (m ImageMeta) CfgScaleString() string { return numString(m.CfgScale) }
+
+// StepsString renders the steps for display (empty when absent).
+func (m ImageMeta) StepsString() string { return numString(m.Steps) }
+
+// SeedString renders the seed for display (empty when absent).
+func (m ImageMeta) SeedString() string { return numString(m.Seed) }
+
+// numString renders a numeric-ish raw JSON value for display: an absent/null
+// value → "", a JSON string ("123" / "unknown") is unwrapped, and any other JSON
+// literal (number, bool, array) is printed verbatim. It never fails and never
+// emits control bytes from a number literal, but callers still route the result
+// through safeTerm defensively.
+func numString(r json.RawMessage) string {
+	s := strings.TrimSpace(string(r))
+	if s == "" || s == "null" {
+		return ""
+	}
+	if s[0] == '"' { // a JSON string — unwrap it
+		var unq string
+		if err := json.Unmarshal(r, &unq); err == nil {
+			return unq
+		}
+	}
+	return s
+}
+
+// MetaState classifies an image's meta field for rendering.
+type MetaState int
+
+const (
+	// MetaAbsent: meta was not requested, or the API returned meta:null (the
+	// uploader hid their generation data).
+	MetaAbsent MetaState = iota
+	// MetaOK: meta parsed into an ImageMeta object.
+	MetaOK
+	// MetaUnparseable: meta was present but not the expected object shape (e.g.
+	// an array, or a scalar) — degrade gracefully rather than fail the page.
+	MetaUnparseable
+)
+
 // ImageItem is the subset of a `GET /api/v1/images` item the CLI renders. The
-// full item (tags, hash, and any meta fields beyond those below) is preserved
-// for --json via Raw.
+// full item (tags, hash, and any meta fields beyond those in ImageMeta) is
+// preserved for --json via Raw.
+//
+// Meta is kept as json.RawMessage — not a decoded *ImageMeta — so a malformed
+// meta on any single image can never fail the whole-page decode (which would
+// also break `--meta --json`, an advertised raw passthrough). It is decoded
+// best-effort at render time via ParseMeta.
 type ImageItem struct {
-	ID        int        `json:"id"`
-	URL       string     `json:"url"`
-	Width     int        `json:"width"`
-	Height    int        `json:"height"`
-	NSFWLevel string     `json:"nsfwLevel"`
-	Type      string     `json:"type"`
-	PostID    *int       `json:"postId"`
-	Username  string     `json:"username"`
-	BaseModel string     `json:"baseModel"`
-	Stats     ImageStats `json:"stats"`
-	// Meta is nil unless the request was made with withMeta=true, and stays nil
-	// when the API returns `meta: null` (uploader hid their generation data).
-	Meta *ImageMeta `json:"meta"`
+	ID        int             `json:"id"`
+	URL       string          `json:"url"`
+	Width     int             `json:"width"`
+	Height    int             `json:"height"`
+	NSFWLevel string          `json:"nsfwLevel"`
+	Type      string          `json:"type"`
+	PostID    *int            `json:"postId"`
+	Username  string          `json:"username"`
+	BaseModel string          `json:"baseModel"`
+	Stats     ImageStats      `json:"stats"`
+	Meta      json.RawMessage `json:"meta"`
+}
+
+// ParseMeta best-effort decodes the raw meta. It never returns an error: an
+// absent or null meta → MetaAbsent, a present-but-unexpected shape →
+// MetaUnparseable, so one odd image can't fail the page or the --json passthrough.
+func (im ImageItem) ParseMeta() (ImageMeta, MetaState) {
+	raw := bytes.TrimSpace(im.Meta)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ImageMeta{}, MetaAbsent
+	}
+	var m ImageMeta
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ImageMeta{}, MetaUnparseable
+	}
+	return m, MetaOK
 }
 
 // ImageSearchResult bundles the parsed items + pagination metadata with the raw

--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 )
 
@@ -14,8 +15,29 @@ type ImageStats struct {
 	CommentCount int `json:"commentCount"`
 }
 
+// ImageMeta is the generation metadata attached to an image when it is requested
+// with `withMeta=true` (and `flatMeta=true`, which forces the flat shape on every
+// query route so this can be parsed uniformly). It is nil on the item when the
+// API returns `meta: null` — either because meta was not requested or because the
+// uploader chose to hide their generation data.
+//
+// Numeric fields use json.Number because the API values are attacker-influenced
+// and can be large or float (seeds routinely exceed int32, e.g.
+// 557589798350441; cfgScale is a float) — a tolerant type keeps a surprising
+// value from failing the whole parse.
+type ImageMeta struct {
+	Prompt         string      `json:"prompt"`
+	NegativePrompt string      `json:"negativePrompt"`
+	Sampler        string      `json:"sampler"`
+	CfgScale       json.Number `json:"cfgScale"`
+	Steps          json.Number `json:"steps"`
+	Seed           json.Number `json:"seed"`
+	Model          string      `json:"Model"` // capitalized in the API payload
+}
+
 // ImageItem is the subset of a `GET /api/v1/images` item the CLI renders. The
-// full item (meta, tags, hash, baseModel) is preserved for --json via Raw.
+// full item (tags, hash, and any meta fields beyond those below) is preserved
+// for --json via Raw.
 type ImageItem struct {
 	ID        int        `json:"id"`
 	URL       string     `json:"url"`
@@ -27,6 +49,9 @@ type ImageItem struct {
 	Username  string     `json:"username"`
 	BaseModel string     `json:"baseModel"`
 	Stats     ImageStats `json:"stats"`
+	// Meta is nil unless the request was made with withMeta=true, and stays nil
+	// when the API returns `meta: null` (uploader hid their generation data).
+	Meta *ImageMeta `json:"meta"`
 }
 
 // ImageSearchResult bundles the parsed items + pagination metadata with the raw

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/civitai/cli/internal/api"
@@ -21,7 +22,8 @@ func newImagesCmd() *cobra.Command {
 (GET /api/v1/images). Works anonymously.`,
 		Example: `  civitai images search --limit 5
   civitai images search --model-id 4384 --sort "Most Reactions"
-  civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week`,
+  civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
+  civitai images search --nsfw --sort "Most Reactions" --period Month --meta`,
 	}
 	cmd.AddCommand(newImagesSearchCmd())
 	return cmd
@@ -32,7 +34,7 @@ func newImagesSearchCmd() *cobra.Command {
 		username, sort, period, cursor, typ          string
 		baseModels                                   []string
 		postID, modelID, modelVersionID, limit, page int
-		nsfw                                         bool
+		nsfw, meta                                   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -45,6 +47,7 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
   civitai images search --model-version-id 128713 --sort Newest
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
   civitai images search --type video --sort "Most Reactions"
+  civitai images search --nsfw --sort "Most Reactions" --period Month --meta
   civitai images search --username some-user --cursor <cursor>`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -82,6 +85,13 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			if cmd.Flags().Changed("nsfw") {
 				q.Set("nsfw", strconv.FormatBool(nsfw))
 			}
+			// meta is opt-in behind withMeta=true (the API omits it by default to
+			// keep payloads small). flatMeta=true forces the flat meta shape on
+			// every query route so the parser never has to branch on shape.
+			if meta {
+				q.Set("withMeta", "true")
+				q.Set("flatMeta", "true")
+			}
 
 			client, _, err := newReader(o)
 			if err != nil {
@@ -94,7 +104,11 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			if o.json {
 				return emitJSON(cmd, res.Raw)
 			}
-			printImageList(cmd, res.Items)
+			if meta {
+				printImageListMeta(cmd, res.Items)
+			} else {
+				printImageList(cmd, res.Items)
+			}
 			printPageFooter(cmd, "civitai images search", res.Metadata)
 			return nil
 		},
@@ -111,6 +125,7 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (\"Most Reactions\", \"Most Comments\", Newest)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
+	cmd.Flags().BoolVar(&meta, "meta", false, "include generation metadata (prompt, sampler, seed, etc.)")
 	bindReadFlags(cmd)
 	return cmd
 }
@@ -130,6 +145,38 @@ func printImageList(cmd *cobra.Command, items []api.ImageItem) {
 			im.Stats.HeartCount, im.Stats.CommentCount, safeTerm(im.URL))
 	}
 	_ = tw.Flush()
+}
+
+// printImageListMeta renders each image as an indented detail block instead of
+// the compact table, so it can carry the generation metadata (prompt, settings)
+// that --meta requests. Every server-origin string is routed through safeTerm —
+// prompts are attacker-controlled user text and can carry ANSI/control bytes.
+func printImageListMeta(cmd *cobra.Command, items []api.ImageItem) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No images found.")
+		return
+	}
+	for _, im := range items {
+		fmt.Fprintf(out, "%d  [%s]  %dx%d  by %s\n",
+			im.ID, orDash(safeTerm(im.NSFWLevel)), im.Width, im.Height, orDash(safeTerm(im.Username)))
+		if im.Meta == nil {
+			// meta: null — either the uploader hid their generation data, or the
+			// API had none for this image. Not an error.
+			fmt.Fprintln(out, "  meta: (hidden by uploader)")
+		} else {
+			m := im.Meta
+			fmt.Fprintf(out, "  model: %s   sampler: %s   cfg: %s   steps: %s   seed: %s\n",
+				orDash(safeTerm(m.Model)), orDash(safeTerm(m.Sampler)),
+				orDash(safeTerm(m.CfgScale.String())), orDash(safeTerm(m.Steps.String())),
+				orDash(safeTerm(m.Seed.String())))
+			fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
+			if strings.TrimSpace(m.NegativePrompt) != "" {
+				fmt.Fprintf(out, "  negative: %s\n", safeTerm(m.NegativePrompt))
+			}
+		}
+		fmt.Fprintf(out, "  url: %s\n", safeTerm(im.URL))
+	}
 }
 
 func orDash(s string) string {

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -160,17 +160,24 @@ func printImageListMeta(cmd *cobra.Command, items []api.ImageItem) {
 	for _, im := range items {
 		fmt.Fprintf(out, "%d  [%s]  %dx%d  by %s\n",
 			im.ID, orDash(safeTerm(im.NSFWLevel)), im.Width, im.Height, orDash(safeTerm(im.Username)))
-		if im.Meta == nil {
+		m, state := im.ParseMeta()
+		switch state {
+		case api.MetaAbsent:
 			// meta: null — either the uploader hid their generation data, or the
 			// API had none for this image. Not an error.
 			fmt.Fprintln(out, "  meta: (hidden by uploader)")
-		} else {
-			m := im.Meta
+		case api.MetaUnparseable:
+			// meta present but not the expected object shape — degrade rather than
+			// drop the whole image.
+			fmt.Fprintln(out, "  meta: (unrecognized format)")
+		default: // api.MetaOK
 			fmt.Fprintf(out, "  model: %s   sampler: %s   cfg: %s   steps: %s   seed: %s\n",
 				orDash(safeTerm(m.Model)), orDash(safeTerm(m.Sampler)),
-				orDash(safeTerm(m.CfgScale.String())), orDash(safeTerm(m.Steps.String())),
-				orDash(safeTerm(m.Seed.String())))
-			fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
+				orDash(safeTerm(m.CfgScaleString())), orDash(safeTerm(m.StepsString())),
+				orDash(safeTerm(m.SeedString())))
+			if strings.TrimSpace(m.Prompt) != "" {
+				fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
+			}
 			if strings.TrimSpace(m.NegativePrompt) != "" {
 				fmt.Fprintf(out, "  negative: %s\n", safeTerm(m.NegativePrompt))
 			}

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -290,6 +291,102 @@ func TestRootHelpMentionsImagesSearch(t *testing.T) {
 	}
 	if !strings.Contains(out, "images search") {
 		t.Errorf("root help should include an `images search` example: %s", out)
+	}
+}
+
+// TestImagesSearchMetaQueryParams asserts the --meta flag toggles the API's
+// opt-in metadata params: with --meta both withMeta=true and flatMeta=true are
+// sent (flatMeta forces the uniform flat shape); without it, neither is present.
+func TestImagesSearchMetaQueryParams(t *testing.T) {
+	body := `{"items":[],"metadata":{}}`
+
+	// With --meta → both params set.
+	var gotWith url.Values
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotWith = r.URL.Query()
+		_, _ = w.Write([]byte(body))
+	})
+	if _, _, err := run(t, "images", "search", "--meta"); err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	if gotWith.Get("withMeta") != "true" {
+		t.Errorf("--meta should set withMeta=true, got %q", gotWith.Get("withMeta"))
+	}
+	if gotWith.Get("flatMeta") != "true" {
+		t.Errorf("--meta should set flatMeta=true, got %q", gotWith.Get("flatMeta"))
+	}
+
+	// Without --meta → neither param present (unchanged default).
+	var gotWithout url.Values
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotWithout = r.URL.Query()
+		_, _ = w.Write([]byte(body))
+	})
+	if _, _, err := run(t, "images", "search"); err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if gotWithout.Has("withMeta") {
+		t.Errorf("default search must not send withMeta: %v", gotWithout)
+	}
+	if gotWithout.Has("flatMeta") {
+		t.Errorf("default search must not send flatMeta: %v", gotWithout)
+	}
+}
+
+// TestImagesSearchMetaHumanOutput asserts --meta renders the generation-metadata
+// detail block, sanitizes attacker-controlled prompt text (safeTerm), and prints
+// "(hidden by uploader)" for a meta:null image instead of crashing.
+func TestImagesSearchMetaHumanOutput(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// One image with meta (prompt carries an ANSI escape), one with meta:null.
+		// Seed exceeds int32 to guard the tolerant numeric type.
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None","username":"alice",
+		   "meta":{"prompt":"a cat\u001b[31m sitting","negativePrompt":"blurry","sampler":"Euler a",
+		           "cfgScale":7.5,"steps":30,"seed":557589798350441,"Model":"SomeCheckpoint"}},
+		  {"id":2,"url":"https://img/2","width":10,"height":20,"nsfwLevel":"None","username":"bob","meta":null}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	for _, want := range []string{
+		"a cat[31m sitting", // prompt printed, ESC byte stripped
+		"negative: blurry",
+		"sampler: Euler a",
+		"seed: 557589798350441", // large seed survives tolerant numeric parse
+		"model: SomeCheckpoint",
+		"meta: (hidden by uploader)", // meta:null image handled gracefully
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--meta output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("prompt ESC byte must be stripped by safeTerm: %q", out)
+	}
+}
+
+// TestImagesSearchMetaJSONPassthrough asserts --meta --json leaves the raw body
+// (including meta) untouched — no human detail block leaks into machine output.
+func TestImagesSearchMetaJSONPassthrough(t *testing.T) {
+	const raw = `{"items":[{"id":1,"url":"u","meta":{"prompt":"hi","seed":557589798350441}}],"metadata":{}}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("withMeta") != "true" {
+			t.Errorf("--meta --json should still request withMeta: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(raw))
+	})
+	out, _, err := run(t, "images", "search", "--meta", "--json")
+	if err != nil {
+		t.Fatalf("images search --meta --json: %v", err)
+	}
+	if strings.Contains(out, "prompt:") {
+		t.Errorf("--json must not carry the human detail block: %s", out)
+	}
+	if !strings.Contains(out, `"meta"`) || !strings.Contains(out, `"prompt"`) {
+		t.Errorf("--json should pass the raw meta through: %s", out)
 	}
 }
 

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -390,6 +390,54 @@ func TestImagesSearchMetaJSONPassthrough(t *testing.T) {
 	}
 }
 
+// TestImagesSearchMetaMalformed asserts a single image with a malformed/oddly-
+// typed meta cannot fail the whole page: the human path degrades to a marker,
+// sibling images still render, and --meta --json still passes the raw body
+// through (the decode captures meta as raw bytes and never aborts on shape).
+func TestImagesSearchMetaMalformed(t *testing.T) {
+	// img 1: meta is an array (not an object) → unparseable.
+	// img 2: meta object with an empty-string cfgScale + non-numeric seed + a good
+	//        prompt → one bad field must not lose the item.
+	// img 3: meta:null → hidden.
+	body := `{"items":[
+	  {"id":1,"url":"https://img/1","width":1,"height":1,"nsfwLevel":"None","username":"a","meta":[1,2,3]},
+	  {"id":2,"url":"https://img/2","width":1,"height":1,"nsfwLevel":"None","username":"b",
+	   "meta":{"prompt":"still here","cfgScale":"","steps":20,"seed":"unknown","Model":"M"}},
+	  {"id":3,"url":"https://img/3","width":1,"height":1,"nsfwLevel":"None","username":"c","meta":null}
+	],"metadata":{}}`
+
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("malformed meta must not fail the command: %v", err)
+	}
+	for _, want := range []string{
+		"meta: (unrecognized format)", // img 1 array meta degrades, page survives
+		"prompt: still here",          // img 2 survives despite empty cfgScale / string seed
+		"seed: unknown",               // non-numeric seed rendered verbatim, not dropped
+		"meta: (hidden by uploader)",  // img 3 null
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("malformed --meta output missing %q:\n%s", want, out)
+		}
+	}
+
+	// --meta --json must still pass the raw (malformed-meta) body through without
+	// erroring — the top-level decode captures meta as raw bytes.
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	jout, _, err := run(t, "images", "search", "--meta", "--json")
+	if err != nil {
+		t.Fatalf("malformed meta must not fail --json passthrough: %v", err)
+	}
+	if !strings.Contains(jout, "still here") {
+		t.Errorf("--json should pass the raw meta through despite a malformed sibling: %s", jout)
+	}
+}
+
 func TestTagsSearchWiring(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/tags" {


### PR DESCRIPTION
## What

Adds an opt-in `--meta` flag to `civitai images search` that surfaces each image's generation metadata: prompt, negative prompt, sampler, cfg, steps, seed, and model.

## Why

The public images endpoint returns `meta: null` by default — metadata is opt-in behind the `withMeta=true` query param (to keep default payloads small). The CLI had no way to request or render it. This flag mirrors the API's own opt-in shape.

## Behavior

- **OFF by default** — default `images search` output (the compact table) is unchanged.
- When `--meta` is set, the request adds `withMeta=true` **and** `flatMeta=true`. `flatMeta` forces the flat `meta` shape on every query route (the legacy `imageId`/`modelId` path otherwise nests meta as `meta: { id, meta: {...} }`), so the parser never has to branch on shape.
- **Human output** with `--meta` renders each image as an indented detail block instead of the table (a table can't hold a prompt):
  ```
  <id>  [<nsfwLevel>]  <WxH>  by <username>
    model: <Model>   sampler: <sampler>   cfg: <cfgScale>   steps: <steps>   seed: <seed>
    prompt: <prompt>
    negative: <negativePrompt>       (omitted when empty)
    url: <url>
  ```
- **Hidden metadata**: images whose uploader hid their generation data return `meta: null` even with the flag. Those print `meta: (hidden by uploader)` and do **not** error.
- **Sanitization**: every meta string is routed through the existing `safeTerm` helper — prompts are attacker-controlled user text and can carry ANSI/control bytes.
- **`--json`** is unchanged: a raw passthrough. With `--meta` the API simply includes the `meta` object in each item; without it, `meta` stays `null`.

## Parsing

`ImageItem` gains a `Meta *ImageMeta` field (nil-when-null, so hidden vs present is distinguishable). Numeric fields (`cfgScale`, `steps`, `seed`) use `json.Number` so a large seed (seeds routinely exceed int32, e.g. `557589798350441`) or a float cfg doesn't fail the parse. `Model` is capitalized in the API payload and mapped accordingly.

## Tests

Added `internal/cmd/read_cmd_test.go` cases:
- `TestImagesSearchMetaQueryParams` — `--meta` sets both `withMeta=true` and `flatMeta=true`; without it, neither param is present.
- `TestImagesSearchMetaHumanOutput` — renders the detail block, strips an ANSI escape from the prompt (`safeTerm`), parses a >int32 seed, and prints `(hidden by uploader)` for a `meta:null` image without crashing.
- `TestImagesSearchMetaJSONPassthrough` — `--meta --json` still requests `withMeta` and leaves the raw body (with `meta`) untouched; no human block leaks into machine output.

`go build ./...`, `go test ./...`, `gofmt`, and `go vet` are clean.

## Verification (live public API)

`images search ... --limit 5 --meta` printed prompts/settings for images that have them, rendered `(hidden by uploader)` for hidden ones, and handled a >int32 seed (`3381636152`). `--meta --json` returned non-null `meta` for images that have it; plain `--json` (no `--meta`) returned `meta: null` for all items — unchanged default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
