### PR TITLE
build: pin Go toolchain go1.25.12 + add windows/arm64 release target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,9 +31,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
 
 archives:
   - id: civitai

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/civitai/cli
 
 go 1.25.0
 
+toolchain go1.25.12
+
 require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/npm/lib/install.js
+++ b/npm/lib/install.js
@@ -23,8 +23,10 @@ const BINARIES_DIR = path.join(__dirname, "binaries");
 const OS_MAP = { linux: "linux", darwin: "darwin", win32: "windows" };
 const ARCH_MAP = { x64: "amd64", arm64: "arm64" };
 
-// Combos GoReleaser does NOT build (see .goreleaser.yaml `ignore:`).
-const UNSUPPORTED = new Set(["windows/arm64"]);
+// Combos GoReleaser does NOT build (keep in sync with .goreleaser.yaml). All
+// OS_MAP×ARCH_MAP combos are now built (windows/arm64 enabled), so this is empty;
+// re-add an entry here if a target is ever dropped from the release matrix.
+const UNSUPPORTED = new Set([]);
 
 function target() {
   const goos = OS_MAP[process.platform];


### PR DESCRIPTION
## Summary

Two low-risk build/release hardening changes:

1. **`toolchain` directive** — add `toolchain go1.25.12` to `go.mod` for reproducible builds, pinning the build toolchain to the current 1.25 patch. The language version stays at `go 1.25.0` (support policy = last 2 minors → 1.25 is still supported; a 1.26 bump is a separate, larger call). The `toolchain` line is `>=` the `go` line as required.
2. **Release matrix widened** — add `windows/arm64` to the goreleaser build matrix by dropping the `ignore` block that excluded it. Pure cross-compile addition; the existing `windows → zip` format override already covers it. darwin/linux entries unchanged.

## Verification

- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` — all clean
- `go mod verify` → all modules verified; `go.sum` unchanged (toolchain directive alone doesn't touch it)
- `goreleaser check` → `1 configuration file(s) validated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)