### PR TITLE
refactor(download): decompose runDownload/downloadOne into single-responsibility helpers

### DIFF
--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -125,40 +125,14 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 }
 
 func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
-	// ── resolve the target version id (exactly one of positional / --model) ──
-	var positional string
-	if len(args) == 1 {
-		positional = strings.TrimSpace(args[0])
+	// Resolve the target version id (exactly one of positional / --model) and
+	// validate the flag combinations up front, before any network work.
+	positional, err := resolveDownloadTarget(args, o)
+	if err != nil {
+		return err
 	}
-	if positional != "" && o.modelID != "" {
-		return fmt.Errorf("provide EITHER a version id or --model <model-id>, not both")
-	}
-	if positional == "" && o.modelID == "" {
-		return fmt.Errorf("provide a model-version id (civitai download <version-id>) or --model <model-id>")
-	}
-
-	// ── validate flag combinations up front ──
-	if o.all && o.file != "" {
-		return fmt.Errorf("--all and --file are mutually exclusive")
-	}
-	if o.out != "" && o.outDir != "" {
-		return fmt.Errorf("--out (a file path) and --out-dir (a directory) are mutually exclusive")
-	}
-	if o.out != "" && o.all {
-		return fmt.Errorf("--out sets a single file path and can't be combined with --all — use --out-dir")
-	}
-	if o.layout != "" {
-		if !validLayout(o.layout) {
-			return fmt.Errorf("--layout must be one of %s, got %q", strings.Join(knownLayouts, "|"), o.layout)
-		}
-		if o.out != "" {
-			return fmt.Errorf("--layout routes files into type folders and can't be combined with --out (an explicit single path)")
-		}
-		if o.outDir != "" {
-			return fmt.Errorf("--layout routes files under --root and can't be combined with --out-dir")
-		}
-	} else if o.root != "" {
-		return fmt.Errorf("--root only applies with --layout")
+	if err := validateDownloadFlags(o); err != nil {
+		return err
 	}
 
 	client, baseURL, err := newReader(&readOpts{anon: o.anon})
@@ -167,8 +141,8 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	}
 	// Cancel the whole download on Ctrl-C (SIGINT): the signal-bound context is
 	// threaded into every request + io.Copy, so an interrupted transfer unblocks
-	// with a cancellation error and downloadOne's cleanup defer removes the
-	// partial ".part" file rather than leaving it behind.
+	// with a cancellation error and downloadOne's cleanup removes the partial
+	// ".part" file rather than leaving it behind.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
@@ -207,12 +181,7 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 
 	// Always surface the version's base model, and (with --for-base) warn on a
 	// confident cross-family mismatch before any bytes move.
-	fmt.Fprintf(out, "base model: %s\n", dashIfEmpty(safeTerm(v.BaseModel)))
-	if o.forBase != "" {
-		if w := baseModelWarning(v.BaseModel, o.forBase); w != "" {
-			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(w)))
-		}
-	}
+	reportBaseModel(out, errW, v.BaseModel, o.forBase)
 
 	// --dry-run: print the resolved plan and exit 0, transferring nothing and
 	// creating no file (not even a ".part").
@@ -222,36 +191,109 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 
 	// Without --layout, warn when `--all` would mis-file differing types into one
 	// directory (the footgun --layout exists to fix).
-	if o.all && o.layout == "" {
-		if w := mixedTypeWarning(fileTypeInfos(selected, o.modelType)); w != "" {
-			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(w)))
-		}
-	}
+	warnMixedTypes(errW, selected, o)
 
-	downloaded := 0
-	for i := range selected {
-		f := selected[i]
-		target, note, err := targetPath(f, o)
-		if err != nil {
-			return err
-		}
-		if note != "" {
-			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(note)))
-		}
-		skipped, err := downloadOne(ctx, client, out, errW, f, target, o)
-		if err != nil {
-			return err
-		}
-		if !skipped {
-			downloaded++
-		}
+	downloaded, err := downloadSelected(ctx, client, out, errW, selected, o)
+	if err != nil {
+		return err
 	}
-
 	if downloaded == 0 && o.all {
 		// Everything was already present on disk.
 		fmt.Fprintln(errW, ui.For(errW).Warn("no files were downloaded (all were already present)"))
 	}
 	return nil
+}
+
+// resolveDownloadTarget returns the positional version id from args after
+// enforcing that EXACTLY one of the positional id / --model is supplied.
+func resolveDownloadTarget(args []string, o *downloadOpts) (string, error) {
+	var positional string
+	if len(args) == 1 {
+		positional = strings.TrimSpace(args[0])
+	}
+	if positional != "" && o.modelID != "" {
+		return "", fmt.Errorf("provide EITHER a version id or --model <model-id>, not both")
+	}
+	if positional == "" && o.modelID == "" {
+		return "", fmt.Errorf("provide a model-version id (civitai download <version-id>) or --model <model-id>")
+	}
+	return positional, nil
+}
+
+// validateDownloadFlags rejects incompatible flag combinations before any
+// network work: --all/--file, --out/--out-dir, --out/--all, and the --layout
+// exclusions (a valid layout, no --out, no --out-dir; --root only with --layout).
+func validateDownloadFlags(o *downloadOpts) error {
+	if o.all && o.file != "" {
+		return fmt.Errorf("--all and --file are mutually exclusive")
+	}
+	if o.out != "" && o.outDir != "" {
+		return fmt.Errorf("--out (a file path) and --out-dir (a directory) are mutually exclusive")
+	}
+	if o.out != "" && o.all {
+		return fmt.Errorf("--out sets a single file path and can't be combined with --all — use --out-dir")
+	}
+	if o.layout != "" {
+		if !validLayout(o.layout) {
+			return fmt.Errorf("--layout must be one of %s, got %q", strings.Join(knownLayouts, "|"), o.layout)
+		}
+		if o.out != "" {
+			return fmt.Errorf("--layout routes files into type folders and can't be combined with --out (an explicit single path)")
+		}
+		if o.outDir != "" {
+			return fmt.Errorf("--layout routes files under --root and can't be combined with --out-dir")
+		}
+	} else if o.root != "" {
+		return fmt.Errorf("--root only applies with --layout")
+	}
+	return nil
+}
+
+// reportBaseModel prints the version's base model and, with --for-base set,
+// warns on stderr about a confident cross-family mismatch.
+func reportBaseModel(out, errW io.Writer, baseModel, forBase string) {
+	fmt.Fprintf(out, "base model: %s\n", dashIfEmpty(safeTerm(baseModel)))
+	if forBase != "" {
+		if w := baseModelWarning(baseModel, forBase); w != "" {
+			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(w)))
+		}
+	}
+}
+
+// warnMixedTypes warns (stderr) when --all without --layout would mis-file
+// differing file types into a single directory.
+func warnMixedTypes(errW io.Writer, selected []api.ModelVersionFile, o *downloadOpts) {
+	if o.all && o.layout == "" {
+		if w := mixedTypeWarning(fileTypeInfos(selected, o.modelType)); w != "" {
+			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(w)))
+		}
+	}
+}
+
+// downloadSelected downloads each selected file — resolving its per-file target
+// (surfacing any routing note on stderr) then transferring it — and returns how
+// many files were actually transferred (an already-present, skipped file does
+// not count). It stops at the first error.
+func downloadSelected(ctx context.Context, dl api.Downloader, out, errW io.Writer, selected []api.ModelVersionFile, o *downloadOpts) (int, error) {
+	downloaded := 0
+	for i := range selected {
+		f := selected[i]
+		target, note, err := targetPath(f, o)
+		if err != nil {
+			return downloaded, err
+		}
+		if note != "" {
+			fmt.Fprintln(errW, ui.For(errW).Warn(safeTerm(note)))
+		}
+		skipped, err := downloadOne(ctx, dl, out, errW, f, target, o)
+		if err != nil {
+			return downloaded, err
+		}
+		if !skipped {
+			downloaded++
+		}
+	}
+	return downloaded, nil
 }
 
 // resolveVersionID returns the version id to download: the positional id verbatim
@@ -500,37 +542,11 @@ func fileTypeInfos(files []api.ModelVersionFile, modelType string) []fileTypeInf
 func downloadOne(ctx context.Context, dl api.Downloader, out, errW io.Writer, f api.ModelVersionFile, target string, o *downloadOpts) (skipped bool, err error) {
 	sha := strings.TrimSpace(f.Hashes.SHA256)
 	verify := !o.noVerify && sha != ""
-	if !o.noVerify && sha == "" {
-		fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf("%s: no SHA256 published — skipping integrity verification", safeTerm(f.Name))))
-	}
-	// Surface the code-execution risk of pickle/archive formats (a .ckpt, .pt, or
-	// .zip lands in a folder ComfyUI/A1111 will auto-load), once per file.
-	if note := pickleArchiveNote(f.Name); note != "" {
-		fmt.Fprintln(errW, note)
-	}
-	// Point ControlNet downloads at the preprocessor/annotator dependency the CLI
-	// can't fetch (a separate ComfyUI custom node, not hosted on Civitai), once
-	// per file. Static hint — stderr only, so --json/pipes on stdout are unaffected.
-	if note := controlnetPreprocessorNote(o.modelType); note != "" {
-		fmt.Fprintln(errW, note)
-	}
+	emitPreDownloadNotes(errW, f.Name, o.modelType, o.noVerify, sha)
 
-	// Idempotency: skip an already-present target unless --force. When verifying
-	// and a hash is known, only skip on a confirmed match; without a hash (or
-	// --no-verify) a present file is trusted.
-	if !o.force {
-		if info, statErr := os.Stat(target); statErr == nil && !info.IsDir() {
-			if !verify {
-				fmt.Fprintf(out, "already present: %s\n", safeTerm(target))
-				return true, nil
-			}
-			match, verr := fileSHA256Matches(target, sha)
-			if verr == nil && match {
-				fmt.Fprintf(out, "already present (SHA256 verified): %s\n", safeTerm(target))
-				return true, nil
-			}
-			// Present but wrong/unverifiable → re-download.
-		}
+	// Idempotency: skip an already-present target unless --force.
+	if presentTargetSatisfies(out, target, sha, verify, o.force) {
+		return true, nil
 	}
 
 	if dir := filepath.Dir(target); dir != "" && dir != "." {
@@ -549,18 +565,103 @@ func downloadOne(ctx context.Context, dl api.Downloader, out, errW io.Writer, f 
 		return false, err
 	}
 
+	total := resp.ContentLength
+	if total <= 0 && f.SizeKB > 0 {
+		total = int64(f.SizeKB * 1024)
+	}
+
 	partPath := target + ".part"
-	// Self-heal a stale ".part" left by a previously aborted run: we don't resume,
-	// so remove it before starting a fresh transfer (os.Create truncates too, but
-	// be explicit).
+	written, got, err := writePart(resp.Body, partPath, errW, f.Name, total, verify)
+	if err != nil {
+		return false, err
+	}
+
+	if verify && !strings.EqualFold(got, sha) {
+		// Delete the corrupt partial so the failure message is honest about the
+		// state on disk.
+		_ = os.Remove(partPath)
+		return false, fmt.Errorf("SHA256 mismatch for %s — expected %s, got %s (deleted the partial download)", f.Name, strings.ToLower(sha), got)
+	}
+
+	if err := os.Rename(partPath, target); err != nil {
+		// The .part is finished but couldn't be installed; don't leave it behind.
+		_ = os.Remove(partPath)
+		return false, fmt.Errorf("install %s: %w", target, err)
+	}
+
+	note := ""
+	if verify {
+		note = "  (SHA256 verified)"
+	}
+	fmt.Fprintf(out, "Saved %s (%s)%s\n", safeTerm(target), humanBytes(written), note)
+	return false, nil
+}
+
+// emitPreDownloadNotes prints the once-per-file stderr notes for a download: the
+// missing-hash verification-skip warning, the pickle/archive code-execution
+// warning, and the ControlNet preprocessor-dependency hint. Notes go to stderr
+// only, so --json / pipes on stdout are unaffected.
+func emitPreDownloadNotes(errW io.Writer, name, modelType string, noVerify bool, sha string) {
+	if !noVerify && sha == "" {
+		fmt.Fprintln(errW, ui.For(errW).Warn(fmt.Sprintf("%s: no SHA256 published — skipping integrity verification", safeTerm(name))))
+	}
+	// Surface the code-execution risk of pickle/archive formats (a .ckpt, .pt, or
+	// .zip lands in a folder ComfyUI/A1111 will auto-load).
+	if note := pickleArchiveNote(name); note != "" {
+		fmt.Fprintln(errW, note)
+	}
+	// Point ControlNet downloads at the preprocessor/annotator dependency the CLI
+	// can't fetch (a separate ComfyUI custom node, not hosted on Civitai).
+	if note := controlnetPreprocessorNote(modelType); note != "" {
+		fmt.Fprintln(errW, note)
+	}
+}
+
+// presentTargetSatisfies reports whether an already-present target lets the
+// download be skipped (idempotency), printing the "already present" line it
+// decides on. With --force it never skips. Otherwise a non-directory file at
+// target is trusted when not verifying (or no hash is known); when verifying it
+// is skipped only on a confirmed SHA256 match. A present-but-wrong/unverifiable
+// file returns false → re-download.
+func presentTargetSatisfies(out io.Writer, target, sha string, verify, force bool) bool {
+	if force {
+		return false
+	}
+	info, statErr := os.Stat(target)
+	if statErr != nil || info.IsDir() {
+		return false
+	}
+	if !verify {
+		fmt.Fprintf(out, "already present: %s\n", safeTerm(target))
+		return true
+	}
+	if match, verr := fileSHA256Matches(target, sha); verr == nil && match {
+		fmt.Fprintf(out, "already present (SHA256 verified): %s\n", safeTerm(target))
+		return true
+	}
+	return false
+}
+
+// writePart streams body into "<target>.part" while updating the progress
+// display and (when verify) a SHA256 hasher. Any stale ".part" from a previous
+// aborted run is removed first (there is no resume). On ANY failure it closes
+// and removes the partial file before returning, so an interrupted or failed
+// transfer never leaves a truncated ".part" behind. On success it returns the
+// byte count written and, when verify is set, the lowercase-hex SHA256 of the
+// streamed bytes; the caller then owns the finished (closed) ".part" file and is
+// responsible for verifying / renaming / removing it.
+func writePart(body io.Reader, partPath string, errW io.Writer, name string, total int64, verify bool) (written int64, gotHash string, err error) {
+	// Self-heal a stale ".part": remove it before a fresh transfer (os.Create
+	// truncates too, but be explicit).
 	if _, statErr := os.Stat(partPath); statErr == nil {
 		_ = os.Remove(partPath)
 	}
 	partFile, err := os.Create(partPath)
 	if err != nil {
-		return false, fmt.Errorf("create %s: %w", partPath, err)
+		return 0, "", fmt.Errorf("create %s: %w", partPath, err)
 	}
-	// Best-effort cleanup of the partial file on any failure before rename.
+	// Best-effort cleanup of the partial file on any failure before we hand a
+	// finished file back to the caller.
 	cleanup := true
 	defer func() {
 		if cleanup {
@@ -569,47 +670,25 @@ func downloadOne(ctx context.Context, dl api.Downloader, out, errW io.Writer, f 
 		}
 	}()
 
-	total := resp.ContentLength
-	if total <= 0 && f.SizeKB > 0 {
-		total = int64(f.SizeKB * 1024)
-	}
-	pw := newProgressWriter(errW, f.Name, total)
-
+	pw := newProgressWriter(errW, name, total)
 	hasher := sha256.New()
 	writers := []io.Writer{partFile, pw}
 	if verify {
 		writers = append(writers, hasher)
 	}
-	if _, err := io.Copy(io.MultiWriter(writers...), resp.Body); err != nil {
-		return false, fmt.Errorf("streaming %s: %w", f.Name, err)
+	if _, err := io.Copy(io.MultiWriter(writers...), body); err != nil {
+		return 0, "", fmt.Errorf("streaming %s: %w", name, err)
 	}
 	pw.done()
 	if err := partFile.Close(); err != nil {
-		return false, fmt.Errorf("finalize %s: %w", partPath, err)
-	}
-
-	if verify {
-		got := hex.EncodeToString(hasher.Sum(nil))
-		if !strings.EqualFold(got, sha) {
-			// Delete the corrupt partial; the defer would also remove it, but be
-			// explicit so the failure message is honest about the state on disk.
-			_ = os.Remove(partPath)
-			cleanup = false
-			return false, fmt.Errorf("SHA256 mismatch for %s — expected %s, got %s (deleted the partial download)", f.Name, strings.ToLower(sha), got)
-		}
-	}
-
-	if err := os.Rename(partPath, target); err != nil {
-		return false, fmt.Errorf("install %s: %w", target, err)
+		return 0, "", fmt.Errorf("finalize %s: %w", partPath, err)
 	}
 	cleanup = false
 
-	note := ""
 	if verify {
-		note = "  (SHA256 verified)"
+		gotHash = hex.EncodeToString(hasher.Sum(nil))
 	}
-	fmt.Fprintf(out, "Saved %s (%s)%s\n", safeTerm(target), humanBytes(pw.written), note)
-	return false, nil
+	return pw.written, gotHash, nil
 }
 
 // pickleExts / archiveExts name the downloaded-file extensions that warrant a

--- a/internal/cmd/download_seams_test.go
+++ b/internal/cmd/download_seams_test.go
@@ -1,0 +1,219 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These characterization tests pin the seams extracted from the download*
+// decomposition so the behavior-preserving refactor stays honest: the part-file
+// streaming+hashing lifecycle (writePart), the idempotency skip decision
+// (presentTargetSatisfies), and — end-to-end through the refactored
+// runDownload → downloadSelected → downloadOne path — the SSRF dial/scheme guard.
+
+// TestWritePartHashesAndInstalls proves writePart streams the bytes into
+// "<target>.part", returns the byte count and (when verifying) the lowercase-hex
+// SHA256 of exactly those bytes, and leaves the finished .part in place for the
+// caller to rename.
+func TestWritePartHashesAndInstalls(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "m.safetensors.part")
+	body := "the-streamed-bytes"
+
+	var errW bytes.Buffer
+	written, got, err := writePart(strings.NewReader(body), part, &errW, "m.safetensors", int64(len(body)), true)
+	if err != nil {
+		t.Fatalf("writePart: %v", err)
+	}
+	if written != int64(len(body)) {
+		t.Errorf("written = %d, want %d", written, len(body))
+	}
+	if got != sha256hex(body) {
+		t.Errorf("hash = %q, want %q", got, sha256hex(body))
+	}
+	// The finished .part exists and holds exactly the streamed bytes.
+	onDisk, rerr := os.ReadFile(part)
+	if rerr != nil {
+		t.Fatalf("finished .part should remain for the caller to rename: %v", rerr)
+	}
+	if string(onDisk) != body {
+		t.Errorf(".part content = %q, want %q", onDisk, body)
+	}
+}
+
+// TestWritePartNoVerifyReturnsEmptyHash proves that with verify=false writePart
+// returns an empty hash (the caller skips the SHA256 comparison) but still writes
+// the file.
+func TestWritePartNoVerifyReturnsEmptyHash(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "x.bin.part")
+	var errW bytes.Buffer
+	_, got, err := writePart(strings.NewReader("abc"), part, &errW, "x.bin", 3, false)
+	if err != nil {
+		t.Fatalf("writePart: %v", err)
+	}
+	if got != "" {
+		t.Errorf("verify=false should return an empty hash, got %q", got)
+	}
+	if _, e := os.Stat(part); e != nil {
+		t.Errorf(".part should still be written: %v", e)
+	}
+}
+
+// errReader fails partway through the stream, exercising writePart's failure
+// cleanup path.
+type errReader struct{ n int }
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.n <= 0 {
+		return 0, errors.New("boom")
+	}
+	c := copy(p, strings.Repeat("a", e.n))
+	e.n = 0
+	return c, nil
+}
+
+// TestWritePartRemovesPartOnStreamError proves a failed transfer never leaves a
+// truncated ".part" behind — writePart deletes it and returns a "streaming"
+// error.
+func TestWritePartRemovesPartOnStreamError(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "half.bin.part")
+	var errW bytes.Buffer
+	_, _, err := writePart(&errReader{n: 4}, part, &errW, "half.bin", 100, true)
+	if err == nil || !strings.Contains(err.Error(), "streaming") {
+		t.Fatalf("expected a streaming error, got %v", err)
+	}
+	if _, e := os.Stat(part); e == nil {
+		t.Error("a failed transfer must remove the partial .part file")
+	}
+}
+
+// TestWritePartSelfHealsStalePart proves a stale ".part" from a previous aborted
+// run is truncated/replaced, not appended to (there is no resume).
+func TestWritePartSelfHealsStalePart(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "s.bin.part")
+	if err := os.WriteFile(part, []byte("STALE-LEFTOVER-BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var errW bytes.Buffer
+	body := "fresh"
+	_, got, err := writePart(strings.NewReader(body), part, &errW, "s.bin", int64(len(body)), true)
+	if err != nil {
+		t.Fatalf("writePart: %v", err)
+	}
+	onDisk, _ := os.ReadFile(part)
+	if string(onDisk) != body {
+		t.Errorf("stale .part should be replaced, got %q", onDisk)
+	}
+	if got != sha256hex(body) {
+		t.Errorf("hash should cover only the fresh bytes: %q", got)
+	}
+}
+
+// TestPresentTargetSatisfies pins the idempotency-skip decision seam.
+func TestPresentTargetSatisfies(t *testing.T) {
+	body := "present-bytes"
+	sha := sha256hex(body)
+
+	writeTarget := func(t *testing.T) string {
+		p := filepath.Join(t.TempDir(), "f.bin")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("force never skips", func(t *testing.T) {
+		var out bytes.Buffer
+		if presentTargetSatisfies(&out, writeTarget(t), sha, true, true) {
+			t.Error("--force must never skip a present file")
+		}
+	})
+
+	t.Run("missing file does not skip", func(t *testing.T) {
+		var out bytes.Buffer
+		missing := filepath.Join(t.TempDir(), "nope.bin")
+		if presentTargetSatisfies(&out, missing, sha, true, false) {
+			t.Error("an absent target must not skip")
+		}
+	})
+
+	t.Run("no verify trusts a present file", func(t *testing.T) {
+		var out bytes.Buffer
+		if !presentTargetSatisfies(&out, writeTarget(t), "", false, false) {
+			t.Error("a present file with verify off should skip")
+		}
+		if !strings.Contains(out.String(), "already present") {
+			t.Errorf("skip line missing: %q", out.String())
+		}
+	})
+
+	t.Run("verify skips only on hash match", func(t *testing.T) {
+		var out bytes.Buffer
+		if !presentTargetSatisfies(&out, writeTarget(t), sha, true, false) {
+			t.Error("a present file whose SHA256 matches should skip")
+		}
+		if !strings.Contains(out.String(), "SHA256 verified") {
+			t.Errorf("verified-skip line missing: %q", out.String())
+		}
+	})
+
+	t.Run("verify re-downloads on hash mismatch", func(t *testing.T) {
+		var out bytes.Buffer
+		if presentTargetSatisfies(&out, writeTarget(t), strings.Repeat("0", 64), true, false) {
+			t.Error("a present file whose SHA256 does NOT match must re-download (not skip)")
+		}
+	})
+
+	t.Run("a directory at target never skips", func(t *testing.T) {
+		var out bytes.Buffer
+		if presentTargetSatisfies(&out, t.TempDir(), "", false, false) {
+			t.Error("a directory at the target path must not skip")
+		}
+	})
+}
+
+// TestDownloadSSRFGuardTriggersThroughCommand proves the SSRF guard still fires
+// through the refactored runDownload → downloadSelected → downloadOne → api
+// download path: with the guard at its default (bypass OFF), a file whose
+// downloadUrl points at an internal address over plain http is refused before any
+// bytes move. (The api-layer guard internals are exhaustively covered in
+// download_ssrf_test.go; this asserts the cmd wiring the refactor moved through.)
+func TestDownloadSSRFGuardTriggersThroughCommand(t *testing.T) {
+	// The version detail is fetched by the ordinary reader (fine over loopback
+	// http); only the file's downloadUrl is the SSRF target the guard must block.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id":128713,"modelId":4384,"name":"v","baseModel":"SD 1.5","files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"http://169.254.169.254/latest/meta-data/"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// NOTE: deliberately do NOT call allowPrivateDownloadHostsInTest — the guard
+	// must be ON for this test.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+
+	_, _, err := run(t, "download", "128713")
+	if err == nil {
+		t.Fatal("SSRF guard should refuse a download URL pointing at an internal address")
+	}
+	// Plain-http internal target is refused at the scheme check ("https").
+	if !strings.Contains(err.Error(), "https") && !strings.Contains(err.Error(), "private/loopback") {
+		t.Errorf("refusal should cite the https/SSRF guard, got %v", err)
+	}
+	if _, e := os.Stat("m.safetensors.part"); e == nil {
+		t.Error("a guard-refused download must not leave a .part file")
+	}
+}


### PR DESCRIPTION
## What

Behavior-preserving decomposition of the two highest-complexity functions in `internal/cmd/download.go`, `runDownload` and `downloadOne`, into small single-responsibility helpers. Pure internal restructuring — **no observable behavior change**: same flags, same stdout/stderr output, same error messages, same exit behavior, same on-disk file layout.

## Complexity (gocyclo)

| Function | Before | After |
|---|---|---|
| `runDownload` | 37 | **14** |
| `downloadOne` | 29 | **15** |

Both now under 20 (target), near ~15.

## Extracted helpers

From `runDownload`:
- `resolveDownloadTarget` — positional-id / `--model` mutual exclusivity
- `validateDownloadFlags` — up-front flag-combination validation
- `reportBaseModel` — base-model line + `--for-base` cross-family warning
- `warnMixedTypes` — the `--all`-without-`--layout` mis-file warning
- `downloadSelected` — per-file target resolution + transfer, returns the transferred count

From `downloadOne`:
- `emitPreDownloadNotes` — missing-hash / pickle-archive / ControlNet stderr notes
- `presentTargetSatisfies` — the idempotency skip decision (`--force` / verify / SHA256 match)
- `writePart` — stale-`.part` self-heal, stream + progress + SHA256 hashing, and cleanup-on-failure of the partial file

## Security / integrity unchanged

- The **SSRF dial + scheme guard** lives in `internal/api/download.go` and is **not touched** by this PR.
- **SHA256 verification** logic is unchanged byte-for-byte. `writePart` preserves the exact partial-file cleanup semantics: remove the `.part` on stream/finalize/rename failure, and delete-then-fail on a hash mismatch.

## Tests

- Full existing suite passes: `go build ./...`, `go test ./... -race`, `go vet ./...`, `gofmt -l .` all clean.
- New `download_seams_test.go` pins the extracted seams directly — `writePart` (hash + install, no-verify empty hash, remove-on-stream-error, stale-part self-heal), `presentTargetSatisfies` (force / missing / no-verify / hash-match / hash-mismatch / directory), and a command-level test proving the **SSRF guard still triggers** through the refactored `runDownload → downloadSelected → downloadOne` path.
- Exercised end-to-end against the live API: downloaded EasyNegative (version 9208, 24 KB) — SHA256-verified success, `--layout comfyui` routed it to `models/embeddings/`, on-disk hash matches the API-advertised hash, and a second run skips via SHA256 match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)