### PR TITLE
ci: add golangci-lint static-analysis gate + fix existing findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,24 @@ jobs:
       - name: build
         run: go build ./...
 
+  # Static-analysis gate: golangci-lint over the whole module using the curated
+  # linter set in .golangci.yml (staticcheck / govet / ineffassign / unused /
+  # misspell + gofmt). Runs on every PR. `make lint` mirrors this locally.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: false # golangci-lint-action manages its own build/analysis cache
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
   # Drift-guard: the vendored block-manifest schema (go:embed'd for offline
   # `civitai app validate`) must stay identical to the canonical the platform
   # publishes at civitai.com/schemas/app-block/v1.json (the single source of

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,57 @@
+# golangci-lint configuration (schema v2).
+#
+# Curated, pragmatic starting set — deliberately NOT maximal. The goal is a gate
+# that lands and stays GREEN, then gets tightened over time.
+#
+# NOTE: `errcheck` is intentionally NOT enabled yet. A prior run surfaced ~33
+# low-value hits (mostly unchecked Fprint/Close return values, largely in tests).
+# Enabling it is a separate, scoped follow-up once those are triaged — leaving it
+# off keeps this first gate honest and actionable rather than noisy.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - staticcheck   # static analysis: SA* (correctness) + ST* (convention) + S1* (simplify)
+    - govet         # go vet checks
+    - ineffassign   # ineffectual assignments
+    - unused        # unused code (functions, vars, consts, types)
+    - misspell      # common English misspellings in comments/strings
+  settings:
+    staticcheck:
+      # Keep the correctness (SA*), simplification (S1*) and the meaningful style
+      # conventions (ST1005 error strings, ST1006, ST1015, ST1017, ST1018, …).
+      # Two families are turned off for this first pragmatic gate:
+      #   * ST1000/ST1003/ST1016/ST1020-ST1022 — these are staticcheck's OWN
+      #     default-off doc-comment/naming conventions (package-comment form,
+      #     initialism casing, receiver-name consistency, exported-symbol comment
+      #     wording). We replicate that default here because setting `checks`
+      #     explicitly otherwise re-enables them.
+      #   * QF* "quickfix" family — opinionated auto-refactor suggestions (De
+      #     Morgan's law, tagged switches, Fprintf-vs-WriteString) rather than
+      #     correctness/convention issues. Churning unrelated logic to satisfy
+      #     them is out of scope for a first gate; revisit to adopt wholesale.
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1004
+        - -QF1005
+        - -QF1006
+        - -QF1007
+        - -QF1008
+        - -QF1009
+        - -QF1010
+        - -QF1011
+        - -QF1012
+
+formatters:
+  enable:
+    - gofmt         # canonical gofmt (matches CI's `gofmt -s` gate)

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,16 @@ test:
 vet:
 	go vet ./...
 
-# `lint` runs golangci-lint if installed, else falls back to vet.
+# `lint` runs the static-analysis gate. golangci-lint is REQUIRED (config in
+# .golangci.yml) — it is the same tool CI runs, so a local `make lint` mirrors
+# the PR gate. Install: https://golangci-lint.run/welcome/install/ (or, on Nix,
+# `nix-shell -p golangci-lint --run "golangci-lint run"`).
 lint:
-	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run; \
-	else \
-		echo "golangci-lint not found; running go vet instead"; \
-		go vet ./...; \
-	fi
+	@command -v golangci-lint >/dev/null 2>&1 || { \
+		echo "golangci-lint not found. Install it: https://golangci-lint.run/welcome/install/"; \
+		exit 1; \
+	}
+	golangci-lint run
 
 fmt:
 	gofmt -s -w .

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -986,7 +986,7 @@ func devTokenError(status int, raw []byte) (err error) {
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("Apps unavailable (503): %s", msg)
+		return fmt.Errorf("apps unavailable (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
@@ -1247,7 +1247,7 @@ func withdrawError(status int, raw []byte) (err error) {
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("Apps unavailable (503): %s", msg)
+		return fmt.Errorf("apps unavailable (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
@@ -1262,13 +1262,13 @@ func submissionsError(status int, raw []byte) (err error) {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("not logged in (401): %s — run `civitai login`", msg)
 	case http.StatusForbidden:
-		return fmt.Errorf("Apps access required — invite-only beta (403): %s", msg)
+		return fmt.Errorf("apps access required — invite-only beta (403): %s", msg)
 	case http.StatusNotFound:
 		return fmt.Errorf("no such submission (404): %s", msg)
 	case http.StatusTooManyRequests:
 		return fmt.Errorf("rate limited (429): %s — wait a moment and retry", msg)
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("Apps is not enabled (503): %s", msg)
+		return fmt.Errorf("apps is not enabled (503): %s", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}

--- a/internal/api/dev_token_test.go
+++ b/internal/api/dev_token_test.go
@@ -143,7 +143,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 		{http.StatusForbidden, map[string]string{"message": "mods only"}, "not authorized (403)"},
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "flag off"}, "Apps unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "flag off"}, "apps unavailable (503)"},
 		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
 	}
 	for _, tc := range cases {

--- a/internal/api/submissions_test.go
+++ b/internal/api/submissions_test.go
@@ -141,7 +141,7 @@ func TestSubmissionsErrorMapping(t *testing.T) {
 		want   string
 	}{
 		{http.StatusUnauthorized, map[string]string{"message": "Invalid API key"}, "civitai login"},
-		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "Apps access required — invite-only beta"},
+		{http.StatusForbidden, map[string]string{"message": "restricted to the civitai team"}, "apps access required — invite-only beta"},
 		{http.StatusNotFound, map[string]string{"message": "Submission not found"}, "no such submission"},
 		{http.StatusTooManyRequests, map[string]string{"message": "Rate limit exceeded"}, "rate limited"},
 		{http.StatusServiceUnavailable, map[string]string{"message": "Apps are not enabled"}, "not enabled"},

--- a/internal/api/withdraw_test.go
+++ b/internal/api/withdraw_test.go
@@ -74,7 +74,7 @@ func TestWithdrawRequestErrorMapping(t *testing.T) {
 		{http.StatusUnauthorized, map[string]string{"message": "bad key"}, "not authorized"},
 		{http.StatusForbidden, map[string]string{"message": "no mod"}, "not authorized"},
 		{http.StatusTooManyRequests, map[string]string{"message": "slow"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]string{"message": "Apps are not enabled"}, "Apps unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]string{"message": "Apps are not enabled"}, "apps unavailable (503)"},
 		{http.StatusInternalServerError, map[string]string{"message": "boom"}, "server returned 500"},
 	}
 	for _, tc := range cases {

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -161,7 +161,7 @@ func TestAppDevTokenErrorMapping(t *testing.T) {
 		{http.StatusForbidden, map[string]any{"message": "mods only"}, "not authorized"},
 		{http.StatusUnauthorized, map[string]any{"message": "bad key"}, "not logged in"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]any{"message": "flag off"}, "Apps unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]any{"message": "flag off"}, "apps unavailable (503)"},
 	}
 	for _, tc := range cases {
 		srv := devTokenServer(t, tc.body, tc.status, nil)

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -79,7 +79,7 @@ server, which this CLI cannot do yet (no programmatic app-source endpoint).
 
 TODO(server): expose a read endpoint that returns a published app's canonical
 source tree by slug, then --from can scaffold from it. For now, run a plain
-init and copy the upstream files in manually.`)
+init and copy the upstream files in manually`)
 	}
 
 	name := ""

--- a/internal/cmd/app_withdraw_test.go
+++ b/internal/cmd/app_withdraw_test.go
@@ -150,7 +150,7 @@ func TestAppWithdrawErrorMapping(t *testing.T) {
 		{http.StatusUnauthorized, map[string]any{"message": "invalid key"}, "not authorized"},
 		{http.StatusForbidden, map[string]any{"message": "no access"}, "not authorized"},
 		{http.StatusTooManyRequests, map[string]any{"message": "slow down"}, "rate limited"},
-		{http.StatusServiceUnavailable, map[string]any{"message": "Rate limiter unavailable; please retry"}, "Apps unavailable (503)"},
+		{http.StatusServiceUnavailable, map[string]any{"message": "Rate limiter unavailable; please retry"}, "apps unavailable (503)"},
 	}
 	for _, tc := range cases {
 		srv := withdrawServer(t, tc.body, tc.status, nil)

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -490,7 +490,7 @@ func checkTargetCollisions(files []api.ModelVersionFile, o *downloadOpts) error 
 	if groups == 0 {
 		return nil
 	}
-	return fmt.Errorf("refusing to download: %d set(s) of files would be written to the same path and silently overwrite each other:\n%s\nPick ONE with --file <id> (the numeric file id shown above), or download them separately to distinct paths (e.g. one at a time with --out <path>).", groups, strings.TrimRight(b.String(), "\n"))
+	return fmt.Errorf("refusing to download: %d set(s) of files would be written to the same path and silently overwrite each other:\n%s\nPick ONE with --file <id> (the numeric file id shown above), or download them separately to distinct paths (e.g. one at a time with --out <path>)", groups, strings.TrimRight(b.String(), "\n"))
 }
 
 // targetPath computes the on-disk destination for a file given the flags:

--- a/internal/cmd/safeterm_test.go
+++ b/internal/cmd/safeterm_test.go
@@ -20,10 +20,10 @@ func TestSafeTerm(t *testing.T) {
 		{"strips BEL", "a\x07b", "ab"},
 		{"strips NUL", "a\x00b", "ab"},
 		{"strips DEL", "a\x7fb", "ab"},
-		{"strips C1 CSI U+009B", "ab", "ab"},
-		{"strips C1 OSC U+009D", "ab", "ab"},
-		{"strips C1 low U+0080", "ab", "ab"},
-		{"strips C1 high U+009F", "ab", "ab"},
+		{"strips C1 CSI U+009B", "a\u009bb", "ab"},
+		{"strips C1 OSC U+009D", "a\u009db", "ab"},
+		{"strips C1 low U+0080", "a\u0080b", "ab"},
+		{"strips C1 high U+009F", "a\u009fb", "ab"},
 		{"keeps multibyte UTF-8 (accents/CJK/emoji)", "café — 日本語 🚀", "café — 日本語 🚀"},
 		{"keeps printable just above C1 (U+00A0 NBSP)", "a z", "a z"},
 	}
@@ -63,7 +63,7 @@ func TestSafeTermRemovesEveryControlRune(t *testing.T) {
 
 // controlBytes are the raw terminal-control byte sequences that must never
 // survive into human-renderer output.
-var controlBytes = []string{"\x1b", "", "\x07", "\x00", "\x7f"}
+var controlBytes = []string{"\x1b", "\u009b", "\x07", "\x00", "\x7f"}
 
 // assertNoControlBytes fails if s contains any raw terminal control sequence.
 func assertNoControlBytes(t *testing.T, label, s string) {

--- a/internal/devtunnel/ssh_dialer.go
+++ b/internal/devtunnel/ssh_dialer.go
@@ -109,13 +109,6 @@ type sshDialer struct {
 // status to log.
 func NewSSHDialer(log io.Writer) Dialer { return &sshDialer{log: log} }
 
-func (d *sshDialer) logf(format string, a ...any) {
-	if d.log == nil {
-		return
-	}
-	fmt.Fprintf(d.log, format, a...)
-}
-
 // pinnedHostKeyCallback builds a FixedHostKey callback from the mint-provided
 // OpenSSH host public-key line, PINNING the sish host key so an on-path attacker
 // impersonating the sish endpoint is rejected at the SSH handshake (a MITM there


### PR DESCRIPTION
## What

Adds a static-analysis CI gate for the CLI and fixes the findings that currently exist so it lands **green**.

### Added
- **`.golangci.yml`** (schema v2) — a curated, deliberately-pragmatic linter set: `staticcheck`, `govet`, `ineffassign`, `unused`, `misspell`, plus `gofmt` formatting, run over the whole module.
  - `errcheck` is **intentionally not enabled yet** — a prior run surfaced ~33 low-value `Fprint`/`Close`-return hits (mostly in tests). The config documents this as a scoped start to tighten later.
  - The staticcheck `QF*` "quickfix" family (opinionated auto-refactors: De Morgan's law, tagged switches, `Fprintf`-vs-`WriteString`) and the default-off doc-comment/naming conventions (`ST1000/1003/1016/1020-1022`) are excluded, with an inline rationale. High-value correctness (`SA*`) and meaningful conventions (`ST1005` error strings, `ST1018`, …) stay on.
- **`lint` CI job** in `.github/workflows/ci.yml` using `golangci/golangci-lint-action@v8`, pinned to `golangci-lint v2.12.2` (compatible with `go 1.25`). Runs on every PR.

### Changed
- **Makefile `lint` target** — previously degraded silently to `go vet` when `golangci-lint` was absent. It now **requires** `golangci-lint` (fails with an install hint), mirroring the CI gate.

### Fixes to land green
- Removed dead unused method `sshDialer.logf` (`internal/devtunnel/ssh_dialer.go`). Its `log` field is still passed to the tunnel — only the method was orphaned.
- `ST1005`: lowercased capitalized error strings (`"Apps …"` → `"apps …"`) in `internal/api/api.go`, and dropped trailing punctuation from two error strings (`internal/cmd/app_init.go`, `internal/cmd/download.go`). **Test assertions on the exact message text were updated in lockstep** (5 assertions across 5 test files).
- `ST1018`: escaped `U+0080/009B/009D/009F` control characters in `internal/cmd/safeterm_test.go` string literals — identical runes, clearer source.

## Verification (local)

```
$ golangci-lint run ./...
0 issues.
```

`go build ./...`, `go test ./...`, `go vet ./...`, and `gofmt -s -l .` are all clean.

No `//nolint` directives were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
