### PR TITLE
feat: differentiated process exit codes by failure kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,34 @@ Not live yet — gen-matrix.civit.ai only serves after the app is approved and d
 Config lives at `~/.config/civitai/config.yaml` (honours `XDG_CONFIG_HOME`),
 written owner-readable only.
 
+## Exit codes
+
+`civitai` returns a differentiated exit code so scripts can branch on the *kind*
+of failure without parsing stderr. The human-readable error message is unchanged
+by this — only `echo $?` differs.
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Generic / unclassified error. |
+| `2` | Usage error — a bad flag or malformed invocation. |
+| `3` | Authentication/authorization — login required, token invalid/expired, or the credential lacks the needed scope (HTTP 401/403, or no token configured). |
+| `4` | Not found — the requested resource does not exist (HTTP 404). |
+| `5` | Network/transport failure or service unavailable — dial/timeout, or HTTP 502/503/504 after retries. |
+| `6` | Rate limited — throttled by the API (HTTP 429). |
+
+```bash
+# Branch on failure kind
+if ! civitai models get "$id" >/dev/null 2>&1; then
+  case $? in
+    3) echo "log in first: civitai login" ;;
+    4) echo "no such model: $id" ;;
+    5|6) echo "transient — retry later" ;;
+    *) echo "failed" ;;
+  esac
+fi
+```
+
 ## Troubleshooting
 
 - **`no token configured`** — run `civitai login` (or set `CIVITAI_TOKEN`).

--- a/cmd/civitai/main.go
+++ b/cmd/civitai/main.go
@@ -2,9 +2,14 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
 	"os"
+	"syscall"
 
+	"github.com/civitai/cli/internal/api"
 	"github.com/civitai/cli/internal/cmd"
 )
 
@@ -17,10 +22,84 @@ var (
 	date    = "unknown"
 )
 
+// Process exit codes. Scripts can branch on the FAILURE KIND without parsing
+// stderr. Keep this scheme in sync with the "Exit codes" section of README.md.
+const (
+	exitOK          = 0 // success
+	exitGeneric     = 1 // generic / unknown / unclassified failure
+	exitUsage       = 2 // bad flags or malformed invocation (Cobra usage error)
+	exitAuth        = 3 // authentication/authorization: login required, token invalid/expired, missing scope
+	exitNotFound    = 4 // the requested resource does not exist (HTTP 404)
+	exitNetwork     = 5 // network/transport failure or service unavailable (dial/timeout, HTTP 502/503/504)
+	exitRateLimited = 6 // throttled by the API (HTTP 429)
+)
+
 func main() {
 	cmd.SetBuildInfo(version, commit, date)
 	if err := cmd.NewRootCmd().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
+		os.Exit(exitCode(err))
 	}
+}
+
+// exitCode maps a command error to a differentiated process exit code so
+// scripts can branch on the KIND of failure. It only inspects the error's
+// classification (via errors.Is/errors.As against the sentinels the internal
+// packages attach) — it never changes what is printed to the user. A nil error
+// is success (0); any error it cannot classify falls back to the generic code
+// (1). It never panics.
+func exitCode(err error) int {
+	switch {
+	case err == nil:
+		return exitOK
+
+	// Usage errors (bad flag / malformed invocation) are tagged by the root
+	// command's FlagErrorFunc. Checked first: a usage mistake is about the
+	// invocation, not the API.
+	case errors.Is(err, cmd.ErrUsage):
+		return exitUsage
+
+	// Authentication / authorization: 401/403, the pre-flight "no token
+	// configured" guards, a lost-scope credential, and OAuth device-login
+	// failures.
+	case errors.Is(err, api.ErrUnauthorized),
+		errors.Is(err, api.ErrBuzzScope),
+		isDeviceFlowErr(err):
+		return exitAuth
+
+	case errors.Is(err, api.ErrNotFound):
+		return exitNotFound
+
+	case errors.Is(err, api.ErrRateLimited):
+		return exitRateLimited
+
+	// Network/transport or service-availability failure: tagged 502/503/504 and
+	// exhausted retries, plus raw transport errors (dial refused/reset, timeout,
+	// deadline exceeded) that reach us unclassified.
+	case errors.Is(err, api.ErrNetwork), isNetworkErr(err):
+		return exitNetwork
+
+	default:
+		return exitGeneric
+	}
+}
+
+// isDeviceFlowErr reports whether err is (or wraps) a terminal OAuth
+// device-login failure — an authentication problem.
+func isDeviceFlowErr(err error) bool {
+	var d *api.DeviceFlowError
+	return errors.As(err, &d)
+}
+
+// isNetworkErr reports whether err is (or wraps) a raw transport/connection
+// failure that was not otherwise classified: a net.Error, a refused/reset
+// connection, or a deadline/timeout.
+func isNetworkErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }

--- a/cmd/civitai/main_test.go
+++ b/cmd/civitai/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/civitai/cli/internal/cmd"
+)
+
+// fakeNetErr is a minimal net.Error for exercising the transport-error branch.
+type fakeNetErr struct{ timeout bool }
+
+func (e fakeNetErr) Error() string   { return "fake net error" }
+func (e fakeNetErr) Timeout() bool   { return e.timeout }
+func (e fakeNetErr) Temporary() bool { return false }
+
+// usageErr mirrors internal/cmd's (unexported) usageError: a flag error tagged
+// with cmd.ErrUsage while preserving its message. It lets this external test
+// verify the same message-preserving classification the FlagErrorFunc produces.
+type usageErr struct{ err error }
+
+func (u usageErr) Error() string   { return u.err.Error() }
+func (u usageErr) Unwrap() []error { return []error{u.err, cmd.ErrUsage} }
+
+func TestExitCode(t *testing.T) {
+	// A message-preserving check: every classified error must map to its code
+	// AND keep its original text (only the exit code differs, per the scheme).
+	cases := []struct {
+		name string
+		err  error
+		want int
+		// msg, when non-empty, is the exact message the tagged error must still
+		// print — proving classification does not alter user-facing output.
+		msg string
+	}{
+		{"nil is success", nil, exitOK, ""},
+
+		{"usage error", usageErr{errors.New("unknown flag: --nope")}, exitUsage, "unknown flag: --nope"},
+		{"usage sentinel", cmd.ErrUsage, exitUsage, ""},
+
+		{"unauthorized sentinel", api.ErrUnauthorized, exitAuth, ""},
+		{"tagged 401 (real readError shape)", api.Tag(api.ErrUnauthorized,
+			fmt.Errorf("unauthorized (401): token expired — run `civitai login`")), exitAuth,
+			"unauthorized (401): token expired — run `civitai login`"},
+		{"buzz scope", api.ErrBuzzScope, exitAuth, ""},
+		{"device flow error", &api.DeviceFlowError{Code: "access_denied"}, exitAuth, ""},
+		{"wrapped device flow error", fmt.Errorf("login: %w", &api.DeviceFlowError{Code: "expired_token"}), exitAuth, ""},
+
+		{"not found sentinel", api.ErrNotFound, exitNotFound, ""},
+		{"tagged 404 (real readError shape)", api.Tag(api.ErrNotFound,
+			fmt.Errorf("not found (404): No model with id 999")), exitNotFound,
+			"not found (404): No model with id 999"},
+
+		{"rate limited sentinel", api.ErrRateLimited, exitRateLimited, ""},
+		{"tagged 429", api.Tag(api.ErrRateLimited, fmt.Errorf("rate limited (429): slow down")), exitRateLimited, "rate limited (429): slow down"},
+
+		{"network sentinel", api.ErrNetwork, exitNetwork, ""},
+		{"tagged 503", api.Tag(api.ErrNetwork, fmt.Errorf("service unavailable (503): retry shortly")), exitNetwork, "service unavailable (503): retry shortly"},
+		{"net.Error timeout", fakeNetErr{timeout: true}, exitNetwork, ""},
+		{"wrapped dial refused", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), exitNetwork, ""},
+		{"deadline exceeded", fmt.Errorf("request: %w", context.DeadlineExceeded), exitNetwork, ""},
+
+		{"generic fallback", errors.New("something unexpected"), exitGeneric, ""},
+		{"wrapped generic", fmt.Errorf("outer: %w", errors.New("inner")), exitGeneric, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCode(tc.err); got != tc.want {
+				t.Errorf("exitCode(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+			if tc.msg != "" && tc.err.Error() != tc.msg {
+				t.Errorf("message changed by classification: got %q, want %q", tc.err.Error(), tc.msg)
+			}
+		})
+	}
+}
+
+// TestExitCodesAreDistinct guards against two kinds accidentally sharing a code.
+func TestExitCodesAreDistinct(t *testing.T) {
+	codes := map[int]string{
+		exitOK: "ok", exitGeneric: "generic", exitUsage: "usage",
+		exitAuth: "auth", exitNotFound: "notFound", exitNetwork: "network",
+		exitRateLimited: "rateLimited",
+	}
+	if len(codes) != 7 {
+		t.Fatalf("expected 7 distinct exit codes, got %d", len(codes))
+	}
+}
+
+// Ensure the interface assertion for net.Error stays valid.
+var _ net.Error = fakeNetErr{}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -606,7 +606,7 @@ func (c *Client) WhoAmI(ctx context.Context) (*Identity, error) {
 		return nil, err
 	}
 	if tok == "" {
-		return nil, fmt.Errorf("no token configured — run `civitai login` first")
+		return nil, tag(ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` first"))
 	}
 	build := func() (*http.Request, error) {
 		return http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v1/me", nil)
@@ -669,7 +669,7 @@ func (c *Client) GetBuzzAccount(ctx context.Context) (*BuzzAccount, error) {
 		return nil, err
 	}
 	if tok == "" {
-		return nil, fmt.Errorf("no token configured — run `civitai login` first")
+		return nil, tag(ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` first"))
 	}
 	build := func() (*http.Request, error) {
 		return http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+BuzzAccountPath, nil)
@@ -838,7 +838,7 @@ func (c *Client) GetForgejoCloneInfo(ctx context.Context, app string) (*ForgejoC
 		return nil, err
 	}
 	if tok == "" {
-		return nil, fmt.Errorf("no token configured — run `civitai login` first")
+		return nil, tag(ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` first"))
 	}
 
 	// tRPC query input: ?input={"json":{"slug":"<app>"}}. The server accepts the
@@ -878,7 +878,8 @@ func (c *Client) GetForgejoCloneInfo(ctx context.Context, app string) (*ForgejoC
 
 // cloneInfoError maps a non-200 from the clone-info tRPC query to an actionable
 // message. tRPC error bodies are {error:{json:{message,code,...}}}.
-func cloneInfoError(status int, raw []byte) error {
+func cloneInfoError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	var env struct {
 		Error struct {
 			JSON struct {
@@ -964,7 +965,8 @@ func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string)
 // not-found-or-not-yours, 403 not-invited-or-insufficient-scope, 429
 // rate-limited, 503 flag-off. The 403 message is the key DX case — a spend
 // token needs a full-scope personal API key (an OAuth login mints read-only).
-func devTokenError(status int, raw []byte) error {
+func devTokenError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusNotFound:
@@ -1184,7 +1186,8 @@ func isInsufficientScopeMsg(msg string) bool {
 // devTunnelError maps a non-200 dev-tunnel tRPC response to an actionable CLI
 // error. tRPC error bodies are {error:{json:{message,code,...}}}; the HTTP
 // status carries the mapped code (403 flag-off/not-author, 404 not-your-app).
-func devTunnelError(status int, raw []byte) error {
+func devTunnelError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	var env struct {
 		Error struct {
 			JSON struct {
@@ -1229,7 +1232,8 @@ func devTunnelError(status int, raw []byte) error {
 // 404 not-found-or-not-yours, 409 not-in-a-withdrawable-(pending)-state (the
 // server's message carries the reason), 401/403 auth, 429 rate-limited, 503
 // flag-off/rate-limiter-incident.
-func withdrawError(status int, raw []byte) error {
+func withdrawError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -1251,7 +1255,8 @@ func withdrawError(status int, raw []byte) error {
 
 // submissionsError maps a non-2xx submissions response to a clear, actionable
 // error, with Apps-specific guidance for 403/404/429/503.
-func submissionsError(status int, raw []byte) error {
+func submissionsError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized:
@@ -1289,7 +1294,8 @@ func serverMessage(raw []byte) string {
 }
 
 // serverError turns a non-2xx response into a clear, actionable error.
-func serverError(status int, raw []byte) error {
+func serverError(status int, raw []byte) (err error) {
+	defer func() { err = tagStatus(status, err) }()
 	msg := serverMessage(raw)
 	switch status {
 	case http.StatusUnauthorized:

--- a/internal/api/errkind.go
+++ b/internal/api/errkind.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+)
+
+// Classification sentinels for the API's failure kinds. They carry NO
+// user-facing text of their own — they are ATTACHED to the existing,
+// message-bearing errors via tag/tagStatus so that errors.Is(err, ErrX)
+// reports the FAILURE KIND while err.Error() stays byte-for-byte unchanged.
+//
+// Consumers (e.g. the CLI's process-exit-code mapping in cmd/civitai) branch on
+// these; nothing here alters what a human sees printed on stderr.
+var (
+	// ErrUnauthorized marks an authentication/authorization failure — a missing,
+	// expired, or invalid credential, or a credential lacking the needed scope
+	// (HTTP 401/403, and the pre-flight "no token configured" guards).
+	ErrUnauthorized = errors.New("authentication required")
+	// ErrNotFound marks a requested resource that does not exist (HTTP 404).
+	ErrNotFound = errors.New("not found")
+	// ErrRateLimited marks a throttled request (HTTP 429).
+	ErrRateLimited = errors.New("rate limited")
+	// ErrNetwork marks a transport/service-availability failure — the gateway/
+	// overload family (HTTP 502/503/504) and exhausted transient retries.
+	ErrNetwork = errors.New("network or service unavailable")
+)
+
+// taggedError attaches a classification sentinel (tag) to an underlying,
+// message-bearing error WITHOUT changing the user-visible message: Error()
+// delegates to the wrapped error, while Unwrap() exposes BOTH the original
+// error chain AND the tag, so errors.Is matches either.
+type taggedError struct {
+	err error // original, message-bearing error (its text is preserved)
+	tag error // classification sentinel (contributes no visible text)
+}
+
+func (t *taggedError) Error() string   { return t.err.Error() }
+func (t *taggedError) Unwrap() []error { return []error{t.err, t.tag} }
+
+// tag attaches classification sentinel k to err while preserving err's message.
+// It is a no-op (returns err unchanged) when either err or k is nil.
+func tag(k, err error) error {
+	if err == nil || k == nil {
+		return err
+	}
+	return &taggedError{err: err, tag: k}
+}
+
+// Tag attaches classification sentinel k to err while preserving err's exact
+// message, so errors.Is(result, k) is true but result.Error() == err.Error().
+// Exported for callers in sibling packages (e.g. internal/auth) that produce an
+// error of a known kind. A nil err or k is returned unchanged.
+func Tag(k, err error) error { return tag(k, err) }
+
+// TagStatus attaches the classification sentinel for an HTTP status to err
+// while preserving err's exact message (statuses with no specific kind leave
+// err unchanged). Exported so command-layer status→error mappers in sibling
+// packages classify identically to the api client's own mappers.
+func TagStatus(status int, err error) error { return tagStatus(status, err) }
+
+// statusKind maps an HTTP status to its classification sentinel, or nil when the
+// status has no specific kind (a generic/unknown failure).
+func statusKind(status int) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return ErrUnauthorized
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return ErrNetwork
+	default:
+		return nil
+	}
+}
+
+// tagStatus attaches the classification sentinel for status to err (message
+// preserved). Statuses with no specific kind leave err unchanged.
+func tagStatus(status int, err error) error {
+	return tag(statusKind(status), err)
+}

--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -104,7 +104,10 @@ func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any
 // readError turns a non-2xx read response into a clear, actionable error,
 // surfacing the API's own error body ({"error": ...} or {"message": ...})
 // rather than a Go struct dump.
-func readError(status int, raw []byte) error {
+func readError(status int, raw []byte) (err error) {
+	// Attach the classification sentinel for status (401/404/429/503…) to the
+	// returned error without changing its user-visible message.
+	defer func() { err = tagStatus(status, err) }()
 	msg := strings.TrimSpace(string(raw))
 	var wrapped struct {
 		Error   json.RawMessage `json:"error"`

--- a/internal/api/retry.go
+++ b/internal/api/retry.go
@@ -161,7 +161,9 @@ func retryExhaustedError(status, attempts int, raw []byte) error {
 	if s := snippet(raw); s != "" {
 		msg += ": " + s
 	}
-	return errors.New(msg)
+	// Exhausted transient retries against an overloaded backend is a
+	// service-availability failure; classify it so scripts can branch on it.
+	return tag(ErrNetwork, errors.New(msg))
 }
 
 // sleepCtx waits for d or until ctx is cancelled, returning ctx.Err() on

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -86,7 +86,7 @@ func (s *Source) Refresh(ctx context.Context) (string, error) {
 func (s *Source) refreshLocked(ctx context.Context) (string, error) {
 	rt := s.cfg.RefreshToken()
 	if rt == "" {
-		return "", fmt.Errorf("no refresh token stored — run `civitai login` again")
+		return "", api.Tag(api.ErrUnauthorized, fmt.Errorf("no refresh token stored — run `civitai login` again"))
 	}
 	tr, err := s.oc.Refresh(ctx, rt)
 	if err != nil {

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -135,7 +135,7 @@ never commit it; re-mint when it expires.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			var slug string

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -338,7 +338,7 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")

--- a/internal/cmd/app_pull.go
+++ b/internal/cmd/app_pull.go
@@ -88,7 +88,7 @@ approved; before then the command tells you so instead of failing obscurely.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			fetch := defaultCloneInfoFetcher(cfg)

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -47,7 +47,7 @@ and deployed (deployState 'live').`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			var blockID string

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -42,7 +42,7 @@ Pass the publish-request id as a positional argument or via --id (find it with
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			if idFlag != "" && len(args) == 1 {

--- a/internal/cmd/buzz.go
+++ b/internal/cmd/buzz.go
@@ -54,7 +54,9 @@ how to switch to a personal key.`,
 					// fixable failure, not "balance is zero").
 					errw := cmd.ErrOrStderr()
 					fmt.Fprintln(errw, ui.For(errw).Warn(buzzScopeHint))
-					return fmt.Errorf("credential can't read Buzz balance")
+					// Re-tag so exitCode maps the lost-scope case to the auth exit
+					// code (3), not the generic fallback — the message is unchanged.
+					return api.Tag(api.ErrBuzzScope, fmt.Errorf("credential can't read Buzz balance"))
 				}
 				return err
 			}

--- a/internal/cmd/buzz.go
+++ b/internal/cmd/buzz.go
@@ -43,7 +43,7 @@ how to switch to a personal key.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -435,6 +436,23 @@ func TestLoginDeviceStartFailureReturnsError(t *testing.T) {
 	// Nothing persisted on a failed login.
 	if _, statErr := os.Stat(filepath.Join(dir, "civitai", "config.yaml")); statErr == nil {
 		t.Error("no config should be written on a failed login")
+	}
+}
+
+// TestFlagErrorTaggedAsUsage exercises the REAL SetFlagErrorFunc → asUsageError
+// wiring on the root command (not a reimplemented stand-in): a bad flag must
+// yield an error that satisfies errors.Is(err, ErrUsage) — which the entrypoint
+// maps to exit code 2 — while the user-visible message stays Cobra's verbatim.
+func TestFlagErrorTaggedAsUsage(t *testing.T) {
+	_, _, err := run(t, "images", "search", "--nope")
+	if err == nil {
+		t.Fatal("expected a flag error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("flag error must be tagged ErrUsage (→ exit 2), got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("message should be Cobra's verbatim flag error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -731,7 +731,10 @@ func controlnetPreprocessorNote(modelType string) string {
 }
 
 // downloadStatusError maps a non-2xx download response to an actionable error.
-func downloadStatusError(status int, name string) error {
+func downloadStatusError(status int, name string) (err error) {
+	// Classify the returned error by status (401/403→auth, 404→not-found, …)
+	// without changing its message, so the process exit code reflects the kind.
+	defer func() { err = api.TagStatus(status, err) }()
 	switch {
 	case status >= 200 && status < 300:
 		return nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -255,6 +255,13 @@ Get started:
 	_ = colorViper.BindEnv("no_color", "CIVITAI_NO_COLOR")
 	_ = colorViper.BindEnv("color", "CIVITAI_COLOR")
 
+	// Classify Cobra's own flag-parsing failures as usage errors (message left
+	// untouched) so the entrypoint can map them to a dedicated exit code. Applies
+	// to every subcommand via cobra's flag-error propagation.
+	root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return asUsageError(err)
+	})
+
 	root.AddCommand(newAppCmd())
 	root.AddCommand(newLoginCmd())
 	root.AddCommand(newWhoAmICmd())

--- a/internal/cmd/usage_error.go
+++ b/internal/cmd/usage_error.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "errors"
+
+// ErrUsage classifies a command-line USAGE error — a bad flag or malformed
+// invocation — as distinct from a runtime failure. It carries no visible text
+// of its own: it is attached to Cobra's own flag-parsing error (see
+// NewRootCmd's SetFlagErrorFunc) so that errors.Is(err, ErrUsage) is true while
+// the message the user sees stays exactly what Cobra produced. The process
+// entrypoint (cmd/civitai) maps it to a dedicated exit code.
+var ErrUsage = errors.New("usage error")
+
+// usageError attaches ErrUsage to a flag-parsing error WITHOUT altering the
+// user-visible message: Error() delegates to the wrapped error while Unwrap()
+// exposes both the original error and the ErrUsage sentinel.
+type usageError struct{ err error }
+
+func (u *usageError) Error() string   { return u.err.Error() }
+func (u *usageError) Unwrap() []error { return []error{u.err, ErrUsage} }
+
+// asUsageError tags err as a usage error (message preserved). A nil err is
+// returned unchanged.
+func asUsageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &usageError{err: err}
+}

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -36,7 +36,7 @@ Reads the token from config or CIVITAI_TOKEN.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
+				return api.Tag(api.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
 			}
 			client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
 			id, err := client.WhoAmI(context.Background())


### PR DESCRIPTION
## What

Give `civitai` **differentiated process exit codes** mapped from the CLI's existing sentinel/typed and HTTP-status errors, so scripts can branch on the *kind* of failure without parsing stderr.

The human-facing error output is **unchanged** — only `echo $?` differs.

### Scheme

| Code | Meaning |
| --- | --- |
| `0` | Success |
| `1` | Generic / unclassified error |
| `2` | Usage error — bad flag / malformed invocation (Cobra flag error) |
| `3` | Auth — login required, token invalid/expired, missing scope (401/403, no-token, OAuth device-login) |
| `4` | Not found (404) |
| `5` | Network/transport or service unavailable (dial/timeout, 502/503/504, exhausted retries) |
| `6` | Rate limited (429) |

## How

Classification is attached with **message-preserving tags** — a small `taggedError` whose `Error()` delegates to the original error while `Unwrap() []error` also exposes a classification sentinel. So `errors.Is(err, api.ErrNotFound)` is true, but `err.Error()` is byte-for-byte identical to before.

- `internal/api/errkind.go` — new sentinels (`ErrUnauthorized`, `ErrNotFound`, `ErrRateLimited`, `ErrNetwork`) + `Tag`/`TagStatus` helpers.
- The status→error mappers (`readError`, and the write-path `cloneInfoError`/`devTokenError`/`devTunnelError`/`withdrawError`/`submissionsError`/`serverError`, plus `downloadStatusError`) tag their result by HTTP status via a one-line `defer` — existing message bodies untouched.
- The pre-flight "no token configured" guards and the auth refresh failure are tagged `ErrUnauthorized`.
- Retry-exhaustion is tagged `ErrNetwork`.
- Root command's `SetFlagErrorFunc` tags Cobra flag errors as `cmd.ErrUsage`.
- `cmd/civitai/main.go` gains `exitCode(err) int` — exhaustive-with-fallback (unknown → 1), never panics; raw transport errors (`net.Error`, `ECONNREFUSED/RESET`, `DeadlineExceeded`) also classify as network.

## Tests

- `cmd/civitai/main_test.go` unit-tests every mapped kind + generic fallback + nil, and asserts the tagged errors keep their exact message.
- Full suite / `go build` / `go vet` / `gofmt -l` all clean.

## Empirical demonstration

```
models search --query dreamshaper --limit 1   -> echo $? = 0
models search --nope                           -> echo $? = 2   (Error: unknown flag: --nope)
whoami            (no token)                    -> echo $? = 3   (Error: no token configured …)
buzz              (no token)                    -> echo $? = 3
models get 999999999                           -> echo $? = 4   (Error: not found (404): No model with id 999999999)
CIVITAI_BASE_URL=http://127.0.0.1:1 models get 1234 -> echo $? = 5
```

(Code `6`/rate-limited is covered by unit test; not triggered live to avoid hammering the API.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
