### PR TITLE
fix(models): label the search DOWNLOADS column as all-time

### DIFF
--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -66,6 +66,15 @@ cursor is printed after the results.`,
 					q.Add("baseModels", bm)
 				}
 			}
+			// The API sorts by the given --period but only ever returns the
+			// all-time stats.downloadCount (there is no per-period download
+			// total), so the DOWNLOADS column can show a lower count on an
+			// earlier row — which reads as a broken sort. Warn so the number
+			// isn't misread as the period's count.
+			if cmd.Flags().Changed("period") {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"note: the DL(all-time) column is the all-time download count; the API does not return per-period download totals, so it does not reflect --period.")
+			}
 			addIfSet(q, "sort", sort)
 			addIfSet(q, "period", period)
 			addIfSet(q, "cursor", cursor)
@@ -144,7 +153,11 @@ func printModelList(cmd *cobra.Command, items []api.ModelListItem) {
 		return
 	}
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tCREATOR\tDOWNLOADS\tTHUMBSUP")
+	// The API returns only the all-time stats.downloadCount — there is no
+	// per-period download total — so label the column all-time to avoid the
+	// "row 2 has more downloads than row 1" read-as-broken-sort confusion when
+	// results are sorted by --period (e.g. --sort "Most Downloaded" --period Month).
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tCREATOR\tDL(all-time)\tTHUMBSUP")
 	for _, m := range items {
 		creator := "-"
 		if m.Creator != nil && m.Creator.Username != "" {

--- a/internal/cmd/read_cmd_test.go
+++ b/internal/cmd/read_cmd_test.go
@@ -51,8 +51,42 @@ func TestModelsSearchHumanOutput(t *testing.T) {
 	if !strings.Contains(out, "Pony") || !strings.Contains(out, "bob") {
 		t.Errorf("human output missing fields: %s", out)
 	}
+	// The downloads column is labelled all-time so a --period sort can't be
+	// misread as a broken sort (the API returns only all-time counts).
+	if !strings.Contains(out, "DL(all-time)") {
+		t.Errorf("downloads header should be labelled all-time: %s", out)
+	}
+	if strings.Contains(out, "DOWNLOADS\t") || strings.Contains(out, "\tDOWNLOADS") {
+		t.Errorf("bare DOWNLOADS header should be gone: %s", out)
+	}
 	if !strings.Contains(out, "next cursor: c1") {
 		t.Errorf("footer should show next cursor: %s", out)
+	}
+}
+
+func TestModelsSearchPeriodNote(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[{"id":1,"name":"Pony","type":"Checkpoint",
+		  "creator":{"username":"bob"},"stats":{"downloadCount":10,"thumbsUpCount":3}}],
+		  "metadata":{}}`))
+	})
+	// With --period set, an all-time note must go to stderr so the count isn't
+	// misread as the period's total.
+	_, errOut, err := run(t, "models", "search", "--sort", "Most Downloaded", "--period", "Month", "--limit", "1")
+	if err != nil {
+		t.Fatalf("models search --period: %v", err)
+	}
+	if !strings.Contains(errOut, "all-time") || !strings.Contains(errOut, "--period") {
+		t.Errorf("stderr should note the all-time column when --period is set: %q", errOut)
+	}
+
+	// Without --period there should be no such note.
+	_, errOut2, err := run(t, "models", "search", "--limit", "1")
+	if err != nil {
+		t.Fatalf("models search: %v", err)
+	}
+	if strings.Contains(errOut2, "all-time") {
+		t.Errorf("no all-time note expected without --period: %q", errOut2)
 	}
 }
 


### PR DESCRIPTION
## Problem (found via blind dogfood)

`civitai models search --base-model X --sort "Most Downloaded" --period Month` sorts results by the period, but the DOWNLOADS column shows **all-time** counts. The API returns only the all-time `stats.downloadCount` — there is no per-period download total — so an earlier row can show *fewer* downloads than a later one, which reads as a broken sort.

## Fix (honesty)

- Rename the table header `DOWNLOADS` → `DL(all-time)` so the all-time nature is explicit. Values unchanged.
- When `--period` is set, print a one-line stderr note (mirroring the `images` command's existing `--sort`-ignored note style) clarifying the column is all-time and does not reflect `--period`.

### Before / after

```
# before
ID      NAME   TYPE   CREATOR   DOWNLOADS      THUMBSUP

# after
ID      NAME   TYPE   CREATOR   DL(all-time)   THUMBSUP
```

Live run:

```
$ civitai models search --limit 3 --sort "Most Downloaded" --period Month
note: the DL(all-time) column is the all-time download count; the API does not return per-period download totals, so it does not reflect --period.
ID      NAME   TYPE        CREATOR     DL(all-time)  THUMBSUP
200255  ...    LORA        EauDeNoire  297402        16191
...
```

## Tests

- `TestModelsSearchHumanOutput` now asserts the `DL(all-time)` header and that the bare `DOWNLOADS` header is gone.
- New `TestModelsSearchPeriodNote` asserts the stderr note appears with `--period` and is absent without it.

Gates clean: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)