### PR TITLE
fix(download): hint --model when a model id is passed as a version id

### DIFF
--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -53,6 +54,11 @@ Identify the version deterministically by its numeric version id:
 …or resolve a model's default (first published) version with --model:
 
   civitai download --model 4384
+
+Note the positional id is a model-VERSION id, NOT a model id: 'civitai models
+search' and 'civitai models get' list MODEL ids, so pass one of those via
+--model. Handing a model id as the positional (e.g. 'civitai download 4384')
+errors with a hint to use --model.
 
 Use --dry-run to print the resolved plan (files, sizes, SHA256, target paths,
 and whether auth is required) without transferring anything.
@@ -156,7 +162,7 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 
 	v, _, err := client.GetModelVersion(ctx, versionID)
 	if err != nil {
-		return err
+		return hintModelIDMistake(ctx, client, positional, o.modelID, err)
 	}
 	// Parent model type (Checkpoint, LORA, …) drives --layout routing of the
 	// weights file; the version detail embeds it under `model`.
@@ -306,7 +312,7 @@ func downloadSelected(ctx context.Context, dl api.Downloader, out, errW io.Write
 func resolveVersionID(ctx context.Context, client api.Reader, positional, modelID string) (string, error) {
 	if positional != "" {
 		if _, err := strconv.Atoi(positional); err != nil {
-			return "", fmt.Errorf("model-version id must be an integer, got %q", positional)
+			return "", fmt.Errorf("model-version id must be an integer, got %q — pass a numeric model-version id, or find one with `civitai models search`", positional)
 		}
 		return positional, nil
 	}
@@ -321,6 +327,40 @@ func resolveVersionID(ctx context.Context, client api.Reader, positional, modelI
 		return "", fmt.Errorf("model %s has no published versions to download", modelID)
 	}
 	return strconv.Itoa(m.ModelVersions[0].ID), nil
+}
+
+// hintModelIDMistake disambiguates the single most common `download` mistake:
+// the positional argument is a model-VERSION id, but `civitai models search`
+// (and `models get`) list MODEL ids — so a user's natural next step,
+// `civitai download <model-id>`, 404s on the version lookup even though the id
+// is a perfectly valid MODEL id, and the bare "Model not found" is actively
+// misleading (the id IS a valid model).
+//
+// When the version lookup fails with a 404 on a POSITIONAL id (not a --model
+// resolution), this checks whether that same id resolves as a MODEL and, if so,
+// replaces the bare not-found with an actionable hint pointing at
+// `--model <id>` — tagged as a usage error so the exit code reflects the
+// invocation mistake rather than a missing resource. Any other failure (auth,
+// network, rate-limit, or a genuinely unknown id that is neither a version nor a
+// model) surfaces the original error unchanged.
+func hintModelIDMistake(ctx context.Context, client api.Reader, positional, modelID string, versionErr error) error {
+	// Only the positional-id path hits this trap, and only a genuine 404 is worth
+	// a second lookup — every other failure kind is the real problem and must
+	// pass through untouched (and unclassified-changed).
+	if positional == "" || modelID != "" || !errors.Is(versionErr, api.ErrNotFound) {
+		return versionErr
+	}
+	// Is the same id a valid MODEL id? If the model lookup fails for ANY reason,
+	// don't mask the original version-not-found error with a misleading hint —
+	// the id simply isn't a known version or model.
+	if _, _, err := client.GetModel(ctx, positional); err != nil {
+		return versionErr
+	}
+	return asUsageError(fmt.Errorf(
+		"%s is a model id, not a model-version id — did you mean: civitai download --model %s ?\n"+
+			"(`civitai download <id>` takes a model-VERSION id, but `civitai models search` / `civitai models get` list MODEL ids. "+
+			"Use --model to download the model's default version, or `civitai models get %s` to pick a specific version id.)",
+		positional, positional, positional))
 }
 
 // printDownloadPlan renders the --dry-run plan: for each selected file its name,

--- a/internal/cmd/download_modelid_hint_test.go
+++ b/internal/cmd/download_modelid_hint_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// TestDownloadModelIDPassedAsVersionHints proves the model-id-vs-version-id
+// trap gives an ACTIONABLE hint: `civitai models search` shows MODEL ids, but
+// `civitai download <id>`'s positional is a model-VERSION id — so a user handing
+// a model id (4384) gets a 404 on the version lookup. When that id IS a valid
+// model id, the error must point at `civitai download --model <id>` instead of a
+// bare "not found", and be classified as a usage error.
+func TestDownloadModelIDPassedAsVersionHints(t *testing.T) {
+	// The version lookup 404s (the id is NOT a version), but the model lookup
+	// succeeds (the id IS a valid model). --dry-run so no bytes ever move.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"Model not found"}`)
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id":4384,"name":"DreamShaper","type":"Checkpoint","modelVersions":[{"id":128713,"name":"v8","baseModel":"SD 1.5","files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"x"}]}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	allowPrivateDownloadHostsInTest(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+
+	_, _, err := run(t, "download", "4384", "--dry-run")
+	if err == nil {
+		t.Fatal("a model id passed as a version id should error")
+	}
+	msg := err.Error()
+	// Actionable: names the mistake and the fix.
+	if !strings.Contains(msg, "is a model id") {
+		t.Errorf("error should say the id is a model id, got: %v", err)
+	}
+	if !strings.Contains(msg, "--model 4384") {
+		t.Errorf("error should suggest `--model 4384`, got: %v", err)
+	}
+	// Must NOT be the bare, misleading not-found message.
+	if strings.Contains(strings.ToLower(msg), "not found") {
+		t.Errorf("hint should replace the bare not-found message, got: %v", err)
+	}
+	// Classified as a usage error (exit code 2), not a not-found (4).
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("the hint should be tagged as a usage error, got: %v", err)
+	}
+}
+
+// TestDownloadUnknownVersionIDKeepsNotFound proves the hint does NOT fire when
+// the id is neither a valid version NOR a valid model: the original 404
+// (classified as not-found) is preserved so scripts still see exit 4.
+func TestDownloadUnknownVersionIDKeepsNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"not found"}`)
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"not found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	allowPrivateDownloadHostsInTest(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+
+	_, _, err := run(t, "download", "99999999", "--dry-run")
+	if err == nil {
+		t.Fatal("an unknown id should still error")
+	}
+	if strings.Contains(err.Error(), "is a model id") {
+		t.Errorf("no model-id hint when the id isn't a model either: %v", err)
+	}
+	if !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("an unknown id must stay classified as not-found (exit 4), got: %v", err)
+	}
+	if errors.Is(err, ErrUsage) {
+		t.Errorf("an unknown id is not a usage error, got: %v", err)
+	}
+}
+
+// TestDownloadValidVersionIDUnaffected proves the happy path is byte-for-byte
+// unchanged: a real version id still resolves + downloads with no model lookup
+// and no hint.
+func TestDownloadValidVersionIDUnaffected(t *testing.T) {
+	d := newDLServer(t, false, []dlFile{
+		{id: 1, name: "m.safetensors", typ: "Model", primary: true, body: "weights", withSHA: true},
+	})
+	setupDownloadEnv(t, d, "")
+
+	out, _, err := run(t, "download", "128713", "--dry-run")
+	if err != nil {
+		t.Fatalf("a valid version id should plan cleanly, got: %v", err)
+	}
+	if !strings.Contains(out, "would download") {
+		t.Errorf("valid version id should still plan the download:\n%s", out)
+	}
+	if strings.Contains(out, "is a model id") {
+		t.Errorf("no hint should appear for a valid version id:\n%s", out)
+	}
+}
+
+// TestDownloadModelFlagUnknownVersionNoHint proves the hint is scoped to the
+// POSITIONAL path: a --model resolution that yields an unknown version id must
+// NOT be reinterpreted as a model-id mistake (positional is empty).
+func TestDownloadModelFlagUnknownVersionNoHint(t *testing.T) {
+	// models/{id} resolves to a version id whose model-versions lookup 404s.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"not found"}`)
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id":4384,"name":"M","type":"Checkpoint","modelVersions":[{"id":777,"name":"v","baseModel":"SD 1.5","files":[]}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	allowPrivateDownloadHostsInTest(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+
+	_, _, err := run(t, "download", "--model", "4384", "--dry-run")
+	if err == nil {
+		t.Fatal("an unknown resolved version should error")
+	}
+	if strings.Contains(err.Error(), "is a model id") {
+		t.Errorf("--model path must not emit the positional model-id hint: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (found via blind dogfood)

`civitai models search` lists **model** IDs, but `civitai download <id>`'s positional argument is a **model-version** ID. So the natural next step after a search — `civitai download 4384` (a valid *model* id) — 404'd with a bare, actively misleading `Error: not found (404): Model not found` (exit 4) and no hint that `--model 4384` is what you want.

## Fix

When the positional version-id lookup 404s, do a quick second lookup to check whether that same id is a valid **model** id. If it is, replace the bare not-found with an actionable hint:

```
Error: 4384 is a model id, not a model-version id — did you mean: civitai download --model 4384 ?
(`civitai download <id>` takes a model-VERSION id, but `civitai models search` / `civitai models get` list MODEL ids. Use --model to download the model's default version, or `civitai models get 4384` to pick a specific version id.)
```

Chose the **hint** over silent auto-fallback (per the task's lower-risk preference): a clear suggestion beats silently downloading a different thing than the user typed. The hint is tagged as a **usage error (exit 2)** so the exit code reflects the invocation mistake rather than a missing resource (exit 4).

Scoping / safety:
- Fires **only** on the positional path (`--model` resolutions are untouched — `positional == ""`), **only** on a genuine 404 (`errors.Is(err, api.ErrNotFound)`), and **only** when the second lookup confirms the id is a real model. Every other failure (auth/network/rate-limit, or an id that is neither a version nor a model) surfaces the **original** error unchanged.
- The happy path (a real version id) is byte-for-byte unchanged — no extra lookup.

Also:
- Appended a `find one with civitai models search` nudge to the non-integer positional message (message prefix preserved).
- Documented the version-id-vs-model-id distinction in the command help.

## Live before/after (against the live API)

| Command | Before | After |
|---|---|---|
| `download 4384 --dry-run` | `not found (404): Model not found` (exit 4) | `4384 is a model id … did you mean: civitai download --model 4384 ?` (exit 2) |
| `download --model 4384 --dry-run` | plans DreamShaper default version | unchanged — plans DreamShaper default version (exit 0) |
| `download 128713 --dry-run` (real version id) | plans the file | unchanged — plans the file (exit 0) |
| `download dreamshaper` | `must be an integer` (exit 1) | `must be an integer … — pass a numeric model-version id, or find one with civitai models search` (exit 1) |

## Tests

Added `internal/cmd/download_modelid_hint_test.go` (httptest):
- model id passed as version → actionable `--model` hint, tagged `ErrUsage`, no bare "not found"
- unknown id (neither version nor model) → original 404 preserved, stays `ErrNotFound` (exit 4), not a usage error
- valid version id → unaffected happy path, no hint
- `--model` resolving an unknown version → no positional model-id hint (scoping guard)

## Gates (all clean)

`go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
