### PR TITLE
fix(exit-codes): complete the differentiated exit-code mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ by this — only `echo $?` differs.
 | --- | --- |
 | `0` | Success. |
 | `1` | Generic / unclassified error. |
-| `2` | Usage error — a bad flag or malformed invocation. |
+| `2` | Usage error — a bad flag, a bad flag value (e.g. `--limit` out of range, a non-integer id), or a request the API rejected as malformed (HTTP 400, e.g. a bad `--period`/`--sort` enum). |
 | `3` | Authentication/authorization — login required, token invalid/expired, or the credential lacks the needed scope (HTTP 401/403, or no token configured). |
 | `4` | Not found — the requested resource does not exist (HTTP 404). |
 | `5` | Network/transport failure or service unavailable — dial/timeout, or HTTP 502/503/504 after retries. |

--- a/cmd/civitai/main.go
+++ b/cmd/civitai/main.go
@@ -27,7 +27,7 @@ var (
 const (
 	exitOK          = 0 // success
 	exitGeneric     = 1 // generic / unknown / unclassified failure
-	exitUsage       = 2 // bad flags or malformed invocation (Cobra usage error)
+	exitUsage       = 2 // bad flags, bad flag value, or a request rejected as malformed (HTTP 400)
 	exitAuth        = 3 // authentication/authorization: login required, token invalid/expired, missing scope
 	exitNotFound    = 4 // the requested resource does not exist (HTTP 404)
 	exitNetwork     = 5 // network/transport failure or service unavailable (dial/timeout, HTTP 502/503/504)
@@ -53,10 +53,12 @@ func exitCode(err error) int {
 	case err == nil:
 		return exitOK
 
-	// Usage errors (bad flag / malformed invocation) are tagged by the root
-	// command's FlagErrorFunc. Checked first: a usage mistake is about the
-	// invocation, not the API.
-	case errors.Is(err, cmd.ErrUsage):
+	// Usage errors are about the invocation, not the API — checked first. This
+	// covers both client-side usage mistakes (bad flag / malformed invocation,
+	// tagged by the root command's FlagErrorFunc or asUsageError) and a request
+	// the server rejected as malformed (HTTP 400, api.ErrBadRequest — e.g. a bad
+	// enum value caught by the API's own validation).
+	case errors.Is(err, cmd.ErrUsage), errors.Is(err, api.ErrBadRequest):
 		return exitUsage
 
 	// Authentication / authorization: 401/403, the pre-flight "no token

--- a/cmd/civitai/main_test.go
+++ b/cmd/civitai/main_test.go
@@ -42,6 +42,10 @@ func TestExitCode(t *testing.T) {
 
 		{"usage error", usageErr{errors.New("unknown flag: --nope")}, exitUsage, "unknown flag: --nope"},
 		{"usage sentinel", cmd.ErrUsage, exitUsage, ""},
+		{"bad request sentinel", api.ErrBadRequest, exitUsage, ""},
+		{"tagged 400 (real readError shape)", api.Tag(api.ErrBadRequest,
+			fmt.Errorf("invalid request parameter (400): period — Invalid option")), exitUsage,
+			"invalid request parameter (400): period — Invalid option"},
 
 		{"unauthorized sentinel", api.ErrUnauthorized, exitAuth, ""},
 		{"tagged 401 (real readError shape)", api.Tag(api.ErrUnauthorized,

--- a/internal/api/errkind.go
+++ b/internal/api/errkind.go
@@ -19,6 +19,12 @@ var (
 	ErrUnauthorized = errors.New("authentication required")
 	// ErrNotFound marks a requested resource that does not exist (HTTP 404).
 	ErrNotFound = errors.New("not found")
+	// ErrBadRequest marks a request the server rejected as malformed — an invalid
+	// flag value or query parameter (HTTP 400, e.g. a bad enum caught by the
+	// server's zod validation). It is a USAGE-class failure (the invocation is
+	// wrong), so the entrypoint maps it to the same exit code as a client-side
+	// usage error.
+	ErrBadRequest = errors.New("bad request")
 	// ErrRateLimited marks a throttled request (HTTP 429).
 	ErrRateLimited = errors.New("rate limited")
 	// ErrNetwork marks a transport/service-availability failure — the gateway/
@@ -65,6 +71,8 @@ func statusKind(status int) error {
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return ErrUnauthorized
+	case http.StatusBadRequest:
+		return ErrBadRequest
 	case http.StatusNotFound:
 		return ErrNotFound
 	case http.StatusTooManyRequests:

--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -130,6 +131,15 @@ func readError(status int, raw []byte) (err error) {
 	switch status {
 	case http.StatusUnauthorized:
 		return fmt.Errorf("unauthorized (401): %s — your token may be expired; run `civitai login` (these endpoints also work without a token)", msg)
+	case http.StatusBadRequest:
+		// A 400 is the server rejecting a bad flag value / query parameter (e.g.
+		// an invalid enum caught by zod). Surface a CONCISE, actionable message —
+		// naming the offending field/value when the body is a ZodError — instead
+		// of dumping the raw ZodError JSON blob at the user.
+		if d := badRequestDetail(raw); d != "" {
+			return fmt.Errorf("invalid request parameter (400): %s", d)
+		}
+		return errors.New("invalid request parameter (400)")
 	case http.StatusNotFound:
 		return fmt.Errorf("not found (404): %s", msg)
 	case http.StatusTooManyRequests:
@@ -139,6 +149,87 @@ func readError(status int, raw []byte) (err error) {
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
+}
+
+// badRequestDetail extracts a concise, human-readable detail from a 400 response
+// body. The Civitai API rejects a bad query parameter with a zod validation
+// error whose body is either `{"error":{"name":"ZodError","message":"<JSON
+// array of issues>"}}` or `{"error":[<issues>]}`; a simpler handler may return
+// `{"error":"..."}` or `{"message":"..."}`. It returns the first issue as
+// `field — message` (or just the message when there is no field path), or the
+// plain string body, or "" when nothing usable can be parsed.
+func badRequestDetail(raw []byte) string {
+	var wrapped struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if json.Unmarshal(raw, &wrapped) != nil {
+		return ""
+	}
+	if len(wrapped.Error) > 0 {
+		// error as a ZodError object: {"name":"ZodError","message":"<issues JSON>"}
+		var zerr struct {
+			Name    string `json:"name"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(wrapped.Error, &zerr) == nil && zerr.Name == "ZodError" {
+			if d := firstZodIssue([]byte(zerr.Message)); d != "" {
+				return snippet([]byte(d))
+			}
+		}
+		// error as a bare array of zod issues.
+		if d := firstZodIssue(wrapped.Error); d != "" {
+			return snippet([]byte(d))
+		}
+		// error as a plain string.
+		var s string
+		if json.Unmarshal(wrapped.Error, &s) == nil && s != "" {
+			return snippet([]byte(s))
+		}
+	}
+	if wrapped.Message != "" {
+		return snippet([]byte(wrapped.Message))
+	}
+	return ""
+}
+
+// firstZodIssue parses a JSON array of zod issues and renders the first one that
+// carries a message as `field — message` (or just the message when the issue
+// has no path). Returns "" when arr is not a parseable non-empty issue array.
+func firstZodIssue(arr []byte) string {
+	var issues []struct {
+		Path    []json.RawMessage `json:"path"`
+		Message string            `json:"message"`
+	}
+	if json.Unmarshal(arr, &issues) != nil {
+		return ""
+	}
+	for _, is := range issues {
+		if strings.TrimSpace(is.Message) == "" {
+			continue
+		}
+		if field := zodPath(is.Path); field != "" {
+			return field + " — " + is.Message
+		}
+		return is.Message
+	}
+	return ""
+}
+
+// zodPath renders a zod issue's path (a list of string keys and/or numeric
+// indices) as a dotted field name, e.g. ["sort"] -> "sort", ["items",0,"id"] ->
+// "items.0.id". Each element is a JSON string or number; strings are unquoted.
+func zodPath(path []json.RawMessage) string {
+	parts := make([]string, 0, len(path))
+	for _, p := range path {
+		var s string
+		if json.Unmarshal(p, &s) == nil {
+			parts = append(parts, s)
+			continue
+		}
+		parts = append(parts, strings.TrimSpace(string(p)))
+	}
+	return strings.Join(parts, ".")
 }
 
 // maxResponseBody bounds how many bytes of a single HTTP response body the

--- a/internal/api/read_test.go
+++ b/internal/api/read_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -204,7 +205,12 @@ func TestReadErrorSurfacesBody(t *testing.T) {
 		// Terminal statuses map through readError.
 		{http.StatusNotFound, `{"error":"No model with id 999"}`, "not found (404): No model with id 999"},
 		{http.StatusUnauthorized, `{"error":"Unauthorized"}`, "unauthorized (401)"},
-		{http.StatusBadRequest, `{"message":"bad param"}`, "server returned 400: bad param"},
+		// A 400 is surfaced as a concise "invalid request parameter" message — the
+		// raw body is never dumped. A plain {"message":...} body carries through.
+		{http.StatusBadRequest, `{"message":"bad param"}`, "invalid request parameter (400): bad param"},
+		// A zod-validation 400 (the shape the API actually returns for a bad enum)
+		// is parsed down to the offending field + its message, NOT the raw blob.
+		{http.StatusBadRequest, `{"error":{"name":"ZodError","message":"[{\"code\":\"invalid_value\",\"path\":[\"period\"],\"message\":\"Invalid option: expected one of \\\"Day\\\"|\\\"Week\\\"\"}]"}}`, `invalid request parameter (400): period — Invalid option: expected one of "Day"|"Week"`},
 		// A 429 without Retry-After is terminal (deep-paging limit): readError's
 		// 429 branch surfaces the --cursor guidance, no retry-exhaustion message.
 		{http.StatusTooManyRequests, `{"error":"too many pages"}`, "rate limited (429): too many pages — for deep paging use --cursor instead of --page"},
@@ -229,6 +235,31 @@ func TestReadErrorSurfacesBody(t *testing.T) {
 		if !strings.Contains(err.Error(), tc.want) {
 			t.Errorf("status %d: error %q should contain %q", tc.status, err, tc.want)
 		}
+	}
+}
+
+// TestReadError400Classification asserts a 400 response is tagged with
+// ErrBadRequest (the usage-class sentinel) and that a ZodError body is rendered
+// concisely — naming the offending field — with no raw blob leaking through.
+func TestReadError400Classification(t *testing.T) {
+	const zodBody = `{"error":{"name":"ZodError","message":"[{\"code\":\"invalid_value\",\"path\":[\"period\"],\"message\":\"Invalid option: expected one of \\\"Day\\\"|\\\"Week\\\"\"}]"}}`
+	err := readError(http.StatusBadRequest, []byte(zodBody))
+	if err == nil {
+		t.Fatal("expected an error for a 400")
+	}
+	if !errors.Is(err, ErrBadRequest) {
+		t.Errorf("400 should be tagged ErrBadRequest, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "ZodError") {
+		t.Errorf("raw ZodError blob must not leak: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "invalid request parameter (400): period — ") {
+		t.Errorf("concise 400 message should name the field, got: %q", err.Error())
+	}
+
+	// A 400 with no parseable detail falls back to the clean generic message.
+	if got := readError(http.StatusBadRequest, []byte(`not json`)).Error(); got != "invalid request parameter (400)" {
+		t.Errorf("unparseable 400 = %q, want %q", got, "invalid request parameter (400)")
 	}
 }
 

--- a/internal/cmd/exit_classify_test.go
+++ b/internal/cmd/exit_classify_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// TestCheckLimitIsUsageTagged asserts an out-of-range --limit is classified as a
+// USAGE error (exit 2), not the generic one. checkLimit is the single shared
+// validator, so tagging it there classifies EVERY read subcommand at once.
+func TestCheckLimitIsUsageTagged(t *testing.T) {
+	err := checkLimit(999, 100)
+	if err == nil {
+		t.Fatal("expected an error for an out-of-range limit")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("out-of-range limit should be a usage error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "between 1 and 100") {
+		t.Errorf("message should be preserved, got: %v", err)
+	}
+}
+
+// TestModelsSearchLimitUsageTaggedEndToEnd drives the real command so the tag is
+// verified through the full RunE path (the bad flag value must reach exit 2).
+func TestModelsSearchLimitUsageTaggedEndToEnd(t *testing.T) {
+	_, _, err := run(t, "models", "search", "--limit", "999")
+	if err == nil {
+		t.Fatal("expected an error for --limit 999")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("--limit 999 should classify as usage, got: %v", err)
+	}
+}
+
+// TestModelVersionsGetNonIntIsUsageTagged asserts a non-integer positional id is
+// a usage error, not a generic one.
+func TestModelVersionsGetNonIntIsUsageTagged(t *testing.T) {
+	_, _, err := run(t, "model-versions", "get", "abc")
+	if err == nil {
+		t.Fatal("expected an error for a non-integer model-version id")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("non-integer id should classify as usage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "must be an integer") {
+		t.Errorf("message should be preserved, got: %v", err)
+	}
+}
+
+// TestUsersGetMissingIsNotFoundTagged asserts a lookup that resolves to zero
+// users is classified as NOT-FOUND (exit 4) even though the search endpoint
+// returns an empty 200, matching the behaviour of a real HTTP 404.
+func TestUsersGetMissingIsNotFoundTagged(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+	_, _, err := run(t, "users", "get", "zzz-no-such-user-zzz")
+	if err == nil {
+		t.Fatal("expected an error for a missing user")
+	}
+	if !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("missing user should classify as not-found, got: %v", err)
+	}
+}
+
+// TestUsersGetNoExactMatchIsNotFoundTagged asserts a name query that returns
+// only fuzzy neighbours (no exact username) is also classified as not-found.
+func TestUsersGetNoExactMatchIsNotFoundTagged(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[{"id":5,"username":"bob"},{"id":6,"username":"bobby"}]}`))
+	})
+	_, _, err := run(t, "users", "get", "bo")
+	if err == nil {
+		t.Fatal("expected an error for a no-exact-match user query")
+	}
+	if !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("no-exact-match user should classify as not-found, got: %v", err)
+	}
+}
+
+// TestImagesSearchBadEnumIsBadRequestTaggedAndClean asserts an invalid enum
+// (rejected by the server with a 400 ZodError body) is (a) classified as a
+// bad-request/usage error and (b) surfaced as a CONCISE message — never the raw
+// ZodError JSON blob.
+func TestImagesSearchBadEnumIsBadRequestTaggedAndClean(t *testing.T) {
+	const zodBody = `{"error":{"name":"ZodError","message":"[\n  {\n    \"code\": \"invalid_value\",\n    \"path\": [\n      \"period\"\n    ],\n    \"message\": \"Invalid option: expected one of \\\"Day\\\"|\\\"Week\\\"|\\\"Month\\\"|\\\"Year\\\"|\\\"AllTime\\\"\"\n  }\n]"}}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(zodBody))
+	})
+	_, _, err := run(t, "images", "search", "--period", "Bogus")
+	if err == nil {
+		t.Fatal("expected an error for an invalid --period enum")
+	}
+	if !errors.Is(err, api.ErrBadRequest) {
+		t.Errorf("400 should classify as bad-request (usage), got: %v", err)
+	}
+	if strings.Contains(err.Error(), "ZodError") {
+		t.Errorf("the raw ZodError blob must not leak into the message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid request parameter (400)") {
+		t.Errorf("message should be the concise 400 form, got: %v", err)
+	}
+	// The concise message should name the offending field.
+	if !strings.Contains(err.Error(), "period") {
+		t.Errorf("concise message should name the invalid field, got: %v", err)
+	}
+}

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -34,7 +34,10 @@ func newModelVersionsGetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := readFlags(cmd)
 			if _, err := strconv.Atoi(args[0]); err != nil {
-				return fmt.Errorf("model version id must be an integer, got %q", args[0])
+				// A non-integer positional arg is a client-side usage mistake, not
+				// an API failure — tag it so the entrypoint maps it to the usage
+				// exit code rather than the generic one.
+				return asUsageError(fmt.Errorf("model version id must be an integer, got %q", args[0]))
 			}
 			client, _, err := newReader(o)
 			if err != nil {

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -90,10 +90,13 @@ func nonModelFileMarker(files []api.ModelVersionFile) string {
 }
 
 // checkLimit validates a --limit against an endpoint's documented maximum. A
-// zero limit means "server default" and is always allowed.
+// zero limit means "server default" and is always allowed. An out-of-range
+// value is a client-side USAGE error (a bad flag value), so it is tagged with
+// ErrUsage — every read subcommand that calls checkLimit thus exits with the
+// usage exit code, not the generic one.
 func checkLimit(limit, max int) error {
 	if limit < 0 || limit > max {
-		return fmt.Errorf("--limit must be between 1 and %d for this endpoint", max)
+		return asUsageError(fmt.Errorf("--limit must be between 1 and %d for this endpoint", max))
 	}
 	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -197,7 +197,23 @@ Get started:
   # Build an App
   civitai login                    store your API token
   civitai app create my-app        scaffold a ready-to-build App
-  civitai app submit               package + submit for review`,
+  civitai app submit               package + submit for review
+
+Exit codes:
+
+  Every command returns a differentiated exit code so scripts can branch on the
+  KIND of failure without parsing stderr (the error message itself is unchanged):
+
+    0  success
+    1  generic / unclassified error
+    2  usage error — a bad flag, a bad flag value, or a request the API rejected
+       as malformed (HTTP 400)
+    3  authentication/authorization — login required, token invalid/expired, or
+       the credential lacks the needed scope (HTTP 401/403)
+    4  not found — the requested resource does not exist (HTTP 404)
+    5  network/transport failure or service unavailable (dial/timeout, HTTP
+       502/503/504 after retries)
+    6  rate limited — throttled by the API (HTTP 429)`,
 		Example: `  # Browse & download the public catalog (no account needed to read).
   civitai models search --query "dreamshaper" --limit 5
   civitai images search --sort "Most Reactions" --period Week

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -64,7 +64,11 @@ is selected when present).`,
 				return emitJSON(cmd, res.Raw)
 			}
 			if len(res.Items) == 0 {
-				return fmt.Errorf("no user found for %q", arg)
+				// "users get" resolves through the public user SEARCH (the per-id
+				// route is an internal webhook), so a missing user comes back as an
+				// empty 200, not an HTTP 404. Tag it as not-found so a scripted
+				// lookup still gets the not-found exit code, matching a real 404.
+				return api.Tag(api.ErrNotFound, fmt.Errorf("no user found for %q", arg))
 			}
 			// A numeric id lookup returns exactly the requested user. A NAME query
 			// hits the search endpoint, which returns ≤5 FUZZY neighbours — so we
@@ -86,7 +90,7 @@ is selected when present).`,
 					for _, u := range res.Items {
 						names = append(names, orDash(safeTerm(u.Username)))
 					}
-					return fmt.Errorf("no user found with exact username %q; closest matches: %s (use the numeric id for an exact lookup)", arg, strings.Join(names, ", "))
+					return api.Tag(api.ErrNotFound, fmt.Errorf("no user found with exact username %q; closest matches: %s (use the numeric id for an exact lookup)", arg, strings.Join(names, ", ")))
 				}
 			}
 			printUser(cmd, match)


### PR DESCRIPTION
## Summary

The differentiated exit-code scheme (0 ok / 2 usage / 3 auth / 4 not-found / 5 network / 6 rate-limit) shipped incomplete — blind dogfooding found several failure kinds falling through to the generic exit **1**, plus one raw `ZodError` JSON blob leaking to the user. This completes the mapping.

## Fixes

| Case | Before | After |
| --- | --- | --- |
| `models search --limit 999` (out-of-range flag value) | 1 | **2** |
| `model-versions get abc` (non-integer id) | 1 | **2** |
| `users get <missing>` / no-exact-match | 1 | **4** |
| `images search --period Bogus` (server 400 ZodError) | 1 + raw blob | **2** + concise message |

- **`checkLimit`** (the single shared read validator in `internal/cmd/read.go`) now returns an `ErrUsage`-tagged error — one change classifies an out-of-range `--limit` on **every** read subcommand (models/images/articles/tags/creators/collections) without per-command edits.
- **`model-versions get <non-int>`** tags its positional-parse error as a usage error.
- **`users get`** resolves through the public user *search* (the per-id route is an internal webhook), so a missing user is an empty `200`, not an HTTP 404. The "no user found" errors are now tagged with `api.ErrNotFound` so a scripted lookup gets exit 4, matching a real 404.
- **HTTP 400** maps to a new `api.ErrBadRequest` sentinel (usage-class → exit 2), and the body is rendered concisely: a `ZodError` is parsed down to the offending field + its message (`invalid request parameter (400): period — Invalid option: expected one of "Day"|"Week"|…`) instead of dumping the raw JSON blob. Falls back to a clean `invalid request parameter (400)` when nothing is parseable.
- **`--help`** now documents the exit-code table in the root command's long help (the README table is kept and clarified).

## Verification (live, against the real API)

```
$ civitai models search --limit 999      → Error: --limit must be between 1 and 100 for this endpoint          exit=2
$ civitai model-versions get abc         → Error: model version id must be an integer, got "abc"                exit=2
$ civitai users get zzz-no-such-user-zzz → Error: no user found with exact username "zzz-…"; closest matches…   exit=4
$ civitai images search --period Bogus    → Error: invalid request parameter (400): period — Invalid option:
                                              expected one of "Day"|"Week"|"Month"|"Year"|"AllTime"             exit=2
$ civitai models search --limit 1         → (success)                                                           exit=0
$ civitai models get 999999999            → Error: not found (404): No model with id 999999999                  exit=4
```

## Tests

Added coverage for the usage-tagged `checkLimit`, the model-versions id parse, users-404 tagging (both empty-result and no-exact-match), 400 → `ErrBadRequest` + concise ZodError message (+ unparseable-body fallback), and `ErrBadRequest` → exit 2 in the entrypoint mapping.

Gates: `go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)