### PR TITLE
feat(images): surface generation resources, add `images get`, `--collection-id`, fix help

### DIFF
--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -236,7 +236,9 @@ func (c *Client) GetImage(ctx context.Context, id string) (*ImageItem, []byte, e
 		return nil, nil, err
 	}
 	if len(res.Items) == 0 {
-		return nil, res.Raw, fmt.Errorf("no image found with id %s", id)
+		// Tag as not-found so the entrypoint maps it to exit 4, matching the
+		// other `get` commands (whose 404 is classified by tagStatus).
+		return nil, res.Raw, tag(ErrNotFound, fmt.Errorf("no image found with id %s", id))
 	}
 	return &res.Items[0], res.Raw, nil
 }

--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -35,6 +36,91 @@ type ImageMeta struct {
 	Steps          json.RawMessage `json:"steps"`
 	Seed           json.RawMessage `json:"seed"`
 	Model          string          `json:"Model"` // capitalized in the API payload
+	// Resources is the generation "recipe" — the checkpoint + LoRAs/embeddings
+	// used, each an ImageResource {type, name, weight?, hash?}. Hashes is the
+	// parallel name→hash map the generator emits. Both are kept as raw JSON (not
+	// decoded structs) so an odd shape on either can never fail the whole meta
+	// decode and drop the prompt/settings alongside it — they're decoded
+	// best-effort at render time via ParseResources / ParseHashes.
+	Resources json.RawMessage `json:"resources"`
+	Hashes    json.RawMessage `json:"hashes"`
+}
+
+// ImageResource is one generation resource named in an image's meta.resources
+// array — the reproduction recipe: a checkpoint ("model"), a LoRA ("lora"), an
+// embedding, etc. Weight is raw JSON because it is generator-supplied and
+// freeform (a float for LoRAs, absent for the base model); render it with
+// WeightString. Hash, when present inline, is the resource's model-file hash.
+type ImageResource struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name"`
+	Weight json.RawMessage `json:"weight"`
+	Hash   string          `json:"hash"`
+}
+
+// WeightString renders the LoRA/resource weight for display (empty when absent).
+func (r ImageResource) WeightString() string { return numString(r.Weight) }
+
+// ParseResources best-effort decodes meta.resources into an ordered slice. It
+// never errors: an absent, null, or unexpectedly-shaped value → nil, so a
+// malformed resources field can't drop the surrounding meta block.
+func (m ImageMeta) ParseResources() []ImageResource {
+	raw := bytes.TrimSpace(m.Resources)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var rs []ImageResource
+	if err := json.Unmarshal(raw, &rs); err != nil {
+		return nil
+	}
+	return rs
+}
+
+// ParseHashes best-effort decodes meta.hashes (a name→hash map). Never errors:
+// absent/null/odd shape → nil.
+func (m ImageMeta) ParseHashes() map[string]string {
+	raw := bytes.TrimSpace(m.Hashes)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var h map[string]string
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil
+	}
+	return h
+}
+
+// ResolveHash returns the display hash for a resource: its inline hash when
+// present, otherwise a best-effort lookup in meta.hashes by resource name (the
+// map is keyed by bare name or "<type>:<name>", e.g. "lora:MyLora"). Returns ""
+// when nothing resolves.
+func (m ImageMeta) ResolveHash(r ImageResource) string {
+	if h := strings.TrimSpace(r.Hash); h != "" {
+		return h
+	}
+	hashes := m.ParseHashes()
+	if len(hashes) == 0 {
+		return ""
+	}
+	name := strings.TrimSpace(r.Name)
+	if name == "" {
+		return ""
+	}
+	if h, ok := hashes[name]; ok {
+		return h
+	}
+	// The map keys the composite form as "<type>:<name>", but the API is
+	// inconsistent about the type's case ("LORA:" vs "lora:"), so match the key
+	// case-insensitively rather than assuming one casing.
+	if typ := strings.TrimSpace(r.Type); typ != "" {
+		want := strings.ToLower(typ + ":" + name)
+		for k, v := range hashes {
+			if strings.ToLower(k) == want {
+				return v
+			}
+		}
+	}
+	return ""
 }
 
 // CfgScaleString renders the cfgScale for display (empty when absent).
@@ -133,4 +219,24 @@ func (c *Client) SearchImages(ctx context.Context, q url.Values) (*ImageSearchRe
 	}
 	res.Raw = raw
 	return &res, nil
+}
+
+// GetImage fetches a single image by its numeric id via the imageId filter on
+// GET /api/v1/images (there is no dedicated per-id route). Generation metadata
+// is requested implicitly (withMeta/flatMeta) so the caller can render the full
+// detail block. The raw {items,metadata} body is returned for --json passthrough;
+// a not-found id yields an error (the API returns an empty items array).
+func (c *Client) GetImage(ctx context.Context, id string) (*ImageItem, []byte, error) {
+	q := url.Values{}
+	q.Set("imageId", id)
+	q.Set("withMeta", "true")
+	q.Set("flatMeta", "true")
+	res, err := c.SearchImages(ctx, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(res.Items) == 0 {
+		return nil, res.Raw, fmt.Errorf("no image found with id %s", id)
+	}
+	return &res.Items[0], res.Raw, nil
 }

--- a/internal/api/images_test.go
+++ b/internal/api/images_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestParseResourcesShapes covers the real meta.resources shapes: a full recipe
+// (base model + weighted LoRAs), an empty array, absent, null, and an odd shape
+// (must degrade to nil, never panic/error).
+func TestParseResourcesShapes(t *testing.T) {
+	full := ImageMeta{Resources: []byte(`[
+	  {"hash":"78bbf8f416","name":"krea2_turbo_bf16","type":"model"},
+	  {"hash":"990d0df641","name":"Purple_Graphics","type":"lora","weight":1.2},
+	  {"hash":"ce0672fe6e","name":"Grainy","type":"lora","weight":0.5}
+	]`)}
+	rs := full.ParseResources()
+	if len(rs) != 3 {
+		t.Fatalf("want 3 resources, got %d: %+v", len(rs), rs)
+	}
+	if rs[0].Type != "model" || rs[0].Name != "krea2_turbo_bf16" || rs[0].Hash != "78bbf8f416" {
+		t.Errorf("base model resource mis-parsed: %+v", rs[0])
+	}
+	if rs[0].WeightString() != "" {
+		t.Errorf("base model should have no weight, got %q", rs[0].WeightString())
+	}
+	if rs[1].WeightString() != "1.2" {
+		t.Errorf("lora weight = %q, want 1.2", rs[1].WeightString())
+	}
+
+	// Absent / null / odd shapes → nil (never error).
+	for name, m := range map[string]ImageMeta{
+		"absent": {},
+		"null":   {Resources: []byte(`null`)},
+		"object": {Resources: []byte(`{"not":"an array"}`)},
+		"scalar": {Resources: []byte(`"nope"`)},
+	} {
+		if got := m.ParseResources(); got != nil {
+			t.Errorf("%s resources should parse to nil, got %+v", name, got)
+		}
+	}
+	// An empty array is a valid "no resources" — len 0 is what the renderer keys
+	// off to omit the section.
+	if got := (ImageMeta{Resources: []byte(`[]`)}).ParseResources(); len(got) != 0 {
+		t.Errorf("empty resources array should have len 0, got %+v", got)
+	}
+}
+
+// TestResolveHash covers inline-hash preference and the meta.hashes fallback
+// (both bare-name and "<type>:<name>" keys), plus a nil hashes map.
+func TestResolveHash(t *testing.T) {
+	m := ImageMeta{Hashes: []byte(`{"model":"aaa","lora:MyLora":"bbb","BareName":"ccc"}`)}
+
+	// Inline hash always wins.
+	if got := m.ResolveHash(ImageResource{Name: "MyLora", Type: "lora", Hash: "inline"}); got != "inline" {
+		t.Errorf("inline hash should win, got %q", got)
+	}
+	// Fallback via "<type>:<name>" key.
+	if got := m.ResolveHash(ImageResource{Name: "MyLora", Type: "lora"}); got != "bbb" {
+		t.Errorf("type:name fallback = %q, want bbb", got)
+	}
+	// Fallback via bare-name key.
+	if got := m.ResolveHash(ImageResource{Name: "BareName", Type: "embed"}); got != "ccc" {
+		t.Errorf("bare-name fallback = %q, want ccc", got)
+	}
+	// Nothing resolvable.
+	if got := m.ResolveHash(ImageResource{Name: "Unknown", Type: "lora"}); got != "" {
+		t.Errorf("unresolvable hash should be empty, got %q", got)
+	}
+	// Nil hashes map + no inline hash → empty.
+	empty := ImageMeta{}
+	if got := empty.ResolveHash(ImageResource{Name: "x", Type: "lora"}); got != "" {
+		t.Errorf("no hashes → empty, got %q", got)
+	}
+}
+
+// TestParseHashesNullAndOdd asserts ParseHashes degrades gracefully.
+func TestParseHashesNullAndOdd(t *testing.T) {
+	for name, m := range map[string]ImageMeta{
+		"null":   {Hashes: []byte(`null`)},
+		"absent": {},
+		"array":  {Hashes: []byte(`[1,2,3]`)},
+	} {
+		if got := m.ParseHashes(); got != nil {
+			t.Errorf("%s hashes should be nil, got %+v", name, got)
+		}
+	}
+	m := ImageMeta{Hashes: []byte(`{"model":"aaa"}`)}
+	if got := m.ParseHashes(); len(got) != 1 || got["model"] != "aaa" {
+		t.Errorf("valid hashes mis-parsed: %+v", got)
+	}
+}
+
+// TestParseMetaKeepsResourcesAndHashes asserts that adding resources/hashes to
+// ImageMeta doesn't disturb the existing prompt/settings decode, and that an
+// odd resources shape still leaves meta MetaOK (raw-JSON-backed tolerance).
+func TestParseMetaKeepsResourcesAndHashes(t *testing.T) {
+	im := ImageItem{Meta: []byte(`{"prompt":"a cat","Model":"M","seed":123,
+	  "resources":"this is not an array","hashes":{"model":"aaa"}}`)}
+	m, state := im.ParseMeta()
+	if state != MetaOK {
+		t.Fatalf("odd resources shape must not fail meta decode, state=%v", state)
+	}
+	if m.Prompt != "a cat" || m.Model != "M" || m.SeedString() != "123" {
+		t.Errorf("prompt/settings decode disturbed: %+v", m)
+	}
+	// The odd resources value degrades to nil at parse time; hashes still parse.
+	if m.ParseResources() != nil {
+		t.Error("odd resources should parse to nil")
+	}
+	if h := m.ParseHashes(); h["model"] != "aaa" {
+		t.Errorf("hashes should still parse: %+v", h)
+	}
+}
+
+// TestGetImageSendsImageIdAndParses asserts GetImage hits /api/v1/images with the
+// imageId + meta params, returns the single item, and surfaces the raw body.
+func TestGetImageSendsImageIdAndParses(t *testing.T) {
+	const body = `{"items":[
+	  {"id":136456589,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None",
+	   "username":"alice","baseModel":"Krea 2",
+	   "meta":{"prompt":"a cat","seed":557589798350441,
+	           "resources":[{"hash":"h1","name":"ckpt","type":"model"}]}}
+	],"metadata":{}}`
+	srv, gotPath, gotQuery, _ := newTestServer(t, body)
+
+	c := New(srv.URL, "", "")
+	im, raw, err := c.GetImage(context.Background(), "136456589")
+	if err != nil {
+		t.Fatalf("GetImage: %v", err)
+	}
+	if *gotPath != "/api/v1/images" {
+		t.Errorf("path = %q, want /api/v1/images", *gotPath)
+	}
+	if gotQuery.Get("imageId") != "136456589" {
+		t.Errorf("imageId not sent: %v", *gotQuery)
+	}
+	if gotQuery.Get("withMeta") != "true" || gotQuery.Get("flatMeta") != "true" {
+		t.Errorf("get should request flat meta: %v", *gotQuery)
+	}
+	if im.ID != 136456589 || im.Username != "alice" {
+		t.Errorf("parsed item wrong: %+v", im)
+	}
+	m, state := im.ParseMeta()
+	if state != MetaOK || len(m.ParseResources()) != 1 {
+		t.Errorf("meta/resources not parsed: state=%v %+v", state, m)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should be returned for --json")
+	}
+}
+
+// TestGetImageNotFound asserts an empty items array yields a not-found error but
+// still returns the raw body.
+func TestGetImageNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "", "")
+	im, raw, err := c.GetImage(context.Background(), "999999999")
+	if err == nil {
+		t.Fatal("expected not-found error for empty items")
+	}
+	if !strings.Contains(err.Error(), "no image found with id 999999999") {
+		t.Errorf("error should name the id: %v", err)
+	}
+	if im != nil {
+		t.Errorf("item should be nil on not-found, got %+v", im)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should still be returned for --json passthrough")
+	}
+}

--- a/internal/api/images_test.go
+++ b/internal/api/images_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -167,6 +168,9 @@ func TestGetImageNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no image found with id 999999999") {
 		t.Errorf("error should name the id: %v", err)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("not-found error must be tagged ErrNotFound (→ exit 4), got %v", err)
 	}
 	if im != nil {
 		t.Errorf("item should be nil on not-found, got %+v", im)

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -21,20 +22,23 @@ func newImagesCmd() *cobra.Command {
 		Long: `Read-only access to Civitai images via the public REST API
 (GET /api/v1/images). Works anonymously.`,
 		Example: `  civitai images search --limit 5
-  civitai images search --model-id 4384 --sort "Most Reactions"
+  civitai images search --model-id 4384 --period Month
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
-  civitai images search --nsfw --sort "Most Reactions" --period Month --meta`,
+  civitai images search --collection-id 104 --limit 10
+  civitai images search --nsfw --sort "Most Reactions" --period Month --meta
+  civitai images get 136456589`,
 	}
 	cmd.AddCommand(newImagesSearchCmd())
+	cmd.AddCommand(newImagesGetCmd())
 	return cmd
 }
 
 func newImagesSearchCmd() *cobra.Command {
 	var (
-		username, sort, period, cursor, typ          string
-		baseModels                                   []string
-		postID, modelID, modelVersionID, limit, page int
-		nsfw, meta                                   bool
+		username, sort, period, cursor, typ                        string
+		baseModels                                                 []string
+		postID, modelID, modelVersionID, collectionID, limit, page int
+		nsfw, meta                                                 bool
 	)
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -47,6 +51,7 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
   civitai images search --model-version-id 128713 --sort Newest
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
   civitai images search --type video --sort "Most Reactions"
+  civitai images search --collection-id 104 --limit 10
   civitai images search --nsfw --sort "Most Reactions" --period Month --meta
   civitai images search --username some-user --cursor <cursor>`,
 		Args: cobra.NoArgs,
@@ -80,6 +85,7 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			addIfPositive(q, "postId", postID)
 			addIfPositive(q, "modelId", modelID)
 			addIfPositive(q, "modelVersionId", modelVersionID)
+			addIfPositive(q, "collectionId", collectionID)
 			addIfPositive(q, "limit", limit)
 			addIfPositive(q, "page", page)
 			if cmd.Flags().Changed("nsfw") {
@@ -119,6 +125,7 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().IntVar(&postID, "post-id", 0, "filter by post id")
 	cmd.Flags().IntVar(&modelID, "model-id", 0, "filter by model id")
 	cmd.Flags().IntVar(&modelVersionID, "model-version-id", 0, "filter by model version id")
+	cmd.Flags().IntVar(&collectionID, "collection-id", 0, "filter by collection id (browse a collection's images)")
 	cmd.Flags().StringVar(&username, "username", "", "filter by uploader username")
 	cmd.Flags().StringSliceVar(&baseModels, "base-model", nil, "filter by base model; repeatable (e.g. --base-model \"Krea 2\" --base-model Flux). The API OR-combines the given values")
 	cmd.Flags().StringVar(&typ, "type", "", "filter by media type (image, video, audio)")
@@ -126,6 +133,41 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (\"Most Reactions\", \"Most Comments\", Newest)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
 	cmd.Flags().BoolVar(&meta, "meta", false, "include generation metadata (prompt, sampler, seed, etc.)")
+	bindReadFlags(cmd)
+	return cmd
+}
+
+func newImagesGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a single image by id (GET /api/v1/images?imageId=<id>)",
+		Long: `Fetch one image by its numeric id — the id in a civitai.com/images/<id>
+URL — and render its generation metadata (prompt, settings, resources), the same
+detail block as ` + "`images search --meta`" + `. Generation metadata is requested
+implicitly.`,
+		Example: `  civitai images get 136456589
+  civitai images get 136456589 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o := readFlags(cmd)
+			if n, err := strconv.Atoi(args[0]); err != nil || n <= 0 {
+				return fmt.Errorf("image id must be a positive integer, got %q", args[0])
+			}
+			client, _, err := newReader(o)
+			if err != nil {
+				return err
+			}
+			im, raw, err := client.GetImage(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if o.json {
+				return emitJSON(cmd, raw)
+			}
+			printImageMetaBlock(cmd.OutOrStdout(), *im)
+			return nil
+		},
+	}
 	bindReadFlags(cmd)
 	return cmd
 }
@@ -158,31 +200,65 @@ func printImageListMeta(cmd *cobra.Command, items []api.ImageItem) {
 		return
 	}
 	for _, im := range items {
-		fmt.Fprintf(out, "%d  [%s]  %dx%d  by %s\n",
-			im.ID, orDash(safeTerm(im.NSFWLevel)), im.Width, im.Height, orDash(safeTerm(im.Username)))
-		m, state := im.ParseMeta()
-		switch state {
-		case api.MetaAbsent:
-			// meta: null — either the uploader hid their generation data, or the
-			// API had none for this image. Not an error.
-			fmt.Fprintln(out, "  meta: (hidden by uploader)")
-		case api.MetaUnparseable:
-			// meta present but not the expected object shape — degrade rather than
-			// drop the whole image.
-			fmt.Fprintln(out, "  meta: (unrecognized format)")
-		default: // api.MetaOK
-			fmt.Fprintf(out, "  model: %s   sampler: %s   cfg: %s   steps: %s   seed: %s\n",
-				orDash(safeTerm(m.Model)), orDash(safeTerm(m.Sampler)),
-				orDash(safeTerm(m.CfgScaleString())), orDash(safeTerm(m.StepsString())),
-				orDash(safeTerm(m.SeedString())))
-			if strings.TrimSpace(m.Prompt) != "" {
-				fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
-			}
-			if strings.TrimSpace(m.NegativePrompt) != "" {
-				fmt.Fprintf(out, "  negative: %s\n", safeTerm(m.NegativePrompt))
-			}
+		printImageMetaBlock(out, im)
+	}
+}
+
+// printImageMetaBlock renders one image as an indented detail block carrying its
+// generation metadata (prompt, settings, and the resources "recipe"). Every
+// server-origin string is routed through safeTerm — prompts, resource names and
+// hashes are attacker-controlled user text that can carry ANSI/control bytes.
+// Shared by `images search --meta` and `images get`.
+func printImageMetaBlock(out io.Writer, im api.ImageItem) {
+	fmt.Fprintf(out, "%d  [%s]  %dx%d  by %s\n",
+		im.ID, orDash(safeTerm(im.NSFWLevel)), im.Width, im.Height, orDash(safeTerm(im.Username)))
+	m, state := im.ParseMeta()
+	switch state {
+	case api.MetaAbsent:
+		// meta: null — either the uploader hid their generation data, or the
+		// API had none for this image. Not an error.
+		fmt.Fprintln(out, "  meta: (hidden by uploader)")
+	case api.MetaUnparseable:
+		// meta present but not the expected object shape — degrade rather than
+		// drop the whole image.
+		fmt.Fprintln(out, "  meta: (unrecognized format)")
+	default: // api.MetaOK
+		fmt.Fprintf(out, "  model: %s   sampler: %s   cfg: %s   steps: %s   seed: %s\n",
+			orDash(safeTerm(m.Model)), orDash(safeTerm(m.Sampler)),
+			orDash(safeTerm(m.CfgScaleString())), orDash(safeTerm(m.StepsString())),
+			orDash(safeTerm(m.SeedString())))
+		if strings.TrimSpace(m.Prompt) != "" {
+			fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
 		}
-		fmt.Fprintf(out, "  url: %s\n", safeTerm(im.URL))
+		if strings.TrimSpace(m.NegativePrompt) != "" {
+			fmt.Fprintf(out, "  negative: %s\n", safeTerm(m.NegativePrompt))
+		}
+		printImageResources(out, m)
+	}
+	fmt.Fprintf(out, "  url: %s\n", safeTerm(im.URL))
+}
+
+// printImageResources renders the meta.resources reproduction recipe — one line
+// per resource (checkpoint/LoRA/embedding) with its type, name, weight (when the
+// generator supplied one) and hash (inline, else resolved from meta.hashes). The
+// section is omitted entirely when there are no resources, so images without a
+// recipe stay compact.
+func printImageResources(out io.Writer, m api.ImageMeta) {
+	rs := m.ParseResources()
+	if len(rs) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "  resources:")
+	for _, r := range rs {
+		line := fmt.Sprintf("    - [%s] %s",
+			orDash(safeTerm(strings.TrimSpace(r.Type))), orDash(safeTerm(strings.TrimSpace(r.Name))))
+		if w := strings.TrimSpace(r.WeightString()); w != "" {
+			line += "  weight " + safeTerm(w)
+		}
+		if h := strings.TrimSpace(m.ResolveHash(r)); h != "" {
+			line += "  hash " + safeTerm(h)
+		}
+		fmt.Fprintln(out, line)
 	}
 }
 

--- a/internal/cmd/images_cmd_test.go
+++ b/internal/cmd/images_cmd_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// A meta payload with 7 resources (a checkpoint + 6 LoRAs) plus a name→hash map
+// and an inline-hashless resource to exercise the meta.hashes fallback.
+const sevenResourceBody = `{"items":[
+  {"id":136456589,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None","username":"alice",
+   "meta":{"prompt":"a cat","Model":"krea2","seed":557589798350441,
+     "resources":[
+       {"hash":"78bbf8f416","name":"krea2_turbo_bf16","type":"model"},
+       {"name":"V0idv1_k2","type":"lora","weight":0.8},
+       {"hash":"605e3c6825","name":"krmj_epoch_4","type":"lora","weight":1.0},
+       {"hash":"5ec8728156","name":"Detailer-KREA2","type":"lora","weight":0.5},
+       {"hash":"3e8ed14ad2","name":"Comic Book V2T2","type":"lora","weight":0.6},
+       {"hash":"9fec63fcf3","name":"Digital_Painting","type":"lora","weight":0.7},
+       {"hash":"43c97c9ebf","name":"masterpieces_v51","type":"lora","weight":0.9}
+     ],
+     "hashes":{"model":"78bbf8f416","LORA:V0idv1_k2":"d2b95713c9"}}}
+],"metadata":{}}`
+
+// TestImagesSearchMetaShowsResources asserts the --meta detail block now carries
+// a resources section listing every resource (all 7), with type/name/weight, and
+// resolves a hashless resource's hash from meta.hashes ("lora:V0idv1_k2").
+func TestImagesSearchMetaShowsResources(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sevenResourceBody))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	if !strings.Contains(out, "resources:") {
+		t.Fatalf("--meta output should have a resources section:\n%s", out)
+	}
+	// All 7 resource names must appear.
+	for _, name := range []string{
+		"krea2_turbo_bf16", "V0idv1_k2", "krmj_epoch_4", "Detailer-KREA2",
+		"Comic Book V2T2", "Digital_Painting", "masterpieces_v51",
+	} {
+		if !strings.Contains(out, name) {
+			t.Errorf("resources section missing %q:\n%s", name, out)
+		}
+	}
+	// Type + weight are rendered.
+	if !strings.Contains(out, "[model]") || !strings.Contains(out, "[lora]") {
+		t.Errorf("resource type not rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "weight 0.8") {
+		t.Errorf("resource weight not rendered:\n%s", out)
+	}
+	// Inline hash of the checkpoint is shown.
+	if !strings.Contains(out, "hash 78bbf8f416") {
+		t.Errorf("inline resource hash not rendered:\n%s", out)
+	}
+	// The hashless V0idv1_k2 LoRA resolves its hash from meta.hashes (LORA:V0idv1_k2).
+	if !strings.Contains(out, "hash d2b95713c9") {
+		t.Errorf("hashless resource should resolve hash from meta.hashes:\n%s", out)
+	}
+}
+
+// TestImagesSearchMetaResourcesOmittedWhenEmpty asserts the resources section is
+// omitted entirely for an image whose meta has no resources (empty array / null),
+// so images without a recipe stay compact.
+func TestImagesSearchMetaResourcesOmittedWhenEmpty(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":1,"height":1,"nsfwLevel":"None","username":"a",
+		   "meta":{"prompt":"hi","resources":[],"hashes":null}},
+		  {"id":2,"url":"https://img/2","width":1,"height":1,"nsfwLevel":"None","username":"b",
+		   "meta":{"prompt":"yo"}}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	if strings.Contains(out, "resources:") {
+		t.Errorf("empty/absent resources should omit the section:\n%s", out)
+	}
+	// The rest of the block still renders.
+	if !strings.Contains(out, "prompt: hi") || !strings.Contains(out, "prompt: yo") {
+		t.Errorf("prompts should still render:\n%s", out)
+	}
+}
+
+// TestImagesSearchMetaResourceSanitized asserts a resource name carrying a
+// terminal escape is stripped by safeTerm before printing.
+func TestImagesSearchMetaResourceSanitized(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":1,"height":1,"nsfwLevel":"None","username":"a",
+		   "meta":{"prompt":"p","resources":[{"name":"evil\u001b[31mlora","type":"lora","hash":"h"}]}}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("resource name ESC byte must be stripped by safeTerm: %q", out)
+	}
+	if !strings.Contains(out, "evil") || !strings.Contains(out, "[31mlora") {
+		t.Errorf("printable resource name should survive: %q", out)
+	}
+}
+
+// TestImagesSearchMetaJSONUnchangedByResources asserts --json stays a raw
+// passthrough — the resources rendering must not touch machine output.
+func TestImagesSearchMetaJSONUnchangedByResources(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sevenResourceBody))
+	})
+	out, _, err := run(t, "images", "search", "--meta", "--json")
+	if err != nil {
+		t.Fatalf("images search --meta --json: %v", err)
+	}
+	if strings.Contains(out, "resources:") {
+		t.Errorf("--json must not carry the human resources section:\n%s", out)
+	}
+	if !strings.Contains(out, `"resources"`) {
+		t.Errorf("--json should pass the raw resources through:\n%s", out)
+	}
+}
+
+// TestImagesSearchCollectionIDParam asserts --collection-id sets collectionId on
+// the query, and that omitting it sends no collectionId.
+func TestImagesSearchCollectionIDParam(t *testing.T) {
+	var got url.Values
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "images", "search", "--collection-id", "104"); err != nil {
+		t.Fatalf("images search --collection-id: %v", err)
+	}
+	if got.Get("collectionId") != "104" {
+		t.Errorf("--collection-id should set collectionId=104, got %q", got.Get("collectionId"))
+	}
+
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	if _, _, err := run(t, "images", "search"); err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if got.Has("collectionId") {
+		t.Errorf("default search must not send collectionId: %v", got)
+	}
+}
+
+// TestImagesGetRegistered asserts the get subcommand shows up in help.
+func TestImagesGetRegistered(t *testing.T) {
+	out, _, err := run(t, "images", "--help")
+	if err != nil {
+		t.Fatalf("images --help: %v", err)
+	}
+	if !strings.Contains(out, "get") {
+		t.Errorf("images help should list the get subcommand:\n%s", out)
+	}
+}
+
+// TestImagesGetRejectsNonNumericId mirrors the other get subcommands' guard.
+func TestImagesGetRejectsNonNumericId(t *testing.T) {
+	if _, _, err := run(t, "images", "get", "abc"); err == nil {
+		t.Fatal("expected error for non-numeric image id")
+	}
+}
+
+// TestImagesGetSendsImageIdAndRenders asserts get hits imageId + flat meta and
+// renders the shared detail block including the resources section.
+func TestImagesGetSendsImageIdAndRenders(t *testing.T) {
+	var got url.Values
+	var path string
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		got = r.URL.Query()
+		_, _ = w.Write([]byte(sevenResourceBody))
+	})
+	out, _, err := run(t, "images", "get", "136456589")
+	if err != nil {
+		t.Fatalf("images get: %v", err)
+	}
+	if path != "/api/v1/images" {
+		t.Errorf("path = %q, want /api/v1/images", path)
+	}
+	if got.Get("imageId") != "136456589" {
+		t.Errorf("imageId not sent: %v", got)
+	}
+	if got.Get("withMeta") != "true" || got.Get("flatMeta") != "true" {
+		t.Errorf("get should implicitly request flat meta: %v", got)
+	}
+	if !strings.Contains(out, "136456589") || !strings.Contains(out, "prompt: a cat") {
+		t.Errorf("detail block not rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "resources:") || !strings.Contains(out, "krea2_turbo_bf16") {
+		t.Errorf("get should render the resources section:\n%s", out)
+	}
+	// Large seed survives the tolerant numeric parse.
+	if !strings.Contains(out, "seed: 557589798350441") {
+		t.Errorf("large seed should render:\n%s", out)
+	}
+}
+
+// TestImagesGetJSONPassthrough asserts get --json emits the raw envelope, not the
+// human block.
+func TestImagesGetJSONPassthrough(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("imageId") != "42" {
+			t.Errorf("imageId not sent on --json: %v", r.URL.Query())
+		}
+		_, _ = w.Write([]byte(`{"items":[{"id":42,"url":"u","meta":{"prompt":"hi","resources":[{"name":"x","type":"lora"}]}}],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "get", "42", "--json")
+	if err != nil {
+		t.Fatalf("images get --json: %v", err)
+	}
+	if strings.Contains(out, "prompt:") || strings.Contains(out, "resources:") {
+		t.Errorf("--json must not carry the human detail block:\n%s", out)
+	}
+	if !strings.Contains(out, `"items"`) || !strings.Contains(out, `"resources"`) {
+		t.Errorf("--json should pass the raw body through:\n%s", out)
+	}
+}
+
+// TestImagesGetSurfacesNotFound asserts an empty items array surfaces a
+// not-found error rather than printing a bogus block.
+func TestImagesGetSurfacesNotFound(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	_, _, err := run(t, "images", "get", "999999999")
+	if err == nil {
+		t.Fatal("expected not-found error for empty items")
+	}
+	if !strings.Contains(err.Error(), "no image found with id 999999999") {
+		t.Errorf("error should name the id: %v", err)
+	}
+}
+
+// TestImagesHelpExampleValid guards Fix 4: the images help must not advertise the
+// --model-id + --sort combo the tool itself warns is ignored.
+func TestImagesHelpExampleValid(t *testing.T) {
+	out, _, err := run(t, "images", "--help")
+	if err != nil {
+		t.Fatalf("images --help: %v", err)
+	}
+	if strings.Contains(out, `--model-id 4384 --sort`) {
+		t.Errorf("help must not demo the model-id + sort combo the tool warns against:\n%s", out)
+	}
+}

--- a/internal/cmd/images_cmd_test.go
+++ b/internal/cmd/images_cmd_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/civitai/cli/internal/api"
 )
 
 // A meta payload with 7 resources (a checkpoint + 6 LoRAs) plus a name→hash map
@@ -241,6 +244,9 @@ func TestImagesGetSurfacesNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no image found with id 999999999") {
 		t.Errorf("error should name the id: %v", err)
+	}
+	if !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("images get not-found must be tagged ErrNotFound (→ exit 4), got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Four dogfood-driven improvements to the `images` command (all verified against the live public API).

### 1. Surface the generation recipe in `--meta` output (highest value)
`images search --meta` printed prompt/sampler/seed but **hid the LoRAs/checkpoint** — one image had 7 resources visible only via `--json`. Now the human block carries a `resources:` section listing each resource's **type, name, weight** (when supplied) and **hash** (inline, else resolved from `meta.hashes` by name / case-insensitive `<type>:<name>` key). Omitted when there are no resources. Raw-JSON-backed and tolerant (an odd shape can't drop the surrounding meta); every string routed through `safeTerm`.

```
  resources:
    - [lora] Purple_Graphics_KR2  weight 1.2  hash 990d0df641
    - [lora] Purple_Grainy_Kr2_AM  weight 0.5  hash ce0672fe6e
    - [model] krea2TurboOfficialComfy_krea2TurboFp8.safetensors  hash eb4dd8c612
```

### 2. `civitai images get <id>` — single-image lookup
The natural "I saw civitai.com/images/`<id>`" entry point (requested by 3 dogfoods) was missing. Fetches via `GET /api/v1/images?imageId=<id>` (implicitly `withMeta`/`flatMeta`), renders the same detail block as `--meta`, with `--json` passthrough. Unknown id → clear not-found error.

### 3. `--collection-id` on `images search`
Wires `collectionId=` so a collection's images become browsable (the CLI answer to "collections are a dead-end").

### 4. Fix the misleading help example
`images search` advertised `--model-id 4384 --sort "Most Reactions"` — a combo the CLI itself warns the API ignores. Replaced with valid examples and surfaced the new `get` / `--collection-id` entry points.

## Verification (live API)
- `images search --sort "Most Reactions" --period Week --limit 3 --meta` → resources section renders.
- `images get 136710538` → full weighted recipe (2 LoRAs + checkpoint) with hashes; `--json` emits the raw envelope.
- `images search --collection-id 104 --limit 3` → returns the collection's images.
- `images --help` → no longer demos the model-id + sort combo.

## Tests
New `internal/api/images_test.go` + `internal/cmd/images_cmd_test.go`:
- resources parse (full recipe incl. weights, empty→len 0, absent/null/odd→nil), hash resolution (inline wins, `meta.hashes` fallback incl. case-insensitive `LORA:`/`lora:`), meta decode still yields the prompt when resources is an odd shape;
- resources rendering (7 resources all shown incl. `meta.hashes`-resolved hash; empty→section omitted; `safeTerm` strips a resource-name escape; `--json` untouched);
- `images get` (imageId + flat-meta params sent, renders resources, `--json` passthrough, non-numeric-id + not-found errors);
- `--collection-id` sets/omits `collectionId`;
- help no longer contains the model-id+sort combo.

`go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
