### PR TITLE
fix(articles): render list markers + coalesce adjacent emphasis in `--content`

### DIFF
--- a/internal/cmd/htmlrender.go
+++ b/internal/cmd/htmlrender.go
@@ -35,16 +35,36 @@ type listState struct {
 	index   int
 }
 
+// emphMark records an open emphasis marker and where it was written on the line,
+// so its close can find the span's inner text (to drop empty spans) and coalesce
+// with an immediately-adjacent same-kind span (to avoid stray "****"/"*****").
+//
+// mergePrev / prevMk / prevAt snapshot the merge state AT OPEN TIME so that
+// nested emphasis (e.g. an empty <em> inside a <strong>) can't clobber the outer
+// span's eligibility to coalesce with its preceding same-kind sibling.
+type emphMark struct {
+	marker    string
+	pos       int  // index in r.line where this open marker begins
+	mergePrev bool // opened exactly where a matching close ended (adjacent sibling)
+	prevMk    string
+	prevAt    int
+}
+
 type htmlRenderer struct {
 	out    strings.Builder // finished block-level lines
 	line   strings.Builder // the current in-progress line (inline content)
 	lists  []listState     // open list stack (for nesting + ordered numbering)
+	inItem bool            // currently between <li> and </li> (item text accumulates on line)
 	quote  int             // blockquote nesting depth
 	inPre  bool            // inside <pre> (preserve/monospace-fence)
 	preBuf strings.Builder // buffered <pre> content
 	href   string          // href of an open <a>, emitted as [text](href) on close
 	aStart int             // len(line) when <a> opened, to wrap its text
 	skip   int             // >0 while inside a <script>/<style> subtree (drop content)
+
+	emph        []emphMark // open emphasis markers (**, *, `), innermost last
+	lastCloseMk string     // marker of the most recently emitted close, "" if none/invalidated
+	lastCloseAt int        // len(line) right after that close marker was written
 }
 
 // run drives the html tokenizer over body and dispatches text/tags. On EOF (or a
@@ -145,11 +165,21 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 		r.flushLine()
 		r.block("---")
 	case "p", "div":
+		if r.inItem {
+			// Inside a list item, TipTap wraps the item's text in a <p>. Don't flush
+			// it as a standalone paragraph (that dropped the list marker — bug #1);
+			// keep the text on the item's line and separate stacked <p>s with a space.
+			if r.line.Len() > 0 && !strings.HasSuffix(r.line.String(), " ") {
+				r.line.WriteString(" ")
+			}
+			return
+		}
 		r.flushLine()
 	case "h1", "h2", "h3", "h4", "h5", "h6":
 		if closing {
 			text := strings.TrimSpace(r.line.String())
 			r.line.Reset()
+			r.lastCloseMk = ""
 			level := int(name[1] - '0')
 			r.block(strings.Repeat("#", level) + " " + text)
 		} else {
@@ -164,7 +194,13 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 				r.flushLine()
 			}
 		} else {
-			r.flushLine()
+			if r.inItem {
+				// A nested list inside an <li>: flush the parent item's text (with its
+				// marker) before descending, so it isn't lost or glued to the children.
+				r.flushListItem()
+			} else {
+				r.flushLine()
+			}
 			r.lists = append(r.lists, listState{ordered: name == "ol"})
 		}
 	case "li":
@@ -173,6 +209,7 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 		} else {
 			r.flushLine()
 			r.startListItem()
+			r.inItem = true
 		}
 	case "a":
 		if closing {
@@ -180,6 +217,9 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 		} else {
 			r.href = attrs["href"]
 			r.aStart = r.line.Len()
+			// An anchor boundary must not coalesce emphasis across it (the anchor
+			// rewrites the line on close, which would invalidate merged positions).
+			r.lastCloseMk = ""
 		}
 	case "img":
 		alt := attrs["alt"]
@@ -191,12 +231,12 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 			r.line.WriteString(fmt.Sprintf("![%s](%s)", alt, src))
 		}
 	case "strong", "b":
-		r.emphasis("**")
+		r.emphasis("**", closing)
 	case "em", "i":
-		r.emphasis("*")
+		r.emphasis("*", closing)
 	case "code":
 		if !r.inPre { // inline code; a <code> inside <pre> is part of the block
-			r.emphasis("`")
+			r.emphasis("`", closing)
 		}
 	case "pre":
 		if closing {
@@ -221,10 +261,86 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 	}
 }
 
-// emphasis writes an emphasis marker; the tokenizer emits the open then the close
-// tag so the surrounding pair balances.
-func (r *htmlRenderer) emphasis(marker string) {
+// emphasis dispatches an emphasis tag (**, *, `) to its open/close handler.
+func (r *htmlRenderer) emphasis(marker string, closing bool) {
+	if closing {
+		r.closeEmphasis(marker)
+	} else {
+		r.openEmphasis(marker)
+	}
+}
+
+// openEmphasis writes an opening emphasis marker and remembers where it went so
+// its close can inspect the span's inner text. It snapshots the merge anchor so a
+// close can coalesce this span with an immediately-preceding same-kind span.
+func (r *htmlRenderer) openEmphasis(marker string) {
+	m := emphMark{
+		marker: marker,
+		pos:    r.line.Len(),
+		prevMk: r.lastCloseMk,
+		prevAt: r.lastCloseAt,
+	}
+	// Adjacent to a matching close (nothing but ignored tags between) → eligible to
+	// merge on close, coalescing "</b><b>" instead of emitting "****".
+	if r.lastCloseMk == marker && r.lastCloseAt == r.line.Len() {
+		m.mergePrev = true
+	}
+	r.emph = append(r.emph, m)
 	r.line.WriteString(marker)
+}
+
+// closeEmphasis finalises an emphasis span. It coalesces adjacent runs and drops
+// empty/whitespace-only spans so abutting or empty <strong>/<em> never produce a
+// malformed "****"/"*****" run (bug #2):
+//   - a span whose inner text is empty or all-whitespace emits NO markers (the
+//     bare whitespace, if any, is kept);
+//   - a span opening exactly where the previous same-kind span closed is merged
+//     into it, yielding one "**A B**" rather than "**A****B**".
+func (r *htmlRenderer) closeEmphasis(marker string) {
+	// Pop the matching open marker (emphasis nests, so it's the nearest one).
+	open, ok := emphMark{}, false
+	for i := len(r.emph) - 1; i >= 0; i-- {
+		if r.emph[i].marker == marker {
+			open = r.emph[i]
+			r.emph = append(r.emph[:i], r.emph[i+1:]...)
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		// Unbalanced close with no matching open: drop it (never emit a lone marker).
+		return
+	}
+	line := r.line.String()
+	if open.pos+len(marker) > len(line) {
+		return
+	}
+	inner := line[open.pos+len(marker):]
+	if strings.TrimSpace(inner) == "" {
+		// Empty or whitespace-only span: strip the open marker, keep the whitespace,
+		// emit no close marker. The span contributed nothing, so RESTORE the merge
+		// anchor it saw at open time — a following same-kind sibling can still merge
+		// with the span that preceded this empty one.
+		r.line.Reset()
+		r.line.WriteString(line[:open.pos] + inner)
+		r.lastCloseMk = open.prevMk
+		r.lastCloseAt = open.prevAt
+		return
+	}
+	before := line[:open.pos]
+	if open.mergePrev && strings.HasSuffix(before, marker) {
+		// The previous same-kind span closed exactly where this one opened: merge the
+		// two into a single span instead of emitting "</b><b>" as "****".
+		merged := before[:len(before)-len(marker)] + inner + marker
+		r.line.Reset()
+		r.line.WriteString(merged)
+		r.lastCloseMk = marker
+		r.lastCloseAt = len(merged)
+		return
+	}
+	r.line.WriteString(marker)
+	r.lastCloseMk = marker
+	r.lastCloseAt = r.line.Len()
 }
 
 // closeAnchor rewrites the anchor's inner text into [text](href).
@@ -249,6 +365,7 @@ func (r *htmlRenderer) closeAnchor() {
 	}
 	r.href = ""
 	r.aStart = 0
+	r.lastCloseMk = "" // line was rewritten — invalidate any pending merge anchor
 }
 
 // startListItem begins a list item, incrementing the ordered counter.
@@ -264,6 +381,8 @@ func (r *htmlRenderer) startListItem() {
 func (r *htmlRenderer) flushListItem() {
 	text := strings.TrimSpace(r.line.String())
 	r.line.Reset()
+	r.inItem = false
+	r.lastCloseMk = "" // line reset — any pending merge anchor is now invalid
 	if text == "" {
 		return
 	}
@@ -310,6 +429,7 @@ func (r *htmlRenderer) flushOpen() {
 func (r *htmlRenderer) flushLine() {
 	text := strings.TrimRight(r.line.String(), " ")
 	r.line.Reset()
+	r.lastCloseMk = "" // line reset — any pending merge anchor is now invalid
 	if strings.TrimSpace(text) == "" {
 		return
 	}

--- a/internal/cmd/htmlrender.go
+++ b/internal/cmd/htmlrender.go
@@ -160,6 +160,14 @@ var wsRe = regexp.MustCompile(`\s+`)
 func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfClose bool) {
 	switch name {
 	case "br":
+		if r.inItem {
+			// Inside a list item, a <br> must not split the item into a plain line
+			// + a mislabeled remainder — keep the text on the item's line, like <p>.
+			if r.line.Len() > 0 && !strings.HasSuffix(r.line.String(), " ") {
+				r.line.WriteString(" ")
+			}
+			return
+		}
 		r.flushLine()
 	case "hr":
 		r.flushLine()
@@ -187,6 +195,12 @@ func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfCl
 		}
 	case "ul", "ol":
 		if closing {
+			if r.inItem {
+				// An <li> left open at list close (</li> is optional HTML and the
+				// tokenizer does no implicit close): emit its text with a marker and
+				// clear inItem, so later blocks don't glue onto the item's line.
+				r.flushListItem()
+			}
 			if len(r.lists) > 0 {
 				r.lists = r.lists[:len(r.lists)-1]
 			}

--- a/internal/cmd/htmlrender_test.go
+++ b/internal/cmd/htmlrender_test.go
@@ -311,3 +311,37 @@ func TestHTMLToTextStripsControlChars(t *testing.T) {
 		t.Errorf("safeTerm newline/tab/CR handling wrong: %q", got)
 	}
 }
+
+// TestHTMLToTextSeparateBoldsStaySplit guards the highest-risk direction of the
+// emphasis-coalescing fix: bolds with any intervening text/space must NOT merge.
+func TestHTMLToTextSeparateBoldsStaySplit(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{`<strong>A</strong> and <strong>B</strong>`, "**A** and **B**"},
+		{`<strong>bold</strong> word <strong>bold</strong>`, "**bold** word **bold**"},
+		{`<strong>A</strong> <strong>B</strong>`, "**A** **B**"},
+	} {
+		if out := htmlToText(tc.in); out != tc.want {
+			t.Errorf("separate bolds from %q: got %q, want %q", tc.in, out, tc.want)
+		}
+	}
+}
+
+// TestHTMLToTextMalformedListState covers the two robustness gaps a #159 audit
+// found: an <li> left open at list close must not leak `inItem` onto following
+// blocks, and a <br> inside a list item must not split off a mislabeled tail.
+func TestHTMLToTextMalformedListState(t *testing.T) {
+	// Missing </li>: content after the list must land on its own lines, not glue.
+	out := htmlToText(`<ul><li><p>x</p></ul><p>A</p><p>B</p>`)
+	for _, want := range []string{"- x", "A", "B"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing-</li> leak: %q absent:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "A B") {
+		t.Errorf("blocks after a malformed list must not glue onto one line:\n%s", out)
+	}
+	// <br> inside a list item keeps the item together (no bullet on the tail).
+	if got := htmlToText(`<ul><li><p>a<br>b</p></li></ul>`); got != "- a b" {
+		t.Errorf("<br> in <li>: got %q, want %q", got, "- a b")
+	}
+}

--- a/internal/cmd/htmlrender_test.go
+++ b/internal/cmd/htmlrender_test.go
@@ -143,6 +143,98 @@ func TestHTMLToTextFlushesUnclosedList(t *testing.T) {
 	}
 }
 
+// TestHTMLToTextListItemsWrappedInParagraphs is the regression for bug #1: TipTap
+// wraps each <li>'s text in a <p> (`<ul><li><p>…</p></li>…`). The inner <p> must
+// not be flushed as a standalone paragraph — that dropped the list marker so items
+// rendered as bare, run-together lines. Each item must keep its marker on its own
+// line, for both unordered and ordered lists.
+func TestHTMLToTextListItemsWrappedInParagraphs(t *testing.T) {
+	ul := htmlToText(`<ul><li><p>Text-to-Image</p></li><li><p>Simple latent upscale</p></li></ul>`)
+	if want := "- Text-to-Image\n- Simple latent upscale"; !strings.Contains(ul, want) {
+		t.Errorf("<ul><li><p> items not marked / not on own lines:\ngot:\n%s\nwant substring:\n%s", ul, want)
+	}
+	ol := htmlToText(`<ol><li><p>first</p></li><li><p>second</p></li><li><p>third</p></li></ol>`)
+	if want := "1. first\n2. second\n3. third"; !strings.Contains(ol, want) {
+		t.Errorf("<ol><li><p> items not numbered / not on own lines:\ngot:\n%s\nwant substring:\n%s", ol, want)
+	}
+	// A multi-paragraph <li> keeps its single marker and doesn't glue words together.
+	multi := htmlToText(`<ul><li><p>one</p><p>two</p></li></ul>`)
+	if !strings.Contains(multi, "- one two") {
+		t.Errorf("multi-paragraph <li> mishandled:\n%s", multi)
+	}
+}
+
+// TestHTMLToTextCoalescesAdjacentEmphasis is the regression for bug #2: abutting or
+// empty <strong>/<em> spans each emitted their own marker, producing malformed
+// "****" / "*****" runs that broke mid-word. Adjacent same-kind spans must coalesce
+// and empty / whitespace-only spans must emit no markers at all.
+func TestHTMLToTextCoalescesAdjacentEmphasis(t *testing.T) {
+	// No case may ever leave a "****" (or longer) run.
+	noStray := []string{
+		`<strong>A</strong><strong>B</strong>`,
+		`text<strong></strong>`,
+		`<strong></strong>text`,
+		`<strong>does not</strong><strong> </strong>do:`,
+		`<strong>We're up to </strong><strong>32 </strong><strong>LoRAs!</strong>`,
+		`<strong><em>If helpful, </em></strong><strong>consider donating<em> </em></strong>`,
+		`<em>a</em><em>b</em>`,
+	}
+	for _, body := range noStray {
+		if out := htmlToText(body); strings.Contains(out, "****") {
+			t.Errorf("stray '****' from %q:\n%s", body, out)
+		}
+	}
+
+	// Adjacent bold runs merge into one span.
+	if out := htmlToText(`<strong>A</strong><strong>B</strong>`); out != "**AB**" {
+		t.Errorf("adjacent bold: got %q, want %q", out, "**AB**")
+	}
+	// Three adjacent bolds (with an ignored <span> shape) coalesce.
+	if out := htmlToText(`<strong>We're up to </strong><strong>32 </strong><strong>LoRAs!</strong>`); out != "**We're up to 32 LoRAs!**" {
+		t.Errorf("three adjacent bolds: got %q, want %q", out, "**We're up to 32 LoRAs!**")
+	}
+	// A trailing empty <strong> drops entirely — no marker survives.
+	if out := htmlToText(`text<strong></strong>`); out != "text" {
+		t.Errorf("empty trailing <strong>: got %q, want %q", out, "text")
+	}
+	// A whitespace-only <strong> between spans: no marker, words stay separated.
+	if out := htmlToText(`<strong>does not</strong><strong> </strong>do:`); out != "**does not** do:" {
+		t.Errorf("whitespace-only <strong>: got %q, want %q", out, "**does not** do:")
+	}
+}
+
+// TestHTMLToTextNestedEmphasis proves nested emphasis renders correctly: <em>
+// inside <strong> becomes ***…***, and a real-article shape mixing nested and
+// empty emphasis never produces a stray "****"/"*****".
+func TestHTMLToTextNestedEmphasis(t *testing.T) {
+	if out := htmlToText(`<p><strong><em>bold italic</em></strong></p>`); out != "***bold italic***" {
+		t.Errorf("strong>em: got %q, want %q", out, "***bold italic***")
+	}
+	if out := htmlToText(`<p><em><strong>italic bold</strong></em></p>`); out != "***italic bold***" {
+		t.Errorf("em>strong: got %q, want %q", out, "***italic bold***")
+	}
+	// Real donation-line shape: nested + trailing whitespace-only emphasis.
+	body := `<strong><em>If helpful, </em></strong><strong>consider donating<em> </em></strong>`
+	if out := htmlToText(body); strings.Contains(out, "****") {
+		t.Errorf("nested+empty emphasis produced a stray run:\n%s", out)
+	}
+}
+
+// TestHTMLToTextWellFormedUnchanged is the golden: a clean, well-formed snippet
+// (heading, paragraph with a single bold/italic/link, a wrapped list) renders to
+// exactly the expected markdown — so the bug fixes don't regress good content.
+func TestHTMLToTextWellFormedUnchanged(t *testing.T) {
+	body := `<h2>Overview</h2>` +
+		`<p>This uses <strong>ComfyUI</strong> and a <em>custom</em> workflow. See the <a href="https://civitai.com/g">guide</a>.</p>` +
+		`<ul><li><p>step one</p></li><li><p>step two</p></li></ul>`
+	want := "## Overview\n\n" +
+		"This uses **ComfyUI** and a *custom* workflow. See the [guide](https://civitai.com/g).\n" +
+		"- step one\n- step two"
+	if out := htmlToText(body); out != want {
+		t.Errorf("well-formed render changed:\ngot:\n%q\nwant:\n%q", out, want)
+	}
+}
+
 // TestHTMLToTextFlushesUnclosedParagraph proves trailing text with no closing tag
 // is still emitted.
 func TestHTMLToTextFlushesUnclosedParagraph(t *testing.T) {


### PR DESCRIPTION
## What

Fixes two article-body HTML rendering bugs in `htmlToText` (the `civitai articles get <id> --content` renderer), found via dogfood.

### Bug 1 — `<ul>/<li>` items rendered with no bullet marker
TipTap wraps each item's text in a `<p>` (`<ul><li><p>…</p></li>`). The inner `<p>` was flushed as a standalone paragraph, so by the time `</li>` fired the item line was empty and no marker was emitted — items read as run-together prose. Now a `<p>`/`<div>` boundary inside an open `<li>` keeps its text on the item's line, so every item renders as `- …` / `N. …` on its own line.

### Bug 2 — adjacent/empty `<strong>`/`<em>` produced malformed `****` / `*****`
Each emphasis tag emitted its marker independently, so abutting bold and empty spans left stray `****`/`*****` that broke mid-word (`does not**** **do:`). Emphasis is now open/close-aware:
- empty or whitespace-only spans emit **no** markers;
- a span opening exactly where a matching close ended **coalesces** with it (`**A****B**` → `**AB**`);
- merge eligibility is snapshotted at open time so nested emphasis (empty `<em>` inside `<strong>`) can't clobber the outer span, and spans are not merged across an anchor boundary.

## Before / after (`articles get 31655 --content`)

```
# BEFORE
What this basic workflow **does not**** **do:
Wildcard prompting
LLM-assisted prompting/analysis
...

# AFTER
What this basic workflow **does not** do:
- Wildcard prompting
- LLM-assisted prompting/analysis
...
```

`articles get 32226 --content` donation line:
```
# BEFORE
***If this was helpful to you, *****consider donating* ****to my**** ***[**Patreon**]...
# AFTER
***If this was helpful to you, *consider donating ***to my* [**Patreon**](...) *or* [**Ko-Fi**](...)!
```

## Tests
Extends the renderer unit tests: wrapped `<li>` lists (ordered + unordered + multi-paragraph), adjacent/empty/whitespace-only emphasis (no stray `****`), nested `<strong>`/`<em>` → `***…***`, and a golden well-formed snippet that must stay byte-identical.

## Gate
`go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)