### PR TITLE
fix(images): remove no-op --collection-id; usage exit-codes for bad ids; --base-model zero-result hint

### DIFF
--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -24,7 +25,6 @@ func newImagesCmd() *cobra.Command {
 		Example: `  civitai images search --limit 5
   civitai images search --model-id 4384 --period Month
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
-  civitai images search --collection-id 104 --limit 10
   civitai images search --nsfw --sort "Most Reactions" --period Month --meta
   civitai images get 136456589`,
 	}
@@ -35,10 +35,10 @@ func newImagesCmd() *cobra.Command {
 
 func newImagesSearchCmd() *cobra.Command {
 	var (
-		username, sort, period, cursor, typ                        string
-		baseModels                                                 []string
-		postID, modelID, modelVersionID, collectionID, limit, page int
-		nsfw, meta                                                 bool
+		username, sort, period, cursor, typ          string
+		baseModels                                   []string
+		postID, modelID, modelVersionID, limit, page int
+		nsfw, meta                                   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -51,7 +51,6 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
   civitai images search --model-version-id 128713 --sort Newest
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
   civitai images search --type video --sort "Most Reactions"
-  civitai images search --collection-id 104 --limit 10
   civitai images search --nsfw --sort "Most Reactions" --period Month --meta
   civitai images search --username some-user --cursor <cursor>`,
 		Args: cobra.NoArgs,
@@ -85,7 +84,6 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			addIfPositive(q, "postId", postID)
 			addIfPositive(q, "modelId", modelID)
 			addIfPositive(q, "modelVersionId", modelVersionID)
-			addIfPositive(q, "collectionId", collectionID)
 			addIfPositive(q, "limit", limit)
 			addIfPositive(q, "page", page)
 			if cmd.Flags().Changed("nsfw") {
@@ -107,6 +105,15 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 			if err != nil {
 				return err
 			}
+			// --base-model is matched literally (the API OR-matches the given
+			// values), so a typo just matches nothing and returns "No images
+			// found." at exit 0 with no signal. When --base-model was given and the
+			// page came back empty, hint that the spelling may be off. Not an error
+			// — zero results is a valid outcome — so this only adds a stderr note.
+			if cmd.Flags().Changed("base-model") && len(res.Items) == 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(),
+					"note: 0 results — check --base-model spelling (it's matched literally).")
+			}
 			if o.json {
 				return emitJSON(cmd, res.Raw)
 			}
@@ -125,7 +132,6 @@ caps page*limit at 1000). The next cursor is printed after the results.`,
 	cmd.Flags().IntVar(&postID, "post-id", 0, "filter by post id")
 	cmd.Flags().IntVar(&modelID, "model-id", 0, "filter by model id")
 	cmd.Flags().IntVar(&modelVersionID, "model-version-id", 0, "filter by model version id")
-	cmd.Flags().IntVar(&collectionID, "collection-id", 0, "filter by collection id (browse a collection's images)")
 	cmd.Flags().StringVar(&username, "username", "", "filter by uploader username")
 	cmd.Flags().StringSliceVar(&baseModels, "base-model", nil, "filter by base model; repeatable (e.g. --base-model \"Krea 2\" --base-model Flux). The API OR-combines the given values")
 	cmd.Flags().StringVar(&typ, "type", "", "filter by media type (image, video, audio)")
@@ -150,8 +156,14 @@ implicitly.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := readFlags(cmd)
-			if n, err := strconv.Atoi(args[0]); err != nil || n <= 0 {
-				return fmt.Errorf("image id must be a positive integer, got %q", args[0])
+			// A bad positional id is a client-side usage mistake, not an API
+			// failure — tag it as a usage error (exit 2), mirroring
+			// `model-versions get`. A non-int, non-positive, or out-of-range id
+			// (image ids are 32-bit) is caught locally so an oversized id can't
+			// leak a host 500 (exit 1) instead of a clean usage error.
+			n, err := strconv.Atoi(args[0])
+			if err != nil || n <= 0 || n > math.MaxInt32 {
+				return asUsageError(fmt.Errorf("image id must be a positive integer, got %q", args[0]))
 			}
 			client, _, err := newReader(o)
 			if err != nil {

--- a/internal/cmd/images_cmd_test.go
+++ b/internal/cmd/images_cmd_test.go
@@ -131,33 +131,6 @@ func TestImagesSearchMetaJSONUnchangedByResources(t *testing.T) {
 	}
 }
 
-// TestImagesSearchCollectionIDParam asserts --collection-id sets collectionId on
-// the query, and that omitting it sends no collectionId.
-func TestImagesSearchCollectionIDParam(t *testing.T) {
-	var got url.Values
-	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
-		got = r.URL.Query()
-		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
-	})
-	if _, _, err := run(t, "images", "search", "--collection-id", "104"); err != nil {
-		t.Fatalf("images search --collection-id: %v", err)
-	}
-	if got.Get("collectionId") != "104" {
-		t.Errorf("--collection-id should set collectionId=104, got %q", got.Get("collectionId"))
-	}
-
-	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
-		got = r.URL.Query()
-		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
-	})
-	if _, _, err := run(t, "images", "search"); err != nil {
-		t.Fatalf("images search: %v", err)
-	}
-	if got.Has("collectionId") {
-		t.Errorf("default search must not send collectionId: %v", got)
-	}
-}
-
 // TestImagesGetRegistered asserts the get subcommand shows up in help.
 func TestImagesGetRegistered(t *testing.T) {
 	out, _, err := run(t, "images", "--help")

--- a/internal/cmd/images_r2_test.go
+++ b/internal/cmd/images_r2_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestImagesSearchCollectionIDRemoved asserts the --collection-id flag is gone:
+// the public /api/v1/images endpoint ignores collectionId (it silently returned
+// the global feed as "the collection"), so the flag was removed. Passing it must
+// now fail with an unknown-flag usage error (exit 2), not succeed at exit 0.
+func TestImagesSearchCollectionIDRemoved(t *testing.T) {
+	_, _, err := run(t, "images", "search", "--collection-id", "104")
+	if err == nil {
+		t.Fatal("--collection-id should be an unknown flag now, got no error")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("expected an unknown-flag error, got: %v", err)
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("unknown flag must be tagged ErrUsage (→ exit 2), got %v", err)
+	}
+	// The flag must not be registered on the command at all.
+	if f := newImagesSearchCmd().Flags().Lookup("collection-id"); f != nil {
+		t.Errorf("collection-id flag should be removed, but it is still registered")
+	}
+}
+
+// TestImagesGetBadIdIsUsageError asserts a non-numeric positional id is a usage
+// error (exit 2), mirroring `model-versions get` — it previously returned a bare
+// error (exit 1).
+func TestImagesGetBadIdIsUsageError(t *testing.T) {
+	_, _, err := run(t, "images", "get", "abc")
+	if err == nil {
+		t.Fatal("expected error for non-numeric image id")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("bad image id must be tagged ErrUsage (→ exit 2), got %v", err)
+	}
+}
+
+// TestImagesGetOutOfRangeIdIsUsageError asserts an oversized id (beyond the
+// 32-bit image-id range) is caught locally as a usage error (exit 2) instead of
+// being sent to the API and leaking a host 500 (exit 1). The server must never
+// be hit.
+func TestImagesGetOutOfRangeIdIsUsageError(t *testing.T) {
+	hit := false
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	_, _, err := run(t, "images", "get", "99999999999")
+	if err == nil {
+		t.Fatal("expected error for out-of-range image id")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("out-of-range image id must be tagged ErrUsage (→ exit 2), got %v", err)
+	}
+	if hit {
+		t.Error("an out-of-range id must be rejected locally, not sent to the API")
+	}
+}
+
+// TestImagesSearchBaseModelZeroResultNote asserts a --base-model that matches
+// nothing prints a spelling hint on stderr (the API OR-matches literally, so a
+// typo just returns an empty page) while still exiting 0 — zero results is not
+// an error.
+func TestImagesSearchBaseModelZeroResultNote(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	out, errOut, err := run(t, "images", "search", "--base-model", "Zzzzz", "--limit", "3")
+	if err != nil {
+		t.Fatalf("zero results must not be an error (exit 0): %v", err)
+	}
+	if !strings.Contains(errOut, "check --base-model spelling") {
+		t.Errorf("expected a --base-model spelling hint on stderr, got: %q", errOut)
+	}
+	if !strings.Contains(out, "No images found.") {
+		t.Errorf("stdout should still report no images: %q", out)
+	}
+}
+
+// TestImagesSearchNoBaseModelNoNote asserts the hint is NOT printed for an empty
+// result when --base-model wasn't given (nothing to blame on spelling).
+func TestImagesSearchNoBaseModelNoNote(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	_, errOut, err := run(t, "images", "search", "--limit", "3")
+	if err != nil {
+		t.Fatalf("images search: %v", err)
+	}
+	if strings.Contains(errOut, "check --base-model spelling") {
+		t.Errorf("no --base-model given → no spelling hint, got: %q", errOut)
+	}
+}


### PR DESCRIPTION
## Summary

Three fixes to the `images` command, driven by verifying real behavior against the public `GET /api/v1/images` endpoint.

### 1. Remove the broken `--collection-id` flag (confirmed silent no-op)
The public `/api/v1/images` endpoint **ignores** `collectionId` — verified: identical items come back across different collection ids and the bare feed, and there is no `/collections/{id}/items` route on the public API. The flag presented the global feed as "the collection" at **exit 0**, which actively misleads. Collection items are genuinely unavailable via the public API, so removal (not a client-side fetch) is the correct fix.

`civitai images search --collection-id 104` now errors `unknown flag` (exit 2).

### 2. `images get <bad-id>` → exit 2 (usage), not exit 1
- A non-numeric positional id previously returned a bare error (exit 1). It's now wrapped with `asUsageError` (exit 2), matching `model-versions get`.
- An oversized id (e.g. `99999999999`) previously passed the local check and hit a **host 500** (exit 1). It's now bounded to the 32-bit image-id range locally and returns a clean usage error (exit 2) without touching the API.

### 3. Hint on a zero-result `--base-model`
When `--base-model` was given and the page comes back empty, print a one-line stderr note. Exit stays 0 (zero results isn't an error). Note: the live API now enum-validates `--base-model`, so a *pure typo* (`Zzzzz`) returns a 400 (exit 2) rather than a silent empty page; the hint still adds value for a **valid** base-model that legitimately matches nothing.

## Live verification
```
$ civitai images search --collection-id 104
Error: unknown flag: --collection-id                     # exit 2

$ civitai images get abc
Error: image id must be a positive integer, got "abc"    # exit 2

$ civitai images get 99999999999
Error: image id must be a positive integer, got "99999999999"   # exit 2 (no host 500)

$ civitai images search --base-model "ODOR" --type video --limit 3
note: 0 results — check --base-model spelling (it's matched literally).
No images found.                                         # exit 0
```

## Tests / gates
- New deterministic tests in `internal/cmd/images_r2_test.go` (collection-id removed / unknown-flag exit 2; get bad-id usage; get out-of-range usage with server-never-hit assertion; base-model zero-result note fires + doesn't fire without the flag).
- Removed the obsolete `TestImagesSearchCollectionIDParam`.
- `go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)