### PR TITLE
fix(app submit): confirmation gate — make `civitai app submit` safe-by-default

### DIFF
--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -22,6 +23,7 @@ func newAppSubmitCmd() *cobra.Command {
 	var outFlag string
 	var packageOnly bool
 	var skipValidate bool
+	var assumeYes bool
 
 	cmd := &cobra.Command{
 		Use:   "submit [dir]",
@@ -43,9 +45,17 @@ Submission path:
 
   --package-only always just writes the .zip and stops.
 
+Submitting creates a real "pending moderator review" request (undone only with
+` + "`civitai app withdraw`" + `), so it is NOT fired blindly: before uploading you are
+shown the app@version and asked to confirm. Pass --yes/-y to skip the prompt
+(for scripts/CI). In a non-interactive shell (no TTY) submit REFUSES unless
+--yes is given, rather than hang or submit silently. --package-only is the safe
+preview — it never submits.
+
 Defaults to the current directory.`,
-		Example: `  civitai app submit                 # validate + package + submit (or print next steps)
-  civitai app submit --package-only  # just write the .zip
+		Example: `  civitai app submit                 # validate + package + confirm + submit
+  civitai app submit --yes           # skip the confirmation prompt (scripts/CI)
+  civitai app submit --package-only  # just write the .zip (safe preview, never submits)
   civitai app submit -o my-block.zip ./my-block`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,6 +105,11 @@ Defaults to the current directory.`,
 			// 3a. Programmatic submit if we have a token (OAuth or personal key).
 			canUpload := !packageOnly && cfg.Token() != ""
 			if canUpload {
+				// Safety gate: submitting fires a REAL moderator-review request
+				// immediately. Confirm (or require --yes) before it goes out.
+				if err := confirmSubmit(cmd, m, cfg.BaseURL(), assumeYes); err != nil {
+					return err
+				}
 				client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), submitPath)
 				return doUpload(cmd, client, pkg.Zip, m, cfg.BaseURL())
 			}
@@ -121,7 +136,42 @@ Defaults to the current directory.`,
 	cmd.Flags().StringVarP(&outFlag, "out", "o", "", "output .zip path (default: <blockId>-<version>.zip)")
 	cmd.Flags().BoolVar(&packageOnly, "package-only", false, "only write the .zip; do not attempt submission")
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "skip manifest validation before packaging")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the confirmation prompt and submit (for scripts/CI)")
 	return cmd
+}
+
+// confirmSubmit gates the actual moderator-review submission behind an explicit
+// confirmation, so a bare `civitai app submit` never fires an outward-facing,
+// hard-to-reverse publish request by accident.
+//
+//   - --yes/-y  → proceed without prompting.
+//   - non-TTY stdin (pipe/CI) without --yes → REFUSE (clear error, non-zero
+//     exit) rather than hang waiting on input or submit silently.
+//   - interactive TTY → print what will happen, prompt "Submit for review?
+//     [y/N]", and proceed only on an explicit yes.
+func confirmSubmit(cmd *cobra.Command, m *manifest.Manifest, baseURL string, assumeYes bool) error {
+	if assumeYes {
+		return nil
+	}
+	if !stdinIsTTY() {
+		return fmt.Errorf("refusing to submit without --yes in a non-interactive shell (submitting creates a real moderator-review request; pass --yes to confirm, or --package-only to just write the .zip)")
+	}
+
+	out := cmd.OutOrStdout()
+	base := strings.TrimRight(baseURL, "/")
+	fmt.Fprintf(out, "About to submit %s@%s for moderator review at %s.\n", m.BlockID, m.Version, base)
+	fmt.Fprintln(out, "This creates a real pending moderator-review request — reversible only via `civitai app withdraw`.")
+	fmt.Fprintln(out, "(Use --package-only to just write the .zip without submitting.)")
+	fmt.Fprint(out, "Submit for review? [y/N]: ")
+
+	r := bufio.NewReader(cmd.InOrStdin())
+	line, _ := r.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("submission cancelled")
+	}
 }
 
 func doUpload(cmd *cobra.Command, client api.Submitter, zipBytes []byte, m *manifest.Manifest, baseURL string) error {

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -121,7 +121,8 @@ func TestAppSubmitUploadsWhenTokenAndPathConfigured(t *testing.T) {
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 	t.Setenv("CIVITAI_SUBMIT_PATH", "/api/blocks/submit-version")
 
-	stdout, _, err := run(t, "app", "submit", tmp)
+	// --yes bypasses the confirmation gate (non-TTY test shell would otherwise refuse).
+	stdout, _, err := run(t, "app", "submit", tmp, "--yes")
 	if err != nil {
 		t.Fatalf("submit upload: %v\n%s", err, stdout)
 	}
@@ -168,7 +169,8 @@ func TestAppSubmitUploadsToV1RouteByDefault(t *testing.T) {
 	// No CIVITAI_SUBMIT_PATH => must default to the v1 token route.
 	t.Setenv("CIVITAI_SUBMIT_PATH", "")
 
-	stdout, _, err := run(t, "app", "submit", tmp)
+	// --yes bypasses the confirmation gate (non-TTY test shell would otherwise refuse).
+	stdout, _, err := run(t, "app", "submit", tmp, "--yes")
 	if err != nil {
 		t.Fatalf("submit default upload: %v\n%s", err, stdout)
 	}

--- a/internal/cmd/app_submit_r2_test.go
+++ b/internal/cmd/app_submit_r2_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+// withStdinTTY forces the package-level stdinIsTTY seam for the duration of a
+// test, restoring it on cleanup. Confirmation behaviour hinges on this seam.
+func withStdinTTY(t *testing.T, isTTY bool) {
+	t.Helper()
+	orig := stdinIsTTY
+	stdinIsTTY = func() bool { return isTTY }
+	t.Cleanup(func() { stdinIsTTY = orig })
+}
+
+func newConfirmCmd(stdin string) (*cobra.Command, *bytes.Buffer) {
+	c := &cobra.Command{}
+	var out bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&out)
+	c.SetIn(strings.NewReader(stdin))
+	return c, &out
+}
+
+// --- confirmSubmit unit tests (the safety logic in isolation) ---
+
+// --yes always proceeds, regardless of TTY, without printing a prompt.
+func TestConfirmSubmit_YesBypassesPrompt(t *testing.T) {
+	withStdinTTY(t, false) // non-TTY, but --yes must still proceed
+	c, out := newConfirmCmd("")
+	m := &manifest.Manifest{BlockID: "demo", Version: "0.1.0"}
+	if err := confirmSubmit(c, m, "https://civitai.com/", true); err != nil {
+		t.Fatalf("confirmSubmit with --yes should proceed, got: %v", err)
+	}
+	if strings.Contains(out.String(), "Submit for review?") {
+		t.Errorf("--yes must not print the confirmation prompt, got:\n%s", out.String())
+	}
+}
+
+// Non-TTY without --yes REFUSES with a clear error (never hangs, never submits).
+func TestConfirmSubmit_NonTTYRefusesWithoutYes(t *testing.T) {
+	withStdinTTY(t, false)
+	c, _ := newConfirmCmd("")
+	m := &manifest.Manifest{BlockID: "demo", Version: "0.1.0"}
+	err := confirmSubmit(c, m, "https://civitai.com/", false)
+	if err == nil {
+		t.Fatal("non-TTY without --yes must refuse")
+	}
+	if !strings.Contains(err.Error(), "refusing to submit without --yes") {
+		t.Errorf("refusal error should be clear, got: %v", err)
+	}
+}
+
+// Interactive TTY + explicit "y" proceeds, after showing what will happen.
+func TestConfirmSubmit_TTYYesProceeds(t *testing.T) {
+	withStdinTTY(t, true)
+	c, out := newConfirmCmd("y\n")
+	m := &manifest.Manifest{BlockID: "my-block", Version: "0.2.0"}
+	if err := confirmSubmit(c, m, "https://civitai.com/", false); err != nil {
+		t.Fatalf("TTY + 'y' should proceed, got: %v", err)
+	}
+	s := out.String()
+	for _, want := range []string{"my-block@0.2.0", "moderator review", "Submit for review? [y/N]"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("prompt output missing %q, got:\n%s", want, s)
+		}
+	}
+}
+
+// Interactive TTY + anything-but-yes (default / "n") cancels — no submission.
+func TestConfirmSubmit_TTYDefaultCancels(t *testing.T) {
+	for _, in := range []string{"\n", "n\n", "no\n", "maybe\n"} {
+		withStdinTTY(t, true)
+		c, _ := newConfirmCmd(in)
+		m := &manifest.Manifest{BlockID: "demo", Version: "0.1.0"}
+		err := confirmSubmit(c, m, "https://civitai.com/", false)
+		if err == nil {
+			t.Fatalf("input %q should cancel the submission", in)
+		}
+		if !strings.Contains(err.Error(), "cancelled") {
+			t.Errorf("input %q: expected a cancellation error, got: %v", in, err)
+		}
+	}
+}
+
+// --- end-to-end command tests via the real submit path ---
+
+// A bare `app submit` in a non-interactive shell (the accidental-footgun case)
+// must NOT reach the submit endpoint even when a token is configured.
+func TestAppSubmit_NonTTYRefusesWithoutYes_NoNetworkCall(t *testing.T) {
+	withStdinTTY(t, false)
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true // reaching here means a real publish request was fired
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfgdir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgdir)
+	t.Setenv("CIVITAI_TOKEN", "tok-should-not-be-used")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_SUBMIT_PATH", "/api/blocks/submit-version")
+
+	stdout, _, err := run(t, "app", "submit", tmp)
+	if err == nil {
+		t.Fatalf("bare submit in non-TTY must fail; stdout:\n%s", stdout)
+	}
+	if hit {
+		t.Fatal("submit endpoint was hit — the gate did NOT prevent the submission")
+	}
+	if !strings.Contains(err.Error(), "refusing to submit without --yes") {
+		t.Errorf("error should explain the refusal, got: %v", err)
+	}
+}
+
+// With --yes, the same non-interactive submit proceeds and DOES reach the
+// (mocked) endpoint — the bypass works and no real endpoint is contacted.
+func TestAppSubmit_YesProceedsToMockedEndpoint(t *testing.T) {
+	withStdinTTY(t, false)
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"publishRequestId":"pubreq_mock","slug":"demo-block","version":"0.1.0","status":"pending"}`))
+	}))
+	defer srv.Close()
+
+	cfgdir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgdir)
+	t.Setenv("CIVITAI_TOKEN", "tok-yes")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_SUBMIT_PATH", "/api/blocks/submit-version")
+
+	stdout, _, err := run(t, "app", "submit", tmp, "--yes")
+	if err != nil {
+		t.Fatalf("submit --yes should proceed: %v\n%s", err, stdout)
+	}
+	if !hit {
+		t.Fatal("submit --yes should have reached the (mocked) endpoint")
+	}
+	if !strings.Contains(stdout, "pubreq_mock") {
+		t.Errorf("output should report the publish request id, got:\n%s", stdout)
+	}
+}
+
+// --package-only never submits even with a token + non-TTY + no --yes: it stays
+// the safe preview and the gate leaves it untouched.
+func TestAppSubmit_PackageOnlyBypassesGate(t *testing.T) {
+	withStdinTTY(t, false)
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfgdir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgdir)
+	t.Setenv("CIVITAI_TOKEN", "tok-present")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_SUBMIT_PATH", "/api/blocks/submit-version")
+
+	out := tmp + "/bundle.zip"
+	stdout, _, err := run(t, "app", "submit", tmp, "--package-only", "--out", out)
+	if err != nil {
+		t.Fatalf("submit --package-only: %v\n%s", err, stdout)
+	}
+	if hit {
+		t.Fatal("--package-only must not contact the submit endpoint")
+	}
+	if !strings.Contains(stdout, "Wrote canonical bundle") {
+		t.Errorf("--package-only should write the bundle, got:\n%s", stdout)
+	}
+}
+
+// The help text advertises the confirmation + --yes bypass so the safety is
+// discoverable.
+func TestAppSubmit_HelpMentionsConfirmationAndYes(t *testing.T) {
+	stdout, _, err := run(t, "app", "submit", "--help")
+	if err != nil {
+		t.Fatalf("submit --help: %v", err)
+	}
+	for _, want := range []string{"--yes", "confirm", "non-interactive"} {
+		if !strings.Contains(strings.ToLower(stdout), strings.ToLower(want)) {
+			t.Errorf("submit --help should mention %q, got:\n%s", want, stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`civitai app submit` with any stored token fired a **real moderator-review publish request immediately** — no confirmation, no dry-run. A dev poking at commands accidentally created a live `pubreq_…` "pending moderator review" and had to `civitai app withdraw` it. An outward-facing, hard-to-reverse action shouldn't fire from a bare command.

## Fix

A confirmation gate in front of the actual submit (the `canUpload` path only):

- **Interactive TTY:** prints the app@version + that it submits to moderator review (and that `--package-only` is the safe preview), then prompts `Submit for review? [y/N]` — proceeds only on an explicit `y`/`yes`.
- **`--yes`/`-y`:** bypasses the prompt for scripts/CI. Mirrors the existing `app create --yes` flag style (`BoolVarP(..., "yes", "y", ...)`).
- **Non-TTY without `--yes`:** does **not** hang on input — refuses with a clear error (`refusing to submit without --yes in a non-interactive shell …`) and a non-zero exit, so it's safe in pipelines.
- **`--package-only`:** unchanged — still never submits; called out in the confirmation text as the safe preview.

Reuses the package's existing `stdinIsTTY` seam (from `app_init.go`) for TTY detection and testability, matching how the scaffold prompt gates itself.

## Behavior evidence (no real submission)

Non-TTY submit with a token present now **refuses before any network call**:

```
$ civitai app submit /tmp/r2app < /dev/null      # token set, stdin not a TTY
Packaged 32 file(s) (90514 bytes compressed, 236133 decompressed)
Error: refusing to submit without --yes in a non-interactive shell (submitting creates a real moderator-review request; pass --yes to confirm, or --package-only to just write the .zip)
EXIT=1
```

`--package-only` still writes the bundle and exits 0 without submitting.

## Tests

`internal/cmd/app_submit_r2_test.go`:
- non-TTY without `--yes` → aborts, and the mocked submit endpoint is **never hit** (asserted)
- `--yes` → proceeds to the mocked endpoint (no real endpoint contacted)
- TTY `y`/`yes` proceeds; default/`n`/`no` cancels
- `--package-only` bypasses the gate without contacting the endpoint
- help text advertises the confirmation + `--yes`
- `confirmSubmit` unit tests for the `--yes` and non-TTY branches

The two pre-existing upload tests now pass `--yes` (bare submit correctly refuses in the non-TTY test shell).

Gates: `go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)