### PR TITLE
fix(articles): drop duplicate bare URL after links in `--content`

### DIFF
--- a/internal/cmd/htmlrender.go
+++ b/internal/cmd/htmlrender.go
@@ -62,6 +62,13 @@ type htmlRenderer struct {
 	aStart int             // len(line) when <a> opened, to wrap its text
 	skip   int             // >0 while inside a <script>/<style> subtree (drop content)
 
+	// pendingAnchorHref holds the href of the just-closed <a>, so an
+	// immediately-following bare "[<href>]" text token (a common TipTap /
+	// markdown-conversion artifact that duplicates the link's URL) can be
+	// dropped instead of rendered a second time. One-shot: consumed by the next
+	// text token, and invalidated by any intervening tag other than <br>.
+	pendingAnchorHref string
+
 	emph        []emphMark // open emphasis markers (**, *, `), innermost last
 	lastCloseMk string     // marker of the most recently emitted close, "" if none/invalidated
 	lastCloseAt int        // len(line) right after that close marker was written
@@ -145,6 +152,29 @@ func (r *htmlRenderer) text(decoded string) {
 	if collapsed == "" {
 		return
 	}
+	// Drop a bare "[<href>]" that duplicates the URL of the link just closed
+	// (TipTap article bodies commonly emit <a href="U">T</a><br />[U], which
+	// would otherwise render as "[T](U) [U]"). Consume the one-shot flag first
+	// so a non-matching token clears it too.
+	if r.pendingAnchorHref != "" {
+		bare := "[" + r.pendingAnchorHref + "]"
+		r.pendingAnchorHref = ""
+		if rest, ok := strings.CutPrefix(strings.TrimLeft(collapsed, " "), bare); ok {
+			// Drop the separator space a <br>/whitespace inserted before the dup.
+			if cur := r.line.String(); strings.HasSuffix(cur, " ") {
+				r.line.Reset()
+				r.line.WriteString(strings.TrimRight(cur, " "))
+			}
+			rest = strings.TrimLeft(rest, " ")
+			if rest == "" {
+				return
+			}
+			if r.line.Len() > 0 {
+				rest = " " + rest
+			}
+			collapsed = rest
+		}
+	}
 	// Avoid a leading space at the very start of a fresh line.
 	if r.line.Len() == 0 {
 		collapsed = strings.TrimLeft(collapsed, " ")
@@ -158,6 +188,12 @@ func (r *htmlRenderer) text(decoded string) {
 var wsRe = regexp.MustCompile(`\s+`)
 
 func (r *htmlRenderer) tag(name string, attrs map[string]string, closing, selfClose bool) {
+	// A pending bare-URL dedup only survives an intervening <br> (TipTap emits
+	// <a>…</a><br />[url]); any other tag ends the anchor's immediate context.
+	// closeAnchor re-arms it below for the <a>-closing case.
+	if name != "br" {
+		r.pendingAnchorHref = ""
+	}
 	switch name {
 	case "br":
 		if r.inItem {
@@ -377,6 +413,9 @@ func (r *htmlRenderer) closeAnchor() {
 	default:
 		r.line.WriteString(fmt.Sprintf("[%s](%s)", text, r.href))
 	}
+	// Arm bare-URL dedup: if this link carried a URL, a bare "[<href>]" text
+	// token immediately after it is a duplicate to be dropped (see text()).
+	r.pendingAnchorHref = r.href
 	r.href = ""
 	r.aStart = 0
 	r.lastCloseMk = "" // line was rewritten — invalidate any pending merge anchor

--- a/internal/cmd/htmlrender_test.go
+++ b/internal/cmd/htmlrender_test.go
@@ -345,3 +345,63 @@ func TestHTMLToTextMalformedListState(t *testing.T) {
 		t.Errorf("<br> in <li>: got %q, want %q", got, "- a b")
 	}
 }
+
+// TestHTMLToTextDropsDuplicateBareURL guards the fix for the double-URL bug:
+// TipTap article bodies commonly emit <a href="U">T</a><br />[U], where the bare
+// [U] duplicates the link's URL. The link must render exactly once as [T](U) with
+// NO trailing [U] appended.
+func TestHTMLToTextDropsDuplicateBareURL(t *testing.T) {
+	const u = "https://medium.com/x-c88a8658beb7"
+
+	// The exact article-2054 shape: anchor, <br>, bare [url], all inside <li><p>.
+	got := htmlToText(`<li><p><a href="` + u + `">Part 1</a><br />[` + u + `]</p></li>`)
+	if want := "- [Part 1](" + u + ")"; got != want {
+		t.Fatalf("duplicate bare URL not dropped:\ngot:  %q\nwant: %q", got, want)
+	}
+	if strings.Contains(got, "["+u+"]") {
+		t.Errorf("bare [url] survived:\n%q", got)
+	}
+
+	// Plain paragraph form: <a>…</a> [U] with a space separator.
+	if out := htmlToText(`<p><a href="` + u + `">text</a> [` + u + `]</p>`); out != "[text]("+u+")" {
+		t.Errorf("space-separated dup: got %q, want %q", out, "[text]("+u+")")
+	}
+
+	// The exact-once assertion from the task: <a href="U">T</a> renders [T](U),
+	// never with a trailing " [U]".
+	if out := htmlToText(`<a href="` + u + `">T</a>[` + u + `]`); out != "[T]("+u+")" {
+		t.Errorf("adjacent dup (no separator): got %q, want %q", out, "[T]("+u+")")
+	}
+
+	// A link whose visible text already IS the URL still renders once.
+	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a><br />[` + u + `]</p>`); out != "["+u+"]("+u+")" {
+		t.Errorf("text==url dup: got %q, want %q", out, "["+u+"]("+u+")")
+	}
+	// …and the same link with no trailing bare URL is unchanged.
+	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a></p>`); out != "["+u+"]("+u+")" {
+		t.Errorf("text==url no-dup: got %q, want %q", out, "["+u+"]("+u+")")
+	}
+}
+
+// TestHTMLToTextDedupPreservesNonDuplicates proves the dedup is surgical: a link
+// NOT followed by its own bare URL, and following text that is not the duplicate,
+// are both left intact.
+func TestHTMLToTextDedupPreservesNonDuplicates(t *testing.T) {
+	// A normal link followed by ordinary prose keeps everything.
+	if out := htmlToText(`<p>See <a href="https://civitai.com/g">the guide</a> for details.</p>`); out != "See [the guide](https://civitai.com/g) for details." {
+		t.Errorf("normal link+prose altered:\n%q", out)
+	}
+	// A bare bracket that does NOT match the href must be preserved.
+	got := htmlToText(`<p><a href="https://a.example/1">link</a> [https://b.example/2]</p>`)
+	if !strings.Contains(got, "[link](https://a.example/1)") || !strings.Contains(got, "[https://b.example/2]") {
+		t.Errorf("non-matching bracket wrongly dropped:\n%q", got)
+	}
+	// Trailing text after the dropped duplicate survives with a clean separator.
+	if out := htmlToText(`<p><a href="https://x/y">t</a> [https://x/y] and more</p>`); out != "[t](https://x/y) and more" {
+		t.Errorf("trailing text after dup lost/glued: got %q, want %q", out, "[t](https://x/y) and more")
+	}
+	// An image link is unaffected by the dedup.
+	if out := htmlToText(`<p><img src="https://x/y.png" alt="diagram"></p>`); out != "![diagram](https://x/y.png)" {
+		t.Errorf("image render changed: %q", out)
+	}
+}


### PR DESCRIPTION
## Problem

`civitai articles get <id> --content` renders every link's URL **twice**: once as the markdown link `[text](url)` and again as an appended bare `[url]` — e.g. `[Part 1: …](…c88a8658beb7) [https://…c88a8658beb7]`. In a link-dense guide this roughly doubles the visual noise.

Measured on article 2054: **45 markdown links → 38 bare-URL duplicates**.

## Root cause

The bare `[url]` is **not** something the renderer appends — it is literal source text. TipTap/ProseMirror article bodies commonly emit:

```html
<li><p><a href="U">Part 1: …</a><br />[U]</p></li>
```

i.e. each anchor is followed by `<br />[U]`, the same URL in bare brackets (a common markdown-conversion / "print the URL for readers" artifact). `htmlToText` faithfully rendered both the `[text](url)` link and the trailing `[url]`.

## Fix (deterministic, in `internal/cmd/htmlrender.go`)

- `closeAnchor` records the just-rendered href in a new one-shot field `pendingAnchorHref`.
- `text()` drops a leading bare `[<href>]` from the very next text token when it matches, cleaning up the `<br>`/whitespace separator space; any trailing text after the duplicate is preserved.
- The pending flag survives only an intervening `<br>` (the exact TipTap shape) and is invalidated by any other tag, so the match is tightly scoped.

A link now renders **exactly once** as `[text](url)`. Images (`![alt](src)`), links whose text already IS the URL, and non-matching brackets are unaffected.

## Verification

Live, `civitai articles get 2054 --content`:

| metric | before | after |
|---|---|---|
| bare-URL duplicates (`(url) [url]`) | 38 | **0** |
| markdown links `[text](url)` | 45 | **45** |

Gate — all clean: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` (0 issues). The existing renderer tests (list-marker + emphasis fixes from #159) still pass.

New tests in `htmlrender_test.go`: `TestHTMLToTextDropsDuplicateBareURL` (asserts `<a href="U">T</a>` → `[T](U)` with no trailing ` [U]`, incl. the text==url case) and `TestHTMLToTextDedupPreservesNonDuplicates` (non-matching brackets, trailing text, and images left intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)