### PR TITLE
fix(download): stop silently downloading the wrong file for an ambiguous model/version id

### DIFF
--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -23,6 +23,8 @@ import (
 // downloadOpts holds the resolved flag values for `civitai download`.
 type downloadOpts struct {
 	modelID  string // --model (mutually exclusive with the positional version id)
+	version  string // --version: explicit version id (skips the ambiguous model-id gate)
+	yes      bool   // --yes: proceed past the ambiguous model-id stop (download the version as typed)
 	file     string // --file: select one file by name (exact | unique substring)
 	all      bool   // --all: download every file in the version
 	out      string // --out: target path (single-file only)
@@ -58,7 +60,11 @@ Identify the version deterministically by its numeric version id:
 Note the positional id is a model-VERSION id, NOT a model id: 'civitai models
 search' and 'civitai models get' list MODEL ids, so pass one of those via
 --model. Handing a model id as the positional (e.g. 'civitai download 4384')
-errors with a hint to use --model.
+errors with a hint to use --model. When a pasted number is BOTH a valid model id
+and a valid version id (common for low/mid numbers), the CLI STOPS and asks you
+to disambiguate rather than silently downloading an unrelated model's version —
+re-run with --model <id> (the model's default version) or --version <id> (that
+version as-is). Use --version to name a version id explicitly and skip that stop.
 
 Use --dry-run to print the resolved plan (files, sizes, SHA256, target paths,
 and whether auth is required) without transferring anything.
@@ -78,11 +84,11 @@ if a name is ambiguous. --all refuses to run when two selected files would
 resolve to the same on-disk path (which would silently overwrite one), listing
 the colliding files with their ids so you can --file <id> the one you want.
 
-Authentication: downloading ANY model file requires authentication — run
-'civitai login' (Civitai requires a token even for public files; a 336 KB public
-embedding 401s just like a gated checkpoint). Your stored login token or
-CIVITAI_API_KEY is sent automatically. The read/search commands (models,
-model-versions, articles, images, …) work anonymously; downloads do not.
+Authentication: most model files require a token to download — a gated file
+requires authentication (it 401s without a token), but some public files
+download with no token at all. Run 'civitai login' if a download 401s. Your
+stored login token or CIVITAI_TOKEN is sent automatically. The read/search
+commands (models, model-versions, articles, images, …) always work anonymously.
 
 Folder routing: pass --layout <a1111|comfyui> (with an optional --root <dir>,
 default ".") to write each file into the correct subfolder for that app, routed
@@ -103,6 +109,7 @@ detected by the hash alone. Pickle/executable (.ckpt/.pt/.pth/.bin/.pickle/.pkl)
 and archive (.zip/.tar/.tar.gz/.tgz/.rar/.7z) files can execute code when loaded;
 the CLI notes this on stderr. Only download models from creators you trust.`,
 		Example: `  civitai download 128713
+  civitai download --version 128713                # force a version id (skips the ambiguous-id stop)
   civitai download --model 4384 --out ./dreamshaper.safetensors
   civitai download 128713 --file vae --out-dir ./models
   civitai download 691639 --file 1234567          # pick one of two same-named files by id
@@ -116,6 +123,8 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 	}
 	f := cmd.Flags()
 	f.StringVar(&o.modelID, "model", "", "resolve+download a MODEL's default (first published) version instead of a version id")
+	f.StringVar(&o.version, "version", "", "download this model-VERSION id explicitly (skips the ambiguous model-id safety stop the bare positional id triggers)")
+	f.BoolVar(&o.yes, "yes", false, "proceed past the ambiguous-id safety stop (a bare id that is BOTH a model id and a version id): download the version as typed")
 	f.StringVar(&o.file, "file", "", "select one file by numeric file id, or by name (exact, else a unique case-insensitive substring); use the id to pick one of two same-named files")
 	f.BoolVar(&o.all, "all", false, "download every file in the version (refuses if two files would overwrite the same path — pick one with --file <id>)")
 	f.StringVar(&o.out, "out", "", "target file path (single-file only; mutually exclusive with --all/--out-dir)")
@@ -155,7 +164,7 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	out := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
 
-	versionID, err := resolveVersionID(ctx, client, positional, o.modelID)
+	versionID, err := resolveVersionID(ctx, client, positional, o)
 	if err != nil {
 		return err
 	}
@@ -163,6 +172,13 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	v, _, err := client.GetModelVersion(ctx, versionID)
 	if err != nil {
 		return hintModelIDMistake(ctx, client, positional, o.modelID, err)
+	}
+	// Footgun guard: a bare positional id that is ALSO a valid MODEL id (common
+	// for low/mid numbers) resolves as a version with no 404, so without this the
+	// CLI would silently download an UNRELATED model's version and print a
+	// reassuring "SHA256 verified". Stop and require disambiguation instead.
+	if err := stopIfAmbiguousModelID(ctx, client, positional, o, v); err != nil {
+		return err
 	}
 	// Parent model type (Checkpoint, LORA, …) drives --layout routing of the
 	// weights file; the version detail embeds it under `model`.
@@ -211,17 +227,24 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 }
 
 // resolveDownloadTarget returns the positional version id from args after
-// enforcing that EXACTLY one of the positional id / --model is supplied.
+// enforcing that EXACTLY one of the positional id / --model / --version is
+// supplied. Its errors are invocation mistakes → tagged as usage errors (exit 2).
 func resolveDownloadTarget(args []string, o *downloadOpts) (string, error) {
 	var positional string
 	if len(args) == 1 {
 		positional = strings.TrimSpace(args[0])
 	}
-	if positional != "" && o.modelID != "" {
-		return "", fmt.Errorf("provide EITHER a version id or --model <model-id>, not both")
+	n := 0
+	for _, set := range []bool{positional != "", o.modelID != "", o.version != ""} {
+		if set {
+			n++
+		}
 	}
-	if positional == "" && o.modelID == "" {
-		return "", fmt.Errorf("provide a model-version id (civitai download <version-id>) or --model <model-id>")
+	if n > 1 {
+		return "", asUsageError(fmt.Errorf("provide exactly ONE of a positional version id, --model <model-id>, or --version <version-id> — not both/several"))
+	}
+	if n == 0 {
+		return "", asUsageError(fmt.Errorf("provide a model-version id (civitai download <version-id>), --model <model-id>, or --version <version-id>"))
 	}
 	return positional, nil
 }
@@ -229,28 +252,30 @@ func resolveDownloadTarget(args []string, o *downloadOpts) (string, error) {
 // validateDownloadFlags rejects incompatible flag combinations before any
 // network work: --all/--file, --out/--out-dir, --out/--all, and the --layout
 // exclusions (a valid layout, no --out, no --out-dir; --root only with --layout).
+// Every failure here is a local invocation mistake → tagged as a usage error
+// (exit 2), matching `model-versions get`.
 func validateDownloadFlags(o *downloadOpts) error {
 	if o.all && o.file != "" {
-		return fmt.Errorf("--all and --file are mutually exclusive")
+		return asUsageError(fmt.Errorf("--all and --file are mutually exclusive"))
 	}
 	if o.out != "" && o.outDir != "" {
-		return fmt.Errorf("--out (a file path) and --out-dir (a directory) are mutually exclusive")
+		return asUsageError(fmt.Errorf("--out (a file path) and --out-dir (a directory) are mutually exclusive"))
 	}
 	if o.out != "" && o.all {
-		return fmt.Errorf("--out sets a single file path and can't be combined with --all — use --out-dir")
+		return asUsageError(fmt.Errorf("--out sets a single file path and can't be combined with --all — use --out-dir"))
 	}
 	if o.layout != "" {
 		if !validLayout(o.layout) {
-			return fmt.Errorf("--layout must be one of %s, got %q", strings.Join(knownLayouts, "|"), o.layout)
+			return asUsageError(fmt.Errorf("--layout must be one of %s, got %q", strings.Join(knownLayouts, "|"), o.layout))
 		}
 		if o.out != "" {
-			return fmt.Errorf("--layout routes files into type folders and can't be combined with --out (an explicit single path)")
+			return asUsageError(fmt.Errorf("--layout routes files into type folders and can't be combined with --out (an explicit single path)"))
 		}
 		if o.outDir != "" {
-			return fmt.Errorf("--layout routes files under --root and can't be combined with --out-dir")
+			return asUsageError(fmt.Errorf("--layout routes files under --root and can't be combined with --out-dir"))
 		}
 	} else if o.root != "" {
-		return fmt.Errorf("--root only applies with --layout")
+		return asUsageError(fmt.Errorf("--root only applies with --layout"))
 	}
 	return nil
 }
@@ -309,24 +334,69 @@ func downloadSelected(ctx context.Context, dl api.Downloader, out, errW io.Write
 // default version is modelVersions[0]. Its primary file is downloaded regardless
 // of file type — a "Workflows" model's Archive, training data, or plain weights
 // all download the same way.
-func resolveVersionID(ctx context.Context, client api.Reader, positional, modelID string) (string, error) {
+func resolveVersionID(ctx context.Context, client api.Reader, positional string, o *downloadOpts) (string, error) {
+	if o.version != "" {
+		if _, err := strconv.Atoi(o.version); err != nil {
+			return "", asUsageError(fmt.Errorf("--version id must be an integer, got %q", o.version))
+		}
+		return o.version, nil
+	}
 	if positional != "" {
 		if _, err := strconv.Atoi(positional); err != nil {
-			return "", fmt.Errorf("model-version id must be an integer, got %q — pass a numeric model-version id, or find one with `civitai models search`", positional)
+			return "", asUsageError(fmt.Errorf("model-version id must be an integer, got %q — pass a numeric model-version id, or find one with `civitai models search`", positional))
 		}
 		return positional, nil
 	}
-	if _, err := strconv.Atoi(modelID); err != nil {
-		return "", fmt.Errorf("--model id must be an integer, got %q", modelID)
+	if _, err := strconv.Atoi(o.modelID); err != nil {
+		return "", asUsageError(fmt.Errorf("--model id must be an integer, got %q", o.modelID))
 	}
-	m, _, err := client.GetModel(ctx, modelID)
+	m, _, err := client.GetModel(ctx, o.modelID)
 	if err != nil {
 		return "", err
 	}
 	if len(m.ModelVersions) == 0 {
-		return "", fmt.Errorf("model %s has no published versions to download", modelID)
+		return "", fmt.Errorf("model %s has no published versions to download", o.modelID)
 	}
 	return strconv.Itoa(m.ModelVersions[0].ID), nil
+}
+
+// stopIfAmbiguousModelID is the core footgun guard. `civitai models search` lists
+// MODEL ids, so a user's natural `civitai download <model-id>` pastes a model id
+// into the version-id positional. When that number is NOT a valid version it 404s
+// and hintModelIDMistake catches it — but when the SAME number is ALSO a valid
+// version id (common for low/mid numbers), the version lookup succeeds and the CLI
+// would SILENTLY download an unrelated model's version, laundering it as
+// trustworthy with a "SHA256 verified" line. That is worse than a 404.
+//
+// So: for the bare-positional path only (not --model / --version / --yes), after
+// the version lookup already succeeded, check whether the same number resolves as
+// a MODEL id whose returned id MATCHES (the real REST API echoes back the queried
+// id — a mismatch means the lookup didn't actually resolve that id). If it is BOTH,
+// STOP with a usage error (exit 2) that spells out both interpretations and how to
+// pick one. Any model-lookup failure (404/network/…) means "not ambiguous" → the
+// download proceeds exactly as today.
+func stopIfAmbiguousModelID(ctx context.Context, client api.Reader, positional string, o *downloadOpts, v *api.ModelVersionDetail) error {
+	if positional == "" || o.modelID != "" || o.version != "" || o.yes {
+		return nil
+	}
+	n, err := strconv.Atoi(positional)
+	if err != nil {
+		return nil // non-numeric never reaches here, but stay safe.
+	}
+	m, _, err := client.GetModel(ctx, positional)
+	if err != nil || m == nil || m.ID != n {
+		// Not (confirmably) a model id → unambiguous version download, as today.
+		return nil
+	}
+	parent := ""
+	if v != nil && v.Model != nil {
+		parent = v.Model.Name
+	}
+	return asUsageError(fmt.Errorf(
+		"%s is ambiguous — it's both model %q and version %s (of model %q).\n"+
+			"To download the model's default version:  civitai download --model %s\n"+
+			"To download version %s as-is:             re-run with --version %s (or --yes)",
+		positional, safeTerm(m.Name), positional, safeTerm(dashIfEmpty(parent)), positional, positional, positional))
 }
 
 // hintModelIDMistake disambiguates the single most common `download` mistake:
@@ -413,7 +483,9 @@ func selectFiles(files []api.ModelVersionFile, o *downloadOpts) ([]api.ModelVers
 		return files, nil
 	}
 	if o.file != "" {
-		return selectOneFile(files, o.file)
+		// A bad --file value is an invocation mistake → usage error (exit 2).
+		sel, err := selectOneFile(files, o.file)
+		return sel, asUsageError(err)
 	}
 	primary := api.PrimaryFile(files)
 	return []api.ModelVersionFile{*primary}, nil
@@ -781,7 +853,7 @@ func downloadStatusError(status int, name string) (err error) {
 	case status == http.StatusUnauthorized:
 		// Civitai requires a token to download ANY model file — even public ones —
 		// so an anonymous download 401s. Point the user straight at login.
-		return fmt.Errorf("downloading %s requires authentication (401) — run `civitai login` (or set CIVITAI_API_KEY); Civitai needs a token to download any model file, even public ones", name)
+		return fmt.Errorf("downloading %s requires authentication (401) — run `civitai login` (or set CIVITAI_TOKEN); this file needs a token (most model files do; some public files don't)", name)
 	case status == http.StatusForbidden:
 		// Authenticated but refused: the file is gated, not a login problem.
 		return fmt.Errorf("downloading %s was forbidden (403) — your token is valid but this file is gated (early-access / subscriber-only / not shared with your account), so logging in again won't help", name)

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -51,7 +51,7 @@ func newDownloadCmd() *cobra.Command {
 
 Identify the version deterministically by its numeric version id:
 
-  civitai download 128713
+  civitai download 691639
 
 …or resolve a model's default (first published) version with --model:
 
@@ -108,14 +108,14 @@ compromised source that advertises a matching hash for malicious bytes can't be
 detected by the hash alone. Pickle/executable (.ckpt/.pt/.pth/.bin/.pickle/.pkl)
 and archive (.zip/.tar/.tar.gz/.tgz/.rar/.7z) files can execute code when loaded;
 the CLI notes this on stderr. Only download models from creators you trust.`,
-		Example: `  civitai download 128713
+		Example: `  civitai download 691639
   civitai download --version 128713                # force a version id (skips the ambiguous-id stop)
   civitai download --model 4384 --out ./dreamshaper.safetensors
-  civitai download 128713 --file vae --out-dir ./models
+  civitai download 691639 --file vae --out-dir ./models
   civitai download 691639 --file 1234567          # pick one of two same-named files by id
-  civitai download 128713 --all --out-dir ./models
-  civitai download 128713 --all --layout comfyui --root ~/ComfyUI
-  civitai download 128713 --layout a1111 --for-base "SDXL 1.0"`,
+  civitai download 691639 --all --out-dir ./models
+  civitai download 691639 --all --layout comfyui --root ~/ComfyUI
+  civitai download 691639 --layout a1111 --for-base "SDXL 1.0"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDownload(cmd, args, o)
@@ -134,7 +134,7 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 	f.StringVar(&o.forBase, "for-base", "", "warn if the version's base model is a confidently different family than this target (e.g. \"SDXL 1.0\")")
 	f.BoolVar(&o.noVerify, "no-verify", false, "skip SHA256 verification of the downloaded bytes")
 	f.BoolVar(&o.force, "force", false, "re-download even if the target file already exists")
-	f.BoolVar(&o.anon, "anon", false, "force an anonymous request (ignore any stored login token); NOTE: downloads still 401 without a token — --anon is meaningful for read commands, not downloads")
+	f.BoolVar(&o.anon, "anon", false, "force an anonymous request (ignore any stored login token); NOTE: most downloads 401 without a token — --anon is meaningful for read commands, not downloads")
 	f.BoolVar(&o.dryRun, "dry-run", false, "print the resolved download plan (files, sizes, hashes, targets) and exit without downloading anything")
 	return cmd
 }

--- a/internal/cmd/download_r2_test.go
+++ b/internal/cmd/download_r2_test.go
@@ -1,0 +1,260 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newAmbiguityServer wires a fake API where a single numeric id can resolve as
+// BOTH a model-VERSION and a MODEL — the exact footgun `civitai download <id>`
+// hits when a user pastes a MODEL id (which `models search` lists) into the
+// version-id positional and that number ALSO happens to be a valid version id.
+//
+//   - GET /api/v1/model-versions/{id} always returns a valid version whose parent
+//     model is `parentModel` (this is the UNRELATED model whose file would be
+//     silently downloaded).
+//   - GET /api/v1/models/{id} returns a valid model named `modelName` whose id
+//     ECHOES the requested id when modelIsValid; otherwise it 404s (the id is a
+//     version but NOT a model → unambiguous).
+//
+// The real REST API always echoes the queried id back, so the id-match guard in
+// stopIfAmbiguousModelID keys off it; a stub that returned a different id would
+// (correctly) be treated as not-ambiguous.
+func newAmbiguityServer(t *testing.T, modelName, parentModel string, modelIsValid bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		id := lastPathSeg(r.URL.Path)
+		fmt.Fprintf(w, `{"id":%s,"modelId":99999,"name":"v1","baseModel":"SD 1.5","model":{"name":%q,"type":"LORA"},"files":[{"id":1,"name":"unrelated.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"http://127.0.0.1:1/dl","hashes":{"SHA256":"%s"}}]}`,
+			id, parentModel, strings.Repeat("a", 64))
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		if !modelIsValid {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":"Model not found"}`)
+			return
+		}
+		id := lastPathSeg(r.URL.Path)
+		// Echo the requested id (the real API does) so the id-match guard fires.
+		fmt.Fprintf(w, `{"id":%s,"name":%q,"type":"Checkpoint","modelVersions":[{"id":424242,"name":"default","baseModel":"SDXL","files":[{"id":9,"name":"default.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"http://127.0.0.1:1/dl"}]}]}`,
+			id, modelName)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func lastPathSeg(p string) string {
+	return p[strings.LastIndexByte(p, '/')+1:]
+}
+
+// setupAmbiguityEnv points the CLI at srv with a fresh anonymous config + cwd.
+func setupAmbiguityEnv(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	allowPrivateDownloadHostsInTest(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	chdir(t, t.TempDir())
+}
+
+// TestDownloadAmbiguousModelIDStops is the core footgun fix: a bare positional id
+// that is BOTH a valid version id AND a valid model id must STOP for
+// disambiguation (exit 2) rather than silently downloading the version — which is
+// an unrelated model's file — and laundering it with "SHA256 verified".
+func TestDownloadAmbiguousModelIDStops(t *testing.T) {
+	// 277680: real-world case — model "Pixel Art Diffusion XL" AND version 277680
+	// (of an unrelated model "Kai Ipusiron").
+	srv := newAmbiguityServer(t, "Pixel Art Diffusion XL", "Kai Ipusiron", true)
+	setupAmbiguityEnv(t, srv)
+
+	out, _, err := run(t, "download", "277680", "--dry-run")
+	if err == nil {
+		t.Fatal("an id that is both a model id and a version id must STOP, not download")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("the ambiguous stop must be a usage error (exit 2), got: %v", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"ambiguous", "Pixel Art Diffusion XL", "Kai Ipusiron", "--model 277680", "--version 277680"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ambiguity error should mention %q, got: %v", want, err)
+		}
+	}
+	// It must NOT have planned/printed a download for the unrelated version.
+	if strings.Contains(out, "would download") {
+		t.Errorf("no plan should be printed for an ambiguous id:\n%s", out)
+	}
+}
+
+// TestDownloadAmbiguousBypassedByVersionFlag proves --version <id> names a version
+// explicitly and skips the ambiguity stop (the user has disambiguated by intent).
+func TestDownloadAmbiguousBypassedByVersionFlag(t *testing.T) {
+	srv := newAmbiguityServer(t, "Pixel Art Diffusion XL", "Kai Ipusiron", true)
+	setupAmbiguityEnv(t, srv)
+
+	out, _, err := run(t, "download", "--version", "277680", "--dry-run")
+	if err != nil {
+		t.Fatalf("--version should proceed past the ambiguity stop, got: %v", err)
+	}
+	if !strings.Contains(out, "would download") {
+		t.Errorf("--version should plan the version download:\n%s", out)
+	}
+	if strings.Contains(out, "ambiguous") {
+		t.Errorf("--version must not trigger the ambiguity stop:\n%s", out)
+	}
+}
+
+// TestDownloadAmbiguousBypassedByYes proves --yes lets the bare positional proceed
+// (download the version as typed) after acknowledging the ambiguity.
+func TestDownloadAmbiguousBypassedByYes(t *testing.T) {
+	srv := newAmbiguityServer(t, "Pixel Art Diffusion XL", "Kai Ipusiron", true)
+	setupAmbiguityEnv(t, srv)
+
+	out, _, err := run(t, "download", "277680", "--yes", "--dry-run")
+	if err != nil {
+		t.Fatalf("--yes should proceed past the ambiguity stop, got: %v", err)
+	}
+	if !strings.Contains(out, "would download") {
+		t.Errorf("--yes should plan the version download:\n%s", out)
+	}
+}
+
+// TestDownloadNonAmbiguousVersionUnchanged proves the guard does NOT fire when the
+// id is a valid version but NOT a model id (models/{id} 404s): the download
+// proceeds exactly as before — no extra stop, no behavior change.
+func TestDownloadNonAmbiguousVersionUnchanged(t *testing.T) {
+	srv := newAmbiguityServer(t, "", "Some Parent", false) // model lookup 404s
+	setupAmbiguityEnv(t, srv)
+
+	out, _, err := run(t, "download", "277680", "--dry-run")
+	if err != nil {
+		t.Fatalf("a valid version that is NOT a model id must plan cleanly, got: %v", err)
+	}
+	if !strings.Contains(out, "would download") {
+		t.Errorf("non-ambiguous version should still plan the download:\n%s", out)
+	}
+	if strings.Contains(out, "ambiguous") {
+		t.Errorf("no ambiguity stop when the id is not a model id:\n%s", out)
+	}
+}
+
+// TestDownloadModelIDMismatchNotAmbiguous proves the id-match guard: if the model
+// lookup succeeds but returns a DIFFERENT id than requested (i.e. the number did
+// not actually resolve as that model), it is treated as NOT ambiguous and the
+// version download proceeds. Protects real version downloads from a false stop.
+func TestDownloadModelIDMismatchNotAmbiguous(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		id := lastPathSeg(r.URL.Path)
+		fmt.Fprintf(w, `{"id":%s,"modelId":99999,"name":"v1","baseModel":"SD 1.5","model":{"name":"Parent","type":"LORA"},"files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"http://127.0.0.1:1/dl","hashes":{"SHA256":"%s"}}]}`,
+			id, strings.Repeat("a", 64))
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		// Always returns id 4384 regardless of the requested id (like the shared
+		// newDLServer). A queried id != 4384 must therefore be non-ambiguous.
+		fmt.Fprint(w, `{"id":4384,"name":"Other","type":"Checkpoint","modelVersions":[]}`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	setupAmbiguityEnv(t, srv)
+
+	out, _, err := run(t, "download", "128713", "--dry-run")
+	if err != nil {
+		t.Fatalf("a model lookup that echoes a different id must not stop, got: %v", err)
+	}
+	if strings.Contains(out, "ambiguous") {
+		t.Errorf("id-mismatch must not be treated as ambiguous:\n%s", out)
+	}
+}
+
+// TestDownloadBadPositionalIDIsUsageError proves a non-integer positional id is a
+// local usage error (exit 2), not a generic exit-1 failure.
+func TestDownloadBadPositionalIDIsUsageError(t *testing.T) {
+	srv := newAmbiguityServer(t, "m", "p", true)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "not-a-number", "--dry-run")
+	if err == nil {
+		t.Fatal("a non-integer id should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("a bad positional id should be a usage error (exit 2), got: %v", err)
+	}
+}
+
+// TestDownloadLayoutBogusIsUsageError proves an invalid --layout value is exit 2.
+func TestDownloadLayoutBogusIsUsageError(t *testing.T) {
+	srv := newAmbiguityServer(t, "m", "p", true)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "--version", "277680", "--layout", "bogus", "--dry-run")
+	if err == nil {
+		t.Fatal("--layout bogus should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("--layout bogus should be a usage error (exit 2), got: %v", err)
+	}
+}
+
+// TestDownloadRootWithoutLayoutIsUsageError proves --root without --layout is exit 2.
+func TestDownloadRootWithoutLayoutIsUsageError(t *testing.T) {
+	srv := newAmbiguityServer(t, "m", "p", true)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "--version", "277680", "--root", "/tmp/x", "--dry-run")
+	if err == nil {
+		t.Fatal("--root without --layout should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("--root without --layout should be a usage error (exit 2), got: %v", err)
+	}
+}
+
+// TestDownloadBadFileIsUsageError proves a --file value that matches no file is
+// exit 2 (a bad flag value), not a generic failure.
+func TestDownloadBadFileIsUsageError(t *testing.T) {
+	srv := newAmbiguityServer(t, "", "Parent", false) // non-ambiguous version so we reach file selection
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "277680", "--file", "does-not-exist", "--dry-run")
+	if err == nil {
+		t.Fatal("a --file that matches nothing should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("a bad --file value should be a usage error (exit 2), got: %v", err)
+	}
+}
+
+// TestDownloadVersionFlagBadIntIsUsageError proves a non-integer --version is exit 2.
+func TestDownloadVersionFlagBadIntIsUsageError(t *testing.T) {
+	srv := newAmbiguityServer(t, "m", "p", true)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "--version", "abc", "--dry-run")
+	if err == nil {
+		t.Fatal("a non-integer --version should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("a bad --version should be a usage error (exit 2), got: %v", err)
+	}
+}
+
+// TestDownloadRejectsPositionalPlusVersion proves the three-way exclusivity: a
+// positional id AND --version together is a usage error.
+func TestDownloadRejectsPositionalPlusVersion(t *testing.T) {
+	srv := newAmbiguityServer(t, "m", "p", true)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "277680", "--version", "128713", "--dry-run")
+	if err == nil {
+		t.Fatal("a positional id plus --version should error")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("positional + --version should be a usage error (exit 2), got: %v", err)
+	}
+}


### PR DESCRIPTION
## The footgun

`civitai download <id>` takes a model-**version** id, but `civitai models search` lists **model** ids. The existing `hintModelIDMistake` only helps when the pasted id 404s as a version. But when a number is **both** a valid version id **and** a valid model id (common for low/mid numbers), the version lookup succeeds and the CLI **silently downloaded an unrelated model's version**, printing a reassuring `Saved … (SHA256 verified)` — worse than the pre-hint state.

Verified live before the fix:
- `civitai download 277680` (user searched "Pixel Art Diffusion XL") → downloaded version 277680 of an unrelated model ("Ipusiron").
- `civitai download 128713` → the same collision (model 128713 is a different model than version 128713's parent, DreamShaper).

## The fix

On the **bare-positional path only** (not `--model` / `--version` / `--yes`), after the version lookup succeeds, also check whether the same number resolves as a **model** id. The check is guarded on the returned model's `id` **matching** the queried number — the real REST API always echoes it back, so real version downloads (and the shared test harness, which returns a fixed unrelated id) never false-fire; any model-lookup failure (404/network) means *not ambiguous → proceed as before*.

If it's **both**, STOP with a usage error (exit 2):

```
277680 is ambiguous — it's both model "Pixel Art Diffusion XL" and version 277680 (of model "…Ipusiron").
To download the model's default version:  civitai download --model 277680
To download version 277680 as-is:             re-run with --version 277680 (or --yes)
```

New flags:
- **`--version <id>`** — name a version id explicitly (skips the gate; the user has disambiguated by intent).
- **`--yes`** — proceed past the stop and download the version as typed.

Real, unambiguous version-id downloads are byte-for-byte unchanged; a model id that isn't a version still gets the existing `--model` hint.

## Also folded in
- **Auth help overclaim softened** — the old "downloading ANY model file requires authentication … a 336 KB public embedding 401s just like a gated checkpoint" is false (some public files download with no token). Reworded to "most model files require a token; some public files don't".
- **`CIVITAI_API_KEY` → `CIVITAI_TOKEN`** — the documented env var was ignored; fixed the help text and the 401 error message (grep confirms it was only in `download.go`).
- **Local-validation errors now exit 2** — bad id / `--layout bogus` / `--root` without `--layout` / bad `--file` / bad `--version` / flag exclusivity are wrapped with `asUsageError` (matching `model-versions get`), instead of the generic exit 1.

## Tests (new file `internal/cmd/download_r2_test.go`, 11 tests)
Ambiguous id → stop + exit 2 (httptest where the id resolves as both); `--version` / `--yes` bypass → plans; id-mismatch (model lookup echoes a different id) → not ambiguous; non-ambiguous version → unchanged; bad id / `--layout bogus` / `--root`-without-`--layout` / bad `--file` / bad `--version` / positional+`--version` → exit 2.

## Live before/after (real API)
| Command | Before | After |
|---|---|---|
| `download 277680 --dry-run` | silently plans an unrelated model's file | **STOP, exit 2** (ambiguity message) |
| `download --version 277680 --dry-run` | n/a | plans normally, exit 0 |
| `download 277680 --yes --dry-run` | n/a | plans normally, exit 0 |
| `download 691639 --dry-run` (version exists, model 691639 doesn't) | plans | plans normally, exit 0 (unchanged) |
| `download 4384 --dry-run` (model id, not a version) | `--model` hint | `--model` hint (unchanged) |

## Gate
`go build`, `go test ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` — all clean (lint: 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
