### PR TITLE
fix(read): valid --json output, reject `--limit 0`, single-quote paginated cursor hint

### DIFF
--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -19,10 +19,34 @@ type readOpts struct {
 	anon bool
 }
 
-// bindReadFlags attaches the shared --json / --anon flags to a read subcommand.
+// bindReadFlags attaches the shared --json / --anon flags to a read subcommand
+// and installs a PreRunE guard that rejects a non-positive EXPLICIT --limit.
+//
+// The lower-bound check lives here (not in checkLimit) because it needs the
+// flag's Changed state: every read command binds --limit with a default of 0
+// and passes that value to checkLimit unconditionally, so at the checkLimit
+// call site an explicit `--limit 0` and an unset limit (which means "use the
+// server default page") are the SAME int and indistinguishable. Here we can
+// see cmd.Flags().Changed("limit"), so we reject a caller who explicitly asked
+// for a page size < 1 while leaving the unset default untouched. The upper
+// bound (> endpoint max) stays in checkLimit, which knows the per-endpoint max.
 func bindReadFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
 	cmd.Flags().Bool("anon", false, "force an anonymous request (ignore any stored login token)")
+
+	prev := cmd.PreRunE
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		if f := c.Flags().Lookup("limit"); f != nil && f.Changed {
+			if v, err := c.Flags().GetInt("limit"); err == nil && v < 1 {
+				return asUsageError(fmt.Errorf(
+					"--limit must be a positive integer (got %d); omit --limit to use the server default", v))
+			}
+		}
+		if prev != nil {
+			return prev(c, args)
+		}
+		return nil
+	}
 }
 
 // readFlags reads the shared --json / --anon flag values off cmd.
@@ -59,16 +83,84 @@ func newReader(o *readOpts) (*api.Client, string, error) {
 	return client, cfg.BaseURL(), nil
 }
 
-// emitJSON pretty-prints the raw API body (falling back to the raw bytes if it
-// is not valid JSON) and reports whether output was handled.
+// emitJSON pretty-prints the raw API body for scripting consumers. The whole
+// promise of --json is output that jq / JSON.parse / json.loads can read, so it
+// must be VALID JSON. The Civitai API intermittently returns bodies with raw,
+// unescaped C0 control characters (e.g. a literal 0x0D/0x0A inside a prompt
+// string) — which is invalid JSON — so before indenting we sanitize any such
+// control bytes that appear inside string literals into their proper escapes.
+// Already-valid input is passed through untouched (only json.Indent's
+// indentation is applied, exactly as before). If the body is invalid for some
+// reason sanitizing can't repair, we fall back to emitting the raw bytes.
 func emitJSON(cmd *cobra.Command, raw []byte) error {
+	src := raw
+	if !json.Valid(src) {
+		if fixed := escapeJSONStringControlChars(src); json.Valid(fixed) {
+			src = fixed
+		}
+	}
 	var buf bytes.Buffer
-	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+	if err := json.Indent(&buf, src, "", "  "); err != nil {
 		buf.Reset()
-		buf.Write(raw)
+		buf.Write(src)
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), strings.TrimRight(buf.String(), "\n"))
 	return nil
+}
+
+// escapeJSONStringControlChars walks raw JSON bytes tracking in-string state
+// (respecting \\ and \") and replaces any raw C0 control byte (0x00–0x1F) that
+// appears INSIDE a string literal with its valid JSON escape (\b \f \n \r \t or
+// \u00xx). Control bytes outside strings (structural whitespace) and everything
+// already escaped are left byte-for-byte unchanged, so valid input round-trips
+// identically. This does not attempt to repair other kinds of malformed JSON;
+// callers should verify the result with json.Valid before relying on it.
+func escapeJSONStringControlChars(raw []byte) []byte {
+	var out bytes.Buffer
+	out.Grow(len(raw))
+	inString := false
+	escaped := false
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case !inString:
+			out.WriteByte(c)
+			if c == '"' {
+				inString = true
+			}
+		case escaped:
+			// Previous byte was a backslash; this byte is the escape's payload
+			// (", \\, /, b, f, n, r, t, or the u of a \uXXXX). Emit verbatim.
+			out.WriteByte(c)
+			escaped = false
+		case c == '\\':
+			out.WriteByte(c)
+			escaped = true
+		case c == '"':
+			out.WriteByte(c)
+			inString = false
+		case c < 0x20:
+			// Raw control character inside a string literal — invalid JSON.
+			// Rewrite it as the shortest valid escape.
+			switch c {
+			case '\b':
+				out.WriteString(`\b`)
+			case '\f':
+				out.WriteString(`\f`)
+			case '\n':
+				out.WriteString(`\n`)
+			case '\r':
+				out.WriteString(`\r`)
+			case '\t':
+				out.WriteString(`\t`)
+			default:
+				fmt.Fprintf(&out, `\u%04x`, c)
+			}
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.Bytes()
 }
 
 // nonModelFileMarker returns a short human tag naming a version's PRIMARY file
@@ -89,11 +181,15 @@ func nonModelFileMarker(files []api.ModelVersionFile) string {
 	return "[" + typ + "]"
 }
 
-// checkLimit validates a --limit against an endpoint's documented maximum. A
-// zero limit means "server default" and is always allowed. An out-of-range
-// value is a client-side USAGE error (a bad flag value), so it is tagged with
-// ErrUsage — every read subcommand that calls checkLimit thus exits with the
-// usage exit code, not the generic one.
+// checkLimit validates a --limit against an endpoint's documented maximum. It
+// is called with the raw flag value, where an unset limit is 0 and means "use
+// the server default page"; that 0 is allowed here. An EXPLICIT non-positive
+// --limit (e.g. `--limit 0`) is rejected earlier, in the bindReadFlags PreRunE,
+// which unlike this function can see the flag's Changed state and so can tell an
+// explicit 0 from an unset default. An out-of-range value is a client-side
+// USAGE error (a bad flag value), so it is tagged with ErrUsage — every read
+// subcommand that calls checkLimit thus exits with the usage exit code, not the
+// generic one.
 func checkLimit(limit, max int) error {
 	if limit < 0 || limit > max {
 		return asUsageError(fmt.Errorf("--limit must be between 1 and %d for this endpoint", max))
@@ -140,7 +236,10 @@ func printPageFooter(cmd *cobra.Command, cmdPath string, m api.Metadata) {
 	fmt.Fprintf(out, "\n%s\n", strings.Join(parts, "  ·  "))
 	switch {
 	case cursor != "":
-		fmt.Fprintf(out, "next page: %s --cursor %s\n", cmdPath, cursor)
+		// Cursors contain a space and a `|` (e.g. 2026-07-19 00:10:35.891|2788964),
+		// so the value must be single-quoted or a pasted hint word-splits on the
+		// space and pipes on the `|`.
+		fmt.Fprintf(out, "next page: %s --cursor '%s'\n", cmdPath, cursor)
 	case m.CurrentPage != nil && (m.TotalPages == nil || *m.CurrentPage < *m.TotalPages):
 		fmt.Fprintf(out, "next page: %s --page %d\n", cmdPath, *m.CurrentPage+1)
 	}

--- a/internal/cmd/read_r2_test.go
+++ b/internal/cmd/read_r2_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+// TestEmitJSONEscapesRawControlChars feeds emitJSON a body containing a raw,
+// unescaped C0 control character (0x0D / CR) inside a string literal — which is
+// invalid JSON, exactly what the Civitai API intermittently returns — and
+// asserts the emitted output is valid JSON that decodes back to the intended
+// value. This is the --json scripting-safety guarantee.
+func TestEmitJSONEscapesRawControlChars(t *testing.T) {
+	// {"p":"a\rb"} but with a RAW carriage return byte, not the two-char \r.
+	raw := []byte("{\"p\":\"a\rb\"}")
+	if json.Valid(raw) {
+		t.Fatal("test fixture should be invalid JSON (raw CR inside a string)")
+	}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := emitJSON(cmd, raw); err != nil {
+		t.Fatalf("emitJSON returned error: %v", err)
+	}
+
+	got := out.Bytes()
+	if !json.Valid(got) {
+		t.Fatalf("emitJSON output is not valid JSON:\n%q", got)
+	}
+	var decoded struct {
+		P string `json:"p"`
+	}
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("emitJSON output did not decode: %v\n%q", err, got)
+	}
+	if decoded.P != "a\rb" {
+		t.Fatalf("decoded value = %q, want %q", decoded.P, "a\rb")
+	}
+}
+
+// TestEmitJSONEscapesAllC0ControlChars covers the full 0x00–0x1F range inside a
+// string, ensuring each raw control byte is escaped (via a named escape or
+// \u00xx) rather than emitted raw.
+func TestEmitJSONEscapesAllC0ControlChars(t *testing.T) {
+	var body bytes.Buffer
+	body.WriteString(`{"p":"`)
+	for c := byte(0); c < 0x20; c++ {
+		body.WriteByte(c) // raw control byte inside the string literal
+	}
+	body.WriteString(`x"}`)
+	if json.Valid(body.Bytes()) {
+		t.Fatal("fixture should be invalid JSON")
+	}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitJSON(cmd, body.Bytes()); err != nil {
+		t.Fatalf("emitJSON error: %v", err)
+	}
+	if !json.Valid(out.Bytes()) {
+		t.Fatalf("output not valid JSON:\n%q", out.Bytes())
+	}
+}
+
+// TestEmitJSONValidInputUnchanged asserts already-valid JSON is only indented,
+// with its string contents byte-identical (no spurious escaping).
+func TestEmitJSONValidInputUnchanged(t *testing.T) {
+	raw := []byte(`{"a":1,"b":"hello \"world\"","c":[1,2,3]}`)
+	if !json.Valid(raw) {
+		t.Fatal("fixture should be valid JSON")
+	}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitJSON(cmd, raw); err != nil {
+		t.Fatalf("emitJSON error: %v", err)
+	}
+
+	// Round-trip: indented output must re-marshal to the same canonical form.
+	var want, got any
+	if err := json.Unmarshal(raw, &want); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("valid input became unreadable: %v\n%q", err, out.Bytes())
+	}
+	wantB, _ := json.Marshal(want)
+	gotB, _ := json.Marshal(got)
+	if !bytes.Equal(wantB, gotB) {
+		t.Fatalf("valid input altered: got %s want %s", gotB, wantB)
+	}
+	if !strings.Contains(out.String(), "\n") {
+		t.Fatal("expected indented (multi-line) output for valid input")
+	}
+}
+
+// TestEscapeJSONStringControlCharsLeavesStructuralWhitespace ensures control
+// bytes OUTSIDE string literals (newlines/tabs between tokens, which are valid
+// JSON whitespace) are not molested.
+func TestEscapeJSONStringControlCharsLeavesStructuralWhitespace(t *testing.T) {
+	raw := []byte("{\n\t\"a\": 1\n}")
+	got := escapeJSONStringControlChars(raw)
+	if !bytes.Equal(got, raw) {
+		t.Fatalf("structural whitespace altered:\n got %q\nwant %q", got, raw)
+	}
+}
+
+// TestCheckLimitExplicitZeroRejected drives the bindReadFlags PreRunE guard:
+// an explicit `--limit 0` must be a usage error (exit code 2), while an UNSET
+// limit must be allowed through to the command body (server default page).
+func TestCheckLimitExplicitZeroRejected(t *testing.T) {
+	// newCmd mirrors how a real read subcommand is wired: it binds --limit with
+	// a 0 default, calls bindReadFlags (which installs the PreRunE guard), and in
+	// RunE calls checkLimit with the endpoint max — exactly the images/models
+	// search shape.
+	newCmd := func() *cobra.Command {
+		var limit int
+		c := &cobra.Command{
+			Use:           "search",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return checkLimit(limit, 200)
+			},
+		}
+		c.Flags().IntVar(&limit, "limit", 0, "results per page")
+		bindReadFlags(c)
+		return c
+	}
+
+	t.Run("explicit zero is a usage error", func(t *testing.T) {
+		c := newCmd()
+		c.SetArgs([]string{"--limit", "0"})
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&out)
+		err := c.Execute()
+		if err == nil {
+			t.Fatal("expected an error for --limit 0")
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Fatalf("--limit 0 error is not a usage error: %v", err)
+		}
+	})
+
+	t.Run("explicit negative is a usage error", func(t *testing.T) {
+		c := newCmd()
+		c.SetArgs([]string{"--limit", "-5"})
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&out)
+		err := c.Execute()
+		if err == nil || !errors.Is(err, ErrUsage) {
+			t.Fatalf("--limit -5 should be a usage error, got: %v", err)
+		}
+	})
+
+	t.Run("unset limit is allowed (server default)", func(t *testing.T) {
+		c := newCmd()
+		c.SetArgs([]string{})
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&out)
+		if err := c.Execute(); err != nil {
+			t.Fatalf("unset --limit should be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("explicit in-range limit is allowed", func(t *testing.T) {
+		c := newCmd()
+		c.SetArgs([]string{"--limit", "20"})
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&out)
+		if err := c.Execute(); err != nil {
+			t.Fatalf("--limit 20 should be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("explicit over-max limit is a usage error", func(t *testing.T) {
+		c := newCmd()
+		c.SetArgs([]string{"--limit", "9999"})
+		var out bytes.Buffer
+		c.SetOut(&out)
+		c.SetErr(&out)
+		err := c.Execute()
+		if err == nil || !errors.Is(err, ErrUsage) {
+			t.Fatalf("--limit 9999 should be a usage error, got: %v", err)
+		}
+	})
+}
+
+// TestPrintPageFooterQuotesCursor asserts the copy-paste "next page" hint wraps
+// the cursor in single quotes, so a cursor containing a space and a `|` pastes
+// as one shell argument instead of word-splitting / piping.
+func TestPrintPageFooterQuotesCursor(t *testing.T) {
+	cursor := "2026-07-19 00:10:35.891|2788964"
+	nc, _ := json.Marshal(cursor) // JSON string value, as the API returns it
+	m := api.Metadata{NextCursor: json.RawMessage(nc)}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	printPageFooter(cmd, "civitai images search", m)
+
+	s := out.String()
+	if !strings.Contains(s, "--cursor '"+cursor+"'") {
+		t.Fatalf("footer did not single-quote the cursor:\n%s", s)
+	}
+}


### PR DESCRIPTION
Three shared read-command fixes surfaced by blind dogfooding, all contained in `internal/cmd/read.go` (+ new `internal/cmd/read_r2_test.go`).

## 1. `emitJSON` always emits valid JSON (highest impact)
The Civitai API intermittently returns bodies with **raw, unescaped C0 control characters** (e.g. a literal `0x0D`/CR inside a prompt string) — which is invalid JSON. The old `emitJSON` did `json.Indent` and, on failure, wrote the raw bytes straight through, so `--json` output intermittently broke `jq`/`JSON.parse`/`json.loads`.

Fix: a byte-scanner (`escapeJSONStringControlChars`) walks the body tracking in-string state (respecting `\\` and `\"`) and rewrites any raw `0x00`–`0x1F` byte **inside a string literal** to its valid escape (`\b \f \n \r \t` or `\u00xx`), then indents. Structural whitespace and already-escaped bytes are untouched, so already-valid input round-trips identically; genuinely-malformed input still falls back to raw.

Live (data-dependent — the offending image drifts in/out of the window):
```
# a raw-CR body, as the old fallback passed through:
$ printf '{"p":"a\rb"}' | jq empty
jq: parse error: Invalid string: control characters ... must be escaped
# 12x loop with the fix: images search --model-version-id 290640 --limit 20 --meta --json | jq empty
run 1..12: valid JSON   TOTAL FAILURES: 0 / 12
```

## 2. `checkLimit` rejects an explicit `--limit 0`
`--limit -5` and `--limit 9999` already exit 2; `--limit 0` slipped through as "server default". Every read command binds `--limit` with a `0` default and passes it to `checkLimit` unconditionally, so at that call site an explicit `0` and an unset limit are the **same int**. The lower-bound guard therefore lives in the `bindReadFlags` `PreRunE`, which can see the flag's `Changed` state — it rejects an explicit non-positive `--limit` while leaving the unset default working. The upper-bound (`> max`) check stays in `checkLimit`.

```
$ civitai models search --limit 0 ; echo $?
Error: --limit must be a positive integer (got 0); omit --limit to use the server default
2
$ civitai models search ; echo $?        # unset still works
0
$ civitai models search --limit -5 ; echo $?   # 2
$ civitai models search --limit 9999 ; echo $?  # 2
```

## 3. `printPageFooter` single-quotes the cursor in the copy-paste hint
Cursors contain a space and a `|` (e.g. `2026-07-19 00:10:35.891|2788964`), so pasting the printed line word-splits and pipes. The hint is now `--cursor '<cursor>'`. The `--json` `.metadata.nextCursor` path is unaffected.

```
$ civitai images search --model-version-id 290640 --limit 3
next page: civitai images search --cursor '3|1715870569002'
```

## Scope / tests
- Changed files: `internal/cmd/read.go`, `internal/cmd/read_r2_test.go` only — deliberately kept out of the per-command files to avoid collision with the sibling dogfood PRs.
- `go build`, `go vet`, `gofmt -l`, `go test ./...`, and `golangci-lint run ./...` (0 issues) all clean.
- New tests: raw-control-char body → `json.Valid`; full `0x00–0x1F` range escaped; valid input unchanged; structural whitespace preserved; explicit `0`/negative/over-max → usage error; unset/in-range allowed; cursor hint single-quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)