### PR TITLE
fix(read): deep-paging-cap 429 is a usage error (exit 2), not rate-limited (exit 6)

### DIFF
--- a/internal/api/read.go
+++ b/internal/api/read.go
@@ -106,9 +106,13 @@ func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any
 // surfacing the API's own error body ({"error": ...} or {"message": ...})
 // rather than a Go struct dump.
 func readError(status int, raw []byte) (err error) {
-	// Attach the classification sentinel for status (401/404/429/503…) to the
-	// returned error without changing its user-visible message.
-	defer func() { err = tagStatus(status, err) }()
+	// The classification sentinel attached to the returned error, without
+	// changing its user-visible message. Normally derived purely from the HTTP
+	// status (401/404/429/503…), but the 429 branch may override `kind` for a
+	// deep-paging cap (see below) — a structural, non-retryable rejection that
+	// masquerades as a 429.
+	kind := statusKind(status)
+	defer func() { err = tag(kind, err) }()
 	msg := strings.TrimSpace(string(raw))
 	var wrapped struct {
 		Error   json.RawMessage `json:"error"`
@@ -143,12 +147,36 @@ func readError(status int, raw []byte) (err error) {
 	case http.StatusNotFound:
 		return fmt.Errorf("not found (404): %s", msg)
 	case http.StatusTooManyRequests:
+		// A genuine 429 is throttling: transient, safe to back off and retry.
+		// But the API also returns 429 for a PERMANENT deep-paging cap — a
+		// `--page`/`--limit` product past the fixed offset ceiling (page*limit >
+		// 1000). That request is structurally doomed: retrying the same page
+		// loops forever. Detect the cap by its message and reclassify it as a
+		// usage error (ErrBadRequest → exit 2) so a scripter's generic 429
+		// backoff-and-retry loop doesn't spin on it, while a real throttle 429
+		// stays ErrRateLimited (exit 6). The visible message is unchanged.
+		if isDeepPagingCap(msg) {
+			kind = ErrBadRequest
+		}
 		return fmt.Errorf("rate limited (429): %s — for deep paging use --cursor instead of --page", msg)
 	case http.StatusServiceUnavailable:
 		return fmt.Errorf("service unavailable (503): %s — the search backend is briefly overloaded; retry shortly", msg)
 	default:
 		return fmt.Errorf("server returned %d: %s", status, msg)
 	}
+}
+
+// isDeepPagingCap reports whether a 429 error message is really the API's
+// PERMANENT deep-paging cap (page*limit past the fixed offset ceiling) rather
+// than transient throttling. The server phrases the cap as e.g. "You've
+// requested too many pages, please use cursors instead"; a genuine throttle
+// 429 carries none of these phrases. The match is deliberately narrow so a real
+// rate-limit 429 is never misclassified as a usage error.
+func isDeepPagingCap(msg string) bool {
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "too many pages") ||
+		strings.Contains(m, "use cursors") ||
+		strings.Contains(m, "deep paging")
 }
 
 // badRequestDetail extracts a concise, human-readable detail from a 400 response

--- a/internal/api/read_r3_test.go
+++ b/internal/api/read_r3_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestReadError429DeepPagingCapIsUsageError asserts that a 429 whose body is the
+// API's PERMANENT deep-paging cap ("too many pages" / "use cursors" / "deep
+// paging") is reclassified as a USAGE error (ErrBadRequest → exit 2) rather than
+// throttling (ErrRateLimited → exit 6). A scripter's generic 429 backoff-and-
+// retry loop would otherwise spin forever on a structurally-doomed page.
+//
+// The helpful message (including the --cursor guidance) must be preserved, and
+// the error must NOT carry the rate-limited sentinel.
+func TestReadError429DeepPagingCapIsUsageError(t *testing.T) {
+	// Bodies the server actually returns for page*limit past the offset ceiling.
+	bodies := []string{
+		`{"error":"You've requested too many pages, please use cursors instead"}`,
+		`{"message":"Too Many Pages — use cursors instead"}`,
+		`{"error":"deep paging is not supported past 1000 results"}`,
+	}
+	for _, body := range bodies {
+		err := readError(http.StatusTooManyRequests, []byte(body))
+		if err == nil {
+			t.Fatalf("body %q: expected an error", body)
+		}
+		if !errors.Is(err, ErrBadRequest) {
+			t.Errorf("body %q: deep-paging cap 429 should be tagged ErrBadRequest (usage/exit-2), got: %v", body, err)
+		}
+		if errors.Is(err, ErrRateLimited) {
+			t.Errorf("body %q: deep-paging cap 429 must NOT be tagged ErrRateLimited (would map to exit-6 retry), got: %v", body, err)
+		}
+		// The helpful message + --cursor guidance is preserved.
+		if !strings.Contains(err.Error(), "rate limited (429)") ||
+			!strings.Contains(err.Error(), "for deep paging use --cursor instead of --page") {
+			t.Errorf("body %q: message not preserved, got: %q", body, err.Error())
+		}
+	}
+}
+
+// TestReadError429PlainThrottleStaysRateLimited asserts a GENUINE throttling
+// 429 — one whose body carries NONE of the deep-paging-cap phrases — still maps
+// to ErrRateLimited (exit 6), so real rate-limit backoff handling is unbroken.
+func TestReadError429PlainThrottleStaysRateLimited(t *testing.T) {
+	bodies := []string{
+		`{"error":"Rate limit exceeded, slow down"}`,
+		`{"message":"Too many requests"}`,
+		`throttled`,
+	}
+	for _, body := range bodies {
+		err := readError(http.StatusTooManyRequests, []byte(body))
+		if err == nil {
+			t.Fatalf("body %q: expected an error", body)
+		}
+		if !errors.Is(err, ErrRateLimited) {
+			t.Errorf("body %q: plain throttle 429 should stay ErrRateLimited (exit-6), got: %v", body, err)
+		}
+		if errors.Is(err, ErrBadRequest) {
+			t.Errorf("body %q: plain throttle 429 must NOT be reclassified as ErrBadRequest, got: %v", body, err)
+		}
+	}
+}
+
+// TestIsDeepPagingCap unit-tests the message matcher in isolation: it fires only
+// on the cap phrases (case-insensitively) and never on generic throttle text.
+func TestIsDeepPagingCap(t *testing.T) {
+	hits := []string{
+		"You've requested too many pages",
+		"please USE CURSORS instead",
+		"deep paging not supported",
+	}
+	for _, s := range hits {
+		if !isDeepPagingCap(s) {
+			t.Errorf("isDeepPagingCap(%q) = false, want true", s)
+		}
+	}
+	misses := []string{
+		"rate limit exceeded",
+		"too many requests",
+		"slow down",
+		"",
+	}
+	for _, s := range misses {
+		if isDeepPagingCap(s) {
+			t.Errorf("isDeepPagingCap(%q) = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`civitai images search --page 11 --limit 100` (any `--page`×`--limit` product past the API's 1000-result offset ceiling) returns:

```
Error: rate limited (429): You've requested too many pages, please use cursors instead — for deep paging use --cursor instead of --page
```

…mapped to **exit 6 (rate-limited)**. But this 429 is a **permanent structural cap**, not throttling. A scripter's generic 429 handler will back off and **retry the same doomed page forever**. It should be a **usage error (exit 2)**.

## Fix

In `internal/api/read.go`'s `readError`, the 429 branch now detects the deep-paging cap by its message (`too many pages` / `use cursors` / `deep paging`, case-insensitively via `isDeepPagingCap`) and reclassifies it as `ErrBadRequest` (usage → exit 2), reusing the existing sentinel so `exitCode` already handles it. The `defer` was refactored to a `kind` variable so the override attaches **only** `ErrBadRequest` (not both sentinels).

**Distinguishing cap-429 from throttle-429:** a genuine throttle 429 (`rate limit exceeded`, `too many requests`, …) carries none of the cap phrases and still maps to `ErrRateLimited` (exit 6). The match is deliberately narrow so real rate-limit handling is never broken. The visible message — including the `--cursor` guidance — is unchanged.

## Verification (live API)

| Command | Before | After |
|---|---|---|
| `images search --page 11 --limit 100` | exit **6** | exit **2** |
| `images search --limit 2 --cursor <cursor>` | exit 0 | exit 0 |

Message byte-identical before/after; deep paging via `--cursor` still works.

## Tests (`internal/api/read_r3_test.go`)

- deep-paging-cap 429 body → `ErrBadRequest` (exit-2 class), NOT `ErrRateLimited`, message preserved
- plain throttle 429 body → still `ErrRateLimited` (exit-6 class), NOT reclassified
- `isDeepPagingCap` unit matcher (hits cap phrases case-insensitively, misses generic throttle text)

`go build`, `go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)