### PR TITLE
fix(articles): collapse self-anchored URLs instead of doubling them

### DIFF
--- a/internal/cmd/htmlrender.go
+++ b/internal/cmd/htmlrender.go
@@ -411,7 +411,13 @@ func (r *htmlRenderer) closeAnchor() {
 	case text == "":
 		r.line.WriteString(r.href)
 	default:
-		r.line.WriteString(fmt.Sprintf("[%s](%s)", text, r.href))
+		if bare, ok := selfLinkBare(text, r.href); ok {
+			// Anchor text is just its own URL (bare link the editor auto-anchored).
+			// Emit a single bare URL instead of doubling it as "[U](U)".
+			r.line.WriteString(bare)
+		} else {
+			r.line.WriteString(fmt.Sprintf("[%s](%s)", text, r.href))
+		}
 	}
 	// Arm bare-URL dedup: if this link carried a URL, a bare "[<href>]" text
 	// token immediately after it is a duplicate to be dropped (see text()).
@@ -419,6 +425,40 @@ func (r *htmlRenderer) closeAnchor() {
 	r.href = ""
 	r.aStart = 0
 	r.lastCloseMk = "" // line was rewritten — invalidate any pending merge anchor
+}
+
+// selfLinkBare reports whether an anchor's visible text is just its own URL —
+// the extremely common case where an author pastes a bare link and the editor
+// auto-anchors it as <a href="U">U</a>. Rendering that as "[U](U)" doubles the
+// whole URL back-to-back, so on a match we collapse to a single bare href.
+//
+// The match tolerates (a) trailing sentence punctuation on the text (e.g. a
+// "." the author typed after the pasted link) and (b) a trivial "https://" vs
+// bare-host scheme difference. On a match it returns the href with the text's
+// trailing punctuation re-appended (so "<a href=U>U.</a>" → "U." once), and
+// reports false for a genuine "[text](url)" where the text differs from the URL.
+func selfLinkBare(text, href string) (string, bool) {
+	if href == "" || text == "" {
+		return "", false
+	}
+	core := strings.TrimRight(text, ".,;:!?")
+	trailer := text[len(core):]
+	if normalizeURL(core) != normalizeURL(href) {
+		return "", false
+	}
+	return href + trailer, true
+}
+
+// normalizeURL strips a leading http(s):// scheme and a trailing slash so two
+// spellings of the same URL compare equal (used only for the self-link check).
+func normalizeURL(u string) string {
+	u = strings.TrimSpace(u)
+	if rest, ok := strings.CutPrefix(u, "https://"); ok {
+		u = rest
+	} else if rest, ok := strings.CutPrefix(u, "http://"); ok {
+		u = rest
+	}
+	return strings.TrimRight(u, "/")
 }
 
 // startListItem begins a list item, incrementing the ordered counter.

--- a/internal/cmd/htmlrender_test.go
+++ b/internal/cmd/htmlrender_test.go
@@ -373,13 +373,50 @@ func TestHTMLToTextDropsDuplicateBareURL(t *testing.T) {
 		t.Errorf("adjacent dup (no separator): got %q, want %q", out, "[T]("+u+")")
 	}
 
-	// A link whose visible text already IS the URL still renders once.
-	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a><br />[` + u + `]</p>`); out != "["+u+"]("+u+")" {
-		t.Errorf("text==url dup: got %q, want %q", out, "["+u+"]("+u+")")
+	// A link whose visible text already IS the URL collapses to a single bare URL
+	// (not "[U](U)"), and the trailing bare-URL dup is still dropped.
+	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a><br />[` + u + `]</p>`); out != u {
+		t.Errorf("text==url dup: got %q, want %q", out, u)
 	}
-	// …and the same link with no trailing bare URL is unchanged.
-	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a></p>`); out != "["+u+"]("+u+")" {
-		t.Errorf("text==url no-dup: got %q, want %q", out, "["+u+"]("+u+")")
+	// …and the same link with no trailing bare URL also renders as a single URL.
+	if out := htmlToText(`<p><a href="` + u + `">` + u + `</a></p>`); out != u {
+		t.Errorf("text==url no-dup: got %q, want %q", out, u)
+	}
+}
+
+// TestHTMLToTextSelfLinkNotDoubled guards the fix for the self-link double-URL
+// bug: <a href="U">U</a> (a bare link the editor auto-anchored) must render as a
+// single bare "U", never "[U](U)". The match tolerates trailing sentence
+// punctuation and a trivial https:// vs bare-host scheme difference, while a
+// genuine [text](url) with text != url is left untouched.
+func TestHTMLToTextSelfLinkNotDoubled(t *testing.T) {
+	const u = "https://civitai.com/models/1234"
+
+	// text == href → single bare URL.
+	if out := htmlToText(`<a href="` + u + `">` + u + `</a>`); out != u {
+		t.Errorf("self-link doubled: got %q, want %q", out, u)
+	}
+	// Inside a heading the same collapse applies (no "[U](U)" in ## headings).
+	if out := htmlToText(`<h2><a href="` + u + `">` + u + `</a></h2>`); out != "## "+u {
+		t.Errorf("self-link in heading doubled: got %q, want %q", out, "## "+u)
+	}
+	// Trailing punctuation on the text is preserved once, appended to the URL.
+	const d = "https://discord.gg/B6BSCbdAJX"
+	if out := htmlToText(`<a href="` + d + `">` + d + `.</a>`); out != d+"." {
+		t.Errorf("self-link trailing punct: got %q, want %q", out, d+".")
+	}
+	// Trivial scheme difference (bare host vs https://) still counts as a self-link;
+	// the canonical href wins.
+	if out := htmlToText(`<a href="` + u + `">civitai.com/models/1234</a>`); out != u {
+		t.Errorf("self-link scheme diff: got %q, want %q", out, u)
+	}
+	// A genuine [text](url) where text != url is left as a proper markdown link.
+	if out := htmlToText(`<a href="` + u + `">click here</a>`); out != "[click here]("+u+")" {
+		t.Errorf("genuine link altered: got %q, want %q", out, "[click here]("+u+")")
+	}
+	// An image whose alt happens to equal its src is NOT collapsed (images untouched).
+	if out := htmlToText(`<img src="` + u + `" alt="` + u + `">`); out != "!["+u+"]("+u+")" {
+		t.Errorf("image collapsed: got %q, want %q", out, "!["+u+"]("+u+")")
 	}
 }
 


### PR DESCRIPTION
## Problem

In rendered article content (`articles get <id> --content`), a link whose visible text **is** its own href — `<a href="U">U</a>`, the extremely common case where an author pastes a bare link and the TipTap editor auto-anchors it — rendered as `[U](U)`, printing the full URL **twice** back-to-back, even inside `##` headings.

A prior fix already de-duplicated the trailing-bare-URL pattern (`<a href="U">T</a>[U]`), but the text-equals-href case slipped through.

### Evidence (blind dogfood)

- **Article 31906** doubled every model/file link: `## diffusion_model: [https://…safetensors](https://…safetensors)`
- **Article 31655** rendered `[https://discord.gg/B6BSCbdAJX.](https://discord.gg/B6BSCbdAJX)` (the source anchor text is the URL + a trailing `.`)

## Fix

`closeAnchor` now detects a self-link before falling back to `[text](href)`. Match rule (`selfLinkBare`):

- Strip trailing sentence punctuation (`.,;:!?`) from the anchor text, keeping it as a *trailer*.
- Normalize both sides by dropping a leading `http(s)://` and a trailing `/`, then compare — so a trivial `https://` vs bare-host difference still counts as a self-link.
- On a match, emit a **single bare href** with the text's trailing punctuation re-appended (`<a href="U">U.</a>` → `U.` once).
- Genuine `[text](url)` where `text != url` is left untouched; images `![alt](src)` are handled on a separate path and unaffected.

## Verification

Live before/after on the two evidenced articles:

**31906** — self-doubled `](http` occurrences: **5 → 0**
```
- ## diffusion_model: [https://…krea2_turbo_fp8.safetensors](https://…krea2_turbo_fp8.safetensors)
+ ## diffusion_model: https://…krea2_turbo_fp8.safetensors
```

**31655** — trailing-punctuation preserved once
```
- …generation: [https://discord.gg/B6BSCbdAJX.](https://discord.gg/B6BSCbdAJX)
+ …generation: https://discord.gg/B6BSCbdAJX.
```

## Tests

New `TestHTMLToTextSelfLinkNotDoubled` covers: `text==href` → single URL; self-link inside a heading; trailing-punct preserved; trivial scheme difference; genuine `[text](url)` unchanged; image with matching alt/src untouched. Updated the two `text==url` assertions in `TestHTMLToTextDropsDuplicateBareURL` to the new (correct) single-URL expectation; all prior list-marker / emphasis / bare-URL-dedup tests still pass.

Gate clean: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)