### PR TITLE
fix(app): enumerate valid slots in slot error; gate submit before packaging

### DIFF
--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -86,14 +86,6 @@ Defaults to the current directory.`,
 				return err
 			}
 
-			// 2. Package the canonical source tree.
-			pkg, err := pkgzip.Build(dir)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(out, "Packaged %d file(s) (%d bytes compressed, %d decompressed)\n",
-				len(pkg.Files), len(pkg.Zip), pkg.DecompressedBy)
-
 			cfg, err := config.Load()
 			if err != nil {
 				return err
@@ -102,14 +94,31 @@ Defaults to the current directory.`,
 			// The submit route defaults to the v1 token route; env overrides it.
 			submitPath := os.Getenv("CIVITAI_SUBMIT_PATH")
 
-			// 3a. Programmatic submit if we have a token (OAuth or personal key).
+			// 2. Confirmation gate BEFORE packaging. A programmatic submit fires a
+			// REAL moderator-review request immediately, so gate it first: a
+			// non-TTY shell without --yes must REFUSE before doing any packaging
+			// work (no wasted "Packaged …" line that momentarily reads as if it's
+			// proceeding). --yes proceeds silently; an interactive TTY prompts
+			// here, then packages + submits below. The --package-only / no-token
+			// fallback path never submits, so it skips the gate and just packages.
 			canUpload := !packageOnly && cfg.Token() != ""
 			if canUpload {
-				// Safety gate: submitting fires a REAL moderator-review request
-				// immediately. Confirm (or require --yes) before it goes out.
 				if err := confirmSubmit(cmd, m, cfg.BaseURL(), assumeYes); err != nil {
 					return err
 				}
+			}
+
+			// 3. Package the canonical source tree.
+			pkg, err := pkgzip.Build(dir)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Packaged %d file(s) (%d bytes compressed, %d decompressed)\n",
+				len(pkg.Files), len(pkg.Zip), pkg.DecompressedBy)
+
+			// 3a. Programmatic submit if we have a token (OAuth or personal key).
+			// The gate above already confirmed (or --yes bypassed) it.
+			if canUpload {
 				client := api.NewWithSource(cfg.BaseURL(), auth.New(cfg), submitPath)
 				return doUpload(cmd, client, pkg.Zip, m, cfg.BaseURL())
 			}

--- a/internal/cmd/app_submit_r2_test.go
+++ b/internal/cmd/app_submit_r2_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -122,6 +123,39 @@ func TestAppSubmit_NonTTYRefusesWithoutYes_NoNetworkCall(t *testing.T) {
 	if !strings.Contains(err.Error(), "refusing to submit without --yes") {
 		t.Errorf("error should explain the refusal, got: %v", err)
 	}
+}
+
+// The non-TTY refusal must fire BEFORE any packaging work: no "Packaged …"
+// line is printed (it momentarily reads as if the submit is proceeding) and no
+// .zip is left on disk. Guards the gate-before-package ordering.
+func TestAppSubmit_NonTTYRefuseHappensBeforePackaging(t *testing.T) {
+	withStdinTTY(t, false)
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+
+	cfgdir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgdir)
+	t.Setenv("CIVITAI_TOKEN", "tok-should-not-be-used")
+	t.Setenv("CIVITAI_BASE_URL", "https://civitai.com")
+
+	stdout, stderr, err := run(t, "app", "submit", tmp)
+	if err == nil {
+		t.Fatalf("bare submit in non-TTY must fail; stdout:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Packaged") {
+		t.Errorf("refusal must happen BEFORE packaging — stdout must not contain \"Packaged\", got:\n%s", stdout)
+	}
+	if !strings.Contains(err.Error(), "refusing to submit without --yes") {
+		t.Errorf("error should explain the refusal, got: %v", err)
+	}
+	// No bundle should have been written anywhere under the app dir.
+	entries, _ := os.ReadDir(tmp)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".zip") {
+			t.Errorf("refusal wrote a .zip (%s) — packaging must not have run", e.Name())
+		}
+	}
+	_ = stderr
 }
 
 // With --yes, the same non-interactive submit proceeds and DOES reach the

--- a/internal/validate/semantic_test.go
+++ b/internal/validate/semantic_test.go
@@ -1,6 +1,9 @@
 package validate
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestToNumber(t *testing.T) {
 	cases := []struct {
@@ -30,6 +33,32 @@ func TestSemanticChecksNonMap(t *testing.T) {
 	}
 	if errs := targetChecks("not-a-map"); errs != nil {
 		t.Errorf("targetChecks on non-map should be nil, got %v", errs)
+	}
+}
+
+// TestUnknownSlotErrorEnumeratesKnownSlots asserts the unknown-slot error is
+// self-documenting like the sibling scope enum error — it must append the full
+// list of known slotIds so the developer sees the valid choices, phrased
+// "value must be one of '…', '…'" (single-quoted, matching the JSON Schema
+// enum error the scope check produces).
+func TestUnknownSlotErrorEnumeratesKnownSlots(t *testing.T) {
+	errs := targetChecks(map[string]any{
+		"targets": []any{
+			map[string]any{"slotId": "model.totally-made-up-slot"},
+		},
+	})
+	if len(errs) != 1 {
+		t.Fatalf("want exactly 1 error, got %d: %v", len(errs), errs)
+	}
+	got := errs[0]
+	if !strings.Contains(got, "value must be one of ") {
+		t.Errorf("error missing the enum phrasing: %q", got)
+	}
+	// Every known slotId must be enumerated, single-quoted.
+	for id := range vendoredSlotIDs {
+		if !strings.Contains(got, "'"+id+"'") {
+			t.Errorf("error does not enumerate known slot %q: %q", id, got)
+		}
 	}
 }
 

--- a/internal/validate/targets.go
+++ b/internal/validate/targets.go
@@ -1,6 +1,10 @@
 package validate
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // targets.go ports the server's targets[].slotId registry check (validator
 // ~L426-460). Each target's slotId must be a KNOWN registered slot id, and a
@@ -33,6 +37,19 @@ var vendoredSlotIDs = map[string]bool{
 func isKnownSlotID(id string) bool { _, ok := vendoredSlotIDs[id]; return ok }
 func isPageSlotID(id string) bool  { return vendoredSlotIDs[id] }
 
+// knownSlotIDList renders the known slotIds as a stable, single-quoted,
+// comma-separated list — matching the JSON Schema enum error's phrasing
+// ("value must be one of 'a', 'b', …", single quotes via the jsonschema
+// library) so the slot error is self-documenting like the scope error.
+func knownSlotIDList() string {
+	ids := make([]string, 0, len(vendoredSlotIDs))
+	for id := range vendoredSlotIDs {
+		ids = append(ids, "'"+id+"'")
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ", ")
+}
+
 // targetChecks validates targets[].slotId against the vendored registry. Shape
 // (array of objects with a non-empty string slotId, ≤16 entries) is already
 // enforced by the JSON Schema; here we add the registry-membership + page-slot
@@ -63,7 +80,8 @@ func targetChecks(generic any) []string {
 			continue // shape handled by the schema.
 		}
 		if !isKnownSlotID(slotID) {
-			errs = append(errs, fmt.Sprintf("target slotId %q is not a known slot", slotID))
+			errs = append(errs, fmt.Sprintf(
+				"target slotId %q is not a known slot — value must be one of %s", slotID, knownSlotIDList()))
 			continue
 		}
 		if isPageSlotID(slotID) {


### PR DESCRIPTION
Two small app-command polish fixes surfaced by a blind dogfood.

## 1. Enumerate valid slots in the slot-validation error (`internal/validate/targets.go`)
An invalid target slot used to fail with a bare `✗ target slotId "model.xyz" is not a known slot` — unlike the sibling scope validator, which lists the valid values. The slot error is now self-documenting, appending the known-slot set in the same single-quoted `value must be one of …` phrasing the JSON Schema enum error uses:

```
target slotId "model.xyz" is not a known slot — value must be one of 'app.page', 'model.actions_extra', 'model.below_images', 'model.sidebar_top'
```

The list is derived from the same `vendoredSlotIDs` set the `isKnownSlotID` check uses (sorted for determinism).

## 2. Move the submit confirmation/TTY gate BEFORE packaging (`internal/cmd/app_submit.go`)
`civitai app submit` (non-TTY, no `--yes`) used to print `Packaged N file(s)…` and *then* refuse — wasted work that momentarily read as if it was proceeding. The `--yes`/TTY confirmation gate now runs before the packaging step, so a non-TTY-without-`--yes` submit refuses (exit 1) without packaging first. All other behaviour is identical: `--package-only` still packages + writes the zip, `--yes` still proceeds, an interactive TTY still prompts then packages+submits.

## Tests
- New direct-validator test asserting the unknown-slot error enumerates every known slotId (`semantic_test.go`).
- New end-to-end test asserting the non-TTY refusal fires with no `Packaged` line and no `.zip` written (`app_submit_r2_test.go`).

## Gate
`go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)