### PR TITLE
fix(cli): usage mistakes at the cobra layer now exit 2, not 0/1

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"runtime/debug"
 	"time"
@@ -298,5 +300,95 @@ Exit codes:
 	root.AddCommand(newArticlesCmd())
 	root.AddCommand(newCollectionsCmd())
 
+	// Close the cobra-layer exit-code gaps: an unknown subcommand, an unknown
+	// top-level command, and a missing/bad-count positional must all classify as
+	// USAGE errors (exit 2) rather than leaking success (0) or the generic code
+	// (1). Done once here, over the fully-assembled tree.
+	enforceUsageExitCodes(root)
+
 	return root
+}
+
+// enforceUsageExitCodes walks the assembled command tree and routes cobra's own
+// argument- and subcommand-validation failures through the ErrUsage tag, so the
+// entrypoint maps them to the usage exit code (2). It closes two leaks that the
+// hand-written validators (which already tag their own errors) don't cover:
+//
+//  1. Cobra's built-in count validators (ExactArgs, MinimumNArgs, …) return
+//     plain errors ("accepts 1 arg(s), received 0") that map to the generic exit
+//     code (1). We wrap each command's existing Args validator so its failures
+//     are tagged ErrUsage too, unifying e.g. `civitai models get` (missing id)
+//     and `civitai model-versions by-hash` (missing hash) onto exit 2. Setting a
+//     (non-nil) Args on every command also disables cobra's Find-time legacyArgs
+//     fallback, so unknown-command handling flows through the single tagged path
+//     below rather than an untagged generic error.
+//  2. Unknown SUBCOMMAND on a group-only parent. A command that only groups
+//     subcommands (has children, defines no Run/RunE of its own) is treated by
+//     cobra as "not runnable", and cobra's execute() short-circuits a
+//     not-runnable command straight to printing help and returning nil — BEFORE
+//     argument validation runs. So `civitai models frobnicate` or the top-level
+//     `civitai nonsensecmd` prints help and exits 0, a silent success. We give
+//     each such parent a RunE: a bare `civitai <parent>` (no args) still prints
+//     help and exits 0, but any leftover argument becomes a usage-tagged
+//     "unknown command" error (exit 2). Defining RunE makes the parent runnable,
+//     so cobra runs it (and our Args) instead of the help short-circuit.
+//
+// It only reclassifies ARGUMENT/subcommand validation. A command's real RunE
+// failures — a 404 not-found, a network error, an auth failure — are never
+// touched, so their differentiated exit codes are preserved.
+func enforceUsageExitCodes(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		enforceUsageExitCodes(child)
+	}
+
+	// (1) Tag the built-in count validators, and make Args non-nil everywhere so
+	// cobra's Find no longer synthesizes an untagged legacyArgs "unknown command".
+	existing := cmd.Args
+	cmd.Args = func(c *cobra.Command, args []string) error {
+		if existing != nil {
+			if err := existing(c, args); err != nil {
+				return asUsageError(err)
+			}
+		}
+		return nil
+	}
+
+	// (2) A group-only parent (subcommands, no direct action) must reject an
+	// unknown subcommand as a usage error instead of silently printing help.
+	// Runnable() reflects the ORIGINAL Run/RunE (the Args set above doesn't
+	// affect it), so this correctly targets only the pure command groups.
+	if cmd.HasSubCommands() && !cmd.Runnable() {
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				// Bare `civitai <parent>` — help, exit 0 (unchanged).
+				return c.Help()
+			}
+			return asUsageError(unknownSubcommandError(c, args[0]))
+		}
+	}
+}
+
+// unknownSubcommandError builds the error for an unrecognized subcommand on a
+// group-only parent, matching cobra's own "unknown command" wording (and its
+// Levenshtein "Did you mean this?" suggestions, via the exported SuggestionsFor)
+// so the message the user sees is unchanged from cobra's native root-level
+// handling — only the classification (and thus the exit code) differs.
+func unknownSubcommandError(c *cobra.Command, name string) error {
+	msg := fmt.Sprintf("unknown command %q for %q", name, c.CommandPath())
+	if !c.DisableSuggestions {
+		// Mirror cobra's own findSuggestions default: the exported SuggestionsFor
+		// reads SuggestionsMinimumDistance verbatim (0 → Levenshtein suggestions
+		// off), whereas cobra's native unknown-command path defaults it to 2.
+		if c.SuggestionsMinimumDistance <= 0 {
+			c.SuggestionsMinimumDistance = 2
+		}
+		if suggestions := c.SuggestionsFor(name); len(suggestions) > 0 {
+			msg += "\n\nDid you mean this?\n"
+			for _, s := range suggestions {
+				msg += fmt.Sprintf("\t%v\n", s)
+			}
+		}
+	}
+	msg += fmt.Sprintf("\nRun '%s --help' for the available subcommands.", c.CommandPath())
+	return errors.New(msg)
 }

--- a/internal/cmd/root_r3_test.go
+++ b/internal/cmd/root_r3_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/api"
+)
+
+// The R3 arc closes cobra-layer exit-code gaps: usage mistakes at the cobra
+// dispatch/arg-validation layer (unknown subcommand, unknown top-level command,
+// missing required positional) used to leak exit 0 (silent success) or exit 1
+// (generic) instead of the usage code (2). These tests pin the classification
+// (errors.Is(err, ErrUsage), which the entrypoint maps to exit 2) WITHOUT
+// reclassifying any genuine runtime failure (a real 404 stays not-found → 4).
+
+// TestUnknownSubcommandIsUsageTagged covers bug 1: an unrecognized subcommand on
+// a group-only parent (models/users/app …) used to print the parent's help and
+// exit 0 — a silent success a script would read as "it worked". It must now be a
+// usage error (exit 2).
+func TestUnknownSubcommandIsUsageTagged(t *testing.T) {
+	cases := [][]string{
+		{"models", "frobnicate"},
+		{"users", "show", "Lykon"}, // `show` is not a users subcommand (`get` is)
+		{"app", "dev"},             // `dev` is not an app subcommand (`dev-token`/`dev-tunnel` are)
+		{"images", "serch"},        // typo'd `search`
+	}
+	for _, args := range cases {
+		_, _, err := run(t, args...)
+		if err == nil {
+			t.Fatalf("%v: expected an error for an unknown subcommand, got nil (silent exit 0)", args)
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Errorf("%v: unknown subcommand should classify as usage (exit 2), got %T: %v", args, err, err)
+		}
+		if !strings.Contains(err.Error(), "unknown command") {
+			t.Errorf("%v: message should name the unknown command, got: %v", args, err)
+		}
+	}
+}
+
+// TestUnknownSubcommandSuggestsClosest proves the message keeps cobra's
+// newcomer-friendly "Did you mean this?" hint — a near-miss typo of a real
+// subcommand surfaces the intended one.
+func TestUnknownSubcommandSuggestsClosest(t *testing.T) {
+	_, _, err := run(t, "models", "serch") // near-miss of `search`
+	if err == nil {
+		t.Fatal("expected an error for `models serch`")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("near-miss subcommand should classify as usage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Did you mean this?") || !strings.Contains(err.Error(), "search") {
+		t.Errorf("message should suggest the closest subcommand (search), got: %v", err)
+	}
+}
+
+// TestMissingRequiredArgIsUsageTagged covers bug 2: the `get`/`by-hash` commands
+// use cobra.ExactArgs, whose "accepts 1 arg(s), received 0" error used to map to
+// the generic code (1). Every one must now be a usage error (exit 2), matching
+// `download` (which already returned 2).
+func TestMissingRequiredArgIsUsageTagged(t *testing.T) {
+	cases := [][]string{
+		{"models", "get"},
+		{"images", "get"},
+		{"articles", "get"},
+		{"collections", "get"},
+		{"model-versions", "get"},
+		{"model-versions", "by-hash"},
+		{"users", "get"},
+	}
+	for _, args := range cases {
+		_, _, err := run(t, args...)
+		if err == nil {
+			t.Fatalf("%v: expected an error for a missing required positional, got nil", args)
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Errorf("%v: missing required arg should classify as usage (exit 2), got %T: %v", args, err, err)
+		}
+	}
+}
+
+// TestTopLevelUnknownCommandIsUsageTagged covers bug 3: an unknown TOP-LEVEL
+// command used to exit 1 (generic) while an unknown FLAG already exited 2. Unify
+// onto usage (exit 2).
+func TestTopLevelUnknownCommandIsUsageTagged(t *testing.T) {
+	_, _, err := run(t, "nonsensecmd")
+	if err == nil {
+		t.Fatal("expected an error for an unknown top-level command")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("unknown top-level command should classify as usage (exit 2), got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("message should name the unknown command, got: %v", err)
+	}
+}
+
+// TestBareParentPrintsHelpAndExitsZero proves the fix does NOT over-reach: a
+// bare `civitai <parent>` with no subcommand must still print help and succeed
+// (exit 0), not be treated as a usage error.
+func TestBareParentPrintsHelpAndExitsZero(t *testing.T) {
+	for _, parent := range []string{"models", "images", "users", "app", "model-versions"} {
+		out, _, err := run(t, parent)
+		if err != nil {
+			t.Errorf("bare `civitai %s` should print help and exit 0, got error: %v", parent, err)
+		}
+		// Help output lists the child commands (e.g. the "Available Commands:"
+		// section), so it should be non-trivial.
+		if !strings.Contains(out, "Available Commands") && !strings.Contains(out, "Usage:") {
+			t.Errorf("bare `civitai %s` should emit help, got: %q", parent, out)
+		}
+	}
+}
+
+// TestValidSubcommandUnaffected proves a genuinely valid subcommand invocation
+// still parses and runs (its own success/RunE path), unchanged by the walk.
+func TestValidSubcommandUnaffected(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+	// `models search` (a valid subcommand with no required positional) succeeds.
+	if _, _, err := run(t, "models", "search", "--limit", "1"); err != nil {
+		t.Errorf("a valid subcommand should still run cleanly, got: %v", err)
+	}
+}
+
+// TestRealNotFoundNotReclassified is the load-bearing guard: a genuine 404 from
+// the API (a valid invocation whose RESOURCE is missing) must keep its not-found
+// classification (exit 4). The usage-tagging walk must never reclassify a real
+// runtime error as a usage error.
+func TestRealNotFoundNotReclassified(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+	_, _, err := run(t, "models", "get", "999999999")
+	if err == nil {
+		t.Fatal("expected a not-found error for a missing model id")
+	}
+	if errors.Is(err, ErrUsage) {
+		t.Errorf("a real 404 must NOT be reclassified as a usage error, got: %v", err)
+	}
+	if !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("a real 404 should stay not-found (exit 4), got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Problem

The differentiated exit-code scheme (`0`/`2`/`3`/`4`/`5`/`6`; `2` = usage) is complete for hand-written validation but leaked at the **cobra dispatch / arg-validation layer**, so scripts couldn't reliably branch on a usage mistake:

1. **Unknown SUBCOMMAND → exit 0 (silent success).** `civitai models frobnicate`, `civitai users show Lykon`, `civitai app dev`, `civitai images serch` printed the parent's help and exited **0**. A script `civitai images serch && …` saw success.
2. **Missing required positional → exit 1.** `models/images/articles/collections/model-versions/users get` (no arg), `model-versions by-hash` (no arg) surfaced cobra's raw `accepts 1 arg(s), received 0` and exited **1** — while `download` (no arg) already exited **2**.
3. **Unknown top-level command → exit 1.** `civitai nonsensecmd` exited **1**, while an unknown *flag* already exited **2**.

## Fix (central, in `internal/cmd/root.go`)

A post-assembly command-tree walk `enforceUsageExitCodes(root)` — no per-command file touched:

- **Wrap every command's built-in `Args` validator** (ExactArgs, …) so its failures are tagged `ErrUsage` (exit 2). Setting a non-nil `Args` on every command also disables cobra's `Find`-time `legacyArgs`, funneling unknown-command handling through the single tagged path.
- **Give each group-only parent** (has subcommands, no direct `Run`/`RunE`) a `RunE`: a bare `civitai <parent>` still prints help (exit 0), but any leftover arg becomes a usage-tagged *"unknown command"* error (exit 2). Defining `RunE` makes the parent *runnable*, so cobra runs it instead of the `!Runnable() → help` short-circuit that (in cobra v1.8.1) precedes `ValidateArgs`.

The `asUsageError` / `ErrUsage` seam and `main.go`'s `ErrUsage → exit 2` mapping are reused unchanged. Message text is identical to cobra's native wording, including the `Did you mean this?` Levenshtein suggestions.

**No real error class is reclassified:** a genuine 404 / network / auth failure keeps flowing through its own `RunE` return, so `civitai models get 999999999` still exits **4**. A dedicated test locks this in.

## Live exit-code matrix

| Invocation | Exit | |
|---|---|---|
| `civitai models frobnicate` | 2 | unknown subcommand |
| `civitai users show Lykon` | 2 | unknown subcommand |
| `civitai app dev` | 2 | unknown subcommand |
| `civitai images serch` | 2 | unknown subcommand |
| `civitai models get` (no arg) | 2 | missing positional |
| `civitai model-versions by-hash` (no arg) | 2 | missing positional |
| `civitai users get` (no arg) | 2 | missing positional |
| `civitai nonsensecmd` | 2 | unknown top-level command |
| `civitai --badflag` | 2 | unknown flag (already) |
| `civitai models get 999999999` | **4** | real 404 — **unchanged** |
| `civitai download` (no arg) | 2 | already 2 — unchanged |
| `civitai models` (no arg) | **0** | prints help — unchanged |
| `civitai` (bare) | 0 | prints help — unchanged |

## Tests

New `internal/cmd/root_r3_test.go`: unknown subcommand → `ErrUsage`; suggestion hint preserved; every `get`/`by-hash` missing-arg → `ErrUsage`; top-level unknown command → `ErrUsage`; bare parent still prints help + exit 0; a valid subcommand unaffected; and a real 404 stays `api.ErrNotFound` (not reclassified).

## Gates

`go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)