### PR TITLE
fix(download): auto-resolve model-id positional, echo --yes interpretation, runnable by-hash hint

### DIFF
--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -57,14 +57,16 @@ Identify the version deterministically by its numeric version id:
 
   civitai download --model 4384
 
-Note the positional id is a model-VERSION id, NOT a model id: 'civitai models
-search' and 'civitai models get' list MODEL ids, so pass one of those via
---model. Handing a model id as the positional (e.g. 'civitai download 4384')
-errors with a hint to use --model. When a pasted number is BOTH a valid model id
-and a valid version id (common for low/mid numbers), the CLI STOPS and asks you
-to disambiguate rather than silently downloading an unrelated model's version —
-re-run with --model <id> (the model's default version) or --version <id> (that
-version as-is). Use --version to name a version id explicitly and skip that stop.
+The positional id is normally a model-VERSION id, but 'civitai models search'
+and 'civitai models get' list MODEL ids — so handing a model id as the positional
+(e.g. 'civitai download 4384') just works: the CLI recognizes it's a model id and
+downloads that model's default version (printing a note that it did). When a
+pasted number is BOTH a valid model id and a valid version id (common for low/mid
+numbers), the CLI STOPS and asks you to disambiguate rather than silently
+downloading an unrelated model's version — re-run with --model <id> (the model's
+default version) or --version <id> (that version as-is). Use --version to name a
+version id explicitly and skip that stop; --yes proceeds on the version
+interpretation and echoes exactly which version it is downloading.
 
 Use --dry-run to print the resolved plan (files, sizes, SHA256, target paths,
 and whether auth is required) without transferring anything.
@@ -164,21 +166,15 @@ func runDownload(cmd *cobra.Command, args []string, o *downloadOpts) error {
 	out := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
 
-	versionID, err := resolveVersionID(ctx, client, positional, o)
+	// Resolve the version detail to download, handling the three bare-positional
+	// shapes (version-only / model-id auto-resolve / ambiguous stop). `note` is a
+	// user-facing stderr line describing any automatic resolution.
+	v, note, err := resolveDownloadVersion(ctx, client, positional, o)
 	if err != nil {
 		return err
 	}
-
-	v, _, err := client.GetModelVersion(ctx, versionID)
-	if err != nil {
-		return hintModelIDMistake(ctx, client, positional, o.modelID, err)
-	}
-	// Footgun guard: a bare positional id that is ALSO a valid MODEL id (common
-	// for low/mid numbers) resolves as a version with no 404, so without this the
-	// CLI would silently download an UNRELATED model's version and print a
-	// reassuring "SHA256 verified". Stop and require disambiguation instead.
-	if err := stopIfAmbiguousModelID(ctx, client, positional, o, v); err != nil {
-		return err
+	if note != "" {
+		fmt.Fprintln(errW, note)
 	}
 	// Parent model type (Checkpoint, LORA, …) drives --layout routing of the
 	// weights file; the version detail embeds it under `model`.
@@ -327,25 +323,40 @@ func downloadSelected(ctx context.Context, dl api.Downloader, out, errW io.Write
 	return downloaded, nil
 }
 
-// resolveVersionID returns the version id to download: the positional id verbatim
-// (validated numeric), or the default (first published) version of --model.
+// resolveDownloadVersion loads the model-version detail to download from the
+// resolved flags/positional, returning it plus an optional user-facing note
+// (stderr) describing any automatic resolution.
 //
-// For --model, the API returns modelVersions default/latest-first, so the model's
-// default version is modelVersions[0]. Its primary file is downloaded regardless
-// of file type — a "Workflows" model's Archive, training data, or plain weights
-// all download the same way.
-func resolveVersionID(ctx context.Context, client api.Reader, positional string, o *downloadOpts) (string, error) {
+//   - --version <id> / --model <id> resolve deterministically (a --model resolves
+//     the model's default (first published) version) — no ambiguity handling.
+//   - A bare positional id is classified by looking it up as BOTH a version and a
+//     model, then handled by resolveBarePositionalVersion.
+func resolveDownloadVersion(ctx context.Context, client api.Reader, positional string, o *downloadOpts) (*api.ModelVersionDetail, string, error) {
+	if o.version != "" || o.modelID != "" {
+		versionID, err := resolveExplicitVersionID(ctx, client, o)
+		if err != nil {
+			return nil, "", err
+		}
+		v, _, err := client.GetModelVersion(ctx, versionID)
+		if err != nil {
+			return nil, "", err
+		}
+		return v, "", nil
+	}
+	return resolveBarePositionalVersion(ctx, client, positional, o)
+}
+
+// resolveExplicitVersionID returns the version id for the explicit --version /
+// --model paths. For --model, the API returns modelVersions default/latest-first,
+// so the model's default version is modelVersions[0]; its primary file downloads
+// regardless of file type (a "Workflows" model's Archive, training data, or plain
+// weights all download the same way).
+func resolveExplicitVersionID(ctx context.Context, client api.Reader, o *downloadOpts) (string, error) {
 	if o.version != "" {
 		if _, err := strconv.Atoi(o.version); err != nil {
 			return "", asUsageError(fmt.Errorf("--version id must be an integer, got %q", o.version))
 		}
 		return o.version, nil
-	}
-	if positional != "" {
-		if _, err := strconv.Atoi(positional); err != nil {
-			return "", asUsageError(fmt.Errorf("model-version id must be an integer, got %q — pass a numeric model-version id, or find one with `civitai models search`", positional))
-		}
-		return positional, nil
 	}
 	if _, err := strconv.Atoi(o.modelID); err != nil {
 		return "", asUsageError(fmt.Errorf("--model id must be an integer, got %q", o.modelID))
@@ -360,34 +371,109 @@ func resolveVersionID(ctx context.Context, client api.Reader, positional string,
 	return strconv.Itoa(m.ModelVersions[0].ID), nil
 }
 
-// stopIfAmbiguousModelID is the core footgun guard. `civitai models search` lists
-// MODEL ids, so a user's natural `civitai download <model-id>` pastes a model id
-// into the version-id positional. When that number is NOT a valid version it 404s
-// and hintModelIDMistake catches it — but when the SAME number is ALSO a valid
-// version id (common for low/mid numbers), the version lookup succeeds and the CLI
-// would SILENTLY download an unrelated model's version, laundering it as
-// trustworthy with a "SHA256 verified" line. That is worse than a 404.
+// resolveBarePositionalVersion resolves a bare positional id into the version to
+// download. `civitai models search` lists MODEL ids, so a user's natural
+// `civitai download <id>` frequently pastes a MODEL id into the version-id
+// positional. Three shapes are distinguished by looking the id up as BOTH a
+// version and a model:
 //
-// So: for the bare-positional path only (not --model / --version / --yes), after
-// the version lookup already succeeded, check whether the same number resolves as
-// a MODEL id whose returned id MATCHES (the real REST API echoes back the queried
-// id — a mismatch means the lookup didn't actually resolve that id). If it is BOTH,
-// STOP with a usage error (exit 2) that spells out both interpretations and how to
-// pick one. Any model-lookup failure (404/network/…) means "not ambiguous" → the
-// download proceeds exactly as today.
-func stopIfAmbiguousModelID(ctx context.Context, client api.Reader, positional string, o *downloadOpts, v *api.ModelVersionDetail) error {
-	if positional == "" || o.modelID != "" || o.version != "" || o.yes {
-		return nil
-	}
+//   - version-only (valid version, NOT a model) → download that version, as today.
+//   - model-only (valid model, NOT a version) → auto-resolve + download the model's
+//     default version, with a note. This turns the common search→download flow into
+//     a success instead of a hint-wall.
+//   - ambiguous (BOTH a model AND a version) → STOP for disambiguation (exit 2), so
+//     the CLI never silently downloads an UNRELATED model's version and launders it
+//     with a reassuring "SHA256 verified". --yes proceeds (download the version as
+//     typed) but ECHOES exactly which interpretation it chose.
+//
+// A MODEL id is only "confirmable" when the model lookup echoes back the queried
+// id (the real REST API always echoes it — a mismatch means the lookup didn't
+// actually resolve that id).
+func resolveBarePositionalVersion(ctx context.Context, client api.Reader, positional string, o *downloadOpts) (*api.ModelVersionDetail, string, error) {
 	n, err := strconv.Atoi(positional)
 	if err != nil {
-		return nil // non-numeric never reaches here, but stay safe.
+		return nil, "", asUsageError(fmt.Errorf("model-version id must be an integer, got %q — pass a numeric model-version id, or find one with `civitai models search`", positional))
 	}
-	m, _, err := client.GetModel(ctx, positional)
+
+	v, _, verErr := client.GetModelVersion(ctx, positional)
+	if verErr != nil {
+		// Not a valid version. If it IS a confirmable MODEL id, auto-resolve its
+		// default version instead of dead-ending on the version 404 — the common
+		// `models search` → `download <model-id>` flow. Only a genuine 404 warrants
+		// the second lookup; any other failure (auth/network/rate-limit) is the real
+		// problem and passes through untouched.
+		if errors.Is(verErr, api.ErrNotFound) {
+			if dv, note, handled, aerr := autoResolveModelDefault(ctx, client, positional, n); handled {
+				return dv, note, aerr
+			}
+		}
+		return nil, "", verErr
+	}
+
+	// The id IS a valid version. Is it ALSO a confirmable model id? If so it's the
+	// ambiguity footgun.
+	m := lookupConfirmedModel(ctx, client, positional, n)
+	if m == nil {
+		return v, "", nil // version-only — unambiguous, download as today.
+	}
+	if o.yes {
+		// --yes bypasses the stop; echo EXACTLY which interpretation it chose so a
+		// reflexive --yes can't silently grab an unrelated model.
+		return v, ambiguousYesNote(positional, v, m), nil
+	}
+	return nil, "", ambiguousStopError(positional, v, m)
+}
+
+// lookupConfirmedModel returns the model for id only when it resolves as a model
+// whose returned id ECHOES the queried id (a mismatch means the lookup didn't
+// actually resolve that id). Any lookup failure or id mismatch returns nil ("not
+// a confirmable model id").
+func lookupConfirmedModel(ctx context.Context, client api.Reader, id string, n int) *api.ModelDetail {
+	m, _, err := client.GetModel(ctx, id)
 	if err != nil || m == nil || m.ID != n {
-		// Not (confirmably) a model id → unambiguous version download, as today.
 		return nil
 	}
+	return m
+}
+
+// autoResolveModelDefault handles a bare positional that is a valid MODEL id but
+// NOT a valid version id: it resolves the model's default (first published)
+// version and returns its detail plus a one-line note. handled=false means the id
+// is not a confirmable model id → the caller keeps the original version error.
+func autoResolveModelDefault(ctx context.Context, client api.Reader, id string, n int) (v *api.ModelVersionDetail, note string, handled bool, err error) {
+	m := lookupConfirmedModel(ctx, client, id, n)
+	if m == nil {
+		return nil, "", false, nil
+	}
+	if len(m.ModelVersions) == 0 {
+		return nil, "", true, fmt.Errorf("model %s has no published versions to download", id)
+	}
+	defVerID := strconv.Itoa(m.ModelVersions[0].ID)
+	dv, _, gerr := client.GetModelVersion(ctx, defVerID)
+	if gerr != nil {
+		return nil, "", true, gerr
+	}
+	return dv, fmt.Sprintf("note: %s is a model id — downloading its default version %s", id, defVerID), true, nil
+}
+
+// ambiguousYesNote is the --yes echo for an ambiguous id: it spells out EXACTLY
+// which interpretation was chosen (the VERSION, of its own parent model) and how
+// to get the OTHER one (the model whose id was pasted), so a reflexive --yes can't
+// silently grab an unrelated model.
+func ambiguousYesNote(id string, v *api.ModelVersionDetail, m *api.ModelDetail) string {
+	parent := ""
+	if v != nil && v.Model != nil {
+		parent = v.Model.Name
+	}
+	return fmt.Sprintf(
+		"--yes: downloading VERSION %s %q (use --model %s for the model %q instead)",
+		id, safeTerm(dashIfEmpty(parent)), id, safeTerm(dashIfEmpty(m.Name)))
+}
+
+// ambiguousStopError is the core footgun guard's usage error (exit 2): a bare
+// positional id that is BOTH a valid model id and a valid version id STOPs and
+// spells out both interpretations and how to pick one.
+func ambiguousStopError(id string, v *api.ModelVersionDetail, m *api.ModelDetail) error {
 	parent := ""
 	if v != nil && v.Model != nil {
 		parent = v.Model.Name
@@ -396,41 +482,7 @@ func stopIfAmbiguousModelID(ctx context.Context, client api.Reader, positional s
 		"%s is ambiguous — it's both model %q and version %s (of model %q).\n"+
 			"To download the model's default version:  civitai download --model %s\n"+
 			"To download version %s as-is:             re-run with --version %s (or --yes)",
-		positional, safeTerm(m.Name), positional, safeTerm(dashIfEmpty(parent)), positional, positional, positional))
-}
-
-// hintModelIDMistake disambiguates the single most common `download` mistake:
-// the positional argument is a model-VERSION id, but `civitai models search`
-// (and `models get`) list MODEL ids — so a user's natural next step,
-// `civitai download <model-id>`, 404s on the version lookup even though the id
-// is a perfectly valid MODEL id, and the bare "Model not found" is actively
-// misleading (the id IS a valid model).
-//
-// When the version lookup fails with a 404 on a POSITIONAL id (not a --model
-// resolution), this checks whether that same id resolves as a MODEL and, if so,
-// replaces the bare not-found with an actionable hint pointing at
-// `--model <id>` — tagged as a usage error so the exit code reflects the
-// invocation mistake rather than a missing resource. Any other failure (auth,
-// network, rate-limit, or a genuinely unknown id that is neither a version nor a
-// model) surfaces the original error unchanged.
-func hintModelIDMistake(ctx context.Context, client api.Reader, positional, modelID string, versionErr error) error {
-	// Only the positional-id path hits this trap, and only a genuine 404 is worth
-	// a second lookup — every other failure kind is the real problem and must
-	// pass through untouched (and unclassified-changed).
-	if positional == "" || modelID != "" || !errors.Is(versionErr, api.ErrNotFound) {
-		return versionErr
-	}
-	// Is the same id a valid MODEL id? If the model lookup fails for ANY reason,
-	// don't mask the original version-not-found error with a misleading hint —
-	// the id simply isn't a known version or model.
-	if _, _, err := client.GetModel(ctx, positional); err != nil {
-		return versionErr
-	}
-	return asUsageError(fmt.Errorf(
-		"%s is a model id, not a model-version id — did you mean: civitai download --model %s ?\n"+
-			"(`civitai download <id>` takes a model-VERSION id, but `civitai models search` / `civitai models get` list MODEL ids. "+
-			"Use --model to download the model's default version, or `civitai models get %s` to pick a specific version id.)",
-		positional, positional, positional))
+		id, safeTerm(m.Name), id, safeTerm(dashIfEmpty(parent)), id, id, id))
 }
 
 // printDownloadPlan renders the --dry-run plan: for each selected file its name,

--- a/internal/cmd/download_modelid_hint_test.go
+++ b/internal/cmd/download_modelid_hint_test.go
@@ -11,17 +11,22 @@ import (
 	"github.com/civitai/cli/internal/api"
 )
 
-// TestDownloadModelIDPassedAsVersionHints proves the model-id-vs-version-id
-// trap gives an ACTIONABLE hint: `civitai models search` shows MODEL ids, but
-// `civitai download <id>`'s positional is a model-VERSION id — so a user handing
-// a model id (4384) gets a 404 on the version lookup. When that id IS a valid
-// model id, the error must point at `civitai download --model <id>` instead of a
-// bare "not found", and be classified as a usage error.
-func TestDownloadModelIDPassedAsVersionHints(t *testing.T) {
-	// The version lookup 404s (the id is NOT a version), but the model lookup
-	// succeeds (the id IS a valid model). --dry-run so no bytes ever move.
+// TestDownloadModelIDPositionalAutoResolves proves the model-id-vs-version-id
+// trap now RESOLVES instead of hint-walling: `civitai models search` lists MODEL
+// ids, so a user handing a model id (4384) into the version-id positional — an id
+// that is a valid MODEL but NOT a valid version — has its default version
+// resolved + downloaded automatically, with a note saying it did. This turns the
+// common search→download flow into a success instead of an error.
+func TestDownloadModelIDPositionalAutoResolves(t *testing.T) {
+	// model-versions/4384 404s (4384 is NOT a version) but model-versions/128713
+	// (the model's default version) succeeds; models/4384 echoes the model with
+	// its default version 128713. --dry-run so no bytes ever move.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		if lastPathSeg(r.URL.Path) == "128713" {
+			fmt.Fprint(w, `{"id":128713,"modelId":4384,"name":"v8","baseModel":"SD 1.5","model":{"name":"DreamShaper","type":"Checkpoint"},"files":[{"id":1,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":1,"downloadUrl":"http://127.0.0.1:1/dl","hashes":{"SHA256":"`+strings.Repeat("a", 64)+`"}}]}`)
+			return
+		}
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"error":"Model not found"}`)
 	})
@@ -37,25 +42,20 @@ func TestDownloadModelIDPassedAsVersionHints(t *testing.T) {
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 	chdir(t, t.TempDir())
 
-	_, _, err := run(t, "download", "4384", "--dry-run")
-	if err == nil {
-		t.Fatal("a model id passed as a version id should error")
+	out, errOut, err := run(t, "download", "4384", "--dry-run")
+	if err != nil {
+		t.Fatalf("a model id positional should auto-resolve its default version, got: %v", err)
 	}
-	msg := err.Error()
-	// Actionable: names the mistake and the fix.
-	if !strings.Contains(msg, "is a model id") {
-		t.Errorf("error should say the id is a model id, got: %v", err)
+	// The plan is for the model's default version, and a note explains the resolve.
+	if !strings.Contains(out, "would download") {
+		t.Errorf("model-id positional should plan its default version:\n%s", out)
 	}
-	if !strings.Contains(msg, "--model 4384") {
-		t.Errorf("error should suggest `--model 4384`, got: %v", err)
+	if !strings.Contains(errOut, "4384 is a model id") || !strings.Contains(errOut, "default version 128713") {
+		t.Errorf("a note should say 4384 is a model id and name the resolved version 128713, got stderr:\n%s", errOut)
 	}
-	// Must NOT be the bare, misleading not-found message.
-	if strings.Contains(strings.ToLower(msg), "not found") {
-		t.Errorf("hint should replace the bare not-found message, got: %v", err)
-	}
-	// Classified as a usage error (exit code 2), not a not-found (4).
-	if !errors.Is(err, ErrUsage) {
-		t.Errorf("the hint should be tagged as a usage error, got: %v", err)
+	// It must NOT hint-wall with the old "--model" error.
+	if strings.Contains(out, "did you mean") || strings.Contains(errOut, "did you mean") {
+		t.Errorf("the old hint-wall must be gone; it should just resolve:\nstdout: %s\nstderr: %s", out, errOut)
 	}
 }
 

--- a/internal/cmd/download_ux_r3_test.go
+++ b/internal/cmd/download_ux_r3_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestDownloadYesEchoesVersionInterpretation proves fix 2: when --yes bypasses the
+// ambiguity stop, the CLI ECHOES exactly which interpretation it chose — the
+// VERSION (named by its own parent model) plus how to get the OTHER model whose id
+// was pasted — so a reflexive --yes can't silently grab the wrong thing. The echo
+// goes to stderr (stdout stays the plan/JSON channel).
+func TestDownloadYesEchoesVersionInterpretation(t *testing.T) {
+	// 277680: version's parent is "Kai Ipusiron"; the SAME id is also model
+	// "Pixel Art Diffusion XL" — the unrelated model a reflexive --yes would miss.
+	srv := newAmbiguityServer(t, "Pixel Art Diffusion XL", "Kai Ipusiron", true)
+	setupAmbiguityEnv(t, srv)
+
+	out, errOut, err := run(t, "download", "277680", "--yes", "--dry-run")
+	if err != nil {
+		t.Fatalf("--yes should proceed past the ambiguity stop, got: %v", err)
+	}
+	// The echo names the VERSION being downloaded (by its parent model) and points
+	// at --model for the OTHER interpretation.
+	if !strings.Contains(errOut, "downloading VERSION 277680") {
+		t.Errorf("--yes echo should name the version being downloaded, got stderr:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "Kai Ipusiron") {
+		t.Errorf("--yes echo should name the version's parent model \"Kai Ipusiron\", got stderr:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "--model 277680") || !strings.Contains(errOut, "Pixel Art Diffusion XL") {
+		t.Errorf("--yes echo should point at --model for the other (pasted) model, got stderr:\n%s", errOut)
+	}
+	// The plan itself still proceeds on stdout.
+	if !strings.Contains(out, "would download") {
+		t.Errorf("--yes should plan the version download:\n%s", out)
+	}
+}
+
+// TestDownloadModelIDNoVersionsErrors proves the auto-resolve path fails cleanly
+// when the pasted model id is a valid model that has NO published versions: there
+// is nothing to resolve, so it errors rather than silently doing nothing.
+func TestDownloadModelIDNoVersionsErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/model-versions/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"Model not found"}`)
+	})
+	mux.HandleFunc("/api/v1/models/", func(w http.ResponseWriter, r *http.Request) {
+		// A valid model (echoes the id) but with an empty modelVersions list.
+		fmt.Fprintf(w, `{"id":%s,"name":"Empty","type":"Checkpoint","modelVersions":[]}`, lastPathSeg(r.URL.Path))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	setupAmbiguityEnv(t, srv)
+
+	_, _, err := run(t, "download", "4384", "--dry-run")
+	if err == nil {
+		t.Fatal("a model id with no published versions should error, not silently succeed")
+	}
+	if !strings.Contains(err.Error(), "no published versions") {
+		t.Errorf("error should explain there are no published versions to download, got: %v", err)
+	}
+}

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"text/tabwriter"
 
@@ -79,11 +80,28 @@ func newModelVersionsByHashCmd() *cobra.Command {
 				return emitJSON(cmd, raw)
 			}
 			printModelVersionDetail(cmd, v)
+			// A by-hash lookup is almost always the prelude to a download, so emit a
+			// ready-to-run command. It uses --version (never a bare positional id) so
+			// the printed command can never trip the download model-id/version-id
+			// ambiguity stop, and pairs it with --layout for type-routed placement.
+			printDownloadCommandHint(cmd.OutOrStdout(), v)
 			return nil
 		},
 	}
 	bindReadFlags(cmd)
 	return cmd
+}
+
+// printDownloadCommandHint prints a runnable, ambiguity-gate-immune download
+// command for a resolved version (empty/zero version → nothing). Using --version
+// keeps the suggested command from ever hitting the model-id/version-id ambiguity
+// stop; --layout comfyui is a sensible type-routed default the user can drop or
+// change (e.g. --layout a1111, or --out-dir).
+func printDownloadCommandHint(out io.Writer, v *api.ModelVersionDetail) {
+	if v == nil || v.ID == 0 {
+		return
+	}
+	fmt.Fprintf(out, "  ↳ download: civitai download --version %d --layout comfyui\n", v.ID)
 }
 
 func printModelVersionDetail(cmd *cobra.Command, v *api.ModelVersionDetail) {

--- a/internal/cmd/model_versions_hint_test.go
+++ b/internal/cmd/model_versions_hint_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestByHashEmitsRunnableDownloadCommand proves fix 3: `model-versions by-hash`
+// output includes a ready-to-run `civitai download --version <id>` command (not
+// only the raw API download URL a user would otherwise hand-reconstruct and trip
+// the ambiguity gate with). It uses --version so the suggested command is immune
+// to the model-id/version-id ambiguity stop.
+func TestByHashEmitsRunnableDownloadCommand(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/by-hash/") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":128713,"modelId":4384,"name":"v8","baseModel":"SD 1.5",
+		  "downloadUrl":"https://civitai.com/api/download/models/128713",
+		  "files":[{"id":9,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":2000000}]}`))
+	})
+
+	out, _, err := run(t, "model-versions", "by-hash", "5D8D26E2A6")
+	if err != nil {
+		t.Fatalf("by-hash: %v", err)
+	}
+	// The runnable command names the resolved version via --version (gate-immune).
+	if !strings.Contains(out, "download --version 128713") {
+		t.Errorf("by-hash output should include a runnable `download --version 128713` command:\n%s", out)
+	}
+	// The raw download URL is still shown (kept as useful).
+	if !strings.Contains(out, "https://civitai.com/api/download/models/128713") {
+		t.Errorf("by-hash output should still show the raw download URL:\n%s", out)
+	}
+}
+
+// TestByHashDownloadHintUsesVersionNotPositional proves the suggested command uses
+// the --version flag (never a bare positional id), the whole point of fix 3: a
+// bare `civitai download <id>` can trip the ambiguity stop, but `--version <id>`
+// never does.
+func TestByHashDownloadHintUsesVersionNotPositional(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":277680,"modelId":4384,"name":"v","baseModel":"SDXL",
+		  "files":[{"id":9,"name":"m.safetensors","type":"Model","primary":true,"sizeKB":2000000}]}`))
+	})
+
+	out, _, err := run(t, "model-versions", "by-hash", "ABC123")
+	if err != nil {
+		t.Fatalf("by-hash: %v", err)
+	}
+	if !strings.Contains(out, "--version 277680") {
+		t.Errorf("hint must use --version:\n%s", out)
+	}
+	// The bare `civitai download 277680` (no --version) would be the gate-tripping
+	// form; it must not be what we suggest.
+	if strings.Contains(out, "civitai download 277680 ") || strings.Contains(out, "civitai download 277680\n") {
+		t.Errorf("hint must NOT suggest the bare-positional form that can trip the gate:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Download command UX refinements

Two blind-dogfood personas converged on these three fixes to `civitai download` / `model-versions by-hash`. All preserve the ambiguity-gate safety added in #164.

### 1. Auto-resolve an unambiguous model-id positional
`models search` lists **MODEL** ids, so the natural `civitai download <id>` pastes a model id into the version-id positional. Previously a valid model id that was **not** also a version id hit a "did you mean --model" hint-wall — ~100% of the search→download flow. Now it just works: the CLI recognizes the model id and downloads its default version, printing a note.

```
$ civitai download 4384 --dry-run
note: 4384 is a model id — downloading its default version 128713
...  status: would download
```

### 2. `--yes` echoes which interpretation it chose
`--yes` bypasses the ambiguity stop by downloading the **version** interpretation — which for a pasted MODEL id is an unrelated model, laundered with a matching-hash "success". A footgun. Now `--yes` echoes exactly what it's grabbing:

```
$ civitai download 277680 --yes --dry-run
--yes: downloading VERSION 277680 "アストロキング…Ipusiron" (use --model 277680 for the model "Pixel Art Diffusion XL" instead)
```

### 3. `by-hash` emits a runnable, gate-immune download command
Previously `by-hash` printed only the raw API download URL, which users hand-reconstructed into the ambiguity gate. Now it also prints a ready-to-run command using `--version` (never trips the gate):

```
  download:  https://civitai.com/api/download/models/128713
  ↳ download: civitai download --version 128713 --layout comfyui
```

### Safety preserved
An id that is **both** a model and a version still STOPs for disambiguation (exit 2) unless `--version`/`--yes` is given — no id that's both silently downloads.

```
$ civitai download 277680 --dry-run
Error: 277680 is ambiguous — it's both model "Pixel Art Diffusion XL" and version 277680 (of model "…Ipusiron").
```

### Tests / gate
- New/updated tests: model-id positional auto-resolves + notes; model-id-with-no-versions errors; `--yes` echo names the version's model; `by-hash` output contains a `download --version <id>` line and uses `--version` (not the bare positional). Unchanged cases (version-only download, ambiguous stop, `--version`/`--model` paths, unknown-id 404 passthrough) still pass.
- `go build`, `go test ./...`, `go vet`, `gofmt -l`, `golangci-lint run ./...` all clean.
- Verified live against the real API (dry-run) for all three fixes + the ambiguous-stop safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
