### PR TITLE
fix(collections): don't advertise a dead cursor for non-Newest sorts

### DIFF
--- a/internal/cmd/collections.go
+++ b/internal/cmd/collections.go
@@ -43,7 +43,12 @@ func newCollectionsSearchCmd() *cobra.Command {
 
 Pagination is cursor-based (a keyset cursor on the collection id — there is no
 --page). The next cursor is printed after the results; pass it back via --cursor.
-Cursor paging is only supported for the default (Newest) sort.`,
+
+Cursor paging is only supported for the default (Newest) sort. This is a server
+constraint: for any other --sort (e.g. "Most Followers") the API returns a
+nextCursor that it then rejects — a dead cursor that yields no further pages. So
+for a non-Newest sort the CLI shows the first page only and does NOT print a
+next-page hint; deep paging requires --sort Newest.`,
 		Example: `  civitai collections search --query "anime" --limit 5
   civitai collections search --sort Newest --cursor <cursor>`,
 		Args: cobra.NoArgs,
@@ -69,11 +74,27 @@ Cursor paging is only supported for the default (Newest) sort.`,
 			if err != nil {
 				return err
 			}
+
+			// The collections endpoint only supports cursor pagination for the
+			// default (Newest) sort. For any other sort the server still returns a
+			// nextCursor, but feeding it back is rejected — a dead cursor. When the
+			// requested sort can't cursor-paginate yet the server handed us a
+			// cursor, emit a one-line note on STDERR (so --json stdout stays pure)
+			// and DON'T print the misleading next-page hint. Exit stays 0.
+			pageable := collectionsSortIsCursorPageable(sort)
+			if !pageable && res.Metadata.CursorString() != "" {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"note: cursor pagination isn't available for --sort %q (API limitation); "+
+						"showing the first page only — use --sort Newest for deep paging.\n", sort)
+			}
+
 			if o.json {
 				return emitJSON(cmd, res.Raw)
 			}
 			printCollectionList(cmd, res.Items)
-			printPageFooter(cmd, "civitai collections search", res.Metadata)
+			if pageable {
+				printPageFooter(cmd, "civitai collections search", res.Metadata)
+			}
 			return nil
 		},
 	}
@@ -118,6 +139,19 @@ func newCollectionsGetCmd() *cobra.Command {
 	}
 	bindReadFlags(cmd)
 	return cmd
+}
+
+// collectionsSortIsCursorPageable reports whether the Civitai collections
+// endpoint (GET /api/v1/collections) supports cursor pagination for the given
+// --sort value. Per the API, cursor paging works ONLY for the default (Newest)
+// sort; every other accepted sort (currently just "Most Followers") returns a
+// nextCursor that the server then rejects, so the CLI must not advertise a
+// next-page hint for it. An empty sort means "use the server default", which is
+// Newest — hence pageable. Deriving the rule from the documented "cursor =
+// Newest only" constraint (rather than a denylist) means a newly added
+// non-Newest sort is correctly treated as non-pageable by default.
+func collectionsSortIsCursorPageable(sort string) bool {
+	return sort == "" || sort == "Newest"
 }
 
 func printCollectionList(cmd *cobra.Command, items []api.CollectionListItem) {

--- a/internal/cmd/collections_cursor_test.go
+++ b/internal/cmd/collections_cursor_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The collections endpoint only supports cursor pagination for the default
+// (Newest) sort. For any other accepted sort (currently just "Most Followers")
+// the API returns a nextCursor that it then rejects — a dead cursor. These
+// tests pin the CLI behavior: a working next-page hint for the pageable sorts,
+// and a stderr note (no misleading hint, exit 0) for the non-pageable ones.
+
+// collectionsCursorServer stands up an httptest collections endpoint that
+// always returns one item plus the given nextCursor (raw JSON literal, so
+// callers can pass a numeric `3`, a quoted `"3"`, or `null` for "no cursor").
+func collectionsCursorServer(t *testing.T, nextCursor string) {
+	t.Helper()
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/collections" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		body := `{"items":[{"id":3,"name":"Anime Picks","type":"Image",` +
+			`"read":"Public","isPublic":true,"itemCount":25,` +
+			`"user":{"id":9,"username":"carol"}}],` +
+			`"metadata":{"nextCursor":` + nextCursor + `}}`
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+const noteFragment = "cursor pagination isn't available"
+
+// Newest sort with a server nextCursor → the working next-page hint IS printed
+// on stdout, and no suppression note is emitted.
+func TestCollectionsSearchNewestPrintsCursorHint(t *testing.T) {
+	collectionsCursorServer(t, `3`)
+	out, errOut, err := run(t, "collections", "search", "--sort", "Newest", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search --sort Newest: %v", err)
+	}
+	if !strings.Contains(out, "next cursor: 3") {
+		t.Errorf("Newest should print the next-cursor footer: %s", out)
+	}
+	if !strings.Contains(out, "next page: civitai collections search --cursor '3'") {
+		t.Errorf("Newest should print the working next-page hint: %s", out)
+	}
+	if strings.Contains(errOut, noteFragment) {
+		t.Errorf("Newest must NOT emit the suppression note: %s", errOut)
+	}
+}
+
+// "Most Followers" with a server nextCursor → the hint is NOT printed, the
+// stderr note IS printed, and the command exits 0.
+func TestCollectionsSearchMostFollowersSuppressesHint(t *testing.T) {
+	collectionsCursorServer(t, `6686272`)
+	out, errOut, err := run(t, "collections", "search", "--sort", "Most Followers", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search --sort Most Followers should exit 0, got: %v", err)
+	}
+	// Items still render.
+	if !strings.Contains(out, "Anime Picks") {
+		t.Errorf("first page items should still be shown: %s", out)
+	}
+	// No cursor footer or next-page hint on stdout — the cursor is dead.
+	if strings.Contains(out, "next cursor") || strings.Contains(out, "next page") {
+		t.Errorf("Most Followers must NOT print a next-cursor/next-page hint: %s", out)
+	}
+	// The note is on stderr and names the sort.
+	if !strings.Contains(errOut, noteFragment) {
+		t.Errorf("Most Followers should emit the suppression note on stderr: %s", errOut)
+	}
+	if !strings.Contains(errOut, `--sort "Most Followers"`) {
+		t.Errorf("note should name the offending sort: %s", errOut)
+	}
+	if !strings.Contains(errOut, "--sort Newest for deep paging") {
+		t.Errorf("note should point at --sort Newest: %s", errOut)
+	}
+}
+
+// Default (no --sort) behaves as the cursor-pageable (Newest) case: working
+// hint, no spurious note.
+func TestCollectionsSearchDefaultSortPageable(t *testing.T) {
+	collectionsCursorServer(t, `17329876`)
+	out, errOut, err := run(t, "collections", "search", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search (default sort): %v", err)
+	}
+	if !strings.Contains(out, "next page: civitai collections search --cursor '17329876'") {
+		t.Errorf("default sort should print the working next-page hint: %s", out)
+	}
+	if strings.Contains(errOut, noteFragment) {
+		t.Errorf("default sort must NOT emit the suppression note: %s", errOut)
+	}
+}
+
+// --json for a non-pageable sort → stdout is pure valid JSON carrying the raw
+// nextCursor, and the note appears only on stderr (never on stdout).
+func TestCollectionsSearchMostFollowersJSONStdoutClean(t *testing.T) {
+	collectionsCursorServer(t, `6686272`)
+	out, errOut, err := run(t, "collections", "search", "--sort", "Most Followers", "--limit", "1", "--json")
+	if err != nil {
+		t.Fatalf("collections search --json: %v", err)
+	}
+	// stdout must be valid JSON (the raw body, untouched).
+	if !json.Valid([]byte(out)) {
+		t.Errorf("--json stdout must be valid JSON, got: %s", out)
+	}
+	// The raw nextCursor is still present in the body — --json is untouched.
+	if !strings.Contains(out, `"nextCursor"`) || !strings.Contains(out, "6686272") {
+		t.Errorf("--json body should still carry the raw nextCursor: %s", out)
+	}
+	// The human note must never leak onto stdout.
+	if strings.Contains(out, noteFragment) {
+		t.Errorf("--json stdout must not contain the note: %s", out)
+	}
+	// But the note is still surfaced on stderr.
+	if !strings.Contains(errOut, noteFragment) {
+		t.Errorf("--json should still emit the note on stderr: %s", errOut)
+	}
+}
+
+// A non-pageable sort with NO nextCursor from the server (a genuine last page)
+// → no hint AND no note: there is nothing to page, so nothing to warn about.
+func TestCollectionsSearchMostFollowersNoCursorNoNote(t *testing.T) {
+	collectionsCursorServer(t, `null`)
+	out, errOut, err := run(t, "collections", "search", "--sort", "Most Followers", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search: %v", err)
+	}
+	if strings.Contains(out, "next cursor") || strings.Contains(out, "next page") {
+		t.Errorf("no cursor → no hint: %s", out)
+	}
+	if strings.Contains(errOut, noteFragment) {
+		t.Errorf("no cursor → no note (nothing to page): %s", errOut)
+	}
+}
+
+// Newest with NO nextCursor (last page) → no hint, no note either.
+func TestCollectionsSearchNewestNoCursorNoFooterHint(t *testing.T) {
+	collectionsCursorServer(t, `null`)
+	out, errOut, err := run(t, "collections", "search", "--sort", "Newest", "--limit", "1")
+	if err != nil {
+		t.Fatalf("collections search: %v", err)
+	}
+	if strings.Contains(out, "next page") {
+		t.Errorf("no cursor → no next-page hint: %s", out)
+	}
+	if strings.Contains(errOut, noteFragment) {
+		t.Errorf("Newest last page must not emit a note: %s", errOut)
+	}
+}
+
+// Unit-level guard on the pageability rule so the allowlist is pinned: Newest
+// and the empty (default) sort are pageable; everything else is not.
+func TestCollectionsSortIsCursorPageable(t *testing.T) {
+	cases := map[string]bool{
+		"":               true, // default → Newest
+		"Newest":         true,
+		"Most Followers": false,
+		"newest":         false, // API is case-sensitive; only exact "Newest" pages
+		"Oldest":         false, // hypothetical future sort → non-pageable by default
+	}
+	for sort, want := range cases {
+		if got := collectionsSortIsCursorPageable(sort); got != want {
+			t.Errorf("collectionsSortIsCursorPageable(%q) = %v, want %v", sort, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`collections search` supports cursor pagination **only for `--sort Newest`** (a server constraint). For any other accepted sort (the endpoint accepts exactly `Newest` and `"Most Followers"`), the API returns a `metadata.nextCursor` that it then **rejects** when you feed it back — a dead cursor. The CLI faithfully printed the copy-paste hint anyway:

```
$ civitai collections search --sort "Most Followers" --limit 3
...
next cursor: 6686272
next page: civitai collections search --cursor '6686272'

$ civitai collections search --sort "Most Followers" --cursor '6686272'
Error: invalid request parameter (400): Cursor pagination is only supported for
the default (Newest) sort. ...
```

So following the printed hint is a guaranteed error (it was a silent empty page when first diagnosed; the API now 400s — either way it's a dead-end).

**Scope: collections-only.** Verified that `models`/`images` cursor with non-Newest sorts (e.g. `--sort "Most Downloaded"`) page correctly, so this fix does not touch them.

## The fix

Gate the **human** next-page hint on whether the sort is cursor-pageable, derived from the documented "cursor = Newest only" constraint (allowlist `{Newest}` + the default/empty sort, which maps to Newest) rather than a denylist — so a future non-Newest sort is treated as non-pageable by default.

- **Pageable sort** (`Newest`, default) → working next-page hint, as today.
- **Non-pageable sort** with a returned cursor → suppress the hint, print a one-line **stderr** note; exit 0:
  `note: cursor pagination isn't available for --sort "Most Followers" (API limitation); showing the first page only — use --sort Newest for deep paging.`
- **`--json`** → raw body untouched (still carries the API's `nextCursor`); the note only ever goes to **stderr**, so `--json` stdout stays pure.

The constraint is documented in the command's `Long` help.

## Live before/after (against the real API)

**Before** — `--sort "Most Followers"` printed `next cursor: 6686272` + `next page: ... --cursor '6686272'`; following it → `400 Cursor pagination is only supported for the default (Newest) sort`.

**After:**
```
$ civitai collections search --sort "Most Followers" --limit 3
ID       NAME               TYPE   OWNER          ITEMS
3870938  Beggars Board      Image  JustMaier      156
...
# stderr:
note: cursor pagination isn't available for --sort "Most Followers" (API limitation); showing the first page only — use --sort Newest for deep paging.

$ civitai collections search --sort Newest --limit 3
...
next cursor: 17329750
next page: civitai collections search --cursor '17329750'      # ← following this returns items

$ civitai collections search --sort "Most Followers" --limit 2 --json | jq .metadata.nextCursor
6596928        # stdout stays pure JSON; note went to stderr
```

## Tests (`internal/cmd/collections_cursor_test.go`, httptest-driven)

- Newest + server cursor → working hint printed, no note.
- `Most Followers` + server cursor → hint NOT printed, stderr note printed, exit 0.
- Default (no `--sort`) → pageable case: working hint, no note.
- `--json` non-pageable → stdout pure valid JSON w/ raw `nextCursor`, note only on stderr.
- Non-pageable + NO cursor (last page) → no hint, no note.
- Newest + NO cursor (last page) → no hint, no note.
- Unit guard on the pageability rule (allowlist pinned; API is case-sensitive).

## Gate

`go build`, `go test ./...`, `go vet`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all clean.

## Files changed

- `internal/cmd/collections.go` — pageability helper + gated hint + stderr note + help text.
- `internal/cmd/collections_cursor_test.go` — new test file.

`printPageFooter` and its other callers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
