### PR TITLE
fix(cli): lead onboarding with the free dev:harness path + surface the Comfy Cloud sample + real recipe-request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-recipe.yml
+++ b/.github/ISSUE_TEMPLATE/request-recipe.yml
@@ -1,0 +1,54 @@
+name: Request a Comfy Cloud recipe
+description: Request a new Civitai Comfy Cloud (customComfy) recipe your App can invoke.
+title: "[Recipe request] "
+labels: ["recipe-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Comfy Cloud recipes are server-registered + code-reviewed** — an App can't ship its own graph. The iframe only picks a **recipe id** plus a small, per-recipe-validated `params` object; the Civitai server owns the ComfyUI graph, the resource allowlist, the checkpoint policy, and a hard per-job Buzz ceiling.
+
+        Use this form to request a NEW recipe. Describe the graph/workflow you want, the params your App needs to expose, and the use case. We'll review it and, if approved, register it as a recipe id you can invoke via `buildComfyBody({ recipe, params })` (see `src/comfy.ts` in the page-money scaffold).
+  - type: input
+    id: username
+    attributes:
+      label: Civitai username
+      description: The account you're building the App with.
+      placeholder: your-civitai-username
+    validations:
+      required: true
+  - type: textarea
+    id: graph
+    attributes:
+      label: Intended graph / workflow
+      description: Describe the ComfyUI graph or workflow this recipe should run. Link an exported workflow JSON or a screenshot if you have one.
+      placeholder: "e.g. a Z-Image txt2img graph with an upscale pass and a face-detailer node…"
+    validations:
+      required: true
+  - type: textarea
+    id: params
+    attributes:
+      label: Params the App needs to expose
+      description: Which inputs should the block be able to set per generation? Name each param, its type, and any bounds. Everything else is server-fixed.
+      placeholder: |
+        - prompt (string, required)
+        - steps (int, 10–40)
+        - upscale (bool)
+    validations:
+      required: true
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case
+      description: What is the App for, and who will use it? Helps us prioritize and scope the recipe.
+      placeholder: "e.g. a one-click portrait upscaler for my model's landing page…"
+    validations:
+      required: true
+  - type: input
+    id: budget
+    attributes:
+      label: Rough per-job Buzz ceiling (optional)
+      description: An estimate of what one generation should cost. We set the authoritative ceiling server-side.
+      placeholder: "e.g. ~30"
+    validations:
+      required: false

--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -28,11 +28,18 @@ Buzz spend), with a mock-host dev harness and a unit test. The scaffold is
 immediately runnable (npm install && npm run dev:harness), test-green, and
 validates clean.
 
+The default scaffold ships TWO samples in the one app: a runnable txt2img money
+path AND a Comfy Cloud (customComfy) sample that runs a server-registered recipe
+(invite-only beta) — both share the estimate -> consent -> submit -> poll driver,
+switched by an on-screen mode toggle. Both work end-to-end in "npm run
+dev:harness" (mock host); see the generated README's "Comfy Cloud sample" section.
+
 Templates (override with --template):
   static      a no-build page app (index.html + a tiny JS, no build step)
   page-vite   a vite + React page app (config-as-code build: buildCommand + outputDir)
   page-money  a vite + React + TS full-page (W10) money-path app wired to the
-              published App SDK (estimate -> consent -> submit -> poll -> Buzz spend)
+              published App SDK (estimate -> consent -> submit -> poll -> Buzz
+              spend); includes a txt2img + a Comfy Cloud (customComfy) sample
               [default for create]
 
 The display name can be free-form ("My Cool Block"); it is slugified for the

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -60,23 +60,42 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	if !strings.Contains(stdout, "1. cd ") || !strings.Contains(stdout, "npm install") {
 		t.Errorf("create should print a numbered cd+install step:\n%s", stdout)
 	}
-	// The DEV TUNNEL is the highlighted prod-fidelity preview path.
-	if !strings.Contains(stdout, "civitai app dev-tunnel") {
-		t.Errorf("create should highlight the dev-tunnel preview step:\n%s", stdout)
-	}
-	// submit must precede the tunnel (the tunnel resolves the app server-side, so
-	// it must be registered first).
+	// Onboarding must LEAD with the free, works-today path (`dev:harness`, mock
+	// host, no beta access) and DEMOTE the invite-only beta surfaces (`civitai app
+	// submit` + the dev tunnel) below it — a newcomer should hit the free path
+	// first, not the gated wall. Assert the RELATIVE ORDER, not just presence.
+	iHarness := strings.Index(stdout, "dev:harness")
 	iSubmit := strings.Index(stdout, "civitai app submit")
 	iTunnel := strings.Index(stdout, "civitai app dev-tunnel")
+	if iHarness < 0 {
+		t.Errorf("create should lead with the free dev:harness path:\n%s", stdout)
+	}
 	if iSubmit < 0 {
 		t.Errorf("create should print the submit next step:\n%s", stdout)
 	}
+	if iTunnel < 0 {
+		t.Errorf("create should print the dev-tunnel preview step:\n%s", stdout)
+	}
+	// dev:harness must come BEFORE submit AND before the dev tunnel.
+	if iHarness >= 0 && iSubmit >= 0 && iHarness > iSubmit {
+		t.Errorf("dev:harness (free path) must lead BEFORE civitai app submit (beta):\n%s", stdout)
+	}
+	if iHarness >= 0 && iTunnel >= 0 && iHarness > iTunnel {
+		t.Errorf("dev:harness (free path) must lead BEFORE the dev-tunnel step (beta):\n%s", stdout)
+	}
+	// Among the demoted beta surfaces, submit still precedes the tunnel (the
+	// tunnel resolves the app server-side, so it must be registered first).
 	if iSubmit >= 0 && iTunnel >= 0 && iSubmit > iTunnel {
 		t.Errorf("submit must be sequenced BEFORE the dev-tunnel step (register first):\n%s", stdout)
 	}
-	// The harness remains as the single-line offline/mock fallback tip.
-	if !strings.Contains(stdout, "dev:harness") {
-		t.Errorf("create should keep the dev:harness fallback tip:\n%s", stdout)
+	// The beta surfaces are gated behind an honest "beta access" heading.
+	if !strings.Contains(stdout, "beta access") {
+		t.Errorf("create should gate submit/dev-tunnel under a beta-access heading:\n%s", stdout)
+	}
+	// The Comfy Cloud (customComfy) sample is surfaced (finding #2: it was
+	// undiscoverable) — honestly flagged as invite-only beta.
+	if !strings.Contains(stdout, "Comfy Cloud") {
+		t.Errorf("create should surface the Comfy Cloud sample in the output:\n%s", stdout)
 	}
 	// The trimmed message drops the old multi-line Buzz/OAuth/personal-key
 	// paragraph (dev:live now lives in dev-token/README, not the scaffold banner).
@@ -99,6 +118,21 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	}
 	if !strings.Contains(string(manifest), "ai:write:budgeted") {
 		t.Errorf("page-money manifest missing the budgeted scope:\n%s", manifest)
+	}
+}
+
+// TestAppCreateHelpMentionsComfy guards finding #2: the Comfy Cloud sample must
+// be discoverable from `civitai app create --help` (it was previously described
+// as a txt2img-only app).
+func TestAppCreateHelpMentionsComfy(t *testing.T) {
+	out, _, err := run(t, "app", "create", "--help")
+	if err != nil {
+		t.Fatalf("app create --help: %v", err)
+	}
+	for _, want := range []string{"Comfy Cloud", "customComfy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("app create help should mention %q (Comfy Cloud discoverability):\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -185,22 +185,34 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 	// One scannable line: name, template, where, and how many files — no tree.
 	fmt.Fprintln(out, ui.Success(fmt.Sprintf("Created App %q (%s)  ·  %s/  ·  %d files", display, tmpl, destDir, len(written))))
 
+	// page-money ships TWO samples in the one app — a runnable txt2img money path
+	// and a Comfy Cloud (customComfy) sample. Surface it (honestly: invite-only
+	// beta) and point at the README's Comfy Cloud section rather than the raw
+	// file count.
+	if tmpl.NeedsHarness() {
+		fmt.Fprintln(out, ui.Dim("  Includes a txt2img sample + a Comfy Cloud (customComfy) sample (invite-only beta) — see the Comfy Cloud section in README.md."))
+	}
+
 	fmt.Fprintln(out, "\n"+ui.Bold("Next steps:"))
 	switch {
 	case tmpl.NeedsHarness():
-		// SDK/page-money apps preview best via the DEV TUNNEL — your LOCAL code
-		// rendered INSIDE the real Civitai host (real session/Buzz/pickers),
-		// prod-fidelity. The tunnel resolves the app server-side, so it must be
-		// registered first: `civitai app submit` creates the (pending) app row that
-		// `civitai app dev-tunnel` then resolves — hence submit precedes the tunnel.
-		// dev-tunnel is cohort-gated, so the harness tip is the offline/mock
-		// fallback for quick iteration (or authors not yet in the cohort).
+		// LEAD with the free, works-today path: `npm run dev:harness` mounts a
+		// MOCK host (no Buzz, no beta access, no network) so a newcomer can build
+		// and iterate immediately. The real-host surfaces — `civitai app submit`
+		// (register) + the DEV TUNNEL (your LOCAL code rendered INSIDE the real
+		// Civitai host, prod-fidelity) — are invite-only beta, so they're demoted
+		// under a "When you have beta access" heading rather than led with (they'd
+		// otherwise walk a first-time author straight into the gated wall). The
+		// tunnel resolves the app server-side, so submit (which creates the pending
+		// app row) still precedes it.
 		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
-		fmt.Fprintln(out, "  2. civitai app submit      # validate + register (required before a dev tunnel)")
-		fmt.Fprintln(out, "  3. npm run dev:tunnel      # in another terminal: serve your app for the tunnel")
-		fmt.Fprintln(out, "  4. civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
+		fmt.Fprintln(out, "  2. npm run dev:harness     # mock host, no Buzz — works today")
+		fmt.Fprintln(out, "  3. edit src/App.tsx and iterate")
 		fmt.Fprintln(out)
-		fmt.Fprintln(out, "  Quick offline iteration, or not in the tunnel cohort? npm run dev:harness (mock host, no Buzz).")
+		fmt.Fprintln(out, "  When you have beta access (invite-only):")
+		fmt.Fprintln(out, "     civitai app submit      # validate + register (required before a dev tunnel)")
+		fmt.Fprintln(out, "     npm run dev:tunnel      # in another terminal: serve your app for the tunnel")
+		fmt.Fprintln(out, "     civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
 	case tmpl == scaffold.PageVite:
 		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev              # preview locally")

--- a/internal/scaffold/recipe_template_test.go
+++ b/internal/scaffold/recipe_template_test.go
@@ -1,0 +1,90 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// repoRoot returns the repository root, resolved from this test file's location
+// (internal/scaffold) so the test is cwd-independent.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// …/internal/scaffold/recipe_template_test.go -> repo root is two dirs up.
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+// TestRequestRecipeIssueTemplateExists guards finding #3: the README template's
+// recipe-request link must point at a real GitHub issue template. This asserts
+// the dedicated request-recipe.yml template exists at the repo root and parses
+// as a valid GitHub issue form (name + body). It is a REPO-LEVEL file, not
+// scaffold output, so it must NOT be embedded under templates/ (guarded below).
+func TestRequestRecipeIssueTemplateExists(t *testing.T) {
+	path := filepath.Join(repoRoot(t), ".github", "ISSUE_TEMPLATE", "request-recipe.yml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("request-recipe.yml issue template missing (%s): %v", path, err)
+	}
+	var form struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+		Body        []struct {
+			Type string `yaml:"type"`
+		} `yaml:"body"`
+	}
+	if err := yaml.Unmarshal(raw, &form); err != nil {
+		t.Fatalf("request-recipe.yml is not valid YAML: %v", err)
+	}
+	if form.Name == "" {
+		t.Error("request-recipe.yml must set a name")
+	}
+	if len(form.Body) == 0 {
+		t.Error("request-recipe.yml must declare a body (form fields)")
+	}
+	if !strings.Contains(strings.ToLower(form.Name+form.Description), "recipe") {
+		t.Errorf("request-recipe.yml should be about a recipe request, got name=%q", form.Name)
+	}
+}
+
+// TestReadmeTemplateRecipeLinkPointsAtRealTemplate guards finding #3: the
+// page-money README template's "Requesting a new recipe" link must target the
+// real request-recipe.yml issue template, not the dead bare-repo URL.
+func TestReadmeTemplateRecipeLinkPointsAtRealTemplate(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "internal", "scaffold", "templates", "page-money", "README.md.tmpl")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read README template: %v", err)
+	}
+	readme := string(raw)
+	if !strings.Contains(readme, "issues/new?template=request-recipe.yml") {
+		t.Errorf("README template recipe-request link must point at request-recipe.yml issue template:\n%s", readme)
+	}
+	// The old dead link (bare repo root, no template) must be gone.
+	if strings.Contains(readme, "issue form at <https://github.com/civitai/cli>") {
+		t.Error("README template still uses the dead bare-repo recipe-request link")
+	}
+}
+
+// TestRecipeIssueTemplateNotEmbeddedInScaffold guards that the new repo-level
+// .github file did not leak into the embedded scaffold template set (it must not
+// be shipped into a scaffolded app). The scaffold embeds `all:templates`, so a
+// file outside templates/ can't leak — this asserts that invariant explicitly.
+func TestRecipeIssueTemplateNotEmbeddedInScaffold(t *testing.T) {
+	entries, err := templatesFS.ReadDir("templates")
+	if err != nil {
+		t.Fatalf("read embedded templates: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == ".github" || strings.Contains(e.Name(), "request-recipe") {
+			t.Errorf("repo-level .github file leaked into embedded scaffold templates: %s", e.Name())
+		}
+	}
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -128,7 +128,7 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.33.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.34.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.26.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -114,8 +114,10 @@ declared.
 
 **Requesting a new recipe.** Because recipes are server-registered + code-reviewed,
 you can't add one from the app. Request a new Comfy Cloud recipe via the CLI's
-issue form at <https://github.com/civitai/cli> (describe the graph + the intended
-`params`). It ships as a registered id once reviewed.
+issue form at
+<https://github.com/civitai/cli/issues/new?template=request-recipe.yml> (describe
+the graph + the intended `params` + the use case). It ships as a registered id
+once reviewed.
 
 **Dev loop — honest state.** In `npm run dev:harness` (the **mock** host) the Comfy
 Cloud sample **works end-to-end** (estimate → submit → poll → succeeded with a mock

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.26.0",
-    "@civitai/blocks-react": "^0.33.0",
+    "@civitai/blocks-react": "^0.34.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## What & why

A blind dogfood of the external-dev onboarding flow surfaced three gaps in the `civitai` CLI. This PR fixes all three (verified each against the code first). No release cut here.

### 1. 🟡 Onboarding led newcomers into the invite-gated wall
`civitai app create`'s "Next steps" led with `civitai app submit` + `dev-tunnel` (both invite-only beta) and buried the free, works-today `npm run dev:harness` as a bottom parenthetical. There were **three orderings that disagreed** — the `create` output, the scaffold's `postinstall` banner, and the generated README. The postinstall + README already led with `dev:harness`; this aligns `create` to them.

**Before** (`create` output):
```
Next steps:
  1. cd <dir> && npm install
  2. civitai app submit      # validate + register (required before a dev tunnel)
  3. npm run dev:tunnel      # in another terminal: serve your app for the tunnel
  4. civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity

  Quick offline iteration, or not in the tunnel cohort? npm run dev:harness (mock host, no Buzz).
```

**After** (`create` output):
```
  Includes a txt2img sample + a Comfy Cloud (customComfy) sample (invite-only beta) — see the Comfy Cloud section in README.md.

Next steps:
  1. cd <dir> && npm install
  2. npm run dev:harness     # mock host, no Buzz — works today
  3. edit src/App.tsx and iterate

  When you have beta access (invite-only):
     civitai app submit      # validate + register (required before a dev tunnel)
     npm run dev:tunnel      # in another terminal: serve your app for the tunnel
     civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity
```

All three surfaces now lead with the free `dev:harness` path:
- **postinstall banner**: `✓ Installed. Next: npm run dev:harness   (preview — mock host, no Buzz) …`
- **README Develop section**: `npm install` / `npm run dev:harness   # … mounts a MOCK host …`
- **create output**: as above.

### 2. 🟡 Comfy Cloud was undiscoverable from the CLI
The `app create` help described the default as a txt2img-only app. Added a concise, honest (invite-only beta) mention of the bundled **Comfy Cloud (customComfy)** sample to the `app create` Long/help text AND one line in the `create` success output pointing at the README's Comfy Cloud section (this also names the two samples behind the file count).

### 3. 🟡 Dead recipe-request link
The generated README pointed the "request a new Comfy Cloud recipe" link at the bare repo (no form). Added a dedicated **`.github/ISSUE_TEMPLATE/request-recipe.yml`** ("Request a Comfy Cloud recipe" — intended graph/workflow, params to expose, use case) and repointed the README template link at `issues/new?template=request-recipe.yml`.

## Test coverage added
- `create` next-steps **relative ordering** — `dev:harness` appears BEFORE both `civitai app submit` and `civitai app dev-tunnel`; submit still precedes the tunnel; the beta surfaces sit under a "beta access" heading.
- `create` output + `app create --help` mention the **Comfy Cloud** sample.
- New `request-recipe.yml` issue template exists + parses as a valid GitHub issue form; the README template link targets it; and the repo-level `.github` file does **not** leak into the embedded scaffold set.
- Existing scaffold golden/file-set + pins-vs-published + antipattern guards still pass.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `go test ./...` — all packages pass.
- Scaffolded a temp app end-to-end: `npm install` + `npm test` (137 pass) + `npm run build` + `civitai app validate` — all green; the rendered README link + the postinstall/README orderings confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
