### PR TITLE
feat(civitai): batch by-hash lookup (GetModelVersionsByHashes)

### DIFF
--- a/pkg/civitai/hashes.go
+++ b/pkg/civitai/hashes.go
@@ -1,0 +1,127 @@
+package civitai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// batchByHashPath is the batch hash-lookup endpoint. It accepts a JSON array of
+// uppercase 64-char SHA256 hashes and returns the [{modelVersionId, modelId,
+// hash}] entries that matched (misses are simply absent from the response).
+const batchByHashPath = "/api/v1/model-versions/by-hash/ids"
+
+// maxHashesPerBatch is the server-enforced cap on how many hashes may be sent in
+// a single POST to batchByHashPath. GetModelVersionsByHashes chunks any larger
+// input into consecutive requests, so one call handles a slice of any size.
+const maxHashesPerBatch = 10000
+
+// sha256HexLen is the length of a SHA256 digest rendered as hex (32 bytes).
+const sha256HexLen = 64
+
+// HashMatch is one entry of the batch by-hash response: the model version (and
+// its parent model) a given file hash resolves to. Field names track the live
+// endpoint EXACTLY (modelVersionId, modelId, hash). Hash is echoed back
+// UPPER-cased, matching what the request sent.
+type HashMatch struct {
+	ModelVersionID int    `json:"modelVersionId"`
+	ModelID        int    `json:"modelId"`
+	Hash           string `json:"hash"`
+}
+
+// GetModelVersionsByHashes resolves a batch of file hashes to their model
+// versions via POST /api/v1/model-versions/by-hash/ids — the batch replacement
+// for N sequential GET /by-hash/{hash} calls.
+//
+// Each hash is normalized to upper-case and validated as a 64-char hex SHA256;
+// entries that are not a valid SHA256 are SKIPPED (not sent) so one malformed
+// entry never fails the whole batch — the caller simply gets no match for it,
+// which is indistinguishable from a genuine miss. The surviving hashes are
+// chunked to <= maxHashesPerBatch per request (the endpoint cap), each chunk is
+// POSTed as a bare JSON array body, and the results are merged in request order.
+//
+// Empty input — or input with no valid hashes — makes NO request and returns an
+// empty result. Misses (a hash with no matching version) are absent from the
+// result, exactly as the endpoint reports them; a hash shared across versions
+// may appear in MORE than one HashMatch. Transient failures (429 with
+// Retry-After, 502/503/504, transient network errors) are retried with bounded
+// backoff and classified identically to the GET read path (ErrRateLimited /
+// ErrNetwork / …); ctx cancellation aborts promptly.
+func (c *Client) GetModelVersionsByHashes(ctx context.Context, hashes []string) ([]HashMatch, error) {
+	norm := make([]string, 0, len(hashes))
+	for _, h := range hashes {
+		h = strings.ToUpper(strings.TrimSpace(h))
+		if isSHA256Hex(h) {
+			norm = append(norm, h)
+		}
+	}
+	if len(norm) == 0 {
+		return nil, nil
+	}
+	var out []HashMatch
+	for start := 0; start < len(norm); start += maxHashesPerBatch {
+		end := start + maxHashesPerBatch
+		if end > len(norm) {
+			end = len(norm)
+		}
+		var matches []HashMatch
+		if _, err := c.postInto(ctx, batchByHashPath, norm[start:end], &matches); err != nil {
+			return nil, err
+		}
+		out = append(out, matches...)
+	}
+	return out, nil
+}
+
+// isSHA256Hex reports whether s is a 64-char hex string (a SHA256 digest). The
+// input is already upper-cased by the caller, so only 0-9/A-F are accepted.
+func isSHA256Hex(s string) bool {
+	if len(s) != sha256HexLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+// postInto POSTs body (JSON-encoded) to path and, on a 2xx, unmarshals the
+// response into out (when non-nil), returning the raw body. It mirrors getInto:
+// the same readError status classification, the same maxBody cap, and the same
+// bounded transient-failure retry/backoff via getWithRetry. Retry is safe here
+// because the by-hash lookup is idempotent and the build closure re-creates the
+// body reader on every attempt.
+func (c *Client) postInto(ctx context.Context, path string, body, out any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encoding request body for %s: %w", path, err)
+	}
+	full := c.BaseURL + path
+	build := func() (*http.Request, error) {
+		req, rerr := http.NewRequestWithContext(ctx, http.MethodPost, full, bytes.NewReader(payload))
+		if rerr != nil {
+			return nil, rerr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}
+	status, raw, err := c.getWithRetry(ctx, path, build)
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status >= 300 {
+		return nil, readError(status, raw)
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return nil, fmt.Errorf("unexpected response from %s (status %d): %s", path, status, snippet(raw))
+		}
+	}
+	return raw, nil
+}

--- a/pkg/civitai/hashes_test.go
+++ b/pkg/civitai/hashes_test.go
@@ -1,0 +1,260 @@
+package civitai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// hashOf returns a deterministic valid 64-char uppercase SHA256-shaped hex
+// string for the byte b, so tests can mint distinct valid hashes cheaply.
+func hashOf(b byte) string {
+	return strings.ToUpper(strings.Repeat(fmt.Sprintf("%02x", b), 32))
+}
+
+// batchHandler is a fake /by-hash/ids endpoint. It records every POST's decoded
+// body and, for each request, returns a HashMatch for any requested hash present
+// in matches (keyed by uppercase hash).
+func batchHandler(t *testing.T, matches map[string]HashMatch) (http.HandlerFunc, *[][]string, *string) {
+	t.Helper()
+	var mu sync.Mutex
+	var bodies [][]string
+	var gotAuth string
+	h := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != batchByHashPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, batchByHashPath)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		var req []string
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Errorf("request body is not a JSON array: %q", raw)
+		}
+		mu.Lock()
+		bodies = append(bodies, req)
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		var resp []HashMatch
+		for _, h := range req {
+			if m, ok := matches[strings.ToUpper(h)]; ok {
+				resp = append(resp, m)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+	return h, &bodies, &gotAuth
+}
+
+func TestGetModelVersionsByHashesMapsAndAuth(t *testing.T) {
+	h0, h1, h2 := hashOf(0xa0), hashOf(0xb1), hashOf(0xc2)
+	matches := map[string]HashMatch{
+		h0: {ModelVersionID: 100, ModelID: 10, Hash: h0},
+		h2: {ModelVersionID: 300, ModelID: 30, Hash: h2},
+	}
+	handler, bodies, gotAuth := batchHandler(t, matches)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := New(srv.URL, "tok-9")
+	// h1 has no match (a genuine miss); it must simply be absent from the result.
+	got, err := c.GetModelVersionsByHashes(context.Background(), []string{h0, h1, h2})
+	if err != nil {
+		t.Fatalf("GetModelVersionsByHashes: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 matches, got %d: %+v", len(got), got)
+	}
+	byHash := map[string]HashMatch{}
+	for _, m := range got {
+		byHash[m.Hash] = m
+	}
+	if m := byHash[h0]; m.ModelVersionID != 100 || m.ModelID != 10 {
+		t.Errorf("h0 match wrong: %+v", m)
+	}
+	if m := byHash[h2]; m.ModelVersionID != 300 || m.ModelID != 30 {
+		t.Errorf("h2 match wrong: %+v", m)
+	}
+	if len(*bodies) != 1 {
+		t.Fatalf("want exactly 1 POST, got %d", len(*bodies))
+	}
+	if *gotAuth != "Bearer tok-9" {
+		t.Errorf("auth = %q, want Bearer tok-9", *gotAuth)
+	}
+}
+
+func TestGetModelVersionsByHashesUppercasesAndValidates(t *testing.T) {
+	valid := hashOf(0x4d)
+	handler, bodies, _ := batchHandler(t, map[string]HashMatch{
+		valid: {ModelVersionID: 1, ModelID: 2, Hash: valid},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	// A lowercase valid hash (must be upper-cased on the wire), a too-short one,
+	// a non-hex one, and blank — the invalid three are skipped, not sent.
+	got, err := c.GetModelVersionsByHashes(context.Background(), []string{
+		strings.ToLower(valid), "abc123", strings.Repeat("z", 64), "  ",
+	})
+	if err != nil {
+		t.Fatalf("GetModelVersionsByHashes: %v", err)
+	}
+	if len(*bodies) != 1 {
+		t.Fatalf("want 1 POST, got %d", len(*bodies))
+	}
+	sent := (*bodies)[0]
+	if len(sent) != 1 || sent[0] != valid {
+		t.Errorf("only the valid hash should be sent, upper-cased: got %v", sent)
+	}
+	if len(got) != 1 || got[0].ModelVersionID != 1 {
+		t.Errorf("match wrong: %+v", got)
+	}
+}
+
+func TestGetModelVersionsByHashesChunksOver10k(t *testing.T) {
+	handler, bodies, _ := batchHandler(t, map[string]HashMatch{})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// 10001 distinct valid hashes -> ceil(10001/10000) = 2 POSTs (10000 + 1).
+	const n = maxHashesPerBatch + 1
+	in := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		in = append(in, fmt.Sprintf("%064X", i))
+	}
+	c := New(srv.URL, "")
+	if _, err := c.GetModelVersionsByHashes(context.Background(), in); err != nil {
+		t.Fatalf("GetModelVersionsByHashes: %v", err)
+	}
+	if len(*bodies) != 2 {
+		t.Fatalf("want 2 chunked POSTs, got %d", len(*bodies))
+	}
+	if len((*bodies)[0]) != maxHashesPerBatch || len((*bodies)[1]) != 1 {
+		t.Errorf("chunk sizes = %d,%d, want %d,1", len((*bodies)[0]), len((*bodies)[1]), maxHashesPerBatch)
+	}
+}
+
+func TestGetModelVersionsByHashesChunksMergeResults(t *testing.T) {
+	// Two chunks each returning one match -> merged into a 2-element result.
+	first := fmt.Sprintf("%064X", 0)
+	last := fmt.Sprintf("%064X", maxHashesPerBatch) // the sole hash in chunk 2
+	handler, bodies, _ := batchHandler(t, map[string]HashMatch{
+		first: {ModelVersionID: 11, ModelID: 1, Hash: first},
+		last:  {ModelVersionID: 22, ModelID: 2, Hash: last},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	const n = maxHashesPerBatch + 1
+	in := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		in = append(in, fmt.Sprintf("%064X", i))
+	}
+	c := New(srv.URL, "")
+	got, err := c.GetModelVersionsByHashes(context.Background(), in)
+	if err != nil {
+		t.Fatalf("GetModelVersionsByHashes: %v", err)
+	}
+	if len(*bodies) != 2 {
+		t.Fatalf("want 2 POSTs, got %d", len(*bodies))
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 merged matches, got %d: %+v", len(got), got)
+	}
+}
+
+func TestGetModelVersionsByHashesEmptyMakesNoRequest(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	for _, in := range [][]string{nil, {}, {"", "  ", "not-a-hash"}} {
+		got, err := c.GetModelVersionsByHashes(context.Background(), in)
+		if err != nil {
+			t.Fatalf("input %v: %v", in, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("input %v: want empty result, got %+v", in, got)
+		}
+	}
+	if called {
+		t.Error("no HTTP request should be made for empty/all-invalid input")
+	}
+}
+
+func TestGetModelVersionsByHashesRateLimited(t *testing.T) {
+	// A 429 WITHOUT Retry-After is terminal (no retry) and classified ErrRateLimited.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"slow down"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.RetryBackoffBase = zeroBackoff()
+	c.Stderr = io.Discard
+	_, err := c.GetModelVersionsByHashes(context.Background(), []string{hashOf(0x01)})
+	if err == nil {
+		t.Fatal("expected an error for a 429")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("429 should classify as ErrRateLimited, got: %v", err)
+	}
+}
+
+func TestGetModelVersionsByHashesMalformedBody(t *testing.T) {
+	// A 200 whose body is not a JSON array of HashMatch -> a clear parse error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totally":"not an array"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	_, err := c.GetModelVersionsByHashes(context.Background(), []string{hashOf(0x02)})
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed body")
+	}
+	if !strings.Contains(err.Error(), "unexpected response") {
+		t.Errorf("want an 'unexpected response' parse error, got: %v", err)
+	}
+}
+
+func TestGetModelVersionsByHashesServerError(t *testing.T) {
+	// A persistent 503 is retried then surfaces as ErrNetwork (service unavailable).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"overloaded"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.RetryBackoffBase = zeroBackoff()
+	c.Stderr = io.Discard
+	_, err := c.GetModelVersionsByHashes(context.Background(), []string{hashOf(0x03)})
+	if err == nil {
+		t.Fatal("expected an error for a persistent 503")
+	}
+	if !errors.Is(err, ErrNetwork) {
+		t.Errorf("503 should classify as ErrNetwork, got: %v", err)
+	}
+}
+
+// TestReaderInterfaceHasBatchByHash is a compile-time assertion that *Client
+// satisfies the Reader interface (which now includes GetModelVersionsByHashes).
+func TestReaderInterfaceHasBatchByHash(t *testing.T) {
+	var _ Reader = (*Client)(nil)
+}

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -23,6 +23,7 @@ type Reader interface {
 	GetModel(ctx context.Context, id string) (*ModelDetail, []byte, error)
 	GetModelVersion(ctx context.Context, id string) (*ModelVersionDetail, []byte, error)
 	GetModelVersionByHash(ctx context.Context, hash string) (*ModelVersionDetail, []byte, error)
+	GetModelVersionsByHashes(ctx context.Context, hashes []string) ([]HashMatch, error)
 	SearchImages(ctx context.Context, q url.Values) (*ImageSearchResult, error)
 	SearchTags(ctx context.Context, q url.Values) (*TagSearchResult, error)
 	SearchCreators(ctx context.Context, q url.Values) (*CreatorSearchResult, error)


### PR DESCRIPTION
## What

Add a **batch by-hash** lookup to the `pkg/civitai` read SDK:
`GetModelVersionsByHashes(ctx, []string) ([]HashMatch, error)`, backed by
`POST /api/v1/model-versions/by-hash/ids`.

CivitAI recently merged `modelId` into this endpoint, which accepts a JSON array
of up to 10,000 uppercase 64-char SHA256 hashes and returns
`[{ modelVersionId, modelId, hash }]` for the ones that match (misses are simply
absent). This is the batch replacement for the N sequential
`GET /api/v1/model-versions/by-hash/{hash}` calls consumers do today — a
hundreds-fewer-requests win for a large local library scan.

## API

```go
type HashMatch struct {
    ModelVersionID int    `json:"modelVersionId"`
    ModelID        int    `json:"modelId"`
    Hash           string `json:"hash"`
}

func (c *Client) GetModelVersionsByHashes(ctx context.Context, hashes []string) ([]HashMatch, error)
```

- **Normalizes** each hash to upper-case; **validates** it as a 64-char hex
  SHA256. Invalid entries (wrong length / non-hex / blank) are **skipped**, so
  one malformed hash never fails the whole batch — the caller just gets no match
  for it, indistinguishable from a genuine miss.
- **Chunks internally** to `<= 10,000` per request (the endpoint cap), POSTs each
  chunk as a bare JSON array body, and merges results in request order. One call
  handles a slice of any size.
- **Empty / all-invalid input** makes no HTTP request and returns an empty
  result.
- A hash shared across versions may appear in more than one `HashMatch` — the
  method returns the endpoint's rows verbatim; de-duplication is the caller's
  choice.
- Reuses the SDK's auth (bearer token + single 401-refresh) and, via a new
  `postInto` helper, mirrors `getInto`'s `readError` status classification
  (`429 -> ErrRateLimited`, `502/503/504 -> ErrNetwork`), the `maxBody` cap, and
  the same bounded transient-retry/backoff (safe because the lookup is
  idempotent). Honors `ctx` cancellation.
- `GetModelVersionsByHashes` is added to the **`Reader` interface** so consumers
  can fake it.

## Tests

`httptest`-based coverage (a fake `/by-hash/ids` endpoint): match mapping with
misses absent, bearer auth, uppercase normalization + skipping of invalid
hashes, `>10k` chunking into `ceil(N/10k)` POSTs with merged results, empty /
all-invalid input making no request, `429 -> ErrRateLimited`, persistent
`503 -> ErrNetwork`, and a malformed `200` body -> parse error, plus a
compile-time `*Client` satisfies `Reader` assertion.

`go build ./... && go vet ./... && go test ./...` green; `gofmt` clean.

> Verified only against the `httptest` fake — not against live CivitAI.

Draft: opening for review of the SDK surface ahead of a consumer
(`civitai-manager`) that depends on it via a temporary `replace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
