### PR TITLE
fix(scaffold): bump page-money pins to current published (@civitai/blocks-react 0.35.2)

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -128,7 +128,7 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.34.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.35.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.26.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -177,7 +177,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.26.0` + `@civitai/blocks-react@^0.34.0` (already pinned in
+`@civitai/app-sdk@^0.26.0` + `@civitai/blocks-react@^0.35.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.26.0",
-    "@civitai/blocks-react": "^0.34.0",
+    "@civitai/blocks-react": "^0.35.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## What

Mechanical fix for the repo-wide-red `pins-vs-published` CI check (`TestScaffoldPinsSatisfyPublished` in `internal/scaffold`).

The `page-money` scaffold template pinned `@civitai/blocks-react` at `^0.34.0`, but the published latest on npm is `0.35.2`. A pre-1.0 caret locks the minor, so `^0.34.0` does **not** admit `0.35.2` — every app scaffolded from `page-money` was born stale, and the guard test went red on `main` and therefore on **every open PR** (incl. #176).

## How

Regenerated the scaffold pins with the repo's own generator:

```
go run ./internal/scaffold/cmd/bump-pins
```

## Exact pin changes

- `@civitai/blocks-react`: `^0.34.0` → `^0.35.0` (the minor floor `^0.35.0` satisfies published `0.35.2`)
- `@civitai/app-sdk`: unchanged (`^0.26.0`, still current)

## Files changed

- `internal/scaffold/templates/page-money/package.json.tmpl` — dependency pin
- `internal/scaffold/templates/page-money/README.md.tmpl` — matching prose pin reference
- `internal/scaffold/scaffold_test.go` — matching `mustContain` assertion

## Verification (local)

- `CIVITAI_CHECK_PUBLISHED_PINS=1 go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -v` → **PASS**
- `go build ./...`, `go vet ./...`, `go test ./...` → all green
- `gofmt -l internal/scaffold` → clean

Unblocks the `pins-vs-published` check across all open cli PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)