### PR TITLE
feat(app): CLI App-store discovery — `app list` + `app view` (SearchApps/GetApp SDK)

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -16,13 +16,17 @@ The typical lifecycle is create -> validate -> submit.
 "civitai app create" is the friendly, batteries-included scaffolder (defaults to
 the rich page-money SDK template); "civitai app init" is the same scaffolder
 with a no-build static default (back-compat alias).`,
-		Example: `  civitai app create my-block
+		Example: `  civitai app list
+  civitai app view my-block
+  civitai app create my-block
   civitai app validate ./my-block
   civitai app submit ./my-block
   civitai app status
   civitai app withdraw pubreq_01H
   civitai app dev-token my-block`,
 	}
+	cmd.AddCommand(newAppListCmd())
+	cmd.AddCommand(newAppViewCmd())
 	cmd.AddCommand(newAppCreateCmd())
 	cmd.AddCommand(newAppInitCmd())
 	cmd.AddCommand(newAppValidateCmd())

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/pkg/civitai"
+	"github.com/spf13/cobra"
+)
+
+// appsLimitMax is the server-enforced page-size cap for GET /api/v1/apps (1-50,
+// default 20). Kept in sync with the endpoint's zod bound.
+const appsLimitMax = 50
+
+// newAppListCmd is `civitai app list` — discover published Apps in the store.
+//
+// This is FILTER-based discovery (kind/category/sort + keyset cursor), NOT
+// keyword search: the backend store service exposes no free-text query, so there
+// is deliberately no `app search` command yet (it would duplicate `list`). When
+// text search lands, `app search <query>` is a trivial addition over SearchApps.
+func newAppListCmd() *cobra.Command {
+	var kind, category, sort, cursor string
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Discover published Apps in the store (GET /api/v1/apps)",
+		Long: `List published Apps from the Civitai store via GET /api/v1/apps.
+
+This is filter-based discovery — filter by --kind / --category, order by --sort,
+and page with --cursor. There is no free-text search yet (the store service
+doesn't support it), so there is no ` + "`app search`" + ` command.
+
+Login is required (` + "`civitai login`" + `): the endpoint keys the visible catalog
+off your identity, so an anonymous call would see nothing. Pagination is keyset
+cursor-based (no --page); the next cursor is printed after the results — pass it
+back via --cursor.
+
+The store is rate-limited per caller; a tight scripted loop may see 429s (the CLI
+backs off and retries automatically).
+
+NOTE: the store is gated by a launch flag — until it opens publicly you will only
+see apps if your account is a moderator or app-dev-tester; a normal login may get
+an empty list. This command is useless until the backing API is deployed.`,
+		Example: `  civitai app list
+  civitai app list --kind onsite --sort popular --limit 10
+  civitai app list --category productivity --json
+  civitai app list --cursor '<next-cursor-from-a-previous-page>'`,
+		Args: cobra.NoArgs,
+		PreRunE: func(c *cobra.Command, args []string) error {
+			// An EXPLICIT non-positive --limit is a usage mistake (an unset --limit
+			// is 0 and means "server default"); reject only the explicit case.
+			if f := c.Flags().Lookup("limit"); f != nil && f.Changed && limit < 1 {
+				return asUsageError(fmt.Errorf(
+					"--limit must be a positive integer (got %d); omit --limit to use the server default", limit))
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkLimit(limit, appsLimitMax); err != nil {
+				return err
+			}
+			jsonOut, _ := cmd.Flags().GetBool("json")
+
+			q := url.Values{}
+			addIfSet(q, "kind", kind)
+			addIfSet(q, "category", category)
+			addIfSet(q, "sort", sort)
+			addIfSet(q, "cursor", cursor)
+			addIfPositive(q, "limit", limit)
+
+			client, err := newLoginGatedReader()
+			if err != nil {
+				return err
+			}
+			res, err := client.SearchApps(context.Background(), q)
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				return emitJSON(cmd, res.Raw)
+			}
+			printAppList(cmd, res.Items)
+			printPageFooter(cmd, "civitai app list", res.Metadata)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "", "filter by kind (all, onsite, offsite)")
+	cmd.Flags().StringVar(&category, "category", "", "filter by marketplace category")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order (top-rated, popular, newest, name)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	cmd.Flags().IntVar(&limit, "limit", 0, fmt.Sprintf("results per page (1-%d)", appsLimitMax))
+	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
+	return cmd
+}
+
+// newAppViewCmd is `civitai app view <slug>` — one App's public detail.
+func newAppViewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view <slug>",
+		Short: "Show one App's detail (GET /api/v1/apps/{slug})",
+		Long: `Show the public detail for one published App by slug via
+GET /api/v1/apps/{slug} — its description, category, rating, gallery, and the
+kind-specific action target (an on-site app's live URL, or an off-site app's
+external / connect target).
+
+Login is required (` + "`civitai login`" + `). A missing or out-of-scope slug returns a
+clean "not found" message. This command is useless until the backing API is
+deployed.`,
+		Example: `  civitai app view my-cool-app
+  civitai app view my-cool-app --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jsonOut, _ := cmd.Flags().GetBool("json")
+
+			client, err := newLoginGatedReader()
+			if err != nil {
+				return err
+			}
+			d, raw, err := client.GetApp(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return emitJSON(cmd, raw)
+			}
+			printAppDetail(cmd, d)
+			return nil
+		},
+	}
+	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
+	return cmd
+}
+
+// newLoginGatedReader builds a civitai.Client for the App-store read endpoints,
+// REQUIRING a stored login token client-side. The endpoint is optional-bearer
+// server-side, but the CLI requires login for a stable caller identity (per-user
+// rate-limit + the identity-scoped visible catalog) — mirroring the token guard
+// on `civitai app status`. The token (OAuth device-login or a personal key) is
+// sent as a bearer and refreshed transparently on a 401.
+func newLoginGatedReader() (*civitai.Client, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Token() == "" {
+		return nil, civitai.Tag(civitai.ErrUnauthorized,
+			fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN) to browse the App store"))
+	}
+	return civitai.NewWithSource(cfg.BaseURL(), auth.New(cfg)), nil
+}
+
+// appRating renders a recommend rollup as a compact percentage, or a dash when
+// there are no reviews yet (recommendPct is null, not 0).
+func appRating(r civitai.ListingRecommend) string {
+	if r.RecommendPct == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d%%", int(*r.RecommendPct*100+0.5))
+}
+
+// appCardAuthor renders a card's creator username, or a dash when the creator
+// chip is absent (a vanished owner row).
+func appCardAuthor(c *civitai.AppCard) string {
+	if c.Creator != nil && c.Creator.Username != "" {
+		return safeTerm(c.Creator.Username)
+	}
+	return "-"
+}
+
+func printAppList(cmd *cobra.Command, items []civitai.AppCard) {
+	out := cmd.OutOrStdout()
+	if len(items) == 0 {
+		fmt.Fprintln(out, "No apps found — the store may not be publicly launched yet, or no app matches these filters.")
+		fmt.Fprintln(out, "If you are a moderator or app-dev-tester, make sure you are logged in (`civitai login`).")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tSLUG\tKIND\tCATEGORY\tAUTHOR\tRATING\tREVIEWS")
+	for i := range items {
+		c := &items[i]
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\n",
+			safeTerm(c.Name),
+			dashIfEmpty(safeTerm(c.Slug)),
+			dashIfEmpty(safeTerm(c.Kind)),
+			dashIfEmpty(safeTerm(c.Category)),
+			appCardAuthor(c),
+			appRating(c.Recommend),
+			c.ReviewCount,
+		)
+	}
+	_ = tw.Flush()
+}
+
+func printAppDetail(cmd *cobra.Command, d *civitai.AppDetail) {
+	out := cmd.OutOrStdout()
+	author := "-"
+	if d.Creator != nil && d.Creator.Username != "" {
+		author = safeTerm(d.Creator.Username)
+	}
+	fmt.Fprintf(out, "%s (%s)\n", safeTerm(d.Name), safeTerm(d.Slug))
+	if d.Tagline != "" {
+		fmt.Fprintf(out, "  %s\n", safeTerm(truncate(d.Tagline, 200)))
+	}
+	fmt.Fprintf(out, "  kind:     %s\n", dashIfEmpty(safeTerm(d.Kind)))
+	fmt.Fprintf(out, "  category: %s\n", dashIfEmpty(safeTerm(d.Category)))
+	fmt.Fprintf(out, "  rating:   %s (%d review(s))\n", appRating(d.Recommend), d.ReviewCount)
+	if d.ContentRating != "" {
+		fmt.Fprintf(out, "  rating:   content %s\n", safeTerm(d.ContentRating))
+	}
+	fmt.Fprintf(out, "  author:   %s\n", author)
+
+	// Kind-specific action data.
+	switch d.KindData.Kind {
+	case "onsite":
+		if d.KindData.LiveURL != "" {
+			fmt.Fprintf(out, "  live:     %s\n", safeTerm(d.KindData.LiveURL))
+		}
+		fmt.Fprintf(out, "  page:     %t\n", d.KindData.HasPage)
+	case "offsite":
+		if d.KindData.SubKind != "" {
+			fmt.Fprintf(out, "  offsite:  %s\n", safeTerm(d.KindData.SubKind))
+		}
+		if d.KindData.ExternalURL != "" {
+			fmt.Fprintf(out, "  url:      %s\n", safeTerm(d.KindData.ExternalURL))
+		}
+		if d.KindData.ConnectClientID != "" {
+			fmt.Fprintf(out, "  clientId: %s\n", safeTerm(d.KindData.ConnectClientID))
+		}
+	}
+
+	if len(d.Screenshots) > 0 {
+		fmt.Fprintf(out, "  gallery:  %d screenshot(s)\n", len(d.Screenshots))
+	}
+	if d.Description != "" {
+		fmt.Fprintf(out, "\n%s\n", safeTerm(truncate(strings.TrimSpace(d.Description), 600)))
+	}
+}

--- a/internal/cmd/apps_cmd_test.go
+++ b/internal/cmd/apps_cmd_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// setupAuthedAppsServer points the CLI at a local server via CIVITAI_BASE_URL
+// AND configures a token (the App-store commands are login-gated client-side,
+// so a hermetic anonymous setup like setupReadServer would trip the login guard
+// before the request). Returns nothing; the handler asserts what it needs.
+func setupAuthedAppsServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	setupReadServer(t, handler)
+	// setupReadServer clears the token for anonymous reads; re-set it so the
+	// login gate passes and the bearer is sent.
+	t.Setenv("CIVITAI_TOKEN", "tok-apps")
+}
+
+const appsListCmdBody = `{
+  "items": [
+    {"id":"a1","slug":"cool-onsite","kind":"onsite","name":"Cool Onsite","tagline":"neat",
+     "category":"productivity","contentRating":"pg",
+     "creator":{"id":7,"username":"alice","image":""},
+     "recommend":{"recommendedCount":9,"notRecommendedCount":1,"recommendPct":0.9},
+     "reviewCount":10,"kindData":{"kind":"onsite","appBlockId":"blk_9","hasPage":true}},
+    {"id":"a2","slug":"ext-app","kind":"offsite","name":"Ext App","tagline":null,"category":null,
+     "contentRating":null,"creator":null,
+     "recommend":{"recommendedCount":0,"notRecommendedCount":0,"recommendPct":null},
+     "reviewCount":0,"kindData":{"kind":"offsite","subKind":"external-link","externalUrl":"https://ext/x"}}
+  ],
+  "metadata": {"nextCursor":"cur-2"}
+}`
+
+func TestAppListHumanTable(t *testing.T) {
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer tok-apps" {
+			t.Errorf("bearer not sent: %q", r.Header.Get("Authorization"))
+		}
+		// Filter params must be threaded onto the request.
+		for k, want := range map[string]string{"kind": "onsite", "sort": "popular", "limit": "10"} {
+			if got := r.URL.Query().Get(k); got != want {
+				t.Errorf("query %s = %q, want %q", k, got, want)
+			}
+		}
+		_, _ = w.Write([]byte(appsListCmdBody))
+	})
+
+	out, _, err := run(t, "app", "list", "--kind", "onsite", "--sort", "popular", "--limit", "10")
+	if err != nil {
+		t.Fatalf("app list: %v", err)
+	}
+	// Table headers + rows.
+	for _, want := range []string{"NAME", "SLUG", "KIND", "CATEGORY", "AUTHOR", "RATING", "REVIEWS",
+		"Cool Onsite", "cool-onsite", "onsite", "alice", "90%", "Ext App", "ext-app", "offsite"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q:\n%s", want, out)
+		}
+	}
+	// The next-cursor footer + paste-ready hint.
+	if !strings.Contains(out, "next cursor: cur-2") {
+		t.Errorf("footer should show next cursor: %s", out)
+	}
+	if !strings.Contains(out, "civitai app list --cursor 'cur-2'") {
+		t.Errorf("footer should show the next-page hint: %s", out)
+	}
+}
+
+func TestAppListJSON(t *testing.T) {
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(appsListCmdBody))
+	})
+
+	out, _, err := run(t, "app", "list", "--json")
+	if err != nil {
+		t.Fatalf("app list --json: %v", err)
+	}
+	// --json must emit valid, parseable JSON (the raw body round-tripped).
+	var parsed struct {
+		Items    []map[string]any `json:"items"`
+		Metadata map[string]any   `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Items) != 2 {
+		t.Errorf("--json should carry both items, got %d", len(parsed.Items))
+	}
+	// The human table must NOT be present under --json.
+	if strings.Contains(out, "NAME\t") || strings.Contains(out, "next cursor:") {
+		t.Errorf("--json output should be pure JSON, got: %s", out)
+	}
+}
+
+func TestAppListEmptyHint(t *testing.T) {
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+	})
+	out, _, err := run(t, "app", "list")
+	if err != nil {
+		t.Fatalf("app list (empty): %v", err)
+	}
+	if !strings.Contains(out, "No apps found") {
+		t.Errorf("empty list should print a hint, got: %s", out)
+	}
+}
+
+// The login gate: with no token configured, `app list` must fail with a clear
+// "run civitai login" error (ErrUnauthorized), never reaching the network.
+func TestAppListLoginGated(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	_, _, err := run(t, "app", "list")
+	if err == nil {
+		t.Fatal("expected a login-required error with no token")
+	}
+	if !errors.Is(err, civitai.ErrUnauthorized) {
+		t.Errorf("no-token error should classify as ErrUnauthorized, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "civitai login") {
+		t.Errorf("error should point at `civitai login`, got: %v", err)
+	}
+}
+
+func TestAppListExplicitZeroLimitRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "tok-apps")
+	_, _, err := run(t, "app", "list", "--limit", "0")
+	if err == nil {
+		t.Fatal("expected an explicit --limit 0 to be rejected")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("bad --limit should be a usage error, got: %v", err)
+	}
+}
+
+func TestAppViewDetail(t *testing.T) {
+	const body = `{
+	  "id":"d1","serialId":42,"slug":"cool-onsite","kind":"onsite","name":"Cool Onsite",
+	  "tagline":"neat","description":"A longer description.","category":"productivity","contentRating":"pg",
+	  "creator":{"id":7,"username":"alice","image":""},
+	  "recommend":{"recommendedCount":9,"notRecommendedCount":1,"recommendPct":0.9},"reviewCount":10,
+	  "screenshots":[{"url":"https://x/s1.png","caption":"first"}],
+	  "kindData":{"kind":"onsite","appBlockId":"blk_9","hasPage":true,"liveUrl":"https://cool-onsite.civit.ai"}
+	}`
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps/cool-onsite" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(body))
+	})
+
+	out, _, err := run(t, "app", "view", "cool-onsite")
+	if err != nil {
+		t.Fatalf("app view: %v", err)
+	}
+	for _, want := range []string{"Cool Onsite", "cool-onsite", "productivity", "alice",
+		"90%", "https://cool-onsite.civit.ai", "A longer description."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A 404 from the detail endpoint must render as a clean not-found message
+// (classified ErrNotFound), not a stack trace.
+func TestAppViewNotFound(t *testing.T) {
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"App not found"}`))
+	})
+
+	_, _, err := run(t, "app", "view", "ghost")
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("404 should classify as ErrNotFound, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should read as not-found, got: %v", err)
+	}
+}
+
+func TestAppViewLoginGated(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("CIVITAI_TOKEN", "")
+	_, _, err := run(t, "app", "view", "any-slug")
+	if err == nil {
+		t.Fatal("expected a login-required error with no token")
+	}
+	if !errors.Is(err, civitai.ErrUnauthorized) {
+		t.Errorf("no-token error should classify as ErrUnauthorized, got: %v", err)
+	}
+}
+
+func TestAppHelpListsDiscoveryCommands(t *testing.T) {
+	out, _, err := run(t, "app", "--help")
+	if err != nil {
+		t.Fatalf("app --help: %v", err)
+	}
+	for _, want := range []string{"list", "view"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("app help missing discovery subcommand %q:\n%s", want, out)
+		}
+	}
+}

--- a/pkg/civitai/apps.go
+++ b/pkg/civitai/apps.go
@@ -1,0 +1,166 @@
+package civitai
+
+import (
+	"context"
+	"net/url"
+)
+
+// The App Store discovery read surface — GET /api/v1/apps (list) and
+// GET /api/v1/apps/{slug} (detail). These back `civitai app list` / `app view`.
+//
+// The endpoint serves the unified `/apps` marketplace over BOTH kinds of app
+// (`onsite` AppBlocks and `offsite` external/connect listings) from the durable
+// AppListing record. It is filter-based discovery only — kind/category/sort +
+// keyset cursor paging — with NO free-text query or slot filter (the store
+// service exposes neither; keyword search is a deferred follow-up). The bearer
+// is optional server-side but the CLI requires login for a stable caller
+// identity (per-user rate-limit + the auto-widening visibility scope).
+//
+// The Go structs below MIRROR the backend public DTOs field-for-field (json
+// tags track `ListingCard` / `ListingDetail` in
+// civitai:src/server/schema/blocks/app-listing-read.schema.ts EXACTLY, like
+// HashMatch tracks the by-hash endpoint) — the DTOs are a public-field
+// allowlist, so a backend field rename would silently null a column here and
+// the field-mapping tests are the guard.
+
+// ListingCreatorChip is the public creator chip (id/username/image only — no
+// PII). It is `null` in JSON only when the owner row vanished, so the field is a
+// pointer on the card/detail structs.
+type ListingCreatorChip struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Image    string `json:"image"`
+}
+
+// ListingRecommend is the recommend rollup read from the AppListingMetric
+// rollup. RecommendPct is a POINTER because it is `null` (not 0) when there are
+// no reviews yet — so the CLI can render "no reviews" instead of a bogus "0%".
+type ListingRecommend struct {
+	RecommendedCount    int `json:"recommendedCount"`
+	NotRecommendedCount int `json:"notRecommendedCount"`
+	// RecommendPct is up/(up+down) in [0,1], or nil when there are no reviews.
+	RecommendPct *float64 `json:"recommendPct"`
+}
+
+// AppCardKindData is the discriminated kind-specific card data. The backend
+// emits ONLY the fields for the row's `kind` (onsite: appBlockId/hasPage;
+// offsite: subKind/externalUrl); a flat struct captures both shapes with the
+// absent side left zero — Kind is the discriminator to read.
+type AppCardKindData struct {
+	Kind string `json:"kind"`
+	// onsite:
+	AppBlockID string `json:"appBlockId"`
+	HasPage    bool   `json:"hasPage"`
+	// offsite:
+	SubKind     string `json:"subKind"`
+	ExternalURL string `json:"externalUrl"`
+}
+
+// AppCard is one store card over EITHER kind (the unified `/apps` grid item).
+// Mirrors backend `ListingCard`. Nullable string fields (tagline/category/…)
+// are plain strings — a JSON null decodes to "" and renders as a dash.
+type AppCard struct {
+	ID            string              `json:"id"`
+	Slug          string              `json:"slug"`
+	Kind          string              `json:"kind"`
+	Name          string              `json:"name"`
+	Tagline       string              `json:"tagline"`
+	Category      string              `json:"category"`
+	ContentRating string              `json:"contentRating"`
+	IconURL       string              `json:"iconUrl"`
+	CoverURL      string              `json:"coverUrl"`
+	Creator       *ListingCreatorChip `json:"creator"`
+	Recommend     ListingRecommend    `json:"recommend"`
+	ReviewCount   int                 `json:"reviewCount"`
+	KindData      AppCardKindData     `json:"kindData"`
+}
+
+// AppSearchResult bundles the parsed cards + pagination metadata with the raw
+// response body (for --json passthrough). It uses the shared Metadata type —
+// exactly like every other Search* result — so CursorString + printPageFooter
+// work unchanged; the apps endpoint populates only nextCursor/nextPage on it
+// (keyset cursor pagination, no page/offset).
+type AppSearchResult struct {
+	Items    []AppCard `json:"items"`
+	Metadata Metadata  `json:"metadata"`
+	Raw      []byte    `json:"-"`
+}
+
+// SearchApps calls GET /api/v1/apps with the given query params (kind, category,
+// sort, cursor, limit — encoded from q). It returns a SINGLE page plus the next
+// cursor in Metadata; the caller paginates by feeding Metadata.CursorString()
+// back as `cursor` (it does NOT auto-page), mirroring SearchModels/SearchImages.
+//
+// This is filter-based discovery: the endpoint accepts no free-text `query` or
+// `slot` param (the store service supports neither). TODO(app search): when the
+// backend store service adds text search, a `civitai app search <query>` becomes
+// a trivial addition — set q.Set("query", …) here and add the command; the
+// transport/paging/auth path is unchanged.
+func (c *Client) SearchApps(ctx context.Context, q url.Values) (*AppSearchResult, error) {
+	var res AppSearchResult
+	raw, err := c.getInto(ctx, "/api/v1/apps", q, &res)
+	if err != nil {
+		return nil, err
+	}
+	res.Raw = raw
+	return &res, nil
+}
+
+// ListingScreenshot is one ordered gallery screenshot on the detail page.
+type ListingScreenshot struct {
+	URL     string `json:"url"`
+	Caption string `json:"caption"`
+}
+
+// AppDetailKindData is the discriminated kind-specific action data on the detail
+// page. Mirrors backend `ListingDetailKindData` — onsite adds `liveUrl` (the
+// already-public standalone block origin), offsite adds `connectClientId` (the
+// public OAuth client_id, NOT a secret). Kind is the discriminator.
+type AppDetailKindData struct {
+	Kind string `json:"kind"`
+	// onsite:
+	AppBlockID string `json:"appBlockId"`
+	HasPage    bool   `json:"hasPage"`
+	LiveURL    string `json:"liveUrl"`
+	// offsite:
+	SubKind         string `json:"subKind"`
+	ExternalURL     string `json:"externalUrl"`
+	ConnectClientID string `json:"connectClientId"`
+}
+
+// AppDetail is the full public detail for one approved listing (card fields +
+// gallery + body). Mirrors backend `ListingDetail`. SerialID is the integer
+// surrogate key carried for the comments discussion; the store `id` is a TEXT
+// ULID.
+type AppDetail struct {
+	ID            string              `json:"id"`
+	SerialID      int                 `json:"serialId"`
+	Slug          string              `json:"slug"`
+	Kind          string              `json:"kind"`
+	Name          string              `json:"name"`
+	Tagline       string              `json:"tagline"`
+	Description   string              `json:"description"`
+	Category      string              `json:"category"`
+	ContentRating string              `json:"contentRating"`
+	IconURL       string              `json:"iconUrl"`
+	CoverURL      string              `json:"coverUrl"`
+	Creator       *ListingCreatorChip `json:"creator"`
+	Recommend     ListingRecommend    `json:"recommend"`
+	ReviewCount   int                 `json:"reviewCount"`
+	Screenshots   []ListingScreenshot `json:"screenshots"`
+	KindData      AppDetailKindData   `json:"kindData"`
+}
+
+// GetApp calls GET /api/v1/apps/{slug}. Returns the parsed detail and the raw
+// body (for --json), like GetModel/GetArticle. A missing / out-of-scope slug
+// yields HTTP 404, which readError classifies as ErrNotFound (the entrypoint
+// maps it to the not-found exit code) — the detail endpoint 404s natively, so
+// no empty-search faking is needed.
+func (c *Client) GetApp(ctx context.Context, slug string) (*AppDetail, []byte, error) {
+	var d AppDetail
+	raw, err := c.getInto(ctx, "/api/v1/apps/"+url.PathEscape(slug), nil, &d)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &d, raw, nil
+}

--- a/pkg/civitai/apps_test.go
+++ b/pkg/civitai/apps_test.go
@@ -1,0 +1,391 @@
+package civitai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// appsListBody is a two-card GET /api/v1/apps page: one on-site card (with a
+// recommend rollup) and one off-site card (no reviews yet → recommendPct null),
+// plus a nextCursor. It exercises the full field-mapping + both kind shapes.
+const appsListBody = `{
+  "items": [
+    {
+      "id": "app_01onsite",
+      "slug": "cool-onsite",
+      "kind": "onsite",
+      "name": "Cool Onsite",
+      "tagline": "does cool things",
+      "category": "productivity",
+      "contentRating": "pg",
+      "iconUrl": "https://x/icon.png",
+      "coverUrl": "https://x/cover.png",
+      "creator": {"id": 7, "username": "alice", "image": "https://x/a.png"},
+      "recommend": {"recommendedCount": 9, "notRecommendedCount": 1, "recommendPct": 0.9},
+      "reviewCount": 10,
+      "kindData": {"kind": "onsite", "appBlockId": "blk_9", "hasPage": true}
+    },
+    {
+      "id": "app_02offsite",
+      "slug": "ext-offsite",
+      "kind": "offsite",
+      "name": "Ext Offsite",
+      "tagline": null,
+      "category": null,
+      "contentRating": null,
+      "iconUrl": null,
+      "coverUrl": null,
+      "creator": null,
+      "recommend": {"recommendedCount": 0, "notRecommendedCount": 0, "recommendPct": null},
+      "reviewCount": 0,
+      "kindData": {"kind": "offsite", "subKind": "external-link", "externalUrl": "https://ext.example/app"}
+    }
+  ],
+  "metadata": {"nextCursor": "cur-2", "nextPage": "https://civitai.com/api/v1/apps?cursor=cur-2"}
+}`
+
+func TestSearchAppsMapsFieldsParamsAndAuth(t *testing.T) {
+	var gotQuery url.Values
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps" {
+			t.Errorf("path = %q, want /api/v1/apps", r.URL.Path)
+		}
+		gotQuery = r.URL.Query()
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, appsListBody)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok-apps")
+	q := valuesOf(map[string]string{
+		"kind":     "onsite",
+		"category": "productivity",
+		"sort":     "popular",
+		"cursor":   "cur-1",
+		"limit":    "25",
+	})
+	res, err := c.SearchApps(context.Background(), q)
+	if err != nil {
+		t.Fatalf("SearchApps: %v", err)
+	}
+
+	// Every filter param must be encoded onto the request URL.
+	for k, want := range map[string]string{
+		"kind": "onsite", "category": "productivity", "sort": "popular",
+		"cursor": "cur-1", "limit": "25",
+	} {
+		if got := gotQuery.Get(k); got != want {
+			t.Errorf("query %s = %q, want %q", k, got, want)
+		}
+	}
+	// Bearer sent.
+	if gotAuth != "Bearer tok-apps" {
+		t.Errorf("auth = %q, want Bearer tok-apps", gotAuth)
+	}
+
+	if len(res.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(res.Items))
+	}
+
+	// On-site card field mapping.
+	on := res.Items[0]
+	if on.ID != "app_01onsite" || on.Slug != "cool-onsite" || on.Kind != "onsite" || on.Name != "Cool Onsite" {
+		t.Errorf("onsite core fields wrong: %+v", on)
+	}
+	if on.Tagline != "does cool things" || on.Category != "productivity" || on.ContentRating != "pg" {
+		t.Errorf("onsite string fields wrong: %+v", on)
+	}
+	if on.Creator == nil || on.Creator.ID != 7 || on.Creator.Username != "alice" {
+		t.Errorf("onsite creator wrong: %+v", on.Creator)
+	}
+	if on.Recommend.RecommendedCount != 9 || on.Recommend.NotRecommendedCount != 1 {
+		t.Errorf("onsite recommend counts wrong: %+v", on.Recommend)
+	}
+	if on.Recommend.RecommendPct == nil || *on.Recommend.RecommendPct != 0.9 {
+		t.Errorf("onsite recommendPct = %v, want 0.9", on.Recommend.RecommendPct)
+	}
+	if on.ReviewCount != 10 {
+		t.Errorf("onsite reviewCount = %d, want 10", on.ReviewCount)
+	}
+	if on.KindData.Kind != "onsite" || on.KindData.AppBlockID != "blk_9" || !on.KindData.HasPage {
+		t.Errorf("onsite kindData wrong: %+v", on.KindData)
+	}
+
+	// Off-site card: nullable strings decode to "", null creator → nil, null
+	// recommendPct → nil (distinct from 0).
+	off := res.Items[1]
+	if off.Kind != "offsite" || off.Tagline != "" || off.Category != "" || off.Creator != nil {
+		t.Errorf("offsite nullable handling wrong: %+v", off)
+	}
+	if off.Recommend.RecommendPct != nil {
+		t.Errorf("offsite recommendPct should be nil (no reviews), got %v", *off.Recommend.RecommendPct)
+	}
+	if off.KindData.Kind != "offsite" || off.KindData.SubKind != "external-link" ||
+		off.KindData.ExternalURL != "https://ext.example/app" {
+		t.Errorf("offsite kindData wrong: %+v", off.KindData)
+	}
+
+	// Cursor + raw preserved.
+	if res.Metadata.CursorString() != "cur-2" {
+		t.Errorf("nextCursor = %q, want cur-2", res.Metadata.CursorString())
+	}
+	if len(res.Raw) == 0 {
+		t.Error("Raw body should be preserved for --json")
+	}
+}
+
+// TestSearchAppsCursorPagination drives a real 2-page fetch: page 1 hands back a
+// nextCursor; the client feeds it back via ?cursor= and gets page 2 with fresh
+// items and no further cursor.
+func TestSearchAppsCursorPagination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			_, _ = io.WriteString(w, `{"items":[{"id":"a1","slug":"one","kind":"onsite","name":"One",
+				"recommend":{"recommendedCount":0,"notRecommendedCount":0,"recommendPct":null},
+				"reviewCount":0,"kindData":{"kind":"onsite"}}],"metadata":{"nextCursor":"page2"}}`)
+		case "page2":
+			_, _ = io.WriteString(w, `{"items":[{"id":"a2","slug":"two","kind":"onsite","name":"Two",
+				"recommend":{"recommendedCount":0,"notRecommendedCount":0,"recommendPct":null},
+				"reviewCount":0,"kindData":{"kind":"onsite"}}],"metadata":{}}`)
+		default:
+			t.Errorf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	page1, err := c.SearchApps(context.Background(), url.Values{})
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1.Items) != 1 || page1.Items[0].Slug != "one" {
+		t.Fatalf("page1 items wrong: %+v", page1.Items)
+	}
+	next := page1.Metadata.CursorString()
+	if next != "page2" {
+		t.Fatalf("page1 nextCursor = %q, want page2", next)
+	}
+
+	page2, err := c.SearchApps(context.Background(), valuesOf(map[string]string{"cursor": next}))
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page2.Items) != 1 || page2.Items[0].Slug != "two" {
+		t.Fatalf("page2 items wrong: %+v", page2.Items)
+	}
+	if page2.Metadata.CursorString() != "" {
+		t.Errorf("page2 should have no further cursor, got %q", page2.Metadata.CursorString())
+	}
+}
+
+func TestSearchAppsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"items":[],"metadata":{}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	res, err := c.SearchApps(context.Background(), url.Values{})
+	if err != nil {
+		t.Fatalf("SearchApps: %v", err)
+	}
+	if len(res.Items) != 0 {
+		t.Errorf("want empty items, got %+v", res.Items)
+	}
+	if res.Metadata.CursorString() != "" {
+		t.Errorf("empty page should have no cursor, got %q", res.Metadata.CursorString())
+	}
+}
+
+// TestSearchApps401Refresh: a refreshable source is rejected once (401), the
+// client refreshes and retries with the fresh token and succeeds — the same
+// single-401-refresh contract as the other read methods.
+func TestSearchApps401Refresh(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		seen = append(seen, auth)
+		if auth != "Bearer good" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"message":"expired"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"items":[],"metadata":{}}`)
+	}))
+	defer srv.Close()
+
+	c := NewWithSource(srv.URL, &refreshOnceSource{badTok: "bad", goodTok: "good"})
+	if _, err := c.SearchApps(context.Background(), url.Values{}); err != nil {
+		t.Fatalf("SearchApps after refresh: %v", err)
+	}
+	if len(seen) != 2 || seen[0] != "Bearer bad" || seen[1] != "Bearer good" {
+		t.Errorf("auth sequence = %v, want [bad good]", seen)
+	}
+}
+
+func TestSearchAppsRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":"slow down"}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.RetryBackoffBase = zeroBackoff()
+	c.Stderr = io.Discard
+	_, err := c.SearchApps(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("expected an error for a 429")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("429 should classify as ErrRateLimited, got: %v", err)
+	}
+}
+
+func TestSearchAppsServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":"overloaded"}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	c.RetryBackoffBase = zeroBackoff()
+	c.Stderr = io.Discard
+	_, err := c.SearchApps(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("expected an error for a persistent 503")
+	}
+	if !errors.Is(err, ErrNetwork) {
+		t.Errorf("503 should classify as ErrNetwork, got: %v", err)
+	}
+}
+
+func TestSearchAppsMalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items": "not an array"}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	_, err := c.SearchApps(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed body")
+	}
+	if !strings.Contains(err.Error(), "unexpected response") {
+		t.Errorf("want an 'unexpected response' parse error, got: %v", err)
+	}
+}
+
+func TestGetAppFound(t *testing.T) {
+	const body = `{
+	  "id": "app_detail1",
+	  "serialId": 4242,
+	  "slug": "cool-onsite",
+	  "kind": "onsite",
+	  "name": "Cool Onsite",
+	  "tagline": "does cool things",
+	  "description": "A longer description of the app.",
+	  "category": "productivity",
+	  "contentRating": "pg",
+	  "iconUrl": "https://x/icon.png",
+	  "coverUrl": "https://x/cover.png",
+	  "creator": {"id": 7, "username": "alice", "image": "https://x/a.png"},
+	  "recommend": {"recommendedCount": 9, "notRecommendedCount": 1, "recommendPct": 0.9},
+	  "reviewCount": 10,
+	  "screenshots": [{"url": "https://x/s1.png", "caption": "first"}, {"url": "https://x/s2.png", "caption": null}],
+	  "kindData": {"kind": "onsite", "appBlockId": "blk_9", "hasPage": true, "liveUrl": "https://cool-onsite.civit.ai"}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps/cool-onsite" {
+			t.Errorf("path = %q, want /api/v1/apps/cool-onsite", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok")
+	d, raw, err := c.GetApp(context.Background(), "cool-onsite")
+	if err != nil {
+		t.Fatalf("GetApp: %v", err)
+	}
+	if d.ID != "app_detail1" || d.SerialID != 4242 || d.Slug != "cool-onsite" {
+		t.Errorf("detail core fields wrong: %+v", d)
+	}
+	if d.Description != "A longer description of the app." {
+		t.Errorf("description wrong: %q", d.Description)
+	}
+	if d.KindData.Kind != "onsite" || d.KindData.LiveURL != "https://cool-onsite.civit.ai" || !d.KindData.HasPage {
+		t.Errorf("detail kindData wrong: %+v", d.KindData)
+	}
+	if len(d.Screenshots) != 2 || d.Screenshots[0].URL != "https://x/s1.png" || d.Screenshots[0].Caption != "first" {
+		t.Errorf("screenshots wrong: %+v", d.Screenshots)
+	}
+	if d.Recommend.RecommendPct == nil || *d.Recommend.RecommendPct != 0.9 {
+		t.Errorf("recommendPct = %v, want 0.9", d.Recommend.RecommendPct)
+	}
+	if len(raw) == 0 {
+		t.Error("raw body should be returned for --json")
+	}
+}
+
+func TestGetAppNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":"App not found"}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok")
+	_, _, err := c.GetApp(context.Background(), "ghost")
+	if err == nil {
+		t.Fatal("expected an error for a 404")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("404 should classify as ErrNotFound, got: %v", err)
+	}
+}
+
+func TestGetAppMalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `["not","an","object"]`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok")
+	_, _, err := c.GetApp(context.Background(), "slug")
+	if err == nil {
+		t.Fatal("expected a parse error for a malformed body")
+	}
+	if !strings.Contains(err.Error(), "unexpected response") {
+		t.Errorf("want an 'unexpected response' parse error, got: %v", err)
+	}
+}
+
+// TestReaderInterfaceHasApps is a compile-time assertion that *Client satisfies
+// Reader (which now includes SearchApps + GetApp).
+func TestReaderInterfaceHasApps(t *testing.T) {
+	var _ Reader = (*Client)(nil)
+}
+
+// valuesOf builds a url.Values from a plain map (test convenience).
+func valuesOf(m map[string]string) url.Values {
+	v := url.Values{}
+	for k, val := range m {
+		v.Set(k, val)
+	}
+	return v
+}

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -32,6 +32,8 @@ type Reader interface {
 	GetArticle(ctx context.Context, id string) (*ArticleDetail, []byte, error)
 	SearchCollections(ctx context.Context, q url.Values) (*CollectionSearchResult, error)
 	GetCollection(ctx context.Context, id string) (*CollectionDetail, []byte, error)
+	SearchApps(ctx context.Context, q url.Values) (*AppSearchResult, error)
+	GetApp(ctx context.Context, slug string) (*AppDetail, []byte, error)
 }
 
 // Metadata is the pagination envelope the list endpoints return under


### PR DESCRIPTION
Adds the **client half** of CLI app discovery: two new `pkg/civitai` read-SDK methods and two commands that consume the new public REST endpoints.

## What this adds
- **`pkg/civitai` read SDK** (both added to the `Reader` interface for fakeability):
  - `SearchApps(ctx, url.Values) (*AppSearchResult, error)` → `GET /api/v1/apps`. Returns a **single page** plus a keyset cursor in the shared `Metadata` (the caller paginates via `--cursor`; it does **not** auto-page), mirroring `SearchModels`/`SearchImages`.
  - `GetApp(ctx, slug) (*AppDetail, []byte, error)` → `GET /api/v1/apps/{slug}` (typed + raw bytes, like `GetModel`). A 404 maps to the SDK's `ErrNotFound` via the existing `readError` classification.
  - Reuses `getInto`/`readError`/retry/backoff/`maxBody`/bearer+single-401-refresh unchanged. The `AppCard`/`AppDetail` (+ `ListingCreatorChip`/`ListingRecommend`/`…KindData`/`ListingScreenshot`) structs mirror the backend `ListingCard`/`ListingDetail` public DTOs **field-for-field** (json tags).
- **Commands** under `civitai app`:
  - `civitai app list` — flags `--kind --category --sort --cursor --limit --json`. Human tabwriter table by default (NAME/SLUG/KIND/CATEGORY/AUTHOR/RATING/REVIEWS), `--json` emits the raw body; prints the next-cursor page hint via the existing `printPageFooter`.
  - `civitai app view <slug>` — `--json` flag; human detail block by default; a 404 renders as a clean "not found", not a stack trace.

## Design notes
- **Filter-based discovery**, not keyword search: the backing store service exposes no free-text `query`/`slot` param, so there is deliberately **no `app search` command** (it would duplicate `list`). `SearchApps` is shaped so a future `app search <query>` is a one-line addition — marked with a `TODO(app search)` — once the backend store service adds text search.
- **Login-gated** client-side: the endpoint is optional-bearer server-side, but the commands require a stored login (clear `ErrUnauthorized` "run `civitai login`" when absent), mirroring `civitai app status`. The identity-scoped catalog means an anon call would see nothing pre-launch anyway.

## ⚠️ Depends on civitai/civitai #3385 — do NOT merge/release yet
The endpoints `GET /api/v1/apps` + `GET /api/v1/apps/{slug}` are added in **civitai/civitai #3385**. Until that PR is **merged AND deployed**, `app list`/`app view` will 404. This PR must **not** be merged or released before then (sequencing depends on the backend). The SDK is verified against **httptest fakes only**, not live CivitAI yet.

## Tests
20 new tests, all green: SDK field mapping, per-param URL encoding, cursor pagination (2-page round-trip), empty page, bearer sent + 401→refresh, 429→`ErrRateLimited`, persistent 503→`ErrNetwork`, malformed-200 parse error, `GetApp` found/404/malformed, the `Reader` compile-time assertion; command-level table-vs-`--json`, login-gate guard, explicit-`--limit 0` usage error, and 404 rendering. `go build`/`go vet`/`go test ./...` all pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)