### PR TITLE
fix(app): five UX papercuts in `app list` / `app view` discovery

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -2,16 +2,19 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// newAppCmd is the `civitai app` command group for Apps authoring.
+// newAppCmd is the `civitai app` command group for browsing + authoring Apps.
 func newAppCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "app",
-		Short: "Author and ship Civitai Apps",
-		Long: `Author and ship Civitai Apps.
+		Short: "Browse, author, and ship Civitai Apps",
+		Long: `Browse, author, and ship Civitai Apps.
+
+Browse the published App store with "civitai app list" (filter-based discovery)
+and inspect one App with "civitai app view <slug>".
 
 An App is a sandboxed static web app served in an iframe. The platform
 owns the build and the runtime; the only mandatory file is block.manifest.json.
-The typical lifecycle is create -> validate -> submit.
+The typical authoring lifecycle is create -> validate -> submit.
 
 "civitai app create" is the friendly, batteries-included scaffolder (defaults to
 the rich page-money SDK template); "civitai app init" is the same scaffolder

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -17,6 +17,40 @@ import (
 // default 20). Kept in sync with the endpoint's zod bound.
 const appsLimitMax = 50
 
+// appKinds / appSorts are the FIXED enums the store's zod schema accepts for
+// --kind and --sort. They rarely change, so the CLI validates them client-side
+// for a fast, offline error (mirroring --limit's local check) instead of a
+// round-trip. --category is deliberately NOT hardcoded here: the marketplace
+// category set grows as the backend adds categories, so a client-side allowlist
+// would drift — an invalid --category is left to the server's 400, which the SDK
+// now surfaces with the offending field + allowed values (see badRequestDetail).
+var (
+	appKinds = []string{"all", "onsite", "offsite"}
+	appSorts = []string{"top-rated", "popular", "newest", "name"}
+	// appCategoriesHint documents the current marketplace category enum for the
+	// --category flag help. It mirrors the backend MARKETPLACE_CATEGORIES /
+	// listAppListingsSchema enum; it is NOT enforced client-side (see above), so a
+	// backend-added category still works even before this list is updated.
+	appCategoriesHint = "generation, games, utility, discovery, moderation, analytics, other"
+)
+
+// validateEnumFlag rejects an explicitly-set flag value that is not in the
+// allowed set, with a clear allowed-values message (a usage error, no HTTP
+// call). An empty value ("", the unset default) passes — it means "server
+// default", exactly like an unset --limit.
+func validateEnumFlag(name, value string, allowed []string) error {
+	if value == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return asUsageError(fmt.Errorf(
+		"invalid --%s %q; must be one of: %s", name, value, strings.Join(allowed, ", ")))
+}
+
 // newAppListCmd is `civitai app list` — discover published Apps in the store.
 //
 // This is FILTER-based discovery (kind/category/sort + keyset cursor), NOT
@@ -49,7 +83,7 @@ see apps if your account is a moderator or app-dev-tester; a normal login may ge
 an empty list. This command is useless until the backing API is deployed.`,
 		Example: `  civitai app list
   civitai app list --kind onsite --sort popular --limit 10
-  civitai app list --category productivity --json
+  civitai app list --category generation --json
   civitai app list --cursor '<next-cursor-from-a-previous-page>'`,
 		Args: cobra.NoArgs,
 		PreRunE: func(c *cobra.Command, args []string) error {
@@ -58,6 +92,14 @@ an empty list. This command is useless until the backing API is deployed.`,
 			if f := c.Flags().Lookup("limit"); f != nil && f.Changed && limit < 1 {
 				return asUsageError(fmt.Errorf(
 					"--limit must be a positive integer (got %d); omit --limit to use the server default", limit))
+			}
+			// Fast, offline validation of the FIXED enums (--category is left to the
+			// server's 400 — its allowed set drifts as the backend adds categories).
+			if err := validateEnumFlag("kind", kind, appKinds); err != nil {
+				return err
+			}
+			if err := validateEnumFlag("sort", sort, appSorts); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -91,9 +133,9 @@ an empty list. This command is useless until the backing API is deployed.`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&kind, "kind", "", "filter by kind (all, onsite, offsite)")
-	cmd.Flags().StringVar(&category, "category", "", "filter by marketplace category")
-	cmd.Flags().StringVar(&sort, "sort", "", "sort order (top-rated, popular, newest, name)")
+	cmd.Flags().StringVar(&kind, "kind", "", "filter by kind ("+strings.Join(appKinds, ", ")+")")
+	cmd.Flags().StringVar(&category, "category", "", "filter by marketplace category ("+appCategoriesHint+")")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort order ("+strings.Join(appSorts, ", ")+")")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
 	cmd.Flags().IntVar(&limit, "limit", 0, fmt.Sprintf("results per page (1-%d)", appsLimitMax))
 	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
@@ -177,8 +219,8 @@ func appCardAuthor(c *civitai.AppCard) string {
 func printAppList(cmd *cobra.Command, items []civitai.AppCard) {
 	out := cmd.OutOrStdout()
 	if len(items) == 0 {
-		fmt.Fprintln(out, "No apps found — the store may not be publicly launched yet, or no app matches these filters.")
-		fmt.Fprintln(out, "If you are a moderator or app-dev-tester, make sure you are logged in (`civitai login`).")
+		fmt.Fprintln(out, "No apps visible for your account — until the store opens publicly you only see apps if your account is a moderator or app-dev-tester, or nothing matches your filters.")
+		fmt.Fprintln(out, "Make sure you are logged in (`civitai login`), or relax --kind / --category / --sort.")
 		return
 	}
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
@@ -212,7 +254,7 @@ func printAppDetail(cmd *cobra.Command, d *civitai.AppDetail) {
 	fmt.Fprintf(out, "  category: %s\n", dashIfEmpty(safeTerm(d.Category)))
 	fmt.Fprintf(out, "  rating:   %s (%d review(s))\n", appRating(d.Recommend), d.ReviewCount)
 	if d.ContentRating != "" {
-		fmt.Fprintf(out, "  rating:   content %s\n", safeTerm(d.ContentRating))
+		fmt.Fprintf(out, "  content:  %s\n", safeTerm(d.ContentRating))
 	}
 	fmt.Fprintf(out, "  author:   %s\n", author)
 

--- a/internal/cmd/apps_cmd_test.go
+++ b/internal/cmd/apps_cmd_test.go
@@ -108,8 +108,13 @@ func TestAppListEmptyHint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app list (empty): %v", err)
 	}
-	if !strings.Contains(out, "No apps found") {
+	// The empty-list hint explains the gating (mod/tester) + the filter angle,
+	// matching the wording in `app list --help`.
+	if !strings.Contains(out, "No apps visible for your account") {
 		t.Errorf("empty list should print a hint, got: %s", out)
+	}
+	if !strings.Contains(out, "moderator or app-dev-tester") {
+		t.Errorf("empty-list hint should explain the mod/tester gating, got: %s", out)
 	}
 }
 
@@ -170,6 +175,17 @@ func TestAppViewDetail(t *testing.T) {
 			t.Errorf("detail output missing %q:\n%s", want, out)
 		}
 	}
+	// Fix #3: the content rating is labeled `content:`, NOT a second `rating:`.
+	if !strings.Contains(out, "content:") {
+		t.Errorf("detail should label the content rating `content:`, got:\n%s", out)
+	}
+	if n := strings.Count(out, "rating:"); n != 1 {
+		t.Errorf("detail should print `rating:` exactly once (star rating), got %d:\n%s", n, out)
+	}
+	// The content-rating VALUE ("pg") must be on the `content:` line, not orphaned.
+	if !strings.Contains(out, "content:  pg") {
+		t.Errorf("content rating line malformed, got:\n%s", out)
+	}
 }
 
 // A 404 from the detail endpoint must render as a clean not-found message
@@ -202,6 +218,108 @@ func TestAppViewLoginGated(t *testing.T) {
 	}
 	if !errors.Is(err, civitai.ErrUnauthorized) {
 		t.Errorf("no-token error should classify as ErrUnauthorized, got: %v", err)
+	}
+}
+
+// Fix #4 (server-error surfacing): a bad --category round-trips to the server,
+// which returns a FLATTENED zod 400 ({"error":{"formErrors":...,"fieldErrors":
+// {"category":[...]}}}). The CLI must surface the field-specific message (naming
+// the bad field + constraint), NOT the bare generic "invalid request parameter".
+func TestAppListBadCategorySurfacesFieldError(t *testing.T) {
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"formErrors":[],"fieldErrors":{"category":["Invalid enum value. Expected 'generation' | 'games' | 'utility', received 'productivity'"]}}}`))
+	})
+	_, _, err := run(t, "app", "list", "--category", "productivity")
+	if err == nil {
+		t.Fatal("expected a 400 for an invalid --category")
+	}
+	if !errors.Is(err, civitai.ErrBadRequest) {
+		t.Errorf("400 should classify as ErrBadRequest, got %T: %v", err, err)
+	}
+	// The field name + constraint from the server body must be surfaced…
+	if !strings.Contains(err.Error(), "category") {
+		t.Errorf("error should name the bad field `category`, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid enum value") {
+		t.Errorf("error should carry the server's constraint message, got: %v", err)
+	}
+	// …instead of the bare generic string.
+	if strings.TrimSpace(err.Error()) == "invalid request parameter (400)" {
+		t.Errorf("bare generic 400 should have been replaced by the field detail, got: %v", err)
+	}
+}
+
+// Fix #4 (client-side fixed-enum validation): a bad --kind / --sort fails FAST
+// and LOCALLY with an allowed-values message, without any HTTP call.
+func TestAppListBadFixedEnumValidatedLocally(t *testing.T) {
+	for _, tc := range []struct {
+		flag, value string
+		allowed     string
+	}{
+		{"kind", "bogus", "onsite"},
+		{"sort", "nonsense", "top-rated"},
+	} {
+		called := false
+		setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			_, _ = w.Write([]byte(`{"items":[],"metadata":{}}`))
+		})
+		_, _, err := run(t, "app", "list", "--"+tc.flag, tc.value)
+		if err == nil {
+			t.Fatalf("--%s %s: expected a local validation error", tc.flag, tc.value)
+		}
+		if called {
+			t.Errorf("--%s %s: a bad fixed enum must NOT reach the network", tc.flag, tc.value)
+		}
+		if !errors.Is(err, ErrUsage) {
+			t.Errorf("--%s %s: bad enum should be a usage error, got: %v", tc.flag, tc.value, err)
+		}
+		if !strings.Contains(err.Error(), "must be one of") || !strings.Contains(err.Error(), tc.allowed) {
+			t.Errorf("--%s %s: error should list allowed values, got: %v", tc.flag, tc.value, err)
+		}
+	}
+}
+
+// Fix #1/#2 regression guards: the `app` group advertises BROWSING (not just
+// authoring), and the `list` help Example no longer uses the invalid
+// `--category productivity`.
+func TestAppHelpAdvertisesBrowsing(t *testing.T) {
+	out, _, err := run(t, "app", "--help")
+	if err != nil {
+		t.Fatalf("app --help: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "browse") {
+		t.Errorf("app help should advertise browsing, got:\n%s", out)
+	}
+}
+
+func TestRootHelpAdvertisesAppBrowsing(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help: %v", err)
+	}
+	if !strings.Contains(out, "civitai app list") {
+		t.Errorf("root help should surface `civitai app list`, got:\n%s", out)
+	}
+}
+
+func TestAppListHelpExampleUsesValidCategory(t *testing.T) {
+	out, _, err := run(t, "app", "list", "--help")
+	if err != nil {
+		t.Fatalf("app list --help: %v", err)
+	}
+	// The broken example (`--category productivity`, an invalid enum → 400) must
+	// be gone…
+	if strings.Contains(out, "--category productivity") {
+		t.Errorf("list help must not use the invalid `--category productivity`:\n%s", out)
+	}
+	// …replaced by a valid category, and the flag help must list the valid set.
+	if !strings.Contains(out, "--category generation") {
+		t.Errorf("list help example should use a valid category (generation):\n%s", out)
+	}
+	if !strings.Contains(out, "generation, games, utility") {
+		t.Errorf("--category flag help should list the valid categories:\n%s", out)
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -221,6 +221,10 @@ Exit codes:
   civitai images search --sort "Most Reactions" --period Week
   civitai download 128713 --layout comfyui --root ~/ComfyUI
 
+  # Browse the App store.
+  civitai app list
+  civitai app view <slug>
+
   # Build & ship an App.
   civitai login
   civitai app create my-first-app

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -212,6 +212,14 @@ func badRequestDetail(raw []byte) string {
 		if d := firstZodIssue(wrapped.Error); d != "" {
 			return snippet([]byte(d))
 		}
+		// error as a FLATTENED zod error: {"formErrors":[...],"fieldErrors":{"<field>":["<msg>"]}}
+		// (the shape zod's .flatten() emits — what the apps store endpoint returns
+		// for a bad --kind/--sort/--category enum). Surface the field-specific
+		// message so it names the bad field + constraint, staying in sync with the
+		// backend enum (no client-side allowlist to drift).
+		if d := flattenedZodDetail(wrapped.Error); d != "" {
+			return snippet([]byte(d))
+		}
 		// error as a plain string.
 		var s string
 		if json.Unmarshal(wrapped.Error, &s) == nil && s != "" {
@@ -243,6 +251,56 @@ func firstZodIssue(arr []byte) string {
 			return field + " — " + is.Message
 		}
 		return is.Message
+	}
+	return ""
+}
+
+// flattenedZodDetail renders a concise detail from a FLATTENED zod error body —
+// the shape `zod`'s `.flatten()` produces and the apps-store endpoint returns:
+//
+//	{"formErrors":["..."],"fieldErrors":{"sort":["Invalid enum value..."]}}
+//
+// It prefers the first field-specific message, rendered as `field — message`
+// (matching firstZodIssue's format), so the user sees WHICH flag was wrong and
+// WHY; it falls back to the first top-level formError. Returns "" when err is
+// not this shape or carries no message. fieldErrors is decoded into an ordered
+// slice (not a map) so the reported field is DETERMINISTIC — Go map iteration
+// order is random, and a stable message keeps the field-mapping tests meaningful.
+func flattenedZodDetail(errBody []byte) string {
+	var flat struct {
+		FormErrors  []string        `json:"formErrors"`
+		FieldErrors json.RawMessage `json:"fieldErrors"`
+	}
+	if json.Unmarshal(errBody, &flat) != nil {
+		return ""
+	}
+	// fieldErrors as an ordered list of {field, [messages]} pairs.
+	dec := json.NewDecoder(strings.NewReader(string(flat.FieldErrors)))
+	if _, err := dec.Token(); err == nil { // consume the opening '{'
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				break
+			}
+			field, _ := keyTok.(string)
+			var msgs []string
+			if err := dec.Decode(&msgs); err != nil {
+				break
+			}
+			for _, m := range msgs {
+				if strings.TrimSpace(m) != "" {
+					if field != "" {
+						return field + " — " + m
+					}
+					return m
+				}
+			}
+		}
+	}
+	for _, m := range flat.FormErrors {
+		if strings.TrimSpace(m) != "" {
+			return m
+		}
 	}
 	return ""
 }

--- a/pkg/civitai/read_test.go
+++ b/pkg/civitai/read_test.go
@@ -263,6 +263,47 @@ func TestReadError400Classification(t *testing.T) {
 	}
 }
 
+// TestReadError400FlattenedZod asserts the FLATTENED zod 400 shape (formErrors/
+// fieldErrors, what the apps-store endpoint returns for a bad enum) is surfaced
+// as `field — message`, not the bare generic string — so the user learns WHICH
+// field was wrong and WHY, staying in sync with the backend enum.
+func TestReadError400FlattenedZod(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"fieldErrors",
+			`{"error":{"formErrors":[],"fieldErrors":{"sort":["Invalid enum value. Expected 'top-rated' | 'popular', received 'best'"]}}}`,
+			`invalid request parameter (400): sort — Invalid enum value. Expected 'top-rated' | 'popular', received 'best'`,
+		},
+		{
+			// formErrors-only (no field path) falls back to the top-level message.
+			"formErrors",
+			`{"error":{"formErrors":["Unrecognized key(s) in object: 'foo'"],"fieldErrors":{}}}`,
+			`invalid request parameter (400): Unrecognized key(s) in object: 'foo'`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := readError(http.StatusBadRequest, []byte(tc.body))
+			if err == nil {
+				t.Fatal("expected an error for a 400")
+			}
+			if !errors.Is(err, ErrBadRequest) {
+				t.Errorf("400 should be tagged ErrBadRequest, got: %v", err)
+			}
+			if err.Error() != tc.want {
+				t.Errorf("flattened-zod 400 = %q, want %q", err.Error(), tc.want)
+			}
+			if strings.Contains(err.Error(), "fieldErrors") || strings.Contains(err.Error(), "formErrors") {
+				t.Errorf("raw flatten keys must not leak: %q", err.Error())
+			}
+		})
+	}
+}
+
 func TestCursorStringEmpty(t *testing.T) {
 	var m Metadata
 	if got := m.CursorString(); got != "" {


### PR DESCRIPTION
## Why

A **blind dogfood** of the new App-discovery commands (`civitai app list` / `app view`, added in #178) surfaced five UX papercuts. This PR fixes all five, with tests.

## The five papercuts & fixes

**1. (biggest) Top-level help hid app-browsing.** The `app` group's `Short` was authoring-only ("Author and ship Civitai Apps"), so a user who wanted to *browse* the store never learned `app list` / `app view` existed from `civitai --help`.
- `Short` → `Browse, author, and ship Civitai Apps`; the group `Long` now opens with the browse commands.
- Added a "Browse the App store" block to the **root** Examples (`root.go`) so `civitai --help` surfaces `civitai app list` / `civitai app view <slug>`.

**2. Broken help example.** `app list`'s Example used `--category productivity` — **not** a valid category, returns HTTP 400.
- Replaced with `--category generation` (a real category).
- The `--category` flag help now lists the valid set (`generation, games, utility, discovery, moderation, analytics, other`), mirroring the backend `MARKETPLACE_CATEGORIES` enum.

**3. `app view` printed `rating:` twice.** Both the star rating *and* the content rating were labeled `rating:` (`rating: - (0 review(s))` then `rating: content g`).
- The content-rating line is now labeled `content:` → `content:  g`.

**4. Enum flags 400'd with an unhelpful generic message.** A bad `--kind`/`--sort`/`--category` round-tripped to a bare `invalid request parameter (400)`.
- **Server-error surfacing (primary):** the store endpoint returns zod's **flattened** shape `{"error":{"formErrors":[...],"fieldErrors":{"<field>":["<msg>"]}}}`, which the SDK's `badRequestDetail` didn't parse. Added `flattenedZodDetail` so a 400 now surfaces the **field-specific message** (naming the bad field + constraint) — e.g. `invalid request parameter (400): category — Invalid enum value. Expected 'generation' | 'games', received 'productivity'`. This stays in sync with the backend enum (no client-side drift). fieldErrors is decoded in document order so the reported field is deterministic.
- **Client-side (secondary):** the **fixed** enums `--kind` (all/onsite/offsite) and `--sort` (top-rated/popular/newest/name) are validated locally for a fast, offline allowed-values error — no HTTP call. `--category` is **deliberately not** hardcoded client-side (its allowlist grows as the backend adds categories); it relies on the improved 400 handling above. `--limit`'s existing local validation is unchanged.

**5. Empty list gave a bare header.** For a non-mod user (the common case — the catalog is identity/flag-gated) `app list` printed only the table header, unexplained.
- Now prints a hint matching the `--help` gating wording: `No apps visible for your account — until the store opens publicly you only see apps if your account is a moderator or app-dev-tester, or nothing matches your filters.` + a login/relax-filters follow-up.

## Tests
- **#4** server-400 surfacing: httptest fake returning the flattened `fieldErrors` 400 → the command prints the field-specific message (cmd-level), plus an SDK unit test on `readError` for both `fieldErrors` and `formErrors`-only bodies.
- **#4** client-side: a bad `--kind`/`--sort` fails locally (asserts **no** HTTP call) with the allowed-values message.
- **#3** `view` output contains `content:` and prints `rating:` exactly once.
- **#5** empty `items` → the hint line is printed (incl. the mod/tester wording).
- **#1/#2** regression guards: `app`/root help advertise browsing; the `list` help Example does **not** contain `--category productivity` and does use a valid category + lists the enum.

## Verification
`go build ./... && go vet ./... && go test ./...` all green (16 packages ok); `gofmt -l pkg/civitai internal/cmd` clean. Built the binary and eyeballed `app --help`, `app list --help`, and `app view` (shows `content:  g`, not a second `rating:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
