### PR TITLE
feat(validate): catch a lockfile that disagrees with buildCommand before the platform build does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ func newWhoAmICmd() *cobra.Command {
 
 ## Intentional decisions that look wrong (read before "fixing")
 
-Items 1–2 are deliberate mirrors of `civitai/civitai` (item 3 is a deliberate
+Items 1–3 are deliberate mirrors of the platform (item 4 is a deliberate
 *non*-mirror). The durable fix for the mirroring is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
@@ -124,7 +124,19 @@ until that exists, vendoring is on purpose.
    hard-codes `vendoredSlotIDs` (4 entries) mirroring
    `civitai/civitai → src/shared/constants/slot-registry.ts`. Go can't import the
    TS registry; the set is small and historically stable, so vendoring is cheap.
-3. **The CLI does NOT vendor the server's token-scope bitmask — and shouldn't.**
+3. **The lockfile check in `internal/validate/lockfile.go` mirrors the PLATFORM
+   BUILD RECIPE, not `BlockManifestValidator`.** It is the one build-time rule
+   `validate` reproduces, because the platform build installs *strictly* from the
+   committed lockfile (no registry re-resolve fallback) and a mismatch surfaces
+   only as an opaque server-side "build failed". The recipe derives the package
+   manager from the **first word** of `buildCommand` and requires that manager's
+   lockfile; `npm`, `vite`, `npx` and an omitted `buildCommand` all take the npm
+   branch. Keep `packageManagerFor` in lockstep with the recipe if the recipe's
+   `case` arms ever change, and keep the remedy text mentioning `outputDir` — the
+   schema's `allOf` requires it whenever `buildCommand` is set, so a remedy that
+   omits it walks the author into a second failure. It fires only when
+   `package.json` exists; static blocks never install and must never be flagged.
+4. **The CLI does NOT vendor the server's token-scope bitmask — and shouldn't.**
    The `whoami` / `dev-token` "can spend Buzz" capability check decodes the JWT
    `scopes` (a **string array**) and looks for the `ai:write:budgeted` scope
    string (see `tokenCanSpend` in `internal/cmd/app_dev_token.go`). It does NOT

--- a/README.md
+++ b/README.md
@@ -549,6 +549,17 @@ project checks. A few checks are necessarily approximate locally (the slot
 registry is vendored; per-app origin-binding/scope checks the CLI can't see are
 not reproduced).
 
+It also mirrors one **build-time** rule, because the failure it prevents is
+otherwise an opaque server-side "build failed": your committed **lockfile must
+match the package manager the platform derives from `buildCommand`**. The
+platform build installs *strictly* from the lockfile — no registry re-resolve
+fallback — so `"buildCommand": "pnpm run build"` needs `pnpm-lock.yaml`,
+`"yarn run build"` needs `yarn.lock`, and `npm run …` / `vite build` /
+`npx vite build` / an omitted `buildCommand` all need `package-lock.json`. A
+mismatch or a missing lockfile is a hard `validate` error; an *extra* unused
+lockfile is a warning. Apps with no `package.json` are static — the platform
+never installs for them and they are never flagged.
+
 The **durable fix** is a server-side `civitai app validate` endpoint that calls
 the real `BlockManifestValidator` (the faithful contract), with this schema
 published as the syntactic half. See [`AGENTS.md`](AGENTS.md) for the full

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/civitai/cli/internal/validate"
 )
 
+// simulateInstall writes the lockfile a scaffolded npm project gets from its
+// first `npm install` (next step 1). `validate` requires it because the platform
+// build installs strictly from the committed lockfile; the scaffold cannot ship
+// one (a checked-in lockfile would be stale on arrival), so a test that asserts
+// the FULL `validate` passes has to stand in for the author's install.
+func simulateInstall(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err != nil {
+		return // static template: no install step, no lockfile
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write package-lock.json: %v", err)
+	}
+}
+
 // assertScaffoldValid asserts the scaffolded dir is non-empty and passes the
 // same self-validation the scaffold commands run.
 func assertScaffoldValid(t *testing.T, dir string) {
@@ -23,6 +38,7 @@ func assertScaffoldValid(t *testing.T, dir string) {
 	if _, err := os.Stat(filepath.Join(dir, "block.manifest.json")); err != nil {
 		t.Errorf("block.manifest.json missing: %v", err)
 	}
+	simulateInstall(t, dir)
 	res, err := validate.Dir(dir)
 	if err != nil {
 		t.Fatalf("validate.Dir: %v", err)

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -167,7 +167,13 @@ init and copy the upstream files in manually`)
 
 	// Sanity-check the scaffold we just produced is schema-valid. If it
 	// isn't, that's a bug in our own templates — fail loudly.
-	res, verr := validate.Dir(destDir)
+	//
+	// ManifestOnly, not Dir: the project-state checks describe the AUTHOR's
+	// working tree, not the template. A scaffold has no lockfile until the
+	// author's first `npm install` (next step 1), and reporting that as
+	// "internal error: scaffolded manifest failed validation" would be a lie.
+	// `civitai app validate` still flags it on the same directory.
+	res, verr := validate.ManifestOnly(destDir)
 	if verr != nil {
 		return verr
 	}
@@ -205,7 +211,7 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 		// otherwise walk a first-time author straight into the gated wall). The
 		// tunnel resolves the app server-side, so submit (which creates the pending
 		// app row) still precedes it.
-		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
+		fmt.Fprintf(out, "  1. cd %s && npm install    # writes package-lock.json — COMMIT it\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev:harness     # mock host, no Buzz — works today")
 		fmt.Fprintln(out, "  3. edit src/App.tsx and iterate")
 		fmt.Fprintln(out)
@@ -214,12 +220,25 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 		fmt.Fprintln(out, "     npm run dev:tunnel      # in another terminal: serve your app for the tunnel")
 		fmt.Fprintln(out, "     civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
 	case tmpl == scaffold.PageVite:
-		fmt.Fprintf(out, "  1. cd %s && npm install\n", destDir)
+		fmt.Fprintf(out, "  1. cd %s && npm install    # writes package-lock.json — COMMIT it\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev              # preview locally")
 		fmt.Fprintln(out, "  3. civitai app submit       # validate + submit for review")
 	default:
 		fmt.Fprintf(out, "  1. cd %s              # then open index.html or serve the directory\n", destDir)
 		fmt.Fprintln(out, "  2. civitai app submit       # validate + submit for review")
+	}
+
+	// The lockfile is load-bearing, and the failure it causes is remote and
+	// opaque: the platform build installs STRICTLY from the committed lockfile
+	// (no registry re-resolve fallback), so a scaffold that is never `npm
+	// install`ed — or one installed with pnpm/yarn while buildCommand still says
+	// npm — fails the build with nothing wrong locally. `civitai app validate`
+	// catches both, but say it here too, at the moment the choice is made.
+	if tmpl.NeedsInstall() {
+		fmt.Fprintln(out, "\n"+ui.Dim("  Commit the lockfile. The platform build installs strictly from it (`npm ci`) and"))
+		fmt.Fprintln(out, ui.Dim("  will not build without it. If you install with pnpm or yarn instead, set"))
+		fmt.Fprintln(out, ui.Dim("  \"buildCommand\" to that package manager (and the \"outputDir\" the schema requires"))
+		fmt.Fprintln(out, ui.Dim("  alongside it) and commit THAT lockfile — a mismatch fails the build."))
 	}
 }
 

--- a/internal/cmd/app_submit_lockfile_test.go
+++ b/internal/cmd/app_submit_lockfile_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `app submit` MUST run the STRICT validator (validate.Dir), not the weaker
+// validate.ManifestOnly the scaffold self-check uses. Submitting creates a real
+// pending-moderator-review request, so a silent downgrade there would let an app
+// the platform build cannot build reach a moderator — and the author, who cannot
+// read the server-side build log, would only see it fail later.
+//
+// These are BEHAVIOURAL, not symbol assertions: they drive `app submit` on a
+// project whose only defect is a project-state one (a pnpm lockfile under the
+// scaffold's `npm run build`), which ManifestOnly by construction does not
+// report. Swapping app_submit.go's validate.Dir for validate.ManifestOnly makes
+// both of them fail.
+
+// It must refuse, and must not do the packaging work.
+func TestAppSubmitRefusesLockfileMismatchAndDoesNotPackage(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "pnpm-lock.yaml")
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+
+	stdout, stderr, err := run(t, "app", "submit", dir, "--package-only", "--out", out)
+	if err == nil {
+		t.Fatalf("submit must refuse a lockfile the platform build cannot install from\nstdout:%s\nstderr:%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "validation failed") {
+		t.Errorf("stderr should report validation failure: %s", stderr)
+	}
+	// Specifically the project-state check — a generic manifest error would not
+	// prove submit still runs the strict validator.
+	if !strings.Contains(stderr, "pnpm-lock.yaml is committed") {
+		t.Errorf("submit must surface the lockfile ↔ buildCommand error: %s", stderr)
+	}
+	if _, serr := os.Stat(out); serr == nil {
+		t.Error("submit must not package a project it refused to validate")
+	}
+	if strings.Contains(stdout, "Packaged") {
+		t.Errorf("submit must not report packaging after refusing: %s", stdout)
+	}
+}
+
+// And with a token configured (the path that actually creates the review
+// request), it must refuse BEFORE anything reaches the server.
+func TestAppSubmitRefusesLockfileMismatchAndDoesNotUpload(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "pnpm-lock.yaml")
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-lock")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_SUBMIT_PATH", "/api/blocks/submit-version")
+
+	stdout, stderr, err := run(t, "app", "submit", dir, "--yes")
+	if err == nil {
+		t.Fatalf("submit must refuse before uploading\nstdout:%s\nstderr:%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "pnpm-lock.yaml is committed") {
+		t.Errorf("submit must surface the lockfile ↔ buildCommand error: %s", stderr)
+	}
+	if hits != 0 {
+		t.Errorf("submit sent %d request(s) to the server; a failed validation must never reach it", hits)
+	}
+}
+
+// The control: the SAME project with the matching lockfile submits fine. Without
+// this, a submit that refused everything would satisfy the tests above.
+func TestAppSubmitAcceptsMatchingLockfile(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "package-lock.json")
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+
+	if stdout, stderr, err := run(t, "app", "submit", dir, "--package-only", "--out", out); err != nil {
+		t.Fatalf("a matching lockfile must submit: %v\nstdout:%s\nstderr:%s", err, stdout, stderr)
+	}
+	if _, serr := os.Stat(out); serr != nil {
+		t.Errorf("bundle should have been written: %v", serr)
+	}
+}

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -35,6 +35,12 @@ plus the ported semantic rules and structural checks:
   - renderMode inline/hybrid is rejected (requires a verified tier the platform
     only assigns post-submit)
   - targets[].slotId must be a known registered slot
+  - the committed LOCKFILE matches the package manager the platform build
+    derives from buildCommand (its first word): pnpm -> pnpm-lock.yaml,
+    yarn -> yarn.lock, and npm/vite/npx/unset -> package-lock.json. The
+    platform installs strictly from the lockfile, so a mismatch or a missing
+    lockfile is a guaranteed build failure. Only applies when package.json
+    exists — a static app never installs.
 
 It also emits non-fatal WARNINGS for money-path footguns the schema can't catch
 as hard errors (e.g. a budgeted page with no page.buzzBudgetPerGen). Warnings do

--- a/internal/cmd/app_validate_lockfile_test.go
+++ b/internal/cmd/app_validate_lockfile_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeLockProject writes a package.json + the given lockfiles alongside a
+// page-vite scaffold (which declares `"buildCommand": "npm run build"`).
+func scaffoldWithLockfiles(t *testing.T, lockfiles ...string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	if _, _, err := run(t, "app", "init", "lock-block", "--template", "page-vite"); err != nil {
+		t.Fatalf("app init page-vite: %v", err)
+	}
+	dir := filepath.Join(tmp, "lock-block")
+	for _, name := range lockfiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// The headline case, end to end through the CLI: a pnpm lockfile under the
+// scaffold's `npm run build`. It must fail (non-zero exit), and the message must
+// name the committed lockfile, the install the platform will actually run, and
+// BOTH remedies — including the outputDir the schema couples to buildCommand.
+func TestAppValidateFailsOnPnpmLockWithNpmBuildCommand(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "pnpm-lock.yaml")
+
+	stdout, stderr, err := run(t, "app", "validate", dir)
+	if err == nil {
+		t.Fatalf("a mismatched lockfile must fail validate\nstdout:%s\nstderr:%s", stdout, stderr)
+	}
+	for _, want := range []string{
+		"pnpm-lock.yaml is committed",
+		`buildCommand is "npm run build"`,
+		"npm ci",
+		`"buildCommand": "pnpm run build"`,
+		`"outputDir"`,
+		"npm install",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("validate stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	// Diagnostics belong on stderr — stdout stays clean for piping.
+	if strings.Contains(stdout, "pnpm-lock.yaml") {
+		t.Errorf("validation errors must not go to stdout:\n%s", stdout)
+	}
+}
+
+// --json must stay machine-clean: the lockfile error rides the existing errors
+// array on stdout with nothing else, and the exit stays non-zero.
+func TestAppValidateJSONCarriesLockfileError(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "pnpm-lock.yaml")
+
+	stdout, _, err := run(t, "app", "validate", dir, "--json")
+	if err == nil {
+		t.Fatal("a mismatched lockfile must exit non-zero in --json mode")
+	}
+	var got validateJSON
+	if jerr := json.Unmarshal([]byte(stdout), &got); jerr != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", jerr, stdout)
+	}
+	if got.OK {
+		t.Error("ok must be false when the lockfile mismatches")
+	}
+	found := false
+	for _, e := range got.Errors {
+		if strings.Contains(e.Message, "pnpm-lock.yaml is committed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("--json errors should carry the lockfile message: %+v", got.Errors)
+	}
+}
+
+// A matching lockfile clears the check end to end.
+func TestAppValidatePassesWithMatchingLockfile(t *testing.T) {
+	dir := scaffoldWithLockfiles(t, "package-lock.json")
+	if stdout, stderr, err := run(t, "app", "validate", dir); err != nil {
+		t.Fatalf("a matching lockfile must validate: %v\nstdout:%s\nstderr:%s", err, stdout, stderr)
+	}
+}
+
+// A static block has no package.json, so the platform never installs — it must
+// validate clean with no lockfile at all.
+func TestAppValidateStaticScaffoldNeedsNoLockfile(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	if _, _, err := run(t, "app", "init", "static-block", "--template", "static"); err != nil {
+		t.Fatalf("app init static: %v", err)
+	}
+	if stdout, stderr, err := run(t, "app", "validate", filepath.Join(tmp, "static-block")); err != nil {
+		t.Fatalf("a static block must validate with no lockfile: %v\nstdout:%s\nstderr:%s", err, stdout, stderr)
+	}
+}
+
+// `civitai app create` must keep working on a machine that has not installed
+// anything: the scaffold self-check is about OUR templates, not the author's
+// install state. The next steps must nonetheless tell them to commit it.
+func TestAppCreateSucceedsWithoutLockfileAndSaysToCommitIt(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "fresh-block")
+	stdout, _, err := run(t, "app", "create", "fresh-block", dest, "--template", "page-vite")
+	if err != nil {
+		t.Fatalf("app create must not fail on a missing lockfile: %v\n%s", err, stdout)
+	}
+	if _, serr := os.Stat(filepath.Join(dest, "package-lock.json")); serr == nil {
+		t.Fatal("the scaffold must not fabricate a lockfile")
+	}
+	for _, want := range []string{"package-lock.json", "Commit the lockfile"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("create next steps should mention %q:\n%s", want, stdout)
+		}
+	}
+	// And that fresh directory does NOT pass the full validate — the platform
+	// build would hard-fail on it.
+	if _, stderr, verr := run(t, "app", "validate", dest); verr == nil {
+		t.Errorf("an uninstalled scaffold must fail validate:\n%s", stderr)
+	}
+}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -155,7 +155,10 @@ func TestAppInitPageMoneyTemplate(t *testing.T) {
 	if strings.Contains(out, "npm run dev\n") {
 		t.Errorf("page-money next steps should NOT suggest plain `npm run dev`: %s", out)
 	}
-	// And it must validate clean (the scaffold sets a budget so no warnings).
+	// And it must validate clean (the scaffold sets a budget so no warnings)
+	// once the author has installed — `validate` requires the committed lockfile
+	// the platform build installs strictly from.
+	simulateInstall(t, filepath.Join(tmp, "money-app"))
 	if _, _, err := run(t, "app", "validate", filepath.Join(tmp, "money-app")); err != nil {
 		t.Errorf("scaffolded page-money should validate: %v", err)
 	}

--- a/internal/scaffold/lockfile_guard_test.go
+++ b/internal/scaffold/lockfile_guard_test.go
@@ -1,0 +1,68 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lockfileNames are the three lockfiles the platform build recipe installs
+// strictly from. Ignoring any of them in a scaffolded .gitignore would produce
+// an app that cannot be built: the author installs, the lockfile is never
+// committed, and the build hard-fails on the missing file.
+var lockfileNames = []string{"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+
+// TestScaffoldGitignoreDoesNotIgnoreLockfiles guards the scaffold against
+// generating a born-unbuildable app. A `*.lock` / `package-lock.json` line
+// sneaking into a gitignore template is a silent, one-line regression whose only
+// symptom is an opaque server-side build failure weeks later.
+func TestScaffoldGitignoreDoesNotIgnoreLockfiles(t *testing.T) {
+	for _, tmpl := range AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "block")
+			if _, err := Render(tmpl, dir, Data{Slug: "lock-guard", Name: "Lock Guard"}); err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			raw, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+			if err != nil {
+				if os.IsNotExist(err) {
+					return // no .gitignore is fine — nothing can be ignored
+				}
+				t.Fatalf("read .gitignore: %v", err)
+			}
+			for _, line := range strings.Split(string(raw), "\n") {
+				pattern := strings.TrimSpace(line)
+				if pattern == "" || strings.HasPrefix(pattern, "#") || strings.HasPrefix(pattern, "!") {
+					continue
+				}
+				// Strip a leading "/" (anchored pattern) and a trailing "/"
+				// (directory-only) before matching the base name.
+				pattern = strings.TrimSuffix(strings.TrimPrefix(pattern, "/"), "/")
+				for _, lock := range lockfileNames {
+					if ok, _ := filepath.Match(pattern, lock); ok {
+						t.Errorf("%s/.gitignore line %q ignores %s — the platform build installs strictly from the committed lockfile and will hard-fail without it", tmpl, line, lock)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildTemplatesNeedInstall pins NeedsInstall to "the template scaffolds a
+// package.json", which is exactly the condition the platform build recipe keys
+// its install step off (`if [ -f package.json ]`). The scaffold's
+// commit-your-lockfile guidance is gated on it.
+func TestBuildTemplatesNeedInstall(t *testing.T) {
+	for _, tmpl := range AllTemplates() {
+		dir := filepath.Join(t.TempDir(), "block")
+		if _, err := Render(tmpl, dir, Data{Slug: "lock-guard", Name: "Lock Guard"}); err != nil {
+			t.Fatalf("render %s: %v", tmpl, err)
+		}
+		_, statErr := os.Stat(filepath.Join(dir, "package.json"))
+		hasPackageJSON := statErr == nil
+		if hasPackageJSON != tmpl.NeedsInstall() {
+			t.Errorf("%s: NeedsInstall()=%v but package.json present=%v", tmpl, tmpl.NeedsInstall(), hasPackageJSON)
+		}
+	}
+}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -36,6 +36,12 @@ func AllTemplates() []Template { return []Template{Static, PageVite, PageMoney} 
 // rather than a plain `dev` (which renders blank without a host).
 func (t Template) NeedsHarness() bool { return t == PageMoney }
 
+// NeedsInstall reports whether the template scaffolds a package.json — i.e.
+// whether the platform build will run an install step for it, and therefore
+// whether the author MUST commit a lockfile. Static blocks are served as-is and
+// never install.
+func (t Template) NeedsInstall() bool { return t != Static }
+
 // ParseTemplate validates a template name.
 func ParseTemplate(s string) (Template, error) {
 	switch Template(s) {

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -23,6 +23,15 @@ owns the build: it runs `npm ci` then the `buildCommand` from
 `block.manifest.json` (`npm run build`), serving the static output from
 `outputDir` (`dist/`). You do NOT commit `dist/` — the platform builds it.
 
+**Commit your lockfile.** The platform installs *strictly* from it — `npm ci`,
+with no registry re-resolve fallback — so builds are byte-reproducible. Without
+a committed `package-lock.json` the build hard-fails. If you prefer pnpm or
+yarn, set `"buildCommand"` to that package manager (plus the `"outputDir"` the
+manifest schema requires alongside it) and commit *that* lockfile instead:
+`"pnpm run build"` needs `pnpm-lock.yaml`, `"yarn run build"` needs `yarn.lock`.
+A lockfile that disagrees with `buildCommand` is the most common build failure
+there is — `civitai app validate` catches it before you submit.
+
 The money path uses the SDK hooks — never raw `window.parent.postMessage`:
 
 - `useBuzzWorkflow()` — `estimate` / `submit` / `poll` (the spend).

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -9,6 +9,15 @@ platform owns the build: it runs `npm ci` and then the `buildCommand` from
 `block.manifest.json` (`npm run build`), serving the static output from
 `outputDir` (`dist/`). You do NOT commit `dist/` — the platform builds it.
 
+**Commit your lockfile.** The platform installs *strictly* from it — `npm ci`,
+with no registry re-resolve fallback — so builds are byte-reproducible. Without
+a committed `package-lock.json` the build hard-fails. If you prefer pnpm or
+yarn, set `"buildCommand"` to that package manager (plus the `"outputDir"` the
+manifest schema requires alongside it) and commit *that* lockfile instead:
+`"pnpm run build"` needs `pnpm-lock.yaml`, `"yarn run build"` needs `yarn.lock`.
+A lockfile that disagrees with `buildCommand` is the most common build failure
+there is — `civitai app validate` catches it before you submit.
+
 ## Develop
 
 ```bash

--- a/internal/validate/lockfile.go
+++ b/internal/validate/lockfile.go
@@ -1,0 +1,221 @@
+package validate
+
+// lockfile.go implements the LOCKFILE ↔ buildCommand consistency check.
+//
+// WHY THIS EXISTS. The platform build recipe used to install with
+//
+//	npm ci --ignore-scripts || npm install --ignore-scripts
+//
+// That `||` fallback silently converted "no lockfile" / "lockfile out of sync"
+// into a FRESH REGISTRY RESOLVE, so a build stopped being reproducible with
+// nobody noticing, and then broke later — with zero code change — the moment an
+// unrelated upstream published a new version.
+//
+// The fallback is GONE. The recipe now installs strictly from the committed
+// lockfile, and a missing one is a hard build failure:
+//
+//	PM="${BUILD_CMD%% *}"            # the FIRST WORD of buildCommand
+//	pnpm) [ -f pnpm-lock.yaml ]   || exit 1 ; pnpm install --frozen-lockfile …
+//	yarn) [ -f yarn.lock ]        || exit 1 ; yarn  install --frozen-lockfile/--immutable …
+//	*)    [ -f package-lock.json ]|| exit 1 ; npm ci …
+//
+// The dominant real-world misconfiguration (it hit FIVE live first-party apps at
+// once) is a committed `pnpm-lock.yaml` next to `"buildCommand": "npm run build"`:
+// the recipe picks npm from the first word, looks for `package-lock.json`, does
+// not find it, and dies. Nothing about the project looks wrong locally — `pnpm
+// run build` works fine on the author's machine.
+//
+// So this check is a FATAL error, not an advisory: the platform build hard-fails
+// on it, and a green `validate` followed by a failed build is worse than no
+// check at all. It fires ONLY when `package.json` exists — a static block with no
+// `package.json` skips the recipe's install step entirely and must never be
+// flagged.
+//
+// SCOPE. This is a presence check, not a freshness check: verifying a lockfile is
+// actually IN SYNC with package.json requires running the package manager, which
+// `validate` deliberately does not do. `npm ci` / `--frozen-lockfile` still catch
+// a stale lockfile server-side (loudly, which is the point of removing the
+// fallback).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/civitai/cli/internal/manifest"
+)
+
+// legacyDefaultBuildCommand is what the platform build recipe falls back to when
+// the manifest omits buildCommand. Its first word (npm) is what selects the
+// required lockfile in that case.
+const legacyDefaultBuildCommand = "npm run build"
+
+// packageManager is one of the three package managers the platform build recipe
+// knows how to install with, plus the strings needed to explain a mismatch.
+type packageManager struct {
+	// name is the token the recipe matches on — the FIRST WORD of buildCommand.
+	name string
+	// lockfile is the file the recipe requires (and installs strictly from).
+	lockfile string
+	// installCmd is the strict install the recipe runs (flags trimmed to the
+	// part that matters to an author reading the message).
+	installCmd string
+	// refreshCmd is what the author runs LOCALLY to (re)generate the lockfile.
+	refreshCmd string
+	// buildCommand is the manifest buildCommand that selects this manager, used
+	// when suggesting "switch the manifest to match the lockfile you have".
+	buildCommand string
+}
+
+var (
+	pmNpm  = packageManager{"npm", "package-lock.json", "npm ci", "npm install", "npm run build"}
+	pmPnpm = packageManager{"pnpm", "pnpm-lock.yaml", "pnpm install --frozen-lockfile", "pnpm install", "pnpm run build"}
+	pmYarn = packageManager{"yarn", "yarn.lock", "yarn install --frozen-lockfile", "yarn install", "yarn run build"}
+)
+
+// packageManagers is the scan order for reporting which lockfiles are committed.
+// Fixed (npm, pnpm, yarn) so messages are deterministic.
+var packageManagers = []packageManager{pmNpm, pmPnpm, pmYarn}
+
+// packageManagerFor mirrors the recipe's `PM="${BUILD_CMD%% *}"` exactly: take
+// the FIRST WORD of buildCommand and match it against pnpm / yarn; EVERYTHING
+// else falls through to the npm branch. Given the server's buildCommand
+// allowlist (`(npm|pnpm|yarn) run <script>` | `vite build` | `npx vite build`)
+// that "everything else" is `npm`, `vite`, `npx`, and the empty string — the
+// omitted-buildCommand case, where the recipe uses the legacy `npm run build`
+// default. All four therefore require package-lock.json.
+func packageManagerFor(buildCommand string) packageManager {
+	first := buildCommand
+	if i := strings.IndexByte(first, ' '); i >= 0 {
+		first = first[:i]
+	}
+	switch first {
+	case pmPnpm.name:
+		return pmPnpm
+	case pmYarn.name:
+		return pmYarn
+	default:
+		return pmNpm
+	}
+}
+
+// lockfileChecks reports the lockfile ↔ buildCommand inconsistencies for the
+// project in dir. Hard errors are returned first, advisories second.
+func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []string) {
+	// A block with no package.json is STATIC: the recipe's `if [ -f package.json ]`
+	// guard is false, it never installs anything, and the bundle is served as-is.
+	// Never flag it.
+	if !fileExists(filepath.Join(dir, "package.json")) {
+		return nil, nil
+	}
+
+	build := strings.TrimSpace(m.BuildCommand)
+	// A buildCommand outside the allowlist is already a hard error from
+	// buildCoherence, and the server rejects it before any build runs. Deriving a
+	// package manager from it would only stack a second, more confusing message
+	// on top of the real one.
+	if build != "" && !buildCommandRe.MatchString(build) {
+		return nil, nil
+	}
+	want := packageManagerFor(build)
+
+	var committed, foreign []packageManager
+	haveWanted := false
+	for _, pm := range packageManagers {
+		if !fileExists(filepath.Join(dir, pm.lockfile)) {
+			continue
+		}
+		committed = append(committed, pm)
+		if pm.name == want.name {
+			haveWanted = true
+		} else {
+			foreign = append(foreign, pm)
+		}
+	}
+
+	if !haveWanted {
+		return []string{missingLockfileError(want, foreign, build)}, nil
+	}
+	// The required lockfile IS there, so the build installs strictly and
+	// reproducibly — any extra lockfile is unused by the platform. That is not
+	// build-breaking, so it belongs in the advisory tier, but it is worth saying:
+	// an unused lockfile drifts, and the next contributor who runs the other
+	// package manager lands right back in the mismatch above.
+	if len(foreign) > 0 {
+		warns = append(warns, extraLockfileWarning(want, committed, build))
+	}
+	return nil, warns
+}
+
+// pmClause explains, in prose, WHY a particular package manager was selected —
+// either the buildCommand says so, or the manifest omits it and the recipe falls
+// back to the legacy default.
+func pmClause(build string) string {
+	if build == "" {
+		return fmt.Sprintf("the manifest sets no buildCommand (the platform build then falls back to the legacy default %q)", legacyDefaultBuildCommand)
+	}
+	return fmt.Sprintf("buildCommand is %q", build)
+}
+
+// outputDirNote is appended to every remedy that tells an author to SET
+// buildCommand. The manifest schema couples the two with an `allOf`, so a
+// buildCommand without an outputDir fails validation — suggesting one without
+// the other just walks the author into a second failure.
+const outputDirNote = `plus the "outputDir" the manifest schema requires alongside buildCommand`
+
+func missingLockfileError(want packageManager, foreign []packageManager, build string) string {
+	switch len(foreign) {
+	case 0:
+		// No lockfile of any kind. Common right after `civitai app create`, before
+		// the first install — still fatal, because submitting it fails the build.
+		msg := fmt.Sprintf(
+			"package.json is present but no lockfile is committed — %s, so the platform build will run `%s`, which hard-fails without %s. Run `%s` and commit the %s it writes: the platform installs strictly from the committed lockfile so builds are reproducible.",
+			pmClause(build), want.installCmd, want.lockfile, want.refreshCmd, want.lockfile)
+		if build == "" {
+			msg += fmt.Sprintf(
+				" If this app uses pnpm or yarn instead, set \"buildCommand\" to it (e.g. %q) — %s — and commit that lockfile instead.",
+				pmPnpm.buildCommand, outputDirNote)
+		}
+		return msg
+	case 1:
+		// The dominant real shape: a lockfile for a DIFFERENT package manager.
+		have := foreign[0]
+		return fmt.Sprintf(
+			"%s is committed but %s, so the platform build will run `%s` and fail — it installs strictly from %s, which is not committed. Either set \"buildCommand\": %q (%s) to match the lockfile you already have, or run `%s` and commit the %s it writes.",
+			have.lockfile, pmClause(build), want.installCmd, want.lockfile,
+			have.buildCommand, outputDirNote, want.refreshCmd, want.lockfile)
+	default:
+		return fmt.Sprintf(
+			"%s are committed, but none of them is the %s the platform build needs — %s, so it will run `%s` and fail. Keep the lockfile for the package manager this app actually uses and set \"buildCommand\" to match it (e.g. %q, %s), deleting the others; or run `%s` and commit the %s it writes.",
+			joinLockfiles(foreign), want.lockfile, pmClause(build), want.installCmd,
+			foreign[0].buildCommand, outputDirNote, want.refreshCmd, want.lockfile)
+	}
+}
+
+func extraLockfileWarning(want packageManager, committed []packageManager, build string) string {
+	return fmt.Sprintf(
+		"more than one lockfile is committed (%s) — %s, so the platform build installs only from %s and ignores the rest. The unused lockfiles will silently drift out of sync; delete the ones for package managers this app does not use.",
+		joinLockfiles(committed), pmClause(build), want.lockfile)
+}
+
+// joinLockfiles renders "a", "a and b", or "a, b and c".
+func joinLockfiles(pms []packageManager) string {
+	names := make([]string, len(pms))
+	for i, pm := range pms {
+		names[i] = pm.lockfile
+	}
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/validate/lockfile.go
+++ b/internal/validate/lockfile.go
@@ -59,7 +59,8 @@ type packageManager struct {
 	// lockfile is the file the recipe requires (and installs strictly from).
 	lockfile string
 	// installCmd is the strict install the recipe runs (flags trimmed to the
-	// part that matters to an author reading the message).
+	// part that matters to an author reading the message). For yarn the recipe
+	// is VERSION-AWARE, so this names both forms rather than misstating one.
 	installCmd string
 	// refreshCmd is what the author runs LOCALLY to (re)generate the lockfile.
 	refreshCmd string
@@ -71,7 +72,11 @@ type packageManager struct {
 var (
 	pmNpm  = packageManager{"npm", "package-lock.json", "npm ci", "npm install", "npm run build"}
 	pmPnpm = packageManager{"pnpm", "pnpm-lock.yaml", "pnpm install --frozen-lockfile", "pnpm install", "pnpm run build"}
-	pmYarn = packageManager{"yarn", "yarn.lock", "yarn install --frozen-lockfile", "yarn install", "yarn run build"}
+	// The yarn branch of the recipe dispatches on `yarn --version`:
+	//   1.*) yarn install --frozen-lockfile --ignore-scripts
+	//   *)   YARN_ENABLE_SCRIPTS=false yarn install --immutable
+	// so the message names both instead of claiming --frozen-lockfile always.
+	pmYarn = packageManager{"yarn", "yarn.lock", "yarn install --frozen-lockfile (yarn 1) / --immutable (yarn 2+)", "yarn install", "yarn run build"}
 )
 
 // packageManagers is the scan order for reporting which lockfiles are committed.
@@ -106,7 +111,7 @@ func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []st
 	// A block with no package.json is STATIC: the recipe's `if [ -f package.json ]`
 	// guard is false, it never installs anything, and the bundle is served as-is.
 	// Never flag it.
-	if !fileExists(filepath.Join(dir, "package.json")) {
+	if !regularFileExists(filepath.Join(dir, "package.json")) {
 		return nil, nil
 	}
 
@@ -123,7 +128,7 @@ func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []st
 	var committed, foreign []packageManager
 	haveWanted := false
 	for _, pm := range packageManagers {
-		if !fileExists(filepath.Join(dir, pm.lockfile)) {
+		if !regularFileExists(filepath.Join(dir, pm.lockfile)) {
 			continue
 		}
 		committed = append(committed, pm)
@@ -164,14 +169,27 @@ func pmClause(build string) string {
 // the other just walks the author into a second failure.
 const outputDirNote = `plus the "outputDir" the manifest schema requires alongside buildCommand`
 
+// workspaceNote covers the monorepo/workspace shape, where the remedy above is
+// otherwise a dead end: run inside a pnpm/yarn workspace PACKAGE, `pnpm install`
+// writes the lockfile at the workspace ROOT, not beside the manifest — and
+// pkgzip.Build walks only the manifest directory, so a parent-level lockfile is
+// never bundled. This shape used to build under the old `|| npm install`
+// fallback, so these authors are hitting a real platform behaviour change and
+// need to know WHERE the lockfile has to live.
+func workspaceNote(want packageManager) string {
+	return fmt.Sprintf(
+		"The submitted bundle is rooted at the manifest directory, so the %s must sit beside %s — in a workspace package `%s` writes it at the workspace ROOT, which is never bundled; generate one here instead.",
+		want.lockfile, manifest.Filename, want.refreshCmd)
+}
+
 func missingLockfileError(want packageManager, foreign []packageManager, build string) string {
 	switch len(foreign) {
 	case 0:
 		// No lockfile of any kind. Common right after `civitai app create`, before
 		// the first install — still fatal, because submitting it fails the build.
 		msg := fmt.Sprintf(
-			"package.json is present but no lockfile is committed — %s, so the platform build will run `%s`, which hard-fails without %s. Run `%s` and commit the %s it writes: the platform installs strictly from the committed lockfile so builds are reproducible.",
-			pmClause(build), want.installCmd, want.lockfile, want.refreshCmd, want.lockfile)
+			"package.json is present but no lockfile is committed — %s, so the platform build will run `%s`, which hard-fails without %s. Run `%s` and commit the %s it writes: the platform installs strictly from the committed lockfile so builds are reproducible. %s",
+			pmClause(build), want.installCmd, want.lockfile, want.refreshCmd, want.lockfile, workspaceNote(want))
 		if build == "" {
 			msg += fmt.Sprintf(
 				" If this app uses pnpm or yarn instead, set \"buildCommand\" to it (e.g. %q) — %s — and commit that lockfile instead.",
@@ -215,7 +233,18 @@ func joinLockfiles(pms []packageManager) string {
 	}
 }
 
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+// regularFileExists reports whether path is a REGULAR file — deliberately using
+// os.Lstat (which does NOT follow symlinks) plus an IsRegular test, so this
+// mirrors the packager exactly.
+//
+// pkgzip.Build walks the project with filepath.WalkDir and skips every
+// non-regular entry (`if !d.Type().IsRegular() { return nil }`), i.e. symlinks,
+// sockets and devices are never bundled. os.Stat would FOLLOW a symlink, so a
+// symlinked `package-lock.json` would look present here while being dropped
+// from the submitted bundle — a green `validate` in front of exactly the opaque
+// server-side "no lockfile" build failure this check exists to prevent. The two
+// must agree; if pkgzip's rule changes, change this with it.
+func regularFileExists(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/validate/lockfile_test.go
+++ b/internal/validate/lockfile_test.go
@@ -1,0 +1,403 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// lockManifest is an otherwise-valid manifest with the given buildCommand
+// spliced in (plus the outputDir the schema requires alongside it). An empty
+// buildCommand omits BOTH fields — the legacy-default case.
+func lockManifest(buildCommand string) string {
+	build := ""
+	if buildCommand != "" {
+		build = `, "buildCommand": ` + strconv.Quote(buildCommand) + `, "outputDir": "dist"`
+	}
+	return `{
+		"blockId": "lock-block", "version": "0.1.0", "name": "Lock Block",
+		"contentRating": "g", "scopes": [],
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"}` + build + `
+	}`
+}
+
+// project writes a manifest plus the given extra files (name -> contents) into a
+// temp dir and validates it.
+func project(t *testing.T, manifestJSON string, files map[string]string) Result {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(manifestJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := Dir(dir)
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	return res
+}
+
+func lockErrors(res Result) []string {
+	var out []string
+	for _, e := range res.Errors {
+		if strings.Contains(e, "lockfile") || strings.Contains(e, "-lock.") {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func wantLockError(t *testing.T, res Result, substrs ...string) {
+	t.Helper()
+	errs := lockErrors(res)
+	if len(errs) != 1 {
+		t.Fatalf("want exactly 1 lockfile error, got %d: %v (all errors: %v)", len(errs), errs, res.Errors)
+	}
+	for _, s := range substrs {
+		if !strings.Contains(errs[0], s) {
+			t.Errorf("lockfile error missing %q:\n  %s", s, errs[0])
+		}
+	}
+}
+
+func wantNoLockError(t *testing.T, res Result) {
+	t.Helper()
+	if errs := lockErrors(res); len(errs) != 0 {
+		t.Fatalf("want no lockfile error, got: %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The check must NEVER fire on a static block.
+// ---------------------------------------------------------------------------
+
+func TestLockfileSkipsStaticApp(t *testing.T) {
+	// No package.json at all: the platform recipe's `if [ -f package.json ]`
+	// guard is false, so it never installs and never needs a lockfile.
+	res := project(t, lockManifest(""), nil)
+	if !res.OK() {
+		t.Fatalf("static app must validate clean, got: %v", res.Errors)
+	}
+	if res.HasWarnings() {
+		t.Fatalf("static app must be warning-free, got: %v", res.Warnings)
+	}
+}
+
+func TestLockfileSkipsStaticScaffold(t *testing.T) {
+	res, err := Dir(scaffoldRaw(t, scaffold.Static))
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("static scaffold must validate clean with no lockfile, got: %v", res.Errors)
+	}
+}
+
+// A static block that (oddly) ships a lockfile but no package.json is still
+// skipped — the recipe keys off package.json, not the lockfile.
+func TestLockfileSkipsStaticAppWithStrayLockfile(t *testing.T) {
+	res := project(t, lockManifest(""), map[string]string{"pnpm-lock.yaml": "lockfileVersion: '9.0'\n"})
+	if !res.OK() {
+		t.Fatalf("static app with a stray lockfile must validate clean, got: %v", res.Errors)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Matching lockfile -> pass, for every package manager and every legal
+// buildCommand shape the server allowlist permits.
+// ---------------------------------------------------------------------------
+
+func TestLockfileMatchingLockfilePasses(t *testing.T) {
+	cases := []struct {
+		name     string
+		build    string // "" = omitted (legacy `npm run build` default)
+		lockfile string
+	}{
+		{"npm run build + package-lock.json", "npm run build", "package-lock.json"},
+		{"pnpm run build + pnpm-lock.yaml", "pnpm run build", "pnpm-lock.yaml"},
+		{"yarn run build + yarn.lock", "yarn run build", "yarn.lock"},
+		{"vite build + package-lock.json", "vite build", "package-lock.json"},
+		{"npx vite build + package-lock.json", "npx vite build", "package-lock.json"},
+		{"buildCommand omitted + package-lock.json", "", "package-lock.json"},
+		// Non-"build" script names are allowlisted too (`run [a-zA-Z0-9:_-]+`).
+		{"pnpm run build:prod + pnpm-lock.yaml", "pnpm run build:prod", "pnpm-lock.yaml"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := project(t, lockManifest(tc.build), map[string]string{
+				"package.json": `{"name":"lock-block","private":true}`,
+				tc.lockfile:    "{}\n",
+			})
+			if !res.OK() {
+				t.Fatalf("should validate clean, got: %v", res.Errors)
+			}
+			if res.HasWarnings() {
+				t.Errorf("should be warning-free, got: %v", res.Warnings)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mismatched lockfile -> FATAL, with the specific remedy.
+// ---------------------------------------------------------------------------
+
+// The dominant real-world shape: a pnpm lockfile under an npm buildCommand.
+// Five live first-party apps had exactly this.
+func TestLockfilePnpmLockWithNpmBuildCommandIsFatal(t *testing.T) {
+	res := project(t, lockManifest("npm run build"), map[string]string{
+		"package.json":   `{"name":"lock-block","private":true}`,
+		"pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+	})
+	if res.OK() {
+		t.Fatal("a pnpm lockfile under `npm run build` must be a hard error")
+	}
+	wantLockError(t, res,
+		"pnpm-lock.yaml is committed",
+		`buildCommand is "npm run build"`,
+		"npm ci",
+		"package-lock.json, which is not committed",
+		`"buildCommand": "pnpm run build"`,
+		// Setting buildCommand requires outputDir (schema allOf) — a remedy that
+		// omits this sends the author into a second validation failure.
+		`"outputDir"`,
+		"npm install",
+	)
+}
+
+func TestLockfileMismatchIsFatalForEveryPairing(t *testing.T) {
+	cases := []struct {
+		name       string
+		build      string
+		lockfile   string
+		wantLock   string
+		wantRemedy string
+	}{
+		{"npm buildCommand + yarn.lock", "npm run build", "yarn.lock", "package-lock.json", `"buildCommand": "yarn run build"`},
+		{"pnpm buildCommand + package-lock.json", "pnpm run build", "package-lock.json", "pnpm-lock.yaml", `"buildCommand": "npm run build"`},
+		{"yarn buildCommand + pnpm-lock.yaml", "yarn run build", "pnpm-lock.yaml", "yarn.lock", `"buildCommand": "pnpm run build"`},
+		// `vite build` / `npx vite build` take the recipe's npm branch.
+		{"vite build + pnpm-lock.yaml", "vite build", "pnpm-lock.yaml", "package-lock.json", `"buildCommand": "pnpm run build"`},
+		{"npx vite build + yarn.lock", "npx vite build", "yarn.lock", "package-lock.json", `"buildCommand": "yarn run build"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := project(t, lockManifest(tc.build), map[string]string{
+				"package.json": `{"name":"lock-block","private":true}`,
+				tc.lockfile:    "{}\n",
+			})
+			if res.OK() {
+				t.Fatal("mismatched lockfile must be a hard error")
+			}
+			wantLockError(t, res, tc.lockfile+" is committed", tc.wantLock, tc.wantRemedy, `"outputDir"`)
+		})
+	}
+}
+
+// buildCommand OMITTED: the recipe falls back to the legacy `npm run build`, so a
+// pnpm lockfile still fails. The remedy here MUST name outputDir explicitly —
+// this is the case where the author has neither field yet.
+func TestLockfileOmittedBuildCommandWithPnpmLockIsFatal(t *testing.T) {
+	res := project(t, lockManifest(""), map[string]string{
+		"package.json":   `{"name":"lock-block","private":true}`,
+		"pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+	})
+	if res.OK() {
+		t.Fatal("omitted buildCommand + pnpm lockfile must be a hard error")
+	}
+	wantLockError(t, res,
+		"pnpm-lock.yaml is committed",
+		"the manifest sets no buildCommand",
+		"legacy default",
+		"npm ci",
+		`"buildCommand": "pnpm run build"`,
+		`"outputDir"`,
+	)
+}
+
+// ---------------------------------------------------------------------------
+// No lockfile at all -> FATAL (the recipe hard-errors before installing).
+// ---------------------------------------------------------------------------
+
+func TestLockfileMissingEntirelyIsFatal(t *testing.T) {
+	cases := []struct {
+		name       string
+		build      string
+		wantLock   string
+		wantStrict string
+	}{
+		{"npm run build", "npm run build", "package-lock.json", "npm ci"},
+		{"pnpm run build", "pnpm run build", "pnpm-lock.yaml", "pnpm install --frozen-lockfile"},
+		{"yarn run build", "yarn run build", "yarn.lock", "yarn install --frozen-lockfile"},
+		{"vite build", "vite build", "package-lock.json", "npm ci"},
+		{"npx vite build", "npx vite build", "package-lock.json", "npm ci"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := project(t, lockManifest(tc.build), map[string]string{
+				"package.json": `{"name":"lock-block","private":true}`,
+			})
+			if res.OK() {
+				t.Fatal("package.json with no lockfile must be a hard error")
+			}
+			wantLockError(t, res, "no lockfile is committed", tc.wantStrict, tc.wantLock)
+		})
+	}
+}
+
+// With buildCommand omitted AND no lockfile, the message also has to offer the
+// "I actually use pnpm/yarn" branch — and that branch must name outputDir.
+func TestLockfileMissingEntirelyWithOmittedBuildCommand(t *testing.T) {
+	res := project(t, lockManifest(""), map[string]string{
+		"package.json": `{"name":"lock-block","private":true}`,
+	})
+	if res.OK() {
+		t.Fatal("package.json with no lockfile must be a hard error")
+	}
+	wantLockError(t, res,
+		"no lockfile is committed",
+		"the manifest sets no buildCommand",
+		"npm install",
+		`"buildCommand"`,
+		`"outputDir"`,
+	)
+}
+
+// A freshly scaffolded npm project has no lockfile yet, so the full `validate`
+// reports it — that project genuinely cannot be built by the platform. The
+// scaffold self-check (ManifestOnly) must NOT.
+func TestLockfileFreshScaffoldFailsDirButNotManifestOnly(t *testing.T) {
+	for _, tmpl := range []scaffold.Template{scaffold.PageVite, scaffold.PageMoney} {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dir := scaffoldRaw(t, tmpl)
+			res, err := Dir(dir)
+			if err != nil {
+				t.Fatalf("Dir: %v", err)
+			}
+			if res.OK() {
+				t.Fatal("an uninstalled npm scaffold must fail validate (the platform build would hard-fail)")
+			}
+			wantLockError(t, res, "no lockfile is committed", "npm install", "package-lock.json")
+
+			mres, err := ManifestOnly(dir)
+			if err != nil {
+				t.Fatalf("ManifestOnly: %v", err)
+			}
+			if !mres.OK() {
+				t.Fatalf("ManifestOnly must ignore install state, got: %v", mres.Errors)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple lockfiles.
+// ---------------------------------------------------------------------------
+
+// The required lockfile IS present, so the build installs strictly and succeeds:
+// advisory, not fatal.
+func TestLockfileMultipleWithRequiredPresentIsWarning(t *testing.T) {
+	res := project(t, lockManifest("npm run build"), map[string]string{
+		"package.json":      `{"name":"lock-block","private":true}`,
+		"package-lock.json": "{}\n",
+		"pnpm-lock.yaml":    "lockfileVersion: '9.0'\n",
+	})
+	if !res.OK() {
+		t.Fatalf("extra lockfiles must not fail the build-critical tier, got: %v", res.Errors)
+	}
+	if !res.HasWarnings() {
+		t.Fatal("extra lockfiles should raise an advisory")
+	}
+	joined := strings.Join(res.Warnings, "\n")
+	for _, want := range []string{"more than one lockfile is committed", "package-lock.json and pnpm-lock.yaml", "installs only from package-lock.json"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warning missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+// Several lockfiles, none of them the required one: still fatal, and the message
+// lists what IS there.
+func TestLockfileMultipleWithRequiredAbsentIsFatal(t *testing.T) {
+	res := project(t, lockManifest("npm run build"), map[string]string{
+		"package.json":   `{"name":"lock-block","private":true}`,
+		"pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+		"yarn.lock":      "# yarn lockfile v1\n",
+	})
+	if res.OK() {
+		t.Fatal("no matching lockfile must be a hard error")
+	}
+	wantLockError(t, res,
+		"pnpm-lock.yaml and yarn.lock are committed",
+		"none of them is the package-lock.json",
+		"npm ci",
+		`"outputDir"`,
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Interaction with the existing buildCommand allowlist check.
+// ---------------------------------------------------------------------------
+
+// A buildCommand outside the server allowlist is already reported by
+// buildCoherence. Deriving a package manager from it would stack a second,
+// confusing message on top of the real one, so the lockfile check stands down.
+func TestLockfileSilentOnDisallowedBuildCommand(t *testing.T) {
+	res := project(t, lockManifest("make build"), map[string]string{
+		"package.json":   `{"name":"lock-block","private":true}`,
+		"pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+	})
+	if res.OK() {
+		t.Fatal("a disallowed buildCommand must still fail")
+	}
+	wantNoLockError(t, res)
+}
+
+// ---------------------------------------------------------------------------
+// Unit coverage of the recipe mirror itself.
+// ---------------------------------------------------------------------------
+
+// packageManagerFor must mirror `PM="${BUILD_CMD%% *}"` for every shape the
+// server's BUILD_COMMAND_RE admits, plus the omitted case.
+func TestPackageManagerForMirrorsRecipe(t *testing.T) {
+	cases := map[string]string{
+		"":                    "package-lock.json", // legacy default `npm run build`
+		"npm run build":       "package-lock.json",
+		"npm run build:prod":  "package-lock.json",
+		"pnpm run build":      "pnpm-lock.yaml",
+		"pnpm run build_prod": "pnpm-lock.yaml",
+		"yarn run build":      "yarn.lock",
+		"yarn run build-all":  "yarn.lock",
+		"vite build":          "package-lock.json",
+		"npx vite build":      "package-lock.json",
+	}
+	for build, wantLock := range cases {
+		if got := packageManagerFor(build).lockfile; got != wantLock {
+			t.Errorf("packageManagerFor(%q).lockfile = %q, want %q", build, got, wantLock)
+		}
+	}
+}
+
+// Every buildCommand the allowlist admits must map to a known package manager —
+// a new allowed shape that this check does not understand would silently pick
+// the npm branch, so keep the two in lockstep.
+func TestEveryAllowedBuildCommandIsCoveredByTheAllowlist(t *testing.T) {
+	for _, build := range []string{"npm run build", "pnpm run build", "yarn run build", "vite build", "npx vite build"} {
+		if !buildCommandRe.MatchString(build) {
+			t.Errorf("%q should match the buildCommand allowlist", build)
+		}
+	}
+	for _, build := range []string{"make build", "npm install && npm run build", "pnpm build", "yarn build"} {
+		if buildCommandRe.MatchString(build) {
+			t.Errorf("%q should NOT match the buildCommand allowlist", build)
+		}
+	}
+}

--- a/internal/validate/lockfile_test.go
+++ b/internal/validate/lockfile_test.go
@@ -229,16 +229,19 @@ func TestLockfileOmittedBuildCommandWithPnpmLockIsFatal(t *testing.T) {
 
 func TestLockfileMissingEntirelyIsFatal(t *testing.T) {
 	cases := []struct {
-		name       string
-		build      string
-		wantLock   string
-		wantStrict string
+		name  string
+		build string
+		// want is the set of substrings the message must carry: the lockfile the
+		// recipe requires plus the strict install it will actually run.
+		want []string
 	}{
-		{"npm run build", "npm run build", "package-lock.json", "npm ci"},
-		{"pnpm run build", "pnpm run build", "pnpm-lock.yaml", "pnpm install --frozen-lockfile"},
-		{"yarn run build", "yarn run build", "yarn.lock", "yarn install --frozen-lockfile"},
-		{"vite build", "vite build", "package-lock.json", "npm ci"},
-		{"npx vite build", "npx vite build", "package-lock.json", "npm ci"},
+		{"npm run build", "npm run build", []string{"package-lock.json", "npm ci"}},
+		{"pnpm run build", "pnpm run build", []string{"pnpm-lock.yaml", "pnpm install --frozen-lockfile"}},
+		// The recipe's yarn branch is VERSION-AWARE — the message must not claim
+		// --frozen-lockfile is what yarn 2+ runs.
+		{"yarn run build", "yarn run build", []string{"yarn.lock", "yarn install --frozen-lockfile", "--immutable"}},
+		{"vite build", "vite build", []string{"package-lock.json", "npm ci"}},
+		{"npx vite build", "npx vite build", []string{"package-lock.json", "npm ci"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -248,9 +251,28 @@ func TestLockfileMissingEntirelyIsFatal(t *testing.T) {
 			if res.OK() {
 				t.Fatal("package.json with no lockfile must be a hard error")
 			}
-			wantLockError(t, res, "no lockfile is committed", tc.wantStrict, tc.wantLock)
+			wantLockError(t, res, append([]string{"no lockfile is committed"}, tc.want...)...)
 		})
 	}
+}
+
+// The remedy ("run <pm> install and commit the lockfile") is a dead end in a
+// pnpm/yarn WORKSPACE package: that command writes the lockfile at the workspace
+// ROOT, and pkgzip.Build walks only the manifest directory, so the root copy is
+// never bundled. The message must say where the lockfile has to live.
+func TestLockfileMissingEntirelyNamesTheBundleRoot(t *testing.T) {
+	res := project(t, lockManifest("pnpm run build"), map[string]string{
+		"package.json": `{"name":"lock-block","private":true}`,
+	})
+	if res.OK() {
+		t.Fatal("package.json with no lockfile must be a hard error")
+	}
+	wantLockError(t, res,
+		"no lockfile is committed",
+		"rooted at the manifest directory",
+		"beside block.manifest.json",
+		"workspace ROOT",
+	)
 }
 
 // With buildCommand omitted AND no lockfile, the message also has to offer the
@@ -295,6 +317,75 @@ func TestLockfileFreshScaffoldFailsDirButNotManifestOnly(t *testing.T) {
 				t.Fatalf("ManifestOnly must ignore install state, got: %v", mres.Errors)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The check must agree with the PACKAGER about what counts as a file.
+// ---------------------------------------------------------------------------
+
+// A SYMLINKED lockfile is not bundled: pkgzip.Build skips every non-regular
+// entry, so `app submit` would upload a bundle with no lockfile and the platform
+// build would hard-fail — the exact opaque failure this check exists to prevent,
+// with a green `validate` in front of it. So the check must treat a symlink as
+// absent (os.Lstat + IsRegular), matching the packager.
+func TestLockfileSymlinkedLockfileIsNotAccepted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(lockManifest("npm run build")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"lock-block","private":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A REAL lockfile outside the project, symlinked in — the shape that used to
+	// pass because os.Stat follows symlinks.
+	outside := filepath.Join(t.TempDir(), "package-lock.json")
+	if err := os.WriteFile(outside, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "package-lock.json")
+	if err := os.Symlink(outside, link); err != nil {
+		// Symlink creation is not available everywhere (e.g. Windows without
+		// developer mode) — skip rather than fail CI on an unrelated platform.
+		t.Skipf("cannot create a symlink here: %v", err)
+	}
+	// Sanity: the symlink resolves, so an os.Stat-based check WOULD accept it.
+	if _, err := os.Stat(link); err != nil {
+		t.Fatalf("symlink should resolve: %v", err)
+	}
+
+	res, err := Dir(dir)
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if res.OK() {
+		t.Fatal("a symlinked lockfile is dropped from the bundle, so it must NOT pass validation")
+	}
+	wantLockError(t, res, "no lockfile is committed", "package-lock.json", "npm ci")
+}
+
+// The same rule applied to package.json keeps validate and the bundle in
+// agreement the other way: a symlinked package.json is not bundled either, so
+// the uploaded app really is static and the check correctly stands down.
+func TestLockfileSymlinkedPackageJSONIsTreatedAsStatic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(lockManifest("")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "package.json")
+	if err := os.WriteFile(outside, []byte(`{"name":"lock-block","private":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "package.json")); err != nil {
+		t.Skipf("cannot create a symlink here: %v", err)
+	}
+
+	res, err := Dir(dir)
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("a symlinked package.json is not bundled, so the app is static: %v", res.Errors)
 	}
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -73,8 +73,24 @@ func schema() (*jsonschema.Schema, error) {
 	return s, nil
 }
 
-// Dir validates the App project in dir.
-func Dir(dir string) (Result, error) {
+// Dir validates the App project in dir: the manifest checks PLUS the
+// project-state checks that depend on files the AUTHOR maintains (currently the
+// lockfile ↔ buildCommand consistency check — see lockfile.go).
+func Dir(dir string) (Result, error) { return validateDir(dir, true) }
+
+// ManifestOnly validates just the manifest of the project in dir, skipping the
+// project-state checks.
+//
+// `civitai app init` / `app create` use it to self-check the template they just
+// wrote. That self-check exists to catch a bug in OUR templates; a scaffold
+// legitimately has no lockfile yet (the author's first `npm install` writes it),
+// so failing there would turn an author-state issue into "internal error:
+// scaffolded manifest failed validation". `civitai app validate` on that same
+// directory still reports it — which is correct, because the app is not
+// submittable until the lockfile is committed.
+func ManifestOnly(dir string) (Result, error) { return validateDir(dir, false) }
+
+func validateDir(dir string, projectState bool) (Result, error) {
 	var res Result
 
 	// Structural: manifest must exist at the project root.
@@ -119,6 +135,17 @@ func Dir(dir string) (Result, error) {
 	// can express (the schema enforces "outputDir required when buildCommand
 	// set"; here we also check the directory is declared/exists sanely).
 	res.Errors = append(res.Errors, buildCoherence(dir, m)...)
+
+	// Project state: the committed lockfile must match the package manager the
+	// platform build derives from buildCommand. The build recipe installs
+	// STRICTLY from that lockfile (no registry re-resolve fallback), so a
+	// mismatch is a guaranteed build failure. Skipped for a freshly scaffolded
+	// project (see ManifestOnly) and, inside the check, for static blocks.
+	if projectState {
+		lockErrs, lockWarns := lockfileChecks(dir, m)
+		res.Errors = append(res.Errors, lockErrs...)
+		res.Warnings = append(res.Warnings, lockWarns...)
+	}
 
 	// Non-fatal advisories: real money-path footguns the schema can't catch as
 	// hard errors (see warnings.go). These never fail validation unless the

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -10,11 +10,28 @@ import (
 	"github.com/civitai/cli/internal/scaffold"
 )
 
-func scaffoldGood(t *testing.T, tmpl scaffold.Template) string {
+// scaffoldRaw renders a template exactly as `civitai app create` leaves it — no
+// lockfile, because the author's first `npm install` writes that.
+func scaffoldRaw(t *testing.T, tmpl scaffold.Template) string {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "block")
 	if _, err := scaffold.Render(tmpl, dir, scaffold.Data{Slug: "good-block", Name: "Good Block"}); err != nil {
 		t.Fatalf("scaffold: %v", err)
+	}
+	return dir
+}
+
+// scaffoldGood renders a template in the state an author would actually SUBMIT:
+// scaffolded, then installed so the lockfile the platform build installs
+// strictly from is committed.
+func scaffoldGood(t *testing.T, tmpl scaffold.Template) string {
+	t.Helper()
+	dir := scaffoldRaw(t, tmpl)
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err == nil {
+		// The npm templates declare `npm run build`; stand in for `npm install`.
+		if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write package-lock.json: %v", err)
+		}
 	}
 	return dir
 }


### PR DESCRIPTION
## Why

The App Blocks platform build recipe used to install with

```sh
npm ci --ignore-scripts || npm install --ignore-scripts
```

That `||` silently converted "lockfile missing or out of sync" into a **fresh
registry re-resolve**, so a build stopped being reproducible with nobody
noticing — and then broke later, with zero code change, the moment an unrelated
upstream published a new version.

**That fallback is now removed and deployed.** The recipe installs strictly from
the committed lockfile and hard-errors without it:

| `buildCommand` (first word) | strict install | required lockfile |
|---|---|---|
| `pnpm run …` | `pnpm install --frozen-lockfile` | `pnpm-lock.yaml` |
| `yarn run …` | version-aware frozen/immutable install | `yarn.lock` |
| `npm run …`, `vite build`, `npx vite build`, **unset** | `npm ci` | `package-lock.json` |

This misconfiguration is invisible locally (`pnpm run build` works fine on the
author's machine) and shows up remotely as an opaque "build failed". **Five live
first-party apps were in exactly this shape** — a committed `pnpm-lock.yaml`
alongside `"buildCommand": "npm run build"` — and all had to be remediated.

## What this adds

### 1. A lockfile ↔ `buildCommand` check in `civitai app validate`

`internal/validate/lockfile.go` mirrors the recipe's `PM="${BUILD_CMD%% *}"`
derivation exactly (the **first word** of `buildCommand`; `npm`, `vite`, `npx`
and an omitted `buildCommand` all take the npm branch, matching the recipe's
`*)` arm) and checks the lockfile that is actually committed.

**Severity is a hard error**, not the existing advisory tier — the platform build
hard-fails on it, so a green `validate` followed by a failed build would be worse
than no check at all. It rides the existing "validation failed" path, so the exit
code is unchanged (1), and `--json` stays machine-clean: the message lands in the
existing `errors` array on stdout, diagnostics stay on stderr.

Real output:

```
✗ 1 validation error(s) in ./demo:
  - pnpm-lock.yaml is committed but buildCommand is "npm run build", so the
    platform build will run `npm ci` and fail — it installs strictly from
    package-lock.json, which is not committed. Either set "buildCommand":
    "pnpm run build" (plus the "outputDir" the manifest schema requires
    alongside buildCommand) to match the lockfile you already have, or run
    `npm install` and commit the package-lock.json it writes.
```

Every remedy that suggests **setting** `buildCommand` also names `outputDir` —
the schema couples them with an `allOf`, so a remedy that omits it just walks the
author into a second validation failure.

### Decisions worth reviewing

- **No `package.json` ⇒ never flagged.** The recipe's `if [ -f package.json ]`
  guard is false for a static block: it never installs, so it needs no lockfile.
  A static app with a *stray* lockfile is also not flagged (the recipe keys off
  `package.json`, not the lockfile). Three tests pin this.
- **Multiple lockfiles, required one present ⇒ warning, not error.** The build
  installs strictly from the required lockfile and succeeds, so it is not
  build-breaking — but the unused lockfile drifts, and the next contributor who
  runs the other package manager lands straight in the error case. Advisory tier
  is the honest severity.
- **Multiple lockfiles, required one absent ⇒ error**, listing what *is* there.
- **A `buildCommand` outside the server allowlist ⇒ the check stands down.**
  `buildCoherence` already reports it; deriving a package manager from a rejected
  command would stack a second, more confusing message on the real one.
- **`app create` / `app init` self-check now uses `validate.ManifestOnly`.** That
  self-check exists to catch bugs in *our* templates, and a scaffold legitimately
  has no lockfile until the author's first `npm install` — reporting it as
  "internal error: scaffolded manifest failed validation" would be a lie.
  `civitai app validate` on that same fresh directory **does** still report it,
  which is correct: the app is not submittable until the lockfile is committed.
  This is a deliberate behaviour change and the reason two existing tests moved.
- **Presence, not freshness.** Verifying a lockfile is genuinely *in sync* with
  `package.json` means running the package manager, which `validate` does not do.
  `npm ci` / `--frozen-lockfile` still catch a stale lockfile server-side — now
  loudly, which is the whole point of removing the fallback.

### 2. Stop the scaffold generating this shape

- `app create` / `app init` next steps: step 1 now reads
  `npm install    # writes package-lock.json — COMMIT it`, followed by a short
  note that the platform installs strictly from the lockfile and that switching
  to pnpm/yarn means setting `buildCommand` (plus `outputDir`) and committing
  *that* lockfile.
- page-vite / page-money README templates gain a **"Commit your lockfile"**
  paragraph with the per-package-manager mapping.
- **`gitignore.tmpl` already does not ignore lockfiles** — verified, and now
  pinned by a regression test across all templates. A stray `package-lock.json`
  line there would generate born-unbuildable apps whose only symptom is an opaque
  build failure weeks later.

**Not done, on purpose: `civitai app create` does not run an install.** It would
fix the missing-lockfile case at the source, but it adds a network round-trip and
tens of seconds to a command that is currently offline and instant, it fails on a
flaky network / behind a proxy / in CI, it hard-codes a package-manager choice at
scaffold time, and it does not touch the *dominant* failure (the author installs
with pnpm afterwards and never updates `buildCommand` — an npm install at create
time would actually make that worse by leaving a stale `package-lock.json`
behind). The next-steps line plus a validate error that names the exact remedy
covers both shapes at zero cost. Happy to add it behind an opt-in
`--install` flag if maintainers disagree.

## Tests

New: `internal/validate/lockfile_test.go` (static-app skip ×3, matching lockfile
×7 covering every allowlisted `buildCommand` shape incl. `vite build` /
`npx vite build` / unset, mismatch ×6 covering every pairing, missing-entirely
×6, fresh-scaffold `Dir` fails but `ManifestOnly` passes ×2, multiple-lockfile
warning + error, disallowed-`buildCommand` stand-down, and a unit mirror of
`packageManagerFor` vs the recipe). `internal/cmd/app_validate_lockfile_test.go`
drives the same cases through the CLI incl. `--json` and stdout/stderr
separation. `internal/scaffold/lockfile_guard_test.go` guards `.gitignore`.

```
go build ./... && go vet ./... && gofmt -s -l .   # clean
go test ./...                                     # all packages ok
golangci-lint run ./...                           # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
