### PR TITLE
chore(schema): re-vendor the canonical manifest schema (adds optional `tagline`)

### DIFF
--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -166,6 +166,95 @@ func TestValidateAcceptsMissingCategory(t *testing.T) {
 	}
 }
 
+// --- store tagline (optional; enforced by the vendored schema's minLength /
+// maxLength, mirroring the server's BlockManifestValidator tagline check) ---
+//
+// NOTE on a deliberate, SAFE asymmetry: the server checks the TRIMMED length
+// while JSON Schema's maxLength counts the RAW string. So a 140-char tagline
+// padded with trailing spaces is rejected here but accepted server-side — the
+// CLI is the stricter side, which fails locally rather than surprising the
+// author at submit. The schema is a shape hint; the server validator wins.
+
+func TestValidateAcceptsTagline(t *testing.T) {
+	mustAccept(t, "tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "The fastest way to remix a model",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+func TestValidateAcceptsTaglineAtCap(t *testing.T) {
+	// Exactly 140 chars — the boundary must be inclusive.
+	mustAccept(t, "tagline at cap", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "`+strings.Repeat("a", 140)+`",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+func TestValidateRejectsOverLongTagline(t *testing.T) {
+	// One char over the 140 cap fails with a clear, field-keyed error.
+	mustReject(t, "over-long tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "`+strings.Repeat("a", 141)+`",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "tagline")
+}
+
+func TestValidateRejectsWhitespaceOnlyTagline(t *testing.T) {
+	// The server TRIMS before measuring, so a whitespace-only tagline is a blank
+	// one. The schema's `\S` pattern is what keeps this rejection in lockstep —
+	// without it the schema would be MORE permissive than the server, which is
+	// the divergence direction that actually hurts (green locally, rejected at
+	// submit).
+	mustReject(t, "whitespace-only tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "   ",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "tagline")
+}
+
+func TestValidateAcceptsPaddedTagline(t *testing.T) {
+	// Padding AROUND real content is fine — the server trims it off.
+	mustAccept(t, "padded tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "  A crisp one-liner  ",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+func TestValidateRejectsEmptyTagline(t *testing.T) {
+	// An empty tagline is not "no tagline" — omit the field instead.
+	mustReject(t, "empty tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": "",
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "tagline")
+}
+
+func TestValidateRejectsNonStringTagline(t *testing.T) {
+	mustReject(t, "non-string tagline", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": [], "tagline": 42,
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "tagline")
+}
+
+func TestValidateAcceptsMissingTagline(t *testing.T) {
+	// tagline is optional — a manifest omitting it validates (baseGood has none).
+	res := validateManifest(t, baseGood)
+	if !res.OK() {
+		t.Fatalf("manifest without tagline should validate, got: %v", res.Errors)
+	}
+}
+
 func TestValidateRejectsUnknownScopeJustificationKey(t *testing.T) {
 	// End-to-end through the semantic path: an otherwise-valid manifest that
 	// justifies a scope it does not declare must be rejected, matching the

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -28,6 +28,13 @@
       "description": "Human-readable display name. The server only requires a non-empty string (no length cap), so the CLI does not impose one either.",
       "minLength": 1
     },
+    "tagline": {
+      "type": "string",
+      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string — so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
+      "minLength": 1,
+      "maxLength": 140,
+      "pattern": "\\S"
+    },
     "type": {
       "type": "string",
       "description": "Free-form descriptor used by some examples (e.g. \"block\"). Not validated by the platform.",


### PR DESCRIPTION
Re-vendors the canonical App Block manifest schema, which gained an optional
`tagline` in civitai/civitai#3441 — a one-line store pitch shown under an app's
name on its `/apps` card and detail page. For an on-site app the manifest is the
only surface that sets it.

The vendored copy is the single source of truth for offline `civitai app
validate` (it is `go:embed`ed), so until it carries the field, `civitai app
validate` rejects a manifest the server accepts — the exact drift the
`check-canonical-schema.sh` guard exists to prevent.

## What's here

- `schema/app-block.manifest.schema.json` — re-vendored **byte-identical** to the
  live canonical. The only change is the added `tagline` property; verified with
  a full-file `sha256sum` against `public/schemas/app-block/v1.json` at the
  merged commit.
- 8 validator tests covering the boundary: accepted, accepted at exactly 140,
  rejected at 141, rejected when empty / whitespace-only / non-string, accepted
  when padded around real content, and accepted when omitted entirely.

No CLI logic changes — the schema is embedded and evaluated as-is.

## The one deliberate asymmetry

The server measures the **trimmed** length; JSON Schema's `maxLength` counts the
**raw** string. So a 140-character tagline padded with trailing spaces is
rejected here and accepted server-side.

That divergence is one-directional on purpose: this schema is never *more*
permissive than the server, so local validation can't green-light something
`submit` would reject. The `\S` pattern is what holds that direction — without
it, `"   "` would satisfy `minLength: 1` locally and then fail at submit. Both
cases are pinned by tests.

## Verification

Run against the branch, with Go 1.25:

- `go build ./...`, `go vet ./...`, `gofmt` — clean
- `go test ./...` — 16 packages, 0 failures; the 8 new `Tagline` tests pass
- `golangci-lint run ./...` — 0 issues
- `./scripts/check-canonical-schema.sh` — the normalized diff shows the vendored
  copy differs from the live canonical by the `tagline` block and nothing else

That last check is the merge gate, and it stays red until the release train
carries #3441 to production. It goes green on its own the moment the canonical
serves `tagline` — no rebase or edit needed. Please confirm it's green before
merging.
