### PR TITLE
feat(validate): mirror live sensitive-scope-justification enforcement + re-vendor schema

### DIFF
--- a/examples/buzz-generator.block.manifest.json
+++ b/examples/buzz-generator.block.manifest.json
@@ -5,6 +5,9 @@
   "name": "Buzz Generator",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": {
+    "ai:write:budgeted": "Runs image generations on the user's behalf, spending from the per-generation Buzz budget the page grants."
+  },
   "page": {
     "path": "/",
     "title": "Buzz Generator",

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -196,6 +196,13 @@ func (id *Identity) CanSpendBuzz() bool { return id.hasScope(ScopeAIServicesWrit
 // An unknown scope is treated as false.
 func (id *Identity) CanReadBuzz() bool { return id.hasScope(ScopeBuzzRead) }
 
+// CanSubmitApps reports whether the identity's token carries the App-Blocks
+// submit scope (bit 25) — the capability `civitai app submit` needs. It is a
+// SEPARATE opt-in bit that even a full personal key lacks by default (ScopeFull
+// excludes it), so surfacing it in whoami saves an author a submit-time 403.
+// An unknown scope is treated as false.
+func (id *Identity) CanSubmitApps() bool { return id.hasScope(ScopeAppBlocksSubmit) }
+
 // DecodeScopes returns the names of every set scope bit (low → high). A nil
 // (unknown) mask returns nil.
 func (id *Identity) DecodeScopes() []string {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -359,6 +360,43 @@ func TestWhoAmISuccess(t *testing.T) {
 	}
 }
 
+// TestWhoAmISubmitAppsCapability drives the "Submit Apps: yes/no" capability
+// line off the token-scope bitmask whoami already fetches. Bit 25
+// (ScopeAppBlocksSubmit = 1<<25 = 33554432) is the App-Blocks submit scope; a
+// token carrying it must report "yes", one lacking it "no".
+func TestWhoAmISubmitAppsCapability(t *testing.T) {
+	const submitBit = 1 << 25 // ScopeAppBlocksSubmit
+	cases := []struct {
+		name       string
+		tokenScope int
+		want       string
+	}{
+		{"has submit scope", submitBit | 1, "Submit Apps:              yes"},
+		{"lacks submit scope", 1, "Submit Apps:              no"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, `{"username":"bob","id":99,"tokenScope":%d}`, tc.tokenScope)
+			}))
+			defer srv.Close()
+
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			t.Setenv("CIVITAI_TOKEN", "tok-1")
+			t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+			out, _, err := run(t, "whoami")
+			if err != nil {
+				t.Fatalf("whoami: %v", err)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("whoami output should contain %q, got:\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
 func TestLoginStoresToken(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
@@ -486,6 +524,7 @@ func writeBudgetedNoBudgetManifest(t *testing.T, dir string) {
   "name": "No Budget",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": { "ai:write:budgeted": "spends the page's per-gen Buzz budget to run generations" },
   "page": { "path": "/", "title": "No Budget" },
   "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
   "contentRating": "g",

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -55,6 +55,7 @@ Reads the token from config or CIVITAI_TOKEN.`,
 					"scopesKnown":    id.ScopeKnown(),
 					"canReadBalance": id.CanReadBuzz(),
 					"canSpend":       id.CanSpendBuzz(),
+					"canSubmitApps":  id.CanSubmitApps(),
 					"scopes":         id.DecodeScopes(),
 					// Back-compat: the nested capabilities object earlier releases emit.
 					"capabilities": map[string]bool{
@@ -78,6 +79,7 @@ Reads the token from config or CIVITAI_TOKEN.`,
 			}
 			fmt.Fprintf(out, "  Read Buzz balance:        %s\n", yesNo(id.CanReadBuzz()))
 			fmt.Fprintf(out, "  Spend Buzz (AI Services): %s\n", yesNo(id.CanSpendBuzz()))
+			fmt.Fprintf(out, "  Submit Apps:              %s\n", yesNo(id.CanSubmitApps()))
 
 			if showScopes {
 				fmt.Fprintf(out, "\nScopes (%d): %s\n", len(id.DecodeScopes()), strings.Join(id.DecodeScopes(), ", "))

--- a/internal/scaffold/templates/page-money/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/page-money/block.manifest.json.tmpl
@@ -5,6 +5,9 @@
   "name": "{{ .Name }}",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": {
+    "ai:write:budgeted": "Runs image generations on the user's behalf, spending from the per-generation Buzz budget the page grants."
+  },
   "page": {
     "path": "/",
     "title": "{{ .Name }}",

--- a/internal/validate/semantic.go
+++ b/internal/validate/semantic.go
@@ -92,7 +92,85 @@ func semanticChecks(generic any) []string {
 	// express the keys⊆scopes cross-field rule.
 	errs = append(errs, scopeJustificationChecks(m)...)
 
+	// Every declared SENSITIVE scope MUST carry a non-empty justification — the
+	// server now REJECTS a manifest that declares one without it at submit
+	// (block-manifest-validator: unjustifiedSensitiveScopes). Mirror it as a
+	// hard error so `civitai app validate` fails locally with the SAME message
+	// instead of eating a server 400 after a full package+submit round-trip.
+	errs = append(errs, sensitiveScopeJustificationChecks(m)...)
+
 	return errs
+}
+
+// SENSITIVE_BLOCK_SCOPES mirrors the server's single-sourced sensitive set
+// (civitai → src/shared/constants/block-scope.constants.ts SENSITIVE_BLOCK_SCOPES):
+// the scopes that can spend/read the viewer's Buzz, read their PRIVATE data, or
+// write data other users see. A declared scope in this set MUST carry a
+// non-empty scopeJustifications entry or the server rejects the manifest at
+// submit — so this Go mirror fails the same manifests LOCALLY. Keep it byte-in-
+// step with the server set; the sensitiveScopeJustificationError message is
+// mirrored verbatim so CLI and server agree.
+var SENSITIVE_BLOCK_SCOPES = map[string]struct{}{
+	"ai:write:budgeted":         {},
+	"social:tip:self":           {},
+	"buzz:read:self":            {},
+	"collections:read:private":  {},
+	"apps:storage:shared:write": {},
+}
+
+// isSensitiveBlockScope reports whether scope is in SENSITIVE_BLOCK_SCOPES.
+// Scope names are canonical lowercase, so the match is exact (no case-folding),
+// mirroring the server's isSensitiveBlockScope.
+func isSensitiveBlockScope(scope string) bool {
+	_, ok := SENSITIVE_BLOCK_SCOPES[scope]
+	return ok
+}
+
+// unjustifiedSensitiveScopes returns the DECLARED sensitive scopes that lack a
+// non-empty (trimmed) scopeJustifications entry, deduped and in DECLARATION
+// order — mirroring the server helper of the same name so the CLI names the
+// same offenders in the same order as the 400 the server would return. A
+// justification "counts" only when its value is a string with non-whitespace
+// content; an empty/whitespace value, a non-string value, or a missing key all
+// leave the sensitive scope unjustified. A non-array `scopes` yields nil.
+func unjustifiedSensitiveScopes(generic map[string]any) []string {
+	arr, ok := generic["scopes"].([]any)
+	if !ok {
+		return nil
+	}
+	just, _ := generic["scopeJustifications"].(map[string]any)
+
+	var out []string
+	seen := make(map[string]struct{}, len(arr))
+	for _, e := range arr {
+		scope, ok := e.(string)
+		if !ok || !isSensitiveBlockScope(scope) {
+			continue
+		}
+		if _, dup := seen[scope]; dup {
+			continue
+		}
+		seen[scope] = struct{}{}
+		if s, ok := just[scope].(string); ok && strings.TrimSpace(s) != "" {
+			continue // justified
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+// sensitiveScopeJustificationChecks emits ONE hard error naming every declared
+// sensitive scope that lacks a non-empty justification, using the server's exact
+// message so the local failure is byte-identical to the submit-time 400.
+func sensitiveScopeJustificationChecks(generic map[string]any) []string {
+	unjustified := unjustifiedSensitiveScopes(generic)
+	if len(unjustified) == 0 {
+		return nil
+	}
+	return []string{
+		"sensitive scopes require a justification — add a non-empty scopeJustifications entry for: " +
+			strings.Join(unjustified, ", "),
+	}
 }
 
 // scopeJustificationChecks enforces that every key in scopeJustifications is a

--- a/internal/validate/semantic_test.go
+++ b/internal/validate/semantic_test.go
@@ -173,6 +173,135 @@ func TestScopeJustificationChecks(t *testing.T) {
 	}
 }
 
+// TestSensitiveScopeJustificationChecks mirrors the backend enforcement: a
+// declared SENSITIVE scope without a non-empty scopeJustifications entry is a
+// hard error naming every offender, byte-identical to the server's submit-time
+// 400 message. Compliant manifests (non-sensitive scopes, or sensitive-with-
+// justification) produce no error.
+func TestSensitiveScopeJustificationChecks(t *testing.T) {
+	const prefix = "sensitive scopes require a justification — add a non-empty scopeJustifications entry for: "
+	cases := []struct {
+		name    string
+		generic map[string]any
+		want    []string
+	}{
+		{
+			name: "sensitive scope, no justifications at all → hard error naming it",
+			generic: map[string]any{
+				"scopes": []any{"ai:write:budgeted"},
+			},
+			want: []string{prefix + "ai:write:budgeted"},
+		},
+		{
+			name: "sensitive scope, empty scopeJustifications map → hard error",
+			generic: map[string]any{
+				"scopes":              []any{"buzz:read:self"},
+				"scopeJustifications": map[string]any{},
+			},
+			want: []string{prefix + "buzz:read:self"},
+		},
+		{
+			name: "sensitive scope with a whitespace-only justification → still unjustified",
+			generic: map[string]any{
+				"scopes":              []any{"social:tip:self"},
+				"scopeJustifications": map[string]any{"social:tip:self": "   "},
+			},
+			want: []string{prefix + "social:tip:self"},
+		},
+		{
+			name: "sensitive scope with a non-string justification → still unjustified",
+			generic: map[string]any{
+				"scopes":              []any{"apps:storage:shared:write"},
+				"scopeJustifications": map[string]any{"apps:storage:shared:write": 123},
+			},
+			want: []string{prefix + "apps:storage:shared:write"},
+		},
+		{
+			name: "sensitive scope WITH a real justification → no error",
+			generic: map[string]any{
+				"scopes":              []any{"ai:write:budgeted"},
+				"scopeJustifications": map[string]any{"ai:write:budgeted": "needed to run generations for the user"},
+			},
+			want: nil,
+		},
+		{
+			name: "non-sensitive scope, no justification → no error",
+			generic: map[string]any{
+				"scopes": []any{"user:read:self", "apps:storage:shared:read"},
+			},
+			want: nil,
+		},
+		{
+			name: "multiple sensitive, some unjustified → lists all offenders in declaration order",
+			generic: map[string]any{
+				"scopes": []any{
+					"ai:write:budgeted", "user:read:self", "buzz:read:self",
+					"collections:read:private", "apps:storage:shared:write",
+				},
+				"scopeJustifications": map[string]any{
+					// buzz:read:self is justified; the other three are not.
+					"buzz:read:self": "read balance to show the user their spend",
+				},
+			},
+			want: []string{prefix + "ai:write:budgeted, collections:read:private, apps:storage:shared:write"},
+		},
+		{
+			name: "duplicate sensitive scope, unjustified → named once",
+			generic: map[string]any{
+				"scopes": []any{"ai:write:budgeted", "ai:write:budgeted"},
+			},
+			want: []string{prefix + "ai:write:budgeted"},
+		},
+		{
+			name:    "no scopes at all → no error",
+			generic: map[string]any{},
+			want:    nil,
+		},
+		{
+			name: "non-array scopes → no error (schema-handled)",
+			generic: map[string]any{
+				"scopes": "not-an-array",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sensitiveScopeJustificationChecks(tc.generic)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d errors %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("error[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestIsSensitiveBlockScope pins the sensitive set to the server's 5 scopes.
+func TestIsSensitiveBlockScope(t *testing.T) {
+	sensitive := []string{
+		"ai:write:budgeted", "social:tip:self", "buzz:read:self",
+		"collections:read:private", "apps:storage:shared:write",
+	}
+	if len(SENSITIVE_BLOCK_SCOPES) != len(sensitive) {
+		t.Fatalf("SENSITIVE_BLOCK_SCOPES has %d entries, want %d", len(SENSITIVE_BLOCK_SCOPES), len(sensitive))
+	}
+	for _, s := range sensitive {
+		if !isSensitiveBlockScope(s) {
+			t.Errorf("isSensitiveBlockScope(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"user:read:self", "apps:storage:shared:read", "collections:read:self", "AI:WRITE:BUDGETED"} {
+		if isSensitiveBlockScope(s) {
+			t.Errorf("isSensitiveBlockScope(%q) = true, want false", s)
+		}
+	}
+}
+
 func TestSandboxChecksNonStringIgnored(t *testing.T) {
 	if errs := sandboxChecks(map[string]any{"sandbox": 123}); errs != nil {
 		t.Errorf("non-string sandbox is schema-handled, got %v", errs)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -135,6 +135,47 @@ func TestValidateRejectsBadScope(t *testing.T) {
 	}`, "scopes")
 }
 
+// --- current-scope enum + scopeJustifications shape (Part 1: re-vendored
+// schema). These scopes were MISSING from the pre-re-vendor stale schema, so
+// these manifests would have failed the old vendored enum. ---
+
+func TestValidateAcceptsCurrentStorageSharedReadScope(t *testing.T) {
+	// apps:storage:shared:read is a CURRENT, non-sensitive scope absent from the
+	// old stale enum. It must validate with no justification needed.
+	mustAccept(t, "apps:storage:shared:read", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": ["apps:storage:shared:read"],
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+func TestValidateAcceptsSensitiveScopeWithJustification(t *testing.T) {
+	// apps:storage:shared:write is a CURRENT, SENSITIVE scope. With a non-empty
+	// scopeJustifications entry the manifest validates end-to-end — exercising
+	// both the re-vendored enum AND the accepted scopeJustifications shape.
+	mustAccept(t, "sensitive scope + justification", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": ["apps:storage:shared:write"],
+		"scopeJustifications": {"apps:storage:shared:write": "persist the user's saved presets so they survive reloads"},
+		"page": {"path": "/", "title": "X"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`)
+}
+
+// TestValidateRejectsSensitiveScopeWithoutJustification is the Part 2 end-to-end
+// mirror of the live backend enforcement: a declared sensitive scope with no
+// justification is a HARD error (validate fails, non-zero exit) carrying the
+// server's exact message — no server round-trip needed.
+func TestValidateRejectsSensitiveScopeWithoutJustification(t *testing.T) {
+	mustReject(t, "sensitive scope, no justification", `{
+		"blockId": "ok-block", "version": "0.1.0", "name": "X",
+		"contentRating": "g", "scopes": ["ai:write:budgeted"],
+		"page": {"path": "/", "title": "X", "buzzBudgetPerGen": 100},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts allow-forms"}
+	}`, "sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted")
+}
+
 // --- marketplace category (optional; enforced by the vendored schema enum,
 // mirroring the server's BlockManifestValidator category check ~L312) ---
 

--- a/internal/validate/warnings_test.go
+++ b/internal/validate/warnings_test.go
@@ -24,6 +24,7 @@ func TestWarnBudgetedPageWithoutBudget(t *testing.T) {
   "name": "No Budget",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": { "ai:write:budgeted": "spends the page's per-gen Buzz budget to run generations" },
   "page": { "path": "/", "title": "No Budget" },
   "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
   "contentRating": "g",
@@ -48,6 +49,7 @@ func TestWarnBudgetedScopeWithoutPage(t *testing.T) {
   "name": "Money Static",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": { "ai:write:budgeted": "spends the page's per-gen Buzz budget to run generations" },
   "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
   "contentRating": "g"
 }`
@@ -93,6 +95,7 @@ func TestNoWarningsForBudgetedPageWithBudget(t *testing.T) {
   "name": "Good Money",
   "type": "block",
   "scopes": ["ai:write:budgeted"],
+  "scopeJustifications": { "ai:write:budgeted": "spends the page's per-gen Buzz budget to run generations" },
   "page": { "path": "/", "title": "Good Money", "buzzBudgetPerGen": 10 },
   "iframe": { "minHeight": 600, "resizable": true, "sandbox": "allow-scripts allow-forms" },
   "contentRating": "g",

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -92,7 +92,7 @@
     },
     "scopeJustifications": {
       "type": "object",
-      "description": "OPTIONAL per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. Backward-compatible — omit it and the manifest stays valid; `scopes` is unchanged. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. NOTE: this captures the developer's STATED rationale only; the platform does not verify the claims.",
+      "description": "Per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. REQUIRED for SENSITIVE scopes — any declared scope that can spend or read the viewer's Buzz, read the viewer's private data, or write data other users see (e.g. `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`) MUST carry a non-empty justification here, or the manifest is rejected at submit time. OPTIONAL for non-sensitive scopes — omit those and the manifest stays valid. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. The requirement is enforced imperatively by the manifest validator (not expressed as JSON-Schema conditionals here). NOTE: the justification captures the developer's STATED rationale only; the platform does not verify the truth of the claims.",
       "additionalProperties": {
         "type": "string",
         "minLength": 1,


### PR DESCRIPTION
## What

Mirror the now-LIVE backend **sensitive-scope-justification** enforcement in the CLI so App Block authors fail fast **locally** in `civitai app validate` (and thus `app submit`'s pre-submit validation) instead of eating a server **400** after a full package + submit round-trip.

Confirmed live before this change: submitting an `ai:write:budgeted` app with no justification returns

```
server returned 400: sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted
```

…but the CLI's local `app validate` said nothing. This closes that gap.

## Changes

**1. Local hard-error mirror** (`internal/validate/semantic.go`)
- `SENSITIVE_BLOCK_SCOPES` + `isSensitiveBlockScope` + `unjustifiedSensitiveScopes` — a byte-for-byte mirror of the server's single-sourced set (`src/shared/constants/block-scope.constants.ts`): `ai:write:budgeted`, `social:tip:self`, `buzz:read:self`, `collections:read:private`, `apps:storage:shared:write`.
- `semanticChecks` now emits **one hard ERROR** (fails validate, non-zero exit) naming every declared sensitive scope that lacks a non-empty (trimmed) `scopeJustifications` entry, in **declaration order**, using the server's **exact** message so the local failure is byte-identical to the submit-time 400.

**2. Re-vendor the drifted schema** (`schema/app-block.manifest.schema.json`)
- Re-vendored from the canonical `https://civitai.com/schemas/app-block/v1.json` via `scripts/revendor-canonical-schema.sh`. The only remaining drift was the `scopeJustifications` description, which now states the REQUIRED-for-sensitive rule. The `check-canonical-schema.sh` drift guard passes. (The enum + `scopeJustifications` property were already current from the prior re-vendor #182 — all 12 backend scopes present, retired scopes already gone.)

**3. Bring the CLI's own artifacts into compliance**
- The `page-money` scaffold template and the `buzz-generator` example manifest declare `ai:write:budgeted` and now carry a `scopeJustifications` entry — otherwise they would be rejected at submit (the enforcement applies to them too).

**4. whoami capability line** (bonus)
- Adds a **"Submit Apps: yes/no"** line (+ `canSubmitApps` in `--json`), derived from the token-scope bitmask `whoami` already fetches (App-Blocks submit bit 25) — no new endpoint or server change. Saves an author a submit-time 403.

## Tests

- Sensitive-scope hard-error: unit table (no-justification / empty-map / whitespace-only / non-string → error; justified / non-sensitive → pass; multiple offenders listed in declaration order; dedup) + end-to-end through `Dir` (reject) and accept-with-justification.
- Re-vendored schema: a current scope (`apps:storage:shared:read`, `apps:storage:shared:write`) + `scopeJustifications` shape validates (would have failed the stale enum).
- whoami "Submit Apps" line for a token with/without the submit bit.

`go build ./... && go vet ./... && go test ./...` all green (1236 passing); `gofmt -l` clean; schema-drift + Starter-pins guards pass.

Real binary before/after:

```
$ civitai app validate <sensitive, no justification>
✗ 1 validation error(s):
  - sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted
Error: validation failed        # exit 1

$ civitai app validate <sensitive, with justification>
✓ is valid                      # exit 0
```

Mirrors backend PRs civitai#3451 / civitai#3454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
