### PR TITLE
fix(whoami): report Submit Apps correctly for personal API keys

### DIFF
--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -196,12 +196,21 @@ func (id *Identity) CanSpendBuzz() bool { return id.hasScope(ScopeAIServicesWrit
 // An unknown scope is treated as false.
 func (id *Identity) CanReadBuzz() bool { return id.hasScope(ScopeBuzzRead) }
 
-// CanSubmitApps reports whether the identity's token carries the App-Blocks
-// submit scope (bit 25) — the capability `civitai app submit` needs. It is a
-// SEPARATE opt-in bit that even a full personal key lacks by default (ScopeFull
-// excludes it), so surfacing it in whoami saves an author a submit-time 403.
-// An unknown scope is treated as false.
-func (id *Identity) CanSubmitApps() bool { return id.hasScope(ScopeAppBlocksSubmit) }
+// CanSubmitApps reports whether the credential can clear `civitai app submit`'s
+// SCOPE gate. The backend scope-gates submit ONLY on OAuth tokens: an OAuth
+// device-login token must carry the opt-in AppBlocksSubmit bit (bit 25, excluded
+// from ScopeFull), whereas a personal API key is NOT scope-gated for submit at
+// all — submit-version runs the AppBlocksSubmit check only when
+// subject.type == "oauth", so any personal key clears it. (The remaining
+// author-cohort / not-banned gates are server-side and not visible here, so a
+// "yes" means the credential's SCOPE permits submit, not that the account is in
+// the author cohort.) An unknown/absent credential is treated as false.
+func (id *Identity) CanSubmitApps() bool {
+	if id.IsOAuth() {
+		return id.hasScope(ScopeAppBlocksSubmit)
+	}
+	return id.CredentialType() == "personal API key"
+}
 
 // DecodeScopes returns the names of every set scope bit (low → high). A nil
 // (unknown) mask returns nil.

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -361,23 +361,33 @@ func TestWhoAmISuccess(t *testing.T) {
 }
 
 // TestWhoAmISubmitAppsCapability drives the "Submit Apps: yes/no" capability
-// line off the token-scope bitmask whoami already fetches. Bit 25
-// (ScopeAppBlocksSubmit = 1<<25 = 33554432) is the App-Blocks submit scope; a
-// token carrying it must report "yes", one lacking it "no".
+// line. Mirrors submit-version.ts's gate: the ScopeAppBlocksSubmit (bit 25 =
+// 33554432) requirement applies ONLY to OAuth tokens; a personal API key is not
+// scope-gated for submit and always reports "yes". An unknown/absent credential
+// reports "no" (conservative).
 func TestWhoAmISubmitAppsCapability(t *testing.T) {
-	const submitBit = 1 << 25 // ScopeAppBlocksSubmit
+	const submitBit = 1 << 25       // ScopeAppBlocksSubmit
+	const scopeFull = submitBit - 1 // ScopeFull = bits 0..24 (excludes bit 25)
 	cases := []struct {
-		name       string
-		tokenScope int
-		want       string
+		name        string
+		subjectType string // "oauth", "apiKey", or "" for absent/unknown
+		tokenScope  int
+		want        string
 	}{
-		{"has submit scope", submitBit | 1, "Submit Apps:              yes"},
-		{"lacks submit scope", 1, "Submit Apps:              no"},
+		{"oauth with submit scope", "oauth", submitBit | 1, "Submit Apps:              yes"},
+		{"oauth without submit scope (even full scope)", "oauth", scopeFull, "Submit Apps:              no"},
+		{"personal key, full scope, no submit bit", "apiKey", scopeFull, "Submit Apps:              yes"},
+		{"personal key, minimal scope", "apiKey", 1, "Submit Apps:              yes"},
+		{"unknown credential (no subject)", "", 1, "Submit Apps:              no"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprintf(w, `{"username":"bob","id":99,"tokenScope":%d}`, tc.tokenScope)
+				if tc.subjectType == "" {
+					fmt.Fprintf(w, `{"username":"bob","id":99,"tokenScope":%d}`, tc.tokenScope)
+				} else {
+					fmt.Fprintf(w, `{"username":"bob","id":99,"tokenScope":%d,"subject":{"type":%q}}`, tc.tokenScope, tc.subjectType)
+				}
 			}))
 			defer srv.Close()
 


### PR DESCRIPTION
## What

`civitai whoami` reported **`Submit Apps: no`** for a personal API key that can actually submit — a live dogfood submitted an app successfully immediately after `whoami` said it couldn't. A false "no" actively discourages a capable author from submitting.

## Root cause

`Identity.CanSubmitApps()` checked only the OAuth-only `AppBlocksSubmit` scope bit (25). But the backend (`submit-version.ts`) runs that scope check **only when `subject.type === 'oauth'`** — a **personal API key is not scope-gated for submit at all**. A full-scope personal key excludes bit 25 by design (`ScopeFull = (1<<25)-1`), so it was wrongly reported as unable to submit.

## Fix

- **OAuth token** → still requires `AppBlocksSubmit` (bit 25).
- **Personal API key** → reports `yes` (not scope-gated for submit).
- **Unknown/absent credential** → `no` (conservative).

Mirrors the backend's `subject.type` gate exactly. The `yes` reflects the credential's **scope** capability; the author-cohort / not-banned gates are server-side and not visible to the CLI (same philosophy as the other `whoami` capability lines).

## Tests

Rewrote `TestWhoAmISubmitAppsCapability` with **subject-explicit** cases (the old cases were scope-bit-only with no `subject`, which no longer models the real gate): oauth+bit25→yes, oauth-without→no (even at full scope), personal-key-full→yes, personal-key-minimal→yes, unknown→no. Full suite green; build/vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)