### PR TITLE
feat(app): `app listing` commands to set store-listing media (icon/cover/screenshots) — #186

### DIFF
--- a/internal/appapi/imageinfo.go
+++ b/internal/appapi/imageinfo.go
@@ -1,0 +1,95 @@
+package appapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image"
+	_ "image/jpeg" // register JPEG DecodeConfig
+	_ "image/png"  // register PNG DecodeConfig
+)
+
+// ImageInfo is the minimal media metadata the full-resolution persist path
+// (`persistAssetImage`) needs: pixel dimensions + the wire MIME type.
+type ImageInfo struct {
+	Width    int
+	Height   int
+	MimeType string // "image/png" | "image/jpeg" | "image/webp"
+}
+
+// DecodeImageInfo reads width/height/MIME from an image HEADER without a full
+// decode. PNG/JPEG go through the stdlib `image.DecodeConfig`; WebP (which the
+// stdlib does not register) is parsed from its RIFF/VP8 container header. It
+// returns an error for an unrecognized, unsupported, or truncated image so the
+// caller can fail cleanly BEFORE any upload.
+//
+// Only png/jpeg/webp are accepted — the exact set the listing-asset attach
+// validation allows (`LISTING_ASSET_ALLOWED_MIME`).
+func DecodeImageInfo(data []byte) (ImageInfo, error) {
+	// WebP first: the stdlib doesn't register it, and its RIFF/WEBP container is
+	// unambiguous, so detect + parse it before falling through to DecodeConfig.
+	if len(data) >= 12 && bytes.Equal(data[0:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")) {
+		return decodeWebPInfo(data)
+	}
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return ImageInfo{}, fmt.Errorf("unrecognized image (want png, jpeg, or webp): %w", err)
+	}
+	switch format {
+	case "png":
+		return ImageInfo{Width: cfg.Width, Height: cfg.Height, MimeType: "image/png"}, nil
+	case "jpeg":
+		return ImageInfo{Width: cfg.Width, Height: cfg.Height, MimeType: "image/jpeg"}, nil
+	default:
+		return ImageInfo{}, fmt.Errorf("unsupported image format %q (want png, jpeg, or webp)", format)
+	}
+}
+
+// decodeWebPInfo parses canvas dimensions from a WebP RIFF header. It supports
+// the three sub-formats: VP8 (lossy simple), VP8L (lossless), and VP8X
+// (extended, which carries the canvas size directly). Bytes 0..11 are the RIFF
+// + WEBP magic (already checked by the caller); byte 12 begins the first chunk
+// FourCC, byte 16 its 4-byte size, byte 20 its payload.
+func decodeWebPInfo(data []byte) (ImageInfo, error) {
+	if len(data) < 16 {
+		return ImageInfo{}, fmt.Errorf("truncated webp header")
+	}
+	switch string(data[12:16]) {
+	case "VP8 ": // lossy simple
+		// payload@20: 3-byte frame tag, then key-frame start code 0x9d 0x01 0x2a,
+		// then 14-bit width + 14-bit height (each a 16-bit little-endian field).
+		if len(data) < 30 {
+			return ImageInfo{}, fmt.Errorf("truncated VP8 header")
+		}
+		if data[23] != 0x9d || data[24] != 0x01 || data[25] != 0x2a {
+			return ImageInfo{}, fmt.Errorf("bad VP8 key-frame start code")
+		}
+		w := int(binary.LittleEndian.Uint16(data[26:28]) & 0x3fff)
+		h := int(binary.LittleEndian.Uint16(data[28:30]) & 0x3fff)
+		return ImageInfo{Width: w, Height: h, MimeType: "image/webp"}, nil
+	case "VP8L": // lossless
+		// payload@20: 1 signature byte 0x2f, then 4 bytes packing
+		// (width-1):14, (height-1):14, ... little-endian.
+		if len(data) < 25 {
+			return ImageInfo{}, fmt.Errorf("truncated VP8L header")
+		}
+		if data[20] != 0x2f {
+			return ImageInfo{}, fmt.Errorf("bad VP8L signature")
+		}
+		b := binary.LittleEndian.Uint32(data[21:25])
+		w := int(b&0x3fff) + 1
+		h := int((b>>14)&0x3fff) + 1
+		return ImageInfo{Width: w, Height: h, MimeType: "image/webp"}, nil
+	case "VP8X": // extended
+		// payload@20: 1 byte flags, 3 bytes reserved, 3 bytes (width-1) LE,
+		// 3 bytes (height-1) LE.
+		if len(data) < 30 {
+			return ImageInfo{}, fmt.Errorf("truncated VP8X header")
+		}
+		w := int(uint32(data[24])|uint32(data[25])<<8|uint32(data[26])<<16) + 1
+		h := int(uint32(data[27])|uint32(data[28])<<8|uint32(data[29])<<16) + 1
+		return ImageInfo{Width: w, Height: h, MimeType: "image/webp"}, nil
+	default:
+		return ImageInfo{}, fmt.Errorf("unrecognized webp chunk %q", string(data[12:16]))
+	}
+}

--- a/internal/appapi/imageinfo_test.go
+++ b/internal/appapi/imageinfo_test.go
@@ -1,0 +1,109 @@
+package appapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+func pngBytes(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	img.Set(0, 0, color.RGBA{1, 2, 3, 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func jpegBytes(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatalf("jpeg encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// webpVP8X builds a minimal VP8X (extended) WebP header carrying canvas dims.
+func webpVP8X(w, h int) []byte {
+	b := make([]byte, 30)
+	copy(b[0:4], "RIFF")
+	copy(b[8:12], "WEBP")
+	copy(b[12:16], "VP8X")
+	// b[16:20] chunk size, b[20] flags, b[21:24] reserved
+	wm1 := uint32(w - 1)
+	hm1 := uint32(h - 1)
+	b[24], b[25], b[26] = byte(wm1), byte(wm1>>8), byte(wm1>>16)
+	b[27], b[28], b[29] = byte(hm1), byte(hm1>>8), byte(hm1>>16)
+	return b
+}
+
+// webpVP8L builds a minimal VP8L (lossless) WebP header.
+func webpVP8L(w, h int) []byte {
+	b := make([]byte, 25)
+	copy(b[0:4], "RIFF")
+	copy(b[8:12], "WEBP")
+	copy(b[12:16], "VP8L")
+	b[20] = 0x2f
+	packed := uint32(w-1) | uint32(h-1)<<14
+	binary.LittleEndian.PutUint32(b[21:25], packed)
+	return b
+}
+
+// webpVP8 builds a minimal VP8 (lossy) WebP header.
+func webpVP8(w, h int) []byte {
+	b := make([]byte, 30)
+	copy(b[0:4], "RIFF")
+	copy(b[8:12], "WEBP")
+	copy(b[12:16], "VP8 ")
+	b[23], b[24], b[25] = 0x9d, 0x01, 0x2a
+	binary.LittleEndian.PutUint16(b[26:28], uint16(w))
+	binary.LittleEndian.PutUint16(b[28:30], uint16(h))
+	return b
+}
+
+func TestDecodeImageInfo(t *testing.T) {
+	cases := []struct {
+		name     string
+		data     []byte
+		wantW    int
+		wantH    int
+		wantMime string
+	}{
+		{"png", pngBytes(t, 256, 256), 256, 256, "image/png"},
+		{"jpeg", jpegBytes(t, 640, 480), 640, 480, "image/jpeg"},
+		{"webp-vp8x", webpVP8X(1920, 1080), 1920, 1080, "image/webp"},
+		{"webp-vp8l", webpVP8L(300, 200), 300, 200, "image/webp"},
+		{"webp-vp8", webpVP8(128, 128), 128, 128, "image/webp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := DecodeImageInfo(tc.data)
+			if err != nil {
+				t.Fatalf("DecodeImageInfo: %v", err)
+			}
+			if info.Width != tc.wantW || info.Height != tc.wantH || info.MimeType != tc.wantMime {
+				t.Errorf("got %+v, want %dx%d %s", info, tc.wantW, tc.wantH, tc.wantMime)
+			}
+		})
+	}
+}
+
+func TestDecodeImageInfoRejectsNonImage(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("not an image at all"),
+		[]byte("GIF89a\x01\x00\x01\x00"), // gif is not in the allowed set
+		{},
+	} {
+		if _, err := DecodeImageInfo(data); err == nil {
+			t.Errorf("expected error for %q", data)
+		}
+	}
+}

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -1,0 +1,414 @@
+package appapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// App Store Listing MEDIA client (civitai/cli #186). These are AUTHED tRPC calls
+// against the `appListings.*` router — the CLI's SCOPED OAuth token reaches them
+// because civitai/civitai #3472 annotated each with
+// `requiredScope: AppBlocksSubmit` (a bit the `civitai login` token carries).
+//
+// Queries (GET) send `?input={"json":<input>}`; mutations (POST) send a JSON body
+// `{"json":<input>}`. The success envelope is `{result:{data:{json:<result>}}}`.
+// Mirrors the existing `blocks.*` plumbing in appblocks.go.
+
+const (
+	trpcGetMyListingForApp     = "/api/trpc/appListings.getMyListingForApp"
+	trpcGetMyListingForEdit    = "/api/trpc/appListings.getMyListingForEdit"
+	trpcGetAssetScanStatuses   = "/api/trpc/appListings.getAssetScanStatuses"
+	trpcIngestAssetFromDataURI = "/api/trpc/appListings.ingestAssetFromDataUri"
+	trpcPersistAssetImage      = "/api/trpc/appListings.persistAssetImage"
+	trpcSetIcon                = "/api/trpc/appListings.setIcon"
+	trpcSetCover               = "/api/trpc/appListings.setCover"
+	trpcAddScreenshot          = "/api/trpc/appListings.addScreenshot"
+	trpcRemoveScreenshot       = "/api/trpc/appListings.removeScreenshot"
+	trpcReorderScreenshots     = "/api/trpc/appListings.reorderScreenshots"
+	trpcBeginListingRevision   = "/api/trpc/appListings.beginListingRevision"
+	trpcSubmitListingRevision  = "/api/trpc/appListings.submitListingRevision"
+
+	// ImageUploadPath mints a presigned PUT URL for a full-resolution asset
+	// (cover / screenshot). Bearer-authed; returns {id, uploadURL}. The `id` (a
+	// uuid) is the key persistAssetImage stores.
+	ImageUploadPath = "/api/v1/image-upload"
+)
+
+// ListingRef is the result of getMyListingForApp — the entry read that resolves
+// an app's backing AppListing + its lifecycle status.
+type ListingRef struct {
+	AppListingID       string `json:"appListingId"`
+	Status             string `json:"status"` // draft|pending|approved|rejected|removed
+	ContentRating      string `json:"contentRating"`
+	HasPendingRevision bool   `json:"hasPendingRevision"`
+}
+
+// ListingAsset mirrors ListingEditAsset ({imageId, url}); a nil/zero imageId +
+// empty url means the slot is unset.
+type ListingAsset struct {
+	ImageID *int    `json:"imageId"`
+	URL     *string `json:"url"`
+}
+
+// Present reports whether the asset slot is populated.
+func (a ListingAsset) Present() bool { return a.ImageID != nil && *a.ImageID > 0 }
+
+// ListingScreenshot mirrors ListingEditScreenshot.
+type ListingScreenshot struct {
+	ID      string  `json:"id"`
+	ImageID *int    `json:"imageId"`
+	URL     *string `json:"url"`
+	Caption *string `json:"caption"`
+	Order   int     `json:"order"`
+}
+
+// ListingEditView mirrors getMyListingForEdit's result (the subset the CLI reads
+// to render `status` + the trailing floor line). For an APPROVED parent the
+// server resolves the media from the in-flight shadow revision (an idempotent
+// begin), so the assets reflect the pending revision, not the live listing.
+type ListingEditView struct {
+	ParentID           string  `json:"parentId"`
+	Slug               string  `json:"slug"`
+	Status             string  `json:"status"`
+	HasPendingRevision bool    `json:"hasPendingRevision"`
+	ShadowID           *string `json:"shadowId"`
+	Assets             struct {
+		Icon        ListingAsset        `json:"icon"`
+		Cover       ListingAsset        `json:"cover"`
+		Screenshots []ListingScreenshot `json:"screenshots"`
+	} `json:"assets"`
+}
+
+// AttachResult is the (loosely-parsed) union result of setIcon/setCover/
+// addScreenshot. `scanPending` means the image was stored while still scanning —
+// the CLI polls before attaching, so it should already be false.
+type AttachResult struct {
+	Status      string `json:"status"`
+	IconID      *int   `json:"iconId,omitempty"`
+	CoverID     *int   `json:"coverId,omitempty"`
+	ID          string `json:"id,omitempty"` // screenshot id
+	Order       *int   `json:"order,omitempty"`
+	ScanPending bool   `json:"scanPending,omitempty"`
+}
+
+// ScanStatus is a per-image scan state (getAssetScanStatuses).
+type ScanStatus struct {
+	ImageID int    `json:"imageId"`
+	Status  string `json:"status"` // "scanned" | "blocked" | "pending"
+}
+
+// SubmitRevisionResult mirrors submitListingRevision's result.
+type SubmitRevisionResult struct {
+	PublishRequestID string `json:"publishRequestId"`
+	ShadowID         string `json:"shadowId"`
+	Slug             string `json:"slug"`
+}
+
+// trpcQuery issues a tRPC GET query and decodes result.data.json into out.
+func (c *Client) trpcQuery(ctx context.Context, path string, input any, out any) error {
+	inputJSON, err := json.Marshal(map[string]any{"json": input})
+	if err != nil {
+		return err
+	}
+	q := url.Values{}
+	q.Set("input", string(inputJSON))
+	reqURL := c.BaseURL + path + "?" + q.Encode()
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return listingError(status, raw, path)
+	}
+	return decodeTRPCData(raw, out, path)
+}
+
+// trpcMutation issues a tRPC POST mutation and decodes result.data.json into out
+// (out may be nil to ignore the result).
+func (c *Client) trpcMutation(ctx context.Context, path string, input any, out any) error {
+	body, err := json.Marshal(map[string]any{"json": input})
+	if err != nil {
+		return err
+	}
+	build := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return listingError(status, raw, path)
+	}
+	if out == nil {
+		return nil
+	}
+	return decodeTRPCData(raw, out, path)
+}
+
+// decodeTRPCData pulls result.data.json out of a tRPC success envelope.
+func decodeTRPCData(raw []byte, out any, path string) error {
+	var env struct {
+		Result struct {
+			Data struct {
+				JSON json.RawMessage `json:"json"`
+			} `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || len(env.Result.Data.JSON) == 0 {
+		return fmt.Errorf("unexpected %s response: %s", trpcName(path), string(raw))
+	}
+	if err := json.Unmarshal(env.Result.Data.JSON, out); err != nil {
+		return fmt.Errorf("unexpected %s payload: %s", trpcName(path), string(raw))
+	}
+	return nil
+}
+
+// GetMyListingForApp resolves the caller's own listing (by its backing appBlockId)
+// to an AppListing id + lifecycle status. NOT_FOUND (404) means no listing row
+// exists for the app yet.
+func (c *Client) GetMyListingForApp(ctx context.Context, appBlockID string) (*ListingRef, error) {
+	var out ListingRef
+	if err := c.trpcQuery(ctx, trpcGetMyListingForApp, map[string]string{"appBlockId": appBlockID}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetMyListingForEdit reads the effective listing media (icon/cover/screenshots)
+// for the given AppListing id. 🔴 Side effect: for an APPROVED parent the server
+// idempotently opens a shadow revision and returns ITS assets.
+func (c *Client) GetMyListingForEdit(ctx context.Context, listingID string) (*ListingEditView, error) {
+	var out ListingEditView
+	if err := c.trpcQuery(ctx, trpcGetMyListingForEdit, map[string]string{"listingId": listingID}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetAssetScanStatuses polls the scan state of the given image ids.
+func (c *Client) GetAssetScanStatuses(ctx context.Context, imageIDs []int) ([]ScanStatus, error) {
+	var out struct {
+		Statuses []ScanStatus `json:"statuses"`
+	}
+	if err := c.trpcQuery(ctx, trpcGetAssetScanStatuses, map[string]any{"imageIds": imageIDs}, &out); err != nil {
+		return nil, err
+	}
+	return out.Statuses, nil
+}
+
+// IngestAssetFromDataURI ingests inline icon bytes as a `data:image/...;base64,…`
+// URI (the icon-only lean path) and returns the scannable Image id. The server
+// caps the decoded size at ~2 MiB and rasterizes to PNG. `kind` is fixed to
+// "icon" — the proc's schema only accepts icons on this path.
+func (c *Client) IngestAssetFromDataURI(ctx context.Context, data []byte, mimeType string) (int, error) {
+	dataURI := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
+	var out int
+	if err := c.trpcMutation(ctx, trpcIngestAssetFromDataURI, map[string]any{"dataUri": dataURI, "kind": "icon"}, &out); err != nil {
+		return 0, err
+	}
+	return out, nil
+}
+
+// MintImageUpload mints a presigned PUT URL for a full-resolution asset upload.
+func (c *Client) MintImageUpload(ctx context.Context) (id, uploadURL string, err error) {
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+ImageUploadPath, nil)
+	}
+	status, raw, err := c.authedDo(ctx, build)
+	if err != nil {
+		return "", "", err
+	}
+	if status != http.StatusOK {
+		return "", "", listingError(status, raw, ImageUploadPath)
+	}
+	var out struct {
+		ID        string `json:"id"`
+		UploadURL string `json:"uploadURL"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil || out.ID == "" || out.UploadURL == "" {
+		return "", "", fmt.Errorf("unexpected image-upload response: %s", string(raw))
+	}
+	return out.ID, out.UploadURL, nil
+}
+
+// putPresigned uploads bytes to a presigned PUT URL. The URL is signed for a bare
+// PUT (host only — Content-Type is NOT signed), so, mirroring the web client's
+// `xhr.open('PUT'); xhr.send(file)`, no Content-Type / Authorization header is
+// set (they would either be ignored or break the signature).
+func (c *Client) putPresigned(ctx context.Context, uploadURL string, data []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("uploading image bytes: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := c.readBody(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("image upload PUT failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	return nil
+}
+
+// IngestAssetFullRes mints an upload URL, PUTs the raw bytes, then persists the
+// Image row via persistAssetImage — the full-resolution path for cover /
+// screenshot (the data-URI path is icon-only). Returns the scannable Image id.
+func (c *Client) IngestAssetFullRes(ctx context.Context, data []byte, info ImageInfo) (int, error) {
+	id, uploadURL, err := c.MintImageUpload(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := c.putPresigned(ctx, uploadURL, data); err != nil {
+		return 0, err
+	}
+	var imageID int
+	in := map[string]any{
+		"url":       id,
+		"width":     info.Width,
+		"height":    info.Height,
+		"mimeType":  info.MimeType,
+		"sizeBytes": len(data),
+	}
+	if err := c.trpcMutation(ctx, trpcPersistAssetImage, in, &imageID); err != nil {
+		return 0, err
+	}
+	return imageID, nil
+}
+
+// SetIcon attaches an ingested (icon) image to the listing.
+func (c *Client) SetIcon(ctx context.Context, listingID string, imageID int) (*AttachResult, error) {
+	var out AttachResult
+	if err := c.trpcMutation(ctx, trpcSetIcon, map[string]any{"listingId": listingID, "imageId": imageID}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetCover attaches an ingested (cover) image to the listing.
+func (c *Client) SetCover(ctx context.Context, listingID string, imageID int) (*AttachResult, error) {
+	var out AttachResult
+	if err := c.trpcMutation(ctx, trpcSetCover, map[string]any{"listingId": listingID, "imageId": imageID}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AddScreenshot appends an ingested screenshot (with an optional caption).
+func (c *Client) AddScreenshot(ctx context.Context, listingID string, imageID int, caption string) (*AttachResult, error) {
+	in := map[string]any{"listingId": listingID, "imageId": imageID}
+	if caption != "" {
+		in["caption"] = caption
+	}
+	var out AttachResult
+	if err := c.trpcMutation(ctx, trpcAddScreenshot, in, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// RemoveScreenshot removes a screenshot by its id.
+func (c *Client) RemoveScreenshot(ctx context.Context, screenshotID string) error {
+	return c.trpcMutation(ctx, trpcRemoveScreenshot, map[string]any{"screenshotId": screenshotID}, nil)
+}
+
+// ReorderScreenshots writes the listing's screenshots into the given order
+// (orderedIds MUST be exactly the current set).
+func (c *Client) ReorderScreenshots(ctx context.Context, listingID string, orderedIDs []string) error {
+	return c.trpcMutation(ctx, trpcReorderScreenshots, map[string]any{"listingId": listingID, "orderedIds": orderedIDs}, nil)
+}
+
+// BeginListingRevision opens (or reuses) a shadow-draft revision of an approved
+// listing, returning the shadow id to attach media against.
+func (c *Client) BeginListingRevision(ctx context.Context, listingID string) (shadowID string, created bool, err error) {
+	var out struct {
+		ShadowID string `json:"shadowId"`
+		Created  bool   `json:"created"`
+	}
+	if err := c.trpcMutation(ctx, trpcBeginListingRevision, map[string]string{"listingId": listingID}, &out); err != nil {
+		return "", false, err
+	}
+	return out.ShadowID, out.Created, nil
+}
+
+// SubmitListingRevision submits a prepared shadow revision for moderator review.
+func (c *Client) SubmitListingRevision(ctx context.Context, shadowID, changelog string) (*SubmitRevisionResult, error) {
+	in := map[string]any{"shadowId": shadowID}
+	if changelog != "" {
+		in["changelog"] = changelog
+	}
+	var out SubmitRevisionResult
+	if err := c.trpcMutation(ctx, trpcSubmitListingRevision, in, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// trpcName renders a proc path as its bare proc name for error messages.
+func trpcName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// listingError maps a non-200 listing-media response to an actionable CLI error.
+// tRPC error bodies are {error:{json:{message,code}}}; the HTTP status carries
+// the mapped code (403 scope/cohort, 404 no listing, 400 attach/scan rejection).
+func listingError(status int, raw []byte, path string) (err error) {
+	defer func() { err = civitai.TagStatus(status, err) }()
+	var env struct {
+		Error struct {
+			JSON struct {
+				Message string `json:"message"`
+				Code    int    `json:"code"`
+			} `json:"json"`
+		} `json:"error"`
+	}
+	msg := serverMessage(raw)
+	if json.Unmarshal(raw, &env) == nil && env.Error.JSON.Message != "" {
+		msg = env.Error.JSON.Message
+	}
+	name := trpcName(path)
+	switch status {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("not logged in (401) — run `civitai login` (or set CIVITAI_TOKEN)")
+	case http.StatusForbidden:
+		if isInsufficientScopeMsg(msg) {
+			return fmt.Errorf("listing media needs the Apps submit scope (403): %s — re-run `civitai login` (an old token may predate the scope), or use a full-scope personal API key", msg)
+		}
+		return fmt.Errorf("not permitted for your account (403): %s — managing store listings needs Apps-author access (invite-only beta)", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("no store listing found for this app (404): %s — a listing is created when you submit the app; run `civitai app submit` first", msg)
+	case http.StatusBadRequest:
+		return fmt.Errorf("%s rejected the request (400): %s", name, msg)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limited, try again shortly (429): %s", msg)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("apps unavailable (503): %s", msg)
+	default:
+		return fmt.Errorf("%s failed (HTTP %d): %s", name, status, msg)
+	}
+}

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -219,11 +219,15 @@ func (c *Client) GetAssetScanStatuses(ctx context.Context, imageIDs []int) ([]Sc
 // "icon" — the proc's schema only accepts icons on this path.
 func (c *Client) IngestAssetFromDataURI(ctx context.Context, data []byte, mimeType string) (int, error) {
 	dataURI := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
-	var out int
+	// The proc returns `{ imageId: number }` (listing-meta.service.ts) — an OBJECT,
+	// not a bare number.
+	var out struct {
+		ImageID int `json:"imageId"`
+	}
 	if err := c.trpcMutation(ctx, trpcIngestAssetFromDataURI, map[string]any{"dataUri": dataURI, "kind": "icon"}, &out); err != nil {
 		return 0, err
 	}
-	return out, nil
+	return out.ImageID, nil
 }
 
 // MintImageUpload mints a presigned PUT URL for a full-resolution asset upload.
@@ -284,7 +288,6 @@ func (c *Client) IngestAssetFullRes(ctx context.Context, data []byte, info Image
 	if err := c.putPresigned(ctx, uploadURL, data); err != nil {
 		return 0, err
 	}
-	var imageID int
 	in := map[string]any{
 		"url":       id,
 		"width":     info.Width,
@@ -292,10 +295,15 @@ func (c *Client) IngestAssetFullRes(ctx context.Context, data []byte, info Image
 		"mimeType":  info.MimeType,
 		"sizeBytes": len(data),
 	}
-	if err := c.trpcMutation(ctx, trpcPersistAssetImage, in, &imageID); err != nil {
+	// persistListingAssetImage returns `{ imageId: number }` (offsite-listing.service.ts)
+	// — an OBJECT, not a bare number.
+	var out struct {
+		ImageID int `json:"imageId"`
+	}
+	if err := c.trpcMutation(ctx, trpcPersistAssetImage, in, &out); err != nil {
 		return 0, err
 	}
-	return imageID, nil
+	return out.ImageID, nil
 }
 
 // SetIcon attaches an ingested (icon) image to the listing.

--- a/internal/appapi/listing_test.go
+++ b/internal/appapi/listing_test.go
@@ -60,7 +60,10 @@ func TestIngestAssetFromDataURI(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &gotBody)
-		trpcOK(w, 4242)
+		// The backend returns { imageId: N } — an OBJECT, not a bare number. A
+		// bare-int fake here would mask the decode bug (both-wrong-blind), so
+		// encode the REAL shape; the corrected object→struct decode must handle it.
+		trpcOK(w, map[string]any{"imageId": 4242})
 	}))
 	defer srv.Close()
 
@@ -105,7 +108,9 @@ func TestIngestAssetFullRes(t *testing.T) {
 			persisted = true
 			raw, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(raw, &persistBody)
-			trpcOK(w, 777)
+			// Real shape { imageId: N } (not a bare number) so the struct decode is
+			// actually exercised.
+			trpcOK(w, map[string]any{"imageId": 777})
 		default:
 			t.Errorf("unexpected path %s", r.URL.Path)
 		}

--- a/internal/appapi/listing_test.go
+++ b/internal/appapi/listing_test.go
@@ -1,0 +1,250 @@
+package appapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// trpcOK writes a tRPC success envelope {result:{data:{json:<v>}}}.
+func trpcOK(w http.ResponseWriter, v any) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"result": map[string]any{"data": map[string]any{"json": v}},
+	})
+}
+
+// trpcErr writes a tRPC error envelope with the given HTTP status + message.
+func trpcErr(w http.ResponseWriter, status int, msg string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{"json": map[string]any{"message": msg, "code": -32600}},
+	})
+}
+
+func TestGetMyListingForApp(t *testing.T) {
+	var gotInput, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotInput = r.URL.Query().Get("input")
+		gotAuth = r.Header.Get("Authorization")
+		trpcOK(w, map[string]any{
+			"appListingId":       "listing_1",
+			"status":             "draft",
+			"contentRating":      "g",
+			"hasPendingRevision": false,
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	ref, err := c.GetMyListingForApp(context.Background(), "block_9")
+	if err != nil {
+		t.Fatalf("GetMyListingForApp: %v", err)
+	}
+	if gotAuth != "Bearer tok123" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if !strings.Contains(gotInput, `"appBlockId":"block_9"`) {
+		t.Errorf("input should carry appBlockId: %q", gotInput)
+	}
+	if ref.AppListingID != "listing_1" || ref.Status != "draft" {
+		t.Errorf("ref = %+v", ref)
+	}
+}
+
+func TestIngestAssetFromDataURI(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		trpcOK(w, 4242)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	id, err := c.IngestAssetFromDataURI(context.Background(), []byte("PNGBYTES"), "image/png")
+	if err != nil {
+		t.Fatalf("IngestAssetFromDataURI: %v", err)
+	}
+	if id != 4242 {
+		t.Errorf("imageId = %d, want 4242", id)
+	}
+	// The bytes travel under {"json":{"dataUri":"data:image/png;base64,...","kind":"icon"}}.
+	jsonField, _ := gotBody["json"].(map[string]any)
+	dataURI, _ := jsonField["dataUri"].(string)
+	if !strings.HasPrefix(dataURI, "data:image/png;base64,") {
+		t.Errorf("dataUri = %q", dataURI)
+	}
+	if jsonField["kind"] != "icon" {
+		t.Errorf("kind = %v, want icon", jsonField["kind"])
+	}
+}
+
+func TestIngestAssetFullRes(t *testing.T) {
+	var minted, put, persisted bool
+	var persistBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == ImageUploadPath:
+			minted = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "uuid-key", "uploadURL": "http://" + r.Host + "/put/uuid-key"})
+		case strings.HasPrefix(r.URL.Path, "/put/"):
+			put = true
+			if r.Method != http.MethodPut {
+				t.Errorf("presigned upload method = %s, want PUT", r.Method)
+			}
+			// The presigned PUT must NOT carry our bearer.
+			if r.Header.Get("Authorization") != "" {
+				t.Errorf("presigned PUT should not carry Authorization")
+			}
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "persistAssetImage"):
+			persisted = true
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &persistBody)
+			trpcOK(w, 777)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	info := ImageInfo{Width: 1280, Height: 720, MimeType: "image/jpeg"}
+	id, err := c.IngestAssetFullRes(context.Background(), []byte("JPEGBYTES"), info)
+	if err != nil {
+		t.Fatalf("IngestAssetFullRes: %v", err)
+	}
+	if !minted || !put || !persisted {
+		t.Fatalf("flow incomplete: minted=%v put=%v persisted=%v", minted, put, persisted)
+	}
+	if id != 777 {
+		t.Errorf("imageId = %d, want 777", id)
+	}
+	jsonField, _ := persistBody["json"].(map[string]any)
+	if jsonField["url"] != "uuid-key" {
+		t.Errorf("persist url = %v, want uuid-key", jsonField["url"])
+	}
+	if jsonField["width"].(float64) != 1280 || jsonField["mimeType"] != "image/jpeg" {
+		t.Errorf("persist body = %+v", jsonField)
+	}
+}
+
+func TestGetAssetScanStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trpcOK(w, map[string]any{"statuses": []map[string]any{
+			{"imageId": 5, "status": "scanned"},
+		}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	got, err := c.GetAssetScanStatuses(context.Background(), []int{5})
+	if err != nil {
+		t.Fatalf("GetAssetScanStatuses: %v", err)
+	}
+	if len(got) != 1 || got[0].ImageID != 5 || got[0].Status != "scanned" {
+		t.Errorf("statuses = %+v", got)
+	}
+}
+
+func TestSetIcon(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		trpcOK(w, map[string]any{"status": "attached", "iconId": 9})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	res, err := c.SetIcon(context.Background(), "listing_1", 9)
+	if err != nil {
+		t.Fatalf("SetIcon: %v", err)
+	}
+	if res.Status != "attached" || res.IconID == nil || *res.IconID != 9 {
+		t.Errorf("res = %+v", res)
+	}
+	jsonField, _ := body["json"].(map[string]any)
+	if jsonField["listingId"] != "listing_1" || jsonField["imageId"].(float64) != 9 {
+		t.Errorf("setIcon body = %+v", jsonField)
+	}
+}
+
+func TestBeginAndSubmitRevision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "beginListingRevision"):
+			trpcOK(w, map[string]any{"shadowId": "shadow_7", "created": true})
+		case strings.Contains(r.URL.Path, "submitListingRevision"):
+			raw, _ := io.ReadAll(r.Body)
+			var body map[string]any
+			_ = json.Unmarshal(raw, &body)
+			jsonField, _ := body["json"].(map[string]any)
+			if jsonField["changelog"] != "new icon" {
+				t.Errorf("changelog = %v", jsonField["changelog"])
+			}
+			trpcOK(w, map[string]any{"publishRequestId": "pubreq_3", "shadowId": "shadow_7", "slug": "my-app"})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	shadow, created, err := c.BeginListingRevision(context.Background(), "listing_1")
+	if err != nil || shadow != "shadow_7" || !created {
+		t.Fatalf("begin: shadow=%q created=%v err=%v", shadow, created, err)
+	}
+	rev, err := c.SubmitListingRevision(context.Background(), "shadow_7", "new icon")
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if rev.PublishRequestID != "pubreq_3" || rev.Slug != "my-app" {
+		t.Errorf("rev = %+v", rev)
+	}
+}
+
+func TestListingErrorMapping(t *testing.T) {
+	cases := []struct {
+		status     int
+		msg        string
+		wantSubstr string
+		echoMsg    bool // whether the server message is surfaced (401 deliberately drops it)
+	}{
+		{http.StatusUnauthorized, "expired", "not logged in", false},
+		{http.StatusForbidden, "Your API key does not have the required scope for this action", "Apps submit scope", true},
+		{http.StatusForbidden, "Apps authoring is not enabled", "Apps-author access", true},
+		{http.StatusNotFound, "no listing found", "no store listing found", true},
+		{http.StatusBadRequest, "This listing is live", "rejected the request", true},
+	}
+	for _, tc := range cases {
+		body, _ := json.Marshal(map[string]any{"error": map[string]any{"json": map[string]any{"message": tc.msg}}})
+		err := listingError(tc.status, body, trpcSetIcon)
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.wantSubstr) {
+			t.Errorf("status %d error %q should contain %q", tc.status, err, tc.wantSubstr)
+		}
+		if tc.echoMsg && !strings.Contains(err.Error(), tc.msg) {
+			t.Errorf("status %d error %q should echo server msg %q", tc.status, err, tc.msg)
+		}
+	}
+}
+
+// TestSetIconScopeForbiddenEndToEnd confirms a 403 flows through listingError.
+func TestSetIconScopeForbiddenEndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trpcErr(w, http.StatusForbidden, "Your API key does not have the required scope for this action")
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "tok", "")
+	_, err := c.SetIcon(context.Background(), "listing_1", 1)
+	if err == nil || !strings.Contains(err.Error(), "Apps submit scope") {
+		t.Errorf("want scope-403 error, got %v", err)
+	}
+}

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -39,5 +39,6 @@ with a no-build static default (back-compat alias).`,
 	cmd.AddCommand(newAppDevTokenCmd())
 	cmd.AddCommand(newAppDevTunnelCmd())
 	cmd.AddCommand(newAppPullCmd())
+	cmd.AddCommand(newAppListingCmd())
 	return cmd
 }

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -137,8 +137,9 @@ func newAppListingStatusCmd() *cobra.Command {
 		Long: `Show your store listing's attached media (icon, cover, screenshots) and what
 is still required before it can publish (an icon and a cover are mandatory).
 
-For a LIVE (approved) listing this reads the in-progress revision draft, so it
-reflects media you have staged for the next moderator review.`,
+Note: on a LIVE (approved) listing this opens an in-progress revision draft and
+reports ITS media (idempotent — it reuses any existing draft, and nothing is
+submitted for moderator review until you run a set-/add- command and confirm).`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newListingClient()
@@ -379,7 +380,10 @@ func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc li
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s staged on a revision — submitted for moderator review (%s).", capitalize(string(kind)), rev.PublishRequestID)))
+		// submitListingRevision is idempotent: a shadow that already had a pending
+		// request returns THAT request rather than opening a second. The response
+		// carries no fresh-vs-existing flag, so phrase it neutrally.
+		fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s staged on a revision — pending moderator review (%s).", capitalize(string(kind)), rev.PublishRequestID)))
 		fmt.Fprintln(out, "Your live listing is unchanged until a moderator approves the revision.")
 	} else {
 		fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s set ✓", capitalize(string(kind)))))

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -1,0 +1,623 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/civitai/cli/internal/appapi"
+	"github.com/civitai/cli/internal/auth"
+	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/manifest"
+	"github.com/civitai/cli/internal/ui"
+	"github.com/civitai/cli/pkg/civitai"
+	"github.com/spf13/cobra"
+)
+
+// Per-kind source-file byte caps, mirroring the server's listing-asset caps:
+//   - icon uses the inline data-URI path (server decoded cap 2 MiB).
+//   - cover / screenshot use the mint+persist full-res path (4 MiB / 2 MiB).
+const (
+	maxIconBytes       = 2 * 1024 * 1024
+	maxCoverBytes      = 4 * 1024 * 1024
+	maxScreenshotBytes = 2 * 1024 * 1024
+)
+
+// scanPollInterval / scanPollTimeout govern the post-ingest scan poll. Package
+// vars so tests can shrink them; never zero the interval in prod (it would busy-loop).
+var (
+	scanPollInterval = 2 * time.Second
+	scanPollTimeout  = 120 * time.Second
+)
+
+// newAppListingCmd is the `civitai app listing` group: attach the store-listing
+// MEDIA (icon / cover / screenshots) an app needs to clear the publish floor,
+// without the browser. Operates on the app in the current directory (or --slug).
+func newAppListingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "listing",
+		Short: "Manage your App store-listing media (icon, cover, screenshots)",
+		Long: `Manage your App store listing's MEDIA — the icon, cover, and screenshots
+a listing needs before it can publish.
+
+A store listing must have an ICON and a COVER before it can go live; screenshots
+are optional. These commands ingest a local image, wait for the content scan, and
+attach it to your listing — the same pipeline the web submit form uses.
+
+For a listing that is already LIVE (approved), attaching media opens a REVISION
+that goes back to moderator review (the live listing is untouched until the
+revision is approved); pass --changelog to describe the change.
+
+The app is resolved from block.manifest.json in the current directory (or pass
+--slug). A listing exists only after you have submitted the app for review
+(` + "`civitai app submit`" + `).`,
+		Example: `  civitai app listing status
+  civitai app listing set-icon ./assets/icon.png
+  civitai app listing set-cover ./assets/cover.png
+  civitai app listing add-screenshot ./shot.png --caption "Grid view"
+  civitai app listing rm-screenshot alsc_01H...
+  civitai app listing reorder alsc_02 alsc_01 alsc_03`,
+	}
+	cmd.AddCommand(newAppListingStatusCmd())
+	cmd.AddCommand(newAppListingSetIconCmd())
+	cmd.AddCommand(newAppListingSetCoverCmd())
+	cmd.AddCommand(newAppListingAddScreenshotCmd())
+	cmd.AddCommand(newAppListingRmScreenshotCmd())
+	cmd.AddCommand(newAppListingReorderCmd())
+	return cmd
+}
+
+// listingCommon holds the shared --slug/--dir resolution flags.
+type listingCommon struct {
+	slug string
+	dir  string
+}
+
+func (lc *listingCommon) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&lc.slug, "slug", "", "app slug (defaults to block.manifest.json's blockId)")
+	cmd.Flags().StringVar(&lc.dir, "dir", ".", "app directory holding block.manifest.json (when --slug is not given)")
+}
+
+// newListingClient loads config + builds an authed App Blocks client, erroring
+// clearly when no credential is configured.
+func newListingClient() (*appapi.Client, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Token() == "" {
+		return nil, civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
+	}
+	return appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), ""), nil
+}
+
+// resolveListingSlug resolves the app slug from --slug or the manifest.
+func resolveListingSlug(lc listingCommon) (string, error) {
+	if lc.slug != "" {
+		return lc.slug, nil
+	}
+	m, err := manifest.Load(lc.dir)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve the app — run this from your app directory (with block.manifest.json) or pass --slug: %w", err)
+	}
+	if m.BlockID == "" {
+		return "", fmt.Errorf("block.manifest.json has no blockId — pass --slug")
+	}
+	return m.BlockID, nil
+}
+
+// resolveListing resolves slug -> appBlockId (via the submission row) ->
+// listing ref. A submission with no appBlockId (never submitted / not yet an app
+// block) means no listing exists yet.
+func resolveListing(ctx context.Context, client *appapi.Client, slug string) (*appapi.ListingRef, error) {
+	sub, err := client.GetSubmission(ctx, "", slug)
+	if err != nil {
+		return nil, err
+	}
+	if sub.AppBlockID == nil || *sub.AppBlockID == "" {
+		return nil, fmt.Errorf("no store listing exists for %q yet — a listing is created when you submit the app for review. Run `civitai app submit` first", slug)
+	}
+	return client.GetMyListingForApp(ctx, *sub.AppBlockID)
+}
+
+// ----------------------------------------------------------------------------
+// status
+// ----------------------------------------------------------------------------
+
+func newAppListingStatusCmd() *cobra.Command {
+	var lc listingCommon
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show attached media and what's missing vs the publish floor",
+		Long: `Show your store listing's attached media (icon, cover, screenshots) and what
+is still required before it can publish (an icon and a cover are mandatory).
+
+For a LIVE (approved) listing this reads the in-progress revision draft, so it
+reflects media you have staged for the next moderator review.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := newListingClient()
+			if err != nil {
+				return err
+			}
+			slug, err := resolveListingSlug(lc)
+			if err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			ref, err := resolveListing(ctx, client, slug)
+			if err != nil {
+				return err
+			}
+			view, err := client.GetMyListingForEdit(ctx, ref.AppListingID)
+			if err != nil {
+				return err
+			}
+			printListingStatus(cmd.OutOrStdout(), slug, ref, view)
+			return nil
+		},
+	}
+	lc.bind(cmd)
+	return cmd
+}
+
+func printListingStatus(w io.Writer, slug string, ref *appapi.ListingRef, view *appapi.ListingEditView) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "App:\t%s\n", slug)
+	fmt.Fprintf(tw, "Listing status:\t%s\n", ref.Status)
+	fmt.Fprintf(tw, "Icon:\t%s\n", assetLabel(view.Assets.Icon.Present(), true))
+	fmt.Fprintf(tw, "Cover:\t%s\n", assetLabel(view.Assets.Cover.Present(), true))
+	fmt.Fprintf(tw, "Screenshots:\t%d\n", len(view.Assets.Screenshots))
+	_ = tw.Flush()
+
+	for _, s := range view.Assets.Screenshots {
+		caption := ""
+		if s.Caption != nil && *s.Caption != "" {
+			caption = "  — " + *s.Caption
+		}
+		fmt.Fprintf(w, "  %s%s\n", s.ID, caption)
+	}
+
+	iconOK := view.Assets.Icon.Present()
+	coverOK := view.Assets.Cover.Present()
+	fmt.Fprintln(w)
+	if iconOK && coverOK {
+		fmt.Fprintln(w, ui.Success("Publish floor met — icon and cover are set."))
+	} else {
+		missing := []string{}
+		if !iconOK {
+			missing = append(missing, "icon")
+		}
+		if !coverOK {
+			missing = append(missing, "cover")
+		}
+		fmt.Fprintln(w, ui.Warn(fmt.Sprintf("Not publishable yet — missing %s.", strings.Join(missing, " and "))))
+		if !iconOK {
+			fmt.Fprintf(w, "  Add one:  %s\n", ui.Code("civitai app listing set-icon <file>"))
+		}
+		if !coverOK {
+			fmt.Fprintf(w, "  Add one:  %s\n", ui.Code("civitai app listing set-cover <file>"))
+		}
+	}
+	if view.HasPendingRevision {
+		fmt.Fprintln(w, "\nA revision is currently under moderator review.")
+	} else if ref.Status == "approved" {
+		fmt.Fprintln(w, "\nThis listing is live — media changes open a revision for moderator re-review.")
+	}
+}
+
+func assetLabel(present, required bool) string {
+	if present {
+		return "set ✓"
+	}
+	if required {
+		return "MISSING (required)"
+	}
+	return "not set"
+}
+
+// ----------------------------------------------------------------------------
+// set-icon / set-cover / add-screenshot (the shared attach flow)
+// ----------------------------------------------------------------------------
+
+// mediaKind is the asset being attached.
+type mediaKind string
+
+const (
+	kindIcon       mediaKind = "icon"
+	kindCover      mediaKind = "cover"
+	kindScreenshot mediaKind = "screenshot"
+)
+
+func newAppListingSetIconCmd() *cobra.Command {
+	var lc listingCommon
+	var changelog string
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "set-icon <file>",
+		Short: "Set the listing icon (a square-ish image)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetMedia(cmd, kindIcon, args[0], "", lc, changelog, assumeYes)
+		},
+	}
+	lc.bind(cmd)
+	bindRevisionFlags(cmd, &changelog, &assumeYes)
+	return cmd
+}
+
+func newAppListingSetCoverCmd() *cobra.Command {
+	var lc listingCommon
+	var changelog string
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "set-cover <file>",
+		Short: "Set the listing cover (a landscape hero image)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetMedia(cmd, kindCover, args[0], "", lc, changelog, assumeYes)
+		},
+	}
+	lc.bind(cmd)
+	bindRevisionFlags(cmd, &changelog, &assumeYes)
+	return cmd
+}
+
+func newAppListingAddScreenshotCmd() *cobra.Command {
+	var lc listingCommon
+	var changelog string
+	var assumeYes bool
+	var caption string
+	cmd := &cobra.Command{
+		Use:   "add-screenshot <file>",
+		Short: "Add a screenshot (up to 8) with an optional caption",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetMedia(cmd, kindScreenshot, args[0], caption, lc, changelog, assumeYes)
+		},
+	}
+	lc.bind(cmd)
+	bindRevisionFlags(cmd, &changelog, &assumeYes)
+	cmd.Flags().StringVar(&caption, "caption", "", "optional one-line caption for the screenshot")
+	return cmd
+}
+
+func bindRevisionFlags(cmd *cobra.Command, changelog *string, assumeYes *bool) {
+	cmd.Flags().StringVar(changelog, "changelog", "", "changelog for the moderator review (used only when the listing is already live)")
+	cmd.Flags().BoolVarP(assumeYes, "yes", "y", false, "skip the live-listing revision confirmation")
+}
+
+// runSetMedia is the shared resolve -> validate -> ingest -> scan -> attach flow
+// for set-icon / set-cover / add-screenshot, branching on the listing status for
+// the live-listing shadow-revision path.
+func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc listingCommon, changelog string, assumeYes bool) error {
+	out := cmd.OutOrStdout()
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// 1. Local image validation BEFORE any network call.
+	data, info, err := loadAndValidateImage(kind, file)
+	if err != nil {
+		return err
+	}
+
+	client, err := newListingClient()
+	if err != nil {
+		return err
+	}
+	slug, err := resolveListingSlug(lc)
+	if err != nil {
+		return err
+	}
+
+	// 2. Resolve the listing + branch on status.
+	ref, err := resolveListing(ctx, client, slug)
+	if err != nil {
+		return err
+	}
+	switch ref.Status {
+	case "rejected":
+		return fmt.Errorf("this listing was rejected — resubmit the app before editing its media")
+	case "removed":
+		return fmt.Errorf("this listing was removed by a moderator and can no longer be edited")
+	}
+	live := ref.Status == "approved"
+
+	// 3. For a live listing, confirm the revision + resolve a changelog first, so
+	// we don't ingest/upload before the user has agreed to open a review cycle.
+	if live {
+		changelog, err = confirmLiveRevision(cmd, kind, changelog, assumeYes)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 4. Ingest bytes -> imageId (icon: inline data-URI; cover/screenshot: full-res).
+	fmt.Fprintf(out, "Uploading %s (%s)…\n", kind, humanBytes(int64(len(data))))
+	var imageID int
+	if kind == kindIcon {
+		imageID, err = client.IngestAssetFromDataURI(ctx, data, info.MimeType)
+	} else {
+		imageID, err = client.IngestAssetFullRes(ctx, data, info)
+	}
+	if err != nil {
+		return err
+	}
+
+	// 5. Poll the scan until Scanned (or Blocked / timeout).
+	if err := pollScan(ctx, out, client, imageID); err != nil {
+		return err
+	}
+
+	// 6. Attach — direct for draft/pending, via a shadow revision when live.
+	targetID := ref.AppListingID
+	var shadowID string
+	if live {
+		shadowID, _, err = client.BeginListingRevision(ctx, ref.AppListingID)
+		if err != nil {
+			return err
+		}
+		targetID = shadowID
+	}
+	if err := attachMedia(ctx, client, kind, targetID, imageID, caption); err != nil {
+		return err
+	}
+
+	// 7. For a live listing, submit the revision for moderator re-review.
+	if live {
+		rev, err := client.SubmitListingRevision(ctx, shadowID, changelog)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s staged on a revision — submitted for moderator review (%s).", capitalize(string(kind)), rev.PublishRequestID)))
+		fmt.Fprintln(out, "Your live listing is unchanged until a moderator approves the revision.")
+	} else {
+		fmt.Fprintln(out, ui.Success(fmt.Sprintf("%s set ✓", capitalize(string(kind)))))
+	}
+
+	// 8. Print the resulting floor state (best-effort — the attach already succeeded).
+	printFloorAfter(ctx, out, client, ref.AppListingID)
+	return nil
+}
+
+func attachMedia(ctx context.Context, client *appapi.Client, kind mediaKind, listingID string, imageID int, caption string) error {
+	switch kind {
+	case kindIcon:
+		_, err := client.SetIcon(ctx, listingID, imageID)
+		return err
+	case kindCover:
+		_, err := client.SetCover(ctx, listingID, imageID)
+		return err
+	default:
+		_, err := client.AddScreenshot(ctx, listingID, imageID, caption)
+		return err
+	}
+}
+
+// printFloorAfter reads the listing media and prints the remaining floor gap.
+// Best-effort: a read failure after a successful attach is not fatal.
+func printFloorAfter(ctx context.Context, out io.Writer, client *appapi.Client, appListingID string) {
+	view, err := client.GetMyListingForEdit(ctx, appListingID)
+	if err != nil {
+		return
+	}
+	iconOK := view.Assets.Icon.Present()
+	coverOK := view.Assets.Cover.Present()
+	switch {
+	case iconOK && coverOK:
+		fmt.Fprintln(out, "Publish floor met — icon and cover are set.")
+	case !iconOK && !coverOK:
+		fmt.Fprintln(out, "Still required before publishing: icon and cover.")
+	case !iconOK:
+		fmt.Fprintln(out, "Still required before publishing: icon.")
+	case !coverOK:
+		fmt.Fprintln(out, "Still required before publishing: cover.")
+	}
+}
+
+// confirmLiveRevision resolves the changelog + gates the live-listing revision.
+// A provided --changelog proceeds. Otherwise: a non-TTY refuses (needs an
+// explicit --changelog); a TTY warns about the moderator-review cycle and, on a
+// "yes", proceeds with a default changelog. --yes skips the prompt.
+func confirmLiveRevision(cmd *cobra.Command, kind mediaKind, changelog string, assumeYes bool) (string, error) {
+	out := cmd.OutOrStdout()
+	defaultChangelog := fmt.Sprintf("Update listing %s via civitai CLI", kind)
+
+	if changelog != "" {
+		fmt.Fprintln(out, ui.Warn("This listing is live — your change opens a revision for moderator re-review."))
+		return changelog, nil
+	}
+	if assumeYes {
+		return defaultChangelog, nil
+	}
+	if !stdinIsTTY() {
+		return "", fmt.Errorf("this listing is live — attaching media opens a moderator-reviewed revision. Pass --changelog \"...\" (or --yes) to proceed in a non-interactive shell")
+	}
+	fmt.Fprintln(out, ui.Warn("This listing is live — your change opens a revision for moderator re-review."))
+	fmt.Fprintln(out, "The current live listing stays unchanged until the revision is approved.")
+	fmt.Fprint(out, "Open a revision and submit it for review? [y/N]: ")
+	r := bufio.NewReader(cmd.InOrStdin())
+	line, _ := r.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return defaultChangelog, nil
+	default:
+		return "", fmt.Errorf("cancelled")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// rm-screenshot / reorder
+// ----------------------------------------------------------------------------
+
+func newAppListingRmScreenshotCmd() *cobra.Command {
+	var lc listingCommon
+	cmd := &cobra.Command{
+		Use:   "rm-screenshot <screenshotId>",
+		Short: "Remove a screenshot by its id (see `app listing status`)",
+		Long: `Remove a screenshot from your listing by its screenshot id (the id shown by
+` + "`civitai app listing status`" + `, e.g. alsc_...). Note: for a LIVE listing,
+direct screenshot edits are only possible while a revision is open.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newListingClient()
+			if err != nil {
+				return err
+			}
+			// Validate the listing exists (clear error), then remove.
+			if _, err := resolveListingRefFromFlags(cmd, client, lc); err != nil {
+				return err
+			}
+			ctx := cmdCtx(cmd)
+			if err := client.RemoveScreenshot(ctx, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), ui.Success("Screenshot removed ✓"))
+			return nil
+		},
+	}
+	lc.bind(cmd)
+	return cmd
+}
+
+func newAppListingReorderCmd() *cobra.Command {
+	var lc listingCommon
+	cmd := &cobra.Command{
+		Use:   "reorder <screenshotId...>",
+		Short: "Reorder screenshots (pass ALL current screenshot ids in the new order)",
+		Long: `Reorder your listing's screenshots. Pass EXACTLY the current set of screenshot
+ids (from ` + "`civitai app listing status`" + `) in the desired order — a partial or
+unknown set is rejected.`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newListingClient()
+			if err != nil {
+				return err
+			}
+			ref, err := resolveListingRefFromFlags(cmd, client, lc)
+			if err != nil {
+				return err
+			}
+			ctx := cmdCtx(cmd)
+			if err := client.ReorderScreenshots(ctx, ref.AppListingID, args); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), ui.Success(fmt.Sprintf("Reordered %d screenshots ✓", len(args))))
+			return nil
+		},
+	}
+	lc.bind(cmd)
+	return cmd
+}
+
+func resolveListingRefFromFlags(cmd *cobra.Command, client *appapi.Client, lc listingCommon) (*appapi.ListingRef, error) {
+	slug, err := resolveListingSlug(lc)
+	if err != nil {
+		return nil, err
+	}
+	return resolveListing(cmdCtx(cmd), client, slug)
+}
+
+func cmdCtx(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+// ----------------------------------------------------------------------------
+// local validation + scan poll helpers
+// ----------------------------------------------------------------------------
+
+// loadAndValidateImage reads the file, validates its type is png/jpeg/webp and
+// its size is within the per-kind cap, and returns the bytes + header info — all
+// BEFORE any network call.
+func loadAndValidateImage(kind mediaKind, file string) ([]byte, appapi.ImageInfo, error) {
+	fi, err := os.Stat(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, appapi.ImageInfo{}, fmt.Errorf("no such file: %s", file)
+		}
+		return nil, appapi.ImageInfo{}, err
+	}
+	if fi.IsDir() {
+		return nil, appapi.ImageInfo{}, fmt.Errorf("%s is a directory, not an image file", file)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, appapi.ImageInfo{}, err
+	}
+	if len(data) == 0 {
+		return nil, appapi.ImageInfo{}, fmt.Errorf("%s is empty", file)
+	}
+	limit := kindByteCap(kind)
+	if len(data) > limit {
+		return nil, appapi.ImageInfo{}, fmt.Errorf("%s is %s — larger than the %s max for a %s; provide a smaller image", file, humanBytes(int64(len(data))), humanBytes(int64(limit)), kind)
+	}
+	info, err := appapi.DecodeImageInfo(data)
+	if err != nil {
+		return nil, appapi.ImageInfo{}, fmt.Errorf("%s: %w", file, err)
+	}
+	return data, info, nil
+}
+
+func kindByteCap(kind mediaKind) int {
+	switch kind {
+	case kindIcon:
+		return maxIconBytes
+	case kindCover:
+		return maxCoverBytes
+	default:
+		return maxScreenshotBytes
+	}
+}
+
+// pollScan polls the image scan until Scanned, erroring on Blocked or timeout.
+func pollScan(ctx context.Context, out io.Writer, client *appapi.Client, imageID int) error {
+	deadline := time.Now().Add(scanPollTimeout)
+	start := time.Now()
+	for {
+		statuses, err := client.GetAssetScanStatuses(ctx, []int{imageID})
+		if err != nil {
+			return err
+		}
+		st := "pending"
+		for _, s := range statuses {
+			if s.ImageID == imageID {
+				st = s.Status
+			}
+		}
+		switch st {
+		case "scanned":
+			return nil
+		case "blocked":
+			return fmt.Errorf("the image was blocked by the content scan — it can't be attached; use a different image")
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for the image scan (still %s) — check `civitai app listing status` shortly", scanPollTimeout, st)
+		}
+		fmt.Fprintf(out, "  scanning image… (%ds)\n", int(time.Since(start).Seconds()))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(scanPollInterval):
+		}
+	}
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -111,7 +111,7 @@ func TestAppListingSetIconDraft(t *testing.T) {
 			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft", "contentRating": "g"})
 		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
 			ingestCalled = true
-			trpcData(w, 4242)
+			trpcData(w, map[string]any{"imageId": 4242})
 		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
 			// First poll pending, then scanned.
 			n := atomic.AddInt32(&scanCalls, 1)
@@ -173,7 +173,7 @@ func TestAppListingSetIconLiveOpensRevision(t *testing.T) {
 		case strings.Contains(r.URL.Path, "getMyListingForApp"):
 			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "approved", "contentRating": "g"})
 		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
-			trpcData(w, 5)
+			trpcData(w, map[string]any{"imageId": 5})
 		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
 			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": 5, "status": "scanned"}}})
 		case strings.Contains(r.URL.Path, "beginListingRevision"):
@@ -230,7 +230,7 @@ func TestAppListingSetIconBlockedNoAttach(t *testing.T) {
 		case strings.Contains(r.URL.Path, "getMyListingForApp"):
 			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft"})
 		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
-			trpcData(w, 66)
+			trpcData(w, map[string]any{"imageId": 66})
 		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
 			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": 66, "status": "blocked"}}})
 		case strings.Contains(r.URL.Path, "setIcon"):

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// writePNG writes a valid PNG of the given size to a temp file and returns its path.
+func writePNG(t *testing.T, w, h int) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	img.Set(0, 0, color.RGBA{9, 9, 9, 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png encode: %v", err)
+	}
+	p := filepath.Join(t.TempDir(), "icon.png")
+	if err := os.WriteFile(p, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	return p
+}
+
+func trpcData(w http.ResponseWriter, v any) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"result": map[string]any{"data": map[string]any{"json": v}},
+	})
+}
+
+// submissionRow answers GET /api/v1/blocks/submissions?blockId=<slug>.
+func submissionRow(w http.ResponseWriter, slug, appBlockID string) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"submissions": []map[string]any{{"blockId": slug, "appBlockId": appBlockID}},
+	})
+}
+
+func fastScanPoll(t *testing.T) {
+	t.Helper()
+	oldI, oldT := scanPollInterval, scanPollTimeout
+	scanPollInterval = time.Millisecond
+	scanPollTimeout = 5 * time.Second
+	t.Cleanup(func() { scanPollInterval, scanPollTimeout = oldI, oldT })
+}
+
+func listingEnv(t *testing.T, srvURL string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srvURL)
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+}
+
+func TestAppListingStatusRendersFloor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft", "contentRating": "g", "hasPendingRevision": false})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{
+				"parentId": "listing_1", "slug": "my-app", "status": "draft", "hasPendingRevision": false, "shadowId": nil,
+				"assets": map[string]any{
+					"icon":        map[string]any{"imageId": 11, "url": "http://x/i.png"},
+					"cover":       map[string]any{"imageId": nil, "url": nil},
+					"screenshots": []any{map[string]any{"id": "alsc_1", "imageId": 5, "url": "http://x/s.png", "caption": "Grid", "order": 0}},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out, "Icon:") || !strings.Contains(out, "set ✓") {
+		t.Errorf("status should show icon set: %q", out)
+	}
+	if !strings.Contains(out, "missing cover") {
+		t.Errorf("status should flag the missing cover: %q", out)
+	}
+	if !strings.Contains(out, "alsc_1") {
+		t.Errorf("status should list the screenshot id: %q", out)
+	}
+}
+
+func TestAppListingSetIconDraft(t *testing.T) {
+	fastScanPoll(t)
+	var setIconCalled, ingestCalled bool
+	var scanCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft", "contentRating": "g"})
+		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
+			ingestCalled = true
+			trpcData(w, 4242)
+		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
+			// First poll pending, then scanned.
+			n := atomic.AddInt32(&scanCalls, 1)
+			status := "scanned"
+			if n == 1 {
+				status = "pending"
+			}
+			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": 4242, "status": status}}})
+		case strings.Contains(r.URL.Path, "setIcon"):
+			setIconCalled = true
+			raw, _ := readBodyJSON(r)
+			jsonField, _ := raw["json"].(map[string]any)
+			if jsonField["imageId"].(float64) != 4242 {
+				t.Errorf("setIcon imageId = %v, want 4242", jsonField["imageId"])
+			}
+			if jsonField["listingId"] != "listing_1" {
+				t.Errorf("setIcon listingId = %v, want listing_1", jsonField["listingId"])
+			}
+			trpcData(w, map[string]any{"status": "attached", "iconId": 4242})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{"parentId": "listing_1", "status": "draft",
+				"assets": map[string]any{"icon": map[string]any{"imageId": 4242}, "cover": map[string]any{"imageId": nil}, "screenshots": []any{}}})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	iconPath := writePNG(t, 256, 256)
+	out, _, err := run(t, "app", "listing", "set-icon", iconPath, "--slug", "my-app")
+	if err != nil {
+		t.Fatalf("set-icon: %v", err)
+	}
+	if !ingestCalled || !setIconCalled {
+		t.Fatalf("expected ingest+setIcon; ingest=%v setIcon=%v", ingestCalled, setIconCalled)
+	}
+	if atomic.LoadInt32(&scanCalls) < 2 {
+		t.Errorf("expected the scan to be polled at least twice, got %d", scanCalls)
+	}
+	if !strings.Contains(out, "scanning image") {
+		t.Errorf("expected scan progress in output: %q", out)
+	}
+	if !strings.Contains(out, "Icon set") {
+		t.Errorf("expected success output: %q", out)
+	}
+	if !strings.Contains(out, "Still required before publishing: cover") {
+		t.Errorf("expected the trailing floor line: %q", out)
+	}
+}
+
+func TestAppListingSetIconLiveOpensRevision(t *testing.T) {
+	fastScanPoll(t)
+	var began, submitted, attachedToShadow bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "approved", "contentRating": "g"})
+		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
+			trpcData(w, 5)
+		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
+			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": 5, "status": "scanned"}}})
+		case strings.Contains(r.URL.Path, "beginListingRevision"):
+			began = true
+			trpcData(w, map[string]any{"shadowId": "shadow_9", "created": true})
+		case strings.Contains(r.URL.Path, "setIcon"):
+			raw, _ := readBodyJSON(r)
+			jsonField, _ := raw["json"].(map[string]any)
+			if jsonField["listingId"] == "shadow_9" {
+				attachedToShadow = true
+			}
+			trpcData(w, map[string]any{"status": "attached", "iconId": 5})
+		case strings.Contains(r.URL.Path, "submitListingRevision"):
+			submitted = true
+			raw, _ := readBodyJSON(r)
+			jsonField, _ := raw["json"].(map[string]any)
+			if jsonField["changelog"] != "brand refresh" {
+				t.Errorf("changelog = %v, want brand refresh", jsonField["changelog"])
+			}
+			trpcData(w, map[string]any{"publishRequestId": "pubreq_9", "shadowId": "shadow_9", "slug": "my-app"})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{"parentId": "listing_1", "status": "approved",
+				"assets": map[string]any{"icon": map[string]any{"imageId": 5}, "cover": map[string]any{"imageId": 7}, "screenshots": []any{}}})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	iconPath := writePNG(t, 256, 256)
+	out, _, err := run(t, "app", "listing", "set-icon", iconPath, "--slug", "my-app", "--changelog", "brand refresh")
+	if err != nil {
+		t.Fatalf("set-icon live: %v", err)
+	}
+	if !began || !attachedToShadow || !submitted {
+		t.Fatalf("live path incomplete: began=%v attachedToShadow=%v submitted=%v", began, attachedToShadow, submitted)
+	}
+	if !strings.Contains(out, "moderator review") {
+		t.Errorf("expected the mod-review notice: %q", out)
+	}
+	if !strings.Contains(out, "pubreq_9") {
+		t.Errorf("expected the revision id in output: %q", out)
+	}
+}
+
+func TestAppListingSetIconBlockedNoAttach(t *testing.T) {
+	fastScanPoll(t)
+	var setIconCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft"})
+		case strings.Contains(r.URL.Path, "ingestAssetFromDataUri"):
+			trpcData(w, 66)
+		case strings.Contains(r.URL.Path, "getAssetScanStatuses"):
+			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": 66, "status": "blocked"}}})
+		case strings.Contains(r.URL.Path, "setIcon"):
+			setIconCalled = true
+			trpcData(w, map[string]any{"status": "attached"})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	iconPath := writePNG(t, 256, 256)
+	_, _, err := run(t, "app", "listing", "set-icon", iconPath, "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected an error for a blocked image")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error should mention the block: %v", err)
+	}
+	if setIconCalled {
+		t.Error("setIcon must NOT be called after a blocked scan")
+	}
+}
+
+func TestAppListingLocalValidation(t *testing.T) {
+	// A server that fails the test if ANY request reaches it — validation must
+	// short-circuit before the network.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no network call expected, got %s", r.URL.Path)
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	t.Run("missing file", func(t *testing.T) {
+		_, _, err := run(t, "app", "listing", "set-icon", filepath.Join(t.TempDir(), "nope.png"), "--slug", "my-app")
+		if err == nil || !strings.Contains(err.Error(), "no such file") {
+			t.Errorf("want no-such-file, got %v", err)
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "note.txt")
+		_ = os.WriteFile(bad, []byte("i am not an image"), 0o644)
+		_, _, err := run(t, "app", "listing", "set-icon", bad, "--slug", "my-app")
+		if err == nil || !strings.Contains(err.Error(), "unrecognized image") {
+			t.Errorf("want unrecognized-image, got %v", err)
+		}
+	})
+
+	t.Run("too big", func(t *testing.T) {
+		big := filepath.Join(t.TempDir(), "big.png")
+		// A valid PNG header + padding beyond the icon cap so the SIZE check trips.
+		blob := make([]byte, maxIconBytes+1)
+		_ = os.WriteFile(big, blob, 0o644)
+		_, _, err := run(t, "app", "listing", "set-icon", big, "--slug", "my-app")
+		if err == nil || !strings.Contains(err.Error(), "larger than") {
+			t.Errorf("want too-big, got %v", err)
+		}
+	})
+}
+
+func TestAppListingScope403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"json": map[string]any{"message": "Your API key does not have the required scope for this action"}}})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
+	if err == nil || !strings.Contains(err.Error(), "Apps submit scope") {
+		t.Errorf("want a legible scope-403 error, got %v", err)
+	}
+}
+
+func TestSubmitFloorHeadsUp(t *testing.T) {
+	var buf bytes.Buffer
+	printListingFloorHeadsUp(&buf)
+	got := buf.String()
+	for _, want := range []string{"won't publish", "set-icon", "set-cover", "listing status"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("heads-up missing %q: %q", want, got)
+		}
+	}
+}
+
+// readBodyJSON decodes a request body into a generic map.
+func readBodyJSON(r *http.Request) (map[string]any, error) {
+	var m map[string]any
+	dec := json.NewDecoder(r.Body)
+	err := dec.Decode(&m)
+	return m, err
+}

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -209,8 +209,19 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 	fmt.Fprintln(out, "\nTrack it:")
 	fmt.Fprintf(out, "  %s                          # review + deploy status\n", ui.Code("civitai app status"))
 	fmt.Fprintf(out, "  %s/apps/my-submissions               # your submissions\n", base)
+	printListingFloorHeadsUp(out)
 	printMoneyPathNote(out, m)
 	return nil
+}
+
+// printListingFloorHeadsUp is a non-fatal reminder (issue #186 point 4) that a
+// store listing won't publish without an icon + cover, with the exact commands
+// to add them. Kept static (no server call) so it works even pre-first-listing.
+func printListingFloorHeadsUp(out io.Writer) {
+	fmt.Fprintln(out, "\nStore listing: your app won't publish until it has an icon AND a cover.")
+	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-icon <file>"))
+	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-cover <file>"))
+	fmt.Fprintf(out, "  %s   # what's attached vs. required\n", ui.Code("civitai app listing status"))
 }
 
 // manifestNeedsSpend reports whether the manifest declares a Buzz-spend scope


### PR DESCRIPTION
Adds a CLI path to set an app's store-listing **media** so a CLI author can clear the publish floor (icon + cover required) without the browser. Closes civitai/cli#186 (Phase 2).

## 🔴 Do NOT merge yet — depends on civitai/civitai#3472
The backend PR #3472 annotated the listing-media tRPC procs with `requiredScope: AppBlocksSubmit` so the CLI's **scoped** OAuth token can reach them. #3472 is merged to `main` but **not yet deployed to prod** — until it deploys, these procs `403` the CLI token. This PR is built against that contract and verified against httptest fakes only; **it must not merge/release until #3472 is live in prod.**

## What's added
New `civitai app listing` command group:

```
civitai app listing status
civitai app listing set-icon        <file>
civitai app listing set-cover       <file>
civitai app listing add-screenshot  <file> [--caption "..."]
civitai app listing rm-screenshot   <screenshotId>
civitai app listing reorder         <screenshotId...>
```

Each operates on the app in the cwd (manifest `blockId`) or `--slug`.

### The attach flow (per set-/add- command)
1. **Local validation before any network** — file exists, type ∈ png/jpeg/webp, per-kind size cap.
2. **Resolve listing** — manifest slug → submission `appBlockId` → `getMyListingForApp` → `{appListingId, status}`. No listing yet → clear "run `civitai app submit` first" message.
3. **Ingest** — icon uses the inline `ingestAssetFromDataUri` proc (icon-only per its schema); cover/screenshots use the full-res mint (`/api/v1/image-upload`) → presigned PUT → `persistAssetImage`.
4. **Scan poll** — `getAssetScanStatuses` until `Scanned`, honest progress, clean error on `Blocked` / timeout.
5. **Attach — branch on status:** draft/pending attach directly; **live (approved)** opens a shadow revision (`beginListingRevision` → attach to shadow → `submitListingRevision`), requires/prompts `--changelog`, and surfaces the moderator re-review cycle.
6. Prints the resulting publish-floor state.

### submit heads-up (issue point 4)
`app submit` now prints a non-fatal reminder that a listing won't publish without an icon + cover, with the exact `app listing set-icon/set-cover` commands.

## Image-size handling
The `ingestAssetFromDataUri` proc's schema is **icon-only** (`kind: z.literal('icon')`), so the lean data-URI path is used only for the icon; **cover + screenshots take the full-resolution mint→PUT→persist path** (no downscale). `persistAssetImage` needs width/height/mime — supplied by a dependency-free png/jpeg/webp header decoder (`internal/appapi/imageinfo.go`), so no new module dependency and it works offline.

## Verification (httptest only — live deferred to #3472 deploy)
- `go build ./... && go vet ./... && go test ./...` — all 16 packages `ok`; new tests cover the client procs, the draft-vs-live branch, scan-poll (pending→scanned), blocked-no-attach, local validation (missing/wrong-type/too-big), the scope-403 error, and the submit heads-up.
- `gofmt -l internal pkg cmd` clean.
- `./civitai app listing --help` / `status --help` eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)