### PR TITLE
fix(app-listing): listing-created-on-approval messaging + exit 4 + withdraw --yes

### DIFF
--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -409,7 +409,7 @@ func listingError(status int, raw []byte, path string) (err error) {
 		}
 		return fmt.Errorf("not permitted for your account (403): %s — managing store listings needs Apps-author access (invite-only beta)", msg)
 	case http.StatusNotFound:
-		return fmt.Errorf("no store listing found for this app (404): %s — a listing is created when you submit the app; run `civitai app submit` first", msg)
+		return fmt.Errorf("no store listing found for this app (404): %s — your app is still pending review; its store listing is created once a moderator approves it, then these commands will work", msg)
 	case http.StatusBadRequest:
 		return fmt.Errorf("%s rejected the request (400): %s", name, msg)
 	case http.StatusTooManyRequests:

--- a/internal/appapi/listing_test.go
+++ b/internal/appapi/listing_test.go
@@ -3,11 +3,14 @@ package appapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
 )
 
 // trpcOK writes a tRPC success envelope {result:{data:{json:<v>}}}.
@@ -238,6 +241,27 @@ func TestListingErrorMapping(t *testing.T) {
 		if tc.echoMsg && !strings.Contains(err.Error(), tc.msg) {
 			t.Errorf("status %d error %q should echo server msg %q", tc.status, err, tc.msg)
 		}
+	}
+}
+
+// TestListingError404IsNotFoundAndApprovalWorded pins the corrected 404 message
+// (the store listing is created on approval, the app is still pending — NOT "run
+// `civitai app submit` first") and confirms it stays tagged ErrNotFound so the
+// entrypoint maps it to exit 4.
+func TestListingError404IsNotFoundAndApprovalWorded(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{"error": map[string]any{"json": map[string]any{"message": "no listing found"}}})
+	err := listingError(http.StatusNotFound, body, trpcSetIcon)
+	if err == nil {
+		t.Fatal("expected an error for 404")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("404 listing error must be tagged ErrNotFound (→ exit 4), got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "pending review") || !strings.Contains(err.Error(), "approves") {
+		t.Errorf("404 message should explain the listing is created on approval: %v", err)
+	}
+	if strings.Contains(err.Error(), "civitai app submit") {
+		t.Errorf("404 message should not tell the author to submit again: %v", err)
 	}
 }
 

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -54,8 +54,9 @@ that goes back to moderator review (the live listing is untouched until the
 revision is approved); pass --changelog to describe the change.
 
 The app is resolved from block.manifest.json in the current directory (or pass
---slug). A listing exists only after you have submitted the app for review
-(` + "`civitai app submit`" + `).`,
+--slug). Your store listing is created when a moderator APPROVES your app — not
+at submit time — after ` + "`civitai app submit`" + ` and the app deploys. Then use
+these commands to set its media and clear the publish floor before publishing.`,
 		Example: `  civitai app listing status
   civitai app listing set-icon ./assets/icon.png
   civitai app listing set-cover ./assets/cover.png
@@ -120,7 +121,7 @@ func resolveListing(ctx context.Context, client *appapi.Client, slug string) (*a
 		return nil, err
 	}
 	if sub.AppBlockID == nil || *sub.AppBlockID == "" {
-		return nil, fmt.Errorf("no store listing exists for %q yet — a listing is created when you submit the app for review. Run `civitai app submit` first", slug)
+		return nil, civitai.Tag(civitai.ErrNotFound, fmt.Errorf("no store listing exists for %q yet — your app is still pending review; its store listing is created once a moderator approves it. After it's approved, run this command again to set its media", slug))
 	}
 	return client.GetMyListingForApp(ctx, *sub.AppBlockID)
 }
@@ -136,6 +137,9 @@ func newAppListingStatusCmd() *cobra.Command {
 		Short: "Show attached media and what's missing vs the publish floor",
 		Long: `Show your store listing's attached media (icon, cover, screenshots) and what
 is still required before it can publish (an icon and a cover are mandatory).
+
+Your store listing is created when a moderator APPROVES your app — not when you
+submit it for review — so this reports nothing until then.
 
 Note: on a LIVE (approved) listing this opens an in-progress revision draft and
 reports ITS media (idempotent — it reuses any existing draft, and nothing is

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -14,6 +15,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/civitai/cli/pkg/civitai"
 )
 
 // writePNG writes a valid PNG of the given size to a temp file and returns its path.
@@ -318,10 +321,81 @@ func TestSubmitFloorHeadsUp(t *testing.T) {
 	var buf bytes.Buffer
 	printListingFloorHeadsUp(&buf)
 	got := buf.String()
-	for _, want := range []string{"won't publish", "set-icon", "set-cover", "listing status"} {
+	// The heads-up must convey the listing is created on APPROVAL, then media is
+	// added — not that the listing commands work at submit time.
+	for _, want := range []string{"APPROVED", "After approval", "set-icon", "set-cover", "listing status"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("heads-up missing %q: %q", want, got)
 		}
+	}
+	// Regression guard: it must NOT imply the media commands work while pending.
+	for _, gone := range []string{"won't publish until", "when you submit"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("heads-up should not contain stale phrasing %q: %q", gone, got)
+		}
+	}
+}
+
+// TestAppListingPendingNoListingYet drives the pending-app path: the submission
+// exists but has no backing appBlockId yet (the store listing is created only on
+// moderator approval). The CLI must (a) say the app is still pending review and
+// the listing is created on approval — NOT "run `civitai app submit` first" — and
+// (b) tag the error ErrNotFound so the entrypoint maps it to exit 4.
+func TestAppListingPendingNoListingYet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			// A pending submission with no appBlockId yet.
+			submissionRow(w, "my-app", "")
+		default:
+			t.Errorf("unexpected path %s — should short-circuit before the listing lookup", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected a not-found error for a pending app with no listing yet")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("missing-listing error must be tagged ErrNotFound (→ exit 4), got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "pending review") || !strings.Contains(err.Error(), "approves") {
+		t.Errorf("error should explain the listing is created on approval: %v", err)
+	}
+	// Regression guard: it must NOT tell the author to submit again — they did.
+	if strings.Contains(err.Error(), "civitai app submit") {
+		t.Errorf("error should not tell the author to submit again: %v", err)
+	}
+}
+
+// TestAppListingHelpApprovalWording pins the corrected help text on the listing
+// command group and its status subcommand: it must convey the listing is created
+// on APPROVAL, and the old submit-time phrasing must be gone.
+func TestAppListingHelpApprovalWording(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"group help", []string{"app", "listing", "--help"}},
+		{"status help", []string{"app", "listing", "status", "--help"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := run(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			if !strings.Contains(out, "APPROVES") {
+				t.Errorf("help should say the listing is created when a moderator APPROVES the app:\n%s", out)
+			}
+			for _, gone := range []string{"exists only after you have submitted", "created when you submit"} {
+				if strings.Contains(out, gone) {
+					t.Errorf("help still contains stale submit-time phrasing %q:\n%s", gone, out)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -218,10 +218,11 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 // store listing won't publish without an icon + cover, with the exact commands
 // to add them. Kept static (no server call) so it works even pre-first-listing.
 func printListingFloorHeadsUp(out io.Writer) {
-	fmt.Fprintln(out, "\nStore listing: your app won't publish until it has an icon AND a cover.")
+	fmt.Fprintln(out, "\nStore listing: once your app is APPROVED, its store listing needs an icon AND a cover before it can publish.")
+	fmt.Fprintln(out, "After approval, add them with:")
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-icon <file>"))
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-cover <file>"))
-	fmt.Fprintf(out, "  %s   # what's attached vs. required\n", ui.Code("civitai app listing status"))
+	fmt.Fprintf(out, "  %s   # what's attached vs. required (after approval)\n", ui.Code("civitai app listing status"))
 }
 
 // manifestNeedsSpend reports whether the manifest declares a Buzz-spend scope

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -15,6 +15,7 @@ import (
 
 func newAppWithdrawCmd() *cobra.Command {
 	var idFlag string
+	var assumeYes bool
 
 	cmd := &cobra.Command{
 		Use:   "withdraw [pubreq-id]",
@@ -33,7 +34,10 @@ already-approved/rejected (or already-withdrawn) request cannot. Withdrawing is
 idempotent — withdrawing an already-withdrawn request still succeeds.
 
 Pass the publish-request id as a positional argument or via --id (find it with
-"civitai app status").`,
+"civitai app status").
+
+Withdraw is non-interactive (it never prompts); --yes/-y is accepted as a no-op
+for symmetry with "civitai app submit" so the same scripted flag works on both.`,
 		Example: `  civitai app withdraw pubreq_01H        # withdraw by publish-request id
   civitai app withdraw --id pubreq_01H   # same, via the flag`,
 		Args: cobra.MaximumNArgs(1),
@@ -69,5 +73,8 @@ Pass the publish-request id as a positional argument or via --id (find it with
 		},
 	}
 	cmd.Flags().StringVar(&idFlag, "id", "", "the publish-request id to withdraw (pubreq_...)")
+	// Accepted for symmetry with `app submit`; withdraw is non-interactive so this
+	// is a documented no-op (nothing to skip).
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "accepted for symmetry with 'app submit' (withdraw is non-interactive; no-op)")
 	return cmd
 }

--- a/internal/cmd/app_withdraw_test.go
+++ b/internal/cmd/app_withdraw_test.go
@@ -68,6 +68,34 @@ func TestAppWithdrawSuccess(t *testing.T) {
 	}
 }
 
+// TestAppWithdrawYesFlagAccepted proves `withdraw <id> --yes` is accepted (no
+// "unknown flag") for symmetry with `app submit`. Withdraw is non-interactive, so
+// --yes is a no-op that must still parse and complete the withdraw cleanly.
+func TestAppWithdrawYesFlagAccepted(t *testing.T) {
+	var rec withdrawRec
+	srv := withdrawServer(t, map[string]any{"ok": true}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	for _, flag := range []string{"--yes", "-y"} {
+		t.Run(flag, func(t *testing.T) {
+			out, _, err := run(t, "app", "withdraw", "pubreq_01H", flag)
+			if err != nil {
+				t.Fatalf("app withdraw %s: %v", flag, err)
+			}
+			if rec.publishRequestID != "pubreq_01H" {
+				t.Errorf("publishRequestId body = %q, want pubreq_01H", rec.publishRequestID)
+			}
+			if !strings.Contains(out, "Withdrew") {
+				t.Errorf("success output missing the withdrew line: %q", out)
+			}
+		})
+	}
+}
+
 func TestAppWithdrawByIDFlag(t *testing.T) {
 	var rec withdrawRec
 	srv := withdrawServer(t, map[string]any{"ok": true}, http.StatusOK, &rec)


### PR DESCRIPTION
A live dogfood of the `app listing` flow surfaced a self-contradictory dead end: three CLI surfaces wrongly claim the store listing exists at **submit** time, but the backend creates the `AppListing` row at **approval** (`submitVersion` only inserts the publish request). So for a **pending** app, `app listing set-icon`/`set-cover`/`status` all 404 ("no store listing exists yet — run `civitai app submit` first") **even though the author already submitted** — and the messaging directly contradicts `app submit`'s own heads-up.

The correct author flow: `civitai app submit` → moderator approves (app deploys, store listing created below the publish floor) → `civitai app listing set-icon/set-cover` to add media → publish. Media is set **after approval**.

## Changes
- **Corrected the three messaging surfaces + both runtime not-found messages** to say the store listing is created when a moderator **approves** the app (not at submit):
  - `app listing` command-group help (`internal/cmd/app_listing.go`)
  - `app listing status` help (`internal/cmd/app_listing.go`)
  - `app submit` heads-up (`printListingFloorHeadsUp`, `internal/cmd/app_submit.go`) — now says media is added *after approval*, not straight to the commands
  - runtime not-found errors: `resolveListing` (`internal/cmd/app_listing.go`) + `listingError` 404 (`internal/appapi/listing.go`) — "your app is still pending review; its store listing is created once a moderator approves it", no longer "run `civitai app submit` first" (they already did)
- **Exit code:** the missing-listing path (`resolveListing`) returned generic exit 1; now tagged `civitai.ErrNotFound` so the entrypoint maps it to the documented **exit 4** (the `listingError` 404 path already tagged it). Scripts branching on the exit taxonomy now work.
- **`app withdraw --yes`/`-y`:** `app submit` had `--yes` but `app withdraw` didn't (`withdraw <id> --yes` → `unknown flag`). Added as a documented no-op (withdraw is non-interactive), mirroring `submit`'s flag style.

## Tests
- New: pending-app not-found returns **exit 4** (`errors.Is ErrNotFound`) with the approval-based message and NO "run submit again"; `app listing --help`/`status --help` render the approval wording with a regression guard asserting the OLD "created when you submit" / "exists only after you have submitted" phrasing is gone; the submit heads-up renders the approval wording; `withdraw --yes`/`-y` are accepted; appapi 404 stays `ErrNotFound` + approval-worded.
- `go build ./... && go vet ./... && go test ./...` green; `gofmt -l internal pkg cmd` clean.

Refs civitai/cli#186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
