### PR TITLE
fix(app-listing): reach the pre-approval DRAFT by slug + flip the created-on-approval messaging

### DIFF
--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -180,12 +180,30 @@ func decodeTRPCData(raw []byte, out any, path string) error {
 	return nil
 }
 
-// GetMyListingForApp resolves the caller's own listing (by its backing appBlockId)
-// to an AppListing id + lifecycle status. NOT_FOUND (404) means no listing row
-// exists for the app yet.
-func (c *Client) GetMyListingForApp(ctx context.Context, appBlockID string) (*ListingRef, error) {
+// GetMyListingForApp resolves the caller's own listing to an AppListing id +
+// lifecycle status, by its backing appBlockId and/or its slug. At least one must
+// be non-empty (the server enforces the same rule) — pass BOTH when known.
+//
+// 🔴 The SLUG path is what reaches a PRE-APPROVAL DRAFT. A first-version app has no
+// backing AppBlock while it is pending review, so its draft listing (minted at
+// `civitai app submit`) has `appBlockId = NULL` and is resolvable ONLY by slug. That
+// is the whole reason listing media is settable while pending — resolving by
+// appBlockId alone can never see it.
+//
+// NOT_FOUND (404) means no listing row exists for the app at all.
+func (c *Client) GetMyListingForApp(ctx context.Context, appBlockID, slug string) (*ListingRef, error) {
+	in := map[string]string{}
+	if appBlockID != "" {
+		in["appBlockId"] = appBlockID
+	}
+	if slug != "" {
+		in["slug"] = slug
+	}
+	if len(in) == 0 {
+		return nil, fmt.Errorf("getMyListingForApp needs an appBlockId or a slug")
+	}
 	var out ListingRef
-	if err := c.trpcQuery(ctx, trpcGetMyListingForApp, map[string]string{"appBlockId": appBlockID}, &out); err != nil {
+	if err := c.trpcQuery(ctx, trpcGetMyListingForApp, in, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil
@@ -409,7 +427,7 @@ func listingError(status int, raw []byte, path string) (err error) {
 		}
 		return fmt.Errorf("not permitted for your account (403): %s — managing store listings needs Apps-author access (invite-only beta)", msg)
 	case http.StatusNotFound:
-		return fmt.Errorf("no store listing found for this app (404): %s — your app is still pending review; its store listing is created once a moderator approves it, then these commands will work", msg)
+		return fmt.Errorf("no store listing found for this app (404): %s — a store listing is created when you run `civitai app submit` and is settable while the app is pending review; submit the app first, then these commands will work", msg)
 	case http.StatusBadRequest:
 		return fmt.Errorf("%s rejected the request (400): %s", name, msg)
 	case http.StatusTooManyRequests:

--- a/internal/appapi/listing_test.go
+++ b/internal/appapi/listing_test.go
@@ -43,7 +43,7 @@ func TestGetMyListingForApp(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok123", "")
-	ref, err := c.GetMyListingForApp(context.Background(), "block_9")
+	ref, err := c.GetMyListingForApp(context.Background(), "block_9", "my-app")
 	if err != nil {
 		t.Fatalf("GetMyListingForApp: %v", err)
 	}
@@ -53,8 +53,60 @@ func TestGetMyListingForApp(t *testing.T) {
 	if !strings.Contains(gotInput, `"appBlockId":"block_9"`) {
 		t.Errorf("input should carry appBlockId: %q", gotInput)
 	}
+	if !strings.Contains(gotInput, `"slug":"my-app"`) {
+		t.Errorf("input should carry the slug too: %q", gotInput)
+	}
 	if ref.AppListingID != "listing_1" || ref.Status != "draft" {
 		t.Errorf("ref = %+v", ref)
+	}
+}
+
+// 🔴 The PRE-APPROVAL DRAFT path: a first-version app pending review has NO backing
+// AppBlock, so its draft listing is resolvable ONLY by slug. If the request ever
+// carried an empty `appBlockId` key instead of omitting it, the server's
+// "either appBlockId or slug" schema would still see a supplied-but-empty id — so
+// pin that the key is OMITTED entirely and the slug is what's sent.
+func TestGetMyListingForAppBySlugOnlyOmitsAppBlockID(t *testing.T) {
+	var gotInput string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotInput = r.URL.Query().Get("input")
+		trpcOK(w, map[string]any{
+			"appListingId":       "apl_draft",
+			"status":             "draft",
+			"contentRating":      "g",
+			"hasPendingRevision": false,
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	ref, err := c.GetMyListingForApp(context.Background(), "", "my-app")
+	if err != nil {
+		t.Fatalf("GetMyListingForApp(slug-only): %v", err)
+	}
+	if strings.Contains(gotInput, "appBlockId") {
+		t.Errorf("an empty appBlockId must be OMITTED, not sent: %q", gotInput)
+	}
+	if !strings.Contains(gotInput, `"slug":"my-app"`) {
+		t.Errorf("input should carry the slug: %q", gotInput)
+	}
+	if ref.AppListingID != "apl_draft" || ref.Status != "draft" {
+		t.Errorf("ref = %+v", ref)
+	}
+}
+
+// Neither selector is a caller bug — fail locally rather than send an empty query
+// the server would reject with a confusing zod error.
+func TestGetMyListingForAppRequiresASelector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("must not reach the server with neither selector")
+		trpcOK(w, map[string]any{})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok123", "")
+	if _, err := c.GetMyListingForApp(context.Background(), "", ""); err == nil {
+		t.Fatal("expected an error when neither appBlockId nor slug is given")
 	}
 }
 
@@ -257,11 +309,19 @@ func TestListingError404IsNotFoundAndApprovalWorded(t *testing.T) {
 	if !errors.Is(err, civitai.ErrNotFound) {
 		t.Errorf("404 listing error must be tagged ErrNotFound (→ exit 4), got %T: %v", err, err)
 	}
-	if !strings.Contains(err.Error(), "pending review") || !strings.Contains(err.Error(), "approves") {
-		t.Errorf("404 message should explain the listing is created on approval: %v", err)
+	// The listing is now created AT SUBMIT (as a draft) and is settable while the app
+	// is pending — so a 404 means the app was never submitted (or predates
+	// draft-at-submit), and pointing at `civitai app submit` is the correct next step.
+	if !strings.Contains(err.Error(), "civitai app submit") {
+		t.Errorf("404 message should point at `civitai app submit`: %v", err)
 	}
-	if strings.Contains(err.Error(), "civitai app submit") {
-		t.Errorf("404 message should not tell the author to submit again: %v", err)
+	if !strings.Contains(err.Error(), "pending review") {
+		t.Errorf("404 message should say media is settable while pending review: %v", err)
+	}
+	// Regression guard on the INVERTED premise: it must no longer claim the listing
+	// only appears once a moderator approves the app.
+	if strings.Contains(err.Error(), "approves it") {
+		t.Errorf("404 message must not say the listing is created on approval: %v", err)
 	}
 }
 

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -54,9 +54,10 @@ that goes back to moderator review (the live listing is untouched until the
 revision is approved); pass --changelog to describe the change.
 
 The app is resolved from block.manifest.json in the current directory (or pass
---slug). Your store listing is created when a moderator APPROVES your app — not
-at submit time — after ` + "`civitai app submit`" + ` and the app deploys. Then use
-these commands to set its media and clear the publish floor before publishing.`,
+--slug). Your store listing is created as a DRAFT when you run ` + "`civitai app submit`" + `,
+so you can set its media WHILE your app is pending review — the media you attach
+carries forward when a moderator approves it. Set it early to clear the publish
+floor before you go live.`,
 		Example: `  civitai app listing status
   civitai app listing set-icon ./assets/icon.png
   civitai app listing set-cover ./assets/cover.png
@@ -112,18 +113,26 @@ func resolveListingSlug(lc listingCommon) (string, error) {
 	return m.BlockID, nil
 }
 
-// resolveListing resolves slug -> appBlockId (via the submission row) ->
-// listing ref. A submission with no appBlockId (never submitted / not yet an app
-// block) means no listing exists yet.
+// resolveListing resolves slug -> appBlockId (via the submission row) -> listing
+// ref.
+//
+// 🔴 A submission with NO appBlockId is a FIRST-version app still pending review. It
+// still has a store listing: `civitai app submit` mints one as a pre-approval DRAFT
+// so its media is settable while pending. That draft has `appBlockId = NULL` and is
+// resolvable ONLY BY SLUG, so we must still call through — short-circuiting to a
+// "no listing" error here would make the pending-media flow unreachable from the CLI
+// even though the server supports it. The slug is passed on BOTH paths (harmless when
+// the appBlockId resolves; load-bearing when it is absent).
 func resolveListing(ctx context.Context, client *appapi.Client, slug string) (*appapi.ListingRef, error) {
 	sub, err := client.GetSubmission(ctx, "", slug)
 	if err != nil {
 		return nil, err
 	}
-	if sub.AppBlockID == nil || *sub.AppBlockID == "" {
-		return nil, civitai.Tag(civitai.ErrNotFound, fmt.Errorf("no store listing exists for %q yet — your app is still pending review; its store listing is created once a moderator approves it. After it's approved, run this command again to set its media", slug))
+	appBlockID := ""
+	if sub.AppBlockID != nil {
+		appBlockID = *sub.AppBlockID
 	}
-	return client.GetMyListingForApp(ctx, *sub.AppBlockID)
+	return client.GetMyListingForApp(ctx, appBlockID, slug)
 }
 
 // ----------------------------------------------------------------------------
@@ -138,8 +147,8 @@ func newAppListingStatusCmd() *cobra.Command {
 		Long: `Show your store listing's attached media (icon, cover, screenshots) and what
 is still required before it can publish (an icon and a cover are mandatory).
 
-Your store listing is created when a moderator APPROVES your app — not when you
-submit it for review — so this reports nothing until then.
+Your store listing exists as a DRAFT from the moment you run ` + "`civitai app submit`" + `,
+so this works while your app is still pending review.
 
 Note: on a LIVE (approved) listing this opens an in-progress revision draft and
 reports ITS media (idempotent — it reuses any existing draft, and nothing is

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -15,8 +14,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/civitai/cli/pkg/civitai"
 )
 
 // writePNG writes a valid PNG of the given size to a temp file and returns its path.
@@ -321,59 +318,90 @@ func TestSubmitFloorHeadsUp(t *testing.T) {
 	var buf bytes.Buffer
 	printListingFloorHeadsUp(&buf)
 	got := buf.String()
-	// The heads-up must convey the listing is created on APPROVAL, then media is
-	// added — not that the listing commands work at submit time.
-	for _, want := range []string{"APPROVED", "After approval", "set-icon", "set-cover", "listing status"} {
+	// 🔴 INVERTED by draft-at-submit: THIS submit minted the store listing as a draft,
+	// so the heads-up must tell the author the media is settable NOW, while in review,
+	// and that it carries forward on approval.
+	for _, want := range []string{"NOW", "in review", "carry forward", "set-icon", "set-cover", "listing status"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("heads-up missing %q: %q", want, got)
 		}
 	}
-	// Regression guard: it must NOT imply the media commands work while pending.
-	for _, gone := range []string{"won't publish until", "when you submit"} {
+	// Regression guard on the OLD premise: it must no longer make the author wait for
+	// approval before touching listing media.
+	for _, gone := range []string{"After approval", "once your app is APPROVED", "after approval"} {
 		if strings.Contains(got, gone) {
-			t.Errorf("heads-up should not contain stale phrasing %q: %q", gone, got)
+			t.Errorf("heads-up should not contain stale wait-for-approval phrasing %q: %q", gone, got)
 		}
 	}
 }
 
-// TestAppListingPendingNoListingYet drives the pending-app path: the submission
-// exists but has no backing appBlockId yet (the store listing is created only on
-// moderator approval). The CLI must (a) say the app is still pending review and
-// the listing is created on approval — NOT "run `civitai app submit` first" — and
-// (b) tag the error ErrNotFound so the entrypoint maps it to exit 4.
-func TestAppListingPendingNoListingYet(t *testing.T) {
+// 🔴 TestAppListingPendingReachesDraftBySlug — the whole point of draft-at-submit.
+// A first-version app pending review has NO backing appBlockId, but `civitai app
+// submit` minted its store listing as a pre-approval DRAFT, resolvable ONLY BY SLUG.
+//
+// This INVERTS the old TestAppListingPendingNoListingYet, which asserted the CLI
+// short-circuits to a "listing is created on approval" error. That short-circuit is
+// now the bug: it would make the pending-media flow unreachable from the CLI even
+// though the server supports it. So this pins that the CLI (a) does NOT bail before
+// the lookup, (b) sends the SLUG (the only thing that can resolve a null-appBlockId
+// draft) and omits the empty appBlockId, and (c) renders the draft's media.
+func TestAppListingPendingReachesDraftBySlug(t *testing.T) {
+	var listingForAppInput string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
-			// A pending submission with no appBlockId yet.
+			// A pending submission with NO appBlockId — the app is still in review.
 			submissionRow(w, "my-app", "")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			listingForAppInput = r.URL.Query().Get("input")
+			trpcData(w, map[string]any{
+				"appListingId": "apl_draft", "status": "draft",
+				"contentRating": "g", "hasPendingRevision": false,
+			})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{
+				"parentId": "apl_draft", "slug": "my-app", "status": "draft",
+				"hasPendingRevision": false, "shadowId": nil,
+				"assets": map[string]any{
+					"icon":        map[string]any{"imageId": 11, "url": "http://x/i.png"},
+					"cover":       map[string]any{"imageId": nil, "url": nil},
+					"screenshots": []any{},
+				},
+			})
 		default:
-			t.Errorf("unexpected path %s — should short-circuit before the listing lookup", r.URL.Path)
+			t.Errorf("unexpected path %s", r.URL.Path)
 		}
 	}))
 	defer srv.Close()
 	listingEnv(t, srv.URL)
 
-	_, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
-	if err == nil {
-		t.Fatal("expected a not-found error for a pending app with no listing yet")
+	out, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
+	if err != nil {
+		t.Fatalf("a pending app's DRAFT listing must be reachable by slug, got: %v", err)
 	}
-	if !errors.Is(err, civitai.ErrNotFound) {
-		t.Errorf("missing-listing error must be tagged ErrNotFound (→ exit 4), got %T: %v", err, err)
+	if listingForAppInput == "" {
+		t.Fatal("getMyListingForApp was never called — the CLI short-circuited before the lookup")
 	}
-	if !strings.Contains(err.Error(), "pending review") || !strings.Contains(err.Error(), "approves") {
-		t.Errorf("error should explain the listing is created on approval: %v", err)
+	if !strings.Contains(listingForAppInput, `"slug":"my-app"`) {
+		t.Errorf("the pending lookup must carry the slug: %q", listingForAppInput)
 	}
-	// Regression guard: it must NOT tell the author to submit again — they did.
-	if strings.Contains(err.Error(), "civitai app submit") {
-		t.Errorf("error should not tell the author to submit again: %v", err)
+	// An empty appBlockId must be OMITTED, not sent as "" — the server's
+	// "either appBlockId or slug" schema would otherwise see a supplied-but-empty id.
+	if strings.Contains(listingForAppInput, "appBlockId") {
+		t.Errorf("an absent appBlockId must be omitted from the lookup: %q", listingForAppInput)
+	}
+	// The draft's media renders — the author can see what they've attached while pending.
+	if !strings.Contains(out, "icon") && !strings.Contains(out, "Icon") {
+		t.Errorf("status should render the pending draft's media: %q", out)
 	}
 }
 
-// TestAppListingHelpApprovalWording pins the corrected help text on the listing
-// command group and its status subcommand: it must convey the listing is created
-// on APPROVAL, and the old submit-time phrasing must be gone.
-func TestAppListingHelpApprovalWording(t *testing.T) {
+// 🔴 TestAppListingHelpPendingWording pins the INVERTED help text on the listing
+// command group and its status subcommand. Draft-at-submit means the listing exists
+// as a DRAFT from `civitai app submit`, so the help must tell the author the media is
+// settable WHILE PENDING — the previous "created when a moderator APPROVES your app"
+// wording is now false and actively discourages the flow the backend enables.
+func TestAppListingHelpPendingWording(t *testing.T) {
 	cases := []struct {
 		name string
 		args []string
@@ -387,12 +415,24 @@ func TestAppListingHelpApprovalWording(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v: %v", tc.args, err)
 			}
-			if !strings.Contains(out, "APPROVES") {
-				t.Errorf("help should say the listing is created when a moderator APPROVES the app:\n%s", out)
+			if !strings.Contains(out, "DRAFT") {
+				t.Errorf("help should say the listing is created as a DRAFT at submit:\n%s", out)
 			}
-			for _, gone := range []string{"exists only after you have submitted", "created when you submit"} {
+			if !strings.Contains(out, "civitai app submit") {
+				t.Errorf("help should name `civitai app submit` as what creates the listing:\n%s", out)
+			}
+			if !strings.Contains(out, "pending review") {
+				t.Errorf("help should say media is settable while pending review:\n%s", out)
+			}
+			// Regression guard on the OLD, now-false premise.
+			for _, gone := range []string{
+				"created when a moderator APPROVES",
+				"not at submit time",
+				"not when you\nsubmit it",
+				"reports nothing until then",
+			} {
 				if strings.Contains(out, gone) {
-					t.Errorf("help still contains stale submit-time phrasing %q:\n%s", gone, out)
+					t.Errorf("help still contains the stale created-on-approval phrasing %q:\n%s", gone, out)
 				}
 			}
 		})

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -217,12 +217,14 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 // printListingFloorHeadsUp is a non-fatal reminder (issue #186 point 4) that a
 // store listing won't publish without an icon + cover, with the exact commands
 // to add them. Kept static (no server call) so it works even pre-first-listing.
+// This submit MINTED the store listing as a draft, so the media is settable NOW —
+// no need to wait for approval (it carries forward when the app is approved).
 func printListingFloorHeadsUp(out io.Writer) {
-	fmt.Fprintln(out, "\nStore listing: once your app is APPROVED, its store listing needs an icon AND a cover before it can publish.")
-	fmt.Fprintln(out, "After approval, add them with:")
+	fmt.Fprintln(out, "\nStore listing: your listing needs an icon AND a cover before it can publish.")
+	fmt.Fprintln(out, "You can add them NOW, while the app is in review — they carry forward on approval:")
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-icon <file>"))
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-cover <file>"))
-	fmt.Fprintf(out, "  %s   # what's attached vs. required (after approval)\n", ui.Code("civitai app listing status"))
+	fmt.Fprintf(out, "  %s   # what's attached vs. required\n", ui.Code("civitai app listing status"))
 }
 
 // manifestNeedsSpend reports whether the manifest declares a Buzz-spend scope


### PR DESCRIPTION
Ripple from **civitai/civitai#3479** (merged), which inverts the premise this command group was built on: the on-site store listing is now created as a **pre-approval DRAFT at `civitai app submit`**, so its media is settable *while the app is pending review* and carries forward on approval. Previously it was minted only at moderator approval.

## 🔴 This is not just a wording change

The CLI could not reach the new draft. `resolveListing` short-circuited to a *"no listing exists"* error whenever the submission row had no `appBlockId` — which is exactly the pending state a draft lives in. A first-version app has no AppBlock until approve, so its draft carries `appBlockId = NULL` and is resolvable **only by slug**.

Flipping the copy alone would have shipped a CLI that advertises setting media while pending and then refuses to do it.

## Changes

- **`GetMyListingForApp(ctx, appBlockID, slug)`** takes both selectors and sends only the non-empty ones. An empty `appBlockId` is **omitted**, not sent as `""` — the server's *"either appBlockId or slug"* schema would otherwise see a supplied-but-empty id. Neither selector is a local error rather than a confusing server-side zod failure.
- **`resolveListing`** no longer bails on a missing `appBlockId`; it passes the slug through on both paths (harmless when the appBlockId resolves, load-bearing when it is absent).
- **Messaging flipped in all five places** that asserted the old premise: the `listing` group help, `listing status` help, `resolveListing`'s not-found error, `appapi.listingError`'s 404, and the `app submit` heads-up (now: add media *now*, while in review).

## Tests

The two suites that **pinned the old premise** are inverted rather than deleted:

- `TestAppListingPendingNoListingYet` (asserted the short-circuit) → **`TestAppListingPendingReachesDraftBySlug`** (asserts the draft *is* reached, the slug *is* sent, and an absent appBlockId is omitted).
- The help + heads-up guards now assert the new wording and regression-guard the old.
- Adds slug-only and no-selector coverage on the client.

Verified: `go build`, `go vet`, full `go test ./internal/...` green. The `resolveListing` fix is confirmed by a **killing mutation** — restoring the short-circuit fails `TestAppListingPendingReachesDraftBySlug`.

## 🔴 Sequencing

**Do not tag a release until #3479 is deployed to production.** Against an older backend the pending path sends slug-only and the old required-`appBlockId` schema rejects it (400). The approved path is unaffected (zod strips the extra key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)