### PR TITLE
docs(handoff): land both app-analytics handoff docs on main

### DIFF
--- a/claudedocs/2026-08-03-app-analytics-handoff.md
+++ b/claudedocs/2026-08-03-app-analytics-handoff.md
@@ -1,8 +1,57 @@
-# Handoff — App analytics: CLI command + two platform fixes
+# Handoff — App analytics: CLI command + platform fixes
 
-**Session date:** 2026-08-02 → 2026-08-03
+**Session dates:** 2026-08-02 → 2026-08-03 (two sessions)
 **Repos touched:** `civitai/cli`, `civitai/civitai`, `devrc`
-**Status at handoff:** 3 PRs open and audited, 1 re-gate in flight, nothing merged.
+
+> ## ✅ RESOLVED — everything below shipped, plus follow-ups #1, #2 and #4
+>
+> This doc is kept as the record of how the work was found and reasoned about, not as a
+> to-do list. **Read the "Still open" section at the bottom first** — the rest is history.
+>
+> | PR | what | state |
+> |---|---|---|
+> | [civitai#3561](https://github.com/civitai/civitai/pull/3561) | endpoint cardinality fix | merged |
+> | [civitai#3557](https://github.com/civitai/civitai/pull/3557) | dark-flag fabricated-zero fix | merged |
+> | [civitai#3572](https://github.com/civitai/civitai/pull/3572) | follow-up #1 — scope-gate `getMyAppAnalytics` **and** `getMyForgejoCloneInfo` | merged |
+> | [civitai#3574](https://github.com/civitai/civitai/pull/3574) | follow-up #2 — humanise both analytics top-N cards | merged |
+> | [civitai#3581](https://github.com/civitai/civitai/pull/3581) | follow-up #4 — `getMyRevenue` undiscriminated zero | merged |
+> | [cli#190](https://github.com/civitai/cli/pull/190) | `civitai app metrics <slug>` | merged |
+> | [cli#191](https://github.com/civitai/cli/pull/191) | AGENTS.md items 5–7 | merged |
+> | [cli#192](https://github.com/civitai/cli/pull/192) | AGENTS.md item 8 — the CLI/web label divergence | merged |
+>
+> The original merge-order and stale-gate blockers are all discharged. #3561 had to be
+> rebased first: `#3566` landed on main mid-session and edited the same `detail: {}` object,
+> turning it `CONFLICTING` after the recorded gate. That is the whole reason the
+> "re-check how far behind main you are immediately before merging" rule earned its place.
+
+---
+
+## The two decisions that were open, and what the evidence said
+
+**Follow-up #1's scope choice was NOT a coin flip.** `TokenScope.AppBlocksSubmit`, not the
+`stopDevTunnel` precedent. Decided on two pieces of evidence, then confirmed in prod:
+
+- `civitai app metrics` already calls `GET /api/v1/blocks/submissions`, which requires that
+  exact bit — so any other choice makes one command's two hops need different scopes.
+- `app-listings.router.cli-scope.test.ts` fixed the identical bug class (cli#186) with the
+  identical bit.
+- **Prod confirmed it afterwards**: `OauthClient.allowedScopes` for `civitai-cli` is
+  `100663297`, and of the 331 live tokens the fix unblocks, **30 carry `33554433`
+  (`UserRead|AppBlocksSubmit`) and lack bit 26** — so copying `AppBlocksDevTunnel` would
+  have left those 30 still 403ing. `UserRead` would have been actively wrong: it is inside
+  `Full`, i.e. what every third-party "log in with Civitai" client requests.
+- Also measured: **0 credentials** out of 6.68M `ApiKey` rows are in the allow→deny flip
+  class (a strict superset of `Full` lacking bit 25). Beware the naive predicate
+  `(mask & Full) = Full` — it is also true when `mask == Full` and reports 145 false hits;
+  the strict form needs `AND mask <> Full`.
+
+**Follow-up #2's suggested fix was wrong.** This doc originally said to reuse
+`humaniseScopeEndpoint`. Don't — measured against the real function, it returns
+`'(no workflow id)'` for `workflow:submit` and `''` (a blank cell) for
+`user-settings:write`, because it is the per-ROW labeller and an aggregate bucket has no
+`detail`. The actual near-duplicate is `humaniseScopeInvocation`, which is also unsuitable
+but for different reasons (wrong register for a count; no arm for REST paths). Hence a
+separate `analytics-bucket-labels.ts`.
 
 ---
 
@@ -105,8 +154,13 @@ lines, and all three endpoint sites survive in current main at `:4449`, `:6328`,
 rewrite *non-vacuously*. A re-gate against `dd888989fb` was dispatched and had
 not reported at handoff. Its worktree: `/home/zach/workspace/civit/civitai-regate`.
 
-**Do not merge until that re-gate reports.** If #3561's assertions were hollowed
-out, that is a rebase-and-re-verify on #3561 before anything lands.
+~~**Do not merge until that re-gate reports.**~~ **HISTORICAL — do not act on this.** The
+re-gate reported clean, and #3561 has since merged. It did need the rebase-and-re-verify
+this paragraph anticipated, though for a different reason: `#3566` landed later still and
+edited the same `detail: {}` object, which turned #3561 `CONFLICTING`. The non-vacuity was
+then re-proven by mutation against the new base (reverting the three router sites → exactly
+5 red on this guard's own error; deleting the `detail.workflowId` spreads → exactly 4, with
+the `:pending` test correctly staying green because it asserts absence).
 
 ---
 
@@ -143,31 +197,31 @@ Submission state: 16 apps with a live deploy, 100 submissions (2026-06-17 →
 
 ---
 
-## Follow-ups not done (ranked)
+## Follow-ups (ranked) — #1, #2 and #4 are DONE; the rest are still open
 
-1. **`getMyAppAnalytics` has no `.meta({ requiredScope })`** → defaults to
-   `TokenScope.Full`, so a personal API key works but a `civitai login` OAuth
-   token **403s**. Since `login` with no flags is the default auth path, most
-   users cannot use the command. Precedent: `stopDevTunnel`
-   (`blocks.router.ts:1375`). *Decide which scope is right — do not copy blindly;
-   the proc exposes installs, Buzz spend, endpoint names, active-user counts.*
-   This was explicitly deferred as the one item where the right answer was not
-   already determined by evidence.
-2. **`topEndpoints` renders raw in `AppAnalyticsPanel.tsx:343-348`.** A
-   cross-PR interaction only the merged tree shows: after #3561 the bounded
-   `workflow:submit` / `storage:set` tokens collapse into single top-ranked
-   buckets, so the panel will now *prominently* display raw internal tokens.
-   `AppActivityPanel` has `humaniseScopeEndpoint`; `AppAnalyticsPanel` has no
-   humaniser. Cosmetic.
+~~1. `getMyAppAnalytics` has no `.meta({ requiredScope })`~~ — **DONE, civitai#3572.**
+   Fixed with `AppBlocksSubmit`; see "the two decisions" above for why, and note the PR
+   also caught a **second** proc with the identical live defect that this list missed:
+   `getMyForgejoCloneInfo`, which `civitai app pull` drives. Worth remembering that a
+   ranked follow-up list is not a survey — the sibling was found by an audit, not by
+   this doc.
+~~2. `topEndpoints` renders raw~~ — **DONE, civitai#3574.** Both cards, not just
+   endpoints: `topScopes` next to it had rendered raw `ai:write:budgeted` and the
+   middleware's literal `(any-token)` placeholder all along. The suggested fix in this
+   doc was wrong — see "the two decisions" above.
 3. **Owns-zero-apps returns unflagged all-zero counters**
    (`app-analytics.service.ts:187-188`). Flagged independently by two agents. Web
    only — unreachable from the CLI, which always sends a concrete `appBlockId`
    (`metrics <slug>`, `cobra.ExactArgs(1)`). Defensible (an aggregate over an
-   empty set genuinely is zero) but wants a recorded decision.
-4. **`getMyRevenue` has the identical undiscriminated-zero bug**
-   (`blocks.router.ts:5152` → `emptyRevenue()`, no discriminator at all).
-   `/apps/revenue` renders both panels, so that page still shows one fabricated
-   zero surface.
+   empty set genuinely is zero) but wants a recorded decision. **Still open** — and
+   note #3581 established the shape of the answer for its sibling: one discriminator
+   value, not two, because `getRevenueForOwner` never *computes* ownership.
+~~4. `getMyRevenue` has the identical undiscriminated-zero bug~~ — **DONE, civitai#3581.**
+   One discriminator value (`notEntitled`), deliberately not two: the service scopes by
+   `appOwnerUserId` in the WHERE clause, so a not-owned request yields a *truthful*
+   zero-row aggregate and `notOwned` is unproducible. Declaring it would have created the
+   "declared but never satisfied" trap this doc warns about. The PR also consolidated
+   **two** unguarded revenue readers into one shared `RevenuePanel`.
 5. **`normalizeEndpoint` still writes unbounded values**
    (`block-scope.middleware.ts:930`) — templates only `^\d+$`→`:id` and ULIDs;
    a slug or UUID segment passes through verbatim, and the row is written from
@@ -186,6 +240,68 @@ Submission state: 16 apps with a live deploy, 100 submissions (2026-06-17 →
    back-quote trap still live at `app_dev_tunnel.go:395`.
 
 ---
+
+## Still open — start here
+
+Ranked. #6 above (**ClickHouse `blockRenders` has zero readers**) remains the biggest
+*product* gap; the two items below are infrastructure this session uncovered and are
+cheaper.
+
+1. 🔴 **CI does not run the `component` (browser) project at all.** Three PRs merged today
+   ship browser tests — #3574's 7, #3581's 3, plus #3557's existing panel tests — that have
+   **never executed on a canonical browser**. They ran only against a nixpkgs
+   `playwright-chromium-headless-shell` (Chrome for Testing 149) shimmed in via a scratch
+   `PLAYWRIGHT_BROWSERS_PATH`, because Playwright's vendored `chrome-headless-shell` is a
+   generic-linux binary NixOS refuses to exec. As things stand those guards would catch
+   nothing in CI. This is the single largest verification gap the session exposed.
+
+2. 🟡 **A stale `node_modules` silently removes ~1,126 tests.** A worktree installed before
+   main gained the `@civitai/db-queries` workspace package fails at
+   `src/server/db/kyselyDb.ts` module load, so 89 files' tests are never collected and the
+   runner still prints a plausible total (10,131 passed vs 11,257 after `pnpm install`).
+   It cost one agent a full verification pass and produced a mutation matrix measured
+   against a suite missing 10% of itself. Filed on
+   [civitai#3579](https://github.com/civitai/civitai/issues/3579) alongside the related
+   wholesale-mock bug; a lockfile-vs-installed preflight check would close the family.
+
+3. 🟡 **`addCollaborator` may downgrade a write grant — UNVERIFIED.** It is a
+   `PUT …/collaborators/<user>` that *sets* permission, so `civitai app pull` (which grants
+   `read`) on an app where the web `AuthorViaGit` flow already granted `write` could
+   downgrade it and break a later push. Pre-existing, but #3572 made it reachable by the
+   CLI's **default** credential. Nobody has checked Forgejo's live PUT semantics; this rests
+   on the repo's own comment. Cheap to settle, unpleasant if true.
+
+4. 🟡 **`installs: 0` is still unverified, not measured** (as the data section above already
+   says). Uniform across all 16 apps, and no positive control was ever obtained proving the
+   counter can move. Given that this session found false zeros in four separate places —
+   fabricated dashboards, a false `tsc` 0 from an OOM, a prettier "all clean" that matched
+   zero files, and 1,126 tests silently not running — a uniform zero with no positive
+   control should be assumed broken until one exists.
+
+## What actually caught the bugs
+
+Recorded because it is the most transferable thing here. Across 8 PRs and 12 adversarial
+audit rounds, **every fix round found a defect in the previous fix**, and the mechanical
+gate caught none of them — the suite and typecheck were green at every single tip,
+including tips where a comment falsely described the mechanism protecting a scope gate.
+Three consecutive rounds on #3572 found the same class: a comment asserting something the
+code does not implement.
+
+The audits' recurring finds, in rough order of frequency:
+
+- **a comment or docstring asserting a mechanism the code does not implement** (5+ times);
+- **a test that pins the author's belief rather than the contract** — including one that
+  *certified a known-wrong label as intended*, and a "completeness" test that hardcoded the
+  same four strings it was meant to be checking;
+- **a claim broader than its evidence** — "both cards fixed" when two live scopes still
+  rendered raw; a uniqueness regex whose docblock claimed to pin every reader while matching
+  one call form;
+- **an unreachable guard counted as coverage** (one survived mutation and is now labelled as
+  untested rather than quietly kept).
+
+The cheap habits that found them: mutation-test every guard and **verify the mutation
+actually applied** before reading its result; positive-control every harness that can
+report a zero; and count tests rather than reading an exit code.
 
 ## Session learnings (a doc-update PR set was dispatched for these)
 

--- a/claudedocs/2026-08-03-app-analytics-handoff.md
+++ b/claudedocs/2026-08-03-app-analytics-handoff.md
@@ -247,13 +247,44 @@ Ranked. #6 above (**ClickHouse `blockRenders` has zero readers**) remains the bi
 *product* gap; the two items below are infrastructure this session uncovered and are
 cheaper.
 
-1. 🔴 **CI does not run the `component` (browser) project at all.** Three PRs merged today
-   ship browser tests — #3574's 7, #3581's 3, plus #3557's existing panel tests — that have
-   **never executed on a canonical browser**. They ran only against a nixpkgs
-   `playwright-chromium-headless-shell` (Chrome for Testing 149) shimmed in via a scratch
-   `PLAYWRIGHT_BROWSERS_PATH`, because Playwright's vendored `chrome-headless-shell` is a
-   generic-linux binary NixOS refuses to exec. As things stand those guards would catch
-   nothing in CI. This is the single largest verification gap the session exposed.
+1. 🔴 **`preview / component-tests` is RED on some PRs, and #3574 may have regressed it.**
+   ⚠️ An earlier draft of this section asserted "CI does not run the `component` project at
+   all". **That was FALSE** — the `preview / component-tests` external check runs it. The
+   error is worth recording because of how it happened: every status query written during
+   the session filtered for `Unit tests|Typecheck|ESLint|event-engine`, so the check was
+   never in a result set, and its absence was read as evidence it did not exist. Selecting
+   the evidence and then concluding from the selection.
+
+   What the check actually says on #3574, which shipped 7 browser tests:
+
+   | commit | `preview / component-tests` |
+   |---|---|
+   | `075519d380` — before the audit-fix round | success |
+   | `8e75826616` — first fix round | **failure** |
+   | `928273e4dd` — second fix round | **failure** |
+
+   It is REPORT-ONLY (`"Component suite failed (report-only, not blocking)"`), which is why
+   the merge was not stopped. Against that: **PR 3591 passes `component-tests` on a base
+   that CONTAINS the #3574 merge**, and PR 3594 fails on the same base — so the tier is
+   green for some PRs and red for others, which points at flakiness or content-dependence
+   rather than a defect #3574 introduced. Unresolved either way.
+
+   🔴 **This cannot be settled from a NixOS host.** The full-project component run does not
+   complete locally with OR without the #3574 merge — it crashes with "Browser connection
+   was closed" on one and times out at 25 minutes on the other. Single-file runs pass fine
+   (cold cache included). So local runs can validate one file but say nothing about the
+   suite; the preview pipeline's own logs are the only authority. Whoever picks this up
+   needs those logs, not a local repro.
+
+   Related and still true: the browser tests in #3574/#3581/#3557 have only ever run
+   locally against a nixpkgs `playwright-chromium-headless-shell` (Chrome for Testing 149)
+   shimmed in via `PLAYWRIGHT_BROWSERS_PATH`, because Playwright's vendored binary is a
+   generic-linux build NixOS refuses to exec.
+
+   Also stale, and worth fixing while in there: `lint.yml`'s `unit` job comment excludes
+   browser tests because they "carry the cold-optimizeDeps flake documented at
+   vitest.config.mts:98-124". That section documents the **fix**, not an open flake, and a
+   cold-cache single-file run passes — so the stated reason no longer holds.
 
 2. 🟡 **A stale `node_modules` silently removes ~1,126 tests.** A worktree installed before
    main gained the `@civitai/db-queries` workspace package fails at

--- a/claudedocs/2026-08-03-app-analytics-handoff.md
+++ b/claudedocs/2026-08-03-app-analytics-handoff.md
@@ -30,7 +30,39 @@ browser tests had never run against main's `component-setup.tsx` change until th
 gate; cli#190 last because its `notOwned` guard only becomes meaningful once
 #3557 deploys.
 
-### BLOCKER: the integration gate went stale
+### RESOLVED — the re-gate came back clean
+
+**The blocker below is cleared; it is kept for context.** A re-gate ran against
+`main@dd888989fb` and, when main advanced again mid-run, re-ran the whole thing
+against `fdf8e13bed`. Both bases give identical results: merged tree **752 files
+/ 10896 passed / 1 skipped / 0 failed**, typecheck **0 errors** (validated with
+an injected type error proving tsc reports exactly 1), and
+`blocks.router.workflow.test.ts` collects **311** tests. The +10 delta lands in
+exactly 5 PR-owned files — nothing stopped collecting.
+
+**#3561's endpoint assertions survive main's rewrite intact and non-vacuously**,
+proven by two discriminating mutations rather than asserted: reverting the three
+router sites turns exactly 5 tests red on *this* guard's own error
+(`expected 'workflow:submit:pending' to be 'workflow:submit'`); deleting the
+`detail.workflowId` spread turns exactly 4 red, with the `:pending` test
+correctly staying green because it asserts absence.
+
+One real blocker surfaced and was fixed: #3557 failed `prettier --check` on a
+file it created (`AppAnalyticsPanel.browser.test.tsx:48-51`). Fixed in
+`b77f849e9f` — pure line-wrap, no behaviour change. The 9 other prettier
+failures on that tree are pre-existing on main. **#3557's CI needs to re-green
+after that push before merging.**
+
+Caveats carried forward: the component-suite numbers came from a
+**non-canonical browser build** — Playwright's vendored `chrome-headless-shell`
+is a generic-linux binary NixOS refuses to exec, so the gate shimmed nixpkgs
+chromium 1228 into the `-1200` names. Unit results are unaffected and are the
+stronger evidence. The gate also ran prettier only, not ESLint proper.
+
+Gate worktrees left in place: `/home/zach/workspace/civit/civitai-regate` and
+`civitai-regate-ctl`.
+
+### Original blocker (historical — resolved above)
 
 A gate merged #3557 + #3561 off `main@ed6e17ac7d` and **passed** (751 files /
 10852 passed / 1 skipped / 0 failed, typecheck 0 with a positive control).

--- a/claudedocs/2026-08-03-app-analytics-handoff.md
+++ b/claudedocs/2026-08-03-app-analytics-handoff.md
@@ -24,7 +24,29 @@ called it. Building that call surfaced two real platform defects.
 | [#3557](https://github.com/civitai/civitai/pull/3557) | civitai | dark-flag fabricated-zero fix | 8 files, audited (8/8 mutants), `MERGEABLE` |
 | [#3561](https://github.com/civitai/civitai/pull/3561) | civitai | endpoint cardinality fix | 10 files, audited, `CLEAN` |
 
-**Agreed merge order: #3561 → #3557 → cli#190.** Not a correctness constraint
+### Docs PRs (separate, from the session-lessons pass)
+
+| PR | repo | file |
+|---|---|---|
+| [devrc#313](https://github.com/innovation-upstream/devrc/pull/313) | devrc | `claude/RULES.md` + `RULES-ARCHIVE.md` |
+| [#3567](https://github.com/civitai/civitai/pull/3567) | civitai | `CLAUDE.md` (Git Worktrees section) |
+| [cli#191](https://github.com/civitai/cli/pull/191) | cli | `AGENTS.md` (items 5–7) |
+
+🔴 **cli#191 MUST merge after cli#190.** It documents `internal/cmd/app_metrics.go`
+and `internal/appapi/analytics.go`, which only exist on #190's branch. Merging
+#191 first leaves `AGENTS.md` describing a command the tree does not have.
+
+⚠️ **devrc#313 is inert until a `home-manager switch`.** `~/.claude/RULES.md`
+resolves to `/nix/store/…-hm_RULES.md`, a read-only copy. Not run this session.
+
+Note on devrc#313: `RULES.md` is under a **deterministic byte ceiling**
+(`scripts/tests/test_rules_size.py`, 34,500 B hard / 900 B required headroom) and
+had only 495 B free. Rather than ratchet the limit — it exists as an anti-regrowth
+gate — ~1.4 KB of *evidence* was evicted to `RULES-ARCHIVE.md` under five new
+anchors. No rule lost its imperative, triggers, scope, or procedure. Final 33,507 B,
+993 B headroom. The size gate was mutation-tested before its green was trusted.
+
+**Agreed merge order: #3561 → #3557 → cli#190 → cli#191.** Not a correctness constraint
 (the regions are disjoint) — #3561 first because it is behind main and its
 browser tests had never run against main's `component-setup.tsx` change until the
 gate; cli#190 last because its `notOwned` guard only becomes meaningful once

--- a/claudedocs/2026-08-03-app-analytics-handoff.md
+++ b/claudedocs/2026-08-03-app-analytics-handoff.md
@@ -1,0 +1,170 @@
+# Handoff — App analytics: CLI command + two platform fixes
+
+**Session date:** 2026-08-02 → 2026-08-03
+**Repos touched:** `civitai/cli`, `civitai/civitai`, `devrc`
+**Status at handoff:** 3 PRs open and audited, 1 re-gate in flight, nothing merged.
+
+---
+
+## What this was
+
+Started as "tell me about the CLI", became: *can I see analytics for my published
+Apps?* The answer turned out to be **yes on the platform, no from the CLI** — a
+complete owner-scoped analytics service (`blocks.getMyAppAnalytics`, shipped
+2026-06-21) existed behind tRPC with a web UI panel, and the CLI simply never
+called it. Building that call surfaced two real platform defects.
+
+---
+
+## Open PRs — none merged
+
+| PR | repo | what | state |
+|---|---|---|---|
+| [#190](https://github.com/civitai/cli/pull/190) | cli | `civitai app metrics <slug>` | 3 commits, CI green, audited ×2, **verified live** |
+| [#3557](https://github.com/civitai/civitai/pull/3557) | civitai | dark-flag fabricated-zero fix | 8 files, audited (8/8 mutants), `MERGEABLE` |
+| [#3561](https://github.com/civitai/civitai/pull/3561) | civitai | endpoint cardinality fix | 10 files, audited, `CLEAN` |
+
+**Agreed merge order: #3561 → #3557 → cli#190.** Not a correctness constraint
+(the regions are disjoint) — #3561 first because it is behind main and its
+browser tests had never run against main's `component-setup.tsx` change until the
+gate; cli#190 last because its `notOwned` guard only becomes meaningful once
+#3557 deploys.
+
+### BLOCKER: the integration gate went stale
+
+A gate merged #3557 + #3561 off `main@ed6e17ac7d` and **passed** (751 files /
+10852 passed / 1 skipped / 0 failed, typecheck 0 with a positive control).
+
+Then `main` advanced 3 commits to `dd888989fb`. One of them —
+`dd720a8078` *"feat(app-blocks): tie a step's moderation posture to its
+orchestrator $type (#3554)"* — rewrote **779 lines of
+`src/server/routers/blocks.router.ts`** and **483 lines of
+`src/server/routers/__tests__/blocks.router.workflow.test.ts`**. That is the file
+both PRs touch and the test file #3561 edits.
+
+GitHub still reports both `MERGEABLE` — no *textual* conflict. Verified:
+`dd720a8078` does **not** touch the `workflow:submit` / `recordScopeInvocation`
+lines, and all three endpoint sites survive in current main at `:4449`, `:6328`,
+`:7107`. So source-level risk is low.
+
+**Unresolved:** whether #3561's endpoint assertions survive main's test-file
+rewrite *non-vacuously*. A re-gate against `dd888989fb` was dispatched and had
+not reported at handoff. Its worktree: `/home/zach/workspace/civit/civitai-regate`.
+
+**Do not merge until that re-gate reports.** If #3561's assertions were hollowed
+out, that is a rebase-and-re-verify on #3561 before anything lands.
+
+---
+
+## The measured data (owner's own apps, 2026-05-01 → 2026-08-03)
+
+Reachable via `blocks.getMyAppAnalytics`. Totals: **62 runs · 1,819 Buzz spent ·
+343 API calls · 0 installs · 0 Buzz purchased**, max 3 active users.
+
+| app | runs | Buzz | API calls | err |
+|---|---:|---:|---:|---:|
+| gen-matrix | 20 | 65 | 26 | 0% |
+| dogfood-manual | 11 | 35 | 17 | 0% |
+| panorama-360 | 9 | 0 | 9 | 0% |
+| custom-generators | 8 | **1,672** | 19 | 0% |
+| seed-explorer | 6 | 18 | 8 | 0% |
+| model-benchmarking | 5 | 20 | 5 | 0% |
+| w6-ui-dogfood | 2 | 6 | 5 | 0% |
+| buzz-generator | 1 | 3 | 5 | 0% |
+| playable-collections | 0 | 0 | **245** | 2% |
+| app-requests | 0 | 0 | 4 | 0% |
+| 6 others | 0 | 0 | 0 | — |
+
+Dark: `continuous-gen`, `df-qwen-canvas`, `lora-weight-lab`, `model-notes`,
+`notepad`, `prompt-library`.
+
+**`custom-generators` is unexplained and worth a look** — 1,672 Buzz over 8 runs
+is ~209/run against ~3/run everywhere else, i.e. 92% of all spend.
+
+**Treat `installs: 0` as unverified, not measured.** Uniform across all 16 apps;
+no positive control was ever obtained proving that counter can move.
+
+Submission state: 16 apps with a live deploy, 100 submissions (2026-06-17 →
+2026-08-01), 79 approved / 18 withdrawn / 2 rejected / 1 pending (`sensei`).
+
+---
+
+## Follow-ups not done (ranked)
+
+1. **`getMyAppAnalytics` has no `.meta({ requiredScope })`** → defaults to
+   `TokenScope.Full`, so a personal API key works but a `civitai login` OAuth
+   token **403s**. Since `login` with no flags is the default auth path, most
+   users cannot use the command. Precedent: `stopDevTunnel`
+   (`blocks.router.ts:1375`). *Decide which scope is right — do not copy blindly;
+   the proc exposes installs, Buzz spend, endpoint names, active-user counts.*
+   This was explicitly deferred as the one item where the right answer was not
+   already determined by evidence.
+2. **`topEndpoints` renders raw in `AppAnalyticsPanel.tsx:343-348`.** A
+   cross-PR interaction only the merged tree shows: after #3561 the bounded
+   `workflow:submit` / `storage:set` tokens collapse into single top-ranked
+   buckets, so the panel will now *prominently* display raw internal tokens.
+   `AppActivityPanel` has `humaniseScopeEndpoint`; `AppAnalyticsPanel` has no
+   humaniser. Cosmetic.
+3. **Owns-zero-apps returns unflagged all-zero counters**
+   (`app-analytics.service.ts:187-188`). Flagged independently by two agents. Web
+   only — unreachable from the CLI, which always sends a concrete `appBlockId`
+   (`metrics <slug>`, `cobra.ExactArgs(1)`). Defensible (an aggregate over an
+   empty set genuinely is zero) but wants a recorded decision.
+4. **`getMyRevenue` has the identical undiscriminated-zero bug**
+   (`blocks.router.ts:5152` → `emptyRevenue()`, no discriminator at all).
+   `/apps/revenue` renders both panels, so that page still shows one fabricated
+   zero surface.
+5. **`normalizeEndpoint` still writes unbounded values**
+   (`block-scope.middleware.ts:930`) — templates only `^\d+$`→`:id` and ULIDs;
+   a slug or UUID segment passes through verbatim, and the row is written from
+   `res.on('finish')` registered *before* the handler, so a 400 still logs.
+6. **ClickHouse `blockRenders` has zero readers.** Written since 2026-06-22
+   (`Tracker.blockRender()` → `/api/track/block-render`), carries `appBlockId`,
+   `slotId`, `isAnon`. It is the **only** signal covering anonymous viewers and
+   static/no-scope blocks — exactly where the Postgres engagement metrics go
+   flat. Biggest remaining product gap; per-mount, so unique views need
+   query-side dedup.
+7. Minor: `deployDetail: 'Build None'` gave zero diagnostic when `gen-matrix`
+   0.7.2 failed to build · `GET /api/v1/blocks/submissions` caps at
+   `MAX_ROWS = 100` with no cursor (owner is already at exactly 100, so history
+   before 2026-06-17 is unreachable) · five structurally dead `AppListingMetric`
+   columns (`openCount`/`visitCount`/`connectCount`/`tipped*`) · pflag
+   back-quote trap still live at `app_dev_tunnel.go:395`.
+
+---
+
+## Session learnings (a doc-update PR set was dispatched for these)
+
+- **`isolation: "worktree"` binds to the CURRENT repo**, not the target. Two
+  agents aimed at the monorepo got worktrees of the Go repo. Cross-repo dispatch
+  must create its own worktree explicitly.
+- **Scope process kills by `/proc/<pid>/cwd` when agents run in parallel.** A
+  system-wide `chrome-headless-shell|vitest|steam-run` kill took out ~15 PIDs
+  including a sibling's in-flight gate.
+- **A gate is evidence about the base it ran on.** Re-check how far behind main
+  you are immediately before merging.
+- **Submodule missing → `blocks.router.workflow.test.ts` collects 0 tests** and
+  reads as a pass. Validate every worktree run against a nonzero collect count.
+- **The `.envrc` trap fired twice more:** system Node 26.5.0 vs flake 22.22.2
+  (7 spurious failures), and a wrong cwd that let **77 tests silently not run**
+  while the output looked normal.
+- **`prettier --check --stdin-filepath` prints `(stdin)`**, not the path — a
+  grep for the path gave a false CLEAN.
+- **A DTO field that is never branched on is not a guard.** `notOwned` was
+  declared in the panel's type and never read; the not-owned case had been
+  fabricating zeros on the web all along.
+- **Every audit round found something real** — three rounds on #190, and the fix
+  round introduced its own regression (a genuinely nonzero error rate rendering
+  as `0.0%`).
+
+---
+
+## Verification notes
+
+- cli#190 was exercised against the **live** API with a personal key: `2.0%` /
+  `0.0%` error rates matching independent `curl`, exit 4 / 2 / 0, `--json` raw
+  passthrough intact. The `<0.1%` band is fake-server + mutation only — no app of
+  the owner's has a tiny-nonzero error rate to point at.
+- The re-gate's harness must self-validate: nonzero collect on
+  `blocks.router.workflow.test.ts`, and an injected type error proving `tsc` can
+  see one before trusting a `0`.

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -1,0 +1,187 @@
+# Handoff: app-analytics-followups — 2026-08-04
+
+## Goal
+
+Finish the App-analytics follow-up stream. The feature work is **done and merged**; what
+remains is one self-inflicted broken test (diagnosed below, fix is known), and the
+lower-priority follow-ups #3/#5/#6/#7 from the original handoff.
+
+Predecessor doc (history + the original ranked list):
+`claudedocs/2026-08-03-app-analytics-handoff.md` — same branch, same PR.
+
+## State now
+
+- **Branch / PR:** `zach/handoff-app-analytics` → [cli#193](https://github.com/civitai/cli/pull/193) (OPEN, `MERGEABLE`/`BLOCKED` on checks). This doc rides on it.
+- **Worktree for it:** `/home/zach/workspace/civit/cli-handoff-analytics`
+
+**DONE — merged this stream (8 PRs):**
+
+| PR | what |
+|---|---|
+| civitai#3561 | bound `block_scope_invocations.endpoint` so `topEndpoints` aggregates |
+| civitai#3557 | dark-flag fabricated-zero fix (`unavailable` discriminator on analytics) |
+| civitai#3572 | scope-gate `getMyAppAnalytics` **and** `getMyForgejoCloneInfo` (`AppBlocksSubmit`) |
+| civitai#3574 | humanise BOTH analytics top-N cards (`analytics-bucket-labels.ts`) |
+| civitai#3581 | `getMyRevenue` undiscriminated zero + extract shared `RevenuePanel` |
+| cli#190 | `civitai app metrics <slug>` |
+| cli#191 / cli#192 | `AGENTS.md` items 5–7 / item 8 (CLI-vs-web label divergence) |
+
+**IN FLIGHT:** cli#193 only (two docs). Nothing else uncommitted anywhere.
+
+**Deploy/verify status:** all merged to `civitai/main` and `civitai-cli/main`. Verified at
+the unit tier and via prod SQL (below). **NOT verified** at the component/browser tier —
+see the open investigation; that tier is report-only and currently red on #3574.
+
+**Prod facts established (don't re-query):** `OauthClient.allowedScopes` for `civitai-cli`
+= `100663297` (bit 25 live, so #3572 takes effect). Of 6,685,302 `ApiKey` rows: **0** are a
+strict superset of `Full` lacking bit 25 (the allow→deny flip class is empty). **331** live
+tokens were 403ing the analytics proc; **30** of them carry `33554433` and lack bit 26 —
+which is why `AppBlocksSubmit` and not `AppBlocksDevTunnel` was correct.
+Query via: `KUBECONFIG=$KC_DPPROD kubectl exec -n cnpg-database $(kubectl get cluster cnpg-cluster-nvme0 -n cnpg-database -o jsonpath='{.status.currentPrimary}') -- psql -U postgres -d civitai -c "<SQL>"`
+
+---
+
+## Open investigations — live diagnosis state
+
+### `preview / component-tests` is RED on #3574 — ROOT CAUSE FOUND, fix not yet written
+
+- **Symptom + exact repro:** the external `preview / component-tests` check went
+  **success → failure** exactly at my audit-fix round on #3574, and stayed failed through
+  merge. It is report-only (`"Component suite failed (report-only, not blocking)"`) so it
+  did not block. Locally it only reproduces in a **full-project** run:
+  `direnv exec <W> env -C <W> PLAYWRIGHT_BROWSERS_PATH=/tmp/claude-1000/pw-browsers ./node_modules/.bin/vitest run --project component`
+  Single-file runs of the same file pass (7 tests), cold `optimizeDeps` cache included.
+
+- **Observed (with values):**
+  - Check history on #3574's commits:
+    `075519d380` → `success`; `8e75826616` → `failure`; `928273e4dd` → `failure`.
+  - `src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx:105` asserts
+    `await expect.element(page.getByText('Generations')).toBeInTheDocument();`
+  - `src/components/AppBlocks/AppAnalyticsPanel.tsx:263` renders a stat whose Tooltip label is
+    `tooltip="Generations run through your app within the selected range, and the viewer Buzz burned doing so."`
+  - Collision confirmed by computation: `'generations' in tooltip.lower()` → **True**;
+    the PREVIOUS label `'Generation submits'` → **False**. So the rename introduced it.
+  - `getByText` in vitest browser mode is **substring + case-insensitive** (established by
+    civitai#3593, which fixed the identical defect in #3557's discriminator test).
+  - civitai#3593's commit body: *"vitest browser mode shares ONE browser page across every
+    `.browser.test.tsx` file, so in the full-suite run the pointer position left behind by
+    an earlier file can already sit over the stat at mount. The locator then resolves to 2
+    elements and the assertion dies with a strict mode violation after the matcher timeout."*
+  - Local full-project runs (my host, non-canonical browser) fail **both** with the merge
+    (`Error: [vitest] Browser connection was closed while running tests`) and **without** it
+    (`exit=124`, timed out at 1500s). Run the without-merge baseline at `e4d23679c2^`.
+
+- **Ruled out:**
+  - *Cold `optimizeDeps` flake* — cold cache + single file passes (7 tests). `vitest.config.mts:98-124`
+    documents the FIX for that, not an open flake. (Consequence: `lint.yml`'s unit-job comment
+    citing it as the reason to exclude browser tests is **stale** — worth fixing.)
+  - *My changes break the suite universally* — **PR 3591 PASSES `component-tests` on a base
+    containing the #3574 merge**; PR 3594 fails on the same base. Verified with
+    `git merge-base --is-ancestor e4d23679c2 <head>` → YES for both.
+  - *Local repro will settle it* — it will not; the full-project run fails on this NixOS host
+    regardless of the change (see values above).
+
+- **Leading hypothesis (high confidence):** `getByText('Generations')` at
+  `AppAnalyticsPanel.browser.test.tsx:105` resolves to 2 elements whenever the "Runs (range)"
+  tooltip happens to be mounted — which the shared-page/leftover-pointer behaviour makes
+  possible in a full-suite run but never in a single-file run. Strict-mode violation →
+  matcher timeout → suite red. This is exactly #3593's defect class, introduced by my
+  vocabulary rename, at exactly the commit where the check turned red.
+
+- **Next probe / fix (apply verbatim):** mirror #3593's fix in
+  `src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx`:
+  1. anchor the ambiguous assertions with `{ exact: true }` —
+     `page.getByText('Generations', { exact: true })` at line 105 (and audit lines 129/130/144
+     the same way, plus the `'App-local storage writes'` and `'AI workflow submits'` asserts);
+  2. prove it by mutation the way #3593 did: park the pointer over the stat so the tooltip is
+     open, run the file, confirm the OLD assertion fails and the new one passes;
+  3. also re-check `expect(page.getByText('pending').elements()).toHaveLength(0)` (line ~146)
+     — case-insensitive substring, so any future copy containing "spending"/"Pending" turns it
+     into a false failure. `AppAnalyticsPanel.tsx` has no such copy today (grepped), so it is
+     latent, not live.
+
+  Then get the preview pipeline's component log for a post-fix commit to confirm; that log is
+  the only authority and I could not reach it.
+
+---
+
+## Next steps (ranked)
+
+1. **Fix the `getByText('Generations')` ambiguity** (above) and open a small PR. Self-inflicted,
+   diagnosed, ~5 lines. Do this first.
+2. **Merge cli#193** (this doc + the updated predecessor). Docs-only.
+3. **Fix `lint.yml`'s stale unit-job comment** and consider adding the component project to
+   GitHub Actions as `continue-on-error: true` — the same report-only posture the unit job
+   uses, and the only way to get canonical-browser signal. ⚠️ `.github/workflows/*` is
+   ask-first per `AGENTS.md`. Do NOT frame this as "adding a missing tier" — the tier exists
+   (`preview / component-tests`); this is about a second, GH-native runner.
+4. **Follow-up #6 — ClickHouse `blockRenders` has zero readers.** The real remaining product
+   gap: written since 2026-06-22, carries `appBlockId`/`slotId`/`isAnon`, and is the only
+   signal covering anonymous viewers and static blocks. Per-mount, so unique views need
+   query-side dedup.
+5. **Follow-up #5 — `normalizeEndpoint` still writes unbounded values**
+   (`block-scope.middleware.ts`): templates only `^\d+$` and ULIDs, so a slug/UUID segment
+   passes through verbatim into `topEndpoints`.
+6. **Follow-up #3** (owns-zero-apps unflagged all-zero; web-only) and **#7** (minor grab-bag).
+7. **Two unverified leads:** `addCollaborator` is a PUT that *sets* permission, so
+   `civitai app pull` granting `read` where the web flow granted `write` may downgrade it and
+   break a later push (#3572 made it reachable by the CLI's default credential; nobody checked
+   Forgejo's live PUT semantics). And `installs: 0` remains **unverified, not measured** — no
+   positive control has ever shown that counter move.
+
+---
+
+## Gotchas / decisions / dead-ends
+
+**Environment traps — every one produced a false GREEN in this session:**
+- Node tooling needs **both** direnv and a real cwd: `direnv exec <W> env -C <W> ./node_modules/.bin/vitest …`. `--root` alone does not set `process.cwd()` and silently suppressed ~78 cwd-sensitive tests.
+- A `node_modules` predating main's `@civitai/db-queries` package **silently removes ~1,126 tests** (10,131 passed vs 11,257 after `pnpm install --frozen-lockfile`) while still printing a plausible total. Filed on [civitai#3579](https://github.com/civitai/civitai/issues/3579).
+- Bare `tsc --noEmit` OOMs and then reports **zero** errors. Always `NODE_OPTIONS="--max_old_space_size=8192"`.
+- `prettier --check` prints its all-clean message even when it matched **zero** files (zsh passes a newline-joined list as one arg). Use `xargs` + positive-control against `src/components/Apps/AppAnalyticsInline.tsx`, which violates on main.
+- Strip ANSI before grepping vitest output (`sed 's/\x1b\[[0-9;]*m//g'`) or greps match nothing and read as success.
+- Backticks inside a double-quoted `gh ... --body "..."` get **command-substituted** by zsh and mangle the comment. Always `--body-file`.
+- The `component` tier cannot run on this NixOS host with Playwright's vendored `chrome-headless-shell`. Overlay used: `PLAYWRIGHT_BROWSERS_PATH=/tmp/claude-1000/pw-browsers` → nixpkgs Chrome for Testing 149. **Non-canonical** — label any result from it.
+
+**Decisions worth not re-litigating:**
+- `#3572` uses `AppBlocksSubmit`, not `AppBlocksDevTunnel`: prod data shows 30 of 331 affected tokens lack bit 26. Not a style call.
+- `#3581` declares ONE discriminator value (`notEntitled`), not two: `getRevenueForOwner` never *computes* ownership (it scopes by `appOwnerUserId` in the WHERE clause), so a not-owned request is a truthful zero and `notOwned` is unproducible.
+- `#3574` does **not** reuse `humaniseScopeEndpoint`/`humaniseScopeInvocation` — measured, they return `'(no workflow id)'`, `''`, and wrong-register strings for these buckets.
+- The CLI deliberately keeps printing raw tokens where the web humanises them (cli#192, `AGENTS.md` item 8).
+
+**Dead ends / errors I made — recorded so they aren't repeated:**
+- 🔴 **I claimed "CI does not run the `component` project at all". FALSE.** Every status query I wrote filtered for `Unit tests|Typecheck|ESLint|event-engine`, so `preview / component-tests` was never in a result set and I read its absence as nonexistence. Retracted on cli#193, civitai#3574, civitai#3581.
+- 🔴 I diagnosed `get-models-raw.transient-503`'s failures as "tests pinning a widening the implementation lacks" from **test names alone**. Wrong — `model.service.ts:420` calls `isTransientMeiliError`. Real cause is the incomplete wholesale `vi.mock` of `~/server/db/pgDb` ([#3579](https://github.com/civitai/civitai/issues/3579)), which explains **both** of main's failing unit files.
+- I reported "145 flip-risk credentials" from `(mask & Full) = Full`, which is also true when `mask == Full`. The strict-superset form needs `AND mask <> Full` → the real answer is **0**.
+- Across 12 adversarial audit rounds, **every fix round found a defect in the previous fix**, and the mechanical gate caught none — the suite and typecheck were green at every tip. The recurring finds: a comment asserting a mechanism the code doesn't implement (5+ times); a test pinning the author's belief rather than the contract (including one that *certified a known-wrong label as intended*); a claim broader than its evidence; an unreachable guard counted as coverage.
+
+---
+
+## How to verify
+
+```bash
+W=/home/zach/workspace/civit/civitai-regate   # or any worktree; pnpm install FIRST
+git -C $W fetch origin main && git -C $W checkout --detach origin/main
+direnv exec $W env -C $W pnpm install --frozen-lockfile      # else ~1,126 tests vanish
+
+# unit tier — expect 2 failed files (BOTH main's, see #3579), ~11,258 passed
+direnv exec $W env -C $W ./node_modules/.bin/vitest run --project unit --reporter=dot 2>&1 \
+  | sed 's/\x1b\[[0-9;]*m//g' | grep -E "Test Files|Tests "
+
+# typecheck — expect exactly 1 error, main's generated updated-at-tables.ts
+direnv exec $W env -C $W NODE_OPTIONS="--max_old_space_size=8192" ./node_modules/.bin/tsc --noEmit 2>&1 | grep -c "error TS"
+
+# the analytics/revenue guards specifically — expect 40 passed
+direnv exec $W env -C $W ./node_modules/.bin/vitest run --project unit \
+  src/server/services/blocks/__tests__/buzz-attribution.service.test.ts \
+  src/components/AppBlocks/__tests__/revenue-panel-wiring.test.ts \
+  src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+
+# component tier — SINGLE FILE ONLY on this host; full-project does not complete here
+timeout 600 direnv exec $W env -C $W PLAYWRIGHT_BROWSERS_PATH=/tmp/claude-1000/pw-browsers \
+  ./node_modules/.bin/vitest run --project component \
+  src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+```
+
+The CLI command itself: `civitai app metrics <slug>` (needs a login token; the fix in #3572
+is what makes that work). `--json` passes the payload through raw and still exits 0, so a
+script must branch on `notOwned` / `unavailable` itself.

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -27,14 +27,32 @@ Predecessor doc (history + the original ranked list):
 | cli#191 / cli#192 | `AGENTS.md` items 5–7 / item 8 (CLI-vs-web label divergence) |
 | civitai#3606 | anchor the `Generations` locator — fixes the component-suite oscillation this stream caused |
 
-**IN FLIGHT:** cli#193 only (these two docs). Auto-merge is ENABLED; it is `BLOCKED` solely by
-a red required check that is **red on `main` too** — `pins-vs-published` fails because npm has
-published past the scaffold pins (`@civitai/blocks-react` pinned `^0.37.0`, published `0.38.0`;
-`@civitai/app-sdk` `^0.28.0` vs `0.30.0`). Nothing to do with these docs (the PR changes two
-`.md` files). Fix: `go run ./internal/scaffold/cmd/bump-pins` in the cli repo, then update the
-matching assertions in `scaffold_test.go`. That unblocks #193 automatically and fixes a real
-defect — the check's own message is "every app created from this template is born stale".
+**IN FLIGHT:** cli#193 only (these two docs). Auto-merge is ENABLED. It *was* `BLOCKED` solely
+by `pins-vs-published`, a required check that was red on `main` too — npm had published past
+both scaffold pins (`@civitai/blocks-react` pinned `^0.37.0` vs published `0.38.0`;
+`@civitai/app-sdk` `^0.28.0` vs `0.30.0`), and the pre-1.0 caret locks the minor, so the
+check's own words applied: "every app created from this template is born stale". Nothing to do
+with these docs (the PR changes two `.md` files).
+
+**FIXED — cli#194 (merged 2026-08-04, `189d5a4`).** `go run ./internal/scaffold/cmd/bump-pins`
+rewrites all three literal pin sites in lockstep (`package.json.tmpl`, the `README.md.tmpl`
+prose, and the `scaffold_test.go` `mustContain` assertions) — the handoff's "then update the
+matching assertions by hand" step is already automated; don't do it manually. Verified red at
+`6bdab0e` → green on the branch (live npm query both times), `--check` idempotent afterwards,
+and **all five `template-page-money` CI steps reproduced locally** against the actual published
+0.30.0/0.38.0 (install → typecheck → 137 tests → build → `app validate`) because a minor bump
+can break the template. All 10 checks green on #194.
 Nothing else uncommitted anywhere.
+
+⚠️ **This will recur** — it is a scheduled-rot check, not a one-time defect. Any PR can be
+blocked by it the moment npm publishes a new `@civitai/*` minor, regardless of that PR's
+content. The fix is always the same one command. (There is a `bump-scaffold-pins.yml` workflow;
+worth checking why it did not open the bump PR itself before the check went red.)
+
+Minor, left alone deliberately: the bumper also rewrites a README prose line to read
+"`accountType` / … require `@civitai/app-sdk@^0.30.0`", but those APIs arrived in the *older*
+version — post-bump the sentence overstates the minimum. Over-strict, not harmful; rewriting
+that site is the bumper's documented design. Flagged on cli#194, not changed.
 
 **Deploy/verify status:** all merged to `civitai/main` and `civitai-cli/main`. Verified at the
 unit tier and via prod SQL (below). Component/browser tier: the ambiguity that made it
@@ -137,23 +155,23 @@ Query via: `KUBECONFIG=$KC_DPPROD kubectl exec -n cnpg-database $(kubectl get cl
 
 ## Next steps (ranked)
 
-1. **Fix the `getByText('Generations')` ambiguity** (above) and open a small PR. Self-inflicted,
-   diagnosed, ~5 lines. Do this first.
-2. **Merge cli#193** (this doc + the updated predecessor). Docs-only.
-3. **Fix `lint.yml`'s stale unit-job comment** and consider adding the component project to
+1. ~~**Fix the `getByText('Generations')` ambiguity**~~ — DONE, civitai#3606.
+2. ~~**Unblock cli#193** by bumping the stale scaffold pins~~ — DONE, cli#194 (`189d5a4`).
+3. **Merge cli#193** (this doc + the updated predecessor). Docs-only; auto-merge enabled.
+4. **Fix `lint.yml`'s stale unit-job comment** and consider adding the component project to
    GitHub Actions as `continue-on-error: true` — the same report-only posture the unit job
    uses, and the only way to get canonical-browser signal. ⚠️ `.github/workflows/*` is
    ask-first per `AGENTS.md`. Do NOT frame this as "adding a missing tier" — the tier exists
    (`preview / component-tests`); this is about a second, GH-native runner.
-4. **Follow-up #6 — ClickHouse `blockRenders` has zero readers.** The real remaining product
+5. **Follow-up #6 — ClickHouse `blockRenders` has zero readers.** The real remaining product
    gap: written since 2026-06-22, carries `appBlockId`/`slotId`/`isAnon`, and is the only
    signal covering anonymous viewers and static blocks. Per-mount, so unique views need
    query-side dedup.
-5. **Follow-up #5 — `normalizeEndpoint` still writes unbounded values**
+6. **Follow-up #5 — `normalizeEndpoint` still writes unbounded values**
    (`block-scope.middleware.ts`): templates only `^\d+$` and ULIDs, so a slug/UUID segment
    passes through verbatim into `topEndpoints`.
-6. **Follow-up #3** (owns-zero-apps unflagged all-zero; web-only) and **#7** (minor grab-bag).
-7. **Two unverified leads:** `addCollaborator` is a PUT that *sets* permission, so
+7. **Follow-up #3** (owns-zero-apps unflagged all-zero; web-only) and **#7** (minor grab-bag).
+8. **Two unverified leads:** `addCollaborator` is a PUT that *sets* permission, so
    `civitai app pull` granting `read` where the web flow granted `write` may downgrade it and
    break a later push (#3572 made it reachable by the CLI's default credential; nobody checked
    Forgejo's live PUT semantics). And `installs: 0` remains **unverified, not measured** — no

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Finish the App-analytics follow-up stream. The feature work is **done and merged**; what
-remains is one self-inflicted broken test (diagnosed below, fix is known), and the
-lower-priority follow-ups #3/#5/#6/#7 from the original handoff.
+Finish the App-analytics follow-up stream. The feature work is **done and merged**, and the
+one self-inflicted broken test is **fixed and merged** (civitai#3606). What remains is the
+lower-priority follow-ups #3/#5/#6/#7 from the original handoff, plus one unblocking chore.
 
 Predecessor doc (history + the original ranked list):
 `claudedocs/2026-08-03-app-analytics-handoff.md` — same branch, same PR.
@@ -25,12 +25,22 @@ Predecessor doc (history + the original ranked list):
 | civitai#3581 | `getMyRevenue` undiscriminated zero + extract shared `RevenuePanel` |
 | cli#190 | `civitai app metrics <slug>` |
 | cli#191 / cli#192 | `AGENTS.md` items 5–7 / item 8 (CLI-vs-web label divergence) |
+| civitai#3606 | anchor the `Generations` locator — fixes the component-suite oscillation this stream caused |
 
-**IN FLIGHT:** cli#193 only (two docs). Nothing else uncommitted anywhere.
+**IN FLIGHT:** cli#193 only (these two docs). Auto-merge is ENABLED; it is `BLOCKED` solely by
+a red required check that is **red on `main` too** — `pins-vs-published` fails because npm has
+published past the scaffold pins (`@civitai/blocks-react` pinned `^0.37.0`, published `0.38.0`;
+`@civitai/app-sdk` `^0.28.0` vs `0.30.0`). Nothing to do with these docs (the PR changes two
+`.md` files). Fix: `go run ./internal/scaffold/cmd/bump-pins` in the cli repo, then update the
+matching assertions in `scaffold_test.go`. That unblocks #193 automatically and fixes a real
+defect — the check's own message is "every app created from this template is born stale".
+Nothing else uncommitted anywhere.
 
-**Deploy/verify status:** all merged to `civitai/main` and `civitai-cli/main`. Verified at
-the unit tier and via prod SQL (below). **NOT verified** at the component/browser tier —
-see the open investigation; that tier is report-only and currently red on #3574.
+**Deploy/verify status:** all merged to `civitai/main` and `civitai-cli/main`. Verified at the
+unit tier and via prod SQL (below). Component/browser tier: the ambiguity that made it
+oscillate is fixed in #3606, but `preview / component-tests` had **not reported on #3606 at
+merge time** — read that check on the next PR to confirm the suite is actually green. It
+cannot be confirmed locally (see the investigation block).
 
 **Prod facts established (don't re-query):** `OauthClient.allowedScopes` for `civitai-cli`
 = `100663297` (bit 25 live, so #3572 takes effect). Of 6,685,302 `ApiKey` rows: **0** are a

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -44,10 +44,20 @@ and **all five `template-page-money` CI steps reproduced locally** against the a
 can break the template. All 10 checks green on #194.
 Nothing else uncommitted anywhere.
 
-⚠️ **This will recur** — it is a scheduled-rot check, not a one-time defect. Any PR can be
-blocked by it the moment npm publishes a new `@civitai/*` minor, regardless of that PR's
-content. The fix is always the same one command. (There is a `bump-scaffold-pins.yml` workflow;
-worth checking why it did not open the bump PR itself before the check went red.)
+⚠️ **This will recur, and the automation cannot prevent it** — measured, not assumed. The
+`bump-scaffold-pins.yml` workflow is NOT broken: it ran on schedule Mon 2026-08-03 at
+**10:51 UTC** and correctly no-op'd, because both packages published *later that same day* —
+`blocks-react` 0.38.0 at **20:15 UTC**, `app-sdk` 0.30.0 at **22:13 UTC** (npm registry `time`
+field). It is a **weekly cron** (`17 7 * * 1`), so any `@civitai/*` minor publish leaves
+`pins-vs-published` — a REQUIRED check — red on `main` and on every open PR for up to ~7 days
+regardless of that PR's content. We happened to catch this one ~1 day in.
+
+Two things follow: (a) when a PR is blocked by `pins-vs-published`, the fix is always
+`go run ./internal/scaffold/cmd/bump-pins` + a PR — don't re-diagnose it; you can also just
+`gh workflow run bump-scaffold-pins.yml` (someone already did exactly that on 2026-07-29,
+49s after the 0.28.0 publish). (b) If the ~7-day window is judged too wide, the lever is cron
+frequency (daily) — not the bumper, which works. ⚠️ `.github/workflows/*` is ask-first per
+`AGENTS.md`, so that is a decision to raise, not to make.
 
 Minor, left alone deliberately: the bumper also rewrites a README prose line to read
 "`accountType` / … require `@civitai/app-sdk@^0.30.0`", but those APIs arrived in the *older*

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -43,7 +43,7 @@ Query via: `KUBECONFIG=$KC_DPPROD kubectl exec -n cnpg-database $(kubectl get cl
 
 ## Open investigations — live diagnosis state
 
-### `preview / component-tests` is RED on #3574 — ROOT CAUSE FOUND, fix not yet written
+### ~~`preview / component-tests` is RED on #3574~~ — RESOLVED, fixed in civitai#3606
 
 - **Symptom + exact repro:** the external `preview / component-tests` check went
   **success → failure** exactly at my audit-fix round on #3574, and stayed failed through
@@ -88,7 +88,27 @@ Query via: `KUBECONFIG=$KC_DPPROD kubectl exec -n cnpg-database $(kubectl get cl
   matcher timeout → suite red. This is exactly #3593's defect class, introduced by my
   vocabulary rename, at exactly the commit where the check turned red.
 
-- **Next probe / fix (apply verbatim):** mirror #3593's fix in
+- **FIXED — civitai#3606 (merged 2026-08-04).** Anchored with `{ exact: true }`, plus a
+  regression guard that REPRODUCES the breaking state (hovers the tooltip's real target) so
+  reverting the anchor fails a test rather than contradicting a comment.
+
+  🔴 **The trap when reproducing this class:** the tooltip target is the 14px
+  `IconInfoCircle`, NOT the label. Hovering the "Runs (range)" text does **not** mount it —
+  measured `tooltip_mounted=false`. My first attempt hovered the label, saw the old assertion
+  pass, and would have shipped an unproven fix; a positive control on the PROBE is what caught
+  it. Hovering the icon gives `before=1 after=2 tooltip_mounted=true`.
+
+  Proof matrix (all mutations checksum-verified, file restored byte-identical): old assertion
+  + icon hovered → FAILS with `strict mode violation: getByText('Generations') resolved to 2
+  elements`; new assertion + icon hovered → passes; drop the anchor from the new guard →
+  FAILS; hover a non-mounting target → the guard's POSITIVE CONTROL fails, so it cannot pass
+  vacuously.
+
+  ⚠️ **Still unconfirmed by the authority:** `preview / component-tests` had not reported on
+  #3606 at merge time (preview deploy was pending). **Read that check on the next PR** to
+  confirm the suite is green — the local full-project run cannot do it (see below).
+
+- ~~Next probe / fix (apply verbatim):~~ historical — mirror #3593's fix in
   `src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx`:
   1. anchor the ambiguous assertions with `{ exact: true }` —
      `page.getByText('Generations', { exact: true })` at line 105 (and audit lines 129/130/144


### PR DESCRIPTION
Gets the app-analytics handoff doc onto `main` instead of leaving it on a branch, and updates it so it stops reading as a to-do list for work that has since shipped.

## Why now

The doc is the source for everything in this stream — cli#190/#191/#192 and civitai#3557/#3561/#3572/#3574/#3581. It has been sitting on an unmerged branch describing "3 PRs open, nothing merged", with a prominent **"Do not merge until that re-gate reports"** directive that is now three merges out of date. A stranded doc that is also stale is worse than no doc: the next reader acts on the imperatives.

## What changed

- **RESOLVED banner** with the merged-PR table, replacing the "nothing merged" status.
- **Neutralised the stale directive** — and recorded that the rebase it anticipated *was* needed, for a different reason than it guessed: `#3566` landed later still and edited the same `detail: {}` object, turning #3561 `CONFLICTING` after its gate had already passed.
- **Struck follow-ups #1, #2 and #4** with outcomes, including the two places **this doc was wrong**:
  - #1's entry missed a second proc with the identical live defect — `getMyForgejoCloneInfo`, which `civitai app pull` drives. An audit found it, not the list. Worth knowing generally: a ranked follow-up list is not a survey.
  - #2's suggested fix (reuse `humaniseScopeEndpoint`) would have shipped a bug. Measured against the real function it returns `'(no workflow id)'` and `''` for the bounded tokens, because it's the per-*row* labeller and an aggregate bucket has no `detail`.
- **Recorded #1's scope decision with the prod evidence** that confirmed it after the fact: 331 live tokens unblocked, **30 of which lack bit 26** — so copying the nearest precedent would have left those still 403ing. Plus the measurement trap: `(mask & Full) = Full` is also true when `mask == Full` and reports 145 false hits.
- **New "Still open — start here"** section, so the remaining work is findable without reading the history: the CI `component`-tier gap, the stale-`node_modules` trap that silently removes ~1,126 tests, the unverified `addCollaborator` downgrade lead, and a note that `installs: 0` should be assumed broken until a positive control exists.
- **"What actually caught the bugs"** — across 12 adversarial audit rounds, every fix round found a defect in the previous fix, and the mechanical gate caught none of them.

## The two things in here I'd most want a reviewer to see

**CI does not run the `component` (browser) project at all.** Three PRs merged today ship browser tests — #3574's 7, #3581's 3, plus #3557's existing panel tests — that have **never executed on a canonical browser**. They ran only against a nixpkgs `playwright-chromium-headless-shell` shimmed in locally, because Playwright's vendored binary can't exec on NixOS. As things stand those guards would catch nothing in CI.

**A stale `node_modules` silently removes ~1,126 tests.** A worktree installed before main gained `@civitai/db-queries` fails at `kyselyDb.ts` module load, so 89 files' tests are never collected and the runner still prints a plausible total (10,131 passed vs 11,257 after `pnpm install`). Filed on [civitai#3579](https://github.com/civitai/civitai/issues/3579).

Doc-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
