### PR TITLE
fix(scaffold): bump page-money pins to published (app-sdk 0.30.0, blocks-react 0.38.0)

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -128,8 +128,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.37.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.28.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.38.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.30.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -186,7 +186,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.28.0` + `@civitai/blocks-react@^0.37.0` (already pinned in
+`@civitai/app-sdk@^0.30.0` + `@civitai/blocks-react@^0.38.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.28.0",
-    "@civitai/blocks-react": "^0.37.0",
+    "@civitai/app-sdk": "^0.30.0",
+    "@civitai/blocks-react": "^0.38.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## What

npm published past both `@civitai/*` pins in the `page-money` template. The pre-1.0 caret **locks the minor** (`^0.28.0` never installs `0.30.0`), so — in the guard's own words — *"every app created from this template is born stale"*.

| package | was | now | npm `latest` |
|---|---|---|---|
| `@civitai/app-sdk` | `^0.28.0` | `^0.30.0` | 0.30.0 |
| `@civitai/blocks-react` | `^0.37.0` | `^0.38.0` | 0.38.0 |

Produced mechanically by `go run ./internal/scaffold/cmd/bump-pins`, which rewrites all three literal pin sites in lockstep (`package.json.tmpl`, the `README.md.tmpl` prose, and the `scaffold_test.go` `mustContain` assertions). No hand edits.

## Why now

`pins-vs-published` is a **required** check, and it is red on `main` and therefore on every open PR regardless of that PR's content. It is currently the sole blocker on #193 (a two-file docs change). This unblocks that normally rather than via `--admin`.

Note `main`'s last CI run (6bdab0e) was green — the 0.30.0/0.38.0 publishes landed after it, so the check only goes red on re-run.

## Verification

A minor bump can break the template, so the rot-guard was run for real rather than assumed:

- **`pins-vs-published`:** RED at 6bdab0e (`main`) with both stale-pin messages → GREEN on this branch. Live npm query both times.
- **`bump-pins --check`** is a clean no-op afterwards (idempotent, exit 0).
- **`make ci`** green; `gofmt -s -l .` prints nothing.
- **All five `template-page-money` CI steps reproduced locally** against the *actual published* packages (node resolved `app-sdk` 0.30.0 / `blocks-react` 0.38.0 — verified from `node_modules`): scaffold → `npm install` (142 pkgs) → `typecheck` (clean) → `npm test` (11 files, **137 passed**) → `npm run build` → `civitai app validate` (`✓ . is valid`).

⚠️ Caveat on that last one: run on node **v26** locally; CI pins node **22**. CI is the authority.

## One thing worth a look

The bumper also rewrites this README prose line:

> `accountType` / `spentAccountType` / `useBuzzBalance` require `@civitai/app-sdk@^0.30.0` + `@civitai/blocks-react@^0.38.0`

Those APIs actually arrived in the *older* versions, so post-bump the sentence overstates the minimum. It is over-strict rather than wrong-in-a-harmful-direction, the parenthetical ties it to the pin ("already pinned in `package.json`"), and rewriting that site is the bumper's documented design — so I left the behaviour alone here rather than widen an unblocking PR. Flagging in case you'd rather the prose said "pinned at" instead of "require".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vvMdxcMKJP9ripQLEiPm9
