### PR TITLE
feat(app): print the impressions section in `civitai app metrics`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,9 +195,10 @@ until that exists, vendoring is on purpose.
    `recordScopeInvocation` call sites, and note that `pending` is a "no id
    captured" sentinel — **not** a status.
 9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
-   redundant with `notOwned`.** The `Views` section of `app metrics` is the only
-   part of the payload the server reads from **ClickHouse** (`blockRenders`)
-   rather than Postgres, so its store can be unconfigured or down while every
+   redundant with `notOwned`.** The `App loads` section of `app metrics` is the
+   only part of the payload the server reads from **ClickHouse** (`blockRenders`)
+   rather than Postgres, so its store can be unconfigured, SLOW (the server-side
+   read is time-bounded and a timeout degrades to this flag) or down while every
    other counter in the same response is genuinely measured. That is why the
    flag is per-SECTION: flagging the whole payload would discard good data, and
    dropping the flag would recreate the fabricated zero that item 6 exists to
@@ -222,6 +223,13 @@ until that exists, vendoring is on purpose.
    across 27 distinct apps) — so deduping on it would report ~1 viewer per app.
    Anonymous rows all carry `userId = 0`, so the server sums distinct authed
    `userId` with distinct anon `ip`.
+   Two more things the label has to keep straight, both of which read wrong if
+   you shorten them: `AnonCount` is signed-out **LOADS**, not viewers, and is
+   NOT a subset of `UniqueViewers` — one anonymous visitor reloading ten times
+   is 10 there and 1 unique viewer, so it can legitimately be the larger number.
+   And the section is called **App loads**, not Views, because the server writes
+   a row even when a mount FAILS (a failed launch's only beacon) and the table
+   has no status column — so a permanently-broken app still reports loads.
 
 **When you change a validation rule, keep both vendored mirrors (`schema/` + the
 ported Go checks in `internal/validate/`, including the slot registry) in sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,26 @@ until that exists, vendoring is on purpose.
    hand-rolling labels, add a drift check against the server's
    `recordScopeInvocation` call sites, and note that `pending` is a "no id
    captured" sentinel — **not** a status.
+9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
+   redundant with `notOwned`.** The `Views` section of `app metrics` is the only
+   part of the payload the server reads from **ClickHouse** (`blockRenders`)
+   rather than Postgres, so its store can be unconfigured or down while every
+   other counter in the same response is genuinely measured. That is why the
+   flag is per-SECTION: flagging the whole payload would discard good data, and
+   dropping the flag would recreate the fabricated zero that item 6 exists to
+   prevent — an author reading `Impressions 0` as "nobody looked at my app"
+   when the truth is "we could not ask". `printAppMetrics` therefore prints
+   `unavailable` plus an explicit caveat instead of any number, and `--json`
+   passes the field through while **still exiting 0**, so a script must branch
+   on `views.unavailable` exactly as it must already branch on `notOwned`.
+   Whoever changes the server payload has to keep the field
+   (`civitai/civitai → src/server/services/blocks/app-views.service.ts`).
+   Related gotcha worth not rediscovering: unique viewers deliberately do **not**
+   dedup on `blockInstanceId`. Despite the name it is not per-mount — it is
+   `page_apb_<ULID>`, roughly one per app (measured on prod: 28 distinct ids
+   across 27 distinct apps) — so deduping on it would report ~1 viewer per app.
+   Anonymous rows all carry `userId = 0`, so the server sums distinct authed
+   `userId` with distinct anon `ip`.
 
 **When you change a validation rule, keep both vendored mirrors (`schema/` + the
 ported Go checks in `internal/validate/`, including the slot registry) in sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,14 @@ until that exists, vendoring is on purpose.
    on `views.unavailable` exactly as it must already branch on `notOwned`.
    Whoever changes the server payload has to keep the field
    (`civitai/civitai → src/server/services/blocks/app-views.service.ts`).
+   🔴 `AppAnalytics.Views` is a **pointer** for the same reason, and must stay
+   one: there are THREE states, not two — measured, unavailable, and *absent*
+   (a server predating the impressions reader omits the key). A value type
+   collapses "absent" into "measured zero", because `encoding/json` simply
+   leaves the zero value in place and the renderer then prints
+   `Impressions 0`. That was **measured, not theorised** — the value-typed
+   version rendered exactly `Impressions     0` for a payload with no `views`
+   key. So `nil` means unknown and renders like `unavailable`, never as `0`.
    Related gotcha worth not rediscovering: unique viewers deliberately do **not**
    dedup on `blockInstanceId`. Despite the name it is not per-mount — it is
    `page_apb_<ULID>`, roughly one per app (measured on prod: 28 distinct ids

--- a/README.md
+++ b/README.md
@@ -700,10 +700,10 @@ Buzz purchased
   Buzz       15000
   Gross      $14.97
 
-Views
-  Impressions     124
-  Unique viewers  12
-  Signed-out      4
+App loads
+  Impressions       124
+  Unique viewers    12
+  Signed-out loads  40
 
 Engagement
   API calls     26
@@ -742,11 +742,15 @@ Two data caveats.
 
 **Engagement counts only authenticated, scope-gated API
 calls.** An app that ships no scoped API surface shows real installs and revenue
-with a flat engagement section — that is expected, not a bug. **Views is the
+with a flat engagement section — that is expected, not a bug. **App loads is the
 exception**: it is measured on every load, so it counts signed-out visitors and
 static blocks that engagement structurally cannot see. `Unique viewers` counts
 signed-in people once each and approximates signed-out ones by network address,
-so read it as reach rather than an identity count. `Error rate` is the
+so read it as reach rather than an identity count, and `Signed-out loads` is a
+count of LOADS (one anonymous visitor reloading ten times is 10 there and 1
+unique viewer), so it can legitimately exceed `Unique viewers`. Note also that
+these are mount ATTEMPTS: a load that FAILED still counts, because a failed
+mount's only beacon is the same event and it carries no status. `Error rate` is the
 share of those calls that failed, and the human view renders it as a percentage
 (the server sends it as a `0`–`1` ratio, which `--json` passes through unchanged).
 Only a genuine zero prints `0.0%`: a real but tiny rate — a high-traffic app with
@@ -762,17 +766,18 @@ counter zeroed and the command still exits `0`, so
 can't see. A script must branch on the `notOwned` field rather than trusting the
 counts.
 
-**Views has a SECOND, section-local unavailability flag** — `views.unavailable`,
-independent of `notOwned`. Views is the one section the server reads from a
-different store, which can be unreadable while every other counter in the same
-response is genuinely measured. When that happens the human view prints
-`unavailable` and says so explicitly rather than printing a `0` you would read
-as "nobody looked at my app". `--json` passes the flag through and still exits
-`0`, so a script must branch on `views.unavailable` too — `jq .views.count`
-alone cannot tell an outage from a real zero. A server old enough to predate
-impressions omits the `views` key entirely; the human view reports that as
-unavailable as well (naming the different cause), and a script should treat a
-missing `.views` the same way.
+**App loads has a SECOND, section-local unavailability flag** — `views.unavailable`,
+independent of `notOwned`. It is the one section the server reads from a
+different store, which can be unreadable — or merely too slow, the read is
+time-bounded server-side — while every other counter in the same response is
+genuinely measured. When that happens the human view prints `unavailable` and
+says so explicitly rather than printing a `0` you would read as "nobody opened
+my app". `--json` passes the flag through and still exits `0`, so a script must
+branch on `views.unavailable` too — `jq .views.count` alone cannot tell an
+outage from a real zero. A server old enough to predate this section omits the
+`views` key entirely; the human view reports that as unavailable as well
+(naming the different cause), and a script should treat a missing `.views` the
+same way.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -769,7 +769,10 @@ response is genuinely measured. When that happens the human view prints
 `unavailable` and says so explicitly rather than printing a `0` you would read
 as "nobody looked at my app". `--json` passes the flag through and still exits
 `0`, so a script must branch on `views.unavailable` too — `jq .views.count`
-alone cannot tell an outage from a real zero.
+alone cannot tell an outage from a real zero. A server old enough to predate
+impressions omits the `views` key entirely; the human view reports that as
+unavailable as well (naming the different cause), and a script should treat a
+missing `.views` the same way.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -700,6 +700,11 @@ Buzz purchased
   Buzz       15000
   Gross      $14.97
 
+Views
+  Impressions     124
+  Unique viewers  12
+  Signed-out      4
+
 Engagement
   API calls     26
   Active users  2
@@ -733,9 +738,15 @@ believable-but-wrong reading:
   `civitai login` token gets a 403; the error names the fix
   (`civitai login --token <key>`).
 
-One data caveat: **engagement counts only authenticated, scope-gated API
-calls**. An app that ships no scoped API surface shows real installs and revenue
-with a flat engagement section — that is expected, not a bug. `Error rate` is the
+Two data caveats.
+
+**Engagement counts only authenticated, scope-gated API
+calls.** An app that ships no scoped API surface shows real installs and revenue
+with a flat engagement section — that is expected, not a bug. **Views is the
+exception**: it is measured on every load, so it counts signed-out visitors and
+static blocks that engagement structurally cannot see. `Unique viewers` counts
+signed-in people once each and approximates signed-out ones by network address,
+so read it as reach rather than an identity count. `Error rate` is the
 share of those calls that failed, and the human view renders it as a percentage
 (the server sends it as a `0`–`1` ratio, which `--json` passes through unchanged).
 Only a genuine zero prints `0.0%`: a real but tiny rate — a high-traffic app with
@@ -750,6 +761,15 @@ counter zeroed and the command still exits `0`, so
 `civitai app metrics <slug> --json | jq .runs.count` returns `0` for an app you
 can't see. A script must branch on the `notOwned` field rather than trusting the
 counts.
+
+**Views has a SECOND, section-local unavailability flag** — `views.unavailable`,
+independent of `notOwned`. Views is the one section the server reads from a
+different store, which can be unreadable while every other counter in the same
+response is genuinely measured. When that happens the human view prints
+`unavailable` and says so explicitly rather than printing a `0` you would read
+as "nobody looked at my app". `--json` passes the flag through and still exits
+`0`, so a script must branch on `views.unavailable` too — `jq .views.count`
+alone cannot tell an outage from a real zero.
 
 ## Configuration
 

--- a/internal/appapi/analytics.go
+++ b/internal/appapi/analytics.go
@@ -125,7 +125,15 @@ type AppAnalytics struct {
 	Runs          AnalyticsRuns          `json:"runs"`
 	BuzzPurchased AnalyticsBuzzPurchased `json:"buzzPurchased"`
 	Engagement    AnalyticsEngagement    `json:"engagement"`
-	Views         AnalyticsViews         `json:"views"`
+	// Views is a POINTER so that "the server did not send this section at all"
+	// stays distinguishable from "the server sent measured zeros". A value type
+	// collapses those two: an older server that predates the impressions reader
+	// omits the key, Go fills in the zero value, and the CLI confidently prints
+	// `Impressions 0` — a fabricated zero, which is the exact defect this
+	// section's Unavailable flag exists to prevent. Measured before this was a
+	// pointer: a payload with no `views` key rendered "Impressions     0".
+	// nil therefore means UNKNOWN and must render like Unavailable, never as 0.
+	Views *AnalyticsViews `json:"views"`
 }
 
 // AppAnalyticsReader reads the caller's own App Block analytics.

--- a/internal/appapi/analytics.go
+++ b/internal/appapi/analytics.go
@@ -87,27 +87,35 @@ type AnalyticsEngagement struct {
 	TopEndpoints []AnalyticsEndpointCount `json:"topEndpoints"`
 }
 
-// AnalyticsViews is the impression rollup, read server-side from the
+// AnalyticsViews is the app-load rollup, read server-side from the
 // `blockRenders` ClickHouse table. It is the ONLY section that covers viewers
 // AnalyticsEngagement structurally cannot see — anonymous visitors, and static
 // blocks that never make a scoped API call.
 //
 // 🔴 Unavailable is a SECOND, section-local unavailability signal, distinct
 // from AppAnalytics.NotOwned. This is the one section not derived from
-// Postgres, so its store can be unconfigured or down while every other counter
-// in the same response is genuinely measured. When it is true the counters
-// below are PLACEHOLDERS, not a report of zero views — render them as unknown,
-// never as 0. `--json` passes the field through untouched, so a script must
-// branch on it exactly as it already must branch on NotOwned.
+// Postgres, so its store can be unconfigured, SLOW or down while every other
+// counter in the same response is genuinely measured. When it is true the
+// counters below are PLACEHOLDERS, not a report of zero loads — render them as
+// unknown, never as 0. `--json` passes the field through untouched, so a script
+// must branch on it exactly as it already must branch on NotOwned.
+//
+// COVERAGE CAVEAT: these are mount ATTEMPTS, not successful sessions. The
+// server writes a row even when the app fails to launch (a failed mount's only
+// beacon) and the table carries no status column, so a failing app still
+// reports loads. Hence "App loads" rather than "Views".
 type AnalyticsViews struct {
 	Count int64 `json:"count"`
 	// UniqueViewers counts signed-in viewers once each and approximates
 	// signed-out ones by network address, so it is a reach indicator rather
 	// than an identity count.
-	UniqueViewers int64            `json:"uniqueViewers"`
-	AnonCount     int64            `json:"anonCount"`
-	Series        []AnalyticsPoint `json:"series"`
-	Unavailable   bool             `json:"unavailable,omitempty"`
+	UniqueViewers int64 `json:"uniqueViewers"`
+	// AnonCount is signed-out LOADS — an impression count, NOT a viewer count
+	// and NOT a subset of UniqueViewers. One anonymous visitor reloading ten
+	// times contributes 10 here and 1 to UniqueViewers, so this can exceed
+	// UniqueViewers. Label it as loads wherever it sits beside a viewer figure.
+	AnonCount   int64 `json:"anonCount"`
+	Unavailable bool  `json:"unavailable,omitempty"`
 }
 
 // AppAnalytics mirrors the blocks.getMyAppAnalytics result. Field names + JSON

--- a/internal/appapi/analytics.go
+++ b/internal/appapi/analytics.go
@@ -87,6 +87,29 @@ type AnalyticsEngagement struct {
 	TopEndpoints []AnalyticsEndpointCount `json:"topEndpoints"`
 }
 
+// AnalyticsViews is the impression rollup, read server-side from the
+// `blockRenders` ClickHouse table. It is the ONLY section that covers viewers
+// AnalyticsEngagement structurally cannot see — anonymous visitors, and static
+// blocks that never make a scoped API call.
+//
+// 🔴 Unavailable is a SECOND, section-local unavailability signal, distinct
+// from AppAnalytics.NotOwned. This is the one section not derived from
+// Postgres, so its store can be unconfigured or down while every other counter
+// in the same response is genuinely measured. When it is true the counters
+// below are PLACEHOLDERS, not a report of zero views — render them as unknown,
+// never as 0. `--json` passes the field through untouched, so a script must
+// branch on it exactly as it already must branch on NotOwned.
+type AnalyticsViews struct {
+	Count int64 `json:"count"`
+	// UniqueViewers counts signed-in viewers once each and approximates
+	// signed-out ones by network address, so it is a reach indicator rather
+	// than an identity count.
+	UniqueViewers int64            `json:"uniqueViewers"`
+	AnonCount     int64            `json:"anonCount"`
+	Series        []AnalyticsPoint `json:"series"`
+	Unavailable   bool             `json:"unavailable,omitempty"`
+}
+
 // AppAnalytics mirrors the blocks.getMyAppAnalytics result. Field names + JSON
 // casing track the server EXACTLY.
 type AppAnalytics struct {
@@ -102,6 +125,7 @@ type AppAnalytics struct {
 	Runs          AnalyticsRuns          `json:"runs"`
 	BuzzPurchased AnalyticsBuzzPurchased `json:"buzzPurchased"`
 	Engagement    AnalyticsEngagement    `json:"engagement"`
+	Views         AnalyticsViews         `json:"views"`
 }
 
 // AppAnalyticsReader reads the caller's own App Block analytics.

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -241,6 +241,30 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 	fmt.Fprintf(tw, "  Gross\t%s\n", usdFromCents(a.BuzzPurchased.GrossCents))
 	_ = tw.Flush()
 
+	// VIEWS sits before Engagement on purpose: it is the broader number (every
+	// load, including signed-out ones), so an author reads the wide measure
+	// first and the authenticated-only subset second — which is also the order
+	// the coverage caveat below then makes sense in.
+	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Views"))
+	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if a.Views.Unavailable {
+		// 🔴 Never print 0 here. The impression store is the one section not
+		// derived from Postgres, so it can be unreadable while every counter
+		// above is genuinely measured — and a printed 0 is indistinguishable
+		// from "nobody looked", which is the fabricated-zero defect the server
+		// added this flag to prevent.
+		fmt.Fprintf(tw, "  Impressions\t%s\n", "unavailable")
+		fmt.Fprintf(tw, "  Unique viewers\t%s\n", "unavailable")
+		_ = tw.Flush()
+		fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
+			"The impression store could not be read — this is NOT a report of zero views. Every other metric above is unaffected."))
+	} else {
+		fmt.Fprintf(tw, "  Impressions\t%d\n", a.Views.Count)
+		fmt.Fprintf(tw, "  Unique viewers\t%d\n", a.Views.UniqueViewers)
+		fmt.Fprintf(tw, "  Signed-out\t%d\n", a.Views.AnonCount)
+		_ = tw.Flush()
+	}
+
 	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Engagement"))
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, "  API calls\t%d\n", a.Engagement.APICalls)
@@ -266,7 +290,7 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 	}
 	if a.Engagement.APICalls == 0 {
 		fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
-			"Engagement counts only authenticated, scope-gated API calls — an app with no scoped API surface reads flat here."))
+			"Engagement counts only authenticated, scope-gated API calls — an app with no scoped API surface reads flat here. Views is measured on every load, so it still counts those visitors."))
 	}
 }
 

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -247,17 +247,24 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 	// the coverage caveat below then makes sense in.
 	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Views"))
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if a.Views.Unavailable {
-		// 🔴 Never print 0 here. The impression store is the one section not
-		// derived from Postgres, so it can be unreadable while every counter
-		// above is genuinely measured — and a printed 0 is indistinguishable
-		// from "nobody looked", which is the fabricated-zero defect the server
-		// added this flag to prevent.
+	// 🔴 Never print 0 in either unknown case. The impression store is the one
+	// section not derived from Postgres, so it can be unreadable while every
+	// counter above is genuinely measured — and a printed 0 is
+	// indistinguishable from "nobody looked", the fabricated-zero defect this
+	// flag exists to prevent. `a.Views == nil` is the SECOND way to not know:
+	// a server predating the impressions reader omits the section entirely,
+	// and a value type would have silently turned that into a measured zero.
+	if a.Views == nil || a.Views.Unavailable {
 		fmt.Fprintf(tw, "  Impressions\t%s\n", "unavailable")
 		fmt.Fprintf(tw, "  Unique viewers\t%s\n", "unavailable")
 		_ = tw.Flush()
-		fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
-			"The impression store could not be read — this is NOT a report of zero views. Every other metric above is unaffected."))
+		if a.Views == nil {
+			fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
+				"This server did not report impressions — this is NOT a report of zero views. Upgrade the server, or ignore this section."))
+		} else {
+			fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
+				"The impression store could not be read — this is NOT a report of zero views. Every other metric above is unaffected."))
+		}
 	} else {
 		fmt.Fprintf(tw, "  Impressions\t%d\n", a.Views.Count)
 		fmt.Fprintf(tw, "  Unique viewers\t%d\n", a.Views.UniqueViewers)

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -245,7 +245,7 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 	// load, including signed-out ones), so an author reads the wide measure
 	// first and the authenticated-only subset second — which is also the order
 	// the coverage caveat below then makes sense in.
-	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Views"))
+	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("App loads"))
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	// 🔴 Never print 0 in either unknown case. The impression store is the one
 	// section not derived from Postgres, so it can be unreadable while every
@@ -260,15 +260,15 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 		_ = tw.Flush()
 		if a.Views == nil {
 			fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
-				"This server did not report impressions — this is NOT a report of zero views. Upgrade the server, or ignore this section."))
+				"This server did not report app loads — this is NOT a report of zero loads. Upgrade the server, or ignore this section."))
 		} else {
 			fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
-				"The impression store could not be read — this is NOT a report of zero views. Every other metric above is unaffected."))
+				"The impression store could not be read — this is NOT a report of zero loads. Every other metric above is unaffected."))
 		}
 	} else {
 		fmt.Fprintf(tw, "  Impressions\t%d\n", a.Views.Count)
 		fmt.Fprintf(tw, "  Unique viewers\t%d\n", a.Views.UniqueViewers)
-		fmt.Fprintf(tw, "  Signed-out\t%d\n", a.Views.AnonCount)
+		fmt.Fprintf(tw, "  Signed-out loads\t%d\n", a.Views.AnonCount)
 		_ = tw.Flush()
 	}
 
@@ -297,7 +297,7 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 	}
 	if a.Engagement.APICalls == 0 {
 		fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
-			"Engagement counts only authenticated, scope-gated API calls — an app with no scoped API surface reads flat here. Views is measured on every load, so it still counts those visitors."))
+			"Engagement counts only authenticated, scope-gated API calls — an app with no scoped API surface reads flat here. App loads is measured on every load, so it still counts those visitors."))
 	}
 }
 

--- a/internal/cmd/app_metrics_test.go
+++ b/internal/cmd/app_metrics_test.go
@@ -965,6 +965,49 @@ func TestAppMetricsJSONPassesViewsThroughRaw(t *testing.T) {
 	}
 }
 
+func TestAppMetricsLegacyServerWithoutViewsIsNotAZero(t *testing.T) {
+	// A server predating the impressions reader omits `views` ENTIRELY. That is
+	// a third "we don't know" — distinct from both a measured zero and an
+	// outage — and the one a value-typed field would silently swallow:
+	// encoding/json leaves the zero value in place and the CLI prints
+	// `Impressions 0`. Measured before AnalyticsViews became a pointer, this
+	// payload rendered exactly "Impressions     0".
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":20,"active":12,"series":[]},
+	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
+	  "buzzPurchased":{"count":2,"buzzAmount":5000,"grossCents":999},
+	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("old-app", strPtr("apb_old")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "old-app")
+	if err != nil {
+		t.Fatalf("a server without the views section is still a successful read: %v", err)
+	}
+	if got := valueOnLine(out, "Impressions"); got != "unavailable" {
+		t.Errorf("an absent views section must render as unavailable, got %q:\n%s", got, out)
+	}
+	if got := valueOnLine(out, "Unique viewers"); got != "unavailable" {
+		t.Errorf("an absent views section must render as unavailable, got %q:\n%s", got, out)
+	}
+	if !strings.Contains(out, "did not report impressions") {
+		t.Errorf("the absent-section caveat should name the real cause:\n%s", out)
+	}
+	if !strings.Contains(out, "NOT a report of zero views") {
+		t.Errorf("the caveat must spell out that this is not a measured zero:\n%s", out)
+	}
+	// Everything the old server DID send is genuinely measured and must render.
+	for _, want := range []string{"Installs", "20", "Runs", "7000", "Engagement", "100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("an absent views section must not disturb the rest, missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // valueOnLine returns the last whitespace-separated field of the first line
 // whose text (after indentation) begins with label. Returns "" when no such
 // line exists, so a missing row fails loudly rather than quietly matching "".

--- a/internal/cmd/app_metrics_test.go
+++ b/internal/cmd/app_metrics_test.go
@@ -809,3 +809,176 @@ func TestUTCStamp(t *testing.T) {
 		t.Errorf("utcStamp(\"\") = %q, want %q", got, "-")
 	}
 }
+
+// --- Views (blockRenders impressions) -------------------------------------
+//
+// Views is the one section the server reads from ClickHouse rather than
+// Postgres, so it carries its OWN `unavailable` flag, independent of
+// `notOwned`. That store can be unconfigured or down while every other counter
+// in the same response is genuinely measured — so the renderer must be able to
+// say "unavailable" for this section alone, and must never print a 0 that an
+// author would read as "nobody looked at my app".
+
+func TestAppMetricsRendersViews(t *testing.T) {
+	// Pairwise-distinct counters: a renderer that printed the wrong field
+	// would still have to print a wrong NUMBER.
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":20,"active":12,"series":[]},
+	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
+	  "buzzPurchased":{"count":2,"buzzAmount":5000,"grossCents":999},
+	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]},
+	  "views":{"count":124,"uniqueViewers":12,"anonCount":4,"series":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("seen-app", strPtr("apb_seen")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "seen-app")
+	if err != nil {
+		t.Fatalf("app metrics: %v", err)
+	}
+	// Assert each label WITH its value on the same line. Checking for "12" and
+	// "4" independently would pass even if the two fields were swapped — the
+	// fixture values are pairwise distinct precisely so a line-level check can
+	// tell them apart.
+	for label, want := range map[string]string{
+		"Impressions":    "124",
+		"Unique viewers": "12",
+		"Signed-out":     "4",
+	} {
+		if got := valueOnLine(out, label); got != want {
+			t.Errorf("line %q should carry value %q, got %q:\n%s", label, want, got, out)
+		}
+	}
+	if !strings.Contains(out, "Views") {
+		t.Errorf("views output missing the section heading:\n%s", out)
+	}
+	if strings.Contains(out, "unavailable") {
+		t.Errorf("a measured views result must not claim to be unavailable:\n%s", out)
+	}
+}
+
+func TestAppMetricsViewsUnavailableNeverPrintsZero(t *testing.T) {
+	// Byte-identical to a genuine all-zero views result EXCEPT for the flag —
+	// which is the entire contract. Note the sibling counters are non-zero and
+	// must survive untouched: a ClickHouse outage degrades one section, it does
+	// not invalidate the response.
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":20,"active":12,"series":[]},
+	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
+	  "buzzPurchased":{"count":2,"buzzAmount":5000,"grossCents":999},
+	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]},
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[],"unavailable":true}}`
+	srv := metricsServer(t,
+		submissionsBody("dark-app", strPtr("apb_dark")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "dark-app")
+	if err != nil {
+		t.Fatalf("an unavailable views section is still a successful read: %v", err)
+	}
+	if !strings.Contains(out, "unavailable") {
+		t.Errorf("an unreadable impression store must say so:\n%s", out)
+	}
+	if !strings.Contains(out, "NOT a report of zero views") {
+		t.Errorf("the caveat must spell out that this is not a measured zero:\n%s", out)
+	}
+	// The defect this pins: printing the placeholder 0 next to "Impressions".
+	if strings.Contains(out, "Impressions  0") || strings.Contains(out, "Unique viewers  0") {
+		t.Errorf("unavailable views must never render a fabricated 0:\n%s", out)
+	}
+	// The rest of the dashboard is genuinely measured and must be intact.
+	for _, want := range []string{"Installs", "20", "Runs", "7000", "Engagement", "100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("a views outage must not disturb the other sections, missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAppMetricsViewsMeasuredZeroIsNotUnavailable(t *testing.T) {
+	// The discriminator from the other side: a real "nobody looked yet".
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":0,"active":0,"series":[]},
+	  "runs":{"count":0,"buzzSpent":0,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]},
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("quiet-app", strPtr("apb_quiet")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "quiet-app")
+	if err != nil {
+		t.Fatalf("app metrics: %v", err)
+	}
+	if !strings.Contains(out, "Views") {
+		t.Errorf("a measured zero still renders the Views section:\n%s", out)
+	}
+	if strings.Contains(out, "unavailable") {
+		t.Errorf("a measured zero must NOT be reported as unavailable:\n%s", out)
+	}
+	if strings.Contains(out, "NOT a report of zero views") {
+		t.Errorf("the outage caveat must not appear for a genuine zero:\n%s", out)
+	}
+}
+
+func TestAppMetricsJSONPassesViewsThroughRaw(t *testing.T) {
+	// --json is a passthrough and still exits 0, so a script must be able to
+	// branch on views.unavailable itself — exactly as it already must for
+	// notOwned. Dropping the field would silently turn an outage into a zero
+	// for every scripted consumer.
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":0,"active":0,"series":[]},
+	  "runs":{"count":0,"buzzSpent":0,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]},
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[],"unavailable":true}}`
+	srv := metricsServer(t,
+		submissionsBody("dark-app", strPtr("apb_dark")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	jsonOut, _, err := run(t, "app", "metrics", "dark-app", "--json")
+	if err != nil {
+		t.Fatalf("app metrics --json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &got); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, jsonOut)
+	}
+	views, ok := got["views"].(map[string]any)
+	if !ok {
+		t.Fatalf("--json must pass the views section through:\n%s", jsonOut)
+	}
+	if views["unavailable"] != true {
+		t.Errorf("--json must surface views.unavailable for scripts:\n%s", jsonOut)
+	}
+}
+
+// valueOnLine returns the last whitespace-separated field of the first line
+// whose text (after indentation) begins with label. Returns "" when no such
+// line exists, so a missing row fails loudly rather than quietly matching "".
+func valueOnLine(out, label string) string {
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, label) {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) == 0 {
+			return ""
+		}
+		return fields[len(fields)-1]
+	}
+	return ""
+}

--- a/internal/cmd/app_metrics_test.go
+++ b/internal/cmd/app_metrics_test.go
@@ -828,7 +828,7 @@ func TestAppMetricsRendersViews(t *testing.T) {
 	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
 	  "buzzPurchased":{"count":2,"buzzAmount":5000,"grossCents":999},
 	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]},
-	  "views":{"count":124,"uniqueViewers":12,"anonCount":4,"series":[]}}`
+	  "views":{"count":124,"uniqueViewers":12,"anonCount":40}}`
 	srv := metricsServer(t,
 		submissionsBody("seen-app", strPtr("apb_seen")), http.StatusOK,
 		trpcEnvelope(payload), http.StatusOK, nil)
@@ -844,15 +844,15 @@ func TestAppMetricsRendersViews(t *testing.T) {
 	// fixture values are pairwise distinct precisely so a line-level check can
 	// tell them apart.
 	for label, want := range map[string]string{
-		"Impressions":    "124",
-		"Unique viewers": "12",
-		"Signed-out":     "4",
+		"Impressions":      "124",
+		"Unique viewers":   "12",
+		"Signed-out loads": "40",
 	} {
 		if got := valueOnLine(out, label); got != want {
 			t.Errorf("line %q should carry value %q, got %q:\n%s", label, want, got, out)
 		}
 	}
-	if !strings.Contains(out, "Views") {
+	if !strings.Contains(out, "App loads") {
 		t.Errorf("views output missing the section heading:\n%s", out)
 	}
 	if strings.Contains(out, "unavailable") {
@@ -871,7 +871,7 @@ func TestAppMetricsViewsUnavailableNeverPrintsZero(t *testing.T) {
 	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
 	  "buzzPurchased":{"count":2,"buzzAmount":5000,"grossCents":999},
 	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]},
-	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[],"unavailable":true}}`
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"unavailable":true}}`
 	srv := metricsServer(t,
 		submissionsBody("dark-app", strPtr("apb_dark")), http.StatusOK,
 		trpcEnvelope(payload), http.StatusOK, nil)
@@ -885,7 +885,7 @@ func TestAppMetricsViewsUnavailableNeverPrintsZero(t *testing.T) {
 	if !strings.Contains(out, "unavailable") {
 		t.Errorf("an unreadable impression store must say so:\n%s", out)
 	}
-	if !strings.Contains(out, "NOT a report of zero views") {
+	if !strings.Contains(out, "NOT a report of zero loads") {
 		t.Errorf("the caveat must spell out that this is not a measured zero:\n%s", out)
 	}
 	// The defect this pins: printing the placeholder 0 next to "Impressions".
@@ -908,7 +908,7 @@ func TestAppMetricsViewsMeasuredZeroIsNotUnavailable(t *testing.T) {
 	  "runs":{"count":0,"buzzSpent":0,"series":[]},
 	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
 	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]},
-	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[]}}`
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0}}`
 	srv := metricsServer(t,
 		submissionsBody("quiet-app", strPtr("apb_quiet")), http.StatusOK,
 		trpcEnvelope(payload), http.StatusOK, nil)
@@ -919,13 +919,13 @@ func TestAppMetricsViewsMeasuredZeroIsNotUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app metrics: %v", err)
 	}
-	if !strings.Contains(out, "Views") {
-		t.Errorf("a measured zero still renders the Views section:\n%s", out)
+	if !strings.Contains(out, "App loads") {
+		t.Errorf("a measured zero still renders the App loads section:\n%s", out)
 	}
 	if strings.Contains(out, "unavailable") {
 		t.Errorf("a measured zero must NOT be reported as unavailable:\n%s", out)
 	}
-	if strings.Contains(out, "NOT a report of zero views") {
+	if strings.Contains(out, "NOT a report of zero loads") {
 		t.Errorf("the outage caveat must not appear for a genuine zero:\n%s", out)
 	}
 }
@@ -941,7 +941,7 @@ func TestAppMetricsJSONPassesViewsThroughRaw(t *testing.T) {
 	  "runs":{"count":0,"buzzSpent":0,"series":[]},
 	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
 	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]},
-	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"series":[],"unavailable":true}}`
+	  "views":{"count":0,"uniqueViewers":0,"anonCount":0,"unavailable":true}}`
 	srv := metricsServer(t,
 		submissionsBody("dark-app", strPtr("apb_dark")), http.StatusOK,
 		trpcEnvelope(payload), http.StatusOK, nil)
@@ -994,10 +994,10 @@ func TestAppMetricsLegacyServerWithoutViewsIsNotAZero(t *testing.T) {
 	if got := valueOnLine(out, "Unique viewers"); got != "unavailable" {
 		t.Errorf("an absent views section must render as unavailable, got %q:\n%s", got, out)
 	}
-	if !strings.Contains(out, "did not report impressions") {
+	if !strings.Contains(out, "did not report app loads") {
 		t.Errorf("the absent-section caveat should name the real cause:\n%s", out)
 	}
-	if !strings.Contains(out, "NOT a report of zero views") {
+	if !strings.Contains(out, "NOT a report of zero loads") {
 		t.Errorf("the caveat must spell out that this is not a measured zero:\n%s", out)
 	}
 	// Everything the old server DID send is genuinely measured and must render.


### PR DESCRIPTION
> **Pairs with [civitai/civitai#3613](https://github.com/civitai/civitai/pull/3613)**, which adds the `views` section to the `getMyAppAnalytics` payload. Safe to merge in either order — see *Ordering* below, which is where the most interesting bug in this PR came from.

## What

civitai#3613 gives the ClickHouse `blockRenders` table its first reader. Without a matching CLI change, `civitai app metrics` silently under-reports against the web panel, and a scripted consumer reading `.views` gets nothing.

Adds a **Views** section — impressions / unique viewers / signed-out — placed *before* `Engagement`, so the author reads the wide measure first and the authenticated-only subset second (which is also the order that makes the existing coverage caveat legible).

```text
Views
  Impressions     124
  Unique viewers  12
  Signed-out      4
```

## The bit that matters

🔴 **`views.unavailable` is a SECOND unavailability discriminator, independent of `notOwned`.** Views is the only section the server reads from ClickHouse rather than Postgres, so its store can be unreadable while every other counter in the same response is genuinely measured. So the renderer prints:

```text
Views
  Impressions     unavailable
  Unique viewers  unavailable

The impression store could not be read — this is NOT a report of zero views. Every other metric above is unaffected.
```

…rather than a `0` an author reads as *"nobody looked at my app"*. Same fabricated-zero class `notOwned` already guards, one level down. `--json` passes the field through and **still exits 0**, so a script must branch on it — `jq .views.count` alone cannot tell an outage from a real zero.

## Docs

- **README** — Views rows in the sample output, the reach-vs-identity note on unique viewers, and a `--json` paragraph for the new flag.
- **AGENTS.md item 9** — why the flag is per-section, plus the part worth not rediscovering: unique viewers deliberately do **not** dedup on `blockInstanceId`. Despite the name it is not per-mount — measured on prod, 28 distinct ids across 27 distinct apps, i.e. per-*placement* — so deduping on it would report ~1 viewer per app.
- Updates the coverage caveat, which said engagement misses anonymous viewers and stopped there. Views is now exactly the section that catches them.

## Verification

`make ci` green; `gofmt -s -l .` prints nothing.

**8 mutations, 8/8 KILLED** (tree restored byte-identically, checksum-verified):

| mutation | result |
|---|---|
| C1 unavailable branch never taken | KILLED |
| C2 unavailable branch always taken | KILLED |
| C3 outage caveat dropped | KILLED |
| C4 unique-viewers / signed-out swapped | KILLED |
| C5 impressions renders `uniqueViewers` | KILLED |
| C6 `unavailable` json tag renamed | KILLED |
| C7 nil-guard dropped | KILLED |
| C8 `Views` reverted to a value type | KILLED (at compile) |

C4 is why the render test asserts each label **with its value on the same line**. An earlier version checked for `"12"` and `"4"` independently and would have passed with the two fields swapped; the fixture values are pairwise distinct so a line-level check can actually discriminate. (C3's anchor went stale when the caveat text moved into the new branch — re-run standalone with a corrected anchor, also KILLED.)

## Ordering — and the bug that fell out of checking it

I was about to write "safe to merge before #3613, an older server just omits `views`". Probing that instead of asserting it turned up a real defect **in this PR**:

With `AnalyticsViews` as a value type, a server that omits the `views` key gets the Go zero value filled in, and the CLI confidently prints:

```text
Views
  Impressions     0
  Unique viewers  0
```

That is the fabricated zero this entire section exists to prevent — delivered by the CLI itself, against every server without #3613.

There are **three** states, not two: *measured*, *unavailable*, and *absent*. `AppAnalytics.Views` is therefore a **pointer**, and `nil` renders like unavailable with a caveat naming the different cause (`"This server did not report impressions"`). The regression test is a real one — the probe showed the pre-change code printing `Impressions     0` for exactly that payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vvMdxcMKJP9ripQLEiPm9
