### PR TITLE
docs(validate,scaffold): the per-gen Buzz budget is a ceiling, not an estimate

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -475,6 +477,20 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, readme, "Submission lifecycle")
 	mustContain(t, readme, "civitai app withdraw")
 	mustContain(t, readme, "pending")
+
+	// SEAM (writer 3 of 3): the README is the THIRD writer of the budget number,
+	// and the ONLY one with a drift history — when the manifest moved 40 -> 300 it
+	// was the README that kept saying 40, while the manifest <-> generation.ts pair
+	// stayed in sync on its own. A guard over only that pair would have stayed
+	// green straight through the failure it exists to catch, so assert the README
+	// too, against the value the RENDERED manifest actually emitted (never a
+	// literal — a literal just relocates the drift into the test).
+	//
+	// Scope of this assertion: it catches the README naming a budget the manifest
+	// does not emit. It does NOT police how the README explains the number; the
+	// recipe's own per-job ceiling (30) is a different quantity and legitimately
+	// appears alongside it.
+	assertBudgetDocumented(t, readme, budget)
 }
 
 func TestPageMoneyNeedsHarness(t *testing.T) {
@@ -581,6 +597,36 @@ func assertSameSet(t *testing.T, want, got []string) {
 			t.Errorf("missing expected file %q (got %v)", w, got)
 		}
 	}
+}
+
+// assertBudgetDocumented requires the rendered README to name the budget the
+// manifest emitted. Matched on a word boundary so "300" cannot be satisfied by a
+// substring of an unrelated number (4000, 3000, 1300), and reported with the
+// numbers the README DOES carry so a failure is diagnosable without re-running.
+func assertBudgetDocumented(t *testing.T, readme string, budget int) {
+	t.Helper()
+	want := strconv.Itoa(budget)
+	if regexp.MustCompile(`\b` + want + `\b`).MatchString(readme) {
+		return
+	}
+	t.Errorf("README does not document the manifest's buzzBudgetPerGen (%d) — "+
+		"the manifest and the README disagree about the budget. "+
+		"Standalone integers found in the README: %v",
+		budget, uniqueInts(readme))
+}
+
+// uniqueInts lists the distinct standalone integers in a document, so a budget
+// mismatch names the stale value instead of just saying "not found".
+func uniqueInts(s string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, m := range regexp.MustCompile(`\b\d{2,}\b`).FindAllString(s, -1) {
+		if !seen[m] {
+			seen[m] = true
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // budgetFromManifest parses page.buzzBudgetPerGen out of a RENDERED manifest, so

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -110,18 +110,28 @@ owns the graph, the resource allowlist, the checkpoint policy, and a hard per-jo
 the recipe + a small, per-recipe-validated `params` object (here just a prompt,
 plus the shared account picker — no checkpoint/LoRA axis). This sample invokes
 **`starter-comfy-txt2img`** — a cheap, minimal Z-Image txt2img starter recipe
-(per-job Buzz ceiling 30). That's why `page.buzzBudgetPerGen` is **40**: it must
-reserve at least the recipe's ceiling (30) and also covers a cheap txt2img gen.
-The scope is unchanged — `customComfy` needs exactly `ai:write:budgeted`, already
-declared.
+(per-job Buzz ceiling 30). The recipe's ceiling is a hard FLOOR on the manifest
+budget — the server rejects any submit whose recipe ceiling exceeds the token
+budget — so `page.buzzBudgetPerGen` must be at least 30; the scaffold ships
+**40**. The scope is unchanged — `customComfy` needs exactly
+`ai:write:budgeted`, already declared.
 
-> **One budget serves both modes.** A manifest declares a single
-> `page.buzzBudgetPerGen`, so **40** is the per-gen ceiling for the txt2img sample
-> too — higher than a cheap txt2img gen strictly needs. That's inherent to shipping
-> the Comfy sample default-on (the recipe needs ≥30); it isn't expressible
-> per-mode. If you drop the Comfy sample, you can lower this to whatever your
-> txt2img path needs. The server still re-prices + hard-caps every gen at the real
-> per-job ceiling — the budget is only the upper bound the block token may spend.
+> **One budget serves both modes, and it is a CEILING — not an estimate.**
+> `page.buzzBudgetPerGen` is the safety ceiling on what a SINGLE generation your
+> app requests may cost. It exists so a bug, or a compromised bundle, can't drain
+> the viewer's Buzz — not to predict your bill. A manifest declares one value, so
+> **40** is the per-gen ceiling for the txt2img sample too.
+>
+> **Raise it; don't lower it.** Headroom is free: the server re-prices every
+> submit and charges the REAL price, so a generous ceiling never costs anyone
+> more. Sizing it to what you expect a run to cost is the classic mistake — a
+> submit priced ABOVE the budget is rejected outright with `insufficient buzz
+> budget`. Nothing is charged, but the user gets nothing, and it stays broken for
+> every user until you ship a new manifest version and it is re-approved. Any
+> upward drift does that: more steps, a bigger resolution, a pricier model or
+> recipe. Pick several times your worst case (the server clamps at 1000 anyway),
+> and note that cumulative spend is separately capped per viewer per day — a high
+> per-gen ceiling does not widen total exposure.
 
 **Requesting a new recipe.** Because recipes are server-registered + code-reviewed,
 you can't add one from the app. Request a new Comfy on Civitai recipe via the CLI's

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -110,17 +110,36 @@ owns the graph, the resource allowlist, the checkpoint policy, and a hard per-jo
 the recipe + a small, per-recipe-validated `params` object (here just a prompt,
 plus the shared account picker — no checkpoint/LoRA axis). This sample invokes
 **`starter-comfy-txt2img`** — a cheap, minimal Z-Image txt2img starter recipe
-(per-job Buzz ceiling 30). The recipe's ceiling is a hard FLOOR on the manifest
-budget — the server rejects any submit whose recipe ceiling exceeds the token
-budget — so `page.buzzBudgetPerGen` must be at least 30; the scaffold ships
-**40**. The scope is unchanged — `customComfy` needs exactly
+(per-job Buzz ceiling 30). The scope is unchanged — `customComfy` needs exactly
 `ai:write:budgeted`, already declared.
+
+**Two different numbers, and they are not the same quantity.** It is easy to
+read one off the other; don't.
+
+- A recipe's **`maxBuzz` ceiling** (30 here) is what the *server* enforces on a
+  single job. The step runs under a timeout that physically bounds GPU-seconds,
+  so the job cannot accrue more than that no matter what the graph does — and
+  you settle down to the *real* runtime cost anyway. You don't choose this
+  number; the recipe registry does.
+- **`page.buzzBudgetPerGen`** is what *you* choose: the largest single generation
+  your app is permitted to request **at all**. It is a blast-radius limit — the
+  bound on what one generation could cost if your app were exploited or its
+  bundle compromised.
+
+The ceiling constrains the budget in exactly one direction: a submit is rejected
+when the recipe's ceiling exceeds the token budget, so 30 is a hard **floor**
+here. A floor is not a sizing method. "Ceiling plus a margin" pegs your blast
+radius to whatever the cheapest recipe you currently call happens to cost, which
+is an estimate wearing a safety hat — and it re-breaks the app the moment you
+call something pricier. Size the budget from how much damage you are willing to
+absorb, then check it clears the floor. The scaffold ships **300**, ~10× its own
+worst case.
 
 > **One budget serves both modes, and it is a CEILING — not an estimate.**
 > `page.buzzBudgetPerGen` is the safety ceiling on what a SINGLE generation your
 > app requests may cost. It exists so a bug, or a compromised bundle, can't drain
 > the viewer's Buzz — not to predict your bill. A manifest declares one value, so
-> **40** is the per-gen ceiling for the txt2img sample too.
+> **300** is the per-gen ceiling for the txt2img sample too.
 >
 > **Raise it; don't lower it.** Headroom is free: the server re-prices every
 > submit and charges the REAL price, so a generous ceiling never costs anyone

--- a/internal/validate/warnings.go
+++ b/internal/validate/warnings.go
@@ -10,8 +10,24 @@ package validate
 //
 // The budgeted-page-without-budget case is the headline one the page-money
 // dogfood surfaced: a page declaring `ai:write:budgeted` but no
-// `page.buzzBudgetPerGen` mints budget-less tokens, so every generation fails
-// insufficient-budget at the orchestrator — a silent, confusing dead end.
+// `page.buzzBudgetPerGen` is minted with the platform's 10-Buzz fallback budget,
+// which is below almost any real generation, so every submit is rejected
+// insufficient-budget before it runs — a silent, confusing dead end.
+//
+// SIZING — `page.buzzBudgetPerGen` is a SAFETY CEILING, not a forecast. It caps
+// what ONE generation the app requests may cost, so a bug or a compromised
+// bundle can't drain the viewer's Buzz. The server re-prices every submit and
+// charges the REAL price, so headroom is free; a budget sized to an ESTIMATE
+// breaks the app outright (hard `insufficient buzz budget` reject, nothing
+// charged, nothing delivered) the moment real cost drifts up. Advice here must
+// therefore always push budgets UP, never down.
+//
+// DELIBERATELY NOT CHECKED: "this value looks small". The CLI cannot price a
+// generation (that is a server-side whatIf against live model pricing), so any
+// threshold would be arbitrary — and a manifest sized correctly for a cheap
+// single-recipe app is byte-identical to one sized from a per-run estimate. A
+// magnitude warning would also have to fire above this CLI's own page-money
+// scaffold value (40), and `--strict` promotes warnings to hard failures.
 
 const budgetedScope = "ai:write:budgeted"
 
@@ -28,15 +44,19 @@ func warningChecks(generic any) []string {
 	_, hasBudgeted := scopes[budgetedScope]
 	_, hasTargets := m["targets"].([]any)
 
-	// (1) Budgeted scope but no per-gen budget on the page. A page mints
-	//     budget-less ai:write:budgeted tokens → every spend fails at the
-	//     orchestrator. The headline footgun the dogfood found.
+	// (1) Budgeted scope but no per-gen budget on the page. The page's tokens
+	//     fall back to the platform's 10-Buzz default → every submit is rejected
+	//     before it runs. The headline footgun the dogfood found.
 	if hasBudgeted && hasPage {
 		if _, hasBudget := page["buzzBudgetPerGen"]; !hasBudget {
 			warns = append(warns,
 				"scopes include \"ai:write:budgeted\" but page.buzzBudgetPerGen is not set — "+
-					"a page mints budget-less tokens, so every generation will fail with "+
-					"insufficient budget; set page.buzzBudgetPerGen (server-clamped to the per-gen cap)")
+					"tokens fall back to a 10 Buzz budget, below almost any real generation, so "+
+					"every submit is rejected with insufficient budget before it runs. Set "+
+					"page.buzzBudgetPerGen: it is a SAFETY CEILING on what one generation may "+
+					"cost, not a cost estimate — size it several times your worst-case run "+
+					"(headroom is free; you are charged the real price, and the server clamps "+
+					"the budget at the per-gen cap)")
 		}
 	}
 


### PR DESCRIPTION
## The defect

An app author used a coding agent to build an App Block. The agent read our docs,
estimated one generation at ~50 Buzz, and set the manifest budget to **50**.

That is backwards. The per-generation budget is a **safety ceiling** — the bound on
what a *single* generation an app requests may cost, so a buggy or compromised app
cannot drain the viewer's Buzz. It is not a cost forecast. An audit of all four
App Blocks repos found safety-ceiling framing appears **nowhere in a budget
context**, and one surface (the CLI's `page-money` scaffold README) actively
invited *lowering* the value.

## The real consequence (read out of the enforcement code, not assumed)

`page.buzzBudgetPerGen` is mapped onto the block token's `buzzBudget` claim at
mint time, clamped to `BUZZ_BUDGET_CAP = 1000` (`src/pages/api/v1/block-tokens/index.ts`).
Both submit paths in `src/server/routers/blocks.router.ts` compare the **real**
price against that claim **before anything runs**:

- **`textToImage`** — runs a real `whatif` submit, then `if (cost > claims.buzzBudget)`
  returns a `status: 'failed'` snapshot.
- **`customComfy`** — static `if (ceiling > claims.buzzBudget)` against the recipe's
  `budgetFor(params).maxBuzz`.

Both reject **before** the gen-idempotency claim, before `reserveBlockBuzzSpendForClaims`,
and before the orchestrator submit. So an over-budget generation is **refused
outright**: no workflow is created, nothing is reserved, **no Buzz is spent**.

The damage is therefore not a partial charge — it is that **the app is simply
broken**. The user clicks Generate and gets `insufficient buzz budget`, and it
stays broken for **every** user until the author ships a new manifest version and
it is re-approved. Any upward drift in real cost — more steps, a bigger
resolution, a pricier model, a costlier recipe, a colder cache — flips a budget
sized to today's estimate into a hard outage.

Meanwhile a *generous* ceiling costs nobody anything: the server re-prices every
submit and charges the real price, the budget is clamped at 1000 regardless, and
cumulative spend is separately bounded by the per-viewer daily cap
(`BLOCK_BUZZ_CAP_PER_DAY`) and the per-app aggregate cap. A high per-gen ceiling
does **not** widen total exposure. Hence the rule of thumb we now document:
**several times your worst-case run.**

### Correction to the original report

The complaint assumed an over-budget workflow is *killed part-way, consuming the
Buzz and delivering nothing*. It is not — it is rejected at a pre-submit gate and
nothing is charged. Mid-run billing does exist (a `customComfy` job is physically
bounded by the recipe's own step `timeout`, and a mid-run cancel bills the accrued
orchestrator cost, which `settleCustomComfySpend` settles ceiling→actual), but
that timeout comes from the server-side recipe registry, **not** from the
manifest budget. The guidance in this PR is written to the behaviour the code
actually has.

## What this PR changes

**`internal/validate/warnings.go`**
- The budgeted-page-without-budget warning claimed a page "mints budget-less
  tokens". It does not — `resolveBuzzBudget` falls back to `BUZZ_BUDGET_DEFAULT`
  (**10 Buzz**), which is below almost any real generation, so every submit is
  rejected before it runs. Mechanism corrected.
- The warning now carries the ceiling framing + the rule of thumb, because
  `civitai app validate` output is exactly what a coding agent reads.
- A file-level comment records the sizing rule so estimate-shaped advice is not
  reintroduced.

**`internal/scaffold/templates/page-money/README.md.tmpl`** — replaced the passage
that actively invited *lowering* the budget ("If you drop the Comfy sample, you
can lower this to whatever your txt2img path needs") with: the recipe's ceiling is
a **floor**, not a target; headroom is free; a submit priced above the budget is
rejected outright.

## Deliberately not done

### The "value looks small" heuristic — declined, with reasons

The obvious fix is a warning when `page.buzzBudgetPerGen` looks like a per-run
estimate. I did not add one:

1. **The CLI cannot price a generation.** The real price is a server-side
   `whatif` against live model pricing; the CLI has no recipe registry and no
   pricing. Any threshold is a guess.
2. **The defect case and the correct case are byte-identical in the manifest.**
   `40` because "my recipe ceiling is 30 and I added headroom" (correct) and `40`
   because "I estimated 40" (the bug) are the same JSON.
3. **Any threshold that would have caught the reported `50` also fires on this
   CLI's own `page-money` scaffold**, which ships `40`. Self-inconsistent.
4. **`--strict` promotes warnings to hard failures**, so a false positive breaks
   a legitimately-cheap app's CI.

The reasoning is recorded in `warnings.go` under `DELIBERATELY NOT CHECKED`. If we
want it later, the honest prerequisite is raising the scaffold's own `40` to a
value with real headroom first — that value is itself estimate-shaped today.

### The vendored schema mirror — intentionally untouched

`schema/app-block.manifest.schema.json` is a byte-mirror of the canonical, and it
does need the new description. But `scripts/check-canonical-schema.sh` (the
`schema-drift` CI job, `pull_request`) diffs it against the **live published URL**,
not against the `civitai` repo — so editing it here **before** the civitai PR
deploys turns this repo's CI red immediately, and leaves it red on `main` if
merged first. Instead: after the civitai PR merges and deploys, run
`gh workflow run revendor-canonical-schema.yml` in this repo and merge the
resulting bot PR.

⚠️ Note this makes the merge order matter: **this PR is safe to merge now** (it
touches no schema), and the mirror follows via the bot.

## Verification

- `go build ./...` — clean.
- `go test ./...` — **16 packages ok, 0 FAIL, 0 "no test files"**.
- `go test ./internal/validate/... ./internal/scaffold/... -v` — counted from the
  log: **228 RUN / 227 PASS / 1 SKIP / 0 FAIL**.
- Negative control on the touched warning: mutating the message string to
  `PROBE_MUTANT` made `TestWarnBudgetedPageWithoutBudget` **FAIL** (and only that
  test); restoring it made all 6 budget tests pass again. The harness can go red.

## Related

- `civitai/civitai` — the canonical schema description (fix this first): https://github.com/civitai/civitai/pull/3629
- `civitai/civitai-developer-docs` — manifest reference + both guides: https://github.com/civitai/civitai-developer-docs/pull/30
- `civitai/civitai-app-starters` — starter `AGENTS.md` (read by coding agents): https://github.com/civitai/civitai-app-starters/pull/210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi


---

## Follow-up (2026-08-04): scaffold default moved 40 → 300

civitai/cli#200 raises the `page-money` scaffold's `buzzBudgetPerGen` **40 → 300**
(verified from that branch's `block.manifest.json.tmpl`, not from a description).
Commit `d6c7889` updates the two README lines that named `40`.

**It is not a number swap.** The old sentence *argued for* ceiling-plus-a-margin
as the sizing method, with a worked example — the anti-pattern this PR exists to
kill, shipped in the default template every generated app inherits. The rewrite
separates the two quantities:

- a recipe's **`maxBuzz` ceiling** is what the *server* enforces on one job (the
  step timeout physically bounds GPU-seconds; `customComfy` settles to the real
  runtime cost). The recipe registry picks it.
- **`page.buzzBudgetPerGen`** is what *you* pick: the largest single generation
  the app may request at all — the blast radius if the app is exploited.

The ceiling constrains the budget in one direction only (a submit is rejected when
the recipe ceiling exceeds the token budget), so it is a **floor** — and a floor is
not a sizing method.

🔴 **Merge order matters: #200 must merge before this PR.** They are semantically
coupled and textually independent (`git merge-tree --write-tree` on the two
branches exits 0; #200 touches `block.manifest.json.tmpl`, `generation.ts.tmpl`
and `scaffold_test.go`, this PR touches only `README.md.tmpl`). If this merges
first, `main` transiently ships a scaffold whose README documents 300 while the
manifest still emits 40. Merging the combined tree gives README **300** /
manifest **300** / `PAGE_BUZZ_BUDGET = 300` — verified by reading all three files
out of the `merge-tree` result.

⚠️ **Gap worth closing in #200, not here:** its new `PAGE_BUZZ_BUDGET` seam guard
covers the manifest ↔ `generation.ts` pair but **not the README** — which is
exactly the file that just drifted. One line in the function #200 is already
editing would pin it: assert the rendered README contains the budget parsed from
the manifest. Not doing it here because `scaffold_test.go` is mid-change on that
branch and I'd only create a conflict.

Re-verified after the change: `go build ./...` clean; `go test ./...` **16 pkgs ok
/ 0 FAIL / 0 "no test files"**; `-v` on scaffold+validate counted **228 RUN / 227
PASS / 1 SKIP / 0 FAIL**.
