### PR TITLE
feat(scaffold): drop the redundant Buzz balance readout; raise buzzBudgetPerGen to a real ceiling; rebrand Comfy Cloud -> Comfy on Civitai

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-recipe.yml
+++ b/.github/ISSUE_TEMPLATE/request-recipe.yml
@@ -1,12 +1,12 @@
-name: Request a Comfy Cloud recipe
-description: Request a new Civitai Comfy Cloud (customComfy) recipe your App can invoke.
+name: Request a Comfy on Civitai recipe
+description: Request a new Comfy on Civitai (customComfy) recipe your App can invoke.
 title: "[Recipe request] "
 labels: ["recipe-request"]
 body:
   - type: markdown
     attributes:
       value: |
-        **Comfy Cloud recipes are server-registered + code-reviewed** — an App can't ship its own graph. The iframe only picks a **recipe id** plus a small, per-recipe-validated `params` object; the Civitai server owns the ComfyUI graph, the resource allowlist, the checkpoint policy, and a hard per-job Buzz ceiling.
+        **Comfy on Civitai recipes are server-registered + code-reviewed** — an App can't ship its own graph. The iframe only picks a **recipe id** plus a small, per-recipe-validated `params` object; the Civitai server owns the ComfyUI graph, the resource allowlist, the checkpoint policy, and a hard per-job Buzz ceiling.
 
         Use this form to request a NEW recipe. Describe the graph/workflow you want, the params your App needs to expose, and the use case. We'll review it and, if approved, register it as a recipe id you can invoke via `buildComfyBody({ recipe, params })` (see `src/comfy.ts` in the page-money scaffold).
   - type: input

--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -29,17 +29,17 @@ immediately runnable (npm install && npm run dev:harness), test-green, and
 validates clean.
 
 The default scaffold ships TWO samples in the one app: a runnable txt2img money
-path AND a Comfy Cloud (customComfy) sample that runs a server-registered recipe
+path AND a Comfy on Civitai (customComfy) sample that runs a server-registered recipe
 (invite-only beta) — both share the estimate -> consent -> submit -> poll driver,
 switched by an on-screen mode toggle. Both work end-to-end in "npm run
-dev:harness" (mock host); see the generated README's "Comfy Cloud sample" section.
+dev:harness" (mock host); see the generated README's "Comfy on Civitai sample" section.
 
 Templates (override with --template):
   static      a no-build page app (index.html + a tiny JS, no build step)
   page-vite   a vite + React page app (config-as-code build: buildCommand + outputDir)
   page-money  a vite + React + TS full-page (W10) money-path app wired to the
               published App SDK (estimate -> consent -> submit -> poll -> Buzz
-              spend); includes a txt2img + a Comfy Cloud (customComfy) sample
+              spend); includes a txt2img + a Comfy on Civitai (customComfy) sample
               [default for create]
 
 The display name can be free-form ("My Cool Block"); it is slugified for the

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -108,10 +108,10 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	if !strings.Contains(stdout, "beta access") {
 		t.Errorf("create should gate submit/dev-tunnel under a beta-access heading:\n%s", stdout)
 	}
-	// The Comfy Cloud (customComfy) sample is surfaced (finding #2: it was
+	// The Comfy on Civitai (customComfy) sample is surfaced (finding #2: it was
 	// undiscoverable) — honestly flagged as invite-only beta.
-	if !strings.Contains(stdout, "Comfy Cloud") {
-		t.Errorf("create should surface the Comfy Cloud sample in the output:\n%s", stdout)
+	if !strings.Contains(stdout, "Comfy on Civitai") {
+		t.Errorf("create should surface the Comfy on Civitai sample in the output:\n%s", stdout)
 	}
 	// The trimmed message drops the old multi-line Buzz/OAuth/personal-key
 	// paragraph (dev:live now lives in dev-token/README, not the scaffold banner).
@@ -137,7 +137,7 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	}
 }
 
-// TestAppCreateHelpMentionsComfy guards finding #2: the Comfy Cloud sample must
+// TestAppCreateHelpMentionsComfy guards finding #2: the Comfy on Civitai sample must
 // be discoverable from `civitai app create --help` (it was previously described
 // as a txt2img-only app).
 func TestAppCreateHelpMentionsComfy(t *testing.T) {
@@ -145,9 +145,9 @@ func TestAppCreateHelpMentionsComfy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app create --help: %v", err)
 	}
-	for _, want := range []string{"Comfy Cloud", "customComfy"} {
+	for _, want := range []string{"Comfy on Civitai", "customComfy"} {
 		if !strings.Contains(out, want) {
-			t.Errorf("app create help should mention %q (Comfy Cloud discoverability):\n%s", want, out)
+			t.Errorf("app create help should mention %q (Comfy on Civitai discoverability):\n%s", want, out)
 		}
 	}
 }

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -192,11 +192,11 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 	fmt.Fprintln(out, ui.Success(fmt.Sprintf("Created App %q (%s)  ·  %s/  ·  %d files", display, tmpl, destDir, len(written))))
 
 	// page-money ships TWO samples in the one app — a runnable txt2img money path
-	// and a Comfy Cloud (customComfy) sample. Surface it (honestly: invite-only
-	// beta) and point at the README's Comfy Cloud section rather than the raw
+	// and a Comfy on Civitai (customComfy) sample. Surface it (honestly: invite-only
+	// beta) and point at the README's Comfy on Civitai section rather than the raw
 	// file count.
 	if tmpl.NeedsHarness() {
-		fmt.Fprintln(out, ui.Dim("  Includes a txt2img sample + a Comfy Cloud (customComfy) sample (invite-only beta) — see the Comfy Cloud section in README.md."))
+		fmt.Fprintln(out, ui.Dim("  Includes a txt2img sample + a Comfy on Civitai (customComfy) sample (invite-only beta) — see the Comfy on Civitai section in README.md."))
 	}
 
 	fmt.Fprintln(out, "\n"+ui.Bold("Next steps:"))

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -102,8 +102,8 @@ func TestRenderPageMoney(t *testing.T) {
 	}
 
 	// Money-path manifest: budgeted scope + per-gen budget + build fields. The
-	// budget is 40 so it reserves the starter Comfy Cloud recipe's per-job ceiling
-	// (30) — see the Comfy Cloud (customComfy) sample below.
+	// budget is 40 so it reserves the starter Comfy on Civitai recipe's per-job ceiling
+	// (30) — see the Comfy on Civitai (customComfy) sample below.
 	manifest := readFile(t, filepath.Join(dest, "block.manifest.json"))
 	mustContain(t, manifest, `"ai:write:budgeted"`)
 	mustContain(t, manifest, `"buzzBudgetPerGen": 40`)
@@ -201,7 +201,17 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "AccountPicker")
 	mustContain(t, app, "spentAccountType")
 	mustContain(t, app, "pm-account-") // the picker radios' testid prefix
-	mustContain(t, app, "pm-balance")
+
+	// ...but the scaffold renders NO balance readout of its own: an App runs
+	// inside the Civitai chrome, which already shows the viewer's balance, and
+	// agents copy whatever the default template does. The balance is read ONLY to
+	// annotate which account can fund the generation (the AccountPicker above).
+	// Guarding the component + style symbols too, so re-adding a readout under a
+	// different testid still trips this.
+	mustNotContain(t, app, "pm-balance")
+	mustNotContain(t, app, "BalancePanel")
+	mustNotContain(t, app, "PoolChip")
+	mustNotContain(t, app, "POOL_COLORS")
 
 	// LoRA selector (the main feature): the user adds up to MAX_LORAS LoRAs on top
 	// of the checkpoint via the HOST resource picker (type=LORA), each with a
@@ -214,7 +224,7 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "pm-lora-weight")
 	mustContain(t, app, "addLora")
 
-	// Comfy Cloud (customComfy) sample: a mode toggle swaps the body-builder to
+	// Comfy on Civitai (customComfy) sample: a mode toggle swaps the body-builder to
 	// buildComfyBody (a server-registered recipe). The recipe id is FIXED +
 	// server-registered; comfy.ts never sends a graph, only { kind, recipe, params }.
 	comfy := readFile(t, filepath.Join(dest, "src", "comfy.ts"))

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -2,6 +2,7 @@ package scaffold
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,12 +102,23 @@ func TestRenderPageMoney(t *testing.T) {
 		}
 	}
 
-	// Money-path manifest: budgeted scope + per-gen budget + build fields. The
-	// budget is 40 so it reserves the starter Comfy on Civitai recipe's per-job ceiling
-	// (30) — see the Comfy on Civitai (customComfy) sample below.
+	// Money-path manifest: budgeted scope + per-gen budget + build fields.
+	//
+	// buzzBudgetPerGen is a SAFETY CEILING — the most a malicious or exploited
+	// app could spend per generation — NOT a forecast of what a generation costs.
+	// It must sit far ABOVE expected spend: an over-budget generation is refused
+	// at a pre-submit gate (nothing runs, nothing is charged) but the app is then
+	// broken for every user until a new manifest version ships AND is re-approved.
+	// Headroom, by contrast, is never actually spent — the server re-prices and
+	// hard-caps every generation at the real per-job ceiling.
+	//
+	// 300 = 10x the scaffold's worst case (30, the starter Comfy on Civitai
+	// recipe's hard per-job ceiling; the txt2img sample is cheaper). The old 40
+	// was worst-case+10, which read as an estimate and taught authors to size it
+	// like one. Keep this in sync with PAGE_BUZZ_BUDGET in src/generation.ts.
 	manifest := readFile(t, filepath.Join(dest, "block.manifest.json"))
 	mustContain(t, manifest, `"ai:write:budgeted"`)
-	mustContain(t, manifest, `"buzzBudgetPerGen": 40`)
+	mustContain(t, manifest, `"buzzBudgetPerGen": 300`)
 	mustContain(t, manifest, `"buildCommand": "npm run build"`)
 	mustContain(t, manifest, `"outputDir": "dist"`)
 	// Server-owned fields must NOT be set.
@@ -242,6 +254,18 @@ func TestRenderPageMoney(t *testing.T) {
 	gen := readFile(t, filepath.Join(dest, "src", "generation.ts"))
 	mustNotContain(t, gen, "GEN_MODEL")
 	mustContain(t, gen, "checkpoint: CheckpointOption")
+
+	// SEAM: the budget lives in TWO files — the manifest (authoritative; the
+	// server reads it at mint) and PAGE_BUZZ_BUDGET here (the app's own mirror).
+	// Nothing at runtime reconciles them, so a drifted mirror silently misinforms
+	// the author. Pin the RELATIONSHIP, not just each value: parse the number the
+	// manifest actually emitted and require the constant to equal it, so raising
+	// one alone fails.
+	budget := budgetFromManifest(t, manifest)
+	if budget != 300 {
+		t.Errorf("manifest buzzBudgetPerGen = %d, want 300 (safety ceiling, not an estimate)", budget)
+	}
+	mustContain(t, gen, fmt.Sprintf("export const PAGE_BUZZ_BUDGET = %d;", budget))
 	mustContain(t, gen, "modelVersionId: checkpoint.versionId")
 	mustContain(t, gen, "loras: readonly LoraOption[]")
 	mustContain(t, gen, "body.additionalResources = loras.map")
@@ -557,6 +581,25 @@ func assertSameSet(t *testing.T, want, got []string) {
 			t.Errorf("missing expected file %q (got %v)", w, got)
 		}
 	}
+}
+
+// budgetFromManifest parses page.buzzBudgetPerGen out of a RENDERED manifest, so
+// the seam guard compares the value the scaffold actually emitted rather than a
+// string the test happens to spell the same way.
+func budgetFromManifest(t *testing.T, manifest string) int {
+	t.Helper()
+	var m struct {
+		Page struct {
+			BuzzBudgetPerGen *int `json:"buzzBudgetPerGen"`
+		} `json:"page"`
+	}
+	if err := json.Unmarshal([]byte(manifest), &m); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if m.Page.BuzzBudgetPerGen == nil {
+		t.Fatal("manifest has no page.buzzBudgetPerGen")
+	}
+	return *m.Page.BuzzBudgetPerGen
 }
 
 func readFile(t *testing.T, p string) string {

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -37,7 +37,9 @@ The money path uses the SDK hooks — never raw `window.parent.postMessage`:
 - `useBuzzWorkflow()` — `estimate` / `submit` / `poll` (the spend).
 - `useBuzzBalance()` — the viewer's per-pool balance (`{ blue, green, yellow }`),
   read host-side via the `GET_BUZZ_BALANCE` bridge — **no `buzz:read:self` scope
-  needed** (the host resolves the viewer from the block token).
+  needed** (the host resolves the viewer from the block token). Use it to *reason*
+  about spend (which account can fund this?), **not** to re-display the balance —
+  the Civitai chrome around your app already shows it.
 - `useCheckpointPicker()` / `useResourcePicker()` — open the HOST's native
   resource picker for the checkpoint + LoRAs (the app never browses a catalog).
 - `useRequestConsent()` — lazy, on first Generate: `ai:write:budgeted` is
@@ -90,15 +92,15 @@ server is LoRA-only for additional resources and **re-validates** base-model
 compatibility + per-resource entitlement (early-access / Private) AND
 **re-prices** the whole body **before any Buzz spend**.
 
-### Comfy Cloud sample (customComfy)
+### Comfy on Civitai sample (customComfy)
 
 A **mode toggle** at the top switches between two samples that share the one
 estimate → consent → submit → poll driver + the account picker — only the body
 differs:
 
 - **Text to image** (primary, runnable today) — the checkpoint + LoRA path above.
-- **Comfy Cloud recipe** (secondary, invite-only beta) — runs a **Civitai Comfy
-  Cloud (`customComfy`)** generation via `buildComfyBody` in `src/comfy.ts`.
+- **Comfy on Civitai recipe** (secondary, invite-only beta) — runs a **Comfy on
+  Civitai (`customComfy`)** generation via `buildComfyBody` in `src/comfy.ts`.
 
 **How customComfy works — server-owned graph, fail-closed.** The iframe **never
 sends a Comfy graph.** It sends `{ kind: 'customComfy', recipe, params }` where
@@ -122,15 +124,16 @@ declared.
 > per-job ceiling — the budget is only the upper bound the block token may spend.
 
 **Requesting a new recipe.** Because recipes are server-registered + code-reviewed,
-you can't add one from the app. Request a new Comfy Cloud recipe via the CLI's
+you can't add one from the app. Request a new Comfy on Civitai recipe via the CLI's
 issue form at
 <https://github.com/civitai/cli/issues/new?template=request-recipe.yml> (describe
 the graph + the intended `params` + the use case). It ships as a registered id
 once reviewed.
 
-**Dev loop — honest state.** In `npm run dev:harness` (the **mock** host) the Comfy
-Cloud sample **works end-to-end** (estimate → submit → poll → succeeded with a mock
-image + cost), so you can build against it today. That is the fully-working path.
+**Dev loop — honest state.** In `npm run dev:harness` (the **mock** host) the
+Comfy on Civitai sample **works end-to-end** (estimate → submit → poll →
+succeeded with a mock image + cost), so you can build against it today. That is
+the fully-working path.
 
 On **live** civitai.com the sample is **not runnable yet**, for two reasons, and
 its graceful panel is best-effort:
@@ -158,11 +161,18 @@ So: **mock works now**; a real Comfy run needs the invite-only beta cohort (+
 
 ### Buzz balance + account picker (per-account spend)
 
-Above the prompt, the app shows the viewer's **per-pool Buzz balance** —
-**blue** (free / earned), **green** (creator-earned / tips), **yellow**
-(purchased) — plus a total, read via `useBuzzBalance()`. It's purely
-informational and additive: if the balance is loading, errored, or unavailable it
-degrades quietly (a small line) and **never blocks generation**.
+🔴 **Don't render a Buzz balance readout in your app.** Your app runs inside the
+Civitai chrome, which **already shows the viewer's balance** — a second copy
+inside the iframe is redundant, and it competes with the real one whenever the
+two are momentarily out of sync. This scaffold deliberately ships **no** balance
+panel; if you're tempted to add one, that's the signal you want a *host* surface,
+not an app surface.
+
+The app still *reads* the balance via `useBuzzBalance()` — for exactly one
+purpose: annotating **which account can actually fund this generation** in the
+picker below. That's app-specific context the chrome can't provide, so it earns
+its place. It's additive: if the balance is loading, errored, or unavailable the
+annotation just doesn't render and generation is **never blocked**.
 
 Below the LoRA selector, a **"Spend from"** picker lets the viewer choose which
 pool funds the generation:
@@ -336,11 +346,12 @@ The two reads use **different credentials** — by design, and security-critical
 > `useResourcePicker` work in `dev:live`. It does **not** support
 > `SET_USER_CHECKPOINT` persistence, the App-Storage KV protocol, in-band Buzz
 > purchase, or the `GET_BUZZ_BALANCE` read (`useBuzzBalance`) — those reply "not
-> supported in live v1" (use mock mode for them). So in `dev:live` the in-app
-> 3-pool balance panel shows **"Buzz balance unavailable"** (the host nav's total,
-> read via your personal key through the proxy, still works). The panel populates
-> in **`dev:harness`** (synthetic, wired to the `balance` scenario) and on the
-> **real platform** (the civitai host answers `GET_BUZZ_BALANCE` natively).
+> supported in live v1" (use mock mode for them). So in `dev:live` the balance
+> reads as unavailable and the "Spend from" picker simply drops its 0-Buzz
+> annotations — nothing else changes, and the host nav's own balance total (read
+> via your personal key through the proxy) still works. The balance resolves in
+> **`dev:harness`** (synthetic, wired to the `balance` scenario) and on the **real
+> platform** (the civitai host answers `GET_BUZZ_BALANCE` natively).
 
 ### Scenarios (exercise the money / error / storage UX for free)
 

--- a/internal/scaffold/templates/page-money/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/page-money/block.manifest.json.tmpl
@@ -12,7 +12,7 @@
     "path": "/",
     "title": "{{ .Name }}",
     "icon": "bolt",
-    "buzzBudgetPerGen": 40
+    "buzzBudgetPerGen": 300
   },
   "iframe": {
     "minHeight": 600,

--- a/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.test.tsx.tmpl
@@ -29,16 +29,18 @@ describe('App (component)', () => {
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
-  it('anon viewer -> renders the sign-in affordance (no Generate button / balance / picker)', async () => {
+  it('anon viewer -> renders the sign-in affordance (no Generate button / picker)', async () => {
     uninstall = installMockMoneyHost({ viewer: null });
     render(<App />);
 
     // Once BLOCK_INIT arrives with viewer=null, the App swaps the loading state
-    // for the sign-in CTA. The balance panel + account picker are viewer-only.
+    // for the sign-in CTA. The account picker is viewer-only. (No `pm-balance`
+    // assertion here — the app renders no balance readout for ANY viewer, so it
+    // would pass regardless and prove nothing about the anon path. The readout's
+    // absence is guarded by its own test below.)
     const signIn = await screen.findByTestId('pm-signin');
     expect(signIn).toHaveTextContent(/sign in to generate/i);
     expect(screen.queryByTestId('pm-generate')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('pm-balance')).not.toBeInTheDocument();
     expect(screen.queryByTestId('pm-account-auto')).not.toBeInTheDocument();
   });
 
@@ -56,19 +58,45 @@ describe('App (component)', () => {
     expect(screen.getByTestId('pm-lora-add')).toBeInTheDocument();
   });
 
-  it('renders the 3-pool Buzz balance (blue/green/yellow + total) from useBuzzBalance', async () => {
+  it('does NOT render a Buzz balance readout — the Civitai chrome already shows it', async () => {
     // A simulated wallet of 100 splits to yellow 80 / blue 20 / green 0 (mock-buzz),
     // handed to 0.18's native `buzzBalance` option (what useBuzzBalance reads).
+    // The balance IS read (see the next test — it annotates the account picker),
+    // but the app deliberately renders no balance panel/chips/total of its own.
     uninstall = installMockMoneyHost({
       viewer: { id: 2, username: 'dev', status: 'active' },
       buzzBalance: mockBuzzBalance(100),
     });
     render(<App />);
 
-    expect(await screen.findByTestId('pm-balance-blue')).toHaveTextContent(/20/);
-    expect(screen.getByTestId('pm-balance-yellow')).toHaveTextContent(/80/);
-    expect(screen.getByTestId('pm-balance-green')).toHaveTextContent(/0/);
-    expect(screen.getByTestId('pm-balance-total')).toHaveTextContent(/100/);
+    // Wait for a post-BLOCK_INIT frame so this isn't vacuously green pre-render.
+    expect(await screen.findByTestId('pm-generate')).toBeInTheDocument();
+    for (const id of ['pm-balance', 'pm-balance-blue', 'pm-balance-green', 'pm-balance-yellow', 'pm-balance-total']) {
+      expect(screen.queryByTestId(id)).not.toBeInTheDocument();
+    }
+    // No stray balance-readout prose either (the panel's old copy).
+    expect(screen.queryByText(/total .* buzz/i)).not.toBeInTheDocument();
+  });
+
+  it('the balance IS consumed: the account picker annotates a 0-Buzz pool', async () => {
+    // The one legitimate consumer of useBuzzBalance in this scaffold — which
+    // account can fund this generation. yellow 80 / blue 20 / green 0, so ONLY
+    // green is annotated. (This is also the positive control proving the balance
+    // still reaches the app after the readout was removed.)
+    uninstall = installMockMoneyHost({
+      viewer: { id: 2, username: 'dev', status: 'active' },
+      buzzBalance: mockBuzzBalance(100),
+    });
+    render(<App />);
+
+    // findByTitle waits for the balance to land, so this can't pass on the
+    // pre-balance frame.
+    const green = await screen.findByTitle(/0 Buzz in this account/i);
+    expect(green).toBe(screen.getByTestId('pm-account-green'));
+    expect(green).toHaveTextContent(/·\s*0/);
+    // The funded pools are NOT annotated.
+    expect(screen.getByTestId('pm-account-yellow')).not.toHaveAttribute('title');
+    expect(screen.getByTestId('pm-account-blue')).not.toHaveAttribute('title');
   });
 
   it('account picker defaults to Auto and offers all three pools', async () => {
@@ -82,15 +110,22 @@ describe('App (component)', () => {
     }
   });
 
-  it('gracefully shows "unavailable" when the balance read errors (never crashes)', async () => {
+  it('a failed balance read degrades silently — app still generates, picker unannotated', async () => {
     uninstall = installMockMoneyHost({
       viewer: { id: 2, username: 'dev', status: 'active' },
       balanceError: true,
     });
     render(<App />);
 
-    // The app still works — Generate is present; the balance panel degrades.
+    // The app still works — Generate + the full picker are present. With no
+    // balance there is nothing to annotate, and (since the readout is gone) the
+    // error surfaces NO user-visible balance chrome at all.
     expect(await screen.findByTestId('pm-generate')).toBeInTheDocument();
-    expect(await screen.findByText(/balance unavailable/i)).toBeInTheDocument();
+    expect(screen.getByTestId('pm-account-auto')).toBeInTheDocument();
+    for (const pool of ['blue', 'green', 'yellow'] as const) {
+      expect(screen.getByTestId(`pm-account-${pool}`)).not.toHaveAttribute('title');
+    }
+    expect(screen.queryByTestId('pm-balance')).not.toBeInTheDocument();
+    expect(screen.queryByText(/balance unavailable/i)).not.toBeInTheDocument();
   });
 });

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -59,7 +59,7 @@ import { STARTER_COMFY_RECIPE, buildComfyBody } from './comfy.js';
  * Which sample the page is driving.
  *  - `txt2img` — the PRIMARY, runnable-today path (hardcoded-default checkpoint +
  *    host checkpoint/LoRA pickers).
- *  - `comfy`  — the SECONDARY Civitai Comfy Cloud (customComfy) sample: a
+ *  - `comfy`  — the SECONDARY Comfy on Civitai (customComfy) sample: a
  *    server-registered, code-reviewed recipe (`starter-comfy-txt2img`). The app
  *    can't ship a graph; it sends only the recipe id + a prompt. Invite-only beta
  *    on live civitai.com (works end-to-end against the mock host).
@@ -85,8 +85,11 @@ injectBlocksStyles();
  *  - scopes = ['ai:write:budgeted'] ONLY. The viewer's per-pool balance is read
  *    via the host-mediated `useBuzzBalance()` bridge (GET_BUZZ_BALANCE) — the
  *    host resolves the viewer from the block token, so NO `buzz:read:self` scope
- *    is needed and the block never touches the balance API directly. (Insufficient
- *    Buzz is still ALSO surfaced from a `failed` snapshot, as a backstop.)
+ *    is needed and the block never touches the balance API directly. The app does
+ *    NOT render a balance readout: your app runs inside the Civitai chrome, which
+ *    already shows the viewer's balance — duplicating it is noise. The balance is
+ *    read only to annotate the "Spend from" account picker. (Insufficient Buzz is
+ *    still ALSO surfaced from a `failed` snapshot, as a backstop.)
  *  - budget comes from manifest `page.buzzBudgetPerGen`; a page is stateless.
  *  - a page has no HOST model context (entity=none), so the app ships a curated
  *    default checkpoint (DEFAULT_CHECKPOINT) and lets the user change it via the
@@ -122,11 +125,13 @@ export function App() {
   // overlay), and on the real platform. A pick is DISCOVERY ONLY.
   const { open: openCheckpointPicker } = useCheckpointPicker();
   const { open: openResourcePicker } = useResourcePicker();
-  // The viewer's per-pool Buzz balance, read host-side (no scope needed). Purely
-  // informational + additive — it NEVER blocks generation (a missing/errored
+  // The viewer's per-pool Buzz balance, read host-side (no scope needed). NOT
+  // rendered as a balance readout — the surrounding Civitai chrome already shows
+  // the viewer's balance, so an in-app copy is redundant. It is read for ONE
+  // purpose: annotating which account can actually fund a generation in the
+  // "Spend from" picker below. It NEVER blocks generation (a missing/errored
   // balance still lets the user generate; the server is the real gate).
-  const { balance, loading: balanceLoading, error: balanceError, refetch: refetchBalance } =
-    useBuzzBalance();
+  const { balance, refetch: refetchBalance } = useBuzzBalance();
 
   const anon = ready && !viewer;
   const granted = hasBudgetedScope(token.scopes);
@@ -299,7 +304,7 @@ export function App() {
         : buildWorkflowBody(prompt, checkpoint, loras, account);
 
     // Classify a submit/estimate error into a terminal phase. The `'gated'`
-    // (Comfy Cloud invite-only-beta) panel is COMFY-MODE-SCOPED via
+    // (Comfy on Civitai invite-only-beta) panel is COMFY-MODE-SCOPED via
     // phaseForSubmitError: the real gate strings ("Apps are not enabled" flag
     // gate, "Apps authoring is not enabled" author gate, and the pre-deploy
     // unknown-recipe enum rejection) are SHARED with the txt2img path, so a
@@ -501,7 +506,7 @@ export function App() {
         <Stack gap={16}>
           <strong style={titleStyle}>{{ .Name }}</strong>
 
-          {/* Mode toggle: txt2img (primary, runnable today) ⇄ Comfy Cloud
+          {/* Mode toggle: txt2img (primary, runnable today) ⇄ Comfy on Civitai
               (secondary sample, invite-only beta). Switching swaps the input
               controls + the body-builder while REUSING the one estimate ->
               consent -> submit -> poll driver + the account picker below. */}
@@ -513,12 +518,12 @@ export function App() {
             disabled={busy}
             data={[
               { value: 'txt2img', label: 'Text to image' },
-              { value: 'comfy', label: 'Comfy Cloud recipe (sample · invite-only beta)' },
+              { value: 'comfy', label: 'Comfy on Civitai recipe (sample · invite-only beta)' },
             ]}
           />
 
           {isComfy && (
-            <Alert color="info" title="Comfy Cloud recipe (sample · invite-only beta)" data-testid="pm-comfy-beta">
+            <Alert color="info" title="Comfy on Civitai recipe (sample · invite-only beta)" data-testid="pm-comfy-beta">
               A bounded, <strong>server-owned</strong> graph. The app only picks a registered{' '}
               <code>recipe</code> id (<code>{STARTER_COMFY_RECIPE}</code>) + a prompt; the server
               owns the graph and a hard per-job Buzz ceiling. Invite-only beta on live civitai.com —
@@ -529,10 +534,6 @@ export function App() {
               </a>
               .
             </Alert>
-          )}
-
-          {!anon && (
-            <BalancePanel balance={balance} loading={balanceLoading} error={balanceError} />
           )}
 
           <Textarea
@@ -549,8 +550,9 @@ export function App() {
           />
 
           {/* Model + LoRA controls are the TXT2IMG sample's surface. The Comfy
-              Cloud sample sends a server-owned recipe (no client checkpoint/LoRA
-              axis), so these are hidden in comfy mode — just prompt + account. */}
+              on Civitai sample sends a server-owned recipe (no client
+              checkpoint/LoRA axis), so these are hidden in comfy mode — just
+              prompt + account. */}
           {!isComfy && (
             <>
               {/* Model control. A page carries no host model context, so the app
@@ -650,7 +652,7 @@ export function App() {
           )}
 
           {phase === 'gated' && (
-            <Alert color="info" title="Comfy Cloud recipes are in invite-only beta" data-testid="pm-gated">
+            <Alert color="info" title="Comfy on Civitai recipes are in invite-only beta" data-testid="pm-gated">
               Your account isn&apos;t in the tester cohort yet, so this recipe can&apos;t run on live
               civitai.com. Request access at{' '}
               <a href="https://github.com/civitai/cli" target="_blank" rel="noreferrer">
@@ -779,81 +781,6 @@ function LoraSelector({
 }
 
 /**
- * The viewer's per-pool Buzz balance ({ blue, green, yellow } + total), read via
- * the host-mediated `useBuzzBalance()`. Purely INFORMATIONAL and additive — it
- * NEVER blocks generation. Graceful when the balance is loading, errored, or
- * unavailable (`null`): a quiet line, never a crash.
- */
-function BalancePanel({
-  balance,
-  loading,
-  error,
-}: {
-  balance: { blue: number; green: number; yellow: number } | null;
-  loading: boolean;
-  error: Error | null;
-}) {
-  if (!balance) {
-    if (loading) {
-      return (
-        <div style={balancePanelStyle} data-testid="pm-balance">
-          <span style={fieldDescStyle}>Loading your Buzz balance…</span>
-        </div>
-      );
-    }
-    if (error) {
-      return (
-        <div style={balancePanelStyle} data-testid="pm-balance">
-          <span style={fieldDescStyle}>Buzz balance unavailable.</span>
-        </div>
-      );
-    }
-    return null;
-  }
-  const total = balance.blue + balance.green + balance.yellow;
-  return (
-    <div style={balancePanelStyle} data-testid="pm-balance">
-      <PoolChip label="Blue" value={balance.blue} color={POOL_COLORS.blue} testid="pm-balance-blue" />
-      <PoolChip
-        label="Green"
-        value={balance.green}
-        color={POOL_COLORS.green}
-        testid="pm-balance-green"
-      />
-      <PoolChip
-        label="Yellow"
-        value={balance.yellow}
-        color={POOL_COLORS.yellow}
-        testid="pm-balance-yellow"
-      />
-      <span style={balanceTotalStyle} data-testid="pm-balance-total">
-        Total <strong>{formatCost(total)}</strong> Buzz
-      </span>
-    </div>
-  );
-}
-
-function PoolChip({
-  label,
-  value,
-  color,
-  testid,
-}: {
-  label: string;
-  value: number;
-  color: string;
-  testid: string;
-}) {
-  return (
-    <span style={poolChipStyle} data-testid={testid}>
-      <span style={poolDotStyle(color)} aria-hidden />
-      <span style={fieldDescStyle}>{label}</span>{' '}
-      <strong style={poolValueStyle}>{formatCost(value)}</strong>
-    </span>
-  );
-}
-
-/**
  * Choose which Buzz pool funds the generation. Auto (default) omits `accountType`
  * from the submit body entirely — today's host-chosen behavior. Pools with a 0
  * balance are annotated but stay selectable (the server still preferred-first
@@ -963,39 +890,8 @@ const currentModelStyle: React.CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
-// Buzz-pool identity colors (semantic, not theme-derived) for the balance chips.
-const POOL_COLORS = { blue: '#4dabf7', green: '#51cf66', yellow: '#ffd43b' } as const;
-
-// The balance panel + account-picker chrome read the same pack CSS vars as the
-// Model/LoRA controls so they match the surface across themes.
-const balancePanelStyle: React.CSSProperties = {
-  display: 'flex',
-  flexWrap: 'wrap',
-  alignItems: 'center',
-  gap: 12,
-  padding: '8px 12px',
-  borderRadius: 8,
-  border: '1px solid var(--ci-color-border)',
-  background: 'var(--ci-color-surface)',
-  fontSize: 13,
-};
-const balanceTotalStyle: React.CSSProperties = {
-  marginLeft: 'auto',
-  color: 'var(--ci-color-text)',
-  fontVariantNumeric: 'tabular-nums',
-};
-const poolChipStyle: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 4,
-  fontVariantNumeric: 'tabular-nums',
-};
-// A function returning the merged style (rather than an inline object-literal
-// style prop) so the scaffold template renderer can process this file cleanly.
-function poolDotStyle(color: string): React.CSSProperties {
-  return { width: 8, height: 8, borderRadius: '50%', display: 'inline-block', background: color };
-}
-const poolValueStyle: React.CSSProperties = { color: 'var(--ci-color-text)' };
+// The account-picker chrome reads the same pack CSS vars as the Model/LoRA
+// controls so it matches the surface across themes.
 const pickerRowStyle: React.CSSProperties = {
   display: 'flex',
   flexWrap: 'wrap',

--- a/internal/scaffold/templates/page-money/src/comfy.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/comfy.test.ts.tmpl
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { PROMPT_MAX } from './generation.js';
 import { STARTER_COMFY_RECIPE, buildComfyBody } from './comfy.js';
 
-// Pure-logic tests for the Comfy Cloud (customComfy) sample body-builder. Run
+// Pure-logic tests for the Comfy on Civitai (customComfy) sample body-builder. Run
 // with `npm test`. These lock the FIXED customComfy contract: kind, the
 // server-registered recipe id, and the bounded params shape.
 

--- a/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
@@ -1,5 +1,5 @@
-// Pure logic for the {{ .Name }} page app's SECONDARY "Comfy Cloud (sample)"
-// path — a Civitai Comfy Cloud (customComfy) generation. No React, no DOM;
+// Pure logic for the {{ .Name }} page app's SECONDARY "Comfy on Civitai (sample)"
+// path — a Comfy on Civitai (customComfy) generation. No React, no DOM;
 // unit-tested in node (see comfy.test.ts). Mirrors generation.ts's style and
 // REUSES its shared helpers (clampPrompt / AccountChoice) so the two
 // body-builders differ only in the body they produce.
@@ -19,7 +19,7 @@ import { clampPrompt, type AccountChoice } from './generation.js';
  * The starter recipe this sample invokes: a cheap, minimal Z-Image txt2img
  * recipe (per-job Buzz ceiling 30). It is SERVER-registered — an app cannot ship
  * its own graph, so a new recipe must be added + code-reviewed server-side (see
- * README "Comfy Cloud sample"). This id must exist in the server registry for a
+ * README "Comfy on Civitai sample"). This id must exist in the server registry for a
  * real run to resolve; an unknown id is rejected fail-closed.
  */
 export const STARTER_COMFY_RECIPE = 'starter-comfy-txt2img';

--- a/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/e2e.test.tsx.tmpl
@@ -187,7 +187,7 @@ describe('App money path (e2e)', () => {
     expect(screen.queryByAltText(/generated result/i)).not.toBeInTheDocument();
   });
 
-  it('Comfy Cloud sample: switch mode -> customComfy submit -> succeeded (+cost)', async () => {
+  it('Comfy on Civitai sample: switch mode -> customComfy submit -> succeeded (+cost)', async () => {
     const user = userEvent.setup();
     const submittedBodies: Array<{ kind?: string; recipe?: string }> = [];
     uninstall = installMockMoneyHost({
@@ -207,9 +207,9 @@ describe('App money path (e2e)', () => {
     render(<App />);
     await screen.findByTestId('pm-generate');
 
-    // Switch to the Comfy Cloud sample. The txt2img-only Model/LoRA controls go
+    // Switch to the Comfy on Civitai sample. The txt2img-only Model/LoRA controls go
     // away; the beta note + the shared prompt/account picker stay.
-    await user.click(screen.getByRole('tab', { name: /comfy cloud recipe/i }));
+    await user.click(screen.getByRole('tab', { name: /comfy on civitai recipe/i }));
     expect(screen.getByTestId('pm-comfy-beta')).toBeInTheDocument();
     expect(screen.queryByTestId('pm-change-model')).not.toBeInTheDocument();
     expect(screen.queryByTestId('pm-lora-add')).not.toBeInTheDocument();

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -148,7 +148,7 @@ describe('isDisallowedAccountError', () => {
 
 describe('isFeatureGated', () => {
   // The sniff is deliberately NARROW — it matches ONLY the three real
-  // Comfy-Cloud gate signals (verified against civitai/civitai
+  // Comfy-on-Civitai gate signals (verified against civitai/civitai
   // blocks.router.ts + workflow.schema.ts), never broad tokens. Its `'gated'`
   // phase is separately COMFY-MODE-SCOPED at the App.tsx call site, so the
   // strings shared with txt2img (a) never surface the Comfy copy there.

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -60,12 +60,13 @@ export function spentAccountLabel(spent: BuzzAccountType | undefined): string | 
 }
 
 /**
- * Manifest budget (page.buzzBudgetPerGen). Keep in sync with block.manifest.json
- * — the SERVER reads the manifest value at mint and clamps to the per-gen cap;
- * this constant only drives the client-side "Top up · N" CTA amount and budget
- * copy. The real ceiling is enforced server-side.
+ * Mirror of the manifest's `page.buzzBudgetPerGen`. MUST be kept in sync with
+ * block.manifest.json — the SERVER reads the MANIFEST value at mint (and clamps
+ * it to the platform per-gen cap); this constant is exported for your own copy
+ * and is not read by the scaffold's UI. The real ceiling is enforced
+ * server-side, so changing this constant alone changes nothing about spend.
  */
-export const PAGE_BUZZ_BUDGET = 40;
+export const PAGE_BUZZ_BUDGET = 300;
 
 /** The scope the page token must carry before a generation can be submitted. */
 export const BUDGETED_SCOPE = 'ai:write:budgeted';

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -134,7 +134,7 @@ export function isDisallowedAccountError(message: string | null | undefined): bo
 }
 
 /**
- * The Comfy Cloud recipe id this sample sends. MIRRORED from comfy.ts's
+ * The Comfy on Civitai recipe id this sample sends. MIRRORED from comfy.ts's
  * `STARTER_COMFY_RECIPE` (kept as a literal here to avoid a generation.ts ⇄
  * comfy.ts import cycle) — the enum-rejection sniff below keys on it. If you
  * change the recipe id in comfy.ts, change it here too.
@@ -142,7 +142,7 @@ export function isDisallowedAccountError(message: string | null | undefined): bo
 const STARTER_COMFY_RECIPE_ID = 'starter-comfy-txt2img';
 
 /**
- * Sniff a submit/estimate ERROR string for the SPECIFIC Comfy-Cloud gate signals
+ * Sniff a submit/estimate ERROR string for the SPECIFIC Comfy-on-Civitai gate signals
  * so — and ONLY so — the Comfy sample can degrade to a friendly "invite-only
  * beta" panel instead of a raw error. This is deliberately NARROW (deterministic
  * over heuristic): it matches only the three real server signals, verified
@@ -279,7 +279,7 @@ export function isBusyPhase(phase: GenPhase): boolean {
  * terminal phase. Order matters: disallowed-account BEFORE insufficient (the
  * disallowed message contains "buzz").
  *
- * This does NOT itself produce `'gated'`: the Comfy-Cloud gate strings are shared
+ * This does NOT itself produce `'gated'`: the Comfy-on-Civitai gate strings are shared
  * with the txt2img path, so gating is decided at the CALL SITE (App.tsx) and
  * scoped to comfy mode — `isFeatureGated(msg) ? 'gated' : phaseForError(msg)`,
  * only when `mode === 'comfy'`. A txt2img failure therefore falls through here to
@@ -294,7 +294,7 @@ export function phaseForError(message: string | null | undefined): GenPhase {
 
 /**
  * Classify a submit/estimate error into a terminal phase, with the `'gated'`
- * (Comfy Cloud invite-only-beta) phase COMFY-MODE-SCOPED. This is the single seam
+ * (Comfy on Civitai invite-only-beta) phase COMFY-MODE-SCOPED. This is the single seam
  * finding 1b turns on: the gate strings {@link isFeatureGated} matches — the
  * "Apps are not enabled" flag gate + the "Apps authoring is not enabled" author
  * gate (BOTH shared with the txt2img path) and the pre-deploy unknown-recipe enum

--- a/internal/scaffold/templates/page-money/src/mock-buzz.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/mock-buzz.ts.tmpl
@@ -12,7 +12,8 @@
 // TWO per-account behaviours the 0.18 mock host still does NOT model remain here —
 // both test-only, both layered on `createMockHost` via `installMockMoneyHost`:
 //
-//   1. GET_BUZZ_BALANCE returning an ERROR (the "balance unavailable" UI). The
+//   1. GET_BUZZ_BALANCE returning an ERROR (so you can prove the app degrades
+//      silently — the account picker just drops its 0-Buzz annotations). The
 //      mock host always answers with a balance; there is no error mode. We answer
 //      SYNCHRONOUSLY from `onOutbound` (which 0.18 invokes BEFORE its own
 //      GET_BUZZ_BALANCE handler), so the error settles the read first.

--- a/internal/scaffold/templates/page-vite/package.json.tmpl
+++ b/internal/scaffold/templates/page-vite/package.json.tmpl
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
Four scaffold/branding cleanups from a recorded design review.

Docs counterpart: **civitai/civitai-developer-docs#31**

---

## A — Remove the redundant Buzz balance readout from the default scaffold

Every app an AI agent generates rendered blue/green/yellow Buzz chips + a total, because `page-money` (the **default** template — `internal/cmd/app_create.go`) did. Apps run inside the Civitai chrome, which **already shows the viewer's balance**, so the in-app copy is pure redundancy — and it competes with the real one whenever the two are briefly out of sync. Agents copy the scaffold, so it propagated into every generated app.

### Consumers of `useBuzzBalance()` — removed vs kept

| Consumer | Verdict | Why |
|---|---|---|
| `BalancePanel` (3× `PoolChip` + total) | **Removed** | The readout itself. Pure duplication of host chrome. |
| `PoolChip`, `POOL_COLORS`, `balancePanelStyle`, `balanceTotalStyle`, `poolChipStyle`, `poolDotStyle`, `poolValueStyle` | **Removed** | Dead once the panel is gone — no other referents (verified by grep + a clean `tsc --noEmit` on a generated app). |
| `loading` / `error` from the hook | **Removed** | Only ever read by the panel's degraded states. |
| **`balance` → `AccountPicker`** | **KEPT** | Annotates *which account can actually fund this generation* (`· 0` + a `title` on an empty pool). This is app-specific context the host chrome cannot provide — it's reasoning about spend, not re-displaying a number. |
| **`refetch` → post-success effect** | **KEPT** | A generation debits the pools; without the refetch the picker's 0-annotations go stale immediately after the spend that caused them. |

`useBuzzBalance` itself is **not** blanket-removed — only the readout is.

### Coverage

Not deleted to make things pass — **net +1 test** (baseline 137 → 138):

- `renders the 3-pool Buzz balance` → **`does NOT render a Buzz balance readout`** (asserts all five `pm-balance*` testids absent, after waiting for a post-`BLOCK_INIT` frame so it can't pass vacuously).
- **NEW** `the balance IS consumed: the account picker annotates a 0-Buzz pool` — the positive control. A zero-assertion alone can't distinguish "readout removed" from "balance no longer reaching the app"; this proves the hook still delivers (yellow 80 / blue 20 / **green 0** → only green annotated).
- `gracefully shows "unavailable"` → **`a failed balance read degrades silently`** — the graceful-degradation path is retained, retargeted at the picker.
- The anon test's `pm-balance` assertion was **dropped, deliberately**: with no readout for any viewer it would pass regardless and prove nothing about the anon path. Its absence is guarded by its own test.
- Go side: `mustContain(app, "pm-balance")` → `mustNotContain` for `pm-balance`, `BalancePanel`, `PoolChip`, `POOL_COLORS` — so re-adding a readout under a *different* testid still trips it.

The generated README now teaches the rule instead of the pattern.

---

## B — "Comfy Cloud" → "Comfy on Civitai"

The Comfy project holds a trademark on "Comfy Cloud". **39 occurrences** in this repo (more than a line-grep suggests — 3 were line-wrapped across a newline, and 4 more were case/hyphen variants a case-sensitive pass missed: `/comfy cloud recipe/i` in an e2e selector and 3× `Comfy-Cloud`). The regex variant was caught by *running the generated app's suite*, not by review.

### User-facing (39 renamed)

| Surface | Count |
|---|---|
| CLI help — `app_create.go` | 3 |
| CLI stdout — `app_init.go` | 4 (1 string + 3 comment) |
| Issue template `request-recipe.yml` (name, description, body) | 3 |
| Generated README `page-money/README.md.tmpl` | 2 |
| Generated app UI + comments `App.tsx.tmpl` (incl. the tab label + 2 Alert titles) | 6 |
| Generated app `comfy.ts` / `generation.ts` / tests | 12 |
| Go test assertions + comments | 9 |

### Internal — deliberately NOT renamed

- `customComfy` — the `WorkflowBody` discriminant (**35** in-repo / 25 in a generated app)
- `starter-comfy-txt2img` — the server-registered recipe id (**13** / 12)
- `civitai_app_block_customcomfy_*` — **not present in this repo** (metric names live in `civitai/civitai`); nothing to protect here.

---

## C — `page-vite`: React `^18.3.1` → `^19.0.0`

Bumped. The template uses only `createRoot` (`react-dom/client`), `React.StrictMode`, `useState`, `useEffect` — none of React 19's removals (`ReactDOM.render`, `findDOMNode`, string refs, legacy context, `defaultProps` on function components) apply. Left `@vitejs/plugin-react@^4` / `vite@^6` alone — verified working rather than assumed.

---

## D — `buzzBudgetPerGen` default `40` → `300` (safety ceiling, not an estimate)

`buzzBudgetPerGen` bounds what a **malicious or exploited app can spend per generation**. It is not a forecast. The scaffold shipped **40** — the starter Comfy recipe's per-job ceiling (30) **plus 10**. That is worst-case-plus-margin, i.e. estimate-shaped, and since `page-money` is the *default* template, every generated app inherited it and taught authors' agents to size the field like a forecast.

It also blocked a fix: a CLI "this value looks too small" warning can't exist while any threshold catching an author's ~50 would also fire on our own 40.

### Why 300

The scaffold's worst case per generation is **30** — the hard, server-enforced per-job ceiling of `starter-comfy-txt2img`, the priciest thing this template can invoke. (The txt2img sample is cheaper; that's exactly why 40 "also covered" it.) **300 = 10× that.**

The multiple comes from the asymmetry, not from taste:

| | Consequence |
|---|---|
| **Too low** | Refused at a **pre-submit gate** — nothing runs, nothing is charged — but the app is **broken for every user** until a new manifest version ships **and is re-approved**. |
| **Too high** | Nothing. The headroom is **never spent**: the server re-prices and hard-caps every generation at the real per-job ceiling, and clamps the manifest value to the platform per-gen cap at mint. The schema sets only `exclusiveMinimum: 0` — no upper bound. |

So the value must absorb a pricier checkpoint, a full 5-LoRA stack (`MAX_LORAS`), a future recipe with a higher ceiling, and Buzz repricing — and must be unmistakably *not* a forecast. 300 against a 30 worst case cannot be misread as one; 40 can.

### Sites changed

- `templates/page-money/block.manifest.json.tmpl` — authoritative (the server reads this at mint)
- `templates/page-money/src/generation.ts.tmpl` — the `PAGE_BUZZ_BUDGET` mirror
- `scaffold_test.go` — assertion + a **new seam guard**

### New seam guard

The budget lives in **two** files and nothing at runtime reconciles them, so a drifted mirror silently misinforms the author. The guard now parses the number the **rendered** manifest actually emitted and requires `PAGE_BUZZ_BUDGET` to equal it — pinning the *relationship*, not just each value. Mutation-verified: drifting only the mirror fails on `PAGE_BUZZ_BUDGET`; reverting both to 40 fails the literal assertion **and** the parsed-value check, with distinct messages.

Also corrected a comment that contradicted the code: `PAGE_BUZZ_BUDGET` was documented as driving a client-side "Top up · N" CTA, but it has **no consumer** in the scaffold.

### 🔴 Stale prose left in place — needs routing to cli#199

The generated README still names the old number. I did not edit it (budget guidance is owned by cli#199):

- `templates/page-money/README.md.tmpl:113` — *"That's why `page.buzzBudgetPerGen` is **40**: it must reserve at least the recipe's ceiling (30) and also covers a cheap txt2img gen."*
- `templates/page-money/README.md.tmpl:119` — *"so **40** is the per-gen ceiling for the txt2img sample too"*

Both now contradict the manifest, **and both articulate the very "ceiling + margin" reasoning this change removes** — so they need rewriting, not just a number swap.

Two more in the docs repo, same owner (docs#30), also untouched by my docs PR:
- `apps/guide/comfy-cloud.md:158` — a manifest sample with `"buzzBudgetPerGen": 40`
- `apps/guide/comfy-cloud.md:167` — *"pairs `buzzBudgetPerGen: 40` with the `starter-comfy-txt2img` recipe"*

### Not changed: `examples/buzz-generator.block.manifest.json` (sets `10`)

Same anti-pattern, and it would trip any "too small" warning — but the repo README states these examples are **"copied from the shipping `civitai-block-*` apps"**, so editing the value would falsify that provenance claim. It is a record of a real app, not a scaffold default. Flagging rather than silently rewriting: either the shipped app's budget needs raising, or the "a good reference for a correct manifest" framing needs dropping.

---

## Verification

- `go build ./...` clean; `gofmt -l` empty.
- `go test ./...` — **1332 RUN / 1330 PASS / 2 SKIP / 0 FAIL**, 16 packages ok (counted and reconciled exactly, not read off an exit code).
- **Generated a real app from the edited templates** and ran its own gates: `npm test` **138/138 pass** (11 files), `npm run typecheck` **0 errors**. Baseline generated from `origin/main`: **137 pass** → net +1, nothing dropped.
- Typechecker validated against a known-bad input first (injected type error → 2 errors; 0 under test), so the clean result is not a fact about the command line.
- **Mutation-checked every new guard**, each failing for its *own* reason: re-adding a `pm-balance` testid → `TestRenderPageMoney`: `expected NOT to contain "pm-balance"`; reverting the help string → `TestAppCreateHelpMentionsComfy`. Both green again after restore.
- `page-vite`: generated, `npm install` (react **19.2.8**), `npm run build` succeeded (29 modules, dist emitted).
- Budget: generated an app and confirmed the **emitted** manifest carries `"buzzBudgetPerGen": 300`; `civitai app validate` passes; generated suite still 138/138 with 0 TS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
