### PR TITLE
fix(scaffold): bump page-money pins to published (app-sdk 0.31.0, blocks-react 0.39.0)

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -142,8 +142,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.38.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.30.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.39.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.31.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -225,7 +225,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.30.0` + `@civitai/blocks-react@^0.38.0` (already pinned in
+`@civitai/app-sdk@^0.31.0` + `@civitai/blocks-react@^0.39.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.30.0",
-    "@civitai/blocks-react": "^0.38.0",
+    "@civitai/app-sdk": "^0.31.0",
+    "@civitai/blocks-react": "^0.39.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Why

`pins-vs-published` is a **required** check and is currently **red on `main` itself** — so every open PR in the repo is blocked, not just one. The pre-1.0 carets lock the minor, so `^0.30.0` / `^0.38.0` no longer admit the published versions:

| package | pinned | published |
| --- | --- | --- |
| `@civitai/app-sdk` | `^0.30.0` | **0.31.0** |
| `@civitai/blocks-react` | `^0.38.0` | **0.39.0** |

Same shape as #194.

## How

Produced by the repo's own bumper rather than by hand, so the three literal pin sites cannot drift apart:

```bash
go run ./internal/scaffold/cmd/bump-pins
```

That rewrites `templates/page-money/package.json.tmpl`, `templates/page-money/README.md.tmpl` and `scaffold_test.go` — 3 files, 5 lines.

## Verification

A pre-1.0 **minor** bump can break the template's SDK calls, so the guard passing is necessary but not sufficient. I scaffolded a real app with the rebuilt binary and exercised it:

- `npm install` resolved **app-sdk 0.31.0** and **blocks-react 0.39.0** (confirmed from `node_modules`, not from the pin);
- `npm run build` — `tsc -p tsconfig.json --noEmit && vite build` — succeeded;
- the template's own suite passed **138 tests across 11 files**.

Repo side: `make ci` green; full suite with `CIVITAI_CHECK_PUBLISHED_PINS=1` is **1332 run / 1331 pass / 0 fail**, and `TestScaffoldPinsSatisfyPublished` now passes with the network guard enabled (it fails on `main` today — that was the discriminating control confirming this is pre-existing and not caused by any open PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
