### PR TITLE
chore(ci): sweep scaffold pins daily — weekly left a required check red for days

### DIFF
--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -10,9 +10,30 @@ name: bump-scaffold-pins
 
 on:
   schedule:
-    # Weekly, Mondays 07:17 UTC (off the top-of-hour rush). Cron literal in YAML
-    # needs quoting so the `*` isn't parsed as a YAML alias.
-    - cron: "17 7 * * 1"
+    # DAILY at 07:17 UTC (off the top-of-hour rush; the minute is offset from the
+    # sibling drift-bots — revendor-canonical-schema 07:37, bump-flake-vendorhash
+    # 07:47). Cron literal in YAML needs quoting so the `*` isn't parsed as a
+    # YAML alias.
+    #
+    # This was weekly (`17 7 * * 1`) and that cadence was measurably too slow.
+    # `pins-vs-published` is a REQUIRED check on `main` and it reads npm's
+    # published latest, so from the moment a `@civitai/*` minor lands until this
+    # job bumps the pins, EVERY open PR is blocked regardless of its content.
+    # (The sibling `scaffold-currency` is required too but is NOT affected: it
+    # installs `@latest` explicitly, overriding the template pins, so it reds on
+    # a broken SDK export rather than on a stale caret.)
+    #
+    # Publishes measured off the npm registry `time` field: app-sdk 0.26.0
+    # Jul 17, 0.27.0 Jul 28, 0.28.0 Jul 29, 0.29.0 Aug 3 20:15, 0.30.0 Aug 3
+    # 22:13, 0.31.0 Aug 5 03:54 (2026) — six minors in 19 days, a ~3.6-day mean
+    # interval against a 7-day sweep. Upstream published faster than the bot
+    # swept, so a large fraction of each week sat red and the pins had to be
+    # hand-bumped twice in two days (#194, #203).
+    #
+    # Daily bounds that window at ~24h instead of ~168h. A no-op run is cheap:
+    # `detect changes` gates every downstream step, so an already-current sweep
+    # is just checkout + setup-go + the bumper's npm metadata reads.
+    - cron: "17 7 * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/claudedocs/handoff-app-analytics-followups.md
+++ b/claudedocs/handoff-app-analytics-followups.md
@@ -57,8 +57,17 @@ frequency (daily) — not the bumper, which works. ⚠️ `.github/workflows/*` 
 
 🔴 **It recurred within a day, exactly as predicted.** cli#194 bumped to app-sdk `0.30.0` /
 blocks-react `0.38.0` on 2026-08-04; by 2026-08-05 `main` carries **cli#203**, bumping the same
-two pins again to `0.31.0` / `0.39.0`. Treat the ~7-day red window as a standing property of
-this repo, not an incident — and do not spend time diagnosing it a third time.
+two pins again to `0.31.0` / `0.39.0`.
+
+✅ **RESOLVED — the (b) lever was raised and approved, and the cron is now DAILY** (`17 7 * * *`,
+cli#205, 2026-08-05). The window is bounded at ~24h instead of ~168h. The publish cadence that
+justified it, measured off the npm registry `time` field: app-sdk 0.26.0 Jul 17 → 0.27.0 Jul 28
+→ 0.28.0 Jul 29 → 0.29.0 Aug 3 20:15 → 0.30.0 Aug 3 22:13 → 0.31.0 Aug 5 03:54, i.e. six minors
+in 19 days (~3.6-day mean) against a 7-day sweep — upstream published faster than the bot swept.
+**Do not re-raise this as an open decision.** Point (a) still stands unchanged: a blocked PR is
+still fixed by `go run ./internal/scaffold/cmd/bump-pins` + a PR, or by
+`gh workflow run bump-scaffold-pins.yml` — daily narrows the window, it does not close it, so
+pin drift remains a standing property of this repo rather than an incident to diagnose.
 
 Minor, left alone deliberately: the bumper also rewrites a README prose line to read
 "`accountType` / … require `@civitai/app-sdk@^0.30.0`", but those APIs arrived in the *older*


### PR DESCRIPTION
## What

`bump-scaffold-pins` sweeps **daily** (`17 7 * * *`) instead of weekly (`17 7 * * 1`). One cron literal; the bumper, its in-job validation, and the PR it opens are untouched.

## Why

`pins-vs-published` is a **required** status check on `main` and it reads npm's published latest. The page-money template pins `@civitai/*` with pre-1.0 carets that lock the minor, so from the moment a minor lands until this bot rewrites those pins, **every open PR is blocked regardless of its content**.

The bot is not broken — it is too slow. Publish times off the npm registry `time` field:

| version | published (UTC, 2026) |
|---|---|
| app-sdk 0.26.0 | Jul 17 23:57 |
| app-sdk 0.27.0 | Jul 28 20:16 |
| app-sdk 0.28.0 | Jul 29 02:02 |
| app-sdk 0.29.0 | Aug 3 20:15 |
| app-sdk 0.30.0 | Aug 3 22:13 |
| app-sdk 0.31.0 | Aug 5 03:54 |

Six minors in 19 days — a **~3.6-day mean interval against a 7-day sweep**. Upstream publishes faster than the bot swept, so a large fraction of each week sat red. It was hand-bumped twice in two days (#194, #203), and **#203 existed only to unblock an unrelated PR** (#198, whose diff touches no scaffold code at all).

Daily bounds the window at ~24h instead of ~168h.

`scaffold-currency` is required too but is deliberately **not** part of this: it `npm install`s `@latest` explicitly, overriding the template pins, so it reds on a broken SDK export rather than on a stale caret. Only `pins-vs-published` is affected.

## Provenance

This is the **(b) lever** identified in `claudedocs/handoff-app-analytics-followups.md`, which diagnosed the same thing independently and correctly stopped:

> If the ~7-day window is judged too wide, the lever is cron frequency (daily) — not the bumper, which works. ⚠️ `.github/workflows/*` is ask-first per `AGENTS.md`, so that is a decision to raise, not to make.

The decision has now been made by the maintainer, so this PR pulls the lever and updates that doc to record it as settled — otherwise the next agent re-raises a closed question. Point (a) of that note is preserved verbatim: a blocked PR is still fixed by `bump-pins` + a PR, or `gh workflow run bump-scaffold-pins.yml`.

## Verification

A cron change has no unit-test surface, so this leans on tool checks — each with a control, because both tools are silent-on-success and silence is otherwise indistinguishable from "checked nothing".

- **actionlint** clean on the changed workflow. **Positive control:** it rejects `77 7 * * *` with `invalid CRON format … end of range (77) above maximum (59)`, so its acceptance of `17 7 * * *` is a real green and not an unread file.
- **YAML re-parsed** to assert the schedule literal is `["17 7 * * *"]`. Handles the YAML 1.1 trap where a bare `on:` key parses as boolean `True`, not the string `"on"`. **Positive control:** injecting the old weekly value is observed by the parser. **Negative control:** malformed YAML raises rather than passing.
- **The bumper's no-op path exercised live** against npm from this branch: printed `all @civitai/* pins are current — nothing to do` and modified zero files. That is the daily run's common case, and it confirms `detect changes` gates every downstream step — so 7× the runs is not 7× the cost.
- **`make ci` green** — 16 packages `ok`, 0 `FAIL`, `go mod tidy` a no-op, `gofmt -s -l` silent across **206** Go files (file count asserted so "clean" isn't "found nothing to check").

**What is not verified:** that the cron actually fires daily. GitHub only reveals that on the schedule, and scheduled workflows can be delayed or skipped under load — an argument *for* this change (a skipped daily run costs a day, a skipped weekly run costs two weeks) but not something provable pre-merge. Worth a glance at the run history in a few days.

## Residual

Daily narrows the window, it does not close it — a publish minutes after a sweep still blocks PRs until the next day, and the auto-PR still needs a human merge. If that residual bites, the next levers are a 6-hourly cron or a `repository_dispatch` fired from the SDK's release pipeline. Both are larger changes to `.github/` (the latter needs a cross-repo token), so neither is taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTYNRi1WkNWzaVMerFRFAC
