### PR TITLE
fix(app status): say when the submissions listing hit the server's 100-row cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,8 +680,24 @@ Rejection reason:
 Not live yet — gen-matrix.civit.ai only serves after the app is approved and deployed (deployState 'live').
 ```
 
+The unfiltered listing is **capped server-side at 100 rows**, and the API returns
+no cursor and no total — so there is no way to page and no way to know how many
+were dropped. When a full-length page comes back the CLI says so on **stderr**
+rather than presenting it as your complete history:
+
+```text
+note: showing the newest 100 submissions — the API caps this listing and offers no way to page, so older submissions may exist but are not listed. Look up a specific app with `civitai app status <blockId>`.
+```
+
+That is an inference (a page that is exactly full is indistinguishable from one
+that was cut off), so it says *may*. A per-app lookup — `civitai app status
+<blockId>` — is **not** affected: the server narrows to the slug before applying
+the cap.
+
 `--json` emits the raw response for scripting. An empty list prints a friendly
 "run `civitai app submit`" hint; with no token it points you at `civitai login`.
+Notes like the cap caveat go to stderr, so `--json` stdout stays pure and the
+exit code stays 0.
 
 ## App metrics
 

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -306,7 +306,28 @@ const SubmissionsPath = "/api/v1/blocks/submissions"
 // than this many submissions of its own to be truncated. Don't add a caveat
 // there.
 //
-// Keep in lockstep with MAX_ROWS if the server's page size ever changes.
+// KNOWN LIMITATION — this is a vendored mirror, and it can drift SILENTLY in
+// two directions with different severities. Stating them precisely, because a
+// vague "keep in lockstep" comment is exactly what lets both happen unnoticed:
+//
+//	Server RAISES MAX_ROWS (say to 250) — callers holding between 100 and 250
+//	rows get the caveat when nothing is missing. The user-visible text stays
+//	TRUE: it quotes the OBSERVED row count, never this constant, and says older
+//	submissions "may" exist (pinned by TestAppStatusCaveatQuotesObservedCount).
+//	So the failure is a false warning, not a false statement.
+//
+//	Server LOWERS MAX_ROWS (say to 50) — the response carries 50 rows, the
+//	`n >= 100` predicate is false, and NO caveat fires: the silent-truncation
+//	bug this constant exists to prevent comes straight back, and no offline
+//	test can notice. This is the serious direction.
+//
+// Neither direction is detectable from a single response — it carries no total
+// and no cursor, the same gap that makes the truncation itself invisible. So
+// TestSubmissionsCapDriftAgainstLiveAPI (cap_drift_test.go) closes it with a
+// live, credentialed cross-check that catches BOTH directions; that is why that
+// test exists and why a comment alone would not be enough. The durable fix is
+// server-side: a `hasMore` flag (or a cursor) on the listing deletes this
+// constant outright.
 const ListSubmissionsCap = 100
 
 // WithdrawPath is the token-authenticated, self-scoped withdraw route

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -292,6 +292,23 @@ const submitTimeout = 120 * time.Second
 // route (GET; civitai/civitai src/pages/api/v1/blocks/submissions.ts).
 const SubmissionsPath = "/api/v1/blocks/submissions"
 
+// ListSubmissionsCap mirrors MAX_ROWS in that route: the UNFILTERED listing is
+// `take: MAX_ROWS` (submissions.ts) with NO cursor, NO offset and NO total count
+// in the response — its zod query schema accepts ONLY `id` and `blockId`, so
+// there is nothing to page with and nothing to compare a length against.
+// A full-length page is therefore the ONLY evidence available that rows were
+// dropped, and it is INFERENCE, not a signal: a caller holding exactly this many
+// submissions is indistinguishable from one holding more. Callers must present it
+// as "may be incomplete", never as a complete answer and never as a hard fact.
+//
+// A `?blockId=<slug>` (or `?id=`) lookup is NOT affected: the server puts
+// `where.slug` into the query BEFORE `take`, so a single app would need more
+// than this many submissions of its own to be truncated. Don't add a caveat
+// there.
+//
+// Keep in lockstep with MAX_ROWS if the server's page size ever changes.
+const ListSubmissionsCap = 100
+
 // WithdrawPath is the token-authenticated, self-scoped withdraw route
 // (POST {"publishRequestId": ...}; civitai/civitai
 // src/pages/api/v1/blocks/withdraw.ts). 200 on success (incl. an idempotent

--- a/internal/appapi/cap_drift_test.go
+++ b/internal/appapi/cap_drift_test.go
@@ -1,0 +1,449 @@
+package appapi
+
+// Vendored-cap drift guard for ListSubmissionsCap.
+//
+// ListSubmissionsCap mirrors MAX_ROWS in civitai/civitai
+// src/pages/api/v1/blocks/submissions.ts. TestListSubmissionsCapMirrorsServer
+// pins the CLI's own literal, but it cannot SEE the server — so on its own the
+// only thing holding the two together is a comment, and both drift directions
+// fail silently (see the constant's doc comment; the LOWERING direction
+// reintroduces the silent-truncation bug the caveat exists to prevent).
+//
+// The obvious live check — "fetch the listing, assert len == cap" — is unsound
+// and would pass for the wrong reason: an account holding fewer submissions
+// than the cap returns a short page and proves nothing, and a full page is
+// equally consistent with "the cap is 100" and "the cap is 250 and this account
+// happens to hold exactly 100". A green from that check would be noise.
+//
+// So the probe below establishes truncation POSITIVELY before it reads a cap
+// off anything, using the one asymmetry the route offers: `?blockId=<slug>` is
+// narrowed by `where.slug` BEFORE `take`, so a per-app lookup can see rows the
+// unfiltered listing dropped. If any app in the page holds a submission
+// STRICTLY OLDER than the oldest row the unfiltered listing returned, that
+// listing demonstrably withheld rows — truncation is proven, and the size of
+// that page IS the server's cap, whatever the vendored constant says. This
+// catches drift in BOTH directions. With no such evidence the probe answers
+// "cannot observe" and the live test SKIPS; it never turns an absence of
+// evidence into a pass.
+//
+// Strictly-older is also what makes the probe safe against a submission landing
+// between the two calls: a new row is NEWER than the page's oldest, so it can
+// never forge the signal.
+//
+// Two ways the probe legitimately declines, both conservative (skip, never a
+// wrong answer): an app that itself holds more rows than the cap has its own
+// view truncated too, and a page boundary that falls exactly between two apps
+// leaves no straddling app to cross-check.
+//
+// The probe is validated offline against fixtures with KNOWN caps — including
+// the two controls that matter: a page that is exactly full but hides nothing
+// must come back "cannot observe", and a lowered or raised server cap must come
+// back "confirmed" at the server's number so the live assertion goes red.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+)
+
+// capVerdict is the probe's conclusion. There are deliberately only two: either
+// we PROVED the listing was truncated (and therefore measured the server's real
+// cap) or we could not tell. "Looks fine" is not a verdict.
+type capVerdict string
+
+const (
+	capCannotObserve capVerdict = "cannot-observe"
+	capConfirmed     capVerdict = "confirmed"
+)
+
+type capProbe struct {
+	Verdict capVerdict
+	// ObservedCap is the server's actual page size, meaningful ONLY when
+	// Verdict is capConfirmed.
+	ObservedCap int
+	// Evidence names the row that proved the listing withheld history.
+	Evidence string
+	// Probed counts the per-app lookups spent.
+	Probed int
+}
+
+// listFn is the seam: the live test passes Client.ListSubmissions, the offline
+// tests pass a fixture server.
+type listFn func(ctx context.Context, blockID string) ([]Submission, error)
+
+// liveCapProbeBudget bounds the per-app lookups. The route allows 60 requests
+// per minute per user, so 1 + 8 stays comfortably inside one window.
+const liveCapProbeBudget = 8
+
+// probeSubmissionsCap measures the server's unfiltered page size, or reports
+// that it could not. See the file comment for why a plain length check is not
+// sound. It returns an error only when an API call itself fails.
+func probeSubmissionsCap(ctx context.Context, list listFn, maxProbes int) (capProbe, error) {
+	page, err := list(ctx, "")
+	if err != nil {
+		return capProbe{}, err
+	}
+	if len(page) == 0 {
+		return capProbe{Verdict: capCannotObserve}, nil
+	}
+	// The oldest timestamp actually PRESENT in the page, computed as a minimum
+	// rather than read off the last row: trusting the server's `orderBy` would
+	// make this probe silently wrong if that ordering ever changed.
+	oldest, ok := oldestSubmittedAt(page)
+	if !ok {
+		return capProbe{Verdict: capCannotObserve}, nil
+	}
+	probed := 0
+	for _, slug := range slugsOldestFirst(page) {
+		if probed >= maxProbes {
+			break
+		}
+		probed++
+		rows, err := list(ctx, slug)
+		if err != nil {
+			return capProbe{}, err
+		}
+		for _, r := range rows {
+			at, perr := time.Parse(time.RFC3339, r.SubmittedAt)
+			if perr != nil {
+				continue
+			}
+			// STRICTLY older: a row that landed mid-probe is newer than the
+			// page's oldest and therefore cannot forge this.
+			if at.Before(oldest) {
+				return capProbe{
+					Verdict:     capConfirmed,
+					ObservedCap: len(page),
+					Probed:      probed,
+					Evidence: fmt.Sprintf(
+						"app %q holds submission %s at %s, older than the oldest row the unfiltered listing returned (%s) — the listing withheld it",
+						slug, r.ID, r.SubmittedAt, oldest.Format(time.RFC3339)),
+				}, nil
+			}
+		}
+	}
+	return capProbe{Verdict: capCannotObserve, Probed: probed}, nil
+}
+
+// oldestSubmittedAt returns the minimum parseable submittedAt in the page.
+func oldestSubmittedAt(page []Submission) (time.Time, bool) {
+	var oldest time.Time
+	found := false
+	for _, s := range page {
+		at, err := time.Parse(time.RFC3339, s.SubmittedAt)
+		if err != nil {
+			continue
+		}
+		if !found || at.Before(oldest) {
+			oldest, found = at, true
+		}
+	}
+	return oldest, found
+}
+
+// slugsOldestFirst lists the page's distinct apps, the one whose visible
+// history reaches furthest back first — an app sitting at the page's old
+// boundary is the likeliest to have had rows cut off, so it is the
+// highest-yield probe.
+func slugsOldestFirst(page []Submission) []string {
+	minAt := map[string]time.Time{}
+	var order []string
+	for _, s := range page {
+		at, err := time.Parse(time.RFC3339, s.SubmittedAt)
+		if err != nil {
+			continue
+		}
+		cur, seen := minAt[s.BlockID]
+		if !seen {
+			order = append(order, s.BlockID)
+		}
+		if !seen || at.Before(cur) {
+			minAt[s.BlockID] = at
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return minAt[order[i]].Before(minAt[order[j]]) })
+	return order
+}
+
+// ── offline harness validation ───────────────────────────────────────────────
+
+// fakeListing models the route: the unfiltered listing is the newest serverCap
+// rows across every app, while a per-app lookup is narrowed BEFORE the cap
+// applies — and is then capped in its own right, exactly like the server.
+type fakeListing struct {
+	all       []Submission
+	serverCap int
+	calls     int
+	// extra is appended to a per-app lookup only, modelling a submission that
+	// lands between the unfiltered read and the cross-check.
+	extra map[string][]Submission
+}
+
+func (f *fakeListing) list(_ context.Context, blockID string) ([]Submission, error) {
+	f.calls++
+	var rows []Submission
+	for _, s := range f.all {
+		if blockID == "" || s.BlockID == blockID {
+			rows = append(rows, s)
+		}
+	}
+	if blockID != "" {
+		rows = append(rows, f.extra[blockID]...)
+	}
+	// RFC3339 in a fixed zone sorts lexicographically; newest first, like the
+	// server's `orderBy: { submittedAt: 'desc' }`.
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].SubmittedAt > rows[j].SubmittedAt })
+	if len(rows) > f.serverCap {
+		rows = rows[:f.serverCap]
+	}
+	return rows, nil
+}
+
+// sub builds one submission for slug, dated `day` days after an epoch.
+func sub(slug string, day int) Submission {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return Submission{
+		ID:          fmt.Sprintf("pubreq_%s_%04d", slug, day),
+		BlockID:     slug,
+		Version:     "0.1.0",
+		Status:      "approved",
+		SubmittedAt: base.AddDate(0, 0, day).Format(time.RFC3339),
+	}
+}
+
+// contiguousApps builds numApps apps of perApp submissions each, laid out so
+// that EVERY day from 1 to numApps*perApp carries exactly one submission and
+// each app occupies one contiguous block of days. App 0 is the newest.
+//
+// The contiguity matters: a page boundary then always falls INSIDE some app's
+// block unless the cap is an exact multiple of perApp, which is what gives the
+// probe a straddling app to cross-check. Tests pick caps that are not multiples
+// of perApp on purpose — see TestCapProbeDeclinesOnAlignedBoundary for the
+// aligned case, which the probe conservatively declines.
+func contiguousApps(numApps, perApp int) []Submission {
+	total := numApps * perApp
+	var all []Submission
+	for i := 0; i < numApps; i++ {
+		slug := fmt.Sprintf("app-%03d", i)
+		top := total - i*perApp // newest day in this app's block
+		for k := 0; k < perApp; k++ {
+			all = append(all, sub(slug, top-k))
+		}
+	}
+	return all
+}
+
+// soloApps builds n apps holding exactly one submission each — an account with
+// no hidden per-app history, so nothing can ever prove truncation.
+func soloApps(n int) []Submission { return contiguousApps(n, 1) }
+
+// TestCapProbeConfirmsTrueServerCap is the POSITIVE control: against a server
+// whose cap matches the vendored constant, the probe must actually OBSERVE it.
+// A probe that could only ever answer "cannot observe" would make every other
+// result here meaningless.
+func TestCapProbeConfirmsTrueServerCap(t *testing.T) {
+	f := &fakeListing{all: contiguousApps(60, 3), serverCap: ListSubmissionsCap}
+	got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if got.Verdict != capConfirmed {
+		t.Fatalf("verdict = %q, want %q — the probe must be able to observe a real cap", got.Verdict, capConfirmed)
+	}
+	if got.ObservedCap != ListSubmissionsCap {
+		t.Errorf("ObservedCap = %d, want %d", got.ObservedCap, ListSubmissionsCap)
+	}
+	if got.Evidence == "" {
+		t.Error("a confirmed verdict must carry the row that proved it")
+	}
+}
+
+// TestCapProbeCatchesDriftBothDirections is the NEGATIVE control, and the whole
+// point of the guard: a server cap that no longer matches the vendored constant
+// must be OBSERVED as the server's number, so the live assertion goes red. The
+// lowered case is the serious one — that drift silently reintroduces the
+// truncation bug.
+func TestCapProbeCatchesDriftBothDirections(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverCap int
+	}{
+		{"server LOWERED its cap (silently reintroduces truncation)", 50},
+		{"server RAISED its cap", 130},
+	}
+	for _, tc := range cases {
+		f := &fakeListing{all: contiguousApps(60, 3), serverCap: tc.serverCap}
+		got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+		if err != nil {
+			t.Fatalf("%s: probe: %v", tc.name, err)
+		}
+		if got.Verdict != capConfirmed {
+			t.Errorf("%s: verdict = %q, want %q — drift must be OBSERVED, not skipped past",
+				tc.name, got.Verdict, capConfirmed)
+			continue
+		}
+		if got.ObservedCap != tc.serverCap {
+			t.Errorf("%s: ObservedCap = %d, want %d", tc.name, got.ObservedCap, tc.serverCap)
+		}
+		// The live test's own assertion, applied to the probe's answer.
+		if got.ObservedCap == ListSubmissionsCap {
+			t.Errorf("%s: probe reported the vendored value %d for a server capped at %d — the drift would go UNDETECTED",
+				tc.name, got.ObservedCap, tc.serverCap)
+		}
+	}
+}
+
+// TestCapProbeCannotObserve covers every way the probe must decline to answer.
+// The last case is what makes this guard sound: a page that is exactly full but
+// hides nothing must NOT be read as confirmation — that is precisely the
+// wrong-reason pass a naive `len == cap` live check would report.
+func TestCapProbeCannotObserve(t *testing.T) {
+	cases := []struct {
+		name string
+		all  []Submission
+	}{
+		{"account holds nothing", nil},
+		{"account is far under the cap", soloApps(5)},
+		{"page is exactly full but no app hides older history", soloApps(ListSubmissionsCap)},
+	}
+	for _, tc := range cases {
+		f := &fakeListing{all: tc.all, serverCap: ListSubmissionsCap}
+		got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+		if err != nil {
+			t.Fatalf("%s: probe: %v", tc.name, err)
+		}
+		if got.Verdict != capCannotObserve {
+			t.Errorf("%s: verdict = %q (cap %d), want %q — an absence of evidence must not become a confirmation",
+				tc.name, got.Verdict, got.ObservedCap, capCannotObserve)
+		}
+	}
+}
+
+// TestCapProbeDeclinesOnAlignedBoundary pins the known conservative blind spot:
+// when the page boundary lands exactly between two apps, no app straddles it and
+// the probe declines rather than guessing. 150 rows / 3-per-app is such a case.
+func TestCapProbeDeclinesOnAlignedBoundary(t *testing.T) {
+	f := &fakeListing{all: contiguousApps(60, 3), serverCap: 150}
+	got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if got.Verdict != capCannotObserve {
+		t.Errorf("verdict = %q, want %q — an aligned boundary offers no straddling app, so the probe must decline",
+			got.Verdict, capCannotObserve)
+	}
+}
+
+// TestCapProbeIgnoresRowsLandingMidProbe: a submission created between the
+// unfiltered read and the per-app read appears only in the per-app view. It is
+// NEWER than the page's oldest row, so it must not be mistaken for withheld
+// history — otherwise this guard would fail at random on an active account.
+func TestCapProbeIgnoresRowsLandingMidProbe(t *testing.T) {
+	f := &fakeListing{
+		all:       soloApps(ListSubmissionsCap), // exactly a full page, nothing hidden
+		serverCap: ListSubmissionsCap,
+		// Far NEWER than anything in the page, on the app the probe checks first.
+		extra: map[string][]Submission{"app-099": {sub("app-099", 9000)}},
+	}
+	got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if got.Verdict != capCannotObserve {
+		t.Errorf("verdict = %q, want %q — a newly-landed row is not evidence of truncation",
+			got.Verdict, capCannotObserve)
+	}
+}
+
+// TestCapProbeRespectsBudget keeps the live guard inside the route's 60/min
+// per-user rate limit, and asserts the budget is actually SPENT (a probe that
+// bailed after one call would satisfy an upper bound while proving nothing).
+func TestCapProbeRespectsBudget(t *testing.T) {
+	f := &fakeListing{all: soloApps(ListSubmissionsCap), serverCap: ListSubmissionsCap}
+	got, err := probeSubmissionsCap(context.Background(), f.list, liveCapProbeBudget)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if want := 1 + liveCapProbeBudget; f.calls != want {
+		t.Errorf("probe made %d API calls, want exactly %d (1 listing + %d cross-checks)",
+			f.calls, want, liveCapProbeBudget)
+	}
+	if got.Probed != liveCapProbeBudget {
+		t.Errorf("Probed = %d, want %d", got.Probed, liveCapProbeBudget)
+	}
+}
+
+// ── the live guard ───────────────────────────────────────────────────────────
+
+// TestSubmissionsCapDriftAgainstLiveAPI checks the VENDORED ListSubmissionsCap
+// against the real server, in the style of the pins-vs-published guard
+// (internal/scaffold/pins_guard_test.go). It is gated on
+// CIVITAI_CHECK_SUBMISSIONS_CAP=1 plus a credential, so the default
+// `go test ./...` stays offline.
+//
+// It fails ONLY on proven drift. Every other outcome — no credential, an
+// unreachable server, or an account whose submissions cannot demonstrate
+// truncation — is a SKIP carrying its reason, never a pass: a green here has to
+// mean "the server's cap was measured and it is 100", and nothing else.
+//
+// Feasibility, stated plainly: this needs an account that (a) has Apps access
+// and (b) holds more submissions than the server's cap, with at least one app
+// whose older rows fall off the page. That is a real developer account, not a
+// CI fixture — so the guard is useful to a maintainer on demand, and running it
+// in CI would need a dedicated credential secret. Wiring that job touches
+// .github/workflows/*, which is ask-first, so it is PROPOSED in the PR, not
+// wired here.
+func TestSubmissionsCapDriftAgainstLiveAPI(t *testing.T) {
+	if os.Getenv("CIVITAI_CHECK_SUBMISSIONS_CAP") != "1" {
+		t.Skip("live guard; set CIVITAI_CHECK_SUBMISSIONS_CAP=1 (plus CIVITAI_TOKEN) to run")
+	}
+	token := os.Getenv("CIVITAI_TOKEN")
+	if token == "" {
+		t.Skip("CIVITAI_CHECK_SUBMISSIONS_CAP=1 but CIVITAI_TOKEN is empty — the server cannot be observed, so this is a SKIP, not a pass")
+	}
+	base := os.Getenv("CIVITAI_BASE_URL")
+	if base == "" {
+		base = "https://civitai.com"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	res, err := probeSubmissionsCap(ctx, New(base, token, "").ListSubmissions, liveCapProbeBudget)
+	if err != nil {
+		// Unreachable / rate-limited / not entitled: nothing was learned about
+		// the cap. Never a false failure, and never a pass.
+		t.Skipf("could not read %s%s (%v) — cap NOT observed, so this is a SKIP, not a pass", base, SubmissionsPath, err)
+	}
+	if res.Verdict != capConfirmed {
+		t.Skipf("CANNOT OBSERVE the server cap from this account after %d per-app cross-checks: "+
+			"no app showed a submission older than the oldest row the listing returned, so the listing was "+
+			"probably not truncated — which proves nothing about MAX_ROWS. Re-run against an account holding "+
+			"more submissions than the cap. SKIP, not a pass.", res.Probed)
+	}
+	if res.ObservedCap != ListSubmissionsCap {
+		t.Fatalf("VENDORED CAP DRIFT — the server's listing page size is %d, ListSubmissionsCap says %d.\n"+
+			"  evidence: %s\n"+
+			"  impact:   %s\n"+
+			"  fix:      set ListSubmissionsCap (internal/appapi/appblocks.go) AND the literal in "+
+			"TestListSubmissionsCapMirrorsServer to %d, after confirming MAX_ROWS in "+
+			"civitai/civitai src/pages/api/v1/blocks/submissions.ts.",
+			res.ObservedCap, ListSubmissionsCap, res.Evidence, driftImpact(res.ObservedCap), res.ObservedCap)
+	}
+	t.Logf("server cap CONFIRMED at %d after %d cross-check(s) — %s", res.ObservedCap, res.Probed, res.Evidence)
+}
+
+// driftImpact spells out which of the two failure modes a measured drift is, so
+// whoever reads the failure knows whether users are being over-warned or
+// silently under-warned.
+func driftImpact(observed int) string {
+	if observed < ListSubmissionsCap {
+		return "the server's cap is LOWER than the vendored value, so `civitai app status` prints NO truncation " +
+			"caveat on a truncated listing — the silent-truncation bug is live right now"
+	}
+	return "the server's cap is HIGHER than the vendored value, so `civitai app status` warns about truncation " +
+		"for callers whose listing was not truncated"
+}

--- a/internal/appapi/submissions_test.go
+++ b/internal/appapi/submissions_test.go
@@ -163,3 +163,16 @@ func TestSubmissionsErrorMapping(t *testing.T) {
 		srv.Close()
 	}
 }
+
+// TestListSubmissionsCapMirrorsServer pins the VENDORED value, not the predicate
+// that reads it: ListSubmissionsCap mirrors MAX_ROWS in civitai/civitai
+// src/pages/api/v1/blocks/submissions.ts, and every other test is written in
+// terms of the constant, so it would happily follow the constant if someone
+// edited it. The literal is the contract. If the server's page size genuinely
+// changed, update BOTH this literal and the constant in the same change.
+func TestListSubmissionsCapMirrorsServer(t *testing.T) {
+	if ListSubmissionsCap != 100 {
+		t.Errorf("ListSubmissionsCap = %d, want 100 (MAX_ROWS in submissions.ts) — "+
+			"if the server page size really changed, update this literal too", ListSubmissionsCap)
+	}
+}

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -77,6 +77,17 @@ and deployed (deployState 'live').`,
 			if err != nil {
 				return err
 			}
+			// The route caps the unfiltered listing and returns no cursor and no
+			// total, so a full-length page is the only hint that older rows were
+			// dropped. Say so instead of presenting a truncated list as the whole
+			// truth. STDERR (like the other API-limitation notes in this CLI) so
+			// --json stdout stays pure; exit stays 0.
+			if submissionsListTruncated(len(subs)) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"note: showing the newest %d submissions — the API caps this listing and offers no way to page, "+
+						"so older submissions may exist but are not listed. "+
+						"Look up a specific app with `civitai app status <blockId>`.\n", len(subs))
+			}
 			if jsonOut {
 				return writeJSON(out, map[string]any{"submissions": subs})
 			}
@@ -92,6 +103,19 @@ and deployed (deployState 'live').`,
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON (scriptable)")
 	return cmd
 }
+
+// submissionsListTruncated reports whether an UNFILTERED submissions listing of
+// n rows may have been cut off by the server's row cap
+// (appapi.ListSubmissionsCap — see its doc comment for why this can only ever be
+// an inference). The comparison is `>=`, not `==`: at or beyond the cap we know
+// about, this CLI cannot claim the listing is complete. A caller holding exactly
+// the cap gets the caveat while nothing is actually missing — accepted, because
+// the alternative failure (silently reporting a truncated list as complete) is
+// the bug this exists to fix, and the wording says "may exist", not "exist".
+//
+// Only the unfiltered list goes through here: a slug/id lookup is narrowed
+// server-side before the cap applies.
+func submissionsListTruncated(n int) bool { return n >= appapi.ListSubmissionsCap }
 
 func writeJSON(w io.Writer, v any) error {
 	enc := json.NewEncoder(w)

--- a/internal/cmd/app_status_test.go
+++ b/internal/cmd/app_status_test.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/civitai/cli/internal/appapi"
 )
 
 // statusServer stands up an httptest server emulating GET
@@ -179,6 +182,158 @@ func TestAppStatusJSONPassthrough(t *testing.T) {
 	}
 	if len(parsed.Submissions) != 1 || parsed.Submissions[0]["blockId"] != "alpha" {
 		t.Errorf("unexpected --json payload: %s", out)
+	}
+}
+
+// truncationNote is the distinguishing core of the cap caveat. Tests assert on
+// this exact phrase so a generic word ("note:", "submissions") from some other
+// message can't satisfy them.
+const truncationNote = "the API caps this listing and offers no way to page"
+
+// submissionRows builds n plausible listing rows, newest first.
+func submissionRows(n int) []map[string]any {
+	rows := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		rows = append(rows, map[string]any{
+			"id": fmt.Sprintf("pubreq_%03d", n-i), "blockId": fmt.Sprintf("app-%03d", n-i),
+			"version": "0.1.0", "status": "approved", "deployState": "live",
+			"submittedAt": "2026-06-17T08:00:00.000Z", "liveUrl": nil,
+		})
+	}
+	return rows
+}
+
+// TestSubmissionsListTruncatedBoundary pins the cap predicate at BOTH sides of
+// the boundary plus the empty case. A `>` or `==` mutation flips one of these.
+func TestSubmissionsListTruncatedBoundary(t *testing.T) {
+	cases := []struct {
+		n    int
+		want bool
+	}{
+		{0, false},
+		{1, false},
+		{appapi.ListSubmissionsCap - 1, false},
+		{appapi.ListSubmissionsCap, true},
+		{appapi.ListSubmissionsCap + 1, true},
+	}
+	for _, tc := range cases {
+		if got := submissionsListTruncated(tc.n); got != tc.want {
+			t.Errorf("submissionsListTruncated(%d) = %v, want %v", tc.n, got, tc.want)
+		}
+	}
+}
+
+// TestAppStatusCappedListWarns: a full-length page is the only evidence rows were
+// dropped, so the CLI must say the list may be incomplete — on stderr, leaving
+// the stdout table clean.
+func TestAppStatusCappedListWarns(t *testing.T) {
+	rows := submissionRows(appapi.ListSubmissionsCap)
+	srv := statusServer(t, map[string]any{"submissions": rows}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "status")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if !strings.Contains(errOut, truncationNote) {
+		t.Errorf("a %d-row (at-cap) listing must warn that it may be truncated; stderr:\n%s",
+			appapi.ListSubmissionsCap, errOut)
+	}
+	if !strings.Contains(errOut, "civitai app status <blockId>") {
+		t.Errorf("the caveat must name the remedy (a per-app lookup); stderr:\n%s", errOut)
+	}
+	// The note is advisory, not a failure, and must not pollute the table.
+	if strings.Contains(out, truncationNote) {
+		t.Errorf("the caveat belongs on stderr, not in the stdout table:\n%s", out)
+	}
+	if !strings.Contains(out, "BLOCK_ID") || !strings.Contains(out, "app-001") {
+		t.Errorf("the table must still render in full:\n%s", out)
+	}
+}
+
+// TestAppStatusShortListDoesNotWarn is the direction people forget: a listing
+// that fits under the cap is COMPLETE, and claiming otherwise would train users
+// to ignore the caveat. Covers one-under-the-cap and the empty list.
+func TestAppStatusShortListDoesNotWarn(t *testing.T) {
+	for _, n := range []int{0, 1, appapi.ListSubmissionsCap - 1} {
+		srv := statusServer(t, map[string]any{"submissions": submissionRows(n)}, http.StatusOK, nil)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("CIVITAI_TOKEN", "tok")
+		t.Setenv("CIVITAI_BASE_URL", srv.URL)
+		out, errOut, err := run(t, "app", "status")
+		srv.Close()
+		if err != nil {
+			t.Fatalf("%d rows: app status: %v", n, err)
+		}
+		if strings.Contains(errOut, truncationNote) {
+			t.Errorf("%d rows is under the cap — must NOT warn; stderr:\n%s", n, errOut)
+		}
+		if strings.Contains(out, truncationNote) {
+			t.Errorf("%d rows is under the cap — must NOT warn; stdout:\n%s", n, out)
+		}
+	}
+}
+
+// TestAppStatusCappedListJSONStaysPure: --json is the scripted path, so the
+// caveat must not enter stdout — the payload has to stay parseable — while the
+// human running the pipe still sees the warning on stderr.
+func TestAppStatusCappedListJSONStaysPure(t *testing.T) {
+	rows := submissionRows(appapi.ListSubmissionsCap)
+	srv := statusServer(t, map[string]any{"submissions": rows}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "status", "--json")
+	if err != nil {
+		t.Fatalf("app status --json: %v", err)
+	}
+	var parsed struct {
+		Submissions []map[string]any `json:"submissions"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("--json stdout must stay parseable JSON: %v\n%s", err, out)
+	}
+	if len(parsed.Submissions) != appapi.ListSubmissionsCap {
+		t.Errorf("--json payload = %d submissions, want %d", len(parsed.Submissions), appapi.ListSubmissionsCap)
+	}
+	if strings.Contains(out, "note:") {
+		t.Errorf("--json stdout must carry no prose:\n%s", out)
+	}
+	if !strings.Contains(errOut, truncationNote) {
+		t.Errorf("--json must still warn on stderr; stderr:\n%s", errOut)
+	}
+}
+
+// TestAppStatusDetailNeverWarns pins the scope correction: the server applies
+// `where.slug` BEFORE the row cap, so a per-app lookup is not affected and must
+// not carry the caveat — even when the account is at the cap overall.
+func TestAppStatusDetailNeverWarns(t *testing.T) {
+	body := map[string]any{
+		"submissions": []map[string]any{
+			{"id": "pubreq_1", "blockId": "alpha", "version": "0.1.0", "status": "pending",
+				"deployState": nil, "submittedAt": "2026-06-17T08:00:00.000Z", "liveUrl": nil},
+		},
+	}
+	srv := statusServer(t, body, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "status", "alpha")
+	if err != nil {
+		t.Fatalf("app status alpha: %v", err)
+	}
+	if strings.Contains(errOut, truncationNote) || strings.Contains(out, truncationNote) {
+		t.Errorf("a per-app lookup is narrowed server-side before the cap — no caveat.\nstdout:\n%s\nstderr:\n%s", out, errOut)
 	}
 }
 

--- a/internal/cmd/app_status_test.go
+++ b/internal/cmd/app_status_test.go
@@ -255,6 +255,33 @@ func TestAppStatusCappedListWarns(t *testing.T) {
 	}
 }
 
+// TestAppStatusCaveatQuotesObservedCount pins that the caveat's number is what
+// the server actually RETURNED, never the vendored appapi.ListSubmissionsCap.
+// That is what keeps the sentence true if the server's cap drifts ABOVE the
+// vendored value: the failure mode must be a needless warning, never a
+// confidently wrong count. Serving cap+7 rows is a state the constant cannot
+// produce, so a hard-coded number cannot satisfy this.
+func TestAppStatusCaveatQuotesObservedCount(t *testing.T) {
+	const n = appapi.ListSubmissionsCap + 7
+	srv := statusServer(t, map[string]any{"submissions": submissionRows(n)}, http.StatusOK, nil)
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, errOut, err := run(t, "app", "status")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if want := fmt.Sprintf("newest %d submissions", n); !strings.Contains(errOut, want) {
+		t.Errorf("caveat must quote the OBSERVED row count (%q); stderr:\n%s", want, errOut)
+	}
+	if bad := fmt.Sprintf("newest %d submissions", appapi.ListSubmissionsCap); strings.Contains(errOut, bad) {
+		t.Errorf("caveat quoted the vendored cap (%q) instead of what the server returned; stderr:\n%s", bad, errOut)
+	}
+}
+
 // TestAppStatusShortListDoesNotWarn is the direction people forget: a listing
 // that fits under the cap is COMPLETE, and claiming otherwise would train users
 // to ignore the caveat. Covers one-under-the-cap and the empty list.


### PR DESCRIPTION
## The bug — measured, not theorised

`GET /api/v1/blocks/submissions` caps the **unfiltered** listing at `MAX_ROWS = 100`
(`civitai/civitai → src/pages/api/v1/blocks/submissions.ts:73,324`, `take: MAX_ROWS`)
and returns **no cursor and no total count**. `civitai app status` printed that page
as-is, with no indication it had been cut off.

Measured on a real account: `civitai app status` returns **exactly 100 rows, oldest
`2026-06-17`**. Anything submitted before that is invisible, and "I have no older apps"
and "the list stopped at 100" render identically. That is a silently wrong answer, not a
crash — which is what makes it worth fixing.

## The fix

Detect the full-length page and say so, on **stderr**:

```
note: showing the newest 100 submissions — the API caps this listing and offers no way
to page, so older submissions may exist but are not listed. Look up a specific app with
`civitai app status <blockId>`.
```

Reproduced against a fake server with the built binary:

| case | stdout | stderr |
|---|---|---|
| 100 rows | full table, no note | the note |
| 99 rows | full table | **0 bytes** |
| 100 rows `--json` | parses to 100 submissions, no prose | the note |

## Why this fix and not the others

**Rejected — client-side paging.** Not possible. The route's zod query schema accepts
**only** `id` and `blockId` (`submissions.ts:78-86`); there is no `cursor`, `page`,
`offset`, `skip` or `limit` input anywhere in the file (grepped). An extra param is
silently stripped by zod, so a "paging" attempt would loop on page 1 forever.

**Rejected — a server cursor** (`civitai/civitai` API change). It is the only fix that
makes the answer *complete* rather than *honest*, but it is a cross-repo API change
needing its own review, and it is not required to stop the CLI asserting something it
does not know. Not built, per the brief. See "Ask for the server" below — it would also
delete the vendored constant outright.

**Chosen — detect and tell.** No server change, no new flags, no reshaped output.

## The trade-off I accepted

`len == cap` is **inference, not a signal**: a page that is exactly full is
indistinguishable from one that was cut off. So a user holding exactly 100 submissions
gets the caveat while nothing is actually missing.

I accept that, and the wording carries it — it says older submissions **may** exist, and
names the cap as the reason. The alternative failure (silently presenting a truncated
list as a complete history) is the bug this exists to fix. The predicate is `>=`, not
`==`: at or beyond the cap we know about, this CLI cannot claim the listing is complete.
Both directions are pinned by tests at 99/100/101.

## `--json` stays pure — and why there is no `truncated` field

The note goes to **stderr for both paths**, matching the CLI's existing API-limitation
notes (`collections.go:86`, `models.go:75` — same `note: …` shape, same "so `--json`
stdout stays pure", same exit 0). So:

- `--json` stdout is byte-for-byte the same scriptable payload as before — no prose, no
  new key, no reshape. A test asserts it still parses and carries no `note:`.
- A human running `civitai app status --json | jq` still sees the warning.
- Exit stays **0** — an incomplete list is not a failure.

I deliberately did **not** add a `"truncated": true` field. It was the other option, and
it is defensible (a script redirecting stderr loses the signal), but it changes a
documented scriptable payload for a caveat this repo already has a convention for, and
"absent vs false" would then be ambiguous against older CLI versions — the same
three-state trap `AppAnalytics.Views` exists to avoid (AGENTS.md item 9). If a concrete
scripting need shows up, a field can be added then, as a deliberate payload change.

## Slug resolution was checked and is NOT affected

Verified in the server source, not assumed: `where.slug = blockId` is set **before**
`take` (`submissions.ts:302,324`), so a `?blockId=<slug>` lookup is narrowed server-side
and a single app would need >100 submissions **of its own** to truncate. Untouched here:

- `civitai app status <slug>` / `--id` (detail view) — a test pins that it never warns.
- `app metrics`' slug → `appBlockId` resolution (`resolveAppBlockID` calls
  `list(ctx, slug)`, i.e. filtered).
- `SubmitVersion`'s post-timeout recovery poll (`ListSubmissions(ctx, slug)`, filtered).

Only the unfiltered listing goes through the new predicate.

---

# Closing the vendored-mirror gap

`ListSubmissionsCap = 100` mirrors the server's `MAX_ROWS`, and review correctly flagged
that pinning the CLI's own literal cannot observe the server. Both drift directions
failed silently, with very different severities:

- **Server RAISES `MAX_ROWS`** — callers holding between the old and new cap get a
  caveat when nothing is missing. Annoying.
- **Server LOWERS `MAX_ROWS`** (say to 50) — the response carries 50 rows, `n >= 100` is
  false, **no caveat fires, and the silent-truncation bug is back** with no test
  noticing. This is the serious one: the fix's own drift reintroduces the bug it fixes.

## (a) The message no longer asserts anything it cannot verify

Worth stating precisely, because the review's example was slightly off: the caveat
**already** interpolated `len(subs)` — what the server actually returned — never the
constant. Under a raised server cap it would have printed `showing the newest 150
submissions`, not a wrong `100`. The real direction-1 symptom is a **needless warning**,
not a false number.

What changed is that this is now **structural instead of incidental**:
`TestAppStatusCaveatQuotesObservedCount` serves `cap+7` rows — a state the constant
cannot produce — and requires `newest 107 submissions` while forbidding
`newest 100 submissions`. Mutant N6 (interpolate the constant) is killed by it.

So the user-visible claim stays true under a cap change in either direction: it quotes an
observed count and says older submissions *may* exist. The failure mode is "vaguer than
ideal", never "confidently wrong".

## (b) The drift check turned out to be soundly doable

`TestSubmissionsCapDriftAgainstLiveAPI` (`internal/appapi/cap_drift_test.go`), gated on
`CIVITAI_CHECK_SUBMISSIONS_CAP=1` plus a credential, in the style of
`pins_guard_test.go`. The default `go test ./...` stays offline (it SKIPs alongside
`TestScaffoldPinsSatisfyPublished`).

**The naive version would have been worthless**, exactly as review warned: "fetch the
listing, assert `len == cap`" passes for the wrong reason, because a short page proves
nothing and a full page is equally consistent with "cap is 100" and "cap is 250 and this
account happens to hold exactly 100".

So the probe **proves truncation positively before reading a cap off anything**, using
the one asymmetry the route offers — `?blockId=` is narrowed by `where.slug` *before*
`take`, so a per-app lookup can see rows the unfiltered listing dropped:

1. Read the unfiltered listing (`n` rows); compute the oldest `submittedAt` present.
2. Cross-check up to 8 of its apps, oldest-reaching first, via `?blockId=`.
3. If any app holds a submission **strictly older** than that boundary, the listing
   demonstrably withheld rows → **truncation proven**, and `n` **is** the server's cap.
   Compare it to the vendored constant — this catches drift in **both** directions,
   including the serious lowering one.
4. Otherwise → **cannot observe** → `t.Skip` with the reason. Never a pass.

*Strictly* older is also what makes it immune to a submission landing between the two
calls: a new row is newer than the boundary and can never forge the signal.

**Known conservative blind spots** (both decline, never answer wrongly, both pinned by
tests): an app holding more rows than the cap has its own view truncated too, and a page
boundary falling exactly between two apps leaves no straddling app to cross-check.

### The live guard validated end-to-end, against a server with a known cap

Driven through the real HTTP client against a fake `/api/v1/blocks/submissions` whose cap
I control. Verdicts counted from `--- PASS/SKIP/FAIL` lines, never an exit code:

| scenario | verdict | required |
|---|---|---|
| cap 100, history hidden | **PASS** | the only route to green: cap measured **and** equal to 100 |
| server lowered cap to 50 | **FAIL** | the serious drift must go red |
| server raised cap to 130 | **FAIL** | the other direction must go red |
| account far under the cap | **SKIP** | cannot observe ⇒ must not pass |
| page exactly full, nothing hidden | **SKIP** | the wrong-reason pass a naive check would report |
| aligned page boundary | **SKIP** | conservative decline |
| server unreachable | **SKIP** | never a false failure |
| gate on, no credential | **SKIP** | not a pass |

The PASS row is the positive control (the probe *can* reach a confirmation); the two FAIL
rows are the negative controls (it *can* go red in both directions).

### Feasibility, stated plainly

It needs an account that has Apps access **and** holds more submissions than the cap,
with at least one app whose older rows fall off the page. That is a real developer
account, not a CI fixture. So today this is a **maintainer-on-demand** guard:

```
CIVITAI_CHECK_SUBMISSIONS_CAP=1 CIVITAI_TOKEN=<key> go test ./internal/appapi/ -run CapDrift -v
```

**⚠️ Proposed, not wired:** running it in CI needs a dedicated credential secret and a
job in `.github/workflows/ci.yml` alongside the `pins-vs-published` job. That file is
ask-first per AGENTS.md, so I have not touched it — flagging it for you to raise. A
sensible shape is a scheduled (not per-PR) job, since it depends on account state, with
the SKIP outcomes treated as green.

### Ask for the server instead

The durable fix deletes all of this: a `hasMore` boolean on the listing response
(`take: MAX_ROWS + 1`, return `MAX_ROWS`) would replace the inference with a signal, the
vendored constant with nothing, and this drift guard with a field. Worth raising against
`civitai/civitai` independently of this PR.

---

## Tests

`internal/cmd/app_status_test.go`:
- `TestSubmissionsListTruncatedBoundary` — 0 / 1 / 99 / 100 / 101.
- `TestAppStatusCappedListWarns` — at-cap page ⇒ note on stderr (and the remedy named),
  table intact on stdout, note **not** on stdout.
- `TestAppStatusShortListDoesNotWarn` — **the direction people forget**: 0, 1 and 99 rows
  must produce no note on either stream. An always-on caveat trains users to ignore it.
- `TestAppStatusCaveatQuotesObservedCount` — the count is observed, never the constant.
- `TestAppStatusCappedListJSONStaysPure` — stdout parses, 100 submissions, no prose;
  stderr still warns.
- `TestAppStatusDetailNeverWarns` — pins the scope correction above.

`internal/appapi/submissions_test.go`:
- `TestListSubmissionsCapMirrorsServer` — pins the **literal** `100` so a careless edit to
  the constant is loud (every other test is written in terms of it and would follow it).

`internal/appapi/cap_drift_test.go`:
- `TestCapProbeConfirmsTrueServerCap` — positive control.
- `TestCapProbeCatchesDriftBothDirections` — 50 and 130 must be *measured*, not skipped.
- `TestCapProbeCannotObserve` — nothing / under-cap / **full-page-but-nothing-hidden**.
- `TestCapProbeDeclinesOnAlignedBoundary` — the known blind spot, pinned as a decline.
- `TestCapProbeIgnoresRowsLandingMidProbe` — TOCTOU safety.
- `TestCapProbeRespectsBudget` — exactly `1 + 8` calls, inside the 60/min rate limit.
- `TestSubmissionsCapDriftAgainstLiveAPI` — the gated live guard.

## Mutation results — 16 mutants, 16 killed, none deleting code

Both sweeps restore the tree and re-verify every touched file by `sha256sum`.

**Round 1 — the caveat guard** (clean-tree control `RUN=13 PASS=13 FAIL=0`):

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | invert boundary `>=` → `<` | KILLED (4) | `submissionsListTruncated(100) = false, want true` |
| M2 | off-by-one `>=` → `>` | KILLED (3) | same + `a 100-row (at-cap) listing must warn…` |
| M3 | off-by-one `cap` → `cap-1` | KILLED (2) | `submissionsListTruncated(99) = true, want false` |
| M4 | caveat unconditional | KILLED (2) | `0/1/99 rows is under the cap — must NOT warn` |
| M5 | caveat never fires | KILLED (3) | `--json must still warn on stderr` |
| M6 | vendored cap 100 → 250 | KILLED (1) | `ListSubmissionsCap = 250, want 100` |
| M7 | note to stdout | KILLED (2) | `the caveat belongs on stderr`; `--json stdout must stay parseable JSON` |
| M8 | note skipped on `--json` | KILLED (1) | `--json must still warn on stderr` |

**Round 2 — the observed count and the drift probe** (clean-tree control
`RUN=21 PASS=20 FAIL=0`, harness all-expected):

| # | mutant | verdict | killed by |
|---|---|---|---|
| N1 | probe turns "cannot observe" into a confirmation | KILLED (3) | `verdict = "confirmed", want "cannot-observe" — an absence of evidence must not become a confirmation` |
| N2 | probe treats NEWER rows as withheld history | KILLED (4) | `a newly-landed row is not evidence of truncation` |
| N3 | probe reports the vendored cap, not the measured one | KILLED (1) | `probe reported the vendored value 100 for a server capped at 50 — the drift would go UNDETECTED` |
| N4 | `oldestSubmittedAt` returns the newest row | KILLED (4) | the same cannot-observe assertions |
| N5 | probe ignores its rate-limit budget | KILLED (1) | `probe made 101 API calls, want exactly 9` |
| N6 | caveat quotes the vendored cap, not the observed count | KILLED (1) | `caveat quoted the vendored cap ("newest 100 submissions") instead of what the server returned` |
| N7 | live guard stops skipping when it cannot observe | KILLED (3 scenarios) | end-to-end harness: `got FAIL, want SKIP` on all three unobservable scenarios |
| N8 | live guard inverts its drift assertion | KILLED (3 scenarios) | harness: `got PASS, want FAIL` on both drift scenarios, `got FAIL, want PASS` on the matching one |

N7 is the one review asked for specifically: with the skip removed, the unobservable
scenarios turn **FAIL**, never PASS — the skip cannot be silently converted into a green.

## Verification

- `make ci` green.
- `gofmt -s -l .` prints nothing (positive control: 207 `.go` files present to scan).
- Full suite **counted, not exit-coded**: `RUN=1544 PASS=1541 FAIL=0 SKIP=3`, no
  `panic: test timed out`, no `FAIL` package line. The 3 skips are the two network-gated
  guards (new + pins) and a pre-existing env-gated test.
- The user-facing path reproduced with the **built binary** against a fake server.
- The live drift guard reproduced end-to-end across the 8-scenario matrix above.

## Not verified

- The 100-row / oldest-`2026-06-17` measurement is from a live account read before this
  change; I did not re-run against civitai.com with real credentials, so prod behaviour
  is verified by reproduction against a fake server returning the same payload shape.
- **The live drift guard has never run against the real server** — only against fake
  servers with known caps. Its first real run needs a credential on an account holding
  more than 100 submissions; until then, "the vendored 100 matches production" rests on
  reading `submissions.ts`, not on a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
