### PR TITLE
docs(app status): say plainly that nothing runs the cap drift guard

### DIFF
--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -322,12 +322,26 @@ const SubmissionsPath = "/api/v1/blocks/submissions"
 //	test can notice. This is the serious direction.
 //
 // Neither direction is detectable from a single response — it carries no total
-// and no cursor, the same gap that makes the truncation itself invisible. So
-// TestSubmissionsCapDriftAgainstLiveAPI (cap_drift_test.go) closes it with a
-// live, credentialed cross-check that catches BOTH directions; that is why that
-// test exists and why a comment alone would not be enough. The durable fix is
-// server-side: a `hasMore` flag (or a cursor) on the listing deletes this
-// constant outright.
+// and no cursor, the same gap that makes the truncation itself invisible.
+//
+// 🔴 NOTHING CHECKS THIS AUTOMATICALLY. TestSubmissionsCapDriftAgainstLiveAPI
+// (cap_drift_test.go) CAN detect both directions, but it is opt-in — gated on
+// CIVITAI_CHECK_SUBMISSIONS_CAP=1 plus a credential — and NO CI job sets either.
+// It runs only when a maintainer runs it. Do not read its existence as
+// protection; until someone runs it, this constant rests on having read
+// submissions.ts, not on a measurement.
+//
+// That was a DECISION, not an oversight: observing the cap needs a full-scope
+// civitai personal API key on an account holding more than the cap, and this
+// repo is PUBLIC. Putting a production credential in its CI to guard one
+// integer is a worse trade than the drift it prevents. (`pins-vs-published` can
+// be wired precisely because npm needs no credential.) A credential-free job
+// would be worse than none — it would always skip, always report green, and
+// look like a guard.
+//
+// The durable fix removes the question instead of guarding it: a `hasMore` flag
+// (or a cursor) on the listing response deletes this constant, the inference,
+// and that whole test. Ask for it before investing further here.
 const ListSubmissionsCap = 100
 
 // WithdrawPath is the token-authenticated, self-scoped withdraw route

--- a/internal/appapi/cap_drift_test.go
+++ b/internal/appapi/cap_drift_test.go
@@ -392,10 +392,27 @@ func TestCapProbeRespectsBudget(t *testing.T) {
 // Feasibility, stated plainly: this needs an account that (a) has Apps access
 // and (b) holds more submissions than the server's cap, with at least one app
 // whose older rows fall off the page. That is a real developer account, not a
-// CI fixture — so the guard is useful to a maintainer on demand, and running it
-// in CI would need a dedicated credential secret. Wiring that job touches
-// .github/workflows/*, which is ask-first, so it is PROPOSED in the PR, not
-// wired here.
+// CI fixture.
+//
+// 🔴 IT IS DELIBERATELY NOT WIRED INTO CI, and that is settled, not pending.
+// Observing the cap needs a full-scope civitai personal API key (this route
+// rejects OAuth tokens), and civitai/cli is a PUBLIC repo. Adding a production
+// credential as a repo secret to guard one vendored integer costs more than the
+// drift it catches. `pins-vs-published` is wired only because npm needs no
+// credential — that asymmetry is the whole reason, not an inconsistency.
+//
+// And a credential-free job would be actively harmful: it would hit the skip
+// below on every run, report green forever, and read as protection. A guard
+// that cannot fail is worse than an absent one.
+//
+// So: this is a MAINTAINER-ON-DEMAND tool. Run it when you touch
+// ListSubmissionsCap, or when `app status` behaves oddly near the cap:
+//
+//	CIVITAI_CHECK_SUBMISSIONS_CAP=1 CIVITAI_TOKEN=… \
+//	  go test ./internal/appapi/ -run CapDrift -v
+//
+// If you want this checked continuously, ask for a server-side `hasMore` flag
+// instead — it deletes the constant, the inference and this test together.
 func TestSubmissionsCapDriftAgainstLiveAPI(t *testing.T) {
 	if os.Getenv("CIVITAI_CHECK_SUBMISSIONS_CAP") != "1" {
 		t.Skip("live guard; set CIVITAI_CHECK_SUBMISSIONS_CAP=1 (plus CIVITAI_TOKEN) to run")


### PR DESCRIPTION
Comment-only follow-up to #207. No behaviour change.

## The claim that was wrong

#207 added a live drift guard for the vendored `ListSubmissionsCap`, and the constant's comment said that guard **"closes"** the silent-drift gap.

It doesn't. `TestSubmissionsCapDriftAgainstLiveAPI` is gated on `CIVITAI_CHECK_SUBMISSIONS_CAP=1` **plus a credential**, and **no CI job sets either** — verified: `pins-vs-published` appears in `ci.yml:88`, `CHECK_SUBMISSIONS_CAP` appears in no workflow at all. So the test runs only when a maintainer runs it, and until then the constant rests on someone having read `submissions.ts`, not on a measurement.

That's the same overstated-protection claim the guard exists to prevent, one level up. Worth correcting precisely rather than softening.

## The decision, recorded so it stops reading as pending work

Wiring it into CI was considered and **declined**:

- Observing the cap needs a **full-scope civitai personal API key** — this route rejects OAuth tokens — on an account holding more than the cap. `civitai/cli` is a **public** repo. A production credential as a repo secret, to guard one vendored integer, costs more than the drift it catches.
- `pins-vs-published` can be wired precisely because **npm needs no credential**. That asymmetry is the reason, not an inconsistency.
- A credential-free job would be **worse than none**: it would hit the skip on every run, report green forever, and read as protection. A guard that cannot fail is worse than an absent one.

So the guard is documented as **maintainer-on-demand**, with the exact invocation, and the comment points at the durable fix instead: a server-side `hasMore` flag (or a cursor) on the listing would delete the constant, the full-page inference, and the whole guard together.

## Verification

Behaviour is unchanged and I re-checked both halves rather than assuming:

- Without a credential the guard still **SKIPs**, not passes.
- With `CIVITAI_CHECK_SUBMISSIONS_CAP=1` and an empty token it still refuses to pass: *"the server cannot be observed, so this is a SKIP, not a pass"*.

`make ci` green; `gofmt -s -l .` silent; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
