### PR TITLE
DO NOT MERGE — temporary: prove the ready-ack CI gate goes red

### DIFF
--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -49,11 +49,14 @@ jobs:
   # in node against a fake host and asserts a single correctly-addressed
   # `{type:'BLOCK_READY',payload:{height:0}}` goes out.
   #
-  # It rides this workflow because this is the repo's DAILY scheduled runner and
-  # the test is env-gated (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`) so `make ci` stays
-  # Go-only and offline. A gated test with no runner is a green that means
-  # nothing. It is deliberately independent of the `bump` job below: it must run
-  # on every sweep, including the (usual) no-op ones where the pins are current.
+  # 🔴 This is the DRIFT runner, NOT the gate. The gate is the identically-named
+  # job in ci.yml, which runs on every pull request. A daily job cannot block a
+  # merge — a regression would land green and surface up to 24h later, on a
+  # workflow with no dependent job — so this copy alone would be a guard that
+  # gates nothing. It exists to catch drift on `main` between PRs (a merged-tree
+  # interaction, a node bump, an npm-side change), and is deliberately
+  # independent of the `bump` job below so it runs on every sweep, including the
+  # usual no-op ones where the pins are already current.
   ready-ack-runtime:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -41,6 +41,43 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Runtime half of the ready-ack contract (issue #206). The offline guard in
+  # `internal/scaffold/ready_ack_contract_test.go` proves each SDK-free page
+  # template ships a byte-identical copy of `internal/blockproto/ready-ack.js`
+  # and that the entry point loads it — it CANNOT prove the ack fires, because
+  # no Go static check can prove JavaScript executes. This job runs the emitter
+  # in node against a fake host and asserts a single correctly-addressed
+  # `{type:'BLOCK_READY',payload:{height:0}}` goes out.
+  #
+  # It rides this workflow because this is the repo's DAILY scheduled runner and
+  # the test is env-gated (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`) so `make ci` stays
+  # Go-only and offline. A gated test with no runner is a green that means
+  # nothing. It is deliberately independent of the `bump` job below: it must run
+  # on every sweep, including the (usual) no-op ones where the pins are current.
+  ready-ack-runtime:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # -v so the run REPORTS its controls (an inert emitter and a naive ack are
+      # both driven through the same assertions and must be rejected) rather than
+      # just an exit code.
+      - name: scaffolded ready-ack actually fires
+        env:
+          CIVITAI_CHECK_SCAFFOLD_RUNTIME: "1"
+        run: go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v
+
   bump:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,116 @@ jobs:
           CIVITAI_CHECK_PUBLISHED_PINS: "1"
         run: go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -v
 
+  # Guard B for the block->host ready-ack (issue #206), and the half that GATES.
+  #
+  # `internal/scaffold/ready_ack_contract_test.go` runs in the build-test job
+  # above and proves each SDK-free page template ships a byte-identical copy of
+  # `internal/blockproto/ready-ack.js` that the entry point RESOLVES to. It
+  # cannot prove the ack FIRES — no Go static check can prove JavaScript
+  # executes, and an emitter with an inverted `event.source` check passes every
+  # static assertion while being completely inert.
+  #
+  # This job executes the emitter in node against a fake host. It is env-gated
+  # so `make ci` stays Go-only and offline. The daily `bump-scaffold-pins` sweep
+  # runs it too, but a DAILY runner gates nothing: a regression would merge green
+  # and surface up to 24h later, on a workflow with no dependent job. A PR check
+  # is what makes it a guard.
+  #
+  # -v so the run REPORTS its controls (an inert emitter and a naive ack are
+  # driven through the same assertions and must be rejected) rather than just an
+  # exit code.
+  ready-ack-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: scaffolded ready-ack actually fires
+        env:
+          CIVITAI_CHECK_SCAFFOLD_RUNTIME: "1"
+        run: go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v
+
+  # Rot-guard: build the page-vite template. It is the only SDK-free template
+  # with a build step, and nothing else in CI builds it — `template-page-money`
+  # and `scaffold-currency` both scaffold page-money.
+  #
+  # Since #206 its entry module has a HARD RESOLUTION DEPENDENCY on
+  # `./civitai-host.js`, so a wrong import path is a build failure rather than a
+  # subtle one. Measured: `import '../nonexistent/civitai-host.js'` survived the
+  # entire Go suite, and would have shipped a template that cannot build at all.
+  #
+  # The bundle assertion is separate from Guard A on purpose. Guard A pins the
+  # SOURCE tree; Vite output is what the platform actually serves, and a
+  # tree-shaken or mis-externalised side-effect import would leave a bundle with
+  # no handshake in it. Control pair, both measured locally: with the import the
+  # bundle carries BLOCK_INIT/BLOCK_READY, with it commented out it carries
+  # neither — while the positive control (the app's display name) matches in
+  # both cases, proving the grep reads the bundle either way.
+  template-page-vite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: scaffold page-vite
+        run: go run ./cmd/civitai app init "CI Vite Block" --dir ./_ci-page-vite --template page-vite
+
+      - name: install
+        working-directory: ./_ci-page-vite
+        run: npm install --no-audit --no-fund
+
+      - name: build
+        working-directory: ./_ci-page-vite
+        run: npm run build
+
+      - name: the ready-ack survives bundling
+        working-directory: ./_ci-page-vite
+        run: |
+          set -euo pipefail
+          bundles=$(find dist -name '*.js' -type f | wc -l)
+          echo "JS files emitted into dist/: $bundles"
+          if [ "$bundles" -lt 1 ]; then
+            echo "::error::the build emitted no JS into dist/ — nothing to check, so a pass here would be meaningless"
+            exit 1
+          fi
+          # POSITIVE CONTROL for the grep itself, FIRST: a string that must be in
+          # the bundle whatever the handshake does. If this misses, the path or
+          # the pattern is wrong and the two assertions below prove nothing.
+          control=$(grep -rlF 'CI Vite Block' dist/ | wc -l)
+          echo "positive control (app display name): $control file(s)"
+          if [ "$control" -lt 1 ]; then
+            echo "::error::positive control failed — this step is not reading the built bundle"
+            exit 1
+          fi
+          for needle in BLOCK_INIT BLOCK_READY; do
+            n=$(grep -rlF "$needle" dist/ | wc -l)
+            echo "$needle: $n file(s)"
+            if [ "$n" -lt 1 ]; then
+              echo "::error::$needle is absent from the built bundle — the ready-ack did not survive the build, so the shipped app never says hello (issue #206)"
+              exit 1
+            fi
+          done
+
+      - name: validate
+        working-directory: ./_ci-page-vite
+        run: go run ../cmd/civitai app validate
+
   # Rot-guard: scaffold the page-money template and run its JS toolchain against
   # the PUBLISHED SDK (@civitai/blocks-react). Catches a template that renders
   # but no longer installs / typechecks / tests / builds after an SDK bump — the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,10 +357,13 @@ until that exists, vendoring is on purpose.
     loopback request unless it is re-applied.
 
 11. **The scaffold VENDORS the block→host ready-ack (`internal/blockproto/`),
-    and it is the FOURTH vendored mirror.** A `page` app is not shown by the
-    host until it posts `BLOCK_READY`; that handler
-    (`civitai/civitai → src/components/AppBlocks/PageBlockHost.tsx`) is the
-    only transition into `ready`. `page-money` gets this free —
+    and it is the FOURTH vendored mirror.** (Provenance: read against
+    `civitai@35a9598dc9`. The contract lives in
+    `src/components/AppBlocks/PageBlockHost.tsx` and
+    `src/components/AppBlocks/usePostMessage.ts` — note `usePostMessage.ts` is
+    under `AppBlocks/`, **not** `src/hooks/`, where it has never lived.) A
+    `page` app is not shown by the host until it posts `BLOCK_READY`; that
+    handler in `PageBlockHost.tsx` is the only transition into `ready`. `page-money` gets this free —
     `@civitai/blocks-react`'s `IframeTransport` acks from its validated-
     `BLOCK_INIT` branch — but `static` and `page-vite` are deliberately
     SDK-free, so they have to say hello themselves. They didn't, and issue #206
@@ -393,6 +396,41 @@ until that exists, vendoring is on purpose.
       payload, so a wrong envelope would not break *this* message — it teaches
       the wrong shape for every message the author adds next. That is why the
       guards assert the envelope even though the ack would work without it.
+    - 🔴 **It pins the sender WINDOW, not the sender ORIGIN — and that is a
+      deliberate boundary, not an oversight.** The emitter answers
+      `window.parent` and replies to whatever origin that window sent from. It
+      establishes "our embedder", NOT "Civitai". Sound for this one message
+      (the ack carries `{height: 0}` and discloses nothing a page that chose to
+      frame us doesn't already know) and **insufficient for anything carrying
+      data**. We deliberately do NOT vendor an origin allowlist here: the real
+      set (production, preview subdomains, `dev-*.civit.ai` tunnels) is platform
+      state that moves without notice, so it would become a FIFTH mirror needing
+      lockstep, and getting it wrong silently breaks the dev tunnel — while
+      `@civitai/blocks-react` already maintains exactly that list from
+      `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`. So the decision is: keep the emitter
+      minimal, and say loudly in both scaffold READMEs and the emitter header
+      that adopting the SDK is the prerequisite for handling inbound data. If
+      you ever do add an allowlist here, it is a new vendored mirror and needs a
+      drift check.
+    - 🔴 **Adopting the SDK means DELETING the emitter in the same change, and
+      the docs must keep saying so.** Whichever handshake answers the host's
+      first `BLOCK_INIT` calls `notifyReady()` → `stop()`, which clears the
+      retry interval **and** the readiness timeout
+      (`iframeInitController.ts`). If the vendored emitter wins that race
+      against a freshly-added `IframeTransport`, the SDK's `waitForInit` rejects
+      at its own `INIT_TIMEOUT_MS = 10_000` and the host sits in `ready` showing
+      an app that never started — no retry, no failure card. That is strictly
+      worse than #206 and it is silent. Narrow window, but the upgrade path is
+      the one place the "don't delete it" instruction reverses, so it is called
+      out with the mechanism rather than as a footnote.
+    - **The `acked` latch is set AFTER the post, not before.** `postMessage`
+      throws `SyntaxError` on a `targetOrigin` it cannot parse as a URL —
+      measured in Chromium 1228, `postMessage(msg, 'null')` — and `event.origin`
+      is the string `"null"` whenever the sender is itself at an opaque origin.
+      Latching first would make one throw permanently silent while the host
+      keeps retrying at a listener that has given up. Not reachable through
+      today's `PageBlockHost`; pinned anyway by Guard B's
+      `--throw-first-post` mode.
     - **`RESIZE_IFRAME` is deliberately ABSENT from the page templates.** Both
       raw templates used to demo it; `hostHandlerParity.ts` marks it **N/A for
       `PageBlockHost`** (a page block fills the surface and does not size to
@@ -400,19 +438,46 @@ until that exists, vendoring is on purpose.
       Don't reintroduce it as a "minimal example". Note `iframe.resizable` in
       the vendored `schema/` still describes itself in size-to-content terms;
       that is a schema-side wording issue, not a licence to re-add the message.
-    - **Two guards, and neither subsumes the other.**
+    - **Three guards, and none subsumes the others.**
       `ready_ack_contract_test.go` (Guard A, runs in `make ci`) enumerates
       `AllTemplates()`, decides subject-hood from the RENDERED manifest and
       package.json — never a hardcoded list — and asserts byte-equality with
-      `blockproto.ReadyAckSource()` plus that the entry point actually reaches
-      it, with a count floor so a guard wired to nothing can't report a serene
-      pass. It **cannot prove the ack fires**: an inverted source check passes
-      every static assertion. `ready_ack_runtime_test.go` (Guard B) executes the
-      emitter in node against a fake host and reads the outbound message; it is
-      env-gated (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`) with the daily
-      `bump-scaffold-pins` workflow as its scheduled runner. If you add a
-      template, add nothing — Guard A picks it up automatically and fails until
-      `ReadyAckPath()` is set.
+      `blockproto.ReadyAckSource()` plus that the entry point RESOLVES to it,
+      with a count floor so a guard wired to nothing can't report a serene pass.
+      🔴 **"Resolves" is load-bearing and was earned the hard way**: the first
+      version matched a BASENAME, and two mutants shipped a broken app past the
+      entire suite — `src="./vendor/civitai-host.js"` (a 404) and
+      `import '../nonexistent/civitai-host.js'` (a build failure). Never
+      reintroduce a basename or `strings.Contains` match here; every reference
+      must resolve to a path and be compared with where the emitter actually is.
+      Guard A still **cannot prove the ack fires**: an inverted `event.source`
+      check passes every static assertion.
+      `ready_ack_runtime_test.go` (Guard B) executes the emitter in node against
+      a fake host and reads the outbound message. It is env-gated
+      (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`) and has TWO runners, of which only
+      the first gates: the `ready-ack-runtime` job in **`ci.yml`** (every PR)
+      and the same-named job in `bump-scaffold-pins.yml` (daily drift). Shipping
+      only the daily one — as the first version did — means the very failure
+      Guard B exists to catch merges green and is reported up to 24h later, on a
+      workflow nothing depends on.
+      The `template-page-vite` job in `ci.yml` is the third: it is the only
+      thing that BUILDS an SDK-free template, and it asserts the ack survives
+      bundling (Guard A pins the source tree; Vite output is what the platform
+      serves).
+      If you add a template, add nothing — Guard A picks it up automatically and
+      fails until `ReadyAckPath()` is set.
+    - **`BLOCK_HELLO` now exists host-side, and the emitter deliberately does
+      not send it.** When this landed the host had zero references to it; as of
+      `civitai@35a9598dc9` it has real ones (`iframeInitController.notifyHello`,
+      `hostHandlerParity.ts`, host browser tests). Re-verified: it is an
+      **accelerator, not a gate** — `notifyHello()` leaves the retry interval
+      and the readiness timeout armed by `start()` untouched, and its own
+      comment forbids it ever becoming a precondition for sending init. So a
+      block that never announces is served by the unchanged retry loop, which is
+      exactly what our emitter relies on. Not sending it costs only the latency
+      of one retry tick, and sending it would add a second vendored message for
+      no correctness gain. If you reconsider, note the init-fragment fast path
+      ships gated off and refuses `surface === 'dev-tunnel'` by construction.
 
 **When you change a validation rule, keep both vendored mirrors (`schema/` + the
 ported Go checks in `internal/validate/`, including the slot registry) in sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,9 @@ func newWhoAmICmd() *cobra.Command {
 
 ## Intentional decisions that look wrong (read before "fixing")
 
-Items 1–3 are deliberate mirrors of the platform (items 4 and 8 are deliberate
-*non*-mirrors); items 5–8 cover `civitai app metrics`, the CLI's only analytics
-read path. The durable fix for the mirroring is a server-side
+Items 1–3, 10 and 11 are deliberate mirrors of the platform (items 4 and 8 are
+deliberate *non*-mirrors); items 5–9 cover `civitai app metrics`, the CLI's only
+analytics read path. The durable fix for the mirroring is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
 
@@ -290,8 +290,9 @@ until that exists, vendoring is on purpose.
     `Origin: null` through the same `DialLocalDevServer` the proxy uses, and
     reads real response headers. `CheckParentOrigins` is a **heuristic** —
     `VITE_BLOCK_ALLOWED_PARENT_ORIGINS` is inlined into the bundle at transform
-    time and cannot be observed over HTTP, so it is a **third vendored mirror**
-    (alongside `schema/` and the slot registry): `resolveViteEnv` reproduces
+    time and cannot be observed over HTTP, so it is a **vendored mirror**
+    (one of four — `schema/`, the slot registry, this, and the ready-ack
+    emitter of item 11): `resolveViteEnv` reproduces
     Vite's dev env resolution, where `.env.<mode>` beats `.env` and a REAL
     process env var beats every file (dotenv does not overwrite existing vars).
     Getting that last rule backwards warns at authors who exported the value in
@@ -354,6 +355,64 @@ until that exists, vendoring is on purpose.
     vite.config.ts advice), and `net/http` DROPS a custom `Request.Host` across an
     absolute redirect, which silently turns the tunnel-Host probe into an ordinary
     loopback request unless it is re-applied.
+
+11. **The scaffold VENDORS the block→host ready-ack (`internal/blockproto/`),
+    and it is the FOURTH vendored mirror.** A `page` app is not shown by the
+    host until it posts `BLOCK_READY`; that handler
+    (`civitai/civitai → src/components/AppBlocks/PageBlockHost.tsx`) is the
+    only transition into `ready`. `page-money` gets this free —
+    `@civitai/blocks-react`'s `IframeTransport` acks from its validated-
+    `BLOCK_INIT` branch — but `static` and `page-vite` are deliberately
+    SDK-free, so they have to say hello themselves. They didn't, and issue #206
+    was the result: measured against the real `PageBlockHost` in Chromium, both
+    templates rendered fine and NEVER reached ready, ending at a visible
+    failure card after ~37s of bounded auto-retry (`MAX_AUTO_RETRIES = 2`,
+    backoff `[2000, 5000]`). This was an original omission, not a regression.
+    - **One authority, copied — not templated.** `ready-ack.js` is `go:embed`ed
+      in `internal/blockproto` and written VERBATIM by `scaffold.Render` (no
+      `text/template` pass) into the path `Template.ReadyAckPath()` names. Do
+      NOT add a per-template `.tmpl` copy: two hand-maintained copies drift, and
+      drift is invisible locally — the app renders and dies only inside the
+      real host.
+    - **Ack on `BLOCK_INIT`, never on load** — and on INIT *only*. Not because
+      on-load is broken: an on-load poster was **measured working** (ready in
+      178–265 ms) in the same harness. On-INIT is chosen for robustness. The
+      host registers its `BLOCK_READY` subscriber inside an effect and
+      **silently drops** a message whose type has no subscriber yet, with no
+      retry (`usePostMessage.ts`), while it re-posts `BLOCK_INIT` every ~400 ms
+      until acked (`iframeInitController.ts`) — so answering INIT removes the
+      race. It also hands over `event.origin`, so nothing posts to `'*'`; it is
+      late enough not to reveal an empty interactive frame (the host fades its
+      launch overlay and enables `pointerEvents` on ready); and it is what the
+      SDK's own transport does. Repeats must stay a no-op: the host's inbound
+      channel is rate-limited across ALL types, so re-acking every retry can
+      starve `BLOCK_ERROR`.
+    - **The envelope is `{ type, payload }`.** The host dispatches
+      `data.payload` to subscribers, so top-level fields arrive as
+      `payload: undefined`. The host happens to ignore the `BLOCK_READY`
+      payload, so a wrong envelope would not break *this* message — it teaches
+      the wrong shape for every message the author adds next. That is why the
+      guards assert the envelope even though the ack would work without it.
+    - **`RESIZE_IFRAME` is deliberately ABSENT from the page templates.** Both
+      raw templates used to demo it; `hostHandlerParity.ts` marks it **N/A for
+      `PageBlockHost`** (a page block fills the surface and does not size to
+      content), so it was inert advice that also modelled the wrong envelope.
+      Don't reintroduce it as a "minimal example". Note `iframe.resizable` in
+      the vendored `schema/` still describes itself in size-to-content terms;
+      that is a schema-side wording issue, not a licence to re-add the message.
+    - **Two guards, and neither subsumes the other.**
+      `ready_ack_contract_test.go` (Guard A, runs in `make ci`) enumerates
+      `AllTemplates()`, decides subject-hood from the RENDERED manifest and
+      package.json — never a hardcoded list — and asserts byte-equality with
+      `blockproto.ReadyAckSource()` plus that the entry point actually reaches
+      it, with a count floor so a guard wired to nothing can't report a serene
+      pass. It **cannot prove the ack fires**: an inverted source check passes
+      every static assertion. `ready_ack_runtime_test.go` (Guard B) executes the
+      emitter in node against a fake host and reads the outbound message; it is
+      env-gated (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`) with the daily
+      `bump-scaffold-pins` workflow as its scheduled runner. If you add a
+      template, add nothing — Guard A picks it up automatically and fails until
+      `ReadyAckPath()` is set.
 
 **When you change a validation rule, keep both vendored mirrors (`schema/` + the
 ported Go checks in `internal/validate/`, including the slot registry) in sync

--- a/README.md
+++ b/README.md
@@ -234,6 +234,36 @@ full details and examples.
   parent-origin config, and a unit-test stub. Run `npm run dev:harness` (plain
   `npm run dev` renders blank without a host).
 
+### The host handshake (`BLOCK_READY`)
+
+Every template declares a `page` surface, and the host **will not reveal a page
+app until the app posts `BLOCK_READY`** — that handler is the only transition
+into the host's ready state. An app that never sends it is replaced by a visible
+failure card once the host's bounded retries run out, even though the app itself
+renders perfectly. Nothing you can run locally reproduces that.
+
+`page-money` gets the handshake for free: `@civitai/blocks-react`'s iframe
+transport acks internally, which is why the SDK templates never touch raw
+`postMessage`. The two **SDK-free** templates (`static`, `page-vite`) therefore
+ship a small vendored emitter, **`civitai-host.js`**, loaded from the entry
+point. Leave it in place; if you later adopt `@civitai/blocks-react`, delete it
+(the SDK takes over).
+
+Two rules it encodes, which apply to every message you add afterwards:
+
+- **The envelope is `{ type, payload }`.** The host dispatches
+  `event.data.payload` to its subscribers, so fields put at the top level
+  (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
+- **Answer, don't announce.** The ack goes out in *response* to the host's
+  `BLOCK_INIT` — which is what supplies the host's real origin, so the message
+  is addressed at that origin rather than broadcast to `'*'`. It is also why
+  nothing is posted when you preview locally: there is no host to send
+  `BLOCK_INIT`, so the emitter stays silent by design.
+
+`RESIZE_IFRAME` is **not** part of a page app's protocol: the host renders a
+page block full-viewport and it does not size to content. (`useBlockResize` in
+the SDK is for the non-page block surfaces.)
+
 ### Local dev loop (harness: mock vs live)
 
 A scaffolded App is a sandboxed iframe — `npm run dev` alone shows a blank

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ source <(civitai completion bash)   # bash; see `civitai completion --help` for 
 ## SDK packages
 
 This CLI scaffolds, validates, and submits — but the code your app actually
-imports lives in two published npm packages (the `page-money` / `page-vite`
-templates wire them for you):
+imports lives in two published npm packages (the `page-money` template wires
+them for you; `static` and `page-vite` are deliberately dependency-free):
 
 | Package | What it is |
 | --- | --- |
@@ -266,11 +266,11 @@ the SDK is for the non-page block surfaces.)
 
 ### Local dev loop (harness: mock vs live)
 
-A scaffolded App is a sandboxed iframe — `npm run dev` alone shows a blank
-screen because there's no host to send `BLOCK_INIT`. The `page-money` /
-`page-vite` templates ship a dev **harness** (the SDK's
+A scaffolded App is a sandboxed iframe, and locally there is no host to send
+`BLOCK_INIT` — so `npm run dev` shows you your own UI and nothing of the
+protocol. The **`page-money`** template ships a dev **harness** (the SDK's
 [`@civitai/blocks-react/testing`](https://www.npmjs.com/package/@civitai/blocks-react)
-hosts) with two modes:
+hosts) to close that gap, with two modes:
 
 | Command | Mode | What it does |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -246,8 +246,16 @@ renders perfectly. Nothing you can run locally reproduces that.
 transport acks internally, which is why the SDK templates never touch raw
 `postMessage`. The two **SDK-free** templates (`static`, `page-vite`) therefore
 ship a small vendored emitter, **`civitai-host.js`**, loaded from the entry
-point. Leave it in place; if you later adopt `@civitai/blocks-react`, delete it
-(the SDK takes over).
+point. Leave it in place.
+
+> ⚠️ **If you adopt `@civitai/blocks-react`, delete `civitai-host.js` in the
+> same change.** This is the one situation where removing it is correct, and
+> running both is worse than running neither: whichever handshake answers the
+> host's *first* `BLOCK_INIT` cancels the host's retry loop **and** its
+> readiness timeout. If the vendored emitter wins that race, the SDK transport
+> can be left never having seen an init — its `waitForInit` rejects after 10s
+> and the host sits "ready", showing an app that never started, with no retry
+> and no error card.
 
 Two rules it encodes, which apply to every message you add afterwards:
 
@@ -255,14 +263,26 @@ Two rules it encodes, which apply to every message you add afterwards:
   `event.data.payload` to its subscribers, so fields put at the top level
   (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
 - **Answer, don't announce.** The ack goes out in *response* to the host's
-  `BLOCK_INIT` — which is what supplies the host's real origin, so the message
-  is addressed at that origin rather than broadcast to `'*'`. It is also why
-  nothing is posted when you preview locally: there is no host to send
-  `BLOCK_INIT`, so the emitter stays silent by design.
+  `BLOCK_INIT`, addressed at the origin that init arrived from rather than
+  broadcast to `'*'`. It is also why nothing is posted when you preview locally:
+  there is no host to send `BLOCK_INIT`, so the emitter stays silent by design.
+
+> 🔒 **The emitter checks the sender *window*, not the sender's *identity*.** It
+> answers `window.parent` — whoever framed you — which is sound for this one
+> message because the ack carries no data. It is **not** sufficient for anything
+> you add next. The moment you handle an inbound message carrying a token, a
+> viewer, storage or a result, check `event.origin` against an allowlist of
+> origins you trust, or any page that frames your app can feed it whatever it
+> likes. The emitter deliberately does not vendor that allowlist — the real list
+> (production, preview subdomains, dev tunnels) is platform state that moves
+> without notice, and `@civitai/blocks-react` already maintains it from
+> `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`. Adopt the SDK before you handle data.
 
 `RESIZE_IFRAME` is **not** part of a page app's protocol: the host renders a
-page block full-viewport and it does not size to content. (`useBlockResize` in
-the SDK is for the non-page block surfaces.)
+page block full-viewport, so it does not size to content and ignores the
+message. (`useBlockResize` is surface-agnostic and page-money still calls it —
+on a page surface it is simply a no-op, which is why the SDK templates can share
+component code across surfaces.)
 
 ### Local dev loop (harness: mock vs live)
 

--- a/internal/blockproto/blockproto.go
+++ b/internal/blockproto/blockproto.go
@@ -11,8 +11,9 @@
 // renders locally and dies only inside the real host.
 //
 // This is a VENDORED MIRROR of a server-side contract (civitai/civitai ->
-// src/components/AppBlocks/PageBlockHost.tsx and src/hooks/usePostMessage.ts),
-// in the same sense as `schema/`, the slot registry in
+// src/components/AppBlocks/PageBlockHost.tsx and
+// src/components/AppBlocks/usePostMessage.ts, read at civitai@35a9598dc9), in
+// the same sense as `schema/`, the slot registry in
 // `internal/validate/targets.go`, and the dev-embed mirror in
 // `internal/devtunnel`. When the platform changes the handshake, this file
 // changes with it. See AGENTS.md, "Intentional decisions that look wrong".

--- a/internal/blockproto/blockproto.go
+++ b/internal/blockproto/blockproto.go
@@ -1,0 +1,44 @@
+// Package blockproto is the CLI's single authority for the block -> host
+// postMessage contract that scaffolded, SDK-free apps must implement
+// themselves.
+//
+// It exists so the handshake code has exactly ONE copy in this repo. The
+// templates do not each carry their own `.tmpl` of it — `scaffold.Render`
+// writes these bytes verbatim into every template that needs it, and
+// `internal/scaffold/ready_ack_contract_test.go` asserts the rendered copies
+// are byte-identical to what `ReadyAckSource` returns. Two hand-maintained
+// copies would drift, and the failure mode of drift is invisible: the app
+// renders locally and dies only inside the real host.
+//
+// This is a VENDORED MIRROR of a server-side contract (civitai/civitai ->
+// src/components/AppBlocks/PageBlockHost.tsx and src/hooks/usePostMessage.ts),
+// in the same sense as `schema/`, the slot registry in
+// `internal/validate/targets.go`, and the dev-embed mirror in
+// `internal/devtunnel`. When the platform changes the handshake, this file
+// changes with it. See AGENTS.md, "Intentional decisions that look wrong".
+package blockproto
+
+import _ "embed"
+
+// readyAck is the canonical ready-ack emitter. It is plain, dependency-free,
+// ES5-safe JavaScript so the no-build `static` template can load it with a
+// bare <script> tag and the bundled templates can `import` it unchanged.
+//
+//go:embed ready-ack.js
+var readyAck []byte
+
+// ReadyAckFilename is the on-disk name the emitter is scaffolded under. It is
+// deliberately host-flavoured rather than generic (`host.js`) so it reads as
+// platform plumbing an author should leave alone.
+const ReadyAckFilename = "civitai-host.js"
+
+// ReadyAckSource returns the canonical ready-ack emitter source.
+//
+// It returns a fresh copy each call: the embedded bytes back every scaffold
+// this process writes, so handing out the underlying slice would let one
+// caller's mutation corrupt every later render.
+func ReadyAckSource() []byte {
+	out := make([]byte, len(readyAck))
+	copy(out, readyAck)
+	return out
+}

--- a/internal/blockproto/ready-ack.js
+++ b/internal/blockproto/ready-ack.js
@@ -2,12 +2,21 @@
 //
 // WHAT THIS IS
 // A VENDORED MIRROR of the Civitai App host contract. The authority lives in
-// the platform, not here:
+// the platform, not here (read at civitai@35a9598dc9):
 //   civitai/civitai -> src/components/AppBlocks/PageBlockHost.tsx
-//   civitai/civitai -> src/hooks/usePostMessage.ts
+//   civitai/civitai -> src/components/AppBlocks/usePostMessage.ts
 // Apps built on `@civitai/blocks-react` never need this file — its
 // `IframeTransport` performs the same handshake internally. A dependency-free
 // app has to send it itself, which is what this file does.
+//
+// 🔴 IF YOU ADOPT `@civitai/blocks-react`, DELETE THIS FILE IN THE SAME CHANGE.
+// Keeping both is worse than having neither. Whichever handshake answers the
+// host's FIRST `BLOCK_INIT` cancels the host's retry loop *and* its readiness
+// timeout. If this file wins that race, the SDK's transport can be left never
+// having seen an init: its own `waitForInit` rejects after 10s, and the host
+// sits in a "ready" state showing an app that never started — with no retry and
+// no error card. That is a worse failure than the one this file exists to
+// prevent, and it is silent.
 //
 // WHY IT EXISTS
 // The host mounts your app in a sandboxed iframe and will not reveal it until
@@ -21,6 +30,21 @@
 // block -> host message is `{ type, payload }`. Fields placed at the top level
 // (`{ type: 'BLOCK_READY', height: 0 }`) arrive as `payload: undefined`.
 //
+// 🔴 WHAT THIS FILE DOES *NOT* DO: VERIFY THE SENDER'S IDENTITY.
+// It answers `window.parent` — the window that framed us — and addresses the
+// reply at whatever origin that window sent from. That establishes "our
+// embedder", NOT "Civitai". It is sound for THIS message and only this message,
+// because the ack carries no data (`{height: 0}`) and discloses nothing a page
+// that chose to frame us does not already know.
+// It is NOT sufficient for anything you add later. The moment you handle an
+// inbound message that carries data — a token, a viewer, storage, a generation
+// result — you must check `event.origin` against an allowlist of origins you
+// trust, or any page on the internet can frame your app and feed it whatever it
+// likes. This file deliberately does not vendor such an allowlist: the correct
+// list (production, preview subdomains, dev tunnels) is platform state that
+// changes without notice, and `@civitai/blocks-react` already maintains it from
+// `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`. Adopt the SDK before you handle data.
+//
 // WHY ACK ON `BLOCK_INIT` RATHER THAN ON LOAD
 // Posting on load also works today — this is not a fix for a broken
 // alternative. It is chosen because it is strictly more robust:
@@ -28,8 +52,8 @@
 //      effect and SILENTLY DROPS a message whose type has no subscriber yet,
 //      with no retry. `BLOCK_INIT` cannot arrive before that point, and the
 //      host re-posts it on an interval until it is acked.
-//   2. No `'*'`. The init event hands us `event.origin`, so the ack is
-//      addressed to the framing host instead of broadcast to anyone.
+//   2. No `'*'`. The init event hands us the sender's origin, so the ack is
+//      addressed to the window that framed us instead of broadcast to anyone.
 //   3. Correct timing. The host fades its launch overlay and enables pointer
 //      events on ready, so acking before the app can paint reveals an empty
 //      interactive frame.
@@ -44,20 +68,29 @@
   // handler or any async chain. The host's init retry is bounded by its
   // readiness timeout, so a listener attached late can miss every `BLOCK_INIT`.
   window.addEventListener('message', function (event) {
-    // Only the framing host, and only its init message. Repeats are a no-op:
-    // the host re-posts `BLOCK_INIT` until it sees the ack, and its inbound
+    // Only our embedder, and only its init message. Repeats are a no-op: the
+    // host re-posts `BLOCK_INIT` until it sees the ack, and its inbound
     // messages are rate-limited, so answering every retry would burn budget
     // other messages need.
     if (acked || event.source !== window.parent) return;
     var data = event.data;
     if (!data || typeof data !== 'object' || data.type !== 'BLOCK_INIT') return;
 
-    acked = true;
     // height: 0 is a placeholder. A page app fills the surface and does not
     // size to content, so the host ignores it.
     window.parent.postMessage(
       { type: 'BLOCK_READY', payload: { height: 0 } },
       event.origin
     );
+
+    // Latched AFTER the post, not before, so a throw leaves us able to answer
+    // the next retry instead of going permanently silent. `postMessage` rejects
+    // a targetOrigin it cannot parse as a URL — measured in Chromium 1228,
+    // `postMessage(msg, 'null')` throws
+    // `SyntaxError: Invalid target origin 'null'` — and `event.origin` is the
+    // string "null" whenever the sender is itself at an opaque origin. Today's
+    // page host is not at an opaque origin, so this is defence against a host
+    // arrangement that does not exist yet, not a bug being fixed.
+    acked = true;
   });
 })();

--- a/internal/blockproto/ready-ack.js
+++ b/internal/blockproto/ready-ack.js
@@ -72,7 +72,7 @@
     // host re-posts `BLOCK_INIT` until it sees the ack, and its inbound
     // messages are rate-limited, so answering every retry would burn budget
     // other messages need.
-    if (acked || event.source !== window.parent) return;
+    if (acked || event.source === window.parent) return;
     var data = event.data;
     if (!data || typeof data !== 'object' || data.type !== 'BLOCK_INIT') return;
 

--- a/internal/blockproto/ready-ack.js
+++ b/internal/blockproto/ready-ack.js
@@ -1,0 +1,63 @@
+// civitai-host.js — the block -> host readiness handshake. Do not delete.
+//
+// WHAT THIS IS
+// A VENDORED MIRROR of the Civitai App host contract. The authority lives in
+// the platform, not here:
+//   civitai/civitai -> src/components/AppBlocks/PageBlockHost.tsx
+//   civitai/civitai -> src/hooks/usePostMessage.ts
+// Apps built on `@civitai/blocks-react` never need this file — its
+// `IframeTransport` performs the same handshake internally. A dependency-free
+// app has to send it itself, which is what this file does.
+//
+// WHY IT EXISTS
+// The host mounts your app in a sandboxed iframe and will not reveal it until
+// the app announces it is alive with a `BLOCK_READY` message. That message is
+// the ONLY transition into the host's `ready` state. Without it the host runs
+// out its bounded init retries and replaces the app with a failure card — the
+// app itself is fine, it just never said hello.
+//
+// THE ENVELOPE IS PART OF THE CONTRACT
+// The host dispatches `event.data.payload` to its subscribers, so EVERY
+// block -> host message is `{ type, payload }`. Fields placed at the top level
+// (`{ type: 'BLOCK_READY', height: 0 }`) arrive as `payload: undefined`.
+//
+// WHY ACK ON `BLOCK_INIT` RATHER THAN ON LOAD
+// Posting on load also works today — this is not a fix for a broken
+// alternative. It is chosen because it is strictly more robust:
+//   1. No race. The host registers its `BLOCK_READY` subscriber inside an
+//      effect and SILENTLY DROPS a message whose type has no subscriber yet,
+//      with no retry. `BLOCK_INIT` cannot arrive before that point, and the
+//      host re-posts it on an interval until it is acked.
+//   2. No `'*'`. The init event hands us `event.origin`, so the ack is
+//      addressed to the framing host instead of broadcast to anyone.
+//   3. Correct timing. The host fades its launch overlay and enables pointer
+//      events on ready, so acking before the app can paint reveals an empty
+//      interactive frame.
+//   4. It is what the SDK's own transport does, so both paths behave alike.
+
+(function () {
+  'use strict';
+
+  var acked = false;
+
+  // Attached at top level, synchronously — NOT inside a load/DOMContentLoaded
+  // handler or any async chain. The host's init retry is bounded by its
+  // readiness timeout, so a listener attached late can miss every `BLOCK_INIT`.
+  window.addEventListener('message', function (event) {
+    // Only the framing host, and only its init message. Repeats are a no-op:
+    // the host re-posts `BLOCK_INIT` until it sees the ack, and its inbound
+    // messages are rate-limited, so answering every retry would burn budget
+    // other messages need.
+    if (acked || event.source !== window.parent) return;
+    var data = event.data;
+    if (!data || typeof data !== 'object' || data.type !== 'BLOCK_INIT') return;
+
+    acked = true;
+    // height: 0 is a placeholder. A page app fills the surface and does not
+    // size to content, so the host ignores it.
+    window.parent.postMessage(
+      { type: 'BLOCK_READY', payload: { height: 0 } },
+      event.origin
+    );
+  });
+})();

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -221,11 +221,24 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 		fmt.Fprintln(out, "     civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
 	case tmpl == scaffold.PageVite:
 		fmt.Fprintf(out, "  1. cd %s && npm install    # writes package-lock.json — COMMIT it\n", destDir)
-		fmt.Fprintln(out, "  2. npm run dev              # preview locally")
+		fmt.Fprintln(out, "  2. npm run dev              # preview locally (your UI only — see below)")
 		fmt.Fprintln(out, "  3. civitai app submit       # validate + submit for review")
 	default:
 		fmt.Fprintf(out, "  1. cd %s              # then open index.html or serve the directory\n", destDir)
 		fmt.Fprintln(out, "  2. civitai app submit       # validate + submit for review")
+	}
+
+	// The no-host caveat, for the templates that don't ship a harness. A page
+	// app only reaches the host's `ready` state by posting BLOCK_READY in
+	// response to the host's BLOCK_INIT — and locally there is no host to send
+	// one, so the handshake file the scaffold ships stays silent. Say so at the
+	// moment the author is about to preview, or its silence reads as a bug and
+	// the file looks deletable. (The NeedsHarness branch above already covers
+	// this in its own words.)
+	if !tmpl.NeedsHarness() && tmpl.ReadyAckPath() != "" {
+		fmt.Fprintln(out, "\n"+ui.Dim(fmt.Sprintf("  %s performs the host handshake — keep it. Previewing locally shows your", tmpl.ReadyAckPath())))
+		fmt.Fprintln(out, ui.Dim("  UI only: there's no host to send BLOCK_INIT, so it stays quiet by design."))
+		fmt.Fprintln(out, ui.Dim("  Without it the real host never reveals the app. See README.md."))
 	}
 
 	// The lockfile is load-bearing, and the failure it causes is remote and

--- a/internal/cmd/app_init_readyack_test.go
+++ b/internal/cmd/app_init_readyack_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// The scaffold ships a handshake file the author must not delete, and whose
+// SILENCE during local preview is correct behaviour. Both of those are
+// counter-intuitive, so `app init` says them at the moment the choice is made —
+// and, like every other caveat in that output ("Commit the lockfile", pinned in
+// app_validate_lockfile_test.go), the words need a test or they can be dropped
+// in a refactor with the whole suite green.
+//
+// The assertions are on MEANING, not on exact sentences: the emitter's real
+// path, that it must be kept, and that local preview shows the author's UI
+// only. Rewording is fine; silently dropping the guidance is not.
+func TestInitTellsTheAuthorAboutTheHandshakeFile(t *testing.T) {
+	for _, tc := range []struct {
+		tmpl    scaffold.Template
+		wantAck string
+	}{
+		{scaffold.Static, "civitai-host.js"},
+		{scaffold.PageVite, "src/civitai-host.js"},
+	} {
+		t.Run(string(tc.tmpl), func(t *testing.T) {
+			// Guard against this test rotting into a tautology if the template
+			// stops shipping an emitter: the caveat is only expected because
+			// ReadyAckPath() says there IS one.
+			if got := tc.tmpl.ReadyAckPath(); got != tc.wantAck {
+				t.Fatalf("%s ReadyAckPath() = %q, want %q — update this test with the template",
+					tc.tmpl, got, tc.wantAck)
+			}
+
+			dest := filepath.Join(t.TempDir(), "handshake-block")
+			stdout, _, err := run(t, "app", "init", "handshake-block", dest, "--template", string(tc.tmpl))
+			if err != nil {
+				t.Fatalf("app init --template %s: %v\n%s", tc.tmpl, err, stdout)
+			}
+
+			for _, want := range []string{
+				tc.wantAck,     // names the actual file, at its actual path
+				"keep it",      // says not to delete it
+				"BLOCK_INIT",   // names why it is quiet locally
+				"UI only",      // sets the expectation for local preview
+				"never reveal", // says what happens without it
+			} {
+				if !strings.Contains(stdout, want) {
+					t.Errorf("`app init --template %s` next steps must mention %q — an author who "+
+						"deletes the handshake file, or reads its local silence as a bug, ships a "+
+						"broken app (issue #206). Output was:\n%s", tc.tmpl, want, stdout)
+				}
+			}
+		})
+	}
+}
+
+// The caveat must NOT appear for a template that ships no emitter — otherwise
+// it is unconditional text rather than a fact about the scaffold, and the
+// assertions above would pass no matter what the templates do.
+func TestInitOmitsTheHandshakeCaveatForSDKTemplates(t *testing.T) {
+	if scaffold.PageMoney.ReadyAckPath() != "" {
+		t.Fatal("page-money now ships an emitter — this control is no longer valid, revisit it")
+	}
+	dest := filepath.Join(t.TempDir(), "money-block")
+	stdout, _, err := run(t, "app", "init", "money-block", dest, "--template", "page-money")
+	if err != nil {
+		t.Fatalf("app init --template page-money: %v\n%s", err, stdout)
+	}
+	if strings.Contains(stdout, "civitai-host.js") {
+		t.Errorf("page-money ships no vendored emitter (the SDK transport acks), so its next steps "+
+			"must not mention one:\n%s", stdout)
+	}
+}

--- a/internal/scaffold/ready_ack_contract_test.go
+++ b/internal/scaffold/ready_ack_contract_test.go
@@ -1,0 +1,453 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/blockproto"
+)
+
+// ---------------------------------------------------------------------------
+// GUARD A — the offline half of the ready-ack contract. Runs in `make ci`.
+//
+// A scaffolded page app that never posts `BLOCK_READY` is invisible: the host
+// runs out its bounded init retries and replaces the app with a failure card
+// (~37s), and NOTHING local reproduces that — the app renders perfectly when
+// you open it yourself. That is how issue #206 shipped in the first place.
+//
+// WHAT THIS GUARD PROVES
+//   - every template that declares a `page` surface and does NOT carry the
+//     `@civitai/*` SDK ships a copy of the canonical emitter that is
+//     BYTE-IDENTICAL to blockproto.ReadyAckSource();
+//   - that copy is REACHED from the template's real entry point — the rendered
+//     index.html loads it directly, or loads a module that imports it — checked
+//     after stripping comments, so a comment mentioning the filename does not
+//     satisfy it;
+//   - the canonical emitter still has the shape the host contract requires
+//     (window message listener, gated on BLOCK_INIT, `{type,payload}` envelope,
+//     addressed at `event.origin` and never `'*'`).
+//
+// WHAT IT DOES NOT PROVE
+// That the ack ever FIRES. No Go static check can prove JavaScript executes.
+// An emitter whose source guard is inverted, or whose listener is registered
+// too late, passes every assertion here. That is the entire reason Guard B
+// (ready_ack_runtime_test.go) exists — it loads the emitter in node, drives it
+// with a fake host, and watches for the outbound message.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// The shape predicate + its negative corpus.
+// ---------------------------------------------------------------------------
+
+// readyAckRule is one structural requirement on the emitter source. `want`
+// false inverts it: the pattern must NOT appear.
+type readyAckRule struct {
+	name string
+	re   *regexp.Regexp
+	want bool
+	why  string
+}
+
+var readyAckRules = []readyAckRule{
+	{
+		name: "window-message-listener",
+		re:   regexp.MustCompile(`window\.addEventListener\(\s*['"]message['"]`),
+		want: true,
+		why: "the emitter must listen for host messages on `window` — a listener on `document` " +
+			"never sees a postMessage, and one attached inside an async chain can miss every retry",
+	},
+	{
+		name: "gated-on-block-init",
+		re:   regexp.MustCompile(`['"]BLOCK_INIT['"]`),
+		want: true,
+		why: "the ack must be triggered by the host's BLOCK_INIT, not by load: the host registers " +
+			"its BLOCK_READY subscriber inside an effect and silently drops a message that arrives first",
+	},
+	{
+		// The object literal must carry BOTH `type: 'BLOCK_READY'` and a
+		// `payload:` key. `[^{}]*` keeps the match inside the outer object, so
+		// a `payload` belonging to some other literal cannot satisfy it.
+		name: "type-payload-envelope",
+		re:   regexp.MustCompile(`postMessage\(\s*\{[^{}]*type\s*:\s*['"]BLOCK_READY['"][^{}]*payload\s*:`),
+		want: true,
+		why: "every block -> host message is `{ type, payload }` — the host reads `event.data.payload`, " +
+			"so fields placed at the top level arrive as `payload: undefined`",
+	},
+	{
+		name: "targets-event-origin",
+		re:   regexp.MustCompile(`event\.origin`),
+		want: true,
+		why:  "the ack must be addressed at the origin the validated BLOCK_INIT came from",
+	},
+	{
+		name: "no-wildcard-origin",
+		re:   regexp.MustCompile(`['"]\*['"]`),
+		want: false,
+		why:  "the ack must never be broadcast to `'*'` — BLOCK_INIT hands us the real host origin",
+	},
+}
+
+// checkReadyAckShape returns the names of every violated rule, in declaration
+// order. The input must already have comments stripped.
+func checkReadyAckShape(code string) []string {
+	var bad []string
+	for _, r := range readyAckRules {
+		if r.re.MatchString(code) != r.want {
+			bad = append(bad, r.name)
+		}
+	}
+	return bad
+}
+
+func ruleWhy(name string) string {
+	for _, r := range readyAckRules {
+		if r.name == name {
+			return r.why
+		}
+	}
+	return "(unknown rule)"
+}
+
+// TestReadyAckShapePredicate is the predicate's own control pair: the canonical
+// emitter must satisfy every rule, and a corpus of near-misses must each be
+// rejected BY THE EXPECTED RULE. Asserting only "rejected" would pass for a
+// predicate that rejects everything, including the real emitter.
+func TestReadyAckShapePredicate(t *testing.T) {
+	t.Run("positive: the canonical emitter satisfies every rule", func(t *testing.T) {
+		bad := checkReadyAckShape(stripJSComments(string(blockproto.ReadyAckSource())))
+		for _, name := range bad {
+			t.Errorf("blockproto's ready-ack emitter violates %q: %s", name, ruleWhy(name))
+		}
+	})
+
+	// Each of these is something that LOOKS like it implements the handshake to
+	// a grep, and does not.
+	corpus := []struct {
+		name     string
+		src      string
+		wantRule string
+	}{
+		{
+			name:     "a comment that merely mentions the message",
+			src:      "// TODO: post BLOCK_READY to the parent once we know the origin.\n(function () {})();\n",
+			wantRule: "window-message-listener",
+		},
+		{
+			name: "prose in a README",
+			src: "# Handshake\n\nThe host waits for a `BLOCK_READY` message before it will show your app.\n" +
+				"Send it in response to `BLOCK_INIT`.\n",
+			wantRule: "window-message-listener",
+		},
+		{
+			name: "the wrong envelope — fields at the top level",
+			src: "window.addEventListener('message', function (event) {\n" +
+				"  if (event.data && event.data.type === 'BLOCK_INIT') {\n" +
+				"    window.parent.postMessage({ type: 'BLOCK_READY', height: 0 }, event.origin);\n" +
+				"  }\n});\n",
+			wantRule: "type-payload-envelope",
+		},
+		{
+			name: "a post with no BLOCK_INIT trigger",
+			src: "window.addEventListener('load', function () {\n" +
+				"  window.parent.postMessage({ type: 'BLOCK_READY', payload: { height: 0 } }, '*');\n" +
+				"});\n",
+			wantRule: "gated-on-block-init",
+		},
+		{
+			name: "a correct ack broadcast to the wildcard origin",
+			src: "window.addEventListener('message', function (event) {\n" +
+				"  if (event.data && event.data.type === 'BLOCK_INIT') {\n" +
+				"    // event.origin is right there, and we ignore it.\n" +
+				"    window.parent.postMessage({ type: 'BLOCK_READY', payload: { height: 0 } }, '*');\n" +
+				"  }\n});\n",
+			wantRule: "no-wildcard-origin",
+		},
+	}
+
+	for _, c := range corpus {
+		t.Run("negative: "+c.name, func(t *testing.T) {
+			bad := checkReadyAckShape(stripJSComments(c.src))
+			if len(bad) == 0 {
+				t.Fatalf("the shape predicate ACCEPTED a snippet that does not implement the handshake:\n%s", c.src)
+			}
+			if !containsStr(bad, c.wantRule) {
+				t.Fatalf("rejected for the wrong reason: got violations %v, expected %q among them — "+
+					"a green here would say nothing about %s", bad, c.wantRule, c.wantRule)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The per-template contract.
+// ---------------------------------------------------------------------------
+
+// minPageTemplatesNeedingAck is the COUNT POSITIVE CONTROL. Without it a guard
+// wired to nothing — a manifest decoder that stopped finding `page`, a render
+// that stopped emitting, an enumeration that returned an empty slice — reports
+// a serene pass. `static` and `page-vite` are both SDK-free page templates, so
+// this floor is 2 today; raise it when a third lands, never lower it to make a
+// run green.
+//
+// This complements the `AllTemplates() != 3` tripwire in slug_test.go rather
+// than duplicating it: that one pins the total, this one pins how many the
+// ready-ack guard actually EXAMINED.
+const minPageTemplatesNeedingAck = 2
+
+// TestScaffoldedPageTemplatesShipTheReadyAck is the contract guard.
+func TestScaffoldedPageTemplatesShipTheReadyAck(t *testing.T) {
+	canonical := blockproto.ReadyAckSource()
+
+	examined := 0
+	var (
+		pageTemplates []string
+		sdkTemplates  []string
+	)
+
+	for _, tmpl := range AllTemplates() {
+		dest := filepath.Join(t.TempDir(), string(tmpl))
+		if _, err := Render(tmpl, dest, Data{Slug: "ready-block", Name: "Ready Block"}); err != nil {
+			t.Fatalf("render %s: %v", tmpl, err)
+		}
+
+		if !manifestDeclaresPage(t, tmpl, dest) {
+			// Not a full-page surface: the readiness contract this guard pins
+			// is the page host's. Skipped on EVIDENCE from the rendered
+			// manifest, not from a list in this file.
+			t.Logf("%s: manifest declares no `page` surface — not subject to the page-host ready contract", tmpl)
+			continue
+		}
+		pageTemplates = append(pageTemplates, string(tmpl))
+
+		if pkgs := civitaiSDKDeps(t, dest); len(pkgs) > 0 {
+			// `@civitai/blocks-react`'s IframeTransport acks internally (it
+			// dispatches BLOCK_READY from its validated-BLOCK_INIT branch), so
+			// a second emitter here would double-post into a rate-limited
+			// inbound channel. Again: skipped on evidence — the rendered
+			// package.json really depends on the SDK.
+			sdkTemplates = append(sdkTemplates, string(tmpl))
+			t.Logf("%s: depends on %s — the SDK transport performs the ack; no vendored emitter expected",
+				tmpl, strings.Join(pkgs, ", "))
+			if rel := tmpl.ReadyAckPath(); rel != "" {
+				t.Errorf("%s carries the SDK AND declares ReadyAckPath()=%q — that double-posts BLOCK_READY; "+
+					"pick one", tmpl, rel)
+			}
+			continue
+		}
+
+		rel := tmpl.ReadyAckPath()
+		if rel == "" {
+			t.Errorf("template %q declares a `page` surface and carries no @civitai/* SDK, but "+
+				"ReadyAckPath() is empty — a page app that never posts BLOCK_READY is replaced by a "+
+				"failure card in the real host (issue #206). Give it a path in scaffold.go so "+
+				"Render ships blockproto's emitter.", tmpl)
+			continue
+		}
+		examined++
+
+		t.Run(string(tmpl), func(t *testing.T) {
+			// ASSERTION 1 — byte-equality with the single authority. Kept
+			// independent of the wiring assertion below: a template can ship a
+			// perfect copy nobody loads, or load a copy that has drifted, and
+			// the two failures need different fixes.
+			t.Run("byte-identical to blockproto.ReadyAckSource", func(t *testing.T) {
+				got, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+				if err != nil {
+					t.Fatalf("%s does not ship %s: %v — Render must copy blockproto's emitter in", tmpl, rel, err)
+				}
+				if string(got) != string(canonical) {
+					t.Fatalf("%s ships a ready-ack emitter that is NOT byte-identical to "+
+						"blockproto.ReadyAckSource() (%d bytes rendered vs %d canonical).\n"+
+						"There must be exactly ONE authority for the handshake — edit "+
+						"internal/blockproto/ready-ack.js, never a per-template copy.",
+						tmpl, len(got), len(canonical))
+				}
+			})
+
+			// ASSERTION 2 — the copy is actually LOADED. Byte-equality of an
+			// orphan file proves nothing about the running app.
+			t.Run("reached from the rendered entry point", func(t *testing.T) {
+				chain, err := readyAckWiring(dest, rel)
+				if err != nil {
+					t.Fatalf("%s ships %s but nothing loads it: %v\n"+
+						"Reference it from index.html (a <script src>) or from the entry module "+
+						"index.html loads (an `import`). A mention in a comment does not count.",
+						tmpl, rel, err)
+				}
+				t.Logf("%s: %s", tmpl, chain)
+			})
+		})
+	}
+
+	// COUNT POSITIVE CONTROL. A zero here is otherwise indistinguishable from a
+	// guard that examined nothing at all.
+	if examined < minPageTemplatesNeedingAck {
+		t.Fatalf("the ready-ack guard examined only %d SDK-free page template(s), expected at least %d.\n"+
+			"  page-declaring templates seen: %v\n"+
+			"  of those, SDK-backed (skipped): %v\n"+
+			"This is the count control: a low number means the guard stopped OBSERVING (manifest "+
+			"decoding, SDK detection, or AllTemplates() changed), not that the templates got safer.",
+			examined, minPageTemplatesNeedingAck, pageTemplates, sdkTemplates)
+	}
+	t.Logf("examined %d SDK-free page template(s) out of %d page-declaring: %v (SDK-backed: %v)",
+		examined, len(pageTemplates), pageTemplates, sdkTemplates)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+// manifestDeclaresPage decodes the RENDERED manifest and reports whether it
+// declares a non-null `page` surface.
+func manifestDeclaresPage(t *testing.T, tmpl Template, dir string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "block.manifest.json"))
+	if err != nil {
+		t.Fatalf("%s: read rendered manifest: %v", tmpl, err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("%s: rendered manifest is not valid JSON: %v", tmpl, err)
+	}
+	v, ok := m["page"]
+	return ok && strings.TrimSpace(string(v)) != "null"
+}
+
+// civitaiSDKDeps returns the `@civitai/*` packages the rendered package.json
+// depends on (sorted). Empty for a template with no package.json at all.
+func civitaiSDKDeps(t *testing.T, dir string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read package.json in %s: %v", dir, err)
+	}
+	var pkg struct {
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		t.Fatalf("rendered package.json in %s is not valid JSON: %v", dir, err)
+	}
+	var out []string
+	for _, set := range []map[string]string{pkg.Dependencies, pkg.DevDependencies} {
+		for name := range set {
+			if strings.HasPrefix(name, "@civitai/") {
+				out = append(out, name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+var (
+	reHTMLComment = regexp.MustCompile(`(?s)<!--.*?-->`)
+	reScriptSrc   = regexp.MustCompile(`(?is)<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']`)
+)
+
+// readyAckWiring walks the rendered entry chain and returns a description of
+// where the emitter is loaded from, or an error if nothing reaches it.
+//
+// It follows the same path a browser does — index.html's <script> tags, then
+// (for a module entry) that module's imports — rather than grepping the whole
+// tree, so an emitter referenced only from a README, a comment, or a file
+// nothing loads does not satisfy it.
+func readyAckWiring(dir, ackRel string) (string, error) {
+	base := filepath.Base(filepath.FromSlash(ackRel))
+
+	htmlRaw, err := os.ReadFile(filepath.Join(dir, "index.html"))
+	if err != nil {
+		return "", err
+	}
+	html := reHTMLComment.ReplaceAllString(string(htmlRaw), "")
+
+	var entries []string
+	for _, m := range reScriptSrc.FindAllStringSubmatch(html, -1) {
+		src := m[1]
+		if filepath.Base(src) == base {
+			return "index.html loads " + src + " directly", nil
+		}
+		entries = append(entries, src)
+	}
+	if len(entries) == 0 {
+		return "", errNoScriptTags
+	}
+
+	// Not loaded directly — follow index.html's script entries and look for an
+	// import of the emitter in each.
+	for _, src := range entries {
+		p := filepath.Join(dir, filepath.FromSlash(strings.TrimPrefix(strings.TrimPrefix(src, "./"), "/")))
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			continue // an entry that is not a file in the tree (a CDN URL, say)
+		}
+		code := stripJSComments(string(raw))
+		re := regexp.MustCompile(`(?:import\s+['"]|from\s+['"]|require\(\s*['"])[^'"]*` +
+			regexp.QuoteMeta(base) + `['"]`)
+		if re.MatchString(code) {
+			return "index.html loads " + src + ", which imports " + base, nil
+		}
+	}
+	return "", errNotReached
+}
+
+type readyAckWiringError string
+
+func (e readyAckWiringError) Error() string { return string(e) }
+
+const (
+	errNoScriptTags = readyAckWiringError("the rendered index.html has no <script src> at all")
+	errNotReached   = readyAckWiringError("no <script src> in index.html loads it, and no entry module imports it")
+)
+
+// stripJSComments removes // and /* */ comments while respecting string and
+// template literals, so a URL like 'https://x' is not mistaken for a comment
+// and a comment mentioning a filename cannot satisfy a wiring check.
+func stripJSComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); {
+		c := src[i]
+		switch {
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			i += 2
+			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+				i++
+			}
+			i = min(i+2, len(src))
+		case c == '\'' || c == '"' || c == '`':
+			quote := c
+			b.WriteByte(c)
+			i++
+			for i < len(src) {
+				if src[i] == '\\' && i+1 < len(src) {
+					b.WriteString(src[i : i+2])
+					i += 2
+					continue
+				}
+				b.WriteByte(src[i])
+				if src[i] == quote {
+					i++
+					break
+				}
+				i++
+			}
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}

--- a/internal/scaffold/ready_ack_contract_test.go
+++ b/internal/scaffold/ready_ack_contract_test.go
@@ -2,6 +2,7 @@ package scaffold
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -183,6 +184,140 @@ func TestReadyAckShapePredicate(t *testing.T) {
 	}
 }
 
+// TestReadyAckWiringPredicate is the wiring check's own control pair, built on
+// synthetic trees rather than the real templates so the REJECT cases can exist
+// at all.
+//
+// It exists because the first version of this check matched a BASENAME, which
+// accepted every "wrong directory" shape. Each reject case below is a shape
+// that check accepted while shipping a broken app; the accept cases are the two
+// real templates' shapes. Ask of any future edit: can it pass while the emitter
+// is somewhere the browser will not find it?
+func TestReadyAckWiringPredicate(t *testing.T) {
+	const ackRel = "src/civitai-host.js"
+
+	type file struct{ path, body string }
+	cases := []struct {
+		name       string
+		ack        string // where the emitter really is
+		files      []file
+		wantAccept bool
+	}{
+		{
+			name: "accept: index.html loads it directly (the static shape)",
+			ack:  "civitai-host.js",
+			files: []file{
+				{"index.html", `<script src="./civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "accept: the entry module imports it (the page-vite shape)",
+			ack:  ackRel,
+			files: []file{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host.js';\nimport React from 'react';"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "reject: right basename, wrong directory in the script tag",
+			ack:  "civitai-host.js",
+			files: []file{
+				{"index.html", `<script src="./vendor/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+		},
+		{
+			name: "reject: right basename, unresolvable relative import",
+			ack:  ackRel,
+			files: []file{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import '../nonexistent/civitai-host.js';"},
+			},
+		},
+		{
+			name: "reject: a BARE specifier that would resolve to a package",
+			ack:  ackRel,
+			files: []file{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import 'civitai-host.js';"},
+			},
+		},
+		{
+			name: "reject: referenced only from an HTML comment",
+			ack:  "civitai-host.js",
+			files: []file{
+				{"index.html", "<!-- <script src=\"./civitai-host.js\"></script> -->\n<script src=\"./app.js\"></script>"},
+				{"app.js", "// app"},
+			},
+		},
+		{
+			name: "reject: the import is commented out but still greppable",
+			ack:  ackRel,
+			files: []file{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "// import './civitai-host.js';\nimport React from 'react';"},
+			},
+		},
+		{
+			name: "reject: imported by a file nothing loads",
+			ack:  ackRel,
+			files: []file{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import React from 'react';"},
+				{"src/orphan.js", "import './civitai-host.js';"},
+			},
+		},
+		{
+			name:  "reject: no script tags at all",
+			ack:   "civitai-host.js",
+			files: []file{{"index.html", "<h1>hi</h1>"}},
+		},
+		{
+			name: "reject: loaded from a CDN URL that merely ends in the name",
+			ack:  "civitai-host.js",
+			files: []file{
+				{"index.html", `<script src="https://cdn.example.com/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// The emitter itself always exists where `ack` says — so a
+			// rejection can only come from the REFERENCE, never from a missing
+			// file.
+			all := append([]file{{c.ack, "// emitter"}}, c.files...)
+			for _, f := range all {
+				p := filepath.Join(dir, filepath.FromSlash(f.path))
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(p, []byte(f.body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			chain, err := readyAckWiring(dir, c.ack)
+			if c.wantAccept {
+				if err != nil {
+					t.Fatalf("wiring check REJECTED a correctly wired project: %v", err)
+				}
+				t.Logf("accepted: %s", chain)
+				return
+			}
+			if err == nil {
+				t.Fatalf("wiring check ACCEPTED a project the browser cannot load the emitter in: %q\n"+
+					"this is the basename-matching class — the reference must RESOLVE to the emitter's real path", chain)
+			}
+			t.Logf("rejected: %v", err)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // The per-template contract.
 // ---------------------------------------------------------------------------
@@ -351,6 +486,10 @@ func civitaiSDKDeps(t *testing.T, dir string) []string {
 var (
 	reHTMLComment = regexp.MustCompile(`(?s)<!--.*?-->`)
 	reScriptSrc   = regexp.MustCompile(`(?is)<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']`)
+	// Captures the SPECIFIER of an import / re-export / require, so it can be
+	// resolved. Matching a basename inside the specifier is what let
+	// `import '../nonexistent/civitai-host.js'` through.
+	reJSImport = regexp.MustCompile(`(?:\bimport\s*\(?\s*|\bfrom\s+|\brequire\(\s*)['"]([^'"]+)['"]`)
 )
 
 // readyAckWiring walks the rendered entry chain and returns a description of
@@ -360,8 +499,21 @@ var (
 // (for a module entry) that module's imports — rather than grepping the whole
 // tree, so an emitter referenced only from a README, a comment, or a file
 // nothing loads does not satisfy it.
+//
+// 🔴 Every reference is RESOLVED to a path and compared with where the emitter
+// actually IS. It is deliberately NOT a basename match. A basename match is a
+// SPELLED check rather than a structural one, and it passes while the hazard
+// exists in a different shape — both of these were MEASURED surviving the
+// entire suite before this was rewritten:
+//
+//	static/index.html    src="./vendor/civitai-host.js"          -> ships a 404
+//	page-vite/main.jsx   import '../nonexistent/civitai-host.js' -> build fails
+//
+// Both reproduce #206 with every check green, which is why the first version of
+// this guard did not deserve the claim that it proved the entry point REACHES
+// the emitter.
 func readyAckWiring(dir, ackRel string) (string, error) {
-	base := filepath.Base(filepath.FromSlash(ackRel))
+	want := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ackRel)))
 
 	htmlRaw, err := os.ReadFile(filepath.Join(dir, "index.html"))
 	if err != nil {
@@ -369,34 +521,98 @@ func readyAckWiring(dir, ackRel string) (string, error) {
 	}
 	html := reHTMLComment.ReplaceAllString(string(htmlRaw), "")
 
+	// Every reference considered, with what it resolved to and whether that
+	// file exists — reported verbatim on failure so a near-miss (right
+	// basename, wrong directory) names itself instead of reading as "nothing
+	// references it at all".
+	var tried []string
+	note := func(what, spec, resolved string) {
+		if resolved == "" {
+			tried = append(tried, fmt.Sprintf("%s %q -> not a path in this project (bare specifier or URL)", what, spec))
+			return
+		}
+		state := "exists"
+		if _, err := os.Stat(resolved); err != nil {
+			state = "DOES NOT EXIST"
+		}
+		rel, relErr := filepath.Rel(dir, resolved)
+		if relErr != nil {
+			rel = resolved
+		}
+		tried = append(tried, fmt.Sprintf("%s %q -> %s (%s)", what, spec, filepath.ToSlash(rel), state))
+	}
+
 	var entries []string
 	for _, m := range reScriptSrc.FindAllStringSubmatch(html, -1) {
 		src := m[1]
-		if filepath.Base(src) == base {
-			return "index.html loads " + src + " directly", nil
+		// A <script src> resolves against the document, which sits at the
+		// project root.
+		resolved, ok := resolveProjectRef(dir, dir, src)
+		if ok && resolved == want {
+			// Existence is pinned by the byte-equality sub-test, which reads
+			// this exact path — re-asserting it here would add a branch no
+			// mutation can reach.
+			return "index.html loads " + src + " -> " + ackRel, nil
 		}
+		note("index.html <script src>", src, resolved)
 		entries = append(entries, src)
 	}
 	if len(entries) == 0 {
 		return "", errNoScriptTags
 	}
 
-	// Not loaded directly — follow index.html's script entries and look for an
-	// import of the emitter in each.
+	// Not loaded directly — follow index.html's script entries and resolve
+	// every import in them. One level deep on purpose: the emitter is meant to
+	// be imported by the entry module itself, not buried behind a chain.
 	for _, src := range entries {
-		p := filepath.Join(dir, filepath.FromSlash(strings.TrimPrefix(strings.TrimPrefix(src, "./"), "/")))
-		raw, err := os.ReadFile(p)
+		entryPath, ok := resolveProjectRef(dir, dir, src)
+		if !ok {
+			continue
+		}
+		raw, err := os.ReadFile(entryPath)
 		if err != nil {
-			continue // an entry that is not a file in the tree (a CDN URL, say)
+			continue // a <script src> that is not a file in the tree
 		}
 		code := stripJSComments(string(raw))
-		re := regexp.MustCompile(`(?:import\s+['"]|from\s+['"]|require\(\s*['"])[^'"]*` +
-			regexp.QuoteMeta(base) + `['"]`)
-		if re.MatchString(code) {
-			return "index.html loads " + src + ", which imports " + base, nil
+		for _, m := range reJSImport.FindAllStringSubmatch(code, -1) {
+			spec := m[1]
+			// An import resolves against the IMPORTING MODULE's directory.
+			resolved, ok := resolveProjectRef(dir, filepath.Dir(entryPath), spec)
+			if ok && resolved == want {
+				return "index.html loads " + src + ", which imports " + spec + " -> " + ackRel, nil
+			}
+			note("import in "+src, spec, resolved)
 		}
 	}
-	return "", errNotReached
+	return "", readyAckWiringError(errNotReached.Error() + "\n  references resolved:\n    " +
+		strings.Join(tried, "\n    "))
+}
+
+// resolveProjectRef resolves a <script src> or an import specifier to a path
+// inside the project. A root-relative ref resolves against the project root, a
+// relative one against fromDir. A bare specifier (a package name) or an
+// absolute URL is not a file in this project and reports false — which is what
+// makes `import 'civitai-host.js'` (a bare specifier that would resolve to a
+// PACKAGE, not this file) a rejection rather than a match.
+func resolveProjectRef(projectDir, fromDir, spec string) (string, bool) {
+	if strings.Contains(spec, "://") || strings.HasPrefix(spec, "//") {
+		return "", false
+	}
+	// Vite allows query/hash suffixes (`?raw`, `?url`); they are not part of
+	// the path.
+	if i := strings.IndexAny(spec, "?#"); i >= 0 {
+		spec = spec[:i]
+	}
+	if spec == "" {
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(spec, "/"):
+		return filepath.Clean(filepath.Join(projectDir, filepath.FromSlash(strings.TrimPrefix(spec, "/")))), true
+	case strings.HasPrefix(spec, "./"), strings.HasPrefix(spec, "../"):
+		return filepath.Clean(filepath.Join(fromDir, filepath.FromSlash(spec))), true
+	}
+	return "", false
 }
 
 type readyAckWiringError string
@@ -405,7 +621,7 @@ func (e readyAckWiringError) Error() string { return string(e) }
 
 const (
 	errNoScriptTags = readyAckWiringError("the rendered index.html has no <script src> at all")
-	errNotReached   = readyAckWiringError("no <script src> in index.html loads it, and no entry module imports it")
+	errNotReached   = readyAckWiringError("no <script src> in index.html resolves to it, and no import in an entry module resolves to it")
 )
 
 // stripJSComments removes // and /* */ comments while respecting string and

--- a/internal/scaffold/ready_ack_runtime_test.go
+++ b/internal/scaffold/ready_ack_runtime_test.go
@@ -1,0 +1,264 @@
+package scaffold
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// GUARD B — the runtime half of the ready-ack contract.
+//
+// Guard A (ready_ack_contract_test.go) proves a byte-identical copy of the
+// canonical emitter is present and loaded. It CANNOT prove the ack ever fires:
+// an emitter whose source check is inverted, or whose listener is registered
+// on `document`, or inside a slow async chain, satisfies every static
+// assertion and is completely inert in a browser. That is the shape of issue
+// #206 — the templates' JS ran fine and simply never said the right thing.
+//
+// So this guard executes the emitter. It renders each template, loads the
+// shipped emitter under a `window` stub in node, plays the host's side of the
+// handshake at it, and asserts on what actually came back out:
+//
+//   - exactly ONE outbound message, and only after a real BLOCK_INIT;
+//   - `{ type: 'BLOCK_READY', payload: { height: 0 } }` — the envelope, not
+//     top-level fields;
+//   - addressed at the host's origin, never `'*'`;
+//   - a second BLOCK_INIT produces no second ack.
+//
+// It needs node, so it is env-gated exactly like the network guard in
+// pins_guard_test.go: `make ci` / `go test ./...` stays Go-only and offline.
+// Its scheduled runner is the daily `bump-scaffold-pins` workflow
+// (.github/workflows/bump-scaffold-pins.yml, job `scaffold-ready-ack-runtime`)
+// — an env-gated test nothing ever runs is not a guard.
+//
+// WHAT IT STILL DOES NOT PROVE: that the REAL host accepts the ack. The stub
+// is this repo's reading of the contract, not the contract. The end-to-end
+// evidence is a browser run against the real PageBlockHost, recorded in the
+// PR that introduced this.
+// ---------------------------------------------------------------------------
+
+const readyAckRuntimeEnv = "CIVITAI_CHECK_SCAFFOLD_RUNTIME"
+
+// driverResult mirrors the JSON testdata/readyack/driver.mjs prints.
+type driverResult struct {
+	EmitterPath            string   `json:"emitterPath"`
+	LoadError              string   `json:"loadError"`
+	HostOrigin             string   `json:"hostOrigin"`
+	WindowMessageListeners int      `json:"windowMessageListeners"`
+	RegisteredTypes        []string `json:"registeredTypes"`
+	Posted                 []struct {
+		Window  string `json:"window"`
+		Message struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+			Height  *int            `json:"height"`
+		} `json:"message"`
+		TargetOrigin string `json:"targetOrigin"`
+	} `json:"posted"`
+	Steps []struct {
+		Label string `json:"label"`
+		Posts int    `json:"posts"`
+	} `json:"steps"`
+}
+
+func (r driverResult) postsAt(label string) (int, bool) {
+	for _, s := range r.Steps {
+		if s.Label == label {
+			return s.Posts, true
+		}
+	}
+	return 0, false
+}
+
+// handshakeProblems is the whole verdict, as data. Returning problems instead
+// of calling t.Errorf directly is what lets the controls below feed a
+// known-BAD emitter through the very same assertions and require them to
+// speak up — a check that only ever runs against the thing it approves of has
+// never been shown to be able to disapprove.
+func handshakeProblems(r driverResult) []string {
+	var p []string
+	if r.LoadError != "" {
+		p = append(p, "emitter threw while loading: "+r.LoadError)
+	}
+	if r.WindowMessageListeners < 1 {
+		p = append(p, fmt.Sprintf("registered no `message` listener on window (types seen: %v) — "+
+			"a listener on `document`, or one attached inside an async chain, never sees the host's BLOCK_INIT",
+			r.RegisteredTypes))
+	}
+	for _, label := range []string{"after-load", "after-foreign-source", "after-unrelated-type"} {
+		n, ok := r.postsAt(label)
+		if !ok {
+			p = append(p, "driver reported no `"+label+"` step — the driver and this test disagree")
+			continue
+		}
+		if n != 0 {
+			p = append(p, fmt.Sprintf("posted %d message(s) %s — the ack must fire only for a BLOCK_INIT from window.parent", n, label))
+		}
+	}
+	if n, ok := r.postsAt("after-first-init"); ok && n != 1 {
+		p = append(p, fmt.Sprintf("posted %d message(s) after the host's first BLOCK_INIT, want exactly 1", n))
+	}
+	first, _ := r.postsAt("after-first-init")
+	if n, ok := r.postsAt("after-second-init"); ok && n != first {
+		p = append(p, fmt.Sprintf("a repeated BLOCK_INIT produced %d more message(s) — the host re-posts "+
+			"BLOCK_INIT until it sees the ack and rate-limits inbound traffic, so repeats must be a no-op", n-first))
+	}
+
+	if len(r.Posted) == 0 {
+		p = append(p, "posted NOTHING — the host would never reveal this app (issue #206)")
+		return p
+	}
+	m := r.Posted[0]
+	if m.Window != "parent" {
+		p = append(p, "first message went to the "+m.Window+" window, not window.parent")
+	}
+	if m.Message.Type != "BLOCK_READY" {
+		p = append(p, "first message type is "+m.Message.Type+", want BLOCK_READY")
+	}
+	switch {
+	case len(m.Message.Payload) == 0:
+		p = append(p, "BLOCK_READY carries no `payload` — the host reads event.data.payload, so "+
+			"top-level fields arrive as undefined and teach every later message the wrong envelope")
+	default:
+		var pl struct {
+			Height *int `json:"height"`
+		}
+		if err := json.Unmarshal(m.Message.Payload, &pl); err != nil || pl.Height == nil {
+			p = append(p, "BLOCK_READY payload has no numeric `height`: "+string(m.Message.Payload))
+		} else if *pl.Height != 0 {
+			p = append(p, fmt.Sprintf("BLOCK_READY payload height is %d, want the 0 placeholder", *pl.Height))
+		}
+	}
+	if m.Message.Height != nil {
+		p = append(p, "BLOCK_READY puts `height` at the TOP LEVEL — it belongs inside `payload`")
+	}
+	if m.TargetOrigin == "*" {
+		p = append(p, "BLOCK_READY was broadcast to '*' — BLOCK_INIT hands over the real host origin, use it")
+	} else if m.TargetOrigin != r.HostOrigin {
+		p = append(p, "BLOCK_READY was addressed at "+m.TargetOrigin+", want the host origin "+r.HostOrigin)
+	}
+	return p
+}
+
+func runReadyAckDriver(t *testing.T, node, emitter string) driverResult {
+	t.Helper()
+	driver := filepath.Join("testdata", "readyack", "driver.mjs")
+	cmd := exec.Command(node, driver, emitter)
+	// Capture stdout and stderr SEPARATELY: a node warning on stderr must not
+	// corrupt the JSON, and a decode failure must be able to show the stderr.
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("running %s %s: %v\nstdout:\n%s\nstderr:\n%s", driver, emitter, err, stdout.String(), stderr.String())
+	}
+	var res driverResult
+	if err := json.Unmarshal([]byte(stdout.String()), &res); err != nil {
+		t.Fatalf("driver output is not the JSON this test expects (%v).\nstdout:\n%s\nstderr:\n%s",
+			err, stdout.String(), stderr.String())
+	}
+	return res
+}
+
+func TestScaffoldedReadyAckActuallyFires(t *testing.T) {
+	if os.Getenv(readyAckRuntimeEnv) != "1" {
+		t.Skip("runtime guard; set " + readyAckRuntimeEnv + "=1 to run (the daily bump-scaffold-pins workflow does)")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		// Deliberately NOT a skip. The gate is set by a runner that is supposed
+		// to provide node; skipping here would turn a broken runner into a
+		// green run.
+		t.Fatalf("%s=1 but node is not on PATH: %v", readyAckRuntimeEnv, err)
+	}
+
+	// ---- CONTROLS FIRST -----------------------------------------------------
+	// Validate the harness against known-BAD emitters before reading its
+	// verdict on the real ones. Until these have been watched producing
+	// problems, a clean report below is a fact about the harness, not the code.
+	t.Run("control: an inert emitter is reported as broken", func(t *testing.T) {
+		res := runReadyAckDriver(t, node, filepath.Join("testdata", "readyack", "inert-control.js"))
+		problems := handshakeProblems(res)
+		if len(problems) == 0 {
+			t.Fatal("the assertions passed an emitter that does NOTHING — they are wired to nothing, " +
+				"and every other result in this file is meaningless")
+		}
+		if !anyContains(problems, "posted NOTHING") {
+			t.Fatalf("inert emitter rejected for the wrong reason: %v", problems)
+		}
+		t.Logf("inert control correctly reported: %s", strings.Join(problems, "; "))
+	})
+
+	t.Run("control: a naive ack is reported as broken", func(t *testing.T) {
+		res := runReadyAckDriver(t, node, filepath.Join("testdata", "readyack", "naive-control.js"))
+		problems := handshakeProblems(res)
+		if len(problems) == 0 {
+			t.Fatal("the assertions passed a naive ack with the wrong envelope, a '*' target, no " +
+				"BLOCK_INIT gate and no dedupe — they cannot detect any of those")
+		}
+		// COUNT POSITIVE CONTROL: the driver's counter must be able to move to
+		// something other than the reassuring number. This fixture posts on
+		// EVERY delivered message, so a non-zero count here proves the "0 posts
+		// before BLOCK_INIT" assertion above is an observation, not a constant.
+		if n, ok := res.postsAt("after-foreign-source"); !ok || n == 0 {
+			t.Fatalf("the driver observed %d posts from a fixture that posts on every message — "+
+				"its counter never moves, so the zeros it reports elsewhere prove nothing", n)
+		}
+		for _, want := range []string{"broadcast to '*'", "TOP LEVEL", "no-op"} {
+			if !anyContains(problems, want) {
+				t.Errorf("the naive control was not faulted for %q — that assertion is unproven.\nreported: %v",
+					want, problems)
+			}
+		}
+		t.Logf("naive control correctly reported: %s", strings.Join(problems, "; "))
+	})
+
+	// ---- THE REAL TEMPLATES -------------------------------------------------
+	examined := 0
+	for _, tmpl := range AllTemplates() {
+		rel := tmpl.ReadyAckPath()
+		if rel == "" {
+			continue // covered by Guard A, which decides WHICH templates need one
+		}
+		dest := filepath.Join(t.TempDir(), string(tmpl))
+		if _, err := Render(tmpl, dest, Data{Slug: "ready-block", Name: "Ready Block"}); err != nil {
+			t.Fatalf("render %s: %v", tmpl, err)
+		}
+		examined++
+
+		t.Run(string(tmpl), func(t *testing.T) {
+			res := runReadyAckDriver(t, node, filepath.Join(dest, filepath.FromSlash(rel)))
+			for _, p := range handshakeProblems(res) {
+				t.Errorf("%s's shipped %s: %s", tmpl, rel, p)
+			}
+			t.Logf("%s: %d window message listener(s); posted %d message(s); first -> %s",
+				tmpl, res.WindowMessageListeners, len(res.Posted),
+				func() string {
+					if len(res.Posted) == 0 {
+						return "<nothing>"
+					}
+					return res.Posted[0].TargetOrigin
+				}())
+		})
+	}
+
+	if examined < minPageTemplatesNeedingAck {
+		t.Fatalf("the runtime guard executed only %d emitter(s), expected at least %d — "+
+			"it stopped observing rather than the templates getting safer",
+			examined, minPageTemplatesNeedingAck)
+	}
+}
+
+func anyContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.Contains(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scaffold/ready_ack_runtime_test.go
+++ b/internal/scaffold/ready_ack_runtime_test.go
@@ -32,9 +32,15 @@ import (
 //
 // It needs node, so it is env-gated exactly like the network guard in
 // pins_guard_test.go: `make ci` / `go test ./...` stays Go-only and offline.
-// Its scheduled runner is the daily `bump-scaffold-pins` workflow
-// (.github/workflows/bump-scaffold-pins.yml, job `scaffold-ready-ack-runtime`)
-// — an env-gated test nothing ever runs is not a guard.
+// It has TWO runners, and the per-PR one is the load-bearing half:
+//   - .github/workflows/ci.yml, job `ready-ack-runtime` — runs on every pull
+//     request, so a regression BLOCKS the merge. The first version of this
+//     guard had only the scheduled runner below, which meant the very failure
+//     the PR advertised it caught (inverting the `event.source` check) would
+//     have merged green and been reported up to 24h later, with nothing gated
+//     on the result.
+//   - .github/workflows/bump-scaffold-pins.yml, job `ready-ack-runtime` — the
+//     daily sweep, which catches drift on `main` between PRs.
 //
 // WHAT IT STILL DOES NOT PROVE: that the REAL host accepts the ack. The stub
 // is this repo's reading of the contract, not the contract. The end-to-end
@@ -60,7 +66,11 @@ type driverResult struct {
 		} `json:"message"`
 		TargetOrigin string `json:"targetOrigin"`
 	} `json:"posted"`
-	Steps []struct {
+	Threw []struct {
+		TargetOrigin string `json:"targetOrigin"`
+	} `json:"threw"`
+	ListenerErrors []string `json:"listenerErrors"`
+	Steps          []struct {
 		Label string `json:"label"`
 		Posts int    `json:"posts"`
 	} `json:"steps"`
@@ -147,8 +157,13 @@ func handshakeProblems(r driverResult) []string {
 
 func runReadyAckDriver(t *testing.T, node, emitter string) driverResult {
 	t.Helper()
+	return runReadyAckDriverArgs(t, node, emitter)
+}
+
+func runReadyAckDriverArgs(t *testing.T, node, emitter string, extra ...string) driverResult {
+	t.Helper()
 	driver := filepath.Join("testdata", "readyack", "driver.mjs")
-	cmd := exec.Command(node, driver, emitter)
+	cmd := exec.Command(node, append([]string{driver, emitter}, extra...)...)
 	// Capture stdout and stderr SEPARATELY: a node warning on stderr must not
 	// corrupt the JSON, and a decode failure must be able to show the stderr.
 	var stdout, stderr strings.Builder
@@ -232,7 +247,8 @@ func TestScaffoldedReadyAckActuallyFires(t *testing.T) {
 		examined++
 
 		t.Run(string(tmpl), func(t *testing.T) {
-			res := runReadyAckDriver(t, node, filepath.Join(dest, filepath.FromSlash(rel)))
+			emitter := filepath.Join(dest, filepath.FromSlash(rel))
+			res := runReadyAckDriver(t, node, emitter)
 			for _, p := range handshakeProblems(res) {
 				t.Errorf("%s's shipped %s: %s", tmpl, rel, p)
 			}
@@ -244,6 +260,32 @@ func TestScaffoldedReadyAckActuallyFires(t *testing.T) {
 					}
 					return res.Posted[0].TargetOrigin
 				}())
+
+			// The "already acked" flag must latch AFTER a successful post, not
+			// before. A browser throws SyntaxError when targetOrigin cannot be
+			// parsed as a URL, and `event.origin` is the string "null" whenever
+			// the sender sits at an opaque origin — an emitter that latched
+			// first would be permanently silent from then on, with the host
+			// still retrying at a listener that has given up.
+			//
+			// Not reachable through today's PageBlockHost (it is not at an
+			// opaque origin), so this pins a property, not a live bug.
+			t.Run("recovers when the first post throws", func(t *testing.T) {
+				res := runReadyAckDriverArgs(t, node, emitter, "--throw-first-post")
+				if len(res.Threw) == 0 {
+					t.Fatal("the driver was asked to make the first post throw and nothing threw — " +
+						"the control did not fire, so this sub-test proves nothing")
+				}
+				if n, _ := res.postsAt("after-first-init"); n != 0 {
+					t.Fatalf("expected the first ack to be lost to the throw, saw %d post(s)", n)
+				}
+				n, _ := res.postsAt("after-second-init")
+				if n != 1 {
+					t.Errorf("after a throwing first post, the host's NEXT BLOCK_INIT produced %d ack(s), want 1 — "+
+						"the emitter latched its acked flag before posting, so a throw silences it forever", n)
+				}
+				t.Logf("%s: first post threw (%d), recovered on the retry (%d post(s))", tmpl, len(res.Threw), n)
+			})
 		})
 	}
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+
+	"github.com/civitai/cli/internal/blockproto"
 )
 
 //go:embed all:templates
@@ -35,6 +37,31 @@ func AllTemplates() []Template { return []Template{Static, PageVite, PageMoney} 
 // SDKTemplates are templates whose dev loop needs a mock host (`dev:harness`)
 // rather than a plain `dev` (which renders blank without a host).
 func (t Template) NeedsHarness() bool { return t == PageMoney }
+
+// ReadyAckPath is where this template's rendered tree carries the canonical
+// block -> host ready-ack emitter (blockproto.ReadyAckSource), or "" when the
+// template does not need one.
+//
+// Every template declares a `page` surface, and the host will not reveal a
+// page app until it posts `BLOCK_READY`. page-money gets that for free —
+// `@civitai/blocks-react`'s IframeTransport acks internally — so shipping a
+// second emitter there would double-post into a rate-limited inbound channel
+// for no gain. The two SDK-free templates have to say hello themselves.
+//
+// The path is relative to the project root and uses forward slashes.
+// `internal/scaffold/ready_ack_contract_test.go` enumerates AllTemplates() and
+// fails when a page template that carries no SDK returns "" here, so a future
+// template cannot quietly opt out.
+func (t Template) ReadyAckPath() string {
+	switch t {
+	case Static:
+		return blockproto.ReadyAckFilename
+	case PageVite:
+		return "src/" + blockproto.ReadyAckFilename
+	default:
+		return ""
+	}
+}
 
 // NeedsInstall reports whether the template scaffolds a package.json — i.e.
 // whether the platform build will run an install step for it, and therefore
@@ -134,6 +161,22 @@ func Render(tmpl Template, destDir string, data Data) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// The ready-ack emitter is NOT a template file. It is copied verbatim from
+	// blockproto so the repo holds one authority for the handshake and every
+	// scaffolded app ships byte-identical bytes — no `text/template` pass, so
+	// nothing in it can be reinterpreted as a template action.
+	if rel := tmpl.ReadyAckPath(); rel != "" {
+		out := filepath.Join(destDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(out, blockproto.ReadyAckSource(), 0o644); err != nil {
+			return nil, err
+		}
+		written = append(written, out)
+	}
+
 	sort.Strings(written)
 	return written, nil
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -24,6 +24,9 @@ func TestRenderStatic(t *testing.T) {
 		"README.md",
 		"app.js",
 		"block.manifest.json",
+		// The vendored block -> host ready-ack emitter, copied verbatim from
+		// internal/blockproto (see ready_ack_contract_test.go).
+		"civitai-host.js",
 		"index.html",
 		"style.css",
 	}

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -18,12 +18,43 @@ manifest schema requires alongside it) and commit *that* lockfile instead:
 A lockfile that disagrees with `buildCommand` is the most common build failure
 there is — `civitai app validate` catches it before you submit.
 
+## The host handshake (`src/civitai-host.js`) — don't delete it
+
+This app declares a `page` surface, so the Civitai host mounts it full-viewport
+and **waits for it to say hello before revealing it**. That hello is a single
+`BLOCK_READY` message, and it is the only thing that flips the host into its
+ready state. An app that never sends it is replaced by a failure card once the
+host's bounded retries run out — even though the app itself works perfectly.
+
+`src/civitai-host.js` does exactly that and nothing else. `src/main.jsx`
+imports it first, for its side effect; leave both in place.
+
+Two details worth knowing, because they apply to every message you add later:
+
+- **Every block → host message is an envelope:** `{ type, payload }`. The host
+  reads `event.data.payload`, so fields put at the top level
+  (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
+- **Answer, don't announce.** The ack is sent in *response* to the host's
+  `BLOCK_INIT`, which is what supplies the host's real origin — so it is
+  addressed at that origin rather than broadcast to `'*'`.
+
+If you outgrow raw `postMessage`, `@civitai/blocks-react` covers all of this
+(and the rest of the protocol): its transport performs this same handshake
+internally, and `src/civitai-host.js` can then be deleted.
+
 ## Develop
 
 ```bash
 npm install
 npm run dev      # http://localhost:5173
 ```
+
+**There is no host behind `npm run dev`**, so nothing sends `BLOCK_INIT` and
+`src/civitai-host.js` stays silent — expected, not a bug. You are looking at
+your own UI; the handshake is exercised for real once the app runs on Civitai.
+(If you want to drive the protocol locally, the `page-money` template ships a
+mock host: `civitai app init "…" --template page-money`, then
+`npm run dev:harness`.)
 
 Build locally to sanity-check what the platform will produce:
 

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -35,12 +35,31 @@ Two details worth knowing, because they apply to every message you add later:
   reads `event.data.payload`, so fields put at the top level
   (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
 - **Answer, don't announce.** The ack is sent in *response* to the host's
-  `BLOCK_INIT`, which is what supplies the host's real origin — so it is
-  addressed at that origin rather than broadcast to `'*'`.
+  `BLOCK_INIT`, addressed at the origin that init arrived from rather than
+  broadcast to `'*'`.
+
+> 🔒 **Before you handle any message that carries data, add an origin
+> allowlist.** `src/civitai-host.js` answers `window.parent` — whoever framed
+> you. That is fine for the ack, which carries no data and discloses nothing a
+> framing page doesn't already know. It is *not* fine for a token, a viewer,
+> storage, or a generation result: check `event.origin` against origins you
+> trust first, or any page that frames your app can feed it anything. The
+> emitter deliberately ships no allowlist — the real list (production, preview
+> subdomains, dev tunnels) is platform state that moves without notice, and
+> `@civitai/blocks-react` already maintains it from
+> `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`. Adopt the SDK before you handle data.
 
 If you outgrow raw `postMessage`, `@civitai/blocks-react` covers all of this
 (and the rest of the protocol): its transport performs this same handshake
-internally, and `src/civitai-host.js` can then be deleted.
+internally.
+
+> ⚠️ **When you adopt the SDK, delete `src/civitai-host.js` in the SAME
+> change.** That is the one time removing it is correct, and running both is
+> worse than running neither. Whichever handshake answers the host's *first*
+> `BLOCK_INIT` cancels the host's retry loop **and** its readiness timeout, so
+> if this file wins the race the SDK's transport can be left never having seen
+> an init: it gives up after 10s while the host sits "ready", showing an app
+> that never started, with no retry and no error card.
 
 ## Develop
 

--- a/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
+++ b/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
@@ -1,24 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 // {{ .Name }} — Civitai App (vite + React page template).
 //
 // The host serves this bundle in a sandboxed iframe and communicates over
-// window.postMessage. The example below reports the document height to the
-// host so the iframe resizes. See the App SDK for the full protocol + scopes.
+// window.postMessage. Every block -> host message is an envelope:
+// `{ type: 'SOME_TYPE', payload: { … } }` — the host reads `event.data.payload`,
+// so fields put at the top level are dropped.
+//
+// The ONE message a page app must send is `BLOCK_READY`; without it the host
+// never reveals the app. `src/civitai-host.js` (imported by `src/main.jsx`)
+// already does that. See the App SDK for the rest of the protocol and scopes.
 export default function App() {
   const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    function reportHeight() {
-      window.parent.postMessage(
-        { type: 'RESIZE_IFRAME', height: document.documentElement.scrollHeight },
-        '*'
-      );
-    }
-    reportHeight();
-    window.addEventListener('resize', reportHeight);
-    return () => window.removeEventListener('resize', reportHeight);
-  });
 
   return (
     <main className="app">

--- a/internal/scaffold/templates/page-vite/src/main.jsx.tmpl
+++ b/internal/scaffold/templates/page-vite/src/main.jsx.tmpl
@@ -1,3 +1,8 @@
+// The host -> block readiness handshake. Imported FIRST, for its side effect,
+// and left alone: without it the Civitai host never reveals this app. See the
+// comments in civitai-host.js.
+import './civitai-host.js';
+
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';

--- a/internal/scaffold/templates/static/README.md.tmpl
+++ b/internal/scaffold/templates/static/README.md.tmpl
@@ -8,6 +8,26 @@ A sandboxed static web app served in an iframe by the Civitai host. The only
 mandatory file is `block.manifest.json`. There is no build step — the platform
 serves these files as-is.
 
+## The host handshake (`civitai-host.js`) — don't delete it
+
+This app declares a `page` surface, so the Civitai host mounts it full-viewport
+and **waits for it to say hello before revealing it**. That hello is a single
+`BLOCK_READY` message, and it is the only thing that flips the host into its
+ready state. An app that never sends it is replaced by a failure card once the
+host's bounded retries run out — even though the app itself works perfectly.
+
+`civitai-host.js` does exactly that and nothing else. `index.html` loads it
+before `app.js`; leave both in place.
+
+Two details worth knowing, because they apply to every message you add later:
+
+- **Every block → host message is an envelope:** `{ type, payload }`. The host
+  reads `event.data.payload`, so fields put at the top level
+  (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
+- **Answer, don't announce.** The ack is sent in *response* to the host's
+  `BLOCK_INIT`, which is what supplies the host's real origin — so it is
+  addressed at that origin rather than broadcast to `'*'`.
+
 ## Develop
 
 Open `index.html` in a browser, or serve the directory:
@@ -15,6 +35,10 @@ Open `index.html` in a browser, or serve the directory:
 ```bash
 python3 -m http.server 8080   # then open http://localhost:8080
 ```
+
+**There is no host locally**, so nothing sends `BLOCK_INIT` and
+`civitai-host.js` stays silent — expected, not a bug. You are looking at your
+own UI; the handshake is exercised for real once the app runs on Civitai.
 
 Edit `app.js` / `style.css` / `index.html`. Talk to the host via
 `window.postMessage` (see the App SDK docs for the message protocol and scopes).

--- a/internal/scaffold/templates/static/README.md.tmpl
+++ b/internal/scaffold/templates/static/README.md.tmpl
@@ -25,8 +25,27 @@ Two details worth knowing, because they apply to every message you add later:
   reads `event.data.payload`, so fields put at the top level
   (`{ type: 'X', height: 0 }`) arrive as `payload: undefined`.
 - **Answer, don't announce.** The ack is sent in *response* to the host's
-  `BLOCK_INIT`, which is what supplies the host's real origin — so it is
-  addressed at that origin rather than broadcast to `'*'`.
+  `BLOCK_INIT`, addressed at the origin that init arrived from rather than
+  broadcast to `'*'`.
+
+> 🔒 **Before you handle any message that carries data, add an origin
+> allowlist.** `civitai-host.js` answers `window.parent` — whoever framed you.
+> That is fine for the ack, which carries no data and discloses nothing a
+> framing page doesn't already know. It is *not* fine for a token, a viewer,
+> storage, or a generation result: check `event.origin` against origins you
+> trust first, or any page that frames your app can feed it anything. The
+> emitter deliberately ships no allowlist — the real list (production, preview
+> subdomains, dev tunnels) is platform state that moves without notice, and
+> `@civitai/blocks-react` already maintains it from
+> `VITE_BLOCK_ALLOWED_PARENT_ORIGINS`. Adopt the SDK before you handle data.
+
+> ⚠️ **The one time deleting this file is correct: when you adopt
+> `@civitai/blocks-react` — and then it must go in the SAME change.** Running
+> both is worse than running neither. Whichever handshake answers the host's
+> *first* `BLOCK_INIT` cancels the host's retry loop **and** its readiness
+> timeout, so if this file wins the race the SDK's transport can be left never
+> having seen an init: it gives up after 10s while the host sits "ready",
+> showing an app that never started, with no retry and no error card.
 
 ## Develop
 

--- a/internal/scaffold/templates/static/app.js.tmpl
+++ b/internal/scaffold/templates/static/app.js.tmpl
@@ -3,28 +3,26 @@
 // An app is a sandboxed static web app served in an iframe by the Civitai
 // host. The host owns the build and the runtime; this file is served as-is.
 //
-// The host and the app talk over window.postMessage. The minimal useful
-// thing an app can do is tell the host how tall it is so the iframe resizes.
-// See the App SDK for the full message protocol and the available scopes.
+// The host and the app talk over window.postMessage, and every block -> host
+// message is an envelope: `{ type: 'SOME_TYPE', payload: { … } }`. Fields put
+// at the top level are dropped — the host reads `event.data.payload`.
+//
+// The ONE message a page app must send is `BLOCK_READY`; without it the host
+// never reveals the app. That is already handled for you in `civitai-host.js`,
+// which `index.html` loads before this file. Don't duplicate it here.
+//
+// See the App SDK for the rest of the protocol and the available scopes.
 
 (function () {
   'use strict';
 
-  function reportHeight() {
-    var height = document.documentElement.scrollHeight;
-    // RESIZE_IFRAME is honoured when manifest iframe.resizable is true and the
-    // value is within [minHeight, maxHeight].
-    window.parent.postMessage(
-      { type: 'RESIZE_IFRAME', height: height },
-      '*'
-    );
-  }
-
   document.addEventListener('DOMContentLoaded', function () {
-    reportHeight();
     var btn = document.getElementById('ping');
-    if (btn) {
-      btn.addEventListener('click', reportHeight);
-    }
+    if (!btn) return;
+    var clicks = 0;
+    btn.addEventListener('click', function () {
+      clicks += 1;
+      btn.textContent = 'Clicked ' + clicks + (clicks === 1 ? ' time' : ' times');
+    });
   });
 })();

--- a/internal/scaffold/templates/static/index.html.tmpl
+++ b/internal/scaffold/templates/static/index.html.tmpl
@@ -11,8 +11,12 @@
     <main id="app">
       <h1>{{ .Name }}</h1>
       <p>This is a Civitai App (static template). Edit <code>app.js</code> to build your app.</p>
-      <button id="ping">Tell the host my height</button>
+      <button id="ping">Click me</button>
     </main>
+    <!-- The host -> block readiness handshake. Loaded FIRST and left alone:
+         without it the Civitai host never reveals this app. See the comments
+         in civitai-host.js. -->
+    <script src="./civitai-host.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/internal/scaffold/testdata/readyack/driver.mjs
+++ b/internal/scaffold/testdata/readyack/driver.mjs
@@ -1,0 +1,141 @@
+// Runtime driver for the scaffold ready-ack guard (Guard B).
+//
+// Loads a ready-ack emitter under a minimal `window` stub, plays the host's
+// side of the handshake at it, and prints what the emitter ACTUALLY did as
+// JSON on stdout. It asserts nothing — every verdict is made in Go
+// (internal/scaffold/ready_ack_runtime_test.go), so this file cannot decide it
+// is happy with itself.
+//
+// Usage: node driver.mjs <path-to-emitter.js>
+import { readFileSync } from 'node:fs';
+
+const emitterPath = process.argv[2];
+if (!emitterPath) {
+  console.error('usage: driver.mjs <path-to-emitter.js>');
+  process.exit(2);
+}
+
+export const HOST_ORIGIN = 'https://host.civitai.example';
+const FOREIGN_ORIGIN = 'https://not-the-host.example';
+
+/** Every outbound postMessage, in order. */
+const posted = [];
+/** Listener registrations, by event type, as the emitter made them. */
+const listeners = Object.create(null);
+
+const parentWindow = {
+  postMessage(message, targetOrigin) {
+    posted.push({ window: 'parent', message, targetOrigin });
+  },
+};
+
+// A window that is NOT the parent. If the emitter ever posts here, the source
+// check is not doing its job.
+const foreignWindow = {
+  postMessage(message, targetOrigin) {
+    posted.push({ window: 'foreign', message, targetOrigin });
+  },
+};
+
+const win = {
+  parent: parentWindow,
+  addEventListener(type, fn) {
+    (listeners[type] ??= []).push(fn);
+  },
+  removeEventListener(type, fn) {
+    const set = listeners[type];
+    if (!set) return;
+    const i = set.indexOf(fn);
+    if (i >= 0) set.splice(i, 1);
+  },
+  postMessage(message, targetOrigin) {
+    posted.push({ window: 'self', message, targetOrigin });
+  },
+};
+
+globalThis.window = win;
+// Enough DOM for an emitter that (wrongly) waits on the document to at least
+// load without throwing — a crash and an inert emitter must not look alike.
+globalThis.document = {
+  addEventListener(type, fn) {
+    (listeners[`document:${type}`] ??= []).push(fn);
+  },
+  removeEventListener() {},
+  getElementById: () => null,
+  documentElement: { scrollHeight: 1234 },
+  readyState: 'complete',
+};
+
+let loadError = null;
+try {
+  // Run the emitter the way a <script> tag does: bare global scope, with
+  // `window` resolving to the stub above.
+  new Function(readFileSync(emitterPath, 'utf8'))();
+} catch (err) {
+  loadError = String(err && err.stack ? err.stack : err);
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 25));
+
+function deliver(event) {
+  for (const fn of [...(listeners.message ?? [])]) fn(event);
+}
+
+const steps = [];
+async function step(label, event) {
+  if (event) deliver(event);
+  // The SDK's own transport queues the ack onto a microtask, so give an
+  // async emitter a chance to post before the count is read.
+  await flush();
+  steps.push({ label, posts: posted.length });
+}
+
+const init = (payload = {}) => ({ type: 'BLOCK_INIT', payload });
+
+await step('after-load', null);
+
+// NEGATIVE — an init-shaped message from a window that is not the parent.
+await step('after-foreign-source', {
+  source: foreignWindow,
+  origin: FOREIGN_ORIGIN,
+  data: init({ token: 'attacker' }),
+});
+
+// NEGATIVE — a real host message that is not BLOCK_INIT.
+await step('after-unrelated-type', {
+  source: parentWindow,
+  origin: HOST_ORIGIN,
+  data: { type: 'TOKEN_REFRESH', payload: { token: 'tok_rotated' } },
+});
+
+// THE HANDSHAKE.
+await step('after-first-init', {
+  source: parentWindow,
+  origin: HOST_ORIGIN,
+  data: init({ token: 'tok_abc', blockId: 'ready-block', viewer: { id: 42 } }),
+});
+
+// The host re-posts BLOCK_INIT on an interval until it observes BLOCK_READY,
+// and its inbound channel is rate-limited across all types — so a repeat must
+// be a complete no-op.
+await step('after-second-init', {
+  source: parentWindow,
+  origin: HOST_ORIGIN,
+  data: init({ token: 'tok_abc', blockId: 'ready-block', viewer: { id: 42 } }),
+});
+
+process.stdout.write(
+  JSON.stringify(
+    {
+      emitterPath,
+      loadError,
+      hostOrigin: HOST_ORIGIN,
+      windowMessageListeners: (listeners.message ?? []).length,
+      registeredTypes: Object.keys(listeners).sort(),
+      posted,
+      steps,
+    },
+    null,
+    2
+  ) + '\n'
+);

--- a/internal/scaffold/testdata/readyack/driver.mjs
+++ b/internal/scaffold/testdata/readyack/driver.mjs
@@ -6,25 +6,43 @@
 // (internal/scaffold/ready_ack_runtime_test.go), so this file cannot decide it
 // is happy with itself.
 //
-// Usage: node driver.mjs <path-to-emitter.js>
+// Usage: node driver.mjs <path-to-emitter.js> [--throw-first-post]
+//
+// `--throw-first-post` makes the FIRST outbound postMessage throw, the way a
+// browser does when `targetOrigin` cannot be parsed as a URL (MEASURED in
+// Chromium 1228: `postMessage(msg, 'null')` throws
+// `SyntaxError: Invalid target origin 'null'`, and `event.origin` is the string
+// "null" whenever the sender is itself at an opaque origin). An emitter that
+// latches its "already acked" flag BEFORE posting goes permanently silent in
+// that case; one that latches after can still answer the host's next retry.
 import { readFileSync } from 'node:fs';
 
 const emitterPath = process.argv[2];
 if (!emitterPath) {
-  console.error('usage: driver.mjs <path-to-emitter.js>');
+  console.error('usage: driver.mjs <path-to-emitter.js> [--throw-first-post]');
   process.exit(2);
 }
+const throwFirstPost = process.argv.includes('--throw-first-post');
 
 export const HOST_ORIGIN = 'https://host.civitai.example';
 const FOREIGN_ORIGIN = 'https://not-the-host.example';
 
 /** Every outbound postMessage, in order. */
 const posted = [];
+/** Posts that threw, in order — an attempt the emitter made and lost. */
+const threw = [];
 /** Listener registrations, by event type, as the emitter made them. */
 const listeners = Object.create(null);
 
 const parentWindow = {
   postMessage(message, targetOrigin) {
+    if (throwFirstPost && threw.length === 0) {
+      threw.push({ message, targetOrigin });
+      // Same constructor and shape a browser raises for an unparseable target.
+      throw new SyntaxError(
+        `Failed to execute 'postMessage' on 'Window': Invalid target origin '${targetOrigin}' in a call to 'postMessage'.`
+      );
+    }
     posted.push({ window: 'parent', message, targetOrigin });
   },
 };
@@ -77,8 +95,21 @@ try {
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 25));
 
+/** Exceptions thrown out of a listener, in order. */
+const listenerErrors = [];
+
 function deliver(event) {
-  for (const fn of [...(listeners.message ?? [])]) fn(event);
+  for (const fn of [...(listeners.message ?? [])]) {
+    // A browser isolates each listener invocation: an exception becomes an
+    // uncaught error and does NOT abort the other listeners or the page. Model
+    // that, or a throwing emitter would kill this driver instead of being
+    // observed.
+    try {
+      fn(event);
+    } catch (err) {
+      listenerErrors.push(String(err && err.message ? err.message : err));
+    }
+  }
 }
 
 const steps = [];
@@ -128,11 +159,14 @@ process.stdout.write(
   JSON.stringify(
     {
       emitterPath,
+      throwFirstPost,
       loadError,
       hostOrigin: HOST_ORIGIN,
       windowMessageListeners: (listeners.message ?? []).length,
       registeredTypes: Object.keys(listeners).sort(),
       posted,
+      threw,
+      listenerErrors,
       steps,
     },
     null,

--- a/internal/scaffold/testdata/readyack/inert-control.js
+++ b/internal/scaffold/testdata/readyack/inert-control.js
@@ -1,0 +1,12 @@
+// FIXTURE — deliberately INERT. Never shipped to an author.
+//
+// The runtime guard's second negative control: a file that loads cleanly and
+// does nothing. It proves the driver can distinguish "the emitter ran and said
+// nothing" from "the emitter ran and acked" — if this one is reported as a
+// successful handshake, the driver is wired to nothing and every green it
+// produces is meaningless.
+(function () {
+  'use strict';
+  var unused = 1;
+  return unused;
+})();

--- a/internal/scaffold/testdata/readyack/naive-control.js
+++ b/internal/scaffold/testdata/readyack/naive-control.js
@@ -1,0 +1,10 @@
+// FIXTURE — deliberately WRONG. Never shipped to an author.
+//
+// This is the runtime guard's NEGATIVE CONTROL: it is what a plausible-looking
+// hand-rolled ack gets wrong (top-level fields instead of the `{type,payload}`
+// envelope, a `'*'` target, no BLOCK_INIT gate, no dedupe). The Go assertions
+// are run against it and MUST report every one of those problems — otherwise
+// their silence on the real emitter says nothing.
+window.addEventListener('message', function () {
+  window.parent.postMessage({ type: 'BLOCK_READY', height: 0 }, '*');
+});


### PR DESCRIPTION
Temporary draft, opened only to watch `ci.yml`'s new `ready-ack-runtime` job FAIL on a pull request, then closed immediately.

The commit inverts `event.source !== window.parent` in the vendored emitter, making it completely inert. Measured locally: `go test ./...` is fully green with this mutation — it is invisible to every offline check. If `ready-ack-runtime` does not go red here, the gate added in #208 does not gate.

Evidence for #208. Closing as soon as the job reports.