### PR TITLE
fix(validate): tell existing page apps they never post BLOCK_READY (#206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,13 @@ jobs:
   # workflow nobody watches — running it per-PR puts the result in front of a
   # reviewer while the change is still open.
   #
-  # 🔴 NOTE: this REPORTS, it does not GATE. `main`'s required contexts are
-  # exactly `pins-vs-published` and `scaffold-currency` (no rulesets), so a red
-  # run here does not block a merge — `build-test` doesn't either. Adding this
-  # to the required contexts is the outstanding maintainer decision recorded in
-  # AGENTS.md item 11.
+  # 🔴 NOTE: this both reports AND gates. `main`'s required contexts are
+  # `pins-vs-published`, `scaffold-currency`, `build-test`, `ready-ack-runtime`
+  # and `template-page-vite` (no rulesets), so a red run here blocks the merge.
+  # That was a policy change made after this job landed — it did NOT gate when
+  # it shipped. Re-measure with
+  # `gh api repos/civitai/cli/branches/main/protection` before calling any job
+  # here a gate; see AGENTS.md item 11.
   #
   # -v so the run REPORTS its controls (an inert emitter and a naive ack are
   # driven through the same assertions and must be rejected) rather than just an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,9 @@ func newWhoAmICmd() *cobra.Command {
 
 Items 1–3, 10 and 11 are deliberate mirrors of the platform (items 4 and 8 are
 deliberate *non*-mirrors); items 5–9 cover `civitai app metrics`, the CLI's only
-analytics read path. The durable fix for the mirroring is a server-side
+analytics read path; item 12 covers the two checks that tell an author their
+EXISTING app is missing the item-11 handshake. The durable fix for the mirroring
+is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
 
@@ -501,6 +503,72 @@ neither one's.
       of one retry tick, and sending it would add a second vendored message for
       no correctness gain. If you reconsider, note the init-fragment fast path
       ships gated off and refuses `surface === 'dev-tunnel'` by construction.
+
+12. **The ready-ack checks for EXISTING apps are two deliberately different
+    tiers, and neither is allowed to be a hard failure.** #206 fixed the
+    templates; every app scaffolded before `4018e2c` is still broken and nothing
+    told its author. These close that gap, and the tier split is the whole
+    design:
+    - **`internal/antipattern`'s `resize-iframe-page` rule is a GATE** (it fails
+      the scaffold-currency job), because it fires on a *literal that is present
+      in the file* — no inference. It is the first non-REST entry in that
+      denylist: the package's original doctrine was "dead REST route behind a
+      host bridge", and this is a dead host MESSAGE, marked N/A for
+      `PageBlockHost` by `hostHandlerParity.ts`. It matches only a `'`/`"`-quoted
+      literal, deliberately NOT the backtick form, because this repo's README,
+      both scaffold READMEs and item 11 all name `RESIZE_IFRAME` in markdown
+      backticks precisely to tell authors not to post it — a gate that fails the
+      documentation of its own rule is a false positive. It also assumes a page
+      surface rather than reading a manifest: `Rule` is a per-line regex with no
+      manifest context, and every template this CLI ships declares `page`. A
+      non-page template would need that assumption revisited, not the rule
+      deleted.
+    - 🔴 **`validate`'s page-without-ack check is a WARNING and must stay one**
+      (`internal/validate/readyack.go`). It is the mirror image of item 3's
+      reasoning: `lockfile.go` earns hard-error status because the platform
+      *provably* fails (`npm ci` dies), whereas this infers RUNTIME behaviour
+      from STATIC TEXT and there are correct projects it cannot read — an ack
+      from a bundled dependency, a framework wrapper, a code-split chunk, an
+      extension the scan does not open. Hard-failing on a heuristic is the
+      false-warning-at-a-correct-project failure item 10 spent four measured
+      corrections avoiding, and `--strict` already lets anyone who wants a gate
+      have one.
+    - **The dependency is evidence, and it is checked FIRST.** For a project on
+      `@civitai/blocks-react` the ack comes from `IframeTransport` and the
+      literal `BLOCK_READY` NEVER appears in `src/` — measured on a rendered
+      `page-money` (zero occurrences outside `node_modules`). A source-only scan
+      therefore warns at every correct money-path app, which is the worst
+      outcome for advisory output. `sdkDependency` mirrors `civitaiSDKDeps` in
+      `ready_ack_contract_test.go` on purpose: the two answer the same question,
+      and disagreeing would mean the CLI warns at a shape its own scaffold guard
+      calls correct. `TestSDKTemplateIsQuietOnlyBecauseOfTheDependency` pins that
+      the dep gate is the ONLY reason page-money is accepted.
+    - **Comments are stripped, and that is load-bearing rather than tidy.** Both
+      SDK-free templates carry a source comment reading "The ONE message a page
+      app must send is `BLOCK_READY`", and it SURVIVES deleting
+      `civitai-host.js` — so without the strip the check is inert on the exact
+      population it was written for. Measured both ways. `.md` is excluded from
+      the scan for the same reason: a README describing the handshake is not an
+      implementation of it.
+    - 🔴 **Reading NOTHING is not finding nothing.** `emitsReadyAck` reports "no
+      finding" when it opened ZERO source files — a zero-hit scan over a
+      zero-file tree is indistinguishable from a scanner wired to nothing (a
+      broken extension table, an over-eager skip list, or `validate` pointed at a
+      directory holding a manifest and no checkout, which is the shape of every
+      manifest-only fixture in that package). This is not defensive padding: it
+      is what a manifest-only fixture in `warnings_test.go` failed on, and
+      removing it re-breaks that test.
+    - **Placement is a real constraint, not style.** `warningChecks` runs
+      unconditionally *including under `ManifestOnly`*, which `app init` uses to
+      self-check the template it just wrote. A check that reads `src/` must live
+      in the `projectState` branch beside `lockfileChecks`, or init's
+      self-validation starts reading files that are not its business.
+      `TestReadyAckSkippedByManifestOnly` pins it, with a `Dir()` positive
+      control so a green there cannot mean "the check never fires at all".
+    - **What it does NOT prove:** that the ack fires. Only that the message is
+      mentioned in code. The runtime proof is Guard B (item 11), and there is
+      none at all for an app the author already has — which is why this is
+      advisory and says so in its own message.
 
 **When you change a validation rule, keep both vendored mirrors (`schema/` + the
 ported Go checks in `internal/validate/`, including the slot registry) in sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,18 +504,18 @@ neither one's.
       thing that BUILDS an SDK-free template, and it asserts the ack survives
       bundling (Guard A pins the source tree; Vite output is what the platform
       serves).
-      🔴 **REPORTING IS NOT GATING — no ready-ack check currently blocks a
-      merge.** Measured, not assumed, via
+      🔴 **REPORTING VS GATING — measure it, never infer it from the job
+      existing.** These jobs now gate. Measured via
       `gh api repos/civitai/cli/branches/main/protection`: the required contexts
-      are exactly `pins-vs-published` and `scaffold-currency`, with no rulesets.
-      So `ready-ack-runtime`, `template-page-vite` and even `build-test` all
-      report and stop nothing. **Outstanding step:** adding `ready-ack-runtime`
-      (and arguably `build-test`) to the required contexts is what converts
-      reporting into gating. That is a repo-policy change touching every open
-      PR, so it is the maintainer's call and was deliberately not taken by the
-      agent that wrote this. Until it is, do not describe any of these jobs as a
-      gate — an earlier revision of this item, and of
-      `ready_ack_runtime_test.go`, claimed one "BLOCKS the merge". It was false.
+      are `pins-vs-published`, `scaffold-currency`, `build-test`,
+      `ready-ack-runtime` and `template-page-vite`, with no rulesets. That was a
+      deliberate repo-policy change made AFTER this item first shipped; until
+      then all of these reported and stopped nothing — including `build-test`,
+      so the suite itself did not gate. Re-measure before describing any job
+      here as a gate: an earlier revision of this item, and of
+      `ready_ack_runtime_test.go`, claimed one "BLOCKS the merge" while it did
+      not. That claim was false when written and is true now only because the
+      contexts were added — not because the job runs.
       If you add a template, add nothing — Guard A picks it up automatically and
       fails until `ReadyAckPath()` is set.
     - **`BLOCK_HELLO` now exists host-side, and the emitter deliberately does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,18 +511,26 @@ neither one's.
     design:
     - **`internal/antipattern`'s `resize-iframe-page` rule is a GATE** (it fails
       the scaffold-currency job), because it fires on a *literal that is present
-      in the file* — no inference. It is the first non-REST entry in that
-      denylist: the package's original doctrine was "dead REST route behind a
-      host bridge", and this is a dead host MESSAGE, marked N/A for
-      `PageBlockHost` by `hostHandlerParity.ts`. It matches only a `'`/`"`-quoted
-      literal, deliberately NOT the backtick form, because this repo's README,
-      both scaffold READMEs and item 11 all name `RESIZE_IFRAME` in markdown
-      backticks precisely to tell authors not to post it — a gate that fails the
-      documentation of its own rule is a false positive. It also assumes a page
-      surface rather than reading a manifest: `Rule` is a per-line regex with no
-      manifest context, and every template this CLI ships declares `page`. A
-      non-page template would need that assumption revisited, not the rule
-      deleted.
+      in the file* — no inference. It adds a THIRD family to that denylist: not a
+      dead REST route, and not a dead TOOL (`deprecated-blocks-cli` already
+      covered that one), but a dead host MESSAGE — marked N/A for
+      `PageBlockHost` by `hostHandlerParity.ts`.
+      🔴 **A message NAME needs tighter scoping than a route or a package name,
+      because it is far more quotable, and both devices were earned by a false
+      positive.** `Exts: codeExts` keeps it out of `.md`/`.txt`/`.json`, where
+      naming the message in a sentence or using it as a JSON handler-table key is
+      ordinary writing — unscoped, the rule flagged its own documentation, and
+      this repo's README plus both scaffold READMEs exist to say "don't post
+      RESIZE_IFRAME". And it matches only a MATCHING `'` or `"` pair —
+      deliberately not the backtick form (markdown), and not a mismatched pair,
+      which is not a string literal in any language. `What` reads "reference to",
+      not "postMessage of": the regex matches the quoted token anywhere in code
+      (a dispatch-table key, a comparison, a constant — all equally dead on a
+      page surface), and saying "postMessage" would be a claim the pattern does
+      not make. It also assumes a page surface rather than reading a manifest:
+      `Rule` is a per-line regex with no manifest context, and every template this
+      CLI ships declares `page`. A non-page template would need that assumption
+      revisited, not the rule deleted.
     - 🔴 **`validate`'s page-without-ack check is a WARNING and must stay one**
       (`internal/validate/readyack.go`). It is the mirror image of item 3's
       reasoning: `lockfile.go` earns hard-error status because the platform
@@ -533,16 +541,32 @@ neither one's.
       false-warning-at-a-correct-project failure item 10 spent four measured
       corrections avoiding, and `--strict` already lets anyone who wants a gate
       have one.
-    - **The dependency is evidence, and it is checked FIRST.** For a project on
-      `@civitai/blocks-react` the ack comes from `IframeTransport` and the
-      literal `BLOCK_READY` NEVER appears in `src/` — measured on a rendered
-      `page-money` (zero occurrences outside `node_modules`). A source-only scan
-      therefore warns at every correct money-path app, which is the worst
-      outcome for advisory output. `sdkDependency` mirrors `civitaiSDKDeps` in
-      `ready_ack_contract_test.go` on purpose: the two answer the same question,
-      and disagreeing would mean the CLI warns at a shape its own scaffold guard
-      calls correct. `TestSDKTemplateIsQuietOnlyBecauseOfTheDependency` pins that
-      the dep gate is the ONLY reason page-money is accepted.
+    - 🔴 **The evidence is an EXACT SET OF PACKAGES THAT ACK — never the
+      `@civitai/` scope.** This is the claim an audit falsified, so it is stated
+      with its measurement. Of the six published first-party packages, exactly
+      ONE acks: `@civitai/blocks-react@0.39.0`
+      (`dist/internal/iframeTransport.js:311`, `this.dispatch('BLOCK_READY', …)`).
+      `@civitai/app-sdk@0.31.0` does **not** — 17 runtime `.js` files, zero
+      containing the literal, the only hits a `.d.ts` type and the README, and it
+      declares no dependencies so it cannot ack transitively either.
+      `@civitai/theme`, `@civitai/components`, `@civitai/components-react` and
+      `@civitai/cli` contain none at all. A scope test is therefore wrong for
+      FOUR of six, and wrong in the expensive direction: `theme` and `components`
+      are framework-agnostic CSS, exactly what a hand-written no-build page app
+      installs, so the check went **silent on a genuinely broken app** — verified
+      live by adding `@civitai/theme` to a `static` scaffold with
+      `civitai-host.js` deleted.
+      The predicate lives in `blockproto.PackageAcksReady` with the per-package
+      evidence, and is used by BOTH `internal/validate/readyack.go` and
+      `civitaiSDKDeps` in `ready_ack_contract_test.go` — one rule, one place,
+      because Guard A had the identical hole (a future template depending on
+      `@civitai/theme` would have been classified SDK-backed and excused from
+      shipping an emitter: a born-broken template passing its own guard). The
+      match is EXACT; a prefix or substring test accepts a sibling
+      (`@civitai/blocks-react-native`) or a fork, and that widening class is what
+      `TestAckingPackagePredicate` exists to pin. Adding a package there is a
+      claim about its RUNTIME code — verify against the tarball, not the README
+      or the types, and record the version.
     - **Comments are stripped, and that is load-bearing rather than tidy.** Both
       SDK-free templates carry a source comment reading "The ONE message a page
       app must send is `BLOCK_READY`", and it SURVIVES deleting
@@ -550,14 +574,47 @@ neither one's.
       population it was written for. Measured both ways. `.md` is excluded from
       the scan for the same reason: a README describing the handshake is not an
       implementation of it.
-    - 🔴 **Reading NOTHING is not finding nothing.** `emitsReadyAck` reports "no
-      finding" when it opened ZERO source files — a zero-hit scan over a
-      zero-file tree is indistinguishable from a scanner wired to nothing (a
-      broken extension table, an over-eager skip list, or `validate` pointed at a
-      directory holding a manifest and no checkout, which is the shape of every
-      manifest-only fixture in that package). This is not defensive padding: it
-      is what a manifest-only fixture in `warnings_test.go` failed on, and
-      removing it re-breaks that test.
+      🔴 **HTML comment stripping is gated to MARKUP extensions, and an
+      unterminated `<!--` keeps the rest of the file.** `stripHTMLComments` has no
+      string awareness, so running it over `.js` made an ordinary
+      `var OPEN = '<!--';` in a sanitiser open a "comment" that ran to EOF and
+      deleted the emitter below it — a false warning at a correct project,
+      reproduced live. Neither half is optional: the gate stops the common
+      string case, the non-lossy tail stops the rest.
+    - 🔴 **Reading NOTHING is not finding nothing, and neither is reading only
+      PART.** `scanForReadyAck` is three-valued on purpose — found / absent /
+      unobservable — and only `absent` warns. Unobservable covers zero source
+      files read (a zero-hit scan over a zero-file tree is indistinguishable from
+      a scanner wired to nothing, and is the shape of every manifest-only fixture
+      in that package — a `warnings_test.go` fixture failed on exactly this), an
+      unresolvable symlink, a read error, a file over the size cap, and the
+      file-count budget. A partial scan reporting "absent" is manufacturing
+      advice from a gap.
+    - 🔴 **SKIPPING IS A COST DECISION, NEVER A CORRECTNESS ONE**, because this is
+      a PRESENCE check: scanning an extra directory can only ADD evidence, while
+      skipping one can only CREATE a false warning. That asymmetry is why the
+      manifest's `outputDir` is NOT skipped — it was, and a perfectly valid
+      `"outputDir": "src"` on a page-vite app skipped the directory holding the
+      emitter and warned at a project with zero validation errors, while
+      `"outputDir": "."` skipped the entire tree and silenced a broken one. What
+      remains is a fixed list of names that are never source, applied to
+      ENTRIES only so no rule can ever remove the root. `vendor` and `public` are
+      deliberately absent — both routinely hold hand-written source. The residual
+      trade is stated rather than hidden: a stale committed build under a
+      non-conventional output directory can retain an ack the source lost. That
+      is a false negative, which is the cheap direction here.
+    - 🔴 **Directory symlinks are FOLLOWED.** `filepath.WalkDir` does not follow
+      them and does not even report them as directories, so a monorepo whose
+      `src` is a symlink into a shared package had its entire source tree skipped
+      and warned at a correct project — reproduced live. Cycles are bounded by a
+      visited set keyed on the `EvalSymlinks`-resolved path, and total work by
+      the file-count and file-size caps (`validate` used to be a manifest-only
+      read; before the caps, 20,008 files with one 88 MB `.js` peaked at 316 MB
+      RSS).
+    - **The advisory is printed by `app submit` too.** It used to branch only on
+      `res.OK()` and drop warnings, so the highest-traffic path — the last point
+      before an app reaches review — told nobody. It prints and does NOT block;
+      blocking stays the `--strict` contract.
     - **Placement is a real constraint, not style.** `warningChecks` runs
       unconditionally *including under `ManifestOnly`*, which `app init` uses to
       self-check the template it just wrote. A check that reads `src/` must live

--- a/README.md
+++ b/README.md
@@ -282,9 +282,11 @@ Two rules it encodes, which apply to every message you add afterwards:
 page block full-viewport, so it does not size to content and ignores the
 message. (`useBlockResize` is surface-agnostic and page-money still calls it —
 on a page surface it is simply a no-op, which is why the SDK templates can share
-component code across surfaces.) A **raw** `postMessage` of `RESIZE_IFRAME` is
-flagged by the scaffold-currency gate as dead code — the pre-#206 templates
-demoed it, so a project scaffolded before that fix still carries it.
+component code across surfaces.) The pre-#206 templates demoed a **raw**
+`postMessage` of `RESIZE_IFRAME`, so a project scaffolded before that fix still
+carries dead code you can delete. (This CLI's own CI fails if a shipped template
+ever reintroduces it; there is no author-facing command that scans your project
+for it — `civitai app validate` checks the manifest and the handshake, not this.)
 
 ### Local dev loop (harness: mock vs live)
 
@@ -630,21 +632,39 @@ says so. That is the shape of an app scaffolded before the templates were fixed
 a failure card in the real host. It is a **warning, never an error**: unlike the
 lockfile rule (where the platform build provably dies), this one infers
 *runtime* behaviour from *static text* and can be wrong, so it must not fail a
-correct project. Two things follow:
+correct project. Three things follow:
 
-- **An `@civitai/*` dependency ends the check.** `@civitai/blocks-react`'s
-  transport acks internally and the literal never appears in your `src/`, so a
-  `page-money` app is never flagged.
-- **It reads source only** — never `outputDir` (not built yet, and gitignored),
-  never `node_modules`, and never a `.md` file: a README *describing* the
-  handshake is not an implementation of it. Comments are stripped too, so a
-  comment naming `BLOCK_READY` does not satisfy it.
+- **A dependency that acks ends the check** — today that is
+  `@civitai/blocks-react`, and nothing else. Its iframe transport acks internally
+  and the literal never appears in your `src/`, so a `page-money` app is never
+  flagged. This is an *exact* list, not the `@civitai/` scope:
+  `@civitai/app-sdk` is the server-side SDK and no runtime code in it posts
+  `BLOCK_READY`, and `@civitai/theme` / `@civitai/components` are CSS. Depending
+  on those does not give you the handshake, so it does not silence the check
+  either.
+- **It reads source only** — never `node_modules`, never the conventional build
+  directories (`dist`, `build`, `out`, …), and never a `.md` file: a README
+  *describing* the handshake is not an implementation of it. Comments are
+  stripped too, so a comment naming `BLOCK_READY` does not satisfy it. A `src`
+  that is a **symlink** into a shared package *is* followed.
+- **It stays quiet when it cannot see the whole project.** An unreadable file, a
+  file over 2 MiB, a very large tree, or a directory holding only a manifest all
+  mean "we could not look" — reported as nothing, never as a finding.
 
 If it fires on a project you know is correct — your ack arrives from a bundled
 dependency, or from a file type this scan doesn't open — it is a false alarm, and
 it never blocks (exit 0) unless you pass `--strict`. What it proves is narrow:
 that the message is *mentioned* in code. It cannot prove the ack ever **fires**;
 only the real host can.
+
+`civitai app submit` prints the same warnings before it uploads, and likewise
+does not block on them.
+
+> ⚠️ **If you already run `civitai app validate --strict` in CI**, this advisory
+> is new and can turn a previously-green project red — which is what `--strict`
+> asks for. If it is a false alarm for your project, drop `--strict` or add the
+> ack, and please open an issue: a warning at a correct project is a bug in the
+> check, not something you should have to work around.
 
 The **durable fix** is a server-side `civitai app validate` endpoint that calls
 the real `BlockManifestValidator` (the faithful contract), with this schema

--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ Two rules it encodes, which apply to every message you add afterwards:
 page block full-viewport, so it does not size to content and ignores the
 message. (`useBlockResize` is surface-agnostic and page-money still calls it —
 on a page surface it is simply a no-op, which is why the SDK templates can share
-component code across surfaces.)
+component code across surfaces.) A **raw** `postMessage` of `RESIZE_IFRAME` is
+flagged by the scaffold-currency gate as dead code — the pre-#206 templates
+demoed it, so a project scaffolded before that fix still carries it.
 
 ### Local dev loop (harness: mock vs live)
 
@@ -619,6 +621,30 @@ fallback — so `"buildCommand": "pnpm run build"` needs `pnpm-lock.yaml`,
 mismatch or a missing lockfile is a hard `validate` error; an *extra* unused
 lockfile is a warning. Apps with no `package.json` are static — the platform
 never installs for them and they are never flagged.
+
+Finally it emits one **advisory** about the
+[host handshake](#the-host-handshake-block_ready): if your manifest declares a
+`page` surface and **nothing in your source posts `BLOCK_READY`**, `validate`
+says so. That is the shape of an app scaffolded before the templates were fixed
+(#206) — it renders perfectly everywhere you can look locally and is replaced by
+a failure card in the real host. It is a **warning, never an error**: unlike the
+lockfile rule (where the platform build provably dies), this one infers
+*runtime* behaviour from *static text* and can be wrong, so it must not fail a
+correct project. Two things follow:
+
+- **An `@civitai/*` dependency ends the check.** `@civitai/blocks-react`'s
+  transport acks internally and the literal never appears in your `src/`, so a
+  `page-money` app is never flagged.
+- **It reads source only** — never `outputDir` (not built yet, and gitignored),
+  never `node_modules`, and never a `.md` file: a README *describing* the
+  handshake is not an implementation of it. Comments are stripped too, so a
+  comment naming `BLOCK_READY` does not satisfy it.
+
+If it fires on a project you know is correct — your ack arrives from a bundled
+dependency, or from a file type this scan doesn't open — it is a false alarm, and
+it never blocks (exit 0) unless you pass `--strict`. What it proves is narrow:
+that the message is *mentioned* in code. It cannot prove the ack ever **fires**;
+only the real host can.
 
 The **durable fix** is a server-side `civitai app validate` endpoint that calls
 the real `BlockManifestValidator` (the faithful contract), with this schema

--- a/internal/antipattern/antipattern.go
+++ b/internal/antipattern/antipattern.go
@@ -39,11 +39,13 @@
 // deliberately absent from the denylist. We only flag routes that are REMOVED or
 // whose bridge has fully superseded the REST shape (buzz, shared-storage).
 //
-// A SECOND FAMILY: DEAD HOST MESSAGES. The denylist is not only about REST. The
-// same "compiles, installs, ships an app that is broken or inert" failure has a
-// postMessage shape: a block -> host message type the page host does not handle.
-// `RESIZE_IFRAME` is the first of those (see the rule below) — the raw page
-// templates demoed it until #206, and on a `page` surface the host marks it N/A.
+// THE DENYLIST IS NOT ONLY ABOUT REST. It already covered a dead TOOL
+// (`@civitai/blocks-cli`, a retired npm package). `RESIZE_IFRAME` adds a third
+// family — a dead HOST MESSAGE: a block -> host message type the page host does
+// not handle, so the code compiles, installs, ships, and does nothing. The raw
+// page templates demoed it until #206, and on a `page` surface the host marks it
+// N/A. Message-name rules need tighter scoping than route or package rules; see
+// `Rule.Exts`.
 package antipattern
 
 import (
@@ -69,7 +71,26 @@ type Rule struct {
 	Pattern *regexp.Regexp
 	// Replacement is the concrete thing to use instead (a hook / the Go CLI).
 	Replacement string
+	// Exts, when non-nil, restricts this rule to those file extensions
+	// (lowercase, dotted). Nil means every extension in scannedExts.
+	//
+	// It exists because the default corpus deliberately includes prose and data
+	// (.md, .txt, .json) so a documented dead workflow or a dead pin is caught —
+	// right for a rule matching a PACKAGE NAME or a URL, wrong for one matching
+	// a MESSAGE NAME, where quoting the token in a sentence, or using it as a
+	// JSON key in a handler table, is ordinary writing rather than a call.
+	Exts map[string]bool
 }
+
+// codeExts is the Exts value for rules that must only fire on executable code.
+var codeExts = map[string]bool{
+	".ts": true, ".tsx": true, ".js": true, ".jsx": true,
+	".mjs": true, ".cjs": true, ".html": true, ".htm": true,
+}
+
+// appliesTo reports whether the rule is evaluated against a file with the given
+// lowercased, dotted extension.
+func (r Rule) appliesTo(ext string) bool { return r.Exts == nil || r.Exts[ext] }
 
 // Rules is the curated denylist. Keep it SMALL and PRECISE — every entry must be
 // a surface the platform has REMOVED or fully superseded with a host bridge, and
@@ -130,14 +151,26 @@ func Rules() []Rule {
 			// template ever ships, this rule needs manifest awareness, because
 			// RESIZE_IFRAME is honoured on the surfaces that DO size to content.
 			//
-			// The pattern requires a MATCHING ' or " pair, deliberately excluding
-			// the backtick form. Prose discusses this message by name in markdown
-			// backticks — our own scaffold READMEs will say "don't post
-			// RESIZE_IFRAME" — and flagging the doc that tells an author not to
-			// use it is a false positive at a correct project. A JS template
-			// literal for a constant message type is the (vanishingly rare) cost.
+			// TWO precision devices, because a message NAME is a far more
+			// quotable token than a route or a package name:
+			//   1. `Exts: codeExts` — prose and data are not calls. Double-quoting
+			//      a message name in a sentence is ordinary English, and a JSON
+			//      handler table `{"RESIZE_IFRAME": …}` is a data structure, not
+			//      a post. Without this the rule fails a README that says "do not
+			//      post RESIZE_IFRAME".
+			//   2. A MATCHING ' or " pair, deliberately excluding the backtick
+			//      form — markdown backticks are how our own docs name it, and a
+			//      mismatched pair (`'RESIZE_IFRAME"`) is not a JS string literal
+			//      at all. A JS template literal holding a constant message type
+			//      is the (vanishingly rare) cost of excluding backticks.
+			// `What` says "reference to", not "postMessage of": the pattern
+			// matches the quoted token wherever it appears in code — a dispatch
+			// table key, a comparison, a constant — and all of those are dead on
+			// a page surface. Claiming it matched a postMessage call would be a
+			// claim the regex does not make.
 			ID:          "resize-iframe-page",
-			What:        "postMessage of RESIZE_IFRAME, which the page host does not handle",
+			What:        "reference to RESIZE_IFRAME, a message the page host does not handle",
+			Exts:        codeExts,
 			Pattern:     regexp.MustCompile(`'RESIZE_IFRAME'|"RESIZE_IFRAME"`),
 			Replacement: "delete it — hostHandlerParity.ts marks RESIZE_IFRAME N/A for PageBlockHost (a page block fills the host surface and does NOT size to content), so the message is dead code. The one message a page app must send is BLOCK_READY: keep the vendored civitai-host.js emitter `civitai app init` ships, or adopt @civitai/blocks-react (whose transport acks internally) — never both",
 		},
@@ -195,8 +228,12 @@ func ScanDir(dir string) ([]Finding, error) {
 		if readErr != nil {
 			return readErr
 		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
 		for i, line := range strings.Split(string(data), "\n") {
 			for _, r := range rules {
+				if !r.appliesTo(ext) {
+					continue
+				}
 				if r.Pattern.MatchString(line) {
 					findings = append(findings, Finding{
 						File: rel,

--- a/internal/antipattern/antipattern.go
+++ b/internal/antipattern/antipattern.go
@@ -38,6 +38,12 @@
 // Flagging any of those would false-fail a correct scaffold, so they are
 // deliberately absent from the denylist. We only flag routes that are REMOVED or
 // whose bridge has fully superseded the REST shape (buzz, shared-storage).
+//
+// A SECOND FAMILY: DEAD HOST MESSAGES. The denylist is not only about REST. The
+// same "compiles, installs, ships an app that is broken or inert" failure has a
+// postMessage shape: a block -> host message type the page host does not handle.
+// `RESIZE_IFRAME` is the first of those (see the rule below) — the raw page
+// templates demoed it until #206, and on a `page` surface the host marks it N/A.
 package antipattern
 
 import (
@@ -104,6 +110,36 @@ func Rules() []Rule {
 			What:        "reference to the deprecated @civitai/blocks-cli npm package",
 			Pattern:     regexp.MustCompile("@civitai/blocks-cli(?:[@/'\"\\x60\\s),;]|$)"),
 			Replacement: "use the Go civitai CLI (`civitai app <init|submit>`); the @civitai/blocks-cli npm package is deprecated",
+		},
+		{
+			// DEAD MESSAGE (not a route). `hostHandlerParity.ts` marks
+			// RESIZE_IFRAME **N/A for PageBlockHost** — "a page block fills the
+			// surface and does NOT size to content" — so a page app that posts it
+			// is posting into a handler that does not exist. It is inert rather
+			// than broken, which is exactly why it survives every local check and
+			// teaches the next message the author writes to look like this one.
+			// Both raw page templates demoed it until #206 removed them; anything
+			// scaffolded before that still carries it.
+			//
+			// SCOPE (read before widening): this package scans SCAFFOLDED APP
+			// TREES, and every template this CLI ships declares a `page` surface
+			// (scaffold.Template.ReadyAckPath's doc, and the manifest evidence in
+			// ready_ack_contract_test.go). The rule therefore assumes a page
+			// surface rather than reading the manifest — Rule is a per-line regex
+			// with no manifest context by construction. If a non-page (model-slot)
+			// template ever ships, this rule needs manifest awareness, because
+			// RESIZE_IFRAME is honoured on the surfaces that DO size to content.
+			//
+			// The pattern requires a MATCHING ' or " pair, deliberately excluding
+			// the backtick form. Prose discusses this message by name in markdown
+			// backticks — our own scaffold READMEs will say "don't post
+			// RESIZE_IFRAME" — and flagging the doc that tells an author not to
+			// use it is a false positive at a correct project. A JS template
+			// literal for a constant message type is the (vanishingly rare) cost.
+			ID:          "resize-iframe-page",
+			What:        "postMessage of RESIZE_IFRAME, which the page host does not handle",
+			Pattern:     regexp.MustCompile(`'RESIZE_IFRAME'|"RESIZE_IFRAME"`),
+			Replacement: "delete it — hostHandlerParity.ts marks RESIZE_IFRAME N/A for PageBlockHost (a page block fills the host surface and does NOT size to content), so the message is dead code. The one message a page app must send is BLOCK_READY: keep the vendored civitai-host.js emitter `civitai app init` ships, or adopt @civitai/blocks-react (whose transport acks internally) — never both",
 		},
 	}
 }

--- a/internal/antipattern/antipattern_test.go
+++ b/internal/antipattern/antipattern_test.go
@@ -53,6 +53,22 @@ func TestScanDir(t *testing.T) {
 			wantFile:  "README.md",
 			wantInMsg: "civitai app",
 		},
+		{
+			// The pre-#206 page template shape: an app that sizes itself to
+			// content on a surface that does not size to content.
+			name:      "RESIZE_IFRAME posted from a page app fails",
+			dir:       "resize-iframe",
+			wantRule:  "resize-iframe-page",
+			wantFile:  "App.jsx",
+			wantInMsg: "BLOCK_READY",
+		},
+		{
+			// The false-positive direction, which matters more: docs that TELL an
+			// author not to post RESIZE_IFRAME must not be flagged for saying so,
+			// and neither must an app whose only host message is the ready ack.
+			name: "docs naming RESIZE_IFRAME in backticks are not flagged",
+			dir:  "resize-iframe-doc",
+		},
 	}
 
 	for _, tt := range tests {
@@ -151,6 +167,47 @@ func TestBlocksCliBoundary(t *testing.T) {
 		{`import x from '@civitai/blocks-client';`, false},
 		{`"@civitai/blocks-client": "^1.0.0"`, false},
 		{`@civitai/blocks-client-utils`, false},
+	}
+	for _, c := range cases {
+		if got := rule.Pattern.MatchString(c.line); got != c.want {
+			t.Errorf("match(%q) = %v, want %v (pattern %s)", c.line, got, c.want, rule.Pattern)
+		}
+	}
+}
+
+// TestResizeIframeBoundary is the resize-iframe-page rule's control pair. The
+// rule exists to catch a DEAD HOST MESSAGE, and the population it must never
+// touch is prose: this repo's own README and both scaffold READMEs discuss
+// `RESIZE_IFRAME` by name precisely to tell authors not to post it, and a gate
+// that fails the documentation of its own rule is a false positive at a correct
+// project.
+func TestResizeIframeBoundary(t *testing.T) {
+	var rule Rule
+	for _, r := range Rules() {
+		if r.ID == "resize-iframe-page" {
+			rule = r
+		}
+	}
+	if rule.Pattern == nil {
+		t.Fatal("resize-iframe-page rule not found")
+	}
+
+	cases := []struct {
+		line string
+		want bool
+	}{
+		// The real emitting shapes, single- and double-quoted.
+		{`window.parent.postMessage({ type: 'RESIZE_IFRAME', height: h }, '*');`, true},
+		{`window.parent.postMessage({ type: "RESIZE_IFRAME", height: h }, "*");`, true},
+		{`if (msg.type === 'RESIZE_IFRAME') return;`, true},
+		{`const RESIZE = 'RESIZE_IFRAME';`, true},
+		// Prose — the direction that must stay silent.
+		{"`RESIZE_IFRAME` is **not** part of a page app's protocol.", false},
+		{"Do not post RESIZE_IFRAME from a page app.", false},
+		{`// RESIZE_IFRAME is N/A for PageBlockHost — do not send it.`, false},
+		// Neighbouring identifiers must not be dragged in.
+		{`useBlockResize();`, false},
+		{`"description": "Whether the host honours RESIZE_IFRAME messages."`, false},
 	}
 	for _, c := range cases {
 		if got := rule.Pattern.MatchString(c.line); got != c.want {

--- a/internal/antipattern/antipattern_test.go
+++ b/internal/antipattern/antipattern_test.go
@@ -63,10 +63,13 @@ func TestScanDir(t *testing.T) {
 			wantInMsg: "BLOCK_READY",
 		},
 		{
-			// The false-positive direction, which matters more: docs that TELL an
-			// author not to post RESIZE_IFRAME must not be flagged for saying so,
-			// and neither must an app whose only host message is the ready ack.
-			name: "docs naming RESIZE_IFRAME in backticks are not flagged",
+			// The false-positive direction, which matters more. This fixture
+			// carries the message name in every NON-CODE shape at once: markdown
+			// backticks in a README, prose with straight DOUBLE quotes in a .txt,
+			// and a double-quoted JSON key in a handler table. None of them is a
+			// call — the first is literally documentation telling the author not
+			// to post it — and flagging any one fails a correct project.
+			name: "RESIZE_IFRAME named in docs, prose and JSON data is not flagged",
 			dir:  "resize-iframe-doc",
 		},
 	}
@@ -107,6 +110,10 @@ func TestScanDir(t *testing.T) {
 			}
 			if hit.Rule.Replacement == "" {
 				t.Errorf("finding rule %q has an empty Replacement — the message must tell the author what to use instead", hit.Rule.ID)
+			}
+			if strings.TrimSpace(hit.Rule.What) == "" {
+				t.Errorf("finding rule %q has an empty What — the report would name the file and the fix "+
+					"but never say what was wrong", hit.Rule.ID)
 			}
 			// The formatted report must name the file, the pattern, and the fix.
 			msg := Format(findings)
@@ -205,6 +212,11 @@ func TestResizeIframeBoundary(t *testing.T) {
 		{"`RESIZE_IFRAME` is **not** part of a page app's protocol.", false},
 		{"Do not post RESIZE_IFRAME from a page app.", false},
 		{`// RESIZE_IFRAME is N/A for PageBlockHost — do not send it.`, false},
+		// MISMATCHED quote pairs are not string literals in any language. This
+		// pins the "matching pair" claim: a relaxed `['"]RESIZE_IFRAME['"]`
+		// accepts both of these and passes every other case above.
+		{`var x = 'RESIZE_IFRAME";`, false},
+		{`var x = "RESIZE_IFRAME';`, false},
 		// Neighbouring identifiers must not be dragged in.
 		{`useBlockResize();`, false},
 		{`"description": "Whether the host honours RESIZE_IFRAME messages."`, false},
@@ -213,6 +225,46 @@ func TestResizeIframeBoundary(t *testing.T) {
 		if got := rule.Pattern.MatchString(c.line); got != c.want {
 			t.Errorf("match(%q) = %v, want %v (pattern %s)", c.line, got, c.want, rule.Pattern)
 		}
+	}
+
+	// The rule must be scoped to CODE. Without Exts it fires on prose and on a
+	// JSON handler table, which is how it came to flag its own documentation.
+	if rule.Exts == nil {
+		t.Fatal("the resize-iframe-page rule has no Exts — a message NAME is quotable in prose and " +
+			"usable as a JSON key, so an unscoped rule fails a correct project's README")
+	}
+	for _, ext := range []string{".md", ".txt", ".json", ".css"} {
+		if rule.appliesTo(ext) {
+			t.Errorf("the rule applies to %s — that corpus is prose/data, not calls", ext)
+		}
+	}
+	// Positive control on the same predicate: it must still reach real code, or
+	// "does not apply to .md" is satisfied by a rule that applies to nothing.
+	for _, ext := range []string{".js", ".jsx", ".ts", ".tsx", ".html"} {
+		if !rule.appliesTo(ext) {
+			t.Errorf("the rule does NOT apply to %s — that is where the dead post lives", ext)
+		}
+	}
+}
+
+// TestRuleExtScopeDefaultsToEverything pins that adding Exts to one rule did not
+// silently narrow the others: a nil Exts must still mean "the whole corpus", or
+// the package-name and route rules stop catching a documented dead workflow.
+func TestRuleExtScopeDefaultsToEverything(t *testing.T) {
+	unscoped := 0
+	for _, r := range Rules() {
+		if r.Exts != nil {
+			continue
+		}
+		unscoped++
+		for _, ext := range []string{".md", ".txt", ".json", ".js", ".html"} {
+			if !r.appliesTo(ext) {
+				t.Errorf("rule %q has no Exts but does not apply to %s — nil must mean every extension", r.ID, ext)
+			}
+		}
+	}
+	if unscoped == 0 {
+		t.Fatal("no rule is unscoped — this control observed nothing")
 	}
 }
 

--- a/internal/antipattern/testdata/resize-iframe-doc/NOTES.txt
+++ b/internal/antipattern/testdata/resize-iframe-doc/NOTES.txt
@@ -1,0 +1,4 @@
+Migration notes.
+
+The host used to accept a "RESIZE_IFRAME" message from blocks that sized
+themselves to content. On a page surface it is N/A, so we removed ours.

--- a/internal/antipattern/testdata/resize-iframe-doc/README.md
+++ b/internal/antipattern/testdata/resize-iframe-doc/README.md
@@ -1,0 +1,7 @@
+# Sample Block
+
+`RESIZE_IFRAME` is **not** part of a page app's protocol: the host renders a
+page block full-viewport, so it does not size to content and ignores the
+message. Do not post RESIZE_IFRAME from a page app.
+
+The one message a page app must send is `BLOCK_READY`.

--- a/internal/antipattern/testdata/resize-iframe-doc/civitai-host.js
+++ b/internal/antipattern/testdata/resize-iframe-doc/civitai-host.js
@@ -1,0 +1,11 @@
+// The ready-ack emitter. It answers BLOCK_INIT with BLOCK_READY and never
+// posts RESIZE_IFRAME.
+window.addEventListener('message', function (event) {
+  if (event.source !== window.parent) return;
+  var data = event.data;
+  if (!data || data.type !== 'BLOCK_INIT') return;
+  window.parent.postMessage(
+    { type: 'BLOCK_READY', payload: { height: 0 } },
+    event.origin
+  );
+});

--- a/internal/antipattern/testdata/resize-iframe-doc/handlers.json
+++ b/internal/antipattern/testdata/resize-iframe-doc/handlers.json
@@ -1,0 +1,7 @@
+{
+  "comment": "A handler table naming the message as a KEY. Data, not a call.",
+  "handlers": {
+    "RESIZE_IFRAME": "ignored-on-page-surfaces",
+    "BLOCK_READY": "the one message a page app must send"
+  }
+}

--- a/internal/antipattern/testdata/resize-iframe/src/App.jsx
+++ b/internal/antipattern/testdata/resize-iframe/src/App.jsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+// A page app that sizes itself to content. This is the shape the `page-vite`
+// template shipped before #206: the host renders a page block full-viewport and
+// marks RESIZE_IFRAME N/A, so this effect runs forever into nothing.
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    function reportHeight() {
+      window.parent.postMessage(
+        { type: 'RESIZE_IFRAME', height: document.documentElement.scrollHeight },
+        '*'
+      );
+    }
+    reportHeight();
+    window.addEventListener('resize', reportHeight);
+    return () => window.removeEventListener('resize', reportHeight);
+  });
+
+  return <main>count is {count}</main>;
+}

--- a/internal/blockproto/blockproto.go
+++ b/internal/blockproto/blockproto.go
@@ -19,7 +19,10 @@
 // changes with it. See AGENTS.md, "Intentional decisions that look wrong".
 package blockproto
 
-import _ "embed"
+import (
+	_ "embed"
+	"sort"
+)
 
 // readyAck is the canonical ready-ack emitter. It is plain, dependency-free,
 // ES5-safe JavaScript so the no-build `static` template can load it with a
@@ -41,5 +44,60 @@ const ReadyAckFilename = "civitai-host.js"
 func ReadyAckSource() []byte {
 	out := make([]byte, len(readyAck))
 	copy(out, readyAck)
+	return out
+}
+
+// ackingPackages is the set of npm packages that perform the ready-ack FOR the
+// app, so a project depending on one does not need the vendored emitter (and
+// must not also ship it — two handshakes race, see the emitter's own header).
+//
+// 🔴 IT IS AN EXACT SET, NOT THE `@civitai/` SCOPE, AND THAT DISTINCTION IS
+// MEASURED. Of the six published first-party packages, only ONE acks:
+//
+//	@civitai/blocks-react   0.39.0  ACKS — dist/internal/iframeTransport.js:311
+//	                                `this.dispatch('BLOCK_READY', {height: 0})`
+//	@civitai/app-sdk        0.31.0  does NOT — 17 runtime .js files, ZERO contain
+//	                                BLOCK_READY; the only hits are a .d.ts type
+//	                                literal and the README. It is the server-side
+//	                                OAuth/session SDK and declares no dependencies,
+//	                                so it cannot be acking transitively either.
+//	@civitai/theme          0.2.0   does NOT — framework-agnostic CSS tokens
+//	@civitai/components     0.3.0   does NOT — "Plain HTML or any framework" CSS
+//	@civitai/components-react 0.3.0 does NOT — thin React bindings over the above
+//	@civitai/cli            0.1.89  does NOT — installs this Go binary
+//
+// (Measured from fresh npm tarballs at the versions named, 2026-08.)
+//
+// Treating the whole scope as evidence is therefore wrong for FOUR of the six,
+// and wrong in the expensive direction: `@civitai/theme` and `@civitai/components`
+// are exactly what a hand-written, no-build page app would install, so a scope
+// check goes SILENT on a genuinely broken app. Verified live — adding
+// `@civitai/theme` to a static scaffold with `civitai-host.js` deleted (the
+// literal #206 shape) suppressed the warning.
+//
+// Adding a package here is a claim that its RUNTIME code posts BLOCK_READY.
+// Verify that against the published tarball — not the README, not the types —
+// and record the version you measured.
+var ackingPackages = map[string]bool{
+	"@civitai/blocks-react": true,
+}
+
+// PackageAcksReady reports whether an npm dependency named `name` performs the
+// block -> host ready-ack on the app's behalf.
+//
+// The comparison is EXACT. A prefix or substring test would accept a sibling
+// (`@civitai/blocks-react-native`) or a third-party fork
+// (`@myorg/@civitai/blocks-react`) that makes no such promise, which is the
+// widening class every other pattern in this repo carries an explicit boundary
+// against (see the terminating character classes in internal/antipattern).
+func PackageAcksReady(name string) bool { return ackingPackages[name] }
+
+// AckingPackages returns the acking package names, for messages and tests.
+func AckingPackages() []string {
+	out := make([]string, 0, len(ackingPackages))
+	for name := range ackingPackages {
+		out = append(out, name)
+	}
+	sort.Strings(out)
 	return out
 }

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -77,8 +77,18 @@ Defaults to the current directory.`,
 					for _, e := range res.Errors {
 						fmt.Fprintf(errw, "  - %s\n", e)
 					}
+					// Warnings are useful context on a failure too, and this is
+					// the last moment before the app would have gone to review.
+					printWarnings(errw, res)
 					return fmt.Errorf("validation failed")
 				}
+				// Non-fatal advisories still have to be SEEN. `submit` is the
+				// highest-traffic path and the last point before an app reaches
+				// review, so printing them only in `app validate` means the
+				// ready-ack advisory — which predicts a blank failure card in the
+				// real host — reaches nobody who does not run validate by hand.
+				// They do NOT block the submit; that stays the --strict contract.
+				printWarnings(cmd.ErrOrStderr(), res)
 			}
 
 			m, err := manifest.Load(dir)

--- a/internal/cmd/app_submit_cmd_test.go
+++ b/internal/cmd/app_submit_cmd_test.go
@@ -50,6 +50,59 @@ func TestAppSubmitPackageOnly(t *testing.T) {
 	}
 }
 
+// TestAppSubmitSurfacesWarnings pins that a non-fatal advisory REACHES the
+// author on the submit path.
+//
+// `submit` used to branch only on res.OK() and drop res.Warnings on the floor.
+// That is the highest-traffic command and the last point before an app goes to
+// review, so the ready-ack advisory — which predicts a blank failure card in the
+// real host — reached nobody who did not run `app validate` by hand.
+//
+// It must NOT block: warnings failing a submit is the --strict contract, and
+// promoting a heuristic to a gate here would break correct projects.
+func TestAppSubmitSurfacesWarnings(t *testing.T) {
+	tmp := t.TempDir()
+	writeStaticManifest(t, tmp)
+	// A page app whose only source file never posts BLOCK_READY: the #206 shape.
+	if err := os.WriteFile(filepath.Join(tmp, "index.html"), []byte("<html></html>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(tmp, "bundle.zip")
+
+	stdout, stderr, err := run(t, "app", "submit", tmp, "--package-only", "--out", out)
+	if err != nil {
+		t.Fatalf("a warning must not fail the submit: %v\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "BLOCK_READY") {
+		t.Errorf("submit swallowed the ready-ack advisory; it must reach the author here, not only in "+
+			"`app validate`.\nstderr: %s", stderr)
+	}
+	if !strings.Contains(stderr, "warning(s)") {
+		t.Errorf("submit should print the warning header: %s", stderr)
+	}
+	// The submit still has to have happened.
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("the bundle must still be written: %v\n%s", err, stdout)
+	}
+
+	// NEGATIVE CONTROL: a project that is not in the #206 shape must produce no
+	// such line, or the assertion above is satisfied by output that is always
+	// printed regardless of the finding.
+	clean := t.TempDir()
+	writeStaticManifest(t, clean)
+	if err := os.WriteFile(filepath.Join(clean, "index.html"),
+		[]byte("<html><script>parent.postMessage({type:'BLOCK_READY',payload:{}},o)</script></html>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr2, err := run(t, "app", "submit", clean, "--package-only", "--out", filepath.Join(clean, "b.zip"))
+	if err != nil {
+		t.Fatalf("clean submit: %v\n%s", err, stderr2)
+	}
+	if strings.Contains(stderr2, "nothing in this project's source posts") {
+		t.Errorf("a correct app must not get the advisory on submit: %s", stderr2)
+	}
+}
+
 func TestAppSubmitFallbackPrintsManualSteps(t *testing.T) {
 	tmp := t.TempDir()
 	writeStaticManifest(t, tmp)

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -42,9 +42,16 @@ plus the ported semantic rules and structural checks:
     lockfile is a guaranteed build failure. Only applies when package.json
     exists — a static app never installs.
 
-It also emits non-fatal WARNINGS for money-path footguns the schema can't catch
-as hard errors (e.g. a budgeted page with no page.buzzBudgetPerGen). Warnings do
-NOT fail validation (exit 0) unless --strict is passed.
+It also emits non-fatal WARNINGS the schema can't catch as hard errors:
+  - money-path footguns (e.g. a budgeted page with no page.buzzBudgetPerGen)
+  - a "page" app whose source never posts BLOCK_READY. The host will not reveal
+    a page app until it acks BLOCK_INIT, so such an app renders fine locally and
+    is replaced by a failure card in the real host — the shape of anything
+    scaffolded before that was fixed. Advisory ONLY: it infers runtime behaviour
+    from static text. A project depending on @civitai/* is never flagged (the
+    SDK transport acks internally), and it reads source only — never outputDir,
+    node_modules, markdown, or comments.
+Warnings do NOT fail validation (exit 0) unless --strict is passed.
 
 Defaults to the current directory.`,
 		Example: `  civitai app validate            # the current directory

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -929,7 +929,7 @@ func printOutputURLs(out, errw io.Writer, kept []genapi.Output) {
 //
 // 🔴 It must print the REALIZED charge whenever the server reported one. The
 // user approved an ESTIMATE, and this command's whole spend story is that the
-// realized cost can exceed it with no refund (AGENTS.md items 11-16) — so the
+// realized cost can exceed it with no refund (AGENTS.md items 12-17) — so the
 // one number that settles what actually happened cannot be visible only on the
 // --no-wait branch. `cost` is nil when the server sent none; say nothing then
 // rather than printing a fabricated 0.

--- a/internal/scaffold/antipattern_scan_test.go
+++ b/internal/scaffold/antipattern_scan_test.go
@@ -15,7 +15,9 @@ import (
 // author. The network-dependent scaffold-of-record scan runs in CI against the
 // `civitai app init` output; this covers all templates hermetically.
 func TestScaffoldedTemplatesHaveNoAntipatterns(t *testing.T) {
+	examined := 0
 	for _, tmpl := range AllTemplates() {
+		examined++
 		t.Run(string(tmpl), func(t *testing.T) {
 			dest := filepath.Join(t.TempDir(), string(tmpl))
 			if _, err := Render(tmpl, dest, Data{Slug: "sample-block", Name: "Sample Block"}); err != nil {
@@ -29,5 +31,12 @@ func TestScaffoldedTemplatesHaveNoAntipatterns(t *testing.T) {
 				t.Fatalf("template %q ships an anti-pattern:\n%s", tmpl, antipattern.Format(findings))
 			}
 		})
+	}
+	// COUNT POSITIVE CONTROL. This test's reassuring answer is a ZERO ("no
+	// findings"), which is exactly the answer a guard wired to nothing produces:
+	// an empty AllTemplates() makes the loop body never run and the test pass
+	// serenely. Assert it actually examined the templates that exist.
+	if examined < len(AllTemplates()) || examined < 3 {
+		t.Fatalf("scanned only %d template(s), expected at least 3 — the enumeration stopped OBSERVING", examined)
 	}
 }

--- a/internal/scaffold/ready_ack_contract_test.go
+++ b/internal/scaffold/ready_ack_contract_test.go
@@ -419,7 +419,7 @@ func TestScaffoldedPageTemplatesShipTheReadyAck(t *testing.T) {
 
 		rel := tmpl.ReadyAckPath()
 		if rel == "" {
-			t.Errorf("template %q declares a `page` surface and carries no @civitai/* SDK, but "+
+			t.Errorf("template %q declares a `page` surface and depends on no package that acks, but "+
 				"ReadyAckPath() is empty — a page app that never posts BLOCK_READY is replaced by a "+
 				"failure card in the real host (issue #206). Give it a path in scaffold.go so "+
 				"Render ships blockproto's emitter.", tmpl)

--- a/internal/scaffold/ready_ack_contract_test.go
+++ b/internal/scaffold/ready_ack_contract_test.go
@@ -495,8 +495,20 @@ func manifestDeclaresPage(t *testing.T, tmpl Template, dir string) bool {
 	return ok && strings.TrimSpace(string(v)) != "null"
 }
 
-// civitaiSDKDeps returns the `@civitai/*` packages the rendered package.json
-// depends on (sorted). Empty for a template with no package.json at all.
+// civitaiSDKDeps returns the rendered package.json's dependencies that ACK on
+// the app's behalf (sorted). Empty for a template with no package.json at all.
+//
+// 🔴 It asks `blockproto.PackageAcksReady`, NOT "is this name under the
+// `@civitai/` scope". Those are different questions, and the scope answer is
+// wrong for four of the six published first-party packages — `@civitai/theme`,
+// `@civitai/components`, `@civitai/components-react` and `@civitai/cli` contain
+// no BLOCK_READY at all (measured; the per-package evidence is in blockproto).
+// A scope test here would let a future template that depends on, say,
+// `@civitai/theme` be classified SDK-backed and silently excused from shipping
+// an emitter — a born-broken template passing its own contract guard. The same
+// predicate answers the same question for an author's project in
+// internal/validate/readyack.go, which is why it lives in blockproto instead of
+// being open-coded at both sites.
 func civitaiSDKDeps(t *testing.T, dir string) []string {
 	t.Helper()
 	raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
@@ -507,22 +519,60 @@ func civitaiSDKDeps(t *testing.T, dir string) []string {
 		t.Fatalf("read package.json in %s: %v", dir, err)
 	}
 	var pkg struct {
-		Dependencies    map[string]string `json:"dependencies"`
-		DevDependencies map[string]string `json:"devDependencies"`
+		Dependencies     map[string]string `json:"dependencies"`
+		DevDependencies  map[string]string `json:"devDependencies"`
+		PeerDependencies map[string]string `json:"peerDependencies"`
 	}
 	if err := json.Unmarshal(raw, &pkg); err != nil {
 		t.Fatalf("rendered package.json in %s is not valid JSON: %v", dir, err)
 	}
 	var out []string
-	for _, set := range []map[string]string{pkg.Dependencies, pkg.DevDependencies} {
+	for _, set := range []map[string]string{pkg.Dependencies, pkg.DevDependencies, pkg.PeerDependencies} {
 		for name := range set {
-			if strings.HasPrefix(name, "@civitai/") {
+			if blockproto.PackageAcksReady(name) {
 				out = append(out, name)
 			}
 		}
 	}
 	sort.Strings(out)
 	return out
+}
+
+// TestAckingPackagePredicate is the shared predicate's own control pair. Every
+// name blockproto claims must be accepted, and the reject corpus is built
+// entirely from the WIDENING class: a prefix test or a substring test passes
+// every accept case below and fails these, so this is the only thing that
+// distinguishes an exact match from either.
+func TestAckingPackagePredicate(t *testing.T) {
+	accept := blockproto.AckingPackages()
+	if len(accept) == 0 {
+		t.Fatal("blockproto.AckingPackages() is empty — the predicate can never accept anything, " +
+			"which would silently make every SDK project look emitter-less")
+	}
+	for _, name := range accept {
+		if !blockproto.PackageAcksReady(name) {
+			t.Errorf("PackageAcksReady(%q) = false but it IS in AckingPackages()", name)
+		}
+	}
+	reject := []string{
+		// Published first-party packages that do NOT ack (measured — see the
+		// per-package evidence in blockproto). A `@civitai/` prefix test, which
+		// is what this used to be, accepts every one of these.
+		"@civitai/app-sdk", "@civitai/theme", "@civitai/components",
+		"@civitai/components-react", "@civitai/cli", "@civitai/blocks-cli",
+		// Prefix widening: siblings that merely START with an acking name.
+		"@civitai/blocks-react-native", "@civitai/blocks-reactor",
+		// Substring widening: forks/re-scopes that merely CONTAIN one.
+		"@myorg/@civitai/blocks-react", "fork-of-@civitai/blocks-react",
+		// Unscoped lookalikes.
+		"civitai-blocks-react", "blocks-react", "react",
+	}
+	for _, name := range reject {
+		if blockproto.PackageAcksReady(name) {
+			t.Errorf("PackageAcksReady(%q) = true — that package does not perform the ready-ack. "+
+				"This is the widening class (prefix/substring) the exact match exists to prevent.", name)
+		}
+	}
 }
 
 var (

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -1,0 +1,322 @@
+package validate
+
+// readyack.go implements the PAGE-APP READY-ACK advisory.
+//
+// WHY THIS EXISTS. A `page` app is not revealed by the host until it posts
+// `BLOCK_READY` — that handler in `PageBlockHost.tsx` is the only transition
+// into the host's `ready` state. An app that never posts it renders perfectly
+// everywhere you can look locally and is replaced by a visible failure card in
+// the real host once the bounded init retries run out (~37s). That is issue
+// #206, and `4018e2c` fixed the `static` and `page-vite` TEMPLATES — but every
+// app scaffolded before that commit is still broken, and nothing tells its
+// author. This check is the thing that tells them.
+//
+// 🔴 IT IS A WARNING, NOT AN ERROR, AND THAT IS DELIBERATE.
+// The lockfile check next door (lockfile.go) earns hard-error status because the
+// platform PROVABLY fails: the build recipe runs `npm ci` and dies. Nothing here
+// is provable. This check infers RUNTIME behaviour from STATIC TEXT, and there
+// are real, correct projects it cannot read: an ack that arrives through a
+// bundled dependency, a framework wrapper, a code-split chunk, a generated file,
+// or simply a file extension this scan does not open. Hard-failing on a
+// heuristic is the exact false-warning-at-a-correct-project failure the
+// dev-tunnel preflight (AGENTS.md item 10) spent four measured corrections
+// avoiding — and unlike that one, `--strict` here would turn it into a build
+// break in somebody's CI. `Result.Warnings` costs an author nothing to ignore
+// and still puts the sentence in front of them.
+//
+// EVIDENCE ORDER — THE DEPENDENCY IS CHECKED FIRST, AND THAT IS LOAD-BEARING.
+// For a project depending on `@civitai/blocks-react`, the ack comes from the
+// SDK's `IframeTransport` and the literal `BLOCK_READY` NEVER APPEARS in `src/`.
+// A source scan alone therefore warns at every correct page-money app on the
+// platform, which is the worst possible outcome for advisory output: it teaches
+// authors that this warning is noise. So package.json is read first and an
+// `@civitai/*` dependency ENDS the check.
+//
+// WHAT IT DOES NOT PROVE. That the ack FIRES. No static check can — an emitter
+// with an inverted `event.source` guard satisfies every assertion here (that is
+// what the scaffold's Guard B exists for, see AGENTS.md item 11). This check
+// answers one narrower question: does anything in this project's source so much
+// as MENTION the message, outside a comment. A "no" is strong evidence of the
+// #206 shape; a "yes" is weak evidence of correctness, and is treated as
+// conclusive anyway, because being generous here costs a missed warning while
+// being strict costs a false one.
+//
+// SCOPE — IT ONLY FIRES WHERE IT CAN OBSERVE. Mirroring lockfile.go's early-out
+// shape: no `page` surface, no check. Unreadable package.json, no check.
+// Unwalkable tree, no check. And it reads SOURCE only — never `outputDir`,
+// which does not exist before the first build and is gitignored, so its absence
+// says nothing. A check that cannot observe returns NO findings rather than
+// manufacturing advice.
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/civitai/cli/internal/blockproto"
+	"github.com/civitai/cli/internal/manifest"
+)
+
+// readyAckType is the message the page host waits for. It is the same literal
+// blockproto's emitter posts; the emitter is the authority for the SHAPE, this
+// is only the token we look for.
+const readyAckType = "BLOCK_READY"
+
+// civitaiDepPrefix marks a first-party package. Any of them is taken as
+// evidence that a real transport is in play — `@civitai/blocks-react` is the
+// one that acks today, but a project pulling `@civitai/app-sdk` is on the SDK
+// path too, and a false negative is the cheap direction.
+//
+// This deliberately mirrors `civitaiSDKDeps` in
+// internal/scaffold/ready_ack_contract_test.go, which decides the same question
+// for the templates. Keep them agreeing: they answer "does this project's ack
+// come from the SDK", and disagreeing would mean the CLI warns at a shape its
+// own scaffold guard considers correct.
+const civitaiDepPrefix = "@civitai/"
+
+// readyAckSourceExts are the extensions a hand-written emitter can live in.
+// Deliberately CODE ONLY — `.md` is excluded because a README that explains the
+// handshake is not an implementation of it, and both shipped scaffold READMEs
+// describe `BLOCK_READY` at length. Including docs would silence the check for
+// exactly the apps it exists to find.
+var readyAckSourceExts = map[string]bool{
+	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
+	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
+	".html": true, ".htm": true,
+	".vue": true, ".svelte": true, ".astro": true,
+}
+
+// readyAckSkipDirs are never descended into: dependencies, VCS metadata, and
+// build output. The manifest's own outputDir is skipped on top of these.
+var readyAckSkipDirs = map[string]bool{
+	"node_modules": true, ".git": true, "dist": true, "build": true,
+	"out": true, "coverage": true, ".vite": true, ".next": true,
+	".svelte-kit": true, ".output": true,
+}
+
+// readyAckChecks returns the ready-ack advisory for the project in dir, or nil.
+//
+// It runs in the projectState branch of validateDir (beside lockfileChecks) and
+// NOT in warningChecks: warningChecks is reached under ManifestOnly, which
+// `civitai app init` uses to self-check the template it just wrote, and a check
+// that reads `src/` has no business running there.
+func readyAckChecks(dir string, generic any, m *manifest.Manifest) []string {
+	if !declaresPage(generic) {
+		return nil
+	}
+	// The dependency is checked FIRST — see the file header. `unknown` means the
+	// package.json is there but unreadable, i.e. we cannot answer the question
+	// that decides whether a source scan is even meaningful.
+	switch sdkDependency(dir) {
+	case sdkPresent, sdkUnknown:
+		return nil
+	}
+	if emitsReadyAck(dir, m.OutputDir) {
+		return nil
+	}
+	return []string{readyAckAdvice}
+}
+
+// declaresPage reports whether the manifest declares a non-null `page` surface.
+// `"page": null` is not a page app; an absent key is not either.
+func declaresPage(generic any) bool {
+	m, ok := generic.(map[string]any)
+	if !ok {
+		return false
+	}
+	v, present := m["page"]
+	return present && v != nil
+}
+
+// sdkState is the three-valued answer to "does this project depend on a
+// first-party package". The third value is the point: "we could not tell" must
+// not be collapsed into "no", which is what would warn at a project whose
+// package.json this CLI simply failed to parse.
+type sdkState int
+
+const (
+	sdkAbsent sdkState = iota
+	sdkPresent
+	sdkUnknown
+)
+
+func sdkDependency(dir string) sdkState {
+	raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No package.json at all: a static, no-build app. It installs
+			// nothing, so it cannot be acking through a dependency — the source
+			// scan is the whole answer for it.
+			return sdkAbsent
+		}
+		return sdkUnknown
+	}
+	// json.RawMessage values, not strings: a package.json with an unusual
+	// (non-string) version entry must not make the whole decode fail and warn.
+	var pkg struct {
+		Dependencies     map[string]json.RawMessage `json:"dependencies"`
+		DevDependencies  map[string]json.RawMessage `json:"devDependencies"`
+		PeerDependencies map[string]json.RawMessage `json:"peerDependencies"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		return sdkUnknown
+	}
+	for _, set := range []map[string]json.RawMessage{pkg.Dependencies, pkg.DevDependencies, pkg.PeerDependencies} {
+		for name := range set {
+			if strings.HasPrefix(name, civitaiDepPrefix) {
+				return sdkPresent
+			}
+		}
+	}
+	return sdkAbsent
+}
+
+// emitsReadyAck reports whether any source file under dir mentions the ready-ack
+// message OUTSIDE a comment.
+//
+// 🔴 READING NOTHING IS NOT THE SAME AS FINDING NOTHING, and this returns TRUE
+// (no finding) when it opened ZERO source files. That is this check's own
+// positive control, inlined: a zero-hit scan over a zero-file tree is
+// indistinguishable from a scanner wired to nothing — a broken extension table,
+// an over-eager skip list, or `validate` pointed at a directory that holds a
+// manifest and no checkout (which is exactly the shape of every manifest-only
+// fixture in this package). Concluding "this app never acks" from a scan that
+// never read a line is manufacturing advice from an absence.
+//
+// 🔴 The comment strip is load-bearing, not tidiness. Both shipped SDK-free
+// templates carry a source COMMENT naming `BLOCK_READY`
+// (`static/app.js`, `page-vite/src/App.jsx`: "The ONE message a page app must
+// send is `BLOCK_READY`"), and those comments SURVIVE deleting `civitai-host.js`.
+// Without stripping, the exact repair this check exists to demand — restore the
+// emitter — would already look satisfied, and the check would be inert on the
+// one population it was written for. Measured: with the strip, deleting
+// civitai-host.js from a freshly scaffolded static app makes the warning fire;
+// without it, it does not.
+//
+// An unwalkable/unreadable tree reports TRUE (i.e. "no finding"): we could not
+// observe, so we say nothing.
+func emitsReadyAck(dir, outputDir string) bool {
+	skipOut := ""
+	if out := strings.TrimSpace(outputDir); out != "" {
+		skipOut = filepath.Clean(filepath.Join(dir, filepath.FromSlash(out)))
+	}
+
+	found := false
+	scanned := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if readyAckSkipDirs[d.Name()] || (skipOut != "" && filepath.Clean(path) == skipOut) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !readyAckSourceExts[strings.ToLower(filepath.Ext(d.Name()))] {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+		if strings.Contains(stripComments(string(data)), readyAckType) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		// Could not observe the tree — do not manufacture advice.
+		return true
+	}
+	if scanned == 0 {
+		return true
+	}
+	return found
+}
+
+// stripComments removes HTML comments and then JS line/block comments, leaving
+// string and template literals intact (so `'https://x'` is not read as the start
+// of a comment, and an emitter that posts from inside a string still counts).
+func stripComments(src string) string {
+	return stripJSComments(stripHTMLComments(src))
+}
+
+func stripHTMLComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); {
+		if strings.HasPrefix(src[i:], "<!--") {
+			end := strings.Index(src[i+4:], "-->")
+			if end < 0 {
+				return b.String()
+			}
+			i += 4 + end + 3
+			continue
+		}
+		b.WriteByte(src[i])
+		i++
+	}
+	return b.String()
+}
+
+func stripJSComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); {
+		c := src[i]
+		switch {
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			i += 2
+			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+				i++
+			}
+			i = min(i+2, len(src))
+		case c == '\'' || c == '"' || c == '`':
+			quote := c
+			b.WriteByte(c)
+			i++
+			for i < len(src) {
+				if src[i] == '\\' && i+1 < len(src) {
+					b.WriteString(src[i : i+2])
+					i += 2
+					continue
+				}
+				b.WriteByte(src[i])
+				if src[i] == quote {
+					i++
+					break
+				}
+				i++
+			}
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// readyAckAdvice names the concrete next command, per the house rule that a
+// message must tell the author what to run. It also states its own evidentiary
+// limit — an author who knows their ack comes from a bundled dependency needs to
+// be able to recognise this as a false alarm without reading the source of the
+// CLI.
+var readyAckAdvice = "the manifest declares a \"page\" surface but nothing in this project's source posts " +
+	readyAckType + " — the host will not reveal a page app until it acks the host's BLOCK_INIT, so an app " +
+	"that never sends it renders fine locally and is replaced by a failure card in the real host once the " +
+	"bounded init retries run out (issue #206). Apps scaffolded before that fix ship no emitter: run " +
+	"`civitai app init` into a scratch directory and copy its `" + blockproto.ReadyAckFilename + "` " +
+	"into this project, loading it from index.html (a <script src>) or from the entry module — or adopt " +
+	"`@civitai/blocks-react`, whose transport acks for you (never both: whichever answers the first " +
+	"BLOCK_INIT cancels the host's retry). This is a source-text check, so it is wrong about a project " +
+	"whose ack arrives from a bundled dependency or a file type it does not read; it never inspects " +
+	"outputDir, which is not built yet"

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -29,8 +29,16 @@ package validate
 // SDK's `IframeTransport` and the literal `BLOCK_READY` NEVER APPEARS in `src/`.
 // A source scan alone therefore warns at every correct page-money app on the
 // platform, which is the worst possible outcome for advisory output: it teaches
-// authors that this warning is noise. So package.json is read first and an
-// `@civitai/*` dependency ENDS the check.
+// authors that this warning is noise. So package.json is read first and a
+// dependency that ACKS ends the check.
+//
+// 🔴 "A dependency that acks" is an EXACT SET (blockproto.PackageAcksReady), not
+// the `@civitai/` scope. Four of the six published first-party packages do not
+// ack at all — `@civitai/theme` and `@civitai/components` are plain CSS, and are
+// exactly what a hand-written no-build page app installs — so a scope test goes
+// SILENT on a genuinely broken app. Measured per package in blockproto, and
+// reproduced live on a `static` scaffold with the emitter deleted. Do not
+// re-widen this to a prefix.
 //
 // WHAT IT DOES NOT PROVE. That the ack FIRES. No static check can — an emitter
 // with an inverted `event.source` guard satisfies every assertion here (that is
@@ -41,40 +49,40 @@ package validate
 // conclusive anyway, because being generous here costs a missed warning while
 // being strict costs a false one.
 //
-// SCOPE — IT ONLY FIRES WHERE IT CAN OBSERVE. Mirroring lockfile.go's early-out
-// shape: no `page` surface, no check. Unreadable package.json, no check.
-// Unwalkable tree, no check. And it reads SOURCE only — never `outputDir`,
-// which does not exist before the first build and is gitignored, so its absence
-// says nothing. A check that cannot observe returns NO findings rather than
-// manufacturing advice.
+// SCOPE — IT ONLY FIRES WHERE IT CAN OBSERVE, AND "OBSERVE" MEANS THE WHOLE
+// TREE. Mirroring lockfile.go's early-out shape: no `page` surface, no check;
+// unreadable package.json, no check. Beyond that, the scan concludes "this app
+// never acks" ONLY if it read every source file it could reach and found
+// nothing. Anything that leaves a gap — an unresolvable symlink, a read error, a
+// file over the size cap, the file-count budget — reports UNOBSERVABLE and stays
+// silent. A partial scan that says "absent" is manufacturing advice from a gap.
+//
+// 🔴 SKIPPING IS A COST DECISION, NEVER A CORRECTNESS ONE, because this is a
+// PRESENCE check: scanning an extra directory can only ever ADD ack evidence,
+// while skipping one can only ever CREATE a false warning. That asymmetry is why
+// the manifest's `outputDir` is NOT skipped (it was, and it was wrong — a
+// perfectly valid `"outputDir": "src"` on a page-vite app skipped the directory
+// holding the emitter and warned at a correct project; `"outputDir": "."`
+// skipped the entire tree). What remains is a fixed list of names that are
+// never source — dependencies, VCS metadata, and the conventional build
+// directories — chosen for cost. The residual trade is accepted and stated: a
+// stale committed build under a NON-conventional output directory can retain an
+// ack the source has lost, silencing a genuinely broken app. That is a false
+// negative, and false negatives are the cheap direction here.
 
 import (
 	"encoding/json"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/civitai/cli/internal/blockproto"
-	"github.com/civitai/cli/internal/manifest"
 )
 
 // readyAckType is the message the page host waits for. It is the same literal
 // blockproto's emitter posts; the emitter is the authority for the SHAPE, this
 // is only the token we look for.
 const readyAckType = "BLOCK_READY"
-
-// civitaiDepPrefix marks a first-party package. Any of them is taken as
-// evidence that a real transport is in play — `@civitai/blocks-react` is the
-// one that acks today, but a project pulling `@civitai/app-sdk` is on the SDK
-// path too, and a false negative is the cheap direction.
-//
-// This deliberately mirrors `civitaiSDKDeps` in
-// internal/scaffold/ready_ack_contract_test.go, which decides the same question
-// for the templates. Keep them agreeing: they answer "does this project's ack
-// come from the SDK", and disagreeing would mean the CLI warns at a shape its
-// own scaffold guard considers correct.
-const civitaiDepPrefix = "@civitai/"
 
 // readyAckSourceExts are the extensions a hand-written emitter can live in.
 // Deliberately CODE ONLY — `.md` is excluded because a README that explains the
@@ -88,13 +96,44 @@ var readyAckSourceExts = map[string]bool{
 	".vue": true, ".svelte": true, ".astro": true,
 }
 
-// readyAckSkipDirs are never descended into: dependencies, VCS metadata, and
-// build output. The manifest's own outputDir is skipped on top of these.
+// readyAckMarkupExts are the subset whose comments are `<!-- -->`. HTML comment
+// stripping is applied ONLY to these.
+//
+// 🔴 Applying it to `.js`/`.ts` was a false-warning source: `stripHTMLComments`
+// has no string awareness, so a perfectly ordinary `var OPEN = '<!--';` in a
+// sanitiser started a "comment" that ran to end of file and deleted the emitter
+// below it. Reproduced live on a `static` scaffold. JS has no HTML comments
+// worth stripping here — `//` and `/* */` cover it, and Annex B's HTML-like
+// comment form is vanishingly rare next to the literal appearing in a string.
+var readyAckMarkupExts = map[string]bool{
+	".html": true, ".htm": true, ".vue": true, ".svelte": true, ".astro": true,
+}
+
+// readyAckSkipDirs are never descended into. These names are never source:
+// dependencies, VCS metadata, and the conventional build directories. The list
+// is a COST decision (see the header) — every entry can only cost a false
+// warning, so it is kept short and conventional rather than expanded to every
+// directory that might be large. `vendor` and `public` are deliberately ABSENT:
+// both routinely hold hand-written source (a vendored emitter, Vite's static
+// `public/`), and cost is bounded by the caps below instead.
 var readyAckSkipDirs = map[string]bool{
 	"node_modules": true, ".git": true, "dist": true, "build": true,
 	"out": true, "coverage": true, ".vite": true, ".next": true,
 	".svelte-kit": true, ".output": true,
 }
+
+// Scan caps. `validate` used to be a manifest-only read; walking a project tree
+// is new cost, and an app that commits a large bundle or a huge vendored tree
+// must not turn it into a memory event (measured before these existed: 20,008
+// files with one 88 MB .js peaked at 316 MB RSS).
+//
+// Hitting either cap makes the scan UNOBSERVABLE, not "absent" — we stopped
+// reading, so we do not know. That is deliberately the direction that stays
+// silent.
+const (
+	maxAckScanFiles = 5000
+	maxAckFileBytes = 2 << 20 // 2 MiB
+)
 
 // readyAckChecks returns the ready-ack advisory for the project in dir, or nil.
 //
@@ -102,7 +141,7 @@ var readyAckSkipDirs = map[string]bool{
 // NOT in warningChecks: warningChecks is reached under ManifestOnly, which
 // `civitai app init` uses to self-check the template it just wrote, and a check
 // that reads `src/` has no business running there.
-func readyAckChecks(dir string, generic any, m *manifest.Manifest) []string {
+func readyAckChecks(dir string, generic any) []string {
 	if !declaresPage(generic) {
 		return nil
 	}
@@ -113,7 +152,9 @@ func readyAckChecks(dir string, generic any, m *manifest.Manifest) []string {
 	case sdkPresent, sdkUnknown:
 		return nil
 	}
-	if emitsReadyAck(dir, m.OutputDir) {
+	// Only a scan that read the WHOLE reachable tree and found nothing is
+	// evidence of absence.
+	if scanForReadyAck(dir) != ackAbsent {
 		return nil
 	}
 	return []string{readyAckAdvice}
@@ -165,7 +206,7 @@ func sdkDependency(dir string) sdkState {
 	}
 	for _, set := range []map[string]json.RawMessage{pkg.Dependencies, pkg.DevDependencies, pkg.PeerDependencies} {
 		for name := range set {
-			if strings.HasPrefix(name, civitaiDepPrefix) {
+			if blockproto.PackageAcksReady(name) {
 				return sdkPresent
 			}
 		}
@@ -173,17 +214,30 @@ func sdkDependency(dir string) sdkState {
 	return sdkAbsent
 }
 
-// emitsReadyAck reports whether any source file under dir mentions the ready-ack
-// message OUTSIDE a comment.
+// ackScanResult is the THREE-valued outcome of the source scan. Two values
+// would collapse "we did not look" into "it is not there", which is the whole
+// class of bug this check has to avoid.
+type ackScanResult int
+
+const (
+	// ackFound: a source file mentions the message outside a comment.
+	ackFound ackScanResult = iota
+	// ackAbsent: every reachable source file was read, and none mentions it.
+	// This is the ONLY result that produces a warning.
+	ackAbsent
+	// ackUnobservable: the scan left a gap — an unresolvable symlink, a read
+	// error, a file over the size cap, the file budget, or simply no source
+	// files at all.
+	ackUnobservable
+)
+
+// scanForReadyAck walks dir looking for the ready-ack message in source.
 //
-// 🔴 READING NOTHING IS NOT THE SAME AS FINDING NOTHING, and this returns TRUE
-// (no finding) when it opened ZERO source files. That is this check's own
-// positive control, inlined: a zero-hit scan over a zero-file tree is
-// indistinguishable from a scanner wired to nothing — a broken extension table,
-// an over-eager skip list, or `validate` pointed at a directory that holds a
-// manifest and no checkout (which is exactly the shape of every manifest-only
-// fixture in this package). Concluding "this app never acks" from a scan that
-// never read a line is manufacturing advice from an absence.
+// 🔴 READING NOTHING IS NOT THE SAME AS FINDING NOTHING. A zero-hit scan over a
+// zero-file tree is indistinguishable from a scanner wired to nothing — a broken
+// extension table, an over-eager skip list, or `validate` pointed at a directory
+// that holds a manifest and no checkout (the shape of every manifest-only
+// fixture in this package). So "no files read" is ackUnobservable, not ackAbsent.
 //
 // 🔴 The comment strip is load-bearing, not tidiness. Both shipped SDK-free
 // templates carry a source COMMENT naming `BLOCK_READY`
@@ -191,59 +245,112 @@ func sdkDependency(dir string) sdkState {
 // send is `BLOCK_READY`"), and those comments SURVIVE deleting `civitai-host.js`.
 // Without stripping, the exact repair this check exists to demand — restore the
 // emitter — would already look satisfied, and the check would be inert on the
-// one population it was written for. Measured: with the strip, deleting
-// civitai-host.js from a freshly scaffolded static app makes the warning fire;
-// without it, it does not.
+// one population it was written for. Measured both ways.
 //
-// An unwalkable/unreadable tree reports TRUE (i.e. "no finding"): we could not
-// observe, so we say nothing.
-func emitsReadyAck(dir, outputDir string) bool {
-	skipOut := ""
-	if out := strings.TrimSpace(outputDir); out != "" {
-		skipOut = filepath.Clean(filepath.Join(dir, filepath.FromSlash(out)))
+// 🔴 SYMLINKED DIRECTORIES ARE FOLLOWED. filepath.WalkDir does not follow them,
+// and it does not report them as directories either, so a monorepo whose `src`
+// is a symlink into a shared package had its ENTIRE source tree skipped and
+// warned at a correct project — reproduced live. Following is also the safe
+// direction for a presence check (more files can only add evidence). Cycles are
+// bounded by a visited set keyed on the RESOLVED path, and total work by the
+// caps above.
+func scanForReadyAck(dir string) ackScanResult {
+	s := &ackScanner{visited: map[string]bool{}}
+	s.walk(dir)
+	switch {
+	case s.found:
+		return ackFound
+	case s.partial || s.files == 0:
+		return ackUnobservable
+	default:
+		return ackAbsent
 	}
-
-	found := false
-	scanned := 0
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if readyAckSkipDirs[d.Name()] || (skipOut != "" && filepath.Clean(path) == skipOut) {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		if !readyAckSourceExts[strings.ToLower(filepath.Ext(d.Name()))] {
-			return nil
-		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		scanned++
-		if strings.Contains(stripComments(string(data)), readyAckType) {
-			found = true
-			return fs.SkipAll
-		}
-		return nil
-	})
-	if err != nil {
-		// Could not observe the tree — do not manufacture advice.
-		return true
-	}
-	if scanned == 0 {
-		return true
-	}
-	return found
 }
 
-// stripComments removes HTML comments and then JS line/block comments, leaving
-// string and template literals intact (so `'https://x'` is not read as the start
-// of a comment, and an emitter that posts from inside a string still counts).
-func stripComments(src string) string {
-	return stripJSComments(stripHTMLComments(src))
+type ackScanner struct {
+	visited map[string]bool
+	files   int
+	found   bool
+	// partial records that something in the tree could not be read. It is
+	// sticky: once set, the answer can never be ackAbsent.
+	partial bool
+}
+
+func (s *ackScanner) walk(dir string) {
+	if s.found || s.partial {
+		return
+	}
+	// Resolve before recording: two paths that reach the same directory (a
+	// symlink and its target) must count once, or a self-referential link
+	// recurses forever.
+	real, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		s.partial = true
+		return
+	}
+	if s.visited[real] {
+		return
+	}
+	s.visited[real] = true
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		s.partial = true
+		return
+	}
+	for _, e := range entries {
+		if s.found || s.partial {
+			return
+		}
+		path := filepath.Join(dir, e.Name())
+		// os.Stat FOLLOWS symlinks — that is the point: a symlinked source
+		// directory must be walked as a directory. A dangling link fails here
+		// and correctly makes the scan partial.
+		info, err := os.Stat(path)
+		if err != nil {
+			s.partial = true
+			return
+		}
+		if info.IsDir() {
+			// Note the skip list is applied to ENTRIES only, never to the root
+			// we were handed — no skip rule can remove the whole tree.
+			if readyAckSkipDirs[e.Name()] {
+				continue
+			}
+			s.walk(path)
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if !readyAckSourceExts[ext] {
+			continue
+		}
+		if info.Size() > maxAckFileBytes || s.files >= maxAckScanFiles {
+			s.partial = true
+			return
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			s.partial = true
+			return
+		}
+		s.files++
+		if strings.Contains(stripComments(string(data), ext), readyAckType) {
+			s.found = true
+			return
+		}
+	}
+}
+
+// stripComments removes comments from src, given its file extension. JS
+// line/block comments are always stripped, leaving string and template literals
+// intact (so `'https://x'` is not read as the start of a comment, and an emitter
+// that posts from inside a string still counts). HTML comments are stripped only
+// for markup files — see readyAckMarkupExts for why that gate exists.
+func stripComments(src, ext string) string {
+	if readyAckMarkupExts[strings.ToLower(ext)] {
+		src = stripHTMLComments(src)
+	}
+	return stripJSComments(src)
 }
 
 func stripHTMLComments(src string) string {
@@ -253,6 +360,14 @@ func stripHTMLComments(src string) string {
 		if strings.HasPrefix(src[i:], "<!--") {
 			end := strings.Index(src[i+4:], "-->")
 			if end < 0 {
+				// 🔴 UNTERMINATED. Keep the remainder VERBATIM rather than
+				// discarding it. Dropping the tail is lossy in the expensive
+				// direction — everything below an unclosed `<!--` disappears,
+				// including an emitter, and the author gets a warning about a
+				// correct project. There is no upside to the lossy branch: text
+				// after an unclosed marker is not evidence of a comment, it is
+				// evidence the file is not what we assumed.
+				b.WriteString(src[i:])
 				return b.String()
 			}
 			i += 4 + end + 3
@@ -316,7 +431,8 @@ var readyAckAdvice = "the manifest declares a \"page\" surface but nothing in th
 	"bounded init retries run out (issue #206). Apps scaffolded before that fix ship no emitter: run " +
 	"`civitai app init` into a scratch directory and copy its `" + blockproto.ReadyAckFilename + "` " +
 	"into this project, loading it from index.html (a <script src>) or from the entry module — or adopt " +
-	"`@civitai/blocks-react`, whose transport acks for you (never both: whichever answers the first " +
-	"BLOCK_INIT cancels the host's retry). This is a source-text check, so it is wrong about a project " +
-	"whose ack arrives from a bundled dependency or a file type it does not read; it never inspects " +
-	"outputDir, which is not built yet"
+	"`@civitai/blocks-react`, whose iframe transport acks for you (never both: whichever answers the first " +
+	"BLOCK_INIT cancels the host's retry). Note `@civitai/app-sdk` alone does NOT ack — it is the " +
+	"server-side SDK and no runtime code in it posts " + readyAckType + ". This is a source-text check, so " +
+	"it is wrong about a project whose ack arrives from a bundled dependency or a file type it does not " +
+	"read; it is advisory only and never fails `civitai app validate` unless you pass --strict"

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -1,10 +1,12 @@
 package validate
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/civitai/cli/internal/blockproto"
 	"github.com/civitai/cli/internal/scaffold"
@@ -151,19 +153,79 @@ func TestReadyAckWarning(t *testing.T) {
 			wantWarn: false,
 		},
 		{
-			name:     "the SDK dep counts from devDependencies too",
+			name:     "the acking dep counts from devDependencies too",
 			manifest: ackManifest(true),
 			files: map[string]string{
-				"package.json": `{"devDependencies": {"@civitai/app-sdk": "^0.31.0"}}`,
+				"package.json": `{"devDependencies": {"@civitai/blocks-react": "^0.39.0"}}`,
 				"src/main.ts":  `export const x = 1;`,
 			},
 			wantWarn: false,
 		},
 		{
-			// The dep gate must be about @civitai/*, not about "has a
+			name:     "the acking dep counts from peerDependencies too",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"peerDependencies": {"@civitai/blocks-react": "^0.39.0"}}`,
+				"src/main.ts":  `export const x = 1;`,
+			},
+			wantWarn: false,
+		},
+		{
+			// 🔴 THE FALSIFIED CLAIM. `@civitai/theme` is framework-agnostic CSS
+			// tokens and contains no BLOCK_READY at all (measured on 0.2.0), so a
+			// scope test silenced a genuinely broken app. Reproduced live on a
+			// `static` scaffold with the emitter deleted before this case existed.
+			name:     "a non-acking @civitai package does NOT silence the check",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"@civitai/theme": "^0.2.0", "@civitai/components": "^0.3.0"}}`,
+				"index.html":   `<!doctype html><script src="./app.js"></script>`,
+				"app.js":       `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			// `@civitai/app-sdk@0.31.0` ships 17 runtime .js files and NONE posts
+			// BLOCK_READY — the only occurrences are a .d.ts type literal and the
+			// README, and it declares no dependencies, so it cannot be acking
+			// transitively. An app-sdk-only project genuinely does not ack.
+			name:     "@civitai/app-sdk alone does NOT silence the check",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"@civitai/app-sdk": "^0.31.0"}}`,
+				"index.html":   `<!doctype html><script type="module" src="/src/main.ts"></script>`,
+				"src/main.ts":  `export const x = 1;`,
+			},
+			wantWarn: true,
+		},
+		{
+			// Prefix widening: a sibling package name that merely starts the
+			// same way makes no ack promise.
+			name:     "a sibling of the acking package does NOT silence the check",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"@civitai/blocks-react-native": "^1.0.0"}}`,
+				"index.html":   `<!doctype html><script src="./app.js"></script>`,
+				"app.js":       `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			// Substring widening: a fork that merely CONTAINS the acking name.
+			name:     "a re-scoped fork does NOT silence the check",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"@myorg/@civitai/blocks-react": "^1.0.0"}}`,
+				"index.html":   `<!doctype html><script src="./app.js"></script>`,
+				"app.js":       `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			// The dep gate must be about a package that ACKS, not about "has a
 			// package.json". Without this, adding any dependency would silence
 			// the check.
-			name:     "a package.json with no @civitai dep still warns",
+			name:     "a package.json with no acking dep still warns",
 			manifest: ackManifest(true),
 			files: map[string]string{
 				"package.json": `{"dependencies": {"react": "^19.0.0", "react-dom": "^19.0.0"}}`,
@@ -232,6 +294,10 @@ func TestReadyAckWarning(t *testing.T) {
 			// outputDir is never read: it does not exist before the first build
 			// and is gitignored, so a hit there says nothing about what is
 			// submitted... and its ABSENCE must not be read as evidence either.
+			// The conventional build directories are skipped BY NAME, for cost.
+			// A stale `dist` therefore cannot supply ack evidence the source
+			// lacks — the one correctness benefit of skipping, and the reason
+			// the name list keeps these entries.
 			name:     "an ack present only in dist/ warns",
 			manifest: ackManifest(true),
 			files: map[string]string{
@@ -241,22 +307,116 @@ func TestReadyAckWarning(t *testing.T) {
 				"dist/assets/x.js": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
 			},
 			wantWarn: true,
-			why:      "killed by the NAME skip list (dist), not by the outputDir branch — see the case below",
 		},
 		{
-			// 🔴 The one that actually reaches the outputDir branch. `dist` is in
-			// readyAckSkipDirs, so the case above is decided by an EARLIER check
-			// and leaves the manifest-driven skip untested — a mutation that
-			// disabled it survived the whole suite until this case existed. A
-			// non-standard outputDir is the only way in.
-			name:     "an ack present only in a NON-STANDARD outputDir warns",
+			// 🔴 THE FALSIFIED CLAIM, HALF ONE. `outputDir` used to be skipped
+			// from the MANIFEST, which meant a perfectly valid `"outputDir":
+			// "src"` skipped the directory holding the emitter and warned at a
+			// correct project — reproduced live on a page-vite scaffold whose
+			// manifest had ZERO validation errors. Skipping is a cost decision,
+			// never a correctness one: for a presence check, scanning extra can
+			// only ADD evidence while skipping can only CREATE a false warning.
+			name:     `"outputDir": "src" must not hide the emitter that lives there`,
+			manifest: ackManifestOut(true, "src"),
+			files: map[string]string{
+				"package.json":        `{"dependencies": {"react": "^19.0.0"}}`,
+				"index.html":          `<script type="module" src="/src/main.jsx"></script>`,
+				"src/main.jsx":        `import './civitai-host.js';`,
+				"src/civitai-host.js": realEmitter(),
+			},
+			wantWarn: false,
+		},
+		{
+			// 🔴 HALF TWO. `"outputDir": "."` resolved to the project root, so the
+			// manifest-driven skip removed the ENTIRE tree, `scanned == 0`, and a
+			// genuinely broken app was silenced. No skip rule may ever be able to
+			// remove the root: the list is applied to ENTRIES, never to the root
+			// the scanner was handed.
+			name:     `"outputDir": "." must not skip the whole project`,
+			manifest: ackManifestOut(true, "."),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"react": "^19.0.0"}}`,
+				"index.html":   `<!doctype html><script src="./app.js"></script>`,
+				"app.js":       `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			// A non-conventional output directory is now SCANNED. That is the
+			// accepted residual trade: a stale build under `public/` can retain
+			// an ack the source lost and silence the check. A false negative,
+			// deliberately preferred over false-warning at every project whose
+			// outputDir happens to hold source (Vite's `public/` is a SOURCE
+			// directory, which is what made this the realistic shape).
+			name:     "a non-conventional outputDir is scanned rather than skipped",
 			manifest: ackManifestOut(true, "public"),
 			files: map[string]string{
-				"package.json":   `{"dependencies": {"react": "^19.0.0"}}`,
-				"index.html":     `<script type="module" src="/src/main.jsx"></script>`,
-				"src/main.jsx":   `import App from './App';`,
-				"public/app.js":  `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
-				"public/x/y.mjs": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
+				"package.json":  `{"dependencies": {"react": "^19.0.0"}}`,
+				"index.html":    `<script type="module" src="/src/main.jsx"></script>`,
+				"src/main.jsx":  `import App from './App';`,
+				"public/app.js": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
+			},
+			wantWarn: false,
+		},
+		{
+			// 🔴 An unterminated `<!--` in a .js used to truncate the scan of that
+			// file, deleting the emitter below it and warning at a correct
+			// project. Reproduced live by prefixing a scaffold's own
+			// civitai-host.js with this line. Two defences now: HTML stripping is
+			// not applied to .js at all, and an unterminated marker keeps the
+			// remainder verbatim.
+			name:     "an unterminated <!-- in a .js does not truncate the scan",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     "var OPEN_COMMENT = '<!--';\n" + realEmitter(),
+			},
+			wantWarn: false,
+		},
+		{
+			// The same hazard in a MARKUP file, where HTML stripping does apply:
+			// the unterminated marker must keep the tail rather than discard it.
+			name:     "an unterminated <!-- in .html keeps the rest of the file",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": "<!doctype html>\n<!-- unterminated\n<script>\n" +
+					"window.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, o);\n</script>",
+			},
+			wantWarn: false,
+		},
+		{
+			// A .js pair of `<!--` … `-->` in strings must not swallow what is
+			// between them either — the reason HTML stripping is gated to markup.
+			name:     "a matched <!-- --> pair in .js strings does not eat the emitter",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js": "var OPEN = '<!--';\n" +
+					"window.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, o);\n" +
+					"var CLOSE = '-->';\n",
+			},
+			wantWarn: false,
+		},
+		{
+			// A real HTML comment in a markup file must STILL be stripped — the
+			// positive control for the gate above. Without it, "don't strip HTML
+			// in .js" is indistinguishable from "don't strip HTML at all".
+			name:     "an HTML comment in .html is still stripped",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": "<!doctype html>\n<!-- TODO: post BLOCK_READY here -->\n<script src=\"./app.js\"></script>",
+				"app.js":     `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			// A block comment naming the message is still a comment. There was no
+			// /* */ fixture at all before.
+			name:     "an ack named only in a /* */ block comment warns",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     "/*\n * We should post BLOCK_READY at some point.\n */\ndocument.title = 'hi';\n",
 			},
 			wantWarn: true,
 		},
@@ -393,6 +553,145 @@ func TestReadyAckCannotObserve(t *testing.T) {
 	})
 }
 
+// TestReadyAckFollowsSymlinkedSource pins the monorepo shape. filepath.WalkDir
+// does NOT follow symlinks and does not even report them as directories, so a
+// project whose `src` is a symlink into a shared package had its entire source
+// tree silently skipped and warned at a correct project — reproduced live on a
+// page-vite scaffold before this existed.
+func TestReadyAckFollowsSymlinkedSource(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared")
+	proj := filepath.Join(root, "app")
+
+	for _, d := range []string{shared, proj} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(p, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(proj, "block.manifest.json"), ackManifest(true))
+	write(filepath.Join(proj, "package.json"), `{"dependencies": {"react": "^19.0.0"}}`)
+	write(filepath.Join(proj, "package-lock.json"), `{"lockfileVersion":3}`)
+	write(filepath.Join(proj, "index.html"), `<script type="module" src="/src/main.jsx"></script>`)
+	write(filepath.Join(shared, "main.jsx"), `import './civitai-host.js';`)
+	write(filepath.Join(shared, "civitai-host.js"), realEmitter())
+
+	// Positive control FIRST: with the emitter reachable only through the link,
+	// a green below could otherwise mean the scanner found it somewhere else.
+	if err := os.Symlink(filepath.Join("..", "shared"), filepath.Join(proj, "src")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	wantAckWarning(t, proj, false)
+
+	// Negative control: break the symlinked tree the same way #206 breaks an
+	// app, and the warning must come back — otherwise "does not warn" above is
+	// satisfied by a scanner that silently gave up on the symlink.
+	if err := os.Remove(filepath.Join(shared, "civitai-host.js")); err != nil {
+		t.Fatal(err)
+	}
+	wantAckWarning(t, proj, true)
+}
+
+// TestReadyAckSymlinkCycleTerminates pins the cost of following symlinks. A
+// self-referential link is the obvious way a followed walk never returns.
+func TestReadyAckSymlinkCycleTerminates(t *testing.T) {
+	dir := ackProject(t, ackManifest(false), map[string]string{
+		"index.html":      `<!doctype html><script src="./app.js"></script>`,
+		"src/app.js":      `document.title = 'hi';`,
+		"src/nested/x.js": `document.title = 'hi';`,
+	})
+	if err := os.Symlink("..", filepath.Join(dir, "src", "loop")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	// The assertion is that this RETURNS at all; the verdict is secondary.
+	done := make(chan bool, 1)
+	go func() {
+		res, err := Dir(dir)
+		if err != nil {
+			t.Error(err)
+		}
+		done <- hasReadyAckWarning(res)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the scan did not terminate on a symlink cycle — the visited set is not doing its job")
+	}
+}
+
+// TestReadyAckCapsAreUnobservable pins that hitting a cap stays SILENT. A scan
+// that stopped early has a gap in it, and a gap is not evidence of absence.
+func TestReadyAckCapsAreUnobservable(t *testing.T) {
+	t.Run("a file over the size cap silences the check", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script src="./app.js"></script>`,
+			"app.js":     `document.title = 'hi';`,
+		})
+		// Positive control: without the oversized file this project warns.
+		wantAckWarning(t, dir, true)
+		big := strings.Repeat("x", maxAckFileBytes+1)
+		if err := os.WriteFile(filepath.Join(dir, "bundle.js"), []byte(big), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		wantAckWarning(t, dir, false)
+	})
+
+	t.Run("exceeding the file budget silences the check", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script src="./app.js"></script>`,
+			"app.js":     `document.title = 'hi';`,
+		})
+		wantAckWarning(t, dir, true)
+		for i := 0; i <= maxAckScanFiles; i++ {
+			p := filepath.Join(dir, "gen", fmt.Sprintf("f%05d.js", i))
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte("var x=1;\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		wantAckWarning(t, dir, false)
+	})
+}
+
+// TestReadyAckAdviceIsActionable pins the message CONTENT. hasReadyAckWarning
+// compares against the readyAckAdvice variable, which is self-referential —
+// replacing the whole advisory with "something may be wrong" passes every other
+// test in this file. AGENTS.md requires a message to name what to do, so assert
+// the parts an author acts on.
+func TestReadyAckAdviceIsActionable(t *testing.T) {
+	required := []struct{ substr, why string }{
+		{"page", "the author has to know WHICH manifest field put them here"},
+		{readyAckType, "the message that is missing"},
+		{"civitai app init", "the concrete command that produces a correct emitter"},
+		{blockproto.ReadyAckFilename, "the file to copy in"},
+		{"index.html", "where the emitter has to be referenced from"},
+		{"@civitai/blocks-react", "the alternative to hand-writing it"},
+		{"never both", "adopting the SDK without deleting the emitter is strictly worse"},
+		{"#206", "the issue an author can read for the full story"},
+		{"--strict", "so nobody thinks this blocks them today"},
+	}
+	for _, r := range required {
+		if !strings.Contains(readyAckAdvice, r.substr) {
+			t.Errorf("the advisory does not mention %q — %s\ngot: %s", r.substr, r.why, readyAckAdvice)
+		}
+	}
+	// A message that says nothing useful is short. This is a crude floor, but it
+	// is the one thing a "something may be wrong" rewrite cannot satisfy.
+	if len(readyAckAdvice) < 400 {
+		t.Errorf("the advisory is %d chars — too short to carry a diagnosis and a remedy", len(readyAckAdvice))
+	}
+}
+
 // TestReadyAckIsAdvisoryOnly pins the tier. The check must never reach Errors —
 // it infers runtime behaviour from static text, and a hard failure on a
 // heuristic breaks correct projects.
@@ -478,15 +777,42 @@ func TestSDKTemplateIsQuietOnlyBecauseOfTheDependency(t *testing.T) {
 	if _, err := scaffold.Render(scaffold.PageMoney, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
 		t.Fatal(err)
 	}
-	if emitsReadyAck(dest, "dist") {
-		t.Fatalf("page-money's SOURCE mentions %s — the dep gate is no longer the reason it is accepted, "+
-			"so nothing in this suite covers that branch any more", readyAckType)
+	if got := scanForReadyAck(dest); got != ackAbsent {
+		t.Fatalf("scanForReadyAck(page-money) = %v, want ackAbsent — the dep gate is no longer the reason "+
+			"it is accepted, so nothing in this suite covers that branch any more", got)
 	}
 	if got := sdkDependency(dest); got != sdkPresent {
-		t.Fatalf("sdkDependency(page-money) = %v, want sdkPresent — the rendered package.json must depend on %s*",
-			got, civitaiDepPrefix)
+		t.Fatalf("sdkDependency(page-money) = %v, want sdkPresent — the rendered package.json must depend "+
+			"on one of %v", got, blockproto.AckingPackages())
 	}
 	wantAckWarning(t, dest, false)
+}
+
+// TestSDKTemplateDepsAreNotJustAnyCivitaiPackage pins that page-money is
+// accepted because of the package that ACKS, not merely because it has
+// `@civitai/*` dependencies. It depends on BOTH `@civitai/app-sdk` (which does
+// not ack) and `@civitai/blocks-react` (which does), so a scope test and an
+// exact test agree on this template — which is exactly why the template alone
+// could never have caught the widening.
+func TestSDKTemplateDepsAreNotJustAnyCivitaiPackage(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "page-money")
+	if _, err := scaffold.Render(scaffold.PageMoney, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dest, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	acking := 0
+	for _, name := range blockproto.AckingPackages() {
+		if strings.Contains(string(raw), `"`+name+`"`) {
+			acking++
+		}
+	}
+	if acking == 0 {
+		t.Fatalf("page-money depends on no acking package (%v) — it must, or the SDK branch of the check "+
+			"has no real-template coverage at all", blockproto.AckingPackages())
+	}
 }
 
 // TestDeletingTheEmitterMakesTheWarningFire is the NEGATIVE CONTROL for the

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -1,0 +1,455 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/blockproto"
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures.
+// ---------------------------------------------------------------------------
+
+// ackManifest is an otherwise-valid PAGE manifest. `build` splices in the
+// buildCommand + outputDir pair the schema couples, so the outputDir-is-never-
+// scanned case has a real outputDir to be ignored.
+func ackManifest(build bool) string {
+	extra := ""
+	if build {
+		extra = `, "buildCommand": "npm run build", "outputDir": "dist"`
+	}
+	return `{
+		"blockId": "ack-block", "version": "0.1.0", "name": "Ack Block",
+		"contentRating": "g", "scopes": [],
+		"page": {"path": "/", "title": "Ack Block"},
+		"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"}` + extra + `
+	}`
+}
+
+// nonPageManifest declares no `page` surface at all.
+const nonPageManifest = `{
+	"blockId": "slot-block", "version": "0.1.0", "name": "Slot Block",
+	"contentRating": "g", "scopes": [],
+	"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"}
+}`
+
+// realEmitter is what a correctly scaffolded SDK-free page app ships. Taken
+// from blockproto rather than retyped, so this fixture cannot drift away from
+// the thing the CLI actually writes.
+func realEmitter() string { return string(blockproto.ReadyAckSource()) }
+
+// ackProject writes a project (paths may contain subdirectories) and returns it.
+func ackProject(t *testing.T, manifestJSON string, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	all := map[string]string{"block.manifest.json": manifestJSON}
+	for k, v := range files {
+		all[k] = v
+	}
+	for name, body := range all {
+		p := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// hasReadyAckWarning compares against the advisory VALUE, not a substring of its
+// prose. A substring match would keep passing if the message were rewritten into
+// something that no longer says what to do, and would also match a different
+// warning that happened to share a phrase.
+func hasReadyAckWarning(res Result) bool {
+	for _, w := range res.Warnings {
+		if w == readyAckAdvice {
+			return true
+		}
+	}
+	return false
+}
+
+func wantAckWarning(t *testing.T, dir string, want bool) Result {
+	t.Helper()
+	res, err := Dir(dir)
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if got := hasReadyAckWarning(res); got != want {
+		t.Fatalf("ready-ack warning = %v, want %v\nwarnings: %v\nerrors: %v", got, want, res.Warnings, res.Errors)
+	}
+	return res
+}
+
+// ---------------------------------------------------------------------------
+// The table.
+// ---------------------------------------------------------------------------
+
+func TestReadyAckWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		files    map[string]string
+		wantWarn bool
+		why      string
+	}{
+		{
+			// THE TARGET POPULATION: a page app scaffolded before 4018e2c. Its
+			// index.html loads app.js, and neither says hello.
+			name:     "page app with no ack at all warns",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     `document.title = 'hi';`,
+			},
+			wantWarn: true,
+			why:      "this is exactly the #206 shape the check exists to find",
+		},
+		{
+			name:     "page app shipping the real emitter does not warn",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html":       `<!doctype html><script src="./civitai-host.js"></script>`,
+				"civitai-host.js":  realEmitter(),
+				"unrelated.txt":    "BLOCK_READY",
+				"src/component.js": `export const x = 1;`,
+			},
+			wantWarn: false,
+		},
+		{
+			// 🔴 THE REGRESSION THAT WOULD HURT MOST. The SDK's IframeTransport
+			// acks internally and the literal never appears in src/, so a
+			// source-only check warns at EVERY correct page-money app.
+			name:     "page app depending on @civitai/blocks-react does not warn",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"react": "^19.0.0", "@civitai/blocks-react": "^0.39.0"}}`,
+				"index.html":   `<script type="module" src="/src/main.tsx"></script>`,
+				"src/main.tsx": `import { BlockProvider } from '@civitai/blocks-react';`,
+			},
+			wantWarn: false,
+		},
+		{
+			name:     "the SDK dep counts from devDependencies too",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"devDependencies": {"@civitai/app-sdk": "^0.31.0"}}`,
+				"src/main.ts":  `export const x = 1;`,
+			},
+			wantWarn: false,
+		},
+		{
+			// The dep gate must be about @civitai/*, not about "has a
+			// package.json". Without this, adding any dependency would silence
+			// the check.
+			name:     "a package.json with no @civitai dep still warns",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json": `{"dependencies": {"react": "^19.0.0", "react-dom": "^19.0.0"}}`,
+				"index.html":   `<script type="module" src="/src/main.jsx"></script>`,
+				"src/main.jsx": `import App from './App';`,
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "a non-page app never warns",
+			manifest: nonPageManifest,
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     `document.title = 'hi';`,
+			},
+			wantWarn: false,
+			why:      "the ready contract pinned here is the PAGE host's",
+		},
+		{
+			// 🔴 The comment strip. Both shipped SDK-free templates carry this
+			// exact sentence in a source comment, and it SURVIVES deleting the
+			// emitter — so without stripping, the check is inert on the very
+			// apps it was written for.
+			name:     "an ack named only in a comment warns",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js": "// The ONE message a page app must send is `BLOCK_READY`; without it the host\n" +
+					"// shows a failure card.\ndocument.title = 'hi';\n",
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "an ack named only in an HTML comment warns",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": "<!doctype html>\n<!-- we post BLOCK_READY from app.js -->\n<script src=\"./app.js\"></script>",
+				"app.js":     `document.title = 'hi';`,
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "an ack described only in the README warns",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     `document.title = 'hi';`,
+				"README.md":  "The host waits for a `BLOCK_READY` message before it will show your app.",
+			},
+			wantWarn: true,
+			why:      "docs are not an implementation; both scaffold READMEs describe the handshake",
+		},
+		{
+			// outputDir is never read: it does not exist before the first build
+			// and is gitignored, so a hit there says nothing about what is
+			// submitted... and its ABSENCE must not be read as evidence either.
+			name:     "an ack present only in outputDir warns",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json":     `{"dependencies": {"react": "^19.0.0"}}`,
+				"index.html":       `<script type="module" src="/src/main.jsx"></script>`,
+				"src/main.jsx":     `import App from './App';`,
+				"dist/assets/x.js": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "an ack in node_modules does not count",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json":            `{"dependencies": {"react": "^19.0.0"}}`,
+				"src/main.jsx":            `import App from './App';`,
+				"node_modules/dep/idx.js": `postMessage({type:'BLOCK_READY'})`,
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "an inline ack in index.html does not warn",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": "<!doctype html><script>\n" +
+					"window.addEventListener('message', function (e) {\n" +
+					"  if (e.data && e.data.type === 'BLOCK_INIT') {\n" +
+					"    window.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, e.origin);\n" +
+					"  }\n});\n</script>",
+			},
+			wantWarn: false,
+		},
+		{
+			name:     "an ack in a .vue single-file component does not warn",
+			manifest: ackManifest(true),
+			files: map[string]string{
+				"package.json":  `{"dependencies": {"vue": "^3.5.0"}}`,
+				"src/App.vue":   "<script setup>\nwindow.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, origin);\n</script>",
+				"package-x.txt": "ignored",
+			},
+			wantWarn: false,
+		},
+		{
+			// A URL inside a string must not be read as the start of a comment —
+			// otherwise everything after it is stripped and a real ack below it
+			// disappears.
+			name:     "a URL literal does not swallow the rest of the file",
+			manifest: ackManifest(false),
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js": "var docs = 'https://civitai.com/docs';\n" +
+					"window.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, o);\n",
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantAckWarning(t, ackProject(t, tt.manifest, tt.files), tt.wantWarn)
+			if tt.why != "" {
+				t.Logf("%s — %s", tt.name, tt.why)
+			}
+		})
+	}
+}
+
+// TestReadyAckCannotObserve pins the early-outs. Each of these is a project the
+// check cannot answer for, and "cannot answer" must produce NO finding rather
+// than a guess — the false-warning-at-a-correct-project failure AGENTS.md item
+// 10 exists to prevent.
+func TestReadyAckCannotObserve(t *testing.T) {
+	t.Run("an unparseable package.json silences the check", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(true), map[string]string{
+			"package.json": `{"dependencies": {`, // truncated
+			"src/main.jsx": `import App from './App';`,
+		})
+		wantAckWarning(t, dir, false)
+	})
+
+	t.Run("a directory holding only a manifest silences the check", func(t *testing.T) {
+		// Zero source files READ. A zero-hit scan over a zero-file tree says
+		// nothing about the app — it is the same observation a scanner wired to
+		// nothing would produce.
+		dir := ackProject(t, ackManifest(false), nil)
+		wantAckWarning(t, dir, false)
+	})
+
+	t.Run("a tree of only unscanned file types silences the check", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"README.md":  "no code here",
+			"notes.txt":  "nor here",
+			"logo.svg":   "<svg/>",
+			"styles.css": "body{}",
+		})
+		wantAckWarning(t, dir, false)
+	})
+
+	t.Run("one scannable file is enough to conclude", func(t *testing.T) {
+		// The positive control for the two cases above: as soon as the scanner
+		// really reads a line of code, a missing ack IS a finding. Without this,
+		// "scanned == 0 means silence" is indistinguishable from silence always.
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"README.md":  "no code here",
+			"index.html": `<!doctype html><h1>hi</h1>`,
+		})
+		wantAckWarning(t, dir, true)
+	})
+
+	t.Run("an unreadable package.json silences the check", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(true), map[string]string{
+			"src/main.jsx": `import App from './App';`,
+		})
+		// A DIRECTORY where package.json belongs: os.ReadFile fails with
+		// something that is NOT os.IsNotExist, on every platform and as any
+		// user (a chmod-based fixture is a no-op for root).
+		if err := os.Mkdir(filepath.Join(dir, "package.json"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		wantAckWarning(t, dir, false)
+	})
+}
+
+// TestReadyAckIsAdvisoryOnly pins the tier. The check must never reach Errors —
+// it infers runtime behaviour from static text, and a hard failure on a
+// heuristic breaks correct projects.
+func TestReadyAckIsAdvisoryOnly(t *testing.T) {
+	dir := ackProject(t, ackManifest(false), map[string]string{
+		"index.html": `<!doctype html><script src="./app.js"></script>`,
+		"app.js":     `document.title = 'hi';`,
+	})
+	res := wantAckWarning(t, dir, true)
+	for _, e := range res.Errors {
+		if e == readyAckAdvice {
+			t.Fatalf("the ready-ack advisory reached Errors — it must stay a warning")
+		}
+	}
+	if !res.OK() {
+		t.Fatalf("a page app missing the ack must still VALIDATE (exit 0 without --strict); errors: %v", res.Errors)
+	}
+}
+
+// TestReadyAckSkippedByManifestOnly pins the PLACEMENT. warningChecks runs
+// unconditionally, including under ManifestOnly — which `civitai app init` uses
+// to self-check the template it just wrote. A check that reads src/ placed there
+// would make init's self-validation depend on files that are not its business.
+func TestReadyAckSkippedByManifestOnly(t *testing.T) {
+	dir := ackProject(t, ackManifest(false), map[string]string{
+		"index.html": `<!doctype html><script src="./app.js"></script>`,
+		"app.js":     `document.title = 'hi';`,
+	})
+
+	// Positive control: the same directory DOES warn through Dir. Without it, a
+	// green below is indistinguishable from a check that never fires at all.
+	wantAckWarning(t, dir, true)
+
+	res, err := ManifestOnly(dir)
+	if err != nil {
+		t.Fatalf("ManifestOnly: %v", err)
+	}
+	if hasReadyAckWarning(res) {
+		t.Fatalf("ManifestOnly emitted the ready-ack advisory; it must stay in the projectState branch\nwarnings: %v", res.Warnings)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The seam guard: the CHECK against the real TEMPLATES.
+// ---------------------------------------------------------------------------
+
+// TestShippedTemplatesDoNotTripTheReadyAckWarning is the guard that matters
+// most. Every unit case above builds a synthetic project; this one renders the
+// REAL templates and requires the CLI's own check to accept them, so drift on
+// EITHER side (a template that stops shipping the emitter, or a check that
+// stops recognising it) fails loudly. It mirrors the seam guards in
+// internal/scaffold/dev_embed_contract_test.go.
+//
+// It deliberately ignores validation ERRORS: a freshly rendered page-vite has
+// no lockfile yet, which is a legitimate hard error and not this test's subject.
+func TestShippedTemplatesDoNotTripTheReadyAckWarning(t *testing.T) {
+	examined := 0
+	for _, tmpl := range scaffold.AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), string(tmpl))
+			if _, err := scaffold.Render(tmpl, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
+				t.Fatalf("render %s: %v", tmpl, err)
+			}
+			wantAckWarning(t, dest, false)
+		})
+		examined++
+	}
+	// COUNT POSITIVE CONTROL: a zero here is otherwise indistinguishable from an
+	// enumeration that returned nothing.
+	if examined < 3 {
+		t.Fatalf("examined only %d template(s), expected at least 3 — the enumeration stopped OBSERVING", examined)
+	}
+}
+
+// TestSDKTemplateIsQuietOnlyBecauseOfTheDependency is the positive control for
+// the dep gate. page-money is accepted above; this proves WHY. If its source
+// ever did contain the literal, the case above would pass for a reason that has
+// nothing to do with the branch it is meant to cover, and deleting the dep gate
+// would go unnoticed — which is precisely the regression that false-warns at
+// every correct money-path app.
+func TestSDKTemplateIsQuietOnlyBecauseOfTheDependency(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "page-money")
+	if _, err := scaffold.Render(scaffold.PageMoney, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
+		t.Fatal(err)
+	}
+	if emitsReadyAck(dest, "dist") {
+		t.Fatalf("page-money's SOURCE mentions %s — the dep gate is no longer the reason it is accepted, "+
+			"so nothing in this suite covers that branch any more", readyAckType)
+	}
+	if got := sdkDependency(dest); got != sdkPresent {
+		t.Fatalf("sdkDependency(page-money) = %v, want sdkPresent — the rendered package.json must depend on %s*",
+			got, civitaiDepPrefix)
+	}
+	wantAckWarning(t, dest, false)
+}
+
+// TestDeletingTheEmitterMakesTheWarningFire is the NEGATIVE CONTROL for the
+// guard above: it takes a correct scaffold, breaks it exactly the way a
+// pre-4018e2c app is broken, and requires the warning. Without it,
+// "no template warns" is satisfied by a check that never warns about anything.
+func TestDeletingTheEmitterMakesTheWarningFire(t *testing.T) {
+	for _, tmpl := range []scaffold.Template{scaffold.Static, scaffold.PageVite} {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), string(tmpl))
+			if _, err := scaffold.Render(tmpl, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
+				t.Fatal(err)
+			}
+			wantAckWarning(t, dest, false)
+
+			rel := tmpl.ReadyAckPath()
+			if rel == "" {
+				t.Fatalf("%s no longer declares a ReadyAckPath — this control has nothing to delete", tmpl)
+			}
+			if err := os.Remove(filepath.Join(dest, filepath.FromSlash(rel))); err != nil {
+				t.Fatal(err)
+			}
+			wantAckWarning(t, dest, true)
+
+			// The advisory must name the file the author has to restore.
+			if !strings.Contains(readyAckAdvice, blockproto.ReadyAckFilename) {
+				t.Errorf("the advisory does not name %s — an author cannot act on it", blockproto.ReadyAckFilename)
+			}
+		})
+	}
+}

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -17,10 +17,16 @@ import (
 // ackManifest is an otherwise-valid PAGE manifest. `build` splices in the
 // buildCommand + outputDir pair the schema couples, so the outputDir-is-never-
 // scanned case has a real outputDir to be ignored.
-func ackManifest(build bool) string {
+func ackManifest(build bool) string { return ackManifestOut(build, "dist") }
+
+// ackManifestOut is ackManifest with an explicit outputDir. `dist` is ALSO in
+// readyAckSkipDirs, so a fixture using it can never reach the outputDir branch —
+// the name-based skip always wins first. A non-standard outputDir is the only
+// way to exercise that branch, which is why this exists.
+func ackManifestOut(build bool, outputDir string) string {
 	extra := ""
 	if build {
-		extra = `, "buildCommand": "npm run build", "outputDir": "dist"`
+		extra = `, "buildCommand": "npm run build", "outputDir": "` + outputDir + `"`
 	}
 	return `{
 		"blockId": "ack-block", "version": "0.1.0", "name": "Ack Block",
@@ -34,6 +40,15 @@ func ackManifest(build bool) string {
 const nonPageManifest = `{
 	"blockId": "slot-block", "version": "0.1.0", "name": "Slot Block",
 	"contentRating": "g", "scopes": [],
+	"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"}
+}`
+
+// nullPageManifest sets the key EXPLICITLY to null. `encoding/json` decodes that
+// to a present key holding a nil value, so a presence-only test ("is the key
+// there") reads it as a page app and a `v != nil` test does not.
+const nullPageManifest = `{
+	"blockId": "null-page", "version": "0.1.0", "name": "Null Page",
+	"contentRating": "g", "scopes": [], "page": null,
 	"iframe": {"minHeight": 400, "resizable": true, "sandbox": "allow-scripts"}
 }`
 
@@ -168,6 +183,18 @@ func TestReadyAckWarning(t *testing.T) {
 			why:      "the ready contract pinned here is the PAGE host's",
 		},
 		{
+			// An explicit null is not a page surface. Pins the `v != nil` half of
+			// declaresPage: a presence-only test passes every other case in this
+			// table, so without this the two halves are indistinguishable.
+			name:     `an explicit "page": null does not warn`,
+			manifest: nullPageManifest,
+			files: map[string]string{
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     `document.title = 'hi';`,
+			},
+			wantWarn: false,
+		},
+		{
 			// 🔴 The comment strip. Both shipped SDK-free templates carry this
 			// exact sentence in a source comment, and it SURVIVES deleting the
 			// emitter — so without stripping, the check is inert on the very
@@ -205,13 +232,31 @@ func TestReadyAckWarning(t *testing.T) {
 			// outputDir is never read: it does not exist before the first build
 			// and is gitignored, so a hit there says nothing about what is
 			// submitted... and its ABSENCE must not be read as evidence either.
-			name:     "an ack present only in outputDir warns",
+			name:     "an ack present only in dist/ warns",
 			manifest: ackManifest(true),
 			files: map[string]string{
 				"package.json":     `{"dependencies": {"react": "^19.0.0"}}`,
 				"index.html":       `<script type="module" src="/src/main.jsx"></script>`,
 				"src/main.jsx":     `import App from './App';`,
 				"dist/assets/x.js": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
+			},
+			wantWarn: true,
+			why:      "killed by the NAME skip list (dist), not by the outputDir branch — see the case below",
+		},
+		{
+			// 🔴 The one that actually reaches the outputDir branch. `dist` is in
+			// readyAckSkipDirs, so the case above is decided by an EARLIER check
+			// and leaves the manifest-driven skip untested — a mutation that
+			// disabled it survived the whole suite until this case existed. A
+			// non-standard outputDir is the only way in.
+			name:     "an ack present only in a NON-STANDARD outputDir warns",
+			manifest: ackManifestOut(true, "public"),
+			files: map[string]string{
+				"package.json":   `{"dependencies": {"react": "^19.0.0"}}`,
+				"index.html":     `<script type="module" src="/src/main.jsx"></script>`,
+				"src/main.jsx":   `import App from './App';`,
+				"public/app.js":  `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
+				"public/x/y.mjs": `window.parent.postMessage({type:'BLOCK_READY',payload:{}},o)`,
 			},
 			wantWarn: true,
 		},
@@ -248,14 +293,17 @@ func TestReadyAckWarning(t *testing.T) {
 			wantWarn: false,
 		},
 		{
-			// A URL inside a string must not be read as the start of a comment —
-			// otherwise everything after it is stripped and a real ack below it
-			// disappears.
-			name:     "a URL literal does not swallow the rest of the file",
+			// A URL inside a string must not be read as the start of a comment.
+			// The ack is on the SAME LINE as the URL on purpose: with quote
+			// handling defeated, the `//` in `https://` starts a line comment and
+			// swallows everything after it — including the ack. Split across two
+			// lines this case passes with the string handling deleted, which is
+			// how the first version of it left that branch unproven.
+			name:     "a URL literal does not swallow the ack after it",
 			manifest: ackManifest(false),
 			files: map[string]string{
 				"index.html": `<!doctype html><script src="./app.js"></script>`,
-				"app.js": "var docs = 'https://civitai.com/docs';\n" +
+				"app.js": "var docs = 'https://civitai.com/docs'; " +
 					"window.parent.postMessage({ type: 'BLOCK_READY', payload: {} }, o);\n",
 			},
 			wantWarn: false,
@@ -312,6 +360,23 @@ func TestReadyAckCannotObserve(t *testing.T) {
 			"index.html": `<!doctype html><h1>hi</h1>`,
 		})
 		wantAckWarning(t, dir, true)
+	})
+
+	t.Run("an unreadable source file silences the check", func(t *testing.T) {
+		// A DANGLING SYMLINK with a scanned extension: WalkDir hands it over as a
+		// non-directory, os.ReadFile fails, and the walk aborts. We then know
+		// nothing about the rest of the tree — including whatever we had not
+		// reached yet — so the only honest answer is silence. Without this
+		// fixture that branch is unreachable: chmod is a no-op for root, so a
+		// permissions-based fixture proves nothing on a root CI runner.
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script src="./app.js"></script>`,
+			"app.js":     `document.title = 'hi';`,
+		})
+		if err := os.Symlink(filepath.Join(dir, "gone.js"), filepath.Join(dir, "broken.js")); err != nil {
+			t.Skipf("symlinks unavailable here: %v", err)
+		}
+		wantAckWarning(t, dir, false)
 	})
 
 	t.Run("an unreadable package.json silences the check", func(t *testing.T) {

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -638,8 +638,57 @@ func TestReadyAckFollowsSymlinkedSource(t *testing.T) {
 	wantAckWarning(t, proj, true)
 }
 
-// TestReadyAckSymlinkCycleTerminates pins the cost of following symlinks. A
-// self-referential link is the obvious way a followed walk never returns.
+// TestReadyAckScannerVisitsEachDirectoryOnce pins the visited set DIRECTLY, by
+// counting files read.
+//
+// Found by a surviving mutant: deleting the visited set entirely passed the
+// suite, including the cycle test below. That test was proving the wrong thing —
+// a self-referential symlink terminates anyway, because Linux gives up with
+// ELOOP after ~40 resolutions and the resulting error makes the scan partial. So
+// termination is guaranteed by the OS, and the visited set's real job is
+// avoiding DUPLICATE WORK: without it, two links to the same directory read
+// every file in it twice, inflating the file count toward a budget whose only
+// effect is to silence the check.
+//
+// Asserting the count is the only thing that can see that. This walks the
+// scanner directly rather than through Dir(), because the number of files read
+// is the observable and the verdict is not.
+func TestReadyAckScannerVisitsEachDirectoryOnce(t *testing.T) {
+	dir := t.TempDir()
+	shared := filepath.Join(dir, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const nFiles = 3
+	for i := 0; i < nFiles; i++ {
+		p := filepath.Join(shared, fmt.Sprintf("m%d.js", i))
+		if err := os.WriteFile(p, []byte("var x=1;\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Two more routes to the same directory. A walk with no visited set reads
+	// each file three times.
+	for _, link := range []string{"link1", "link2"} {
+		if err := os.Symlink("shared", filepath.Join(dir, link)); err != nil {
+			t.Skipf("symlinks unavailable here: %v", err)
+		}
+	}
+
+	s := &ackScanner{visited: map[string]bool{}}
+	s.walk(dir)
+	if s.partial {
+		t.Fatalf("the scan reported partial on a readable tree — it should have read all %d files", nFiles)
+	}
+	if s.files != nFiles {
+		t.Fatalf("scanner read %d files, want %d — three paths reach the same directory, so a walk that "+
+			"does not record RESOLVED paths reads each file once per route", s.files, nFiles)
+	}
+}
+
+// TestReadyAckSymlinkCycleTerminates pins that a self-referential link does not
+// hang. Note what it does NOT prove: the OS's own ELOOP limit terminates this
+// even with the visited set deleted, so this is a backstop assertion and
+// TestReadyAckScannerVisitsEachDirectoryOnce is what actually covers the guard.
 func TestReadyAckSymlinkCycleTerminates(t *testing.T) {
 	dir := ackProject(t, ackManifest(false), map[string]string{
 		"index.html":      `<!doctype html><script src="./app.js"></script>`,

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -523,12 +523,18 @@ func TestReadyAckCannotObserve(t *testing.T) {
 	})
 
 	t.Run("an unreadable source file silences the check", func(t *testing.T) {
-		// A DANGLING SYMLINK with a scanned extension: WalkDir hands it over as a
-		// non-directory, os.ReadFile fails, and the walk aborts. We then know
-		// nothing about the rest of the tree — including whatever we had not
-		// reached yet — so the only honest answer is silence. Without this
-		// fixture that branch is unreachable: chmod is a no-op for root, so a
-		// permissions-based fixture proves nothing on a root CI runner.
+		// A DANGLING SYMLINK with a scanned extension: os.Stat cannot resolve it,
+		// so the walk stops there. We then know nothing about the rest of the
+		// tree — including whatever we had not reached yet — so the only honest
+		// answer is silence.
+		//
+		// 🔴 This fixture reaches the os.Stat guard, NOT the os.ReadFile one
+		// below it. Measured: mutating that ReadFile branch to `continue` fails
+		// NOTHING in the suite, and the same is true of the os.ReadDir branch.
+		// Both are reachable only via permissions (a mode-0000 file, a mode-0111
+		// dir), and chmod is a no-op for root, so neither can be pinned on a root
+		// CI runner. Shipped behaviour for both was verified by hand — they stay
+		// silent — but do not read this case as covering them.
 		dir := ackProject(t, ackManifest(false), map[string]string{
 			"index.html": `<!doctype html><script src="./app.js"></script>`,
 			"app.js":     `document.title = 'hi';`,

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -553,6 +553,44 @@ func TestReadyAckCannotObserve(t *testing.T) {
 	})
 }
 
+// TestReadyAckSkipListNeverRemovesTheRoot pins the "applied to ENTRIES only"
+// half of the skip rule.
+//
+// Found by a surviving mutant: adding `if readyAckSkipDirs[filepath.Base(dir)]
+// { return }` to the top of the walk passed the ENTIRE suite, because every
+// fixture's project root is a random t.TempDir() name. A project whose own
+// directory is called `build`, `out` or `dist` is perfectly ordinary, and under
+// that mutant it scanned nothing, reported "no files read", and went silent —
+// the same whole-tree removal that `"outputDir": "."` used to cause.
+func TestReadyAckSkipListNeverRemovesTheRoot(t *testing.T) {
+	for _, name := range []string{"dist", "build", "out", "node_modules"} {
+		t.Run("project directory named "+name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), name)
+			if err := os.MkdirAll(root, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			write := func(p, body string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(root, p), []byte(body), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write("block.manifest.json", ackManifest(false))
+			write("index.html", `<!doctype html><script src="./app.js"></script>`)
+			write("app.js", `document.title = 'hi';`)
+			// The #206 shape: it must still be REPORTED even though the project
+			// happens to live in a directory whose name is on the skip list.
+			wantAckWarning(t, root, true)
+
+			// Positive control on the same tree: with an emitter it goes silent,
+			// so the assertion above cannot be satisfied by a scan that warns
+			// unconditionally.
+			write("civitai-host.js", realEmitter())
+			wantAckWarning(t, root, false)
+		})
+	}
+}
+
 // TestReadyAckFollowsSymlinkedSource pins the monorepo shape. filepath.WalkDir
 // does NOT follow symlinks and does not even report them as directories, so a
 // project whose `src` is a symlink into a shared package had its entire source

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -152,7 +152,7 @@ func validateDir(dir string, projectState bool) (Result, error) {
 		// HERE rather than in warningChecks because it reads src/, and
 		// warningChecks also runs under ManifestOnly, where `civitai app init`
 		// self-checks a template it just wrote. See readyack.go.
-		res.Warnings = append(res.Warnings, readyAckChecks(dir, generic, m)...)
+		res.Warnings = append(res.Warnings, readyAckChecks(dir, generic)...)
 	}
 
 	// Non-fatal advisories: real money-path footguns the schema can't catch as

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -145,6 +145,14 @@ func validateDir(dir string, projectState bool) (Result, error) {
 		lockErrs, lockWarns := lockfileChecks(dir, m)
 		res.Errors = append(res.Errors, lockErrs...)
 		res.Warnings = append(res.Warnings, lockWarns...)
+
+		// Project state: a `page` app whose source never posts BLOCK_READY is
+		// invisible in the real host (issue #206). ADVISORY, not fatal — it
+		// infers runtime behaviour from static text and can be wrong. It lives
+		// HERE rather than in warningChecks because it reads src/, and
+		// warningChecks also runs under ManifestOnly, where `civitai app init`
+		// self-checks a template it just wrote. See readyack.go.
+		res.Warnings = append(res.Warnings, readyAckChecks(dir, generic, m)...)
 	}
 
 	// Non-fatal advisories: real money-path footguns the schema can't catch as


### PR DESCRIPTION
Follow-up to #208 (merged as `4018e2c`), closing #206 for apps that already exist.

`4018e2c` fixed the `static` and `page-vite` **templates**, which declared a
`page` surface and never posted `BLOCK_READY`. **Every app scaffolded before that
commit is still broken, and nothing tells its author** — it renders perfectly
everywhere you can look locally and is replaced by a failure card in the real
host after ~37s. This was deliberately deferred out of #208 so it would land
*after* the templates were fixed; landing it first would have turned the shipped
scaffolds' own self-validation red.

Two pieces, with deliberately different evidentiary strength.

---

## 1. `internal/antipattern`: the `resize-iframe-page` rule (a GATE)

`hostHandlerParity.ts` marks `RESIZE_IFRAME` **N/A for `PageBlockHost`** — a page
block fills the surface and does not size to content — so a page app posting it
is dead code that also models the wrong envelope for every message the author
writes next. Both raw templates demoed it until #206 removed them.

This one **is** allowed to fail the build (it fails the `scaffold-currency` job),
because it fires on a **literal that is present in the file**. No inference.

It is the first non-REST entry in that denylist, which until now was strictly
"dead REST route behind a host bridge". Two precision decisions:

- It matches only a **matching `'` or `"` pair** — deliberately *not* the
  backtick form. This repo's README, both scaffold READMEs and AGENTS.md item 11
  all name `` `RESIZE_IFRAME` `` in markdown backticks *precisely to tell authors
  not to post it*. A gate that fails the documentation of its own rule is a false
  positive at a correct project.
- It **assumes a page surface rather than reading a manifest.** `Rule` is a
  per-line regex with no manifest context by construction, and every template
  this CLI ships declares `page`. A non-page template would need that assumption
  revisited, not the rule deleted — the code says so.

## 2. `civitai app validate`: a page-app-without-ack advisory (a WARNING)

🔴 **`Warnings`, never `Errors`, and that must stay true.** The lockfile check
next door earns hard-error status because the platform *provably* fails (`npm ci`
dies). This one infers **runtime** behaviour from **static text**, and there are
correct projects it cannot read: an ack from a bundled dependency, a framework
wrapper, a code-split chunk, an extension the scan does not open. Hard-failing on
a heuristic is the false-warning-at-a-correct-project failure AGENTS.md item 10
spent four measured corrections avoiding — and `--strict` already gives anyone
who wants a gate one.

**The dependency is evidence, and it is checked FIRST.** On
`@civitai/blocks-react` the ack comes from `IframeTransport` and the literal
`BLOCK_READY` **never appears in `src/`** — measured on a rendered `page-money`:
zero occurrences anywhere outside `node_modules`. A source-only scan therefore
false-warns at *every correct money-path app on the platform*, which is the worst
possible outcome for advisory output. `TestSDKTemplateIsQuietOnlyBecauseOfTheDependency`
pins that the dep gate is the **only** reason page-money is accepted, so that
branch cannot rot into a case that passes for an unrelated reason.

Other constraints, each from the #208 audit rounds:

- **Only fires where it can observe.** No `page` surface, no check. Unreadable
  `package.json`, no check. Unwalkable tree, no check. **And reading ZERO source
  files reports "no finding"** — a zero-hit scan over a zero-file tree is
  indistinguishable from a scanner wired to nothing. That is not defensive
  padding: a manifest-only fixture in `warnings_test.go` failed without it.
- **Source only** — never `outputDir` (not built yet, gitignored), never
  `node_modules`, never `.md`.
- **Comments are stripped, and that is load-bearing.** Both SDK-free templates
  carry a source comment reading "The ONE message a page app must send is
  `BLOCK_READY`" — and it *survives deleting `civitai-host.js`*. Without the
  strip the check is inert on the exact population it was written for. Measured
  both ways.
- **Placement.** `warningChecks` runs unconditionally *including under
  `ManifestOnly`*, which `app init` uses to self-check the template it just
  wrote. A check that reads `src/` lives in the `projectState` branch beside
  `lockfileChecks`, or init's self-validation starts reading files that are not
  its business.

---

## Measured before / after

Built binary, real scaffolds on disk. The unit tests are not a substitute for
this.

| Project | `civitai app validate` | antipattern gate |
|---|---|---|
| Scaffold reconstructed from the templates at `4018e2c^` | ⚠ **warns** (exit 0) | ✗ **`app.js:18 — resize-iframe-page`** |
| Fresh `static` (today) | ✓ valid, silent | ✓ clean |
| Fresh `page-vite` (today, + lockfile) | ✓ valid, silent | ✓ clean |
| Fresh `page-money` (today, + lockfile) | ✓ valid, silent | ✓ clean |
| Fresh `static`, `civitai-host.js` deleted | ⚠ **warns** (exit 0; exit 1 under `--strict`) | ✓ clean |
| Fresh `page-vite`, `src/civitai-host.js` deleted | ⚠ **warns** (exit 0) | ✓ clean |

The pre-fix reconstruction is the real population: it trips **both** checks, for
two independent reasons (no emitter, and a live `RESIZE_IFRAME` post).

## What these checks do NOT prove

- **Not that the ack fires.** No static check can — an emitter with an inverted
  `event.source` guard satisfies every assertion here. That is what Guard B
  (`ready_ack_runtime_test.go`) exists for, and there is no runtime guard at all
  for an app an author already has. The advisory says this in its own message.
- **Not that a silent project is correct.** A missing warning means "the literal
  appears in code somewhere", which is weak evidence deliberately treated as
  conclusive: being generous costs a missed warning, being strict costs a false
  one.
- **The server remains the authority.** `validate` is still a best-effort local
  mirror.

## Mutation results

Four rounds, 42 mutant runs. Every mutation was verified to have **actually
changed the tree** (`git diff --stat` non-empty for the expected file) before its
verdict was read, and each round carried a **null mutant** (comment-only edit)
that had to SURVIVE — it did, every time. Kills are **attributed**: several
neighbours in this repo render the same templates, so an unattributed "KILLED" is
not evidence about my guard.

Final state — all attributed to a test added in this PR:

| Mutant | Killed by |
|---|---|
| page gate inverted | `TestReadyAckWarning/a_non-page_app_never_warns` |
| page gate deleted | `.../a_non-page_app_never_warns` |
| `declaresPage` accepts a null page | `.../an_explicit_"page":_null_does_not_warn` |
| **SDK dep gate deleted** | `TestSDKTemplateIsQuietOnlyBecauseOfTheDependency`, `TestShippedTemplatesDoNotTripTheReadyAckWarning/page-money`, `.../page_app_depending_on_@civitai/blocks-react_does_not_warn` |
| SDK gate drops the `unknown` case | `TestReadyAckCannotObserve/an_unreadable_package.json_…` |
| dev/peerDependencies no longer count | `.../the_SDK_dep_counts_from_devDependencies_too` |
| any package.json counts as an SDK | `.../a_package.json_with_no_@civitai_dep_still_warns` |
| missing package.json → `unknown` | `TestDeletingTheEmitterMakesTheWarningFire/static` |
| comment stripping removed | `.../an_ack_named_only_in_a_comment_warns` |
| HTML comments not stripped | `.../an_ack_named_only_in_an_HTML_comment_warns` |
| string literals unprotected in the stripper | `.../a_URL_literal_does_not_swallow_the_ack_after_it` |
| markdown scanned as source | `.../an_ack_described_only_in_the_README_warns` |
| **outputDir scanned** | `.../an_ack_present_only_in_a_NON-STANDARD_outputDir_warns` |
| node_modules scanned | `.../an_ack_in_node_modules_does_not_count` |
| `scanned == 0` no longer silences | `TestReadyAckCannotObserve/a_directory_holding_only_a_manifest_…` |
| walk error warns instead of silencing | `TestReadyAckCannotObserve/an_unreadable_source_file_…` |
| advisory promoted to a hard Error | `TestReadyAckIsAdvisoryOnly` |
| check moved out of `projectState` | `TestReadyAckSkippedByManifestOnly` |
| check removed entirely | `TestReadyAckWarning/page_app_with_no_ack_at_all_warns` |
| resize rule removed from the registry | `TestScanDir/RESIZE_IFRAME_posted_from_a_page_app_fails` |
| resize rule widened to bare prose | `TestScanDir/docs_naming_RESIZE_IFRAME_in_backticks_are_not_flagged` |
| resize rule narrowed to `'` only | `TestResizeIframeBoundary` |
| resize rule's `Replacement` emptied | `TestScanDir/RESIZE_IFRAME_posted_from_a_page_app_fails` |

**The first sweep left four of these unproven, and the second commit here is the
fix.** Three were real gaps and one was a weak mutant of mine:

- **`"page": null`** — nothing covered it, so `declaresPage`'s `v != nil` half
  was indistinguishable from a presence-only test.
- **the outputDir skip** — the fixture used `dist`, which is *also* in the
  name-based skip list, so an **earlier check always won** and the
  manifest-driven branch never executed. The mutation disabling it survived the
  entire suite. A non-standard outputDir (`public`) is the only way in.
- **the string-literal case of the comment stripper** — the URL fixture put the
  URL and the ack on *different lines*, so deleting the quote handling only ate
  the rest of the URL's own line.
- **the walk-error branch** — initially written off as unreachable by any fixture
  (chmod is a no-op for root). It is not: a dangling symlink with a scanned
  extension fails `os.ReadFile` deterministically for any user. The "expected to
  survive" was a rationalisation for an untested branch.

Two further mutants were **weak, not surviving guards**, and were re-expressed:
one left a variable unused and only broke the build; one replaced a prefix of
`Replacement` while leaving the string non-empty.

## Verification

- `make ci` green. Full suite: **1613 `=== RUN`, 1609 `--- PASS`, 0 `--- FAIL`,
  4 `--- SKIP`**, 16 packages `ok`, 0 `FAIL`, 0 `panic: test timed out`. All four
  skips are pre-existing env-gated tests (`TestScanDirFromEnv`,
  `TestSubmissionsCapDriftAgainstLiveAPI`, `TestScaffoldPinsSatisfyPublished`,
  `TestScaffoldedReadyAckActuallyFires`).
- `gofmt -s -l .` prints nothing, against 213 `.go` files found in the tree (the
  count is the positive control — a silent `gofmt` over zero files looks
  identical to a clean one).
- The env-gated `ready-ack-runtime` guard run locally with
  `CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`: PASS, including its two inert/naive
  controls, on node v26.5.0.
- The live scaffold-and-validate demonstration in the table above, with the
  binary built from this branch.

## Deliberately not done

- **No `app doctor` command.** Out of scope.
- **`schema/` untouched** (vendored, ask-first). Worth flagging though:
  `iframe.resizable`'s description still reads *"Whether the host honours
  RESIZE_IFRAME messages"*, which is arguably wrong for a page app — the host
  marks that message N/A on the page surface regardless of the flag. AGENTS.md
  item 11 already notes it as a schema-side wording issue; it needs a
  server-side decision, not a unilateral edit here.
- **No new dependency; templates unchanged.**
- **AGENTS.md numbering:** this takes item **12**, per the append-only convention
  added in `4018e2c`. #210 (`feat/generate`) is also open and adds items — per
  that convention, whichever of us merges **second** renumbers **its own** new
  items and re-greps the `items N–M` range clauses.

Closes the #206 gap for existing apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
