### PR TITLE
feat(app): render installs as n/a for apps that cannot be installed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,20 @@ neither one's.
    across 27 distinct apps) — so deduping on it would report ~1 viewer per app.
    Anonymous rows all carry `userId = 0`, so the server sums distinct authed
    `userId` with distinct anon `ip`.
+   🔴 **`installs` has a THIRD state too, and it is a different KIND of flag.**
+   `installs.notApplicable` means "the question does not apply", not "we could
+   not ask": a page app is stateless by design and has no install slot, so a
+   subscription record cannot exist for it. Rendering `0` there reads as
+   "nobody installed my app" when the truth is "installs do not exist for this
+   app type" — the same fabricated-zero class as items 6 and 9, arrived at from
+   a third direction. The distinction that matters when editing this: a
+   TRUTHFUL zero (an installable app nobody has installed yet) arrives with the
+   flag ABSENT and must keep printing `0`. The server owns that call — do NOT
+   re-derive it in the CLI from the counters, because `total == 0` is true in
+   both states. Measured on prod: every approved app is a page app (0 installs
+   possible), while the model-slot apps that CAN be installed hold real rows,
+   so the two populations are disjoint and the bare `0` was never a
+   measurement of user behaviour.
    Two more things the label has to keep straight, both of which read wrong if
    you shorten them: `AnonCount` is signed-out **LOADS**, not viewers, and is
    NOT a subset of `UniqueViewers` — one anonymous visitor reloading ten times

--- a/README.md
+++ b/README.md
@@ -817,8 +817,11 @@ Two data caveats.
 
 **Engagement counts only authenticated, scope-gated API
 calls.** An app that ships no scoped API surface shows real installs and revenue
-with a flat engagement section — that is expected, not a bug. **App loads is the
-exception**: it is measured on every load, so it counts signed-out visitors and
+with a flat engagement section — that is expected, not a bug. **Installs** is a
+different case again: it shows **`n/a`** for an app that cannot be installed at
+all (a page app has no install slot, so an install record cannot exist), which
+is deliberately distinct from a real `0` on an installable app nobody has
+installed yet. **App loads is the exception**: it is measured on every load, so it counts signed-out visitors and
 static blocks that engagement structurally cannot see. `Unique viewers` counts
 signed-in people once each and approximates signed-out ones by network address,
 so read it as reach rather than an identity count, and `Signed-out loads` is a
@@ -840,6 +843,12 @@ counter zeroed and the command still exits `0`, so
 `civitai app metrics <slug> --json | jq .runs.count` returns `0` for an app you
 can't see. A script must branch on the `notOwned` field rather than trusting the
 counts.
+
+**Installs carries `installs.notApplicable`** for the case above. It is NOT an
+outage flag — it means the question does not apply to this app type, so a script
+should render it as "not applicable" rather than retrying or warning about
+infrastructure. `--json` passes it through and still exits `0`, so branch on it
+rather than trusting the counts.
 
 **App loads has a SECOND, section-local unavailability flag** — `views.unavailable`,
 independent of `notOwned`. It is the one section the server reads from a

--- a/internal/appapi/analytics.go
+++ b/internal/appapi/analytics.go
@@ -41,10 +41,31 @@ type AnalyticsPoint struct {
 }
 
 // AnalyticsInstalls is the install-side rollup.
+//
+// 🔴 NotApplicable is a THIRD state, and it is not the same as a zero. There
+// are three, and collapsing any pair of them is a bug:
+//
+//	total > 0        — a real count.
+//	total == 0       — a TRUTHFUL zero: the app CAN be installed, nobody has yet.
+//	NotApplicable    — the question is meaningless. A page app has no install
+//	                   slot, so a `block_user_subscriptions` row cannot exist
+//	                   for it; rendering `0` there reads as "nobody installed
+//	                   my app" when the truth is "installs do not exist for
+//	                   this app type".
+//
+// Distinct from `AnalyticsViews.Unavailable`, which means "we could not ask".
+// This means "we asked and the question does not apply" — so it is NOT an
+// outage and callers must not retry or warn about infrastructure.
+//
+// Absent (an older server) decodes to false and takes the measured branch,
+// which is exactly the pre-3664 behaviour and therefore safe. `--json` passes
+// the field through untouched and still exits 0, so a script must branch on it
+// itself — the same contract as `notOwned` and `views.unavailable`.
 type AnalyticsInstalls struct {
-	Total  int64            `json:"total"`
-	Active int64            `json:"active"`
-	Series []AnalyticsPoint `json:"series"`
+	Total         int64            `json:"total"`
+	Active        int64            `json:"active"`
+	Series        []AnalyticsPoint `json:"series"`
+	NotApplicable bool             `json:"notApplicable,omitempty"`
 }
 
 // AnalyticsRuns is the run-side rollup: how often the app ran and how much Buzz

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -224,9 +224,27 @@ func printAppMetrics(w io.Writer, slug string, a *appapi.AppAnalytics) {
 
 	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Installs"))
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "  Total\t%d\n", a.Installs.Total)
-	fmt.Fprintf(tw, "  Active\t%d\n", a.Installs.Active)
-	_ = tw.Flush()
+	if a.Installs.NotApplicable {
+		// 🔴 Not a zero, and not an outage. The server sets this only when NO
+		// owned app has an install slot — a page app is stateless by design, so
+		// a subscription row cannot exist for it. Printing `0` here reads as
+		// "nobody installed my app" when the truth is "installs do not exist
+		// for this app type", which is the same fabricated-zero class the
+		// notOwned and views.unavailable branches already guard.
+		//
+		// A TRUTHFUL zero (an installable app nobody has installed yet) does
+		// NOT set the flag and must keep printing 0 — the server owns that
+		// distinction; do not re-derive it here from the counters.
+		fmt.Fprintf(tw, "  Total\t%s\n", "n/a")
+		fmt.Fprintf(tw, "  Active\t%s\n", "n/a")
+		_ = tw.Flush()
+		fmt.Fprintf(w, "\n%s\n", ui.For(w).Dim(
+			"This app cannot be installed — it has no install slot, so installs do not apply. That is different from zero installs."))
+	} else {
+		fmt.Fprintf(tw, "  Total\t%d\n", a.Installs.Total)
+		fmt.Fprintf(tw, "  Active\t%d\n", a.Installs.Active)
+		_ = tw.Flush()
+	}
 
 	fmt.Fprintf(w, "\n%s\n", ui.For(w).Bold("Runs"))
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)

--- a/internal/cmd/app_metrics_test.go
+++ b/internal/cmd/app_metrics_test.go
@@ -1025,3 +1025,178 @@ func valueOnLine(out, label string) string {
 	}
 	return ""
 }
+
+// --- installs.notApplicable (the third state) -----------------------------
+//
+// There are THREE states and every pair of them is a distinct bug if merged:
+// a real count, a TRUTHFUL zero (installable app, nobody has yet), and
+// not-applicable (a page app has no install slot, so a row cannot exist).
+// Both directions are pinned below on purpose — asserting only that the flag
+// renders "n/a" would let it become unconditional and silently hide a real
+// zero, which is a NEW fabricated-zero bug pointing the other way.
+
+func TestAppMetricsInstallsNotApplicableIsNotAZero(t *testing.T) {
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":0,"active":0,"series":[],"notApplicable":true},
+	  "runs":{"count":7,"buzzSpent":7000,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":100,"activeUsers":4,"errorRate":0.1,"topScopes":[],"topEndpoints":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("page-app", strPtr("apb_page")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "page-app")
+	if err != nil {
+		t.Fatalf("a not-applicable installs section is still a successful read: %v", err)
+	}
+	if got := valueOnLine(out, "Total"); got != "n/a" {
+		t.Errorf("Total should render n/a for an uninstallable app, got %q:\n%s", got, out)
+	}
+	if got := valueOnLine(out, "Active"); got != "n/a" {
+		t.Errorf("Active should render n/a for an uninstallable app, got %q:\n%s", got, out)
+	}
+	if !strings.Contains(out, "cannot be installed") {
+		t.Errorf("the caveat must say WHY it is n/a:\n%s", out)
+	}
+	// It is a category error, not an outage — must not read as infrastructure.
+	// Scoped to the Installs SECTION: "unavailable" legitimately appears in the
+	// App loads section when that store cannot be read, and this payload
+	// deliberately omits `views` so that branch is active. Asserting over the
+	// whole output would fail on a neighbouring section's honest wording.
+	installsSection := sectionOf(out, "Installs")
+	if installsSection == "" {
+		t.Fatalf("could not isolate the Installs section:\n%s", out)
+	}
+	if strings.Contains(installsSection, "could not be read") ||
+		strings.Contains(installsSection, "unavailable") {
+		t.Errorf("not-applicable must not be phrased as an outage:\n%s", installsSection)
+	}
+	// Everything else in the payload is genuinely measured and must render.
+	for _, want := range []string{"Runs", "7000", "Engagement", "100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("a not-applicable installs section must not disturb the rest, missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAppMetricsInstallsTruthfulZeroStillRendersZero(t *testing.T) {
+	// The direction people forget. An INSTALLABLE app with no installs yet has
+	// notApplicable ABSENT, and 0 is the honest answer — hiding it behind n/a
+	// would be a new bug pointing the other way.
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":0,"active":0,"series":[]},
+	  "runs":{"count":0,"buzzSpent":0,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("model-app", strPtr("apb_model")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "model-app")
+	if err != nil {
+		t.Fatalf("app metrics: %v", err)
+	}
+	if got := valueOnLine(out, "Total"); got != "0" {
+		t.Errorf("a truthful zero must render 0, got %q:\n%s", got, out)
+	}
+	if strings.Contains(out, "n/a") || strings.Contains(out, "cannot be installed") {
+		t.Errorf("an installable app with no installs must NOT be reported as n/a:\n%s", out)
+	}
+}
+
+func TestAppMetricsInstallsNonZeroNeverSuppressed(t *testing.T) {
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":3,"active":2,"series":[]},
+	  "runs":{"count":0,"buzzSpent":0,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("installed-app", strPtr("apb_inst")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "metrics", "installed-app")
+	if err != nil {
+		t.Fatalf("app metrics: %v", err)
+	}
+	// Distinct values so a swapped field cannot pass by coincidence.
+	if got := valueOnLine(out, "Total"); got != "3" {
+		t.Errorf("Total = %q, want 3:\n%s", got, out)
+	}
+	if got := valueOnLine(out, "Active"); got != "2" {
+		t.Errorf("Active = %q, want 2:\n%s", got, out)
+	}
+	if strings.Contains(out, "n/a") {
+		t.Errorf("a non-zero count must never be suppressed:\n%s", out)
+	}
+}
+
+func TestAppMetricsJSONPassesNotApplicableThroughRaw(t *testing.T) {
+	// --json is a passthrough and still exits 0, so a script must be able to
+	// branch on installs.notApplicable itself — the same contract as notOwned
+	// and views.unavailable. Dropping the field would silently turn a category
+	// error into a zero for every scripted consumer.
+	payload := `{"range":{"from":"2026-07-04T00:00:00.000Z","to":"2026-08-03T00:00:00.000Z","granularity":"day"},
+	  "notOwned":false,
+	  "installs":{"total":0,"active":0,"series":[],"notApplicable":true},
+	  "runs":{"count":0,"buzzSpent":0,"series":[]},
+	  "buzzPurchased":{"count":0,"buzzAmount":0,"grossCents":0},
+	  "engagement":{"apiCalls":0,"activeUsers":0,"errorRate":0,"topScopes":[],"topEndpoints":[]}}`
+	srv := metricsServer(t,
+		submissionsBody("page-app", strPtr("apb_page")), http.StatusOK,
+		trpcEnvelope(payload), http.StatusOK, nil)
+	defer srv.Close()
+	setupMetricsEnv(t, srv.URL)
+
+	jsonOut, _, err := run(t, "app", "metrics", "page-app", "--json")
+	if err != nil {
+		t.Fatalf("app metrics --json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &got); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, jsonOut)
+	}
+	installs, ok := got["installs"].(map[string]any)
+	if !ok {
+		t.Fatalf("--json must pass the installs section through:\n%s", jsonOut)
+	}
+	if installs["notApplicable"] != true {
+		t.Errorf("--json must surface installs.notApplicable for scripts:\n%s", jsonOut)
+	}
+}
+
+// sectionOf returns the lines of one `app metrics` section — from its heading
+// up to the next heading (a non-indented, non-empty line) or EOF. Section-scoped
+// assertions matter here because several sections legitimately use the same
+// words for different reasons: "unavailable" is honest wording in App loads and
+// wrong wording in Installs.
+func sectionOf(out, heading string) string {
+	lines := strings.Split(out, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == heading {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		t := lines[i]
+		if t != "" && !strings.HasPrefix(t, " ") && strings.TrimSpace(t) != "" {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}


### PR DESCRIPTION
Follows [civitai#3664](https://github.com/civitai/civitai/pull/3664), which added `installs.notApplicable` to the `getMyAppAnalytics` payload. Without this the CLI keeps printing `Total 0` for a page app — the fabricated zero that PR exists to remove — while the web panel already shows the honest answer.

## Three states, and every pair is a distinct bug if merged

| payload | meaning | renders |
|---|---|---|
| `total > 0` | a real count | the number |
| `total == 0`, no flag | **truthful zero** — the app *can* be installed, nobody has yet | `0` |
| `notApplicable: true` | the question is meaningless — a page app has no install slot, so a subscription record cannot exist | `n/a` + a caveat |

The server owns that distinction and the CLI deliberately does **not** re-derive it from the counters, because `total == 0` is true in two of the three states. That mutation is in the sweep below and is caught.

It is also **not an outage flag**, and the wording keeps them apart: `views.unavailable` means *"we could not ask"* and invites a retry; `installs.notApplicable` means *"we asked and the question does not apply"* and never should. A test asserts the installs caveat is not phrased as an outage.

Absent (an older server) decodes to `false` and takes the measured branch — exactly the pre-3664 behaviour, so there is no ordering hazard in either direction.

## Verification — 7 mutants, 6 killed, 1 proven equivalent

| mutant | result |
|---|---|
| A1 flag never honoured (category error renders `0`) | KILLED |
| B1 flag always on (hides a truthful zero) | KILLED |
| B2 re-derived from `total == 0` | KILLED |
| C2 `Total` prints the placeholder `0` instead of `n/a` | KILLED |
| C3 caveat reworded as an outage | KILLED |
| C1b json tag renamed `notApplicableXX` | KILLED |
| C1 json tag case-drifted to `notapplicable` | **SURVIVED — equivalent** |

C1 is not a coverage gap, and I measured rather than assumed: Go's `encoding/json` matches field names **case-insensitively**, so the case-drifted tag decodes the same payload. The C1b variant — a genuinely different name — is killed by the same test, which is what separates "equivalent mutant" from "untested".

## One test of mine was wrong before it was right

The outage-phrasing assertion originally scanned the **whole** output and failed — because the fixture omits `views`, so the *App loads* section honestly prints `unavailable`. It is now scoped to the Installs section via a `sectionOf` helper. Several sections legitimately use the same words for different reasons, so section-scoping is the correct shape, not a workaround.

**677 tests pass, 0 fail** (counted); `make ci` green; `gofmt -s -l .` silent. README documents the `n/a` state and the `--json` contract; AGENTS.md item 9 gains the three-state rule and the "don't re-derive it from the counters" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
