### PR TITLE
fix(dev-tunnel): --local-host rendered its default as the value placeholder

### DIFF
--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -409,7 +409,7 @@ enrolled the mint reports "not available" — ask to be added to the cohort.`,
 
 	cmd.Flags().StringVar(&blockFlag, "block", "", "the blockId (app slug) to tunnel (or pass it positionally; defaults to the blockId in "+manifest.Filename+" in the CWD)")
 	cmd.Flags().IntVar(&port, "port", defaultDevTunnelPort, "local dev-server port to tunnel (matches the scaffold's dev:tunnel)")
-	cmd.Flags().StringVar(&localHost, "local-host", defaultLocalHost, "host your local dev server is bound to. Default `localhost` (loopback) — the scaffold's `dev:tunnel` binds localhost, so most users need nothing. Set this for a dev server NOT on the CLI's loopback: a container/pod (e.g. --local-host 10.42.0.100), a VM, or a specific bound interface")
+	cmd.Flags().StringVar(&localHost, "local-host", defaultLocalHost, "host your local dev server is bound to. Default localhost (loopback) — the scaffold's dev:tunnel binds localhost, so most users need nothing. Set this for a dev server NOT on the CLI's loopback: a container/pod (e.g. --local-host 10.42.0.100), a VM, or a specific bound interface")
 	cmd.Flags().StringVar(&endpoint, "tunnel-endpoint", "", "sish SSH endpoint host:port (default "+defaultDevTunnelEndpoint+", or $"+devTunnelEndpointEnv+")")
 	cmd.Flags().DurationVar(&idle, "idle-timeout", defaultDevTunnelIdle, "tear the tunnel down after this much inactivity")
 	cmd.Flags().DurationVar(&readyTimeout, "ready-timeout", defaultReadyTimeout, "cap the wait for the public host to start serving (0 = wait indefinitely until ready or Ctrl-C; a positive value warns + prints the URL anyway on expiry)")

--- a/internal/cmd/generate_wait_test.go
+++ b/internal/cmd/generate_wait_test.go
@@ -587,19 +587,40 @@ func TestGenerate_SubmitWithNoResponseWarnsAboutAPossibleCharge(t *testing.T) {
 // this phase's first draft, not theorised. The existing --max-cost usage
 // carries the same note; this pins it for every flag on both commands at once.
 func TestGenerateFlagUsageHasNoBackquotes(t *testing.T) {
+	// 🔴 WALK THE WHOLE COMMAND TREE, not a hand-listed pair.
+	//
+	// This guard originally listed `newGenerateCmd(), newWorkflowsGetCmd()` —
+	// the two commands its author was working on. Every other command was
+	// unguarded, and one of them had the exact defect: `app dev-tunnel`'s
+	// --local-host usage back-quoted `localhost`, so --help rendered
+	// `--local-host localhost` instead of `--local-host string` while every
+	// sibling showed its type. It shipped and CI stayed green, because a guard
+	// that enumerates its own scope only ever protects what someone remembered
+	// to add.
+	//
+	// Walking from NewRootCmd() means a NEW command is covered the day it is
+	// registered, with nobody having to remember this file exists.
 	checked := 0
-	for _, cmd := range []*cobra.Command{newGenerateCmd(), newWorkflowsGetCmd()} {
-		name := cmd.Name()
+	var walk func(cmd *cobra.Command, path string)
+	walk = func(cmd *cobra.Command, path string) {
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			checked++
 			if strings.Contains(f.Usage, "`") {
-				t.Errorf("%s --%s: usage contains a back-quote, which pflag turns into the flag's VALUE NAME: %q", name, f.Name, f.Usage)
+				t.Errorf("%s --%s: usage contains a back-quote, which pflag turns into the flag's VALUE NAME: %q", path, f.Name, f.Usage)
 			}
 		})
+		for _, sub := range cmd.Commands() {
+			walk(sub, path+" "+sub.Name())
+		}
 	}
-	// POSITIVE CONTROL (a): a zero here would mean VisitAll walked nothing.
-	if checked < 10 {
-		t.Fatalf("POSITIVE CONTROL FAILED: only %d flags inspected — the walk found nothing to check", checked)
+	root := NewRootCmd()
+	walk(root, root.Name())
+
+	// POSITIVE CONTROL (a): a zero here would mean the walk found nothing. The
+	// floor is deliberately far above the old hand-listed pair — if it drops
+	// back to ~10 the tree walk has silently stopped descending.
+	if checked < 60 {
+		t.Fatalf("POSITIVE CONTROL FAILED: only %d flags inspected across the whole command tree — the walk is not descending", checked)
 	}
 	// POSITIVE CONTROL (b): prove the predicate CAN fire, so the clean result
 	// above is a fact about the flags rather than about a check that never


### PR DESCRIPTION
## The visible bug

pflag's `UnquoteUsage` treats the **first** back-quoted span in a usage string as the flag's **value name**. `--local-host` back-quoted `` `localhost` ``, so `--help` rendered:

```
--local-host localhost   ... the scaffold's `dev:tunnel` binds ... (default "localhost")
```

Three things wrong in one line, all measured from the built binary rather than reasoned about:

1. The placeholder is a **value**, where every sibling shows its **type** — `--block string`, `--port int`, `--ready-timeout duration`. It reads as required literal syntax.
2. The **second** back-quoted span survives verbatim, because pflag consumes only the first.
3. It duplicates the `(default "localhost")` already printed at the end.

Now renders `--local-host string`.

## 🔴 The guard for this already existed, and did not cover it

`TestGenerateFlagUsageHasNoBackquotes` walked a **hand-listed pair** — `newGenerateCmd(), newWorkflowsGetCmd()` — the two commands its author was working on. It had *both* positive controls and a clear explanatory comment, and it was still blind to every other command in the CLI. The defect shipped with CI green.

**That's the real finding.** The back-quote is cosmetic; a guard that enumerates its own scope only ever protects what someone remembered to add to the list.

It now walks the whole tree from `NewRootCmd()`, so a new command is covered **the day it is registered** and nobody has to remember this file exists.

| | before | after |
|---|---|---|
| commands walked | 2, hand-listed | whole tree |
| flags checked | ~12 | **170** |
| positive-control floor | `>= 10` | `>= 60` |

The floor is deliberately far above the old pair — if the walk ever stops descending, it fails loudly instead of silently checking less. (170 measured by raising the floor until the failure message reported the count.)

## Order of work

Red-before-green, deliberately in that order: the widened guard was written **first** and failed naming `civitai app dev-tunnel --local-host` exactly; the usage fix then turned it green. Rendered help re-checked from a fresh build both times.

675 tests pass, 0 fail (counted); `make ci` green; `gofmt -s -l .` silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
