### PR TITLE
feat(app dev-token): add --budget to set the token's Buzz budget

### DIFF
--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -879,32 +880,88 @@ func cloneInfoError(status int, raw []byte) (err error) {
 	}
 }
 
+// Vendored dev-token Buzz-budget bounds. Both mirror
+// civitai/civitai src/server/services/blocks/dev-scoped-mint.service.ts:
+//
+//	export const DEV_BUZZ_BUDGET_CAP = 250;
+//	export const DEV_BUZZ_BUDGET_DEFAULT = 50;
+//
+// which that file's resolveDevBuzzBudget composes as
+//
+//	Math.min(requestedBudget ?? manifestDefaultBudget ?? DEFAULT, CAP)
+//
+// gated on the minted token retaining `ai:write:budgeted` (without the spend
+// scope the claim is dropped entirely and no budget is issued, however large the
+// request).
+//
+// The two bounds fail DIFFERENTLY server-side, which is why the CLI checks both
+// itself rather than deferring:
+//   - Below 1 the route's zod schema (`z.number().int().positive()`) answers 400.
+//   - ABOVE the cap there is no schema bound at all — the request succeeds and
+//     `Math.min` silently clamps. A developer who asks for 400 gets a 250-budget
+//     token and no indication the number moved, which is the more expensive
+//     failure of the two and cannot be detected after the fact from the CLI.
+//
+// Neither constant is observable from a minted token (the JWT's budget claim
+// reflects the RESOLVED value, so a clamped 250 and a requested 250 are
+// byte-identical), so there is no sound live drift probe to write here — unlike
+// ListSubmissionsCap above, whose truncation asymmetry makes one possible. These
+// are pinned by TestDevBuzzBudgetBoundsMirrorServer and by the comment above;
+// re-read the server file when touching them.
+const (
+	// DevBuzzBudgetCap is the largest per-generation Buzz budget the dev-token
+	// route will issue. A larger request is clamped, not refused.
+	DevBuzzBudgetCap = 250
+	// DevBuzzBudgetMin is the smallest budget the route's schema accepts.
+	DevBuzzBudgetMin = 1
+	// DevBuzzBudgetDefault is what the server resolves to when NEITHER the
+	// request nor the app's stored manifest names a budget.
+	DevBuzzBudgetDefault = 50
+)
+
 // DevTokenMinter mints a short-lived dev block token for `npm run dev:live`.
 type DevTokenMinter interface {
 	// MintDevToken mints a dev block token for the given app slug and returns
 	// the JWT. scopes carries the caller's LOCAL block.manifest.json scopes for
 	// the server's no-row mint path (clamped server-side); pass nil/empty when
-	// no manifest is available. A non-2xx is mapped by devTokenError.
-	MintDevToken(ctx context.Context, slug string, scopes []string) (string, error)
+	// no manifest is available. buzzBudget is the optional per-generation Buzz
+	// budget — nil means "not requested", leaving the server's own resolution
+	// intact. A non-2xx is mapped by devTokenError.
+	MintDevToken(ctx context.Context, slug string, scopes []string, buzzBudget *int) (string, error)
 }
 
 // devTokenBody is the POST /api/v1/blocks/dev-token request body. Scopes is the
 // caller's LOCAL manifest scopes; it is omitted (not sent) when empty so a
 // registered app's server-side scopes still govern.
+//
+// BuzzBudget is a POINTER, and that is load-bearing rather than stylistic: the
+// server resolves an ABSENT `buzzBudget` differently from a present one, so a
+// plain `int` would make the CLI send `0` (or a CLI-chosen default) on every
+// mint and permanently shadow the server's own resolution. Only nil is omitted
+// by `omitempty` on a pointer, so nil is the one encoding that reproduces
+// today's wire shape exactly.
 type devTokenBody struct {
-	Slug   string   `json:"slug"`
-	Scopes []string `json:"scopes,omitempty"`
+	Slug       string   `json:"slug"`
+	Scopes     []string `json:"scopes,omitempty"`
+	BuzzBudget *int     `json:"buzzBudget,omitempty"`
 }
 
 // MintDevToken mints a short-lived dev block token for the given app slug,
 // returning the JWT from the response's .token field. scopes carries the
 // caller's local manifest scopes for the server's no-row (no app registered
 // yet) mint path; they are clamped server-side and omitted from the body when
-// empty/nil (registered-app and read-only paths are unaffected). The OAuth
-// access token is refreshed transparently on a 401. A non-2xx is mapped by
-// devTokenError.
-func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string) (string, error) {
-	body, err := json.Marshal(devTokenBody{Slug: slug, Scopes: scopes})
+// empty/nil (registered-app and read-only paths are unaffected).
+//
+// buzzBudget is the optional per-generation Buzz budget the token should carry.
+// Pass nil to request nothing — the key is then absent from the body and the
+// server resolves the budget itself (see the DevBuzzBudget* constants). Callers
+// are expected to have range-checked a non-nil value; this method sends what it
+// is given so that a bound the server changes still reaches it.
+//
+// The OAuth access token is refreshed transparently on a 401. A non-2xx is
+// mapped by devTokenError.
+func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string, buzzBudget *int) (string, error) {
+	body, err := json.Marshal(devTokenBody{Slug: slug, Scopes: scopes, BuzzBudget: buzzBudget})
 	if err != nil {
 		return "", err
 	}
@@ -935,15 +992,62 @@ func (c *Client) MintDevToken(ctx context.Context, slug string, scopes []string)
 	return out.Token, nil
 }
 
+// devTokenValidationDetail renders the per-field detail the dev-token route
+// attaches to a 400. The route answers a schema violation with
+//
+//	{"message":"Invalid request body","details":{"formErrors":[],"fieldErrors":{"buzzBudget":["Too small: expected number to be >0"]}}}
+//
+// i.e. zod's flatten(). The top-level message is the same generic sentence for
+// EVERY malformed field, so without the field detail a rejected `--budget` is
+// indistinguishable from a rejected slug — the caller learns that something was
+// wrong and nothing about what. Field names are sorted so the text is stable.
+//
+// Returns "" when the body carries no recognizable detail, so the caller falls
+// back to the plain message rather than printing an empty parenthetical.
+func devTokenValidationDetail(raw []byte) string {
+	var env struct {
+		Details struct {
+			FormErrors  []string            `json:"formErrors"`
+			FieldErrors map[string][]string `json:"fieldErrors"`
+		} `json:"details"`
+	}
+	if json.Unmarshal(raw, &env) != nil {
+		return ""
+	}
+	fields := make([]string, 0, len(env.Details.FieldErrors))
+	for f := range env.Details.FieldErrors {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+	parts := make([]string, 0, len(fields)+len(env.Details.FormErrors))
+	for _, f := range fields {
+		if msgs := env.Details.FieldErrors[f]; len(msgs) > 0 {
+			parts = append(parts, f+": "+strings.Join(msgs, "; "))
+		}
+	}
+	parts = append(parts, env.Details.FormErrors...)
+	return strings.Join(parts, " | ")
+}
+
 // devTokenError maps a non-2xx dev-token response to a clear, actionable CLI
-// error. The route returns {"message": ...} on every error status: 404
-// not-found-or-not-yours, 403 not-invited-or-insufficient-scope, 429
-// rate-limited, 503 flag-off. The 403 message is the key DX case — a spend
-// token needs a full-scope personal API key (an OAuth login mints read-only).
+// error. The route returns {"message": ...} on every error status: 400
+// schema-rejected (with per-field details), 404 not-found-or-not-yours, 403
+// not-invited-or-insufficient-scope, 429 rate-limited, 503 flag-off. The 403
+// message is the key DX case — a spend token needs a full-scope personal API key
+// (an OAuth login mints read-only).
 func devTokenError(status int, raw []byte) (err error) {
 	defer func() { err = civitai.TagStatus(status, err) }()
 	msg := serverMessage(raw)
 	switch status {
+	case http.StatusBadRequest:
+		// Report the server's OWN verdict rather than re-deriving one: the CLI
+		// range-checks --budget before sending, so reaching here means the
+		// server's rules and the CLI's understanding of them have diverged, and
+		// that divergence is exactly what has to reach the developer intact.
+		if detail := devTokenValidationDetail(raw); detail != "" {
+			return fmt.Errorf("the server rejected the request (400): %s — %s", msg, detail)
+		}
+		return fmt.Errorf("the server rejected the request (400): %s", msg)
 	case http.StatusNotFound:
 		// Two 404 shapes: the anti-shadow guard returns a bare "App not found"
 		// when the slug is an approved app owned by another account (the no-row

--- a/internal/appapi/dev_token_budget_test.go
+++ b/internal/appapi/dev_token_budget_test.go
@@ -1,0 +1,227 @@
+package appapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// budgetRecorder stands up a dev-token endpoint that records the RAW request
+// body. Assertions here read the bytes rather than a decoded struct: absent and
+// zero are the same value once decoded into an int, and telling those two apart
+// is the entire contract this flag has to honour.
+func budgetRecorder(t *testing.T, raw *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*raw = b
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "jwt-x"})
+	}))
+}
+
+// TestMintDevTokenBudgetWireShape is the table that pins the absent/present
+// distinction at the transport layer.
+func TestMintDevTokenBudgetWireShape(t *testing.T) {
+	i := func(n int) *int { return &n }
+	cases := []struct {
+		name       string
+		budget     *int
+		wantKey    bool
+		wantNumber float64
+	}{
+		{"nil sends NO buzzBudget key (server default stays reachable)", nil, false, 0},
+		{"the server cap", i(DevBuzzBudgetCap), true, float64(DevBuzzBudgetCap)},
+		{"the server default, requested explicitly", i(DevBuzzBudgetDefault), true, float64(DevBuzzBudgetDefault)},
+		{"the schema minimum", i(DevBuzzBudgetMin), true, float64(DevBuzzBudgetMin)},
+		{"a mid value", i(120), true, 120},
+		// A pointer to zero must still be SENT, not swallowed by omitempty:
+		// "the caller explicitly asked for 0" and "the caller asked for
+		// nothing" are different requests, and only the first should draw the
+		// server's 400. Callers range-check first; this pins that the transport
+		// does not quietly rewrite the request into the other one.
+		{"an explicit zero is sent, not omitted", i(0), true, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw []byte
+			srv := budgetRecorder(t, &raw)
+			defer srv.Close()
+
+			if _, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil, tc.budget); err != nil {
+				t.Fatalf("MintDevToken: %v", err)
+			}
+			var generic map[string]any
+			if err := json.Unmarshal(raw, &generic); err != nil {
+				t.Fatalf("body is not a JSON object (%v): %q", err, string(raw))
+			}
+			got, present := generic["buzzBudget"]
+			if present != tc.wantKey {
+				t.Fatalf("buzzBudget key present = %v, want %v — body %q", present, tc.wantKey, string(raw))
+			}
+			if tc.wantKey && got != tc.wantNumber {
+				t.Errorf("buzzBudget = %v (%T), want %v — body %q", got, got, tc.wantNumber, string(raw))
+			}
+			// The slug must survive alongside the new field.
+			if generic["slug"] != "my-block" {
+				t.Errorf("slug = %v, want my-block — body %q", generic["slug"], string(raw))
+			}
+		})
+	}
+}
+
+// TestMintDevTokenBudgetIsIndependentOfScopes: the two optional fields must not
+// interfere — sending scopes must not suppress the budget, and vice versa.
+func TestMintDevTokenBudgetIsIndependentOfScopes(t *testing.T) {
+	var raw []byte
+	srv := budgetRecorder(t, &raw)
+	defer srv.Close()
+
+	n := 200
+	if _, err := New(srv.URL, "tok", "").MintDevToken(
+		context.Background(), "my-block", []string{"ai:write:budgeted"}, &n); err != nil {
+		t.Fatalf("MintDevToken: %v", err)
+	}
+	var body struct {
+		Slug       string   `json:"slug"`
+		Scopes     []string `json:"scopes"`
+		BuzzBudget *int     `json:"buzzBudget"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v (%q)", err, string(raw))
+	}
+	if body.BuzzBudget == nil || *body.BuzzBudget != 200 {
+		t.Errorf("buzzBudget = %v, want 200 — body %q", body.BuzzBudget, string(raw))
+	}
+	if len(body.Scopes) != 1 || body.Scopes[0] != "ai:write:budgeted" {
+		t.Errorf("scopes = %v, want [ai:write:budgeted] — body %q", body.Scopes, string(raw))
+	}
+}
+
+// TestDevTokenValidationDetail exercises the 400-detail extractor directly,
+// including the shapes that must NOT produce a dangling parenthetical.
+func TestDevTokenValidationDetail(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"a rejected budget names the field and the reason",
+			`{"message":"Invalid request body","details":{"formErrors":[],"fieldErrors":{"buzzBudget":["Too small: expected number to be >0"]}}}`,
+			"buzzBudget: Too small: expected number to be >0",
+		},
+		{
+			"multiple messages on one field are joined",
+			`{"details":{"fieldErrors":{"buzzBudget":["a","b"]}}}`,
+			"buzzBudget: a; b",
+		},
+		{
+			"multiple fields are reported in a stable order",
+			`{"details":{"fieldErrors":{"slug":["bad slug"],"buzzBudget":["bad budget"]}}}`,
+			"buzzBudget: bad budget | slug: bad slug",
+		},
+		{"form-level errors are carried too", `{"details":{"formErrors":["one of appBlockId or slug is required"]}}`,
+			"one of appBlockId or slug is required"},
+		{"no details member yields nothing", `{"message":"Invalid request body"}`, ""},
+		{"an empty fieldErrors map yields nothing", `{"details":{"fieldErrors":{}}}`, ""},
+		{"a field with no messages yields nothing", `{"details":{"fieldErrors":{"buzzBudget":[]}}}`, ""},
+		{"a non-JSON body yields nothing", `<html>502</html>`, ""},
+		{"a JSON array body yields nothing", `[1,2,3]`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := devTokenValidationDetail([]byte(tc.body)); got != tc.want {
+				t.Errorf("devTokenValidationDetail = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMintDevToken400SurfacesServerMessage: a 400 must carry the server's own
+// verdict — the generic message AND the per-field reason — and classify as a
+// usage-class failure so the process exit code matches a bad invocation.
+func TestMintDevToken400SurfacesServerMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		want     []string
+		dontWant []string
+	}{
+		{
+			name: "zod field detail is surfaced",
+			body: `{"message":"Invalid request body","details":{"formErrors":[],"fieldErrors":{"buzzBudget":["Too small: expected number to be >0"]}}}`,
+			want: []string{"400", "Invalid request body", "buzzBudget", "Too small"},
+		},
+		{
+			name: "a detail-free 400 still reports the message, with no empty tail",
+			body: `{"message":"Invalid request body"}`,
+			want: []string{"400", "Invalid request body"},
+			// The em-dash only introduces a detail; without one it must not appear.
+			dontWant: []string{"—"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil, nil)
+			if err == nil {
+				t.Fatal("expected a 400 error")
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("400 error %q should contain %q", err.Error(), w)
+				}
+			}
+			for _, w := range tc.dontWant {
+				if strings.Contains(err.Error(), w) {
+					t.Errorf("400 error %q should NOT contain %q", err.Error(), w)
+				}
+			}
+			if !errors.Is(err, civitai.ErrBadRequest) {
+				t.Errorf("a 400 must classify as ErrBadRequest, got %T: %v", err, err)
+			}
+			// A 400 is NOT a slug collision — it must never trigger the
+			// auto-rename retry loop that the 404 sentinel drives.
+			if errors.Is(err, ErrSlugRegisteredToOtherAccount) {
+				t.Error("a 400 must not wrap the rename-retry sentinel")
+			}
+		})
+	}
+}
+
+// TestDevBuzzBudgetBoundsMirrorServer pins the vendored literals. It cannot see
+// the server, so it is a change-detector by design: whoever edits a bound is
+// forced through this test and its pointer to the file the numbers came from.
+// The relationships below are what actually make the values usable, so they are
+// asserted rather than left implicit.
+func TestDevBuzzBudgetBoundsMirrorServer(t *testing.T) {
+	// civitai/civitai src/server/services/blocks/dev-scoped-mint.service.ts
+	//   export const DEV_BUZZ_BUDGET_CAP = 250;
+	//   export const DEV_BUZZ_BUDGET_DEFAULT = 50;
+	// and the route's schema field `buzzBudget: z.number().int().positive()`.
+	if DevBuzzBudgetCap != 250 {
+		t.Errorf("DevBuzzBudgetCap = %d, want 250 (DEV_BUZZ_BUDGET_CAP)", DevBuzzBudgetCap)
+	}
+	if DevBuzzBudgetDefault != 50 {
+		t.Errorf("DevBuzzBudgetDefault = %d, want 50 (DEV_BUZZ_BUDGET_DEFAULT)", DevBuzzBudgetDefault)
+	}
+	if DevBuzzBudgetMin != 1 {
+		t.Errorf("DevBuzzBudgetMin = %d, want 1 (zod .positive() on an int)", DevBuzzBudgetMin)
+	}
+	if DevBuzzBudgetDefault > DevBuzzBudgetCap || DevBuzzBudgetDefault < DevBuzzBudgetMin {
+		t.Errorf("the default (%d) must lie inside [%d, %d] — otherwise omitting --budget "+
+			"yields a budget the CLI would reject if asked for explicitly",
+			DevBuzzBudgetDefault, DevBuzzBudgetMin, DevBuzzBudgetCap)
+	}
+}

--- a/internal/appapi/dev_token_test.go
+++ b/internal/appapi/dev_token_test.go
@@ -32,7 +32,7 @@ func TestMintDevToken404SentinelWrapping(t *testing.T) {
 				_ = json.NewEncoder(w).Encode(map[string]string{"message": tc.message})
 			}))
 			defer srv.Close()
-			_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
+			_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil, nil)
 			if err == nil {
 				t.Fatal("expected a 404 error")
 			}
@@ -64,7 +64,7 @@ func TestMintDevTokenSendsBearerAndBody(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok123", "")
-	tok, err := c.MintDevToken(context.Background(), "my-block", []string{"ai:write:budgeted"})
+	tok, err := c.MintDevToken(context.Background(), "my-block", []string{"ai:write:budgeted"}, nil)
 	if err != nil {
 		t.Fatalf("MintDevToken: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestMintDevTokenOmitsEmptyScopes(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok", "")
-	if _, err := c.MintDevToken(context.Background(), "my-block", nil); err != nil {
+	if _, err := c.MintDevToken(context.Background(), "my-block", nil, nil); err != nil {
 		t.Fatalf("MintDevToken: %v", err)
 	}
 	if hasScopesKey {
@@ -113,7 +113,7 @@ func TestMintDevTokenOmitsEmptyScopes(t *testing.T) {
 	}
 
 	// An empty (non-nil) slice must also be omitted (omitempty).
-	if _, err := c.MintDevToken(context.Background(), "my-block", []string{}); err != nil {
+	if _, err := c.MintDevToken(context.Background(), "my-block", []string{}, nil); err != nil {
 		t.Fatalf("MintDevToken: %v", err)
 	}
 	if hasScopesKey {
@@ -128,7 +128,7 @@ func TestMintDevTokenEmptyTokenErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	if _, err := c.MintDevToken(context.Background(), "my-block", nil); err == nil {
+	if _, err := c.MintDevToken(context.Background(), "my-block", nil, nil); err == nil {
 		t.Fatal("expected error when response has no token")
 	}
 }
@@ -151,7 +151,7 @@ func TestMintDevTokenErrorMapping(t *testing.T) {
 			w.WriteHeader(tc.status)
 			_ = json.NewEncoder(w).Encode(tc.body)
 		}))
-		_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
+		_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil, nil)
 		srv.Close()
 		if err == nil {
 			t.Fatalf("status %d: expected error", tc.status)
@@ -170,7 +170,7 @@ func TestMintDevToken404DropsSubmitFirst(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"message": "not found"})
 	}))
 	defer srv.Close()
-	_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil)
+	_, err := New(srv.URL, "tok", "").MintDevToken(context.Background(), "my-block", nil, nil)
 	if err == nil {
 		t.Fatal("expected a 404 error")
 	}

--- a/internal/cmd/app_dev_token.go
+++ b/internal/cmd/app_dev_token.go
@@ -100,8 +100,34 @@ func readOnlyTokenWarning(sty ui.Styler, canSpend bool, authKind, slug string) s
 	}
 }
 
+// validateDevTokenBudget range-checks a --budget value against the server's real
+// accepted range, returning a usage error naming the bound it broke.
+//
+// It is a pure function so both bounds are testable without a round trip, and it
+// exists at all because the two bounds fail differently on the server: under the
+// minimum the route answers 400 (so sending it only wastes a call), while OVER
+// the cap the route succeeds and silently clamps — the developer asks for 400,
+// receives a 250-budget token, and nothing anywhere says so. Catching that here
+// is the only place it can be caught.
+func validateDevTokenBudget(budget int) error {
+	switch {
+	case budget < appapi.DevBuzzBudgetMin:
+		return fmt.Errorf(
+			"--budget %d is not a positive Buzz amount — pass an integer between %d and %d, or omit --budget to take the server's default (%d)",
+			budget, appapi.DevBuzzBudgetMin, appapi.DevBuzzBudgetCap, appapi.DevBuzzBudgetDefault)
+	case budget > appapi.DevBuzzBudgetCap:
+		return fmt.Errorf(
+			"--budget %d is above the server's dev-token cap of %d Buzz — the server would clamp it to %d WITHOUT saying so, "+
+				"leaving you a token that does not carry the budget you asked for. Pass --budget %d or lower",
+			budget, appapi.DevBuzzBudgetCap, appapi.DevBuzzBudgetCap, appapi.DevBuzzBudgetCap)
+	default:
+		return nil
+	}
+}
+
 func newAppDevTokenCmd() *cobra.Command {
 	var envOut bool
+	var budget int
 
 	cmd := &cobra.Command{
 		Use:   "dev-token <slug>",
@@ -125,8 +151,27 @@ Pre-GA the mint route is invite-only. You do NOT need to submit the app
 first — for a brand-new slug with no app row yet, the token is minted from the
 scopes in your local block.manifest.json (clamped server-side), so
 "create → dev-token → dev:live" works directly. The token is short-lived —
-never commit it; re-mint when it expires.`,
+never commit it; re-mint when it expires.
+
+BUDGET (--budget, 1-250 Buzz). The token carries a per-generation Buzz budget.
+Omit --budget and the server picks one — 50 for a slug with no submitted app.
+Your LOCAL block.manifest.json page.buzzBudgetPerGen does NOT raise it: until
+the app is submitted there is no server-side manifest to read, so the 50 is a
+flat default, not a clamp of your file. --budget is the only way to move it.
+
+A generation is REFUSED outright when the recipe's Buzz ceiling exceeds that
+budget, so a shipped recipe with a ceiling of 90 dead-ends on the default:
+
+  insufficient buzz budget: recipe ceiling 90 exceeds budget 50
+
+Raise it (--budget 250) rather than editing the recipe.
+
+The trap: for an inline customComfy graph your maxBuzz is BOTH the Buzz ceiling
+and the step timeout in SECONDS. An over-thrifty budget therefore does not fail
+as a billing error — the step runs out of wall clock and comes back "expired",
+which reads like a broken graph. Budget for the seconds the graph needs.`,
 		Example: `  civitai app dev-token my-block               # print the token to stdout
+  civitai app dev-token my-block --budget 250  # max budget (and 250s of customComfy wall clock)
   civitai app dev-token my-block --env         # print VITE_LIVE_BLOCK_TOKEN=<token>
   civitai app dev-token my-block --env >> .env.development.local`,
 		Args: cobra.MaximumNArgs(1),
@@ -147,6 +192,19 @@ never commit it; re-mint when it expires.`,
 				return fmt.Errorf("an app slug is required — e.g. `civitai app dev-token my-block` (find it with `civitai app status`)")
 			}
 
+			// Distinguish "not set" from "set to zero": only a CHANGED flag
+			// becomes a request field. Defaulting the variable and always
+			// sending it would permanently shadow the server's own budget
+			// resolution, which is the behaviour every omitted-flag invocation
+			// depends on today.
+			var buzzBudget *int
+			if cmd.Flags().Changed("budget") {
+				if err := validateDevTokenBudget(budget); err != nil {
+					return asUsageError(err)
+				}
+				buzzBudget = &budget
+			}
+
 			// Read the LOCAL manifest scopes (current working directory — the
 			// user runs this from the scaffolded project dir) so the server can
 			// mint a token for a slug with no app row yet (no submit needed).
@@ -157,7 +215,7 @@ never commit it; re-mint when it expires.`,
 
 			client := appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
 			errOut := cmd.ErrOrStderr()
-			token, slug, err := mintDevTokenWithRename(context.Background(), client, errOut, ".", slug, scopes)
+			token, slug, err := mintDevTokenWithRename(context.Background(), client, errOut, ".", slug, scopes, buzzBudget)
 			if err != nil {
 				return err
 			}
@@ -192,6 +250,9 @@ never commit it; re-mint when it expires.`,
 		},
 	}
 	cmd.Flags().BoolVar(&envOut, "env", false, "print VITE_LIVE_BLOCK_TOKEN=<token> (paste-ready into .env.development.local)")
+	cmd.Flags().IntVar(&budget, "budget", 0, fmt.Sprintf(
+		"per-generation Buzz budget the token may spend (%d-%d; omit to let the server decide — %d for an unsubmitted app). Must clear your recipe's ceiling; for inline customComfy it is ALSO the step timeout in seconds",
+		appapi.DevBuzzBudgetMin, appapi.DevBuzzBudgetCap, appapi.DevBuzzBudgetDefault))
 	return cmd
 }
 
@@ -205,10 +266,14 @@ never commit it; re-mint when it expires.`,
 // Renaming only applies when a local manifest exists in dir (nothing to rewrite
 // otherwise); any non-collision error, or a collision with no manifest, is
 // surfaced verbatim without a rename.
-func mintDevTokenWithRename(ctx context.Context, client *appapi.Client, errOut io.Writer, dir, slug string, scopes []string) (string, string, error) {
+//
+// buzzBudget is carried through every retry unchanged (nil = not requested): a
+// rename changes which slug is minted for, never what the developer asked the
+// token to be able to spend.
+func mintDevTokenWithRename(ctx context.Context, client *appapi.Client, errOut io.Writer, dir, slug string, scopes []string, buzzBudget *int) (string, string, error) {
 	original := slug
 	for attempt := 0; ; attempt++ {
-		token, err := client.MintDevToken(ctx, slug, scopes)
+		token, err := client.MintDevToken(ctx, slug, scopes, buzzBudget)
 		if err == nil {
 			return token, slug, nil
 		}

--- a/internal/cmd/app_dev_token_budget_test.go
+++ b/internal/cmd/app_dev_token_budget_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// devTokenBudgetKey decodes rec.rawBody as a generic object and reports the
+// `buzzBudget` member and whether the KEY was present at all.
+//
+// Reading the raw body is the whole point: a `struct{BuzzBudget int}` decodes an
+// absent key and an explicit `0` to the same value, so a test written against a
+// decoded struct cannot tell "the CLI sent nothing" (server default applies)
+// from "the CLI sent 0" (server 400s). Only the serialized bytes distinguish
+// them, and that distinction is the flag's central requirement.
+func devTokenBudgetKey(t *testing.T, rec *devTokenRec) (any, bool) {
+	t.Helper()
+	var generic map[string]any
+	if err := json.Unmarshal(rec.rawBody, &generic); err != nil {
+		t.Fatalf("request body is not a JSON object (%v): %q", err, string(rec.rawBody))
+	}
+	v, ok := generic["buzzBudget"]
+	return v, ok
+}
+
+// TestAppDevTokenOmitsBudgetWhenFlagUnset is the no-regression pin, and it is an
+// INVARIANT guard rather than a regression test: it passes both before and after
+// --budget exists. That is deliberate — the risk the flag introduces is that a
+// zero-valued Go variable starts being marshalled on EVERY mint, silently
+// pinning every token at a budget of 0 (or 50) and making the server's own
+// resolution unreachable. This pins the pre-flag wire shape so that regression
+// cannot land unseen.
+func TestAppDevTokenOmitsBudgetWhenFlagUnset(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	chdir(t, t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	if _, _, err := run(t, "app", "dev-token", "my-block"); err != nil {
+		t.Fatalf("app dev-token: %v", err)
+	}
+	if v, present := devTokenBudgetKey(t, &rec); present {
+		t.Errorf("body must carry NO buzzBudget key when --budget is unset, got %v (body %q) — "+
+			"sending one makes the server's default resolution unreachable", v, string(rec.rawBody))
+	}
+}
+
+// TestAppDevTokenSendsBudget: --budget N puts an integer buzzBudget on the wire.
+func TestAppDevTokenSendsBudget(t *testing.T) {
+	cases := []struct {
+		name   string
+		budget string
+		want   float64 // encoding/json decodes every JSON number into float64
+	}{
+		{"the server cap", "250", 250},
+		{"clears the seamless-pano-360 ceiling of 90", "120", 120},
+		{"the smallest value the server accepts", "1", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec devTokenRec
+			srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+			defer srv.Close()
+
+			chdir(t, t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("CIVITAI_TOKEN", "tok")
+			t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+			if _, _, err := run(t, "app", "dev-token", "my-block", "--budget", tc.budget); err != nil {
+				t.Fatalf("app dev-token --budget %s: %v", tc.budget, err)
+			}
+			v, present := devTokenBudgetKey(t, &rec)
+			if !present {
+				t.Fatalf("body must carry buzzBudget when --budget is set, got %q", string(rec.rawBody))
+			}
+			if v != tc.want {
+				t.Errorf("buzzBudget = %v (%T), want %v — body %q", v, v, tc.want, string(rec.rawBody))
+			}
+			// The value must be a JSON NUMBER, not a string: the server's zod
+			// schema is z.number().int().positive() and rejects "120" outright.
+			if !strings.Contains(string(rec.rawBody), fmt.Sprintf(`"buzzBudget":%s`, tc.budget)) {
+				t.Errorf("buzzBudget must serialize as a bare JSON number, got %q", string(rec.rawBody))
+			}
+		})
+	}
+}
+
+// TestAppDevTokenRejectsOutOfRangeBudget: a budget outside the server's accepted
+// range fails LOCALLY, names the bound, and sends NO request — shipping a call
+// you already know the server refuses (or silently clamps) wastes a round trip
+// and, in the clamp case, hands back a token whose budget is not what was asked
+// for with no signal at all.
+func TestAppDevTokenRejectsOutOfRangeBudget(t *testing.T) {
+	cases := []struct {
+		name   string
+		budget string
+		want   []string
+	}{
+		// The server's zod schema is .positive(), so 0 and negatives are a 400.
+		{"zero", "0", []string{"--budget", "1", "250"}},
+		{"negative", "-5", []string{"--budget", "1", "250"}},
+		// Over the cap the server does NOT refuse — it silently clamps to 250,
+		// which is the worse failure, so the CLI has to be the one to speak up.
+		{"over the cap", "251", []string{"--budget", "250", "clamp"}},
+		{"far over the cap", "100000", []string{"--budget", "250", "clamp"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec devTokenRec
+			srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+			defer srv.Close()
+
+			chdir(t, t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("CIVITAI_TOKEN", "tok")
+			t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+			out, _, err := run(t, "app", "dev-token", "my-block", "--budget", tc.budget)
+			if err == nil {
+				t.Fatalf("--budget %s must be rejected client-side", tc.budget)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("--budget %s error %q should mention %q", tc.budget, err.Error(), want)
+				}
+			}
+			// No token may reach stdout, and no request may reach the server.
+			if strings.TrimSpace(out) != "" {
+				t.Errorf("a rejected --budget must print nothing to stdout, got %q", out)
+			}
+			if rec.method != "" {
+				t.Errorf("a rejected --budget must not send a request, but the server saw %s %s",
+					rec.method, rec.path)
+			}
+			// Usage-class failure -> the CLI's usage exit code, not a network one.
+			if !errors.Is(err, ErrUsage) {
+				t.Errorf("out-of-range --budget should classify as ErrUsage, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestAppDevTokenSurfacesServerBudgetRejection: when the server DOES refuse a
+// budget it answers 400 with {"message","details"}, where the actionable text
+// lives in details.fieldErrors.buzzBudget (zod's flatten()). Surfacing only the
+// generic top-level "Invalid request body" tells the developer nothing about
+// WHICH field was wrong, so the field detail has to make it into the error.
+func TestAppDevTokenSurfacesServerBudgetRejection(t *testing.T) {
+	body := map[string]any{
+		"message": "Invalid request body",
+		"details": map[string]any{
+			"formErrors": []any{},
+			"fieldErrors": map[string]any{
+				"buzzBudget": []any{"Too small: expected number to be >0"},
+			},
+		},
+	}
+	srv := devTokenServer(t, body, http.StatusBadRequest, nil)
+	defer srv.Close()
+
+	chdir(t, t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	_, _, err := run(t, "app", "dev-token", "my-block")
+	if err == nil {
+		t.Fatal("expected an error for a 400")
+	}
+	for _, want := range []string{"400", "Invalid request body", "buzzBudget", "Too small"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("400 error %q should surface %q — a bare status code is not actionable", err.Error(), want)
+		}
+	}
+	if !errors.Is(err, civitai.ErrBadRequest) {
+		t.Errorf("a 400 should classify as ErrBadRequest, got %T: %v", err, err)
+	}
+}
+
+// TestAppDevTokenBudgetWithEnvKeepsStreamSplit: --budget must not disturb the
+// stdout/stderr contract --env depends on (token on stdout, hints on stderr) —
+// `dev-token --env >> .env.development.local` has to stay clean.
+func TestAppDevTokenBudgetWithEnvKeepsStreamSplit(t *testing.T) {
+	var rec devTokenRec
+	srv := devTokenServer(t, map[string]any{"token": "jwt-x"}, http.StatusOK, &rec)
+	defer srv.Close()
+
+	chdir(t, t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+
+	out, errOut, err := run(t, "app", "dev-token", "my-block", "--budget", "120", "--env")
+	if err != nil {
+		t.Fatalf("app dev-token --budget 120 --env: %v", err)
+	}
+	if strings.TrimSpace(out) != "VITE_LIVE_BLOCK_TOKEN=jwt-x" {
+		t.Errorf("stdout = %q, want exactly VITE_LIVE_BLOCK_TOKEN=jwt-x", out)
+	}
+	if !strings.Contains(errOut, "Paste") {
+		t.Errorf("stderr should still carry the paste hint: %q", errOut)
+	}
+}
+
+// TestAppDevTokenBudgetHelpTeachesTheTrap: the two ways an under-set budget
+// bites are both invisible from the error the developer sees, so help has to
+// name them — a recipe ceiling above the budget REFUSES the generation, and on
+// an inline customComfy graph the same number is also the step timeout in
+// seconds, so being thrifty shows up as `expired`, never as a billing error.
+func TestAppDevTokenBudgetHelpTeachesTheTrap(t *testing.T) {
+	out, _, err := run(t, "app", "dev-token", "--help")
+	if err != nil {
+		t.Fatalf("app dev-token --help: %v", err)
+	}
+	for _, want := range []string{
+		"--budget",
+		"ceiling",
+		"customComfy",
+		"seconds",
+		"expired",
+		// The two server constants, written as LITERALS on purpose: this test
+		// must compile against a tree that does not yet vendor them, so the
+		// red-before-green run is a real runtime failure and not a build break.
+		// appapi's own drift guard is what pins these to the server.
+		"250",
+		"50",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`app dev-token --help` should mention %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cmd/app_dev_token_test.go
+++ b/internal/cmd/app_dev_token_test.go
@@ -17,6 +17,10 @@ type devTokenRec struct {
 	auth, method, path, contentType, slug string
 	scopes                                []string
 	hasScopesKey                          bool
+	// rawBody is the request body EXACTLY as it went on the wire. Assertions
+	// about which keys the CLI sends (or omits) have to read this, not a decoded
+	// struct — a struct field is indistinguishable between "absent" and "zero".
+	rawBody []byte
 }
 
 // devTokenServer stands up an httptest server emulating
@@ -37,6 +41,7 @@ func devTokenServer(t *testing.T, body any, status int, rec *devTokenRec) *httpt
 			rec.path = r.URL.Path
 			rec.contentType = r.Header.Get("Content-Type")
 			raw, _ := io.ReadAll(r.Body)
+			rec.rawBody = raw
 			var parsed struct {
 				Slug   string   `json:"slug"`
 				Scopes []string `json:"scopes"`


### PR DESCRIPTION
`civitai app dev-token` mints a token carrying a Buzz budget. The endpoint has always accepted a `buzzBudget` field; the CLI could not set it, so every token took the server default of **50** — below the ceiling of shipped recipes. `seamless-pano-360` has a ceiling of 90, so it was unrunnable in the only dev environment we offer:

```
insufficient buzz budget: recipe ceiling 90 exceeds budget 50
```

with no way out from the CLI. The same gap expires an inline `customComfy` graph, since on that path `maxBuzz` is *also* the step timeout in seconds.

Found in a blind dogfood; the missing flag cost two separate dead ends.

## The flag

```
--budget int   per-generation Buzz budget the token may spend (1-250; omit to let the
               server decide — 50 for an unsubmitted app). Must clear your recipe's
               ceiling; for inline customComfy it is ALSO the step timeout in seconds
```

Help gained a `BUDGET` section naming both traps (the refusal and the silent `expired`), plus an example line. `--env`'s stdout/stderr split is untouched and pinned by a test.

## Server behaviour — measured, not assumed

Probed the live endpoint directly rather than trusting the source read:

| request | result |
|---|---|
| no `buzzBudget` | HTTP 200, claim **50** |
| `buzzBudget: 120` | HTTP 200, claim **120** |
| `buzzBudget: 250` | HTTP 200, claim **250** |
| `buzzBudget: 100000` | HTTP 200, claim **250** — clamped **silently** |
| `buzzBudget: 0` | HTTP 400, `details.fieldErrors.buzzBudget` |

Three design consequences:

**Omitting the flag sends no field.** Absent and `0` resolve differently server-side, so the request field is a `*int` and only `Changed("budget")` populates it. A plain `int` would have pinned every mint at a CLI-chosen value and made the server's own resolution permanently unreachable.

**Over the cap is checked client-side.** The server does not refuse it — it succeeds and clamps, and the result is undetectable afterwards (a clamped 250 and a requested 250 are byte-identical in the JWT). That is the worse of the two failures, and this is the only place it can be caught. Under the minimum is checked too, so a known-400 request is never sent.

**A 400 now says which field.** It previously surfaced as `server returned 400: Invalid request body` — the same sentence for every malformed field. The zod `flatten()` detail is extracted, so a rejected budget reports `buzzBudget: Too small: expected number to be >0`.

## One correction carried forward

The dogfooder first assumed the 50 was their local `block.manifest.json` being clamped. It was not, and this is now confirmed empirically rather than argued: a local manifest with `page.buzzBudgetPerGen: 200`, `--budget` omitted, still mints a **50**-budget token. Until the app is submitted there is no server-side manifest to read, so the 50 is a flat default and never a clamp of the local file. The help text states this outright.

## Tests

10 new subtests, table-driven, in the existing style. **Red at `origin/main`, green at HEAD** — the flag-omitted case is deliberately an *invariant* guard (green on both sides), pinning the pre-flag wire shape so that regression cannot land unseen; the other 9 are genuinely red before.

Assertions read the **serialized request body**, not a decoded struct — decoding collapses "absent" and "zero" into the same value, and telling those apart is the whole contract.

Every guard was mutation-killed for **its own** specific error, including both range boundaries independently (250 accepted / 251 rejected; 1 accepted / 0 rejected) and the stable-ordering sort.

Full suite: **1862 passed, 0 failed, 4 skipped** across 17 packages. `go build`, `go vet`, `gofmt` clean.

## Scope

`internal/cmd/app_dev_token.go`, `internal/appapi/appblocks.go`, and their tests. No changes to `internal/scaffold/`, README, or docs prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
