### PR TITLE
fix(scaffold): the generated app told developers inline ComfyUI graphs are impossible

### DIFF
--- a/internal/cmd/app_create.go
+++ b/internal/cmd/app_create.go
@@ -28,19 +28,24 @@ Buzz spend), with a mock-host dev harness and a unit test. The scaffold is
 immediately runnable (npm install && npm run dev:harness), test-green, and
 validates clean.
 
-The default scaffold ships TWO samples in the one app: a runnable txt2img money
-path AND a Comfy on Civitai (customComfy) sample that runs a server-registered recipe
-(invite-only beta) — both share the estimate -> consent -> submit -> poll driver,
-switched by an on-screen mode toggle. Both work end-to-end in "npm run
-dev:harness" (mock host); see the generated README's "Comfy on Civitai sample" section.
+The default scaffold ships a runnable txt2img money path AND a Comfy on Civitai
+(customComfy) sample that runs a server-registered recipe (invite-only beta) —
+both share the estimate -> consent -> submit -> poll driver, switched by an
+on-screen mode toggle, and both work end-to-end in "npm run dev:harness".
+
+customComfy has TWO arms. Besides the recipe arm above, an app may also ship
+its own ComfyUI graph inline (mode: 'inline', app developers only). src/comfy.ts
+includes a complete, unit-tested buildInlineComfyBody for it: the graph, the
+declared AIR resource manifest, and the maxBuzz ceiling (which is ALSO the step
+timeout in seconds). See the generated README's "Comfy on Civitai samples" section.
 
 Templates (override with --template):
   static      a no-build page app (index.html + a tiny JS, no build step)
   page-vite   a vite + React page app (config-as-code build: buildCommand + outputDir)
   page-money  a vite + React + TS full-page (W10) money-path app wired to the
               published App SDK (estimate -> consent -> submit -> poll -> Buzz
-              spend); includes a txt2img + a Comfy on Civitai (customComfy) sample
-              [default for create]
+              spend); includes a txt2img + a Comfy on Civitai (customComfy) sample,
+              recipe and inline-graph body builders [default for create]
 
 The display name can be free-form ("My Cool Block"); it is slugified for the
 blockId. A slug-shaped name is used verbatim.

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -150,6 +150,14 @@ func TestAppCreateHelpMentionsComfy(t *testing.T) {
 			t.Errorf("app create help should mention %q (Comfy on Civitai discoverability):\n%s", want, out)
 		}
 	}
+	// BOTH arms must be discoverable, not just the recipe one. The help text
+	// previously described customComfy as recipe-only, which reads as "an app
+	// cannot ship a graph" — the exact claim that cost a dogfooding session.
+	for _, want := range []string{"inline", "its own ComfyUI graph"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("app create help should mention %q (inline-graph arm discoverability):\n%s", want, out)
+		}
+	}
 }
 
 func TestAppCreateRespectsTemplateOverride(t *testing.T) {

--- a/internal/cmd/app_create_cmd_test.go
+++ b/internal/cmd/app_create_cmd_test.go
@@ -99,14 +99,40 @@ func TestAppCreateDefaultsToPageMoney(t *testing.T) {
 	if iHarness >= 0 && iTunnel >= 0 && iHarness > iTunnel {
 		t.Errorf("dev:harness (free path) must lead BEFORE the dev-tunnel step (beta):\n%s", stdout)
 	}
-	// Among the demoted beta surfaces, submit still precedes the tunnel (the
-	// tunnel resolves the app server-side, so it must be registered first).
+	// Among the demoted beta surfaces, submit is still printed before the tunnel.
+	// 🔴 This is a PRESENTATIONAL grouping (publish path, then preview path), NOT
+	// a dependency — submit is not required before a dev tunnel. The previous
+	// version of this comment said "it must be registered first", which is false
+	// and is exactly the claim the banner assertion below now guards against.
 	if iSubmit >= 0 && iTunnel >= 0 && iSubmit > iTunnel {
-		t.Errorf("submit must be sequenced BEFORE the dev-tunnel step (register first):\n%s", stdout)
+		t.Errorf("submit is printed BEFORE the dev-tunnel step (presentational order):\n%s", stdout)
 	}
 	// The beta surfaces are gated behind an honest "beta access" heading.
 	if !strings.Contains(stdout, "beta access") {
 		t.Errorf("create should gate submit/dev-tunnel under a beta-access heading:\n%s", stdout)
+	}
+	// 🔴 The banner must NOT claim submit is a prerequisite for the dev tunnel.
+	// It is not: the mint accepts a brand-new slug with no app row and grants
+	// scopes from the LOCAL manifest (app_dev_tunnel.go's "UNSUBMITTED app (no
+	// submit needed)" path). What the tunnel needs is an Apps-author invite AND
+	// the dev-tunnel flag; an unenrolled account gets a 403 at mint time. A
+	// dogfooding developer opened a working tunnel having never submitted.
+	//
+	// Two halves, because either alone is weak: a NEGATIVE check that the old
+	// phrasing is gone (spelled — it cannot catch a reworded restatement), and a
+	// POSITIVE check that the banner affirmatively says no submit is needed, so
+	// deleting the correction outright also goes red.
+	for _, stale := range []string{
+		"required before a dev tunnel",
+		"required before the dev tunnel",
+		"register first",
+	} {
+		if strings.Contains(stdout, stale) {
+			t.Errorf("create banner must not claim submit gates the dev tunnel (found %q):\n%s", stale, stdout)
+		}
+	}
+	if !strings.Contains(stdout, "no submit needed") {
+		t.Errorf("create banner should say the dev tunnel needs no submit:\n%s", stdout)
 	}
 	// The Comfy on Civitai (customComfy) sample is surfaced (finding #2: it was
 	// undiscoverable) — honestly flagged as invite-only beta.

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -191,12 +191,13 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 	// One scannable line: name, template, where, and how many files — no tree.
 	fmt.Fprintln(out, ui.Success(fmt.Sprintf("Created App %q (%s)  ·  %s/  ·  %d files", display, tmpl, destDir, len(written))))
 
-	// page-money ships TWO samples in the one app — a runnable txt2img money path
-	// and a Comfy on Civitai (customComfy) sample. Surface it (honestly: invite-only
-	// beta) and point at the README's Comfy on Civitai section rather than the raw
-	// file count.
+	// page-money ships a runnable txt2img money path and a Comfy on Civitai
+	// (customComfy) sample, with body builders for BOTH customComfy arms — the
+	// server-registered recipe, and an inline graph the app ships itself. Surface
+	// both honestly (each has its own access gate) and point at the README's
+	// Comfy on Civitai section rather than the raw file count.
 	if tmpl.NeedsHarness() {
-		fmt.Fprintln(out, ui.Dim("  Includes a txt2img sample + a Comfy on Civitai (customComfy) sample (invite-only beta) — see the Comfy on Civitai section in README.md."))
+		fmt.Fprintln(out, ui.Dim("  Includes a txt2img sample + a Comfy on Civitai (customComfy) sample (invite-only beta), with body builders for BOTH arms: a server-registered recipe and an inline ComfyUI graph your own app ships (app developers) — see the Comfy on Civitai section in README.md."))
 	}
 
 	fmt.Fprintln(out, "\n"+ui.Bold("Next steps:"))

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -209,17 +209,30 @@ func printScaffoldResult(out io.Writer, display, slug string, tmpl scaffold.Temp
 		// (register) + the DEV TUNNEL (your LOCAL code rendered INSIDE the real
 		// Civitai host, prod-fidelity) — are invite-only beta, so they're demoted
 		// under a "When you have beta access" heading rather than led with (they'd
-		// otherwise walk a first-time author straight into the gated wall). The
-		// tunnel resolves the app server-side, so submit (which creates the pending
-		// app row) still precedes it.
+		// otherwise walk a first-time author straight into the gated wall).
+		//
+		// 🔴 SUBMIT IS *NOT* A PREREQUISITE FOR THE TUNNEL, AND THIS BANNER USED TO
+		// SAY IT WAS — "(required before a dev tunnel)". It is not: the mint accepts
+		// a brand-new slug with NO app row and grants scopes from the LOCAL manifest
+		// (see the "UNSUBMITTED app (no submit needed)" path in app_dev_tunnel.go,
+		// and the same statement in the generated README's live-mode section, which
+		// this line contradicted). What the tunnel actually needs is an Apps-author
+		// invite AND the dev-tunnel flag — an unenrolled account gets a 403 at mint
+		// time saying exactly that (DevTunnelForbiddenError). Submission is
+		// orthogonal. A dogfooding developer opened a working tunnel having never
+		// submitted, which is what surfaced this.
+		//
+		// The two beta surfaces are still listed submit-first, but that is a
+		// PRESENTATIONAL grouping (publish path, then preview path) — not a
+		// dependency. Do not re-derive an ordering requirement from it.
 		fmt.Fprintf(out, "  1. cd %s && npm install    # writes package-lock.json — COMMIT it\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev:harness     # mock host, no Buzz — works today")
 		fmt.Fprintln(out, "  3. edit src/App.tsx and iterate")
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, "  When you have beta access (invite-only):")
-		fmt.Fprintln(out, "     civitai app submit      # validate + register (required before a dev tunnel)")
+		fmt.Fprintln(out, "     civitai app submit      # validate + register — when you're ready to publish")
 		fmt.Fprintln(out, "     npm run dev:tunnel      # in another terminal: serve your app for the tunnel")
-		fmt.Fprintln(out, "     civitai app dev-tunnel  # preview your LOCAL app INSIDE the real Civitai host — prod-fidelity")
+		fmt.Fprintln(out, "     civitai app dev-tunnel  # your LOCAL app INSIDE the real host, prod-fidelity — no submit needed")
 	case tmpl == scaffold.PageVite:
 		fmt.Fprintf(out, "  1. cd %s && npm install    # writes package-lock.json — COMMIT it\n", destDir)
 		fmt.Fprintln(out, "  2. npm run dev              # preview locally (your UI only — see below)")

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -241,9 +241,10 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "pm-lora-weight")
 	mustContain(t, app, "addLora")
 
-	// Comfy on Civitai (customComfy) sample: a mode toggle swaps the body-builder to
-	// buildComfyBody (a server-registered recipe). The recipe id is FIXED +
-	// server-registered; comfy.ts never sends a graph, only { kind, recipe, params }.
+	// Comfy on Civitai (customComfy) samples: a mode toggle swaps the body-builder
+	// to buildComfyBody (a server-registered recipe) or buildInlineComfyBody (the
+	// app's own graph). BOTH arms must be present — a scaffold that ships only
+	// the recipe arm is how a developer concludes inline graphs don't exist.
 	comfy := readFile(t, filepath.Join(dest, "src", "comfy.ts"))
 	mustContain(t, comfy, "customComfy")
 	mustContain(t, comfy, "starter-comfy-txt2img")
@@ -252,6 +253,49 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "SegmentedControl")
 	mustContain(t, app, "pm-comfy-beta")
 	mustContain(t, app, "pm-gated")
+
+	// The INLINE arm — the app ships its own ComfyUI graph. These are presence
+	// checks for DISCOVERABILITY (the dogfood failure was a developer guessing at
+	// key names because no sample showed them), NOT behavioural guards: this is a
+	// substring match over a rendered template, so a comment or a type declaration
+	// satisfies it just as well as the builder does. It was mutation-tested and it
+	// DOES survive deleting `mode: 'inline'` from the builder body.
+	//
+	// The behavioural guard lives in the generated project itself — comfy.test.ts
+	// asserts the built body, and `npm run typecheck` fails outright on a body
+	// missing `mode` (verified: `Property 'mode' is missing in type … but required
+	// in type 'InlineComfyBody'`). CI runs both against a freshly scaffolded app.
+	mustContain(t, comfy, "buildInlineComfyBody")
+	mustContain(t, comfy, "mode: 'inline'")
+	mustContain(t, comfy, "resources:")
+	mustContain(t, comfy, "maxBuzz")
+	mustContain(t, comfy, "urn:air:")
+	mustContain(t, comfy, "class_type")
+	// The generated unit test must actually exercise the inline builder — an
+	// unreferenced sample rots.
+	comfyTest := readFile(t, filepath.Join(dest, "src", "comfy.test.ts"))
+	mustContain(t, comfyTest, "buildInlineComfyBody")
+
+	// The false invariant this scaffold used to assert. It is not enough to add
+	// the inline sample: the sentence that told a dogfooding developer the
+	// feature could not exist must be GONE from every generated surface.
+	//
+	// NOTE this is a SPELLED guard, not a structural one — it matches phrasings,
+	// so it cannot tell an assertion from a retraction, and it will fire on prose
+	// that merely QUOTES the old claim while correcting it (it did, on the first
+	// draft of the README rewrite). That is the intended bias: describe the old
+	// claim, do not restate it verbatim. It also cannot catch a NEW way of
+	// spelling the same falsehood, so it is a floor, not a proof.
+	comfyReadme := readFile(t, filepath.Join(dest, "README.md"))
+	for _, stale := range []string{
+		"never sends a Comfy graph",
+		"never ships a ComfyUI graph",
+		"cannot ship its own graph",
+	} {
+		mustNotContain(t, comfy, stale)
+		mustNotContain(t, app, stale)
+		mustNotContain(t, comfyReadme, stale)
+	}
 
 	// generation.ts threads the chosen checkpoint into modelId/modelVersionId
 	// instead of a hardcoded constant, AND emits the selected LoRAs as

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -92,26 +92,143 @@ server is LoRA-only for additional resources and **re-validates** base-model
 compatibility + per-resource entitlement (early-access / Private) AND
 **re-prices** the whole body **before any Buzz spend**.
 
-### Comfy on Civitai sample (customComfy)
+### Comfy on Civitai samples (customComfy)
 
 A **mode toggle** at the top switches between two samples that share the one
-estimate → consent → submit → poll driver + the account picker — only the body
-differs:
+estimate → consent → submit → poll driver — only the body differs:
 
 - **Text to image** (primary, runnable today) — the checkpoint + LoRA path above.
-- **Comfy on Civitai recipe** (secondary, invite-only beta) — runs a **Comfy on
-  Civitai (`customComfy`)** generation via `buildComfyBody` in `src/comfy.ts`.
+- **Comfy on Civitai recipe** (invite-only beta) — runs a **server-registered**
+  recipe via `buildComfyBody` in `src/comfy.ts`.
 
-**How customComfy works — server-owned graph, fail-closed.** The iframe **never
-sends a Comfy graph.** It sends `{ kind: 'customComfy', recipe, params }` where
-`recipe` is a **server-registered, code-reviewed recipe id** — the civitai server
-owns the graph, the resource allowlist, the checkpoint policy, and a hard per-job
-`maxBuzz` ceiling. An app **cannot ship its own graph**; the block can only pick
-the recipe + a small, per-recipe-validated `params` object (here just a prompt,
-plus the shared account picker — no checkpoint/LoRA axis). This sample invokes
-**`starter-comfy-txt2img`** — a cheap, minimal Z-Image txt2img starter recipe
-(per-job Buzz ceiling 30). The scope is unchanged — `customComfy` needs exactly
+`src/comfy.ts` also ships **`buildInlineComfyBody`** — a complete, unit-tested
+builder for the OTHER `customComfy` arm, where your app ships **its own ComfyUI
+graph**. It is not on the toggle yet; see [Why inline is not on the
+toggle](#why-inline-is-not-on-the-toggle-yet) below. Read that function and its
+tests — it is the shape you need, and it is why you are not guessing at key
+names.
+
+**`customComfy` has TWO arms, selected by `mode`.** Earlier versions of this
+README stated flatly that an app could not ship a ComfyUI graph. That was true
+once and is not any more — the inline arm below is live. It is called out here
+because a developer reading that stale sentence believed it over a working
+feature and stopped probing.
+
+| | `mode` | The app sends | Who can run it |
+|---|---|---|---|
+| **recipe** | omitted, or `'recipe'` | a registered recipe id + bounded `params` | invite-only beta |
+| **inline** | `'inline'` (required) | the graph itself + a declared resource manifest + `maxBuzz` | app developers |
+
+The scope is the same for both — `customComfy` needs exactly
 `ai:write:budgeted`, already declared.
+
+#### The recipe arm
+
+`{ kind: 'customComfy', recipe, params }`, where `recipe` is a
+**server-registered, code-reviewed recipe id**. The civitai server owns the
+graph, the resource allowlist, the checkpoint policy, and a hard per-job
+`maxBuzz` ceiling; the block picks only the recipe + a small, per-recipe-
+validated `params` object (here just a prompt, plus the shared account picker —
+no checkpoint/LoRA axis). This sample invokes **`starter-comfy-txt2img`** — a
+cheap, minimal Z-Image txt2img starter recipe (per-job Buzz ceiling 30).
+
+Note that `mode` is **omitted**, not set to `'recipe'`. The server declares it an
+optional literal precisely so a body without the key parses as a recipe, which is
+what keeps every already-published app working.
+
+#### The inline arm — ship your own graph
+
+```ts
+{
+  kind: 'customComfy',
+  mode: 'inline',                 // REQUIRED — a `workflow` key alone is not enough
+  workflow: { '1': { class_type: 'CheckpointLoaderSimple', inputs: { … } }, … },
+  resources: ['urn:air:sdxl:checkpoint:civitai:101055@128078'],
+  prompt: 'a mountain at dawn',   // optional; surfaced + audited
+  negativePrompt: '',             // optional
+  maxBuzz: 90,                    // REQUIRED — see below, it is also the timeout
+}
+```
+
+**`mode: 'inline'` is required.** Including a `workflow` key does not select this
+arm. A body without `mode` routes to the *recipe* arm and is then rejected for a
+missing `recipe` — which reads like an unrelated error.
+
+**`resources` is a declared manifest, and declaring is not optional.** Every AIR
+URN that appears anywhere in your graph — including as an object key — must also
+appear in this array, or the submit is rejected. It is not inferred from the
+graph: this flat array is the entire surface the entitlement check runs over, and
+containment is what makes checking it sufficient. Anything the graph references
+that is missing here would also fail at load time inside ComfyUI. A
+`civitai`-sourced AIR must carry a model **version** id
+(`urn:air:<ecosystem>:<type>:civitai:<modelId>@<versionId>`); without one there
+is no version to check entitlement against. At most 24 entries. The permitted AIR
+types are model **weights** (checkpoint, diffusion_model, unet, lora, lycoris,
+dora, embedding, hypernet, controlnet, vae, upscaler, clip, clipvision,
+text_encoders, motion, …); an OCI container-image AIR is not permitted.
+
+**Graph limits, all of which REJECT rather than truncate:** 1–300 nodes, at most
+256 KB serialized, at most 128 levels of nesting. Each node is exactly
+`{ class_type, inputs }` — the node schema is `.strict()`, so the `_meta` key a
+raw ComfyUI "Save (API Format)" export adds per node must be stripped or the
+whole body bounces.
+
+**What replaced code review.** A recipe is reviewed in-repo; an inline graph is
+not, so three server-side gates stand in, all of which run *before* any spend:
+AIR containment (above), an entitlement belt over `resources` that is stricter
+than the on-site generator (early-access and Private/epoch subscription are both
+folded in, and a resource the site would silently swap for a sibling version is
+**rejected** instead — your graph names one exact string and nothing rewrites
+it), and a moderation sweep that reads every string leaf in the graph, not just
+your declared `prompt`.
+
+**Who can run it.** App developers only, on page tokens only — the host runs a
+developer check on every `customComfy` estimate *and* submit, so a non-developer
+viewing your published block cannot submit one. Treat inline as a build-and-
+iterate primitive; to serve a graph to every viewer, get it registered as a
+recipe.
+
+**An inline body has no account picker.** Its schema is `.strict()` with no
+`accountType` field, so the host funds it as Auto. The picker is hidden in that
+mode rather than shown and ignored.
+
+#### 🔴 `maxBuzz` is the step TIMEOUT in seconds, not just a price
+
+The server stamps `stepTimeoutSeconds = maxBuzz`. One number, both roles — which
+is exactly what makes the ceiling physically enforceable rather than merely
+promised.
+
+So **setting it low to be thrifty does not buy a cheaper generation.** It buys a
+job that is killed after that many seconds and comes back `expired`, with nothing
+to show for it. You are billed the *real* cost either way: billing is post-paid
+against measured GPU seconds and settles to actual, refunding the unused
+remainder of the ceiling. Headroom is free; a stingy ceiling is not thrift, it is
+a timeout. Size it to the wall-clock time your graph needs (this sample's 20-step
+SDXL graph gets 90s; the server's hard maximum is 250).
+
+For the same reason, `estimate` on an inline body just echoes your `maxBuzz` back
+as `cost.total`. That is an **upper bound, not a price** — the orchestrator
+forwards the graph opaquely and cannot price it. Surface it as "up to N Buzz".
+
+#### Why inline is not on the toggle yet
+
+Not because the feature is missing — it is live server-side — but because the
+**mock host** in the pinned `@civitai/blocks-react` crashes on an inline body.
+Its `preferredAccountType` helper reads `body.params.accountType`
+unconditionally, and an inline body has no `params`, so `npm run dev:harness`
+fails with `Cannot read properties of undefined (reading 'accountType')` rather
+than generating. That is a bug in the mock, not in your body.
+
+The fix is landing in `@civitai/blocks-react`. Once this scaffold's pin moves
+past it, wiring inline into the toggle is a three-line change: add `'inline'` to
+`GenMode`, add a `SegmentedControl` entry, and select `buildInlineComfyBody(prompt)`
+in `runGeneration`. Two things to remember when you do: hide the account picker
+in that mode (an inline body has no `accountType` field, so a picker there cannot
+affect the request), and drop the `as WorkflowBody` cast the older pinned SDK
+needs.
+
+**None of this affects live civitai.com** — the inline arm works there today for
+an app-developer account. It only affects the offline mock harness.
 
 **Two different numbers, and they are not the same quantity.** It is easy to
 read one off the other; don't.
@@ -152,28 +269,33 @@ worst case.
 > and note that cumulative spend is separately capped per viewer per day — a high
 > per-gen ceiling does not widen total exposure.
 
-**Requesting a new recipe.** Because recipes are server-registered + code-reviewed,
-you can't add one from the app. Request a new Comfy on Civitai recipe via the CLI's
-issue form at
+**Requesting a new recipe.** Recipes are server-registered + code-reviewed, so
+you can't add one from the app. Request one via the CLI's issue form at
 <https://github.com/civitai/cli/issues/new?template=request-recipe.yml> (describe
 the graph + the intended `params` + the use case). It ships as a registered id
-once reviewed.
+once reviewed. **If you just want to run a graph today, use the inline arm** —
+that is what it is for; a recipe is for making a graph available to every viewer.
 
 **Dev loop — honest state.** In `npm run dev:harness` (the **mock** host) the
-Comfy on Civitai sample **works end-to-end** (estimate → submit → poll →
-succeeded with a mock image + cost), so you can build against it today. That is
-the fully-working path.
+**recipe** sample works end-to-end (estimate → submit → poll → succeeded with a
+mock image + cost), so you can build against it today. The **inline** sample's
+builder and its unit tests run under `npm test`, but the mock host cannot drive
+it yet — see [above](#why-inline-is-not-on-the-toggle-yet).
 
-On **live** civitai.com the sample is **not runnable yet**, for two reasons, and
-its graceful panel is best-effort:
+On **live** civitai.com:
 
-- `customComfy` is **invite-only beta** — a submit by a non-tester is rejected by
-  the app-blocks gate (`"Apps are not enabled"` / `"Apps authoring is not enabled
-  for this account"`).
-- The recipe `starter-comfy-txt2img` is **not registered server-side yet** (the
-  registry currently holds only `seamless-pano-360`). Until it ships, a submit is
-  rejected even earlier — at the workflow-schema **enum** boundary
-  (`Invalid enum value … received 'starter-comfy-txt2img'`).
+- **Inline** requires an **app-developer** account (and a page token). With one,
+  the path is live; without one the submit is rejected by the same app-blocks
+  gate below.
+- **The recipe sample** is **not runnable yet**, for two reasons, and its
+  graceful panel is best-effort:
+  - `customComfy` is **invite-only beta** — a submit by a non-tester is rejected
+    by the app-blocks gate (`"Apps are not enabled"` / `"Apps authoring is not
+    enabled for this account"`).
+  - The recipe `starter-comfy-txt2img` is **not registered server-side yet** (the
+    registry currently holds only `seamless-pano-360`). Until it ships, a submit
+    is rejected even earlier — at the workflow-schema **enum** boundary
+    (`Invalid enum value … received 'starter-comfy-txt2img'`).
 
 The app tries to degrade both of these to a friendly **invite-only beta** panel:
 `isFeatureGated` matches those three specific strings and, **in Comfy mode only**,

--- a/internal/scaffold/templates/page-money/src/comfy.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/comfy.test.ts.tmpl
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
 import { PROMPT_MAX } from './generation.js';
-import { STARTER_COMFY_RECIPE, buildComfyBody } from './comfy.js';
+import {
+  STARTER_COMFY_RECIPE,
+  STARTER_INLINE_CHECKPOINT_AIR,
+  STARTER_INLINE_MAX_BUZZ,
+  buildComfyBody,
+  buildInlineComfyBody,
+} from './comfy.js';
 
-// Pure-logic tests for the Comfy on Civitai (customComfy) sample body-builder. Run
-// with `npm test`. These lock the FIXED customComfy contract: kind, the
-// server-registered recipe id, and the bounded params shape.
+// Pure-logic tests for both Comfy on Civitai (customComfy) sample body-builders.
+// Run with `npm test`. These lock the customComfy contract on both arms: the
+// RECIPE arm's kind + server-registered recipe id + bounded params, and the
+// INLINE arm's required `mode`, its declared-resource containment rule, and its
+// dual-purpose `maxBuzz`.
 
 describe('buildComfyBody', () => {
   it('builds a customComfy body with the starter recipe + trimmed/clamped prompt', () => {
@@ -40,5 +48,112 @@ describe('buildComfyBody', () => {
       seed: 7,
       accountType: 'yellow',
     });
+  });
+
+  it("omits `mode` — the server treats an absent mode as the recipe arm", () => {
+    // Load-bearing, not stylistic. The server declares `mode` an OPTIONAL
+    // 'recipe' literal precisely so a body without the key parses as a recipe.
+    expect(buildComfyBody('a cat')).not.toHaveProperty('mode');
+  });
+});
+
+describe('buildInlineComfyBody', () => {
+  it("sets mode:'inline' — a `workflow` key alone does NOT select the inline arm", () => {
+    // Without this literal the body routes to the RECIPE arm and is rejected for
+    // a missing `recipe`. It is the single most likely first-try mistake.
+    const body = buildInlineComfyBody('a mountain');
+    expect(body.kind).toBe('customComfy');
+    expect(body.mode).toBe('inline');
+  });
+
+  it('declares every AIR its graph names (the server-side containment rule)', () => {
+    // The server walks the whole graph — values AND object keys — and rejects
+    // the body if any string that looks like an AIR is not also present in
+    // `resources`. This test is that walk, so a graph edit that adds a resource
+    // without declaring it fails here instead of at submit.
+    const body = buildInlineComfyBody('a mountain');
+    const declared = new Set(body.resources.map((a) => a.trim().toLowerCase()));
+
+    const airsInGraph: string[] = [];
+    const walk = (v: unknown): void => {
+      if (typeof v === 'string') {
+        if (v.toLowerCase().includes('urn:air:')) airsInGraph.push(v);
+        return;
+      }
+      if (Array.isArray(v)) {
+        v.forEach(walk);
+        return;
+      }
+      if (v && typeof v === 'object') {
+        for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+          walk(k);
+          walk(val);
+        }
+      }
+    };
+    walk(body.workflow);
+
+    // Positive control: the walk must actually FIND something. A containment
+    // check over an empty set passes vacuously, and a green that means "I looked
+    // at nothing" is worse than no test.
+    expect(airsInGraph.length).toBeGreaterThan(0);
+    expect(airsInGraph).toContain(STARTER_INLINE_CHECKPOINT_AIR);
+
+    for (const air of airsInGraph) {
+      expect(declared.has(air.trim().toLowerCase())).toBe(true);
+    }
+  });
+
+  it('names a civitai AIR with a model VERSION id', () => {
+    // A civitai-sourced AIR without `@<versionId>` is rejected: there is no
+    // version to check entitlement against.
+    expect(STARTER_INLINE_CHECKPOINT_AIR).toMatch(
+      /^urn:air:[a-z0-9_-]+:[a-z0-9_-]+:civitai:\d+@\d+$/,
+    );
+  });
+
+  it('stays inside the server-side graph bounds', () => {
+    const body = buildInlineComfyBody('a mountain');
+    const nodeCount = Object.keys(body.workflow).length;
+    expect(nodeCount).toBeGreaterThan(0);
+    expect(nodeCount).toBeLessThanOrEqual(300);
+    expect(JSON.stringify(body.workflow).length).toBeLessThanOrEqual(256 * 1024);
+    expect(body.resources.length).toBeLessThanOrEqual(24);
+  });
+
+  it('keeps maxBuzz an integer in 1..250 — it is ALSO the timeout in seconds', () => {
+    const body = buildInlineComfyBody('a mountain');
+    expect(body.maxBuzz).toBe(STARTER_INLINE_MAX_BUZZ);
+    expect(Number.isInteger(body.maxBuzz)).toBe(true);
+    expect(body.maxBuzz).toBeGreaterThanOrEqual(1);
+    expect(body.maxBuzz).toBeLessThanOrEqual(250);
+  });
+
+  it('puts the SAME text in the declared prompt and in the graph', () => {
+    // The declared prompt is what gets surfaced; the graph's CLIPTextEncode is
+    // what actually generates. Letting them drift means showing the user one
+    // thing and generating another.
+    const body = buildInlineComfyBody('  a mountain at dawn  ');
+    expect(body.prompt).toBe('a mountain at dawn');
+    expect(body.workflow['2'].inputs.text).toBe('a mountain at dawn');
+  });
+
+  it('clamps the prompt to the server cap in BOTH places', () => {
+    const body = buildInlineComfyBody('x'.repeat(PROMPT_MAX + 100));
+    expect(body.prompt?.length).toBe(PROMPT_MAX);
+    expect(String(body.workflow['2'].inputs.text).length).toBe(PROMPT_MAX);
+  });
+
+  it('threads the seed into the sampler, and omits an empty negative prompt', () => {
+    expect(buildInlineComfyBody('a cat', 12345).workflow['5'].inputs.seed).toBe(12345);
+    expect(buildInlineComfyBody('a cat')).not.toHaveProperty('negativePrompt');
+    expect(buildInlineComfyBody('a cat', 0, 'blurry').negativePrompt).toBe('blurry');
+  });
+
+  it('carries no accountType anywhere — an inline body is funded as Auto', () => {
+    // The server's inline schema is `.strict()` and has no accountType field, so
+    // sending one is a rejection rather than a dropped key.
+    expect(buildInlineComfyBody('a cat')).not.toHaveProperty('accountType');
+    expect(buildInlineComfyBody('a cat')).not.toHaveProperty('params');
   });
 });

--- a/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
@@ -1,35 +1,60 @@
-// Pure logic for the {{ .Name }} page app's SECONDARY "Comfy on Civitai (sample)"
-// path — a Comfy on Civitai (customComfy) generation. No React, no DOM;
-// unit-tested in node (see comfy.test.ts). Mirrors generation.ts's style and
-// REUSES its shared helpers (clampPrompt / AccountChoice) so the two
-// body-builders differ only in the body they produce.
+// Pure logic for the {{ .Name }} page app's TWO "Comfy on Civitai" sample paths.
+// No React, no DOM; unit-tested in node (see comfy.test.ts). Mirrors
+// generation.ts's style and REUSES its shared helpers (clampPrompt /
+// AccountChoice) so every body-builder differs only in the body it produces.
 //
-// The customComfy contract (server-owned, fail-closed):
-//   The iframe NEVER sends a Comfy graph. It sends a { kind: 'customComfy',
-//   recipe, params } body where `recipe` is a SERVER-registered, code-reviewed
-//   recipe id. The civitai server owns the graph, the resource allowlist, the
-//   checkpoint policy, and a hard per-job `maxBuzz` ceiling — the block can only
-//   pick the recipe + a small, per-recipe-validated `params` object.
+// THE customComfy CONTRACT HAS TWO ARMS, selected by `mode`:
+//
+//   recipe  (`mode` omitted, or 'recipe') — the app names a SERVER-registered,
+//           code-reviewed recipe id. The civitai server owns the graph, the
+//           resource allowlist, the checkpoint policy and the Buzz ceiling; the
+//           app supplies only a small, per-recipe-validated `params` object.
+//
+//   inline  (`mode: 'inline'`) — the app ships THE COMFYUI GRAPH ITSELF, plus a
+//           declared manifest of every resource it needs and a `maxBuzz`
+//           ceiling. This is how you run a workflow the recipe registry does not
+//           contain.
+//
+// Both are live. Earlier revisions of this file stated flatly that an app could
+// not ship its own graph. That was true once and is not any more — it predates
+// the inline arm. It is called out because a developer reading that stale
+// sentence believed it over a working feature and gave up.
+//
+// This file wires the RECIPE arm into App.tsx's mode toggle and provides a
+// complete, unit-tested builder for the INLINE arm. Inline is not on the toggle
+// yet only because the mock host in the pinned @civitai/blocks-react crashes on
+// a body with no `params`; see the README's "Why inline is not on the toggle
+// yet". The arm itself is live on civitai.com for an app-developer account.
 
 import type { WorkflowBodyCustomComfy } from '@civitai/app-sdk/blocks';
 
 import { clampPrompt, type AccountChoice } from './generation.js';
 
 /**
- * The starter recipe this sample invokes: a cheap, minimal Z-Image txt2img
- * recipe (per-job Buzz ceiling 30). It is SERVER-registered — an app cannot ship
- * its own graph, so a new recipe must be added + code-reviewed server-side (see
- * README "Comfy on Civitai sample"). This id must exist in the server registry for a
- * real run to resolve; an unknown id is rejected fail-closed.
+ * The RECIPE arm of `WorkflowBodyCustomComfy`, narrowed out of the SDK type.
+ *
+ * Written as an `Extract` rather than imported by name so it resolves on BOTH
+ * sides of the SDK minor that turned `WorkflowBodyCustomComfy` into a union: on
+ * the older SDK the whole type matches, on the newer one it selects the recipe
+ * arm. Same answer either way.
  */
-export const STARTER_COMFY_RECIPE = 'starter-comfy-txt2img';
+export type ComfyRecipeBody = Extract<WorkflowBodyCustomComfy, { recipe: string }>;
 
 /**
  * The params this sample sends — a subset of the recipe's `.strict()` server
  * schema (only the fields this minimal txt2img recipe accepts). Extra fields are
  * rejected server-side, so we keep it to prompt (+ optional seed/account).
  */
-export type ComfyParams = WorkflowBodyCustomComfy['params'];
+export type ComfyParams = ComfyRecipeBody['params'];
+
+/**
+ * The starter recipe the RECIPE sample invokes: a cheap, minimal Z-Image txt2img
+ * recipe (per-job Buzz ceiling 30). It is SERVER-registered — a recipe id must
+ * exist in the server registry for a real run to resolve, and an unknown id is
+ * rejected fail-closed at the schema enum. To run a graph that is NOT in the
+ * registry, use the inline arm below instead of waiting for a review.
+ */
+export const STARTER_COMFY_RECIPE = 'starter-comfy-txt2img';
 
 /**
  * Build the customComfy submit/estimate body for the starter recipe.
@@ -37,17 +62,22 @@ export type ComfyParams = WorkflowBodyCustomComfy['params'];
  *  - `prompt` is trimmed + clamped to the server cap (reuses generation.ts).
  *  - `accountType` (the shared account picker) is included only when a named
  *    pool is chosen; `'auto'`/omitted lets the host choose the funding order.
- *    NOTE: on a customComfy body it lives UNDER `params` (contrast textToImage,
- *    where it is top-level) — that's the mock host's `preferredAccountType`
- *    contract and the server's per-recipe param schema.
+ *    NOTE: on a customComfy RECIPE body it lives UNDER `params` (contrast
+ *    textToImage, where it is top-level) — that's the mock host's
+ *    `preferredAccountType` contract and the server's per-recipe param schema.
+ *    An INLINE body has no account pick at all; the host funds it as Auto.
  *  - `seed` is included only when a real number is given; `null`/omitted lets the
  *    orchestrator pick.
+ *
+ * `mode` is deliberately NOT set. The server declares it an OPTIONAL `'recipe'`
+ * literal, so omitting the key is the canonical recipe body and stays compatible
+ * with every host.
  */
 export function buildComfyBody(
   prompt: string,
   accountType?: AccountChoice,
   seed?: number | null,
-): WorkflowBodyCustomComfy {
+): ComfyRecipeBody {
   return {
     kind: 'customComfy',
     recipe: STARTER_COMFY_RECIPE,
@@ -56,5 +86,181 @@ export function buildComfyBody(
       ...(seed != null ? { seed } : {}),
       ...(accountType && accountType !== 'auto' ? { accountType } : {}),
     },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// INLINE ARM — the app ships the ComfyUI graph itself.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One node of a ComfyUI `/prompt` graph on the wire: `class_type` + `inputs`,
+ * and NOTHING else — the server's node schema is `.strict()`. A raw "Save (API
+ * Format)" export from ComfyUI often carries a `_meta` key per node; strip it,
+ * or the whole body is rejected rather than the key dropped.
+ *
+ * An `inputs` value is either a literal or a `[nodeId, outputIndex]` pair wiring
+ * this input to another node's output.
+ */
+export type InlineComfyNode = {
+  class_type: string;
+  inputs: Record<string, unknown>;
+};
+
+/**
+ * The INLINE arm's body shape, declared locally.
+ *
+ * It mirrors the server's `.strict()` `blockInlineComfyBodySchema` field-for-
+ * field. Declared here rather than imported because the scaffold pins an SDK
+ * minor that may predate the exported `WorkflowBodyCustomComfyInline`; once the
+ * pin moves past it, delete this and import the SDK type instead — the shapes
+ * are identical by construction.
+ */
+export type InlineComfyBody = {
+  kind: 'customComfy';
+  mode: 'inline';
+  workflow: Record<string, InlineComfyNode>;
+  resources: string[];
+  prompt?: string;
+  negativePrompt?: string;
+  maxBuzz: number;
+};
+
+/**
+ * The checkpoint this sample's graph loads, as an AIR URN.
+ *
+ * SWAP THIS for whatever your graph actually loads. The rules that matter:
+ *  - a `civitai`-sourced AIR MUST carry a model VERSION id
+ *    (`…:civitai:<modelId>@<versionId>`) — without one there is no version to
+ *    check entitlement against and the submit is rejected;
+ *  - entitlement is re-checked server-side against the VIEWER, and it is
+ *    stricter here than on-site: a resource the site would quietly swap for a
+ *    sibling version is REJECTED instead, because your graph names this exact
+ *    string and nothing rewrites it.
+ *
+ * This one is SDXL 1.0 (VAE fix) — public, and enough to make the sample a real
+ * graph rather than a shape sketch.
+ */
+export const STARTER_INLINE_CHECKPOINT_AIR =
+  'urn:air:sdxl:checkpoint:civitai:101055@128078';
+
+/**
+ * How many Buzz — AND how many SECONDS — an inline job may take.
+ *
+ * 🔴 IT IS ONE NUMBER SERVING BOTH ROLES. The server stamps
+ * `stepTimeoutSeconds = maxBuzz`, which is exactly what makes the ceiling
+ * physically enforceable instead of merely promised. So this is NOT a price dial:
+ * lowering it to save Buzz does not buy a cheaper generation, it buys a job that
+ * is KILLED after that many seconds and comes back `expired`.
+ *
+ * You are billed the REAL cost — post-paid against measured GPU seconds,
+ * settling to actual and refunding the unused remainder — so headroom is free.
+ * Size it to the wall-clock time your graph needs. 90s is comfortable for this
+ * 20-step SDXL graph; the server's hard maximum is 250.
+ */
+export const STARTER_INLINE_MAX_BUZZ = 90;
+
+/**
+ * A minimal, real SDXL text-to-image graph in ComfyUI API format.
+ *
+ * Every AIR that appears anywhere in here must ALSO appear in the body's
+ * `resources` array — see `buildInlineComfyBody`. That containment check is what
+ * makes gating that one array sufficient, so it is enforced, not advisory: an
+ * AIR in the graph that is missing from `resources` rejects the submit.
+ *
+ * The prompt is injected as a leaf value into node `'2'` rather than templated
+ * into a string, which is the same discipline the server-side recipes use.
+ */
+export function buildInlineComfyGraph(
+  prompt: string,
+  negativePrompt: string,
+  seed: number,
+): Record<string, InlineComfyNode> {
+  return {
+    '1': {
+      class_type: 'CheckpointLoaderSimple',
+      inputs: { ckpt_name: STARTER_INLINE_CHECKPOINT_AIR },
+    },
+    '2': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: prompt, clip: ['1', 1] },
+    },
+    '3': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: negativePrompt, clip: ['1', 1] },
+    },
+    '4': {
+      class_type: 'EmptyLatentImage',
+      inputs: { width: 1024, height: 1024, batch_size: 1 },
+    },
+    '5': {
+      class_type: 'KSampler',
+      inputs: {
+        seed,
+        steps: 20,
+        cfg: 7,
+        sampler_name: 'euler',
+        scheduler: 'normal',
+        denoise: 1,
+        model: ['1', 0],
+        positive: ['2', 0],
+        negative: ['3', 0],
+        latent_image: ['4', 0],
+      },
+    },
+    '6': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['5', 0], vae: ['1', 2] },
+    },
+    '7': {
+      class_type: 'SaveImage',
+      inputs: { images: ['6', 0], filename_prefix: 'civitai' },
+    },
+  };
+}
+
+/**
+ * Build an INLINE customComfy body — the app's own graph, submitted directly.
+ *
+ * The four things a first-time author gets wrong, all handled here:
+ *
+ *  1. `mode: 'inline'` is REQUIRED. Including a `workflow` key is not enough to
+ *     select this arm — a body without `mode` routes to the RECIPE arm and is
+ *     then rejected for a missing `recipe`.
+ *  2. `resources` is a DECLARED MANIFEST, not something the server infers from
+ *     your graph. Every AIR the graph names must be listed, or the submit is
+ *     rejected; at most 24 entries.
+ *  3. `maxBuzz` is the step TIMEOUT in seconds as well as the Buzz ceiling — see
+ *     {@link STARTER_INLINE_MAX_BUZZ}.
+ *  4. The declared `prompt` is what gets SURFACED and audited alongside the
+ *     graph, but the text that actually generates is whatever the graph's
+ *     `CLIPTextEncode` node carries. We pass the same string to both so they
+ *     cannot disagree. (Moderation sweeps every string in the graph regardless,
+ *     so a clean declared prompt cannot launder a graph prompt.)
+ *
+ * The graph is also bounded server-side: at least 1 node, at most 300, at most
+ * 256 KB serialized, at most 128 levels of nesting. This sample is 7 nodes.
+ *
+ * NOTE ON WHO CAN RUN IT: the inline arm is APP-DEVELOPER-ONLY and PAGE-TOKEN-
+ * only on live civitai.com — the host runs a developer check on every
+ * customComfy estimate and submit. It runs end-to-end against the mock host in
+ * `npm run dev:harness`. Treat inline as a build-and-iterate primitive; to serve
+ * a graph to every viewer, get it registered as a recipe.
+ */
+export function buildInlineComfyBody(
+  prompt: string,
+  seed = 0,
+  negativePrompt = '',
+): InlineComfyBody {
+  const clamped = clampPrompt(prompt.trim());
+  return {
+    kind: 'customComfy',
+    mode: 'inline',
+    workflow: buildInlineComfyGraph(clamped, negativePrompt, seed),
+    // Declared manifest — must contain every AIR the graph above names.
+    resources: [STARTER_INLINE_CHECKPOINT_AIR],
+    prompt: clamped,
+    ...(negativePrompt ? { negativePrompt } : {}),
+    maxBuzz: STARTER_INLINE_MAX_BUZZ,
   };
 }


### PR DESCRIPTION
## What happened

A blind dogfood of the App Blocks **inline ComfyUI** path ended with a capable developer, working against a **live** production feature, concluding it did not exist. Three of the surfaces that told them so are generated by this CLI:

- the scaffold's `src/comfy.ts` header — *"The iframe NEVER sends a Comfy graph."*
- the generated README's Comfy section — *"your block never sends a Comfy graph … An app **cannot ship its own graph**."*
- `civitai app create --help` — described `customComfy` as recipe-only.

All three were true when the recipe arm was the only arm. They are not any more.

## What is actually true

`customComfy` is a discriminated union on `mode`:

| Arm | `mode` | The app sends |
| --- | --- | --- |
| recipe | omitted, or `'recipe'` | a registered recipe id + bounded `params` |
| inline | `'inline'` **required** | the ComfyUI graph itself + a declared AIR manifest + `maxBuzz` |

## The change

Prose alone would not have prevented this failure — the developer was **guessing at key names**. So `src/comfy.ts` now ships `buildInlineComfyBody`: a real 7-node SDXL txt2img graph in ComfyUI API format, the declared `resources` manifest, and **15 unit tests** (was 5). A developer who opens the file for Comfy now *sees* the body instead of inventing it.

The sample and its comments make four first-try mistakes unmissable, each of which otherwise produces a confusing error:

1. **`mode: 'inline'` is required.** A `workflow` key does not select the arm — a body without `mode` routes to the *recipe* arm and is rejected for a missing `recipe`.
2. **`resources` is a declared manifest, not inferred.** Every AIR in the graph must also be listed; a civitai AIR needs a model **version** id.
3. **`maxBuzz` is the step timeout in seconds** as well as the Buzz ceiling — the server stamps `stepTimeoutSeconds = maxBuzz`. Setting it low to be thrifty buys an `expired` job, not a cheap one. Billing settles to real GPU-seconds and refunds the rest, so headroom is free.
4. **The declared `prompt` is surfaced and audited, but the graph's `CLIPTextEncode` is what generates.** The builder puts the same clamped string in both.

The README additionally documents the three server gates that replaced code review, and the access reality (app-developer-only, page-tokens-only).

**Deliberately not documented:** `comfy:nodepack` AIRs (deadlocked) and HuggingFace-sourced weights (open product decision). An unresolved limit gets silence, not a guess.

## 🔴 Inline is NOT wired into the app's mode toggle — a measured decision

It was wired, and the scaffolded app **crashed**:

```
Cannot read properties of undefined (reading 'accountType')
```

The mock host in the pinned `@civitai/blocks-react@0.39.0` reads `body.params.accountType` unconditionally, and an inline body has no `params`. Confirmed by reading the published dist (`node_modules/@civitai/blocks-react/dist/internal/mockHost.js:63`).

Shipping a visible tab that fails on click would create a fresh false signal ("inline is broken") in place of the one being removed. The fix is in the companion [`civitai-app-starters` PR](https://github.com/civitai/civitai-app-starters/pull/215); once it publishes and `bump-scaffold-pins` moves the pin, wiring it is a three-line change the README spells out — including the two non-obvious parts (hide the account picker; drop the version-seam cast). The README says this is a **mock-host** bug that does **not** affect live civitai.com.

## Verification — the full `template-page-money` CI job, reproduced locally

```
go build ./...   clean
go vet ./...     clean
go test ./...    18 packages ok, 0 fail

scaffold -> npm install -> npm run typecheck      clean
                        -> npm test               11 files / 148 tests passed  (was 137)
                        -> npm run build          built, 278 kB
                        -> civitai app validate   "✓ . is valid"
```

`npx vitest run --project node src/comfy.test.ts` enumerates all **15** comfy cases, 9 of them new.

Harness validated against known-bad states rather than trusted:

| Mutation | Result |
| --- | --- |
| Empty the declared `resources` manifest | containment test fails — `expected false to be true` |
| Remove the AIR from the graph | same test fails on its **positive control** — `expected 0 to be greater than 0` |
| Delete `mode: 'inline'` from the builder | generated project's `npm run typecheck` fails — `Property 'mode' is missing … but required in type 'InlineComfyBody'` |

That second row is the point: a containment check over an empty set passes vacuously, so the test refuses to pass without first proving the walk found something.

## 🔴 Two honest limits, recorded as comments in the tests

- The **Go-side `scaffold_test` assertions are substring matches over a rendered template**, so they are *discoverability* checks, not behavioural guards. Mutation-tested: deleting `mode: 'inline'` from the builder body does **not** turn them red, because a comment and a type declaration also contain the string. The behavioural guards are the generated project's own typecheck and `comfy.test.ts`, both of which CI runs.
- The `mustNotContain` sweep for the retracted claim is a **spelled** guard: it cannot distinguish an assertion from a retraction (it fired on the first draft of the README rewrite, which quoted the old sentence while correcting it), and it cannot catch a new spelling of the same falsehood. It is a floor, not a proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
