### PR TITLE
fix(validate): the ready-ack advisory passed an emitter nothing loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,6 +479,18 @@ neither one's.
       Don't reintroduce it as a "minimal example". Note `iframe.resizable` in
       the vendored `schema/` still describes itself in size-to-content terms;
       that is a schema-side wording issue, not a licence to re-add the message.
+    - **The entry-graph resolver moved OUT of Guard A and into
+      `internal/blockproto`** (`entrygraph.go` + `wiring.go`, with the comment
+      stripper in `comments.go`), because `internal/validate` needed the same
+      question answered for an AUTHOR's project and had answered it with a
+      whole-tree grep instead — see item 20 for the false pass that produced.
+      Guard A now calls `blockproto.ReadyAckWiring`; its control corpus moved
+      with the predicate, into `internal/blockproto/entrygraph_test.go`. Nothing
+      about Guard A's strength changed, and the depth bound it relies on
+      (`readyAckWiringDepth = 2`: index.html's `<script src>` entries plus their
+      DIRECT imports) is now pinned by a corpus case — widening it to 99 was a
+      SURVIVING mutant, i.e. the "one level deep on purpose" contract was
+      documented and unheld.
     - **Three guards, and none subsumes the others.**
       `ready_ack_contract_test.go` (Guard A, runs in `make ci`) enumerates
       `AllTemplates()`, decides subject-hood from the RENDERED manifest and
@@ -816,9 +828,16 @@ neither one's.
       `TestReadyAckSkippedByManifestOnly` pins it, with a `Dir()` positive
       control so a green there cannot mean "the check never fires at all".
     - **What it does NOT prove:** that the ack fires. Only that the message is
-      mentioned in code. The runtime proof is Guard B (item 11), and there is
-      none at all for an app the author already has — which is why this is
-      advisory and says so in its own message.
+      mentioned in code the browser loads. The runtime proof is Guard B (item
+      11), and there is none at all for an app the author already has — which is
+      why this is advisory and says so in its own message.
+    - 🔴 **"MENTIONED IN CODE" WAS NOT ENOUGH, AND ITEM 20 IS THE REPAIR.** As
+      first shipped this bullet read "mentioned in code" full stop, and the
+      check's own remedy asked for TWO edits while verifying one. Read item 20
+      before touching `readyack.go`: the whole-tree presence scan described
+      above is now the WEAK tier, reached only when the entry graph cannot be
+      resolved, and the advisory it emits is a different string that discloses
+      the difference.
 
 19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
     `--ecosystem`, and uploads with NO credential — three things that each read
@@ -928,6 +947,83 @@ neither one's.
     blob URLs rather than local paths. An upload spends no Buzz, but it is a
     network write — so `--print-input`'s "reaches no money seam" claim is still
     true while its "no request at all" claim is not, with `--image`.
+
+20. **The ready-ack advisory has TWO TIERS, the message names which one ran, and
+    that disclosure is the fix — not a nicety.** `validate`'s page-without-ack
+    check (item 18) used to ask only "does any file in this tree mention
+    `BLOCK_READY`". Its own remedy asked the author for TWO edits — copy
+    `civitai-host.js` in, and LOAD it from index.html or the entry module — and
+    it verified the first. Measured on a genuinely pre-fix scaffold (`app init`
+    from the CLI at `0ce0025`, emitter copied in, never referenced):
+    `civitai app validate --strict` printed `✓ … is valid` and exited **0** for
+    an app that was still exactly as broken as before #206, and an orphan file
+    containing the literal anywhere in the tree passed identically. 🔴 **A green
+    check earned by obeying our own advice is worse than the silence it
+    replaced** — that is the whole reason this item exists, and it is the same
+    "presence is not reachability" hole Guard A had before it was rewritten,
+    regenerated at a second call site.
+    - **The tiers.** REACHABILITY (strong) runs when
+      `blockproto.ResolveEntryGraph` resolves the project COMPLETELY — a root
+      index.html, and every `<script src>`, inline-module import and import
+      below it accounted for. Then "nothing the browser loads posts
+      `BLOCK_READY`" is a real finding, and an unreferenced emitter is reported
+      as the orphan it is (`readyAckAdviceUnwired`). PRESENCE ONLY (weak) runs
+      when the graph is INCOMPLETE, and falls back to the whole-tree scan
+      (`readyAckAdvicePresenceOnly`).
+    - 🔴 **THE WEAK TIER'S MESSAGE MUST KEEP SAYING WHAT IT DID NOT CHECK**
+      ("it did NOT check that the file is loaded"), and the strong tier's must
+      NOT carry that disclaimer. A check that changes strength SILENTLY between
+      project shapes is exactly how the false pass above shipped, so the
+      strength is part of the output, not an implementation detail.
+      `TestReadyAckAdvisoriesStateTheirOwnStrength` pins both directions.
+    - **THE DECIDABILITY BOUNDARY IS COMPLETENESS, NOT PROJECT TYPE.** The first
+      draft drew it at "does the manifest declare a `buildCommand`" — bundled
+      means undecidable — and that is wrong in both directions: an ordinary Vite
+      project resolves perfectly (index.html IS Vite's entry), while a
+      *no-build* project can still carry a specifier we cannot follow. So the
+      resolver reports `Complete`, and ANY reference it cannot account for
+      clears it: a bundler alias or other bare specifier that is not a declared
+      dependency, an off-project or protocol-relative URL, a path escaping the
+      project root, a reference resolving to a file that is not there, an
+      unreadable file, an exhausted budget. **A bare specifier naming a declared
+      npm dependency is ACCOUNTED FOR** — it is a package, not a file in this
+      project — which is the only reason a React app resolves at all; that is
+      why `packageDeps` returns the dependency NAMES alongside the ack verdict
+      from one read of package.json.
+    - 🔴 **A reference to a file that is NOT THERE is a GAP, not a decided
+      absence.** It is tempting to read it as "the browser 404s that, so it
+      cannot be the ack" — but a project that presumably builds having an
+      unresolvable reference means OUR MODEL is wrong, and a confident finding
+      built on a wrong model is the failure this item is about. It also keeps
+      two documented trades alive: deleting the emitter from a current scaffold
+      (dangling `<script src>`) drops to the presence tier, and the
+      `public/`-holds-a-stale-ack false negative in item 18 stays a false
+      negative instead of silently becoming a warning.
+    - **"Cannot observe" must not become "everything passes" either.** An
+      incomplete graph never produces a WIRING finding (item 10's doctrine), but
+      the presence finding still fires when nothing in the tree mentions the
+      message at all. The residual is stated rather than hidden: an unresolvable
+      graph PLUS the literal somewhere is silence — a false negative, the cheap
+      direction. And an UNOBSERVABLE tree scan (unreadable file, size cap, file
+      budget) gates BOTH tiers: a tree we could not read is not one we can draw
+      a wiring conclusion about.
+    - **Both tiers share the `readyAckSourceExts` gate.** A `.css` an entry
+      module imports really is loaded by the browser and really cannot implement
+      a handshake, so it is in the graph but is not ack evidence. Dropping that
+      gate on the graph scan was a mutant killed by a rendered page-vite fixture
+      with the literal in `src/index.css`.
+    - **Still a Warning, never an Error** — every reason in item 18 stands, and
+      the stronger tier does not change that: reachability is still inference
+      from static text, and `--strict` already gives anyone who wants a gate
+      one.
+    - **Measured, before (`e800129`) → after**, on pre-fix `static` and
+      `page-vite` projects: emitter copied but not wired
+      `silent rc=0 strict 0` → `WARN rc=0 strict 1`; orphan `BLOCK_READY` file
+      the same; properly wired → silent both; fresh `static` / `page-vite` /
+      `page-money` scaffolds → silent both. The harness carries a POSITIVE
+      CONTROL — a pre-fix project with no emitter warns on BOTH binaries — so
+      the silent cells are real false passes rather than a probe wired to
+      nothing.
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1002,9 +1002,21 @@ neither one's.
       scheme-qualified or protocol-relative is DOCUMENT-RELATIVE, there are no
       bare specifiers, and there is no extension or directory-index guessing.
       Under module syntax a bare specifier is a package and a bundler's
-      extension resolution applies. The scheme regex is ANCHORED (`^`) because
-      the scheme check runs BEFORE the `?`/`#` strip, so an unanchored pattern
-      throws away `./x.js?from=https://cdn`. Do not re-merge these paths.
+      extension resolution applies. The scheme regex is ANCHORED (`^`), or an
+      unanchored pattern matches a `https:` in a QUERY STRING and throws away
+      `./x.js?from=https://cdn`. (An earlier revision of this item credited the
+      ORDER of the scheme check and the `?`/`#` strip. It does not matter — two
+      independent sweeps swapped them with nothing failing. Only the anchor is
+      load-bearing.) Do not re-merge these paths.
+      🔴 **And the boundaries are HTML boundaries, not `\b`.** `\b` matches
+      between `-` and `s`, so `\bsrc\s*=` read `data-src=` as `src=` and
+      `<script\b` read `<script-loader>` as a script. Measured on a CORRECT
+      `static` scaffold with `data-src` — a real consent-manager / lazy-load
+      pattern — the wrong reference resolved, `Complete` stayed true, and the
+      STRONG tier warned with `--strict` rc=1: the same false-warning class the
+      unquoted-`src` fix had just closed, reintroduced by the fix itself. RE2
+      has no lookahead, so the tag boundary is spelled as "the character after
+      `<script` is whitespace, `/` or `>`".
     - **THE DECIDABILITY BOUNDARY IS COMPLETENESS, NOT PROJECT TYPE.** The first
       draft drew it at "does the manifest declare a `buildCommand`" — bundled
       means undecidable — and that is wrong in both directions: an ordinary Vite
@@ -1026,21 +1038,43 @@ neither one's.
       three separate comments — this item included — claimed an exhausted budget
       made the graph incomplete. Measured: a CORRECT project whose ack sits ten
       imports below index.html got the STRONG tier's warning and `--strict`
-      rc=1, on a graph we had stopped walking. Only imports that are NOT
-      declared packages count as truncated: a leaf importing `react` and nothing
-      else has nothing left to see, and counting it would make every project as
-      deep as the bound unobservable.
-    - 🔴 **THE GRAPH RETAINS NO FILE CONTENTS, and `EntryFile` must not grow a
-      `Code` field again.** It had one, and a 200-module graph entirely INSIDE
-      the file-count and size budgets peaked **410 MB RSS**, against ~40 MB for
-      the same tree before the graph existed — a check whose caps exist
-      precisely so `validate` cannot become a memory event, blowing past the
-      316 MB figure those caps were sized against, with `app submit` paying it
-      too. Contents now go to `EntryGraphOptions.Inspect` while they are in
-      hand, so the walk holds ONE file at a time exactly like the tree scan.
-      After the fix: 39.5 MB, matching the pre-graph baseline on that fixture.
-      `TestEntryGraphRetainsNoContents` pins it structurally rather than by
-      benchmark.
+      rc=1, on a graph we had stopped walking.
+      🔴 **But the gap must fire ONLY when something was actually truncated, and
+      getting that wrong silenced the defect this whole PR exists to catch.** A
+      declared package was never going to be followed, and a target ALREADY IN
+      THE GRAPH was read by another route. The first version checked only the
+      first, so a DIAMOND — the normal shape of any real module graph — whose
+      deepest module re-imports an already-walked file produced a gap whose
+      message was literally false about a file sitting in `g.Files`, dropped the
+      project to the presence tier, and let an orphaned emitter pass with rc=0.
+      Measured; a self-cycle at the bound did the same. A gap that over-fires is
+      not "conservative", it is the false pass wearing a different hat. See
+      `truncatedBelow`.
+    - 🔴 **THE GRAPH MUST STAY O(ONE FILE), AND THAT TOOK TWO FIXES — THE FIRST
+      ONE ALONE WAS CLAIMED AS COMPLETE AND WAS NOT.** `EntryFile` must not grow
+      a `Code` field again, AND every import specifier must be `strings.Clone`d:
+      a Go substring shares its parent's backing array, so an un-cloned
+      specifier pins its whole file, and it is held in both the BFS queue and
+      `EntryFile.Spec`. Measured on a 200-module graph entirely INSIDE the
+      file-count and size budgets, where every module is ~2 MiB of REAL
+      (non-comment) code AND carries an import:
+
+      | build | peak RSS (3 runs) |
+      |---|---|
+      | `e800129`, before the graph existed | 26.4 – 27.8 MB |
+      | retaining `Code` | 421 – 439 MB |
+      | `Code` dropped, specifiers aliased | 558 – 628 MB |
+      | both fixed | 31.4 – 33.3 MB |
+
+      🔴 **THE FIXTURE SHAPE IS THE MEASUREMENT.** A tree padded with COMMENTS
+      leaves almost nothing after stripping, and a tree whose leaves carry no
+      imports has no specifier to alias — both report a reassuring number while
+      exercising neither hazard. That is exactly how the first round certified
+      "39.5 MB, one file at a time" from a fixture the depth bound truncated to
+      ten files. State the fixture with the number.
+      `TestEntryGraphRetainsNoContents` pins the `Code` half structurally, and
+      says in its own body that it CANNOT see the aliasing half —
+      `strings.Contains` reads the logical string, not the backing array.
     - 🔴 **A reference to a file that is NOT THERE is a GAP, not a decided
       absence.** It is tempting to read it as "the browser 404s that, so it
       cannot be the ack" — but a project that presumably builds having an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,8 +485,16 @@ neither one's.
       question answered for an AUTHOR's project and had answered it with a
       whole-tree grep instead — see item 20 for the false pass that produced.
       Guard A now calls `blockproto.ReadyAckWiring`; its control corpus moved
-      with the predicate, into `internal/blockproto/entrygraph_test.go`. Nothing
-      about Guard A's strength changed, and the depth bound it relies on
+      with the predicate, into `internal/blockproto/entrygraph_test.go`.
+      🔴 **Guard A's REJECTION set is unchanged, but its ACCEPTANCE set moved —
+      state both, because "nothing changed" was the claim an audit falsified.**
+      It now also accepts an emitter imported by an INLINE
+      `<script type="module">` in index.html (a real browser load it used to
+      miss, and missing it manufactured a finding at a correct project), and the
+      unquoted / no-`./` HTML spellings a browser resolves identically. It also
+      briefly accepted an extensionless `src="./civitai-host"`, which was a BUG
+      rather than a widening — a 404 on a no-build template — and is reverted;
+      see item 20. The depth bound it relies on
       (`readyAckWiringDepth = 2`: index.html's `<script src>` entries plus their
       DIRECT imports) is now pinned by a corpus case — widening it to 99 was a
       SURVIVING mutant, i.e. the "one level deep on purpose" contract was
@@ -976,20 +984,63 @@ neither one's.
       project shapes is exactly how the false pass above shipped, so the
       strength is part of the output, not an implementation detail.
       `TestReadyAckAdvisoriesStateTheirOwnStrength` pins both directions.
+    - 🔴 **AN HTML `src` IS A URL; A JS SPECIFIER IS A MODULE SPECIFIER. THE
+      FIRST VERSION CONFLATED THEM, AND THAT ONE MISTAKE PRODUCED THREE BUGS,
+      TWO OF THEM OPPOSITES.** Measured, each on a project one character from a
+      shipped template. `<script src="app.js">` — no `./`, entirely ordinary
+      HTML — was read as a BARE specifier, resolved to nothing, made the graph
+      incomplete, and left the headline defect SILENT: the fix did not cover the
+      projects it was written for. `<script src="./civitai-host">` was
+      extension-guessed to `.js` and ACCEPTED on the no-build `static` template,
+      where the browser fetches the literal path and 404s — the exact "ships a
+      404" shape `wiring.go` claims to reject. And an unquoted
+      `src=./civitai-host.js`, also legal HTML, was dropped by a quotes-only
+      regex and then re-classified as an *inline* script with an empty body: the
+      reference vanished with `Complete` still TRUE, so a CORRECT scaffold got
+      the strong tier's warning and `--strict` rc=1.
+      `refSyntax` now splits the two. Under URL syntax a specifier that is not
+      scheme-qualified or protocol-relative is DOCUMENT-RELATIVE, there are no
+      bare specifiers, and there is no extension or directory-index guessing.
+      Under module syntax a bare specifier is a package and a bundler's
+      extension resolution applies. The scheme regex is ANCHORED (`^`) because
+      the scheme check runs BEFORE the `?`/`#` strip, so an unanchored pattern
+      throws away `./x.js?from=https://cdn`. Do not re-merge these paths.
     - **THE DECIDABILITY BOUNDARY IS COMPLETENESS, NOT PROJECT TYPE.** The first
       draft drew it at "does the manifest declare a `buildCommand`" — bundled
       means undecidable — and that is wrong in both directions: an ordinary Vite
       project resolves perfectly (index.html IS Vite's entry), while a
       *no-build* project can still carry a specifier we cannot follow. So the
       resolver reports `Complete`, and ANY reference it cannot account for
-      clears it: a bundler alias or other bare specifier that is not a declared
-      dependency, an off-project or protocol-relative URL, a path escaping the
-      project root, a reference resolving to a file that is not there, an
-      unreadable file, an exhausted budget. **A bare specifier naming a declared
-      npm dependency is ACCOUNTED FOR** — it is a package, not a file in this
+      clears it: a bundler alias or other bare MODULE specifier that is not a
+      declared dependency, an off-project or protocol-relative URL, a path
+      escaping the project root, a reference resolving to a file that is not
+      there, an unreadable file, an exhausted file/size budget, **and an import
+      below the depth bound**. **A bare MODULE specifier naming a declared npm
+      dependency is ACCOUNTED FOR** — it is a package, not a file in this
       project — which is the only reason a React app resolves at all; that is
       why `packageDeps` returns the dependency NAMES alongside the ack verdict
-      from one read of package.json.
+      from one read of package.json. The name matches at a PATH SEPARATOR, never
+      a character offset: `reactive-ui` is not `react`.
+    - 🔴 **THE DEPTH BOUND IS A BUDGET LIKE ANY OTHER, AND TRUNCATING IT IS A
+      GAP.** It was not: `continue`-ing at `MaxDepth` left `Complete` true while
+      three separate comments — this item included — claimed an exhausted budget
+      made the graph incomplete. Measured: a CORRECT project whose ack sits ten
+      imports below index.html got the STRONG tier's warning and `--strict`
+      rc=1, on a graph we had stopped walking. Only imports that are NOT
+      declared packages count as truncated: a leaf importing `react` and nothing
+      else has nothing left to see, and counting it would make every project as
+      deep as the bound unobservable.
+    - 🔴 **THE GRAPH RETAINS NO FILE CONTENTS, and `EntryFile` must not grow a
+      `Code` field again.** It had one, and a 200-module graph entirely INSIDE
+      the file-count and size budgets peaked **410 MB RSS**, against ~40 MB for
+      the same tree before the graph existed — a check whose caps exist
+      precisely so `validate` cannot become a memory event, blowing past the
+      316 MB figure those caps were sized against, with `app submit` paying it
+      too. Contents now go to `EntryGraphOptions.Inspect` while they are in
+      hand, so the walk holds ONE file at a time exactly like the tree scan.
+      After the fix: 39.5 MB, matching the pre-graph baseline on that fixture.
+      `TestEntryGraphRetainsNoContents` pins it structurally rather than by
+      benchmark.
     - 🔴 **A reference to a file that is NOT THERE is a GAP, not a decided
       absence.** It is tempting to read it as "the browser 404s that, so it
       cannot be the ack" — but a project that presumably builds having an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1050,6 +1050,15 @@ neither one's.
       Measured; a self-cycle at the bound did the same. A gap that over-fires is
       not "conservative", it is the false pass wearing a different hat. See
       `truncatedBelow`.
+      🔴 **And the question is DEFERRED to the end of the walk, because
+      `g.Files` cannot answer it while the walk is running.** Files enter
+      `g.Files` when POPPED, not when QUEUED, so a target already enqueued looks
+      absent. Two modules at exactly `MaxDepth` where the first-enqueued imports
+      the second therefore gapped or did not according to THE TEXTUAL ORDER OF
+      TWO IMPORT STATEMENTS — and in the losing order an orphaned emitter
+      shipped silently. Measured flat and nested. Do not move the check back
+      inline; the fixture pair that pins it is two copies of one graph with the
+      imports swapped.
     - 🔴 **THE GRAPH MUST STAY O(ONE FILE), AND THAT TOOK TWO FIXES — THE FIRST
       ONE ALONE WAS CLAIMED AS COMPLETE AND WAS NOT.** `EntryFile` must not grow
       a `Code` field again, AND every import specifier must be `strings.Clone`d:
@@ -1065,6 +1074,15 @@ neither one's.
       | retaining `Code` | 421 – 439 MB |
       | `Code` dropped, specifiers aliased | 558 – 628 MB |
       | both fixed | 31.4 – 33.3 MB |
+
+      🔴 **EVERY ROW IS FIXTURE-DEPENDENT; QUOTE THE FIXTURE WITH THE NUMBER.**
+      These four are one 400 MB tree of 200 modules (`~2 MiB` each, real code,
+      each carrying an import). The `e800129` row is the WHOLE-TREE GREP, not
+      the graph, so it moves with the tree rather than with the entry graph — an
+      independent measurement on a smaller tree put it at 17.6 – 17.8 MB, and
+      both are right about their own fixture. The three graph rows reproduce
+      independently. The ratio is the durable fact: the aliased build is ~18×
+      the fixed one.
 
       🔴 **THE FIXTURE SHAPE IS THE MEASUREMENT.** A tree padded with COMMENTS
       leaves almost nothing after stripping, and a tree whose leaves carry no
@@ -1101,6 +1119,32 @@ neither one's.
       the stronger tier does not change that: reachability is still inference
       from static text, and `--strict` already gives anyone who wants a gate
       one.
+    - 🔴 **THE RESIDUALS THIS CHECK KNOWINGLY SHIPS WITH.** Written down because
+      every one of them was found by an audit rather than by the author, and a
+      residual nobody records is indistinguishable from a bug nobody noticed:
+      - **An extensionless `src`** (`<script src="./civitai-host">`) resolves to
+        nothing, so the graph gaps and the check goes quiet on the presence
+        tier. Correct — a browser 404s that URL and we stopped modelling — but
+        it IS a false negative, not approval.
+      - **A large graph falls to the presence tier more often than the caps
+        suggest.** With truncation now a gap, any project deeper than
+        `MaxDepth` or wider than `MaxFiles` is checked on presence alone. The
+        strong tier covers small and pre-fix apps — which is the #206
+        population — not big ones. Raising the caps is a separate, measurable
+        change.
+      - **The `strings.Clone` property is guarded by a MEASUREMENT, not a
+        test.** No unit assertion can see a shared backing array; dropping the
+        clone passes the entire suite while costing ~18× peak RSS. The mutant
+        is declared a known survivor and `TestEntryGraphRetainsNoContents` says
+        in its own body that it cannot see that half.
+      - **An attribute VALUE containing ` src=` hijacks the reference.**
+        `<script data-x="foo src=./nope.js" src="./civitai-host.js">` resolves
+        the decoy. Pre-existing and byte-identical before and after this work,
+        so it was left alone here; fixing it needs a real attribute parser
+        rather than a regex, which is a bigger change than this check earns.
+      - **A computed `import(expr)`** is not matched at all: the specifier must
+        be a literal. That makes the graph silently smaller, not incomplete —
+        the one residual here that does NOT set a gap.
     - **Measured, before (`e800129`) → after**, on pre-fix `static` and
       `page-vite` projects: emitter copied but not wired
       `silent rc=0 strict 0` → `WARN rc=0 strict 1`; orphan `BLOCK_READY` file

--- a/README.md
+++ b/README.md
@@ -688,9 +688,10 @@ correct project.
 > fetches a file nothing references, so the emitter has to be *loaded* too — a
 > `<script src="./civitai-host.js"></script>` in `index.html`, or an
 > `import './civitai-host.js';` at the top of the entry module `index.html`
-> loads. Until v0.1.90 this check looked only for the *text* `BLOCK_READY`
-> anywhere in your tree, so an unreferenced copy silenced it and a still-broken
-> app validated clean. It now resolves what your `index.html` actually loads.
+> loads. Earlier releases of this check looked only for the *text*
+> `BLOCK_READY` anywhere in your tree, so an unreferenced copy silenced it and a
+> still-broken app validated clean. It now resolves what your `index.html`
+> actually loads.
 
 Four things follow:
 
@@ -700,7 +701,8 @@ Four things follow:
   resolution is complete you get a precise finding — including "you have an
   emitter, but nothing loads it". When it *isn't* — no `index.html` at your
   project root, a bundler alias (`import '@/…'`), a reference to a file that
-  isn't there — it falls back to scanning your whole tree for the text, and the
+  isn't there, an import chain deeper than it follows — it falls back to
+  scanning your whole tree for the text, and the
   warning **says so in as many words**: *"it did NOT check that the file is
   loaded"*. Read that sentence as it is written; in that mode, adding the emitter
   without referencing it will silence the warning and leave the app broken.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,12 @@ renders perfectly. Nothing you can run locally reproduces that.
 transport acks internally, which is why the SDK templates never touch raw
 `postMessage`. The two **SDK-free** templates (`static`, `page-vite`) therefore
 ship a small vendored emitter, **`civitai-host.js`**, loaded from the entry
-point. Leave it in place.
+point. Leave it in place — and if you are retrofitting it into an older app,
+note that the file has to be *referenced* as well as copied: `static` loads it
+with `<script src="./civitai-host.js"></script>` in `index.html`, `page-vite`
+with `import './civitai-host.js';` as the first line of `src/main.jsx`.
+`civitai app validate` checks that reference where it can resolve your entry
+point, and tells you when it can't.
 
 > ⚠️ **If you adopt `@civitai/blocks-react`, delete `civitai-host.js` in the
 > same change.** This is the one situation where removing it is correct, and
@@ -671,14 +676,34 @@ never installs for them and they are never flagged.
 
 Finally it emits one **advisory** about the
 [host handshake](#the-host-handshake-block_ready): if your manifest declares a
-`page` surface and **nothing in your source posts `BLOCK_READY`**, `validate`
+`page` surface and **nothing your app loads posts `BLOCK_READY`**, `validate`
 says so. That is the shape of an app scaffolded before the templates were fixed
 (#206) — it renders perfectly everywhere you can look locally and is replaced by
 a failure card in the real host. It is a **warning, never an error**: unlike the
 lockfile rule (where the platform build provably dies), this one infers
 *runtime* behaviour from *static text* and can be wrong, so it must not fail a
-correct project. Three things follow:
+correct project.
 
+> ⚠️ **Copying `civitai-host.js` in is only half the fix.** A browser never
+> fetches a file nothing references, so the emitter has to be *loaded* too — a
+> `<script src="./civitai-host.js"></script>` in `index.html`, or an
+> `import './civitai-host.js';` at the top of the entry module `index.html`
+> loads. Until v0.1.90 this check looked only for the *text* `BLOCK_READY`
+> anywhere in your tree, so an unreferenced copy silenced it and a still-broken
+> app validated clean. It now resolves what your `index.html` actually loads.
+
+Four things follow:
+
+- **It checks REACHABILITY where it can, and says when it can't.** Starting at
+  `index.html` it follows every `<script src>`, inline module and `import` it can
+  resolve, and asks whether any of *those* files posts the message. When that
+  resolution is complete you get a precise finding — including "you have an
+  emitter, but nothing loads it". When it *isn't* — no `index.html` at your
+  project root, a bundler alias (`import '@/…'`), a reference to a file that
+  isn't there — it falls back to scanning your whole tree for the text, and the
+  warning **says so in as many words**: *"it did NOT check that the file is
+  loaded"*. Read that sentence as it is written; in that mode, adding the emitter
+  without referencing it will silence the warning and leave the app broken.
 - **A dependency that acks ends the check** — today that is
   `@civitai/blocks-react`, and nothing else. Its iframe transport acks internally
   and the literal never appears in your `src/`, so a `page-money` app is never
@@ -694,13 +719,16 @@ correct project. Three things follow:
   that is a **symlink** into a shared package *is* followed.
 - **It stays quiet when it cannot see the whole project.** An unreadable file, a
   file over 2 MiB, a very large tree, or a directory holding only a manifest all
-  mean "we could not look" — reported as nothing, never as a finding.
+  mean "we could not look" — reported as nothing, never as a finding. Likewise a
+  project whose entry graph can't be resolved *and* which contains the literal
+  somewhere: quiet, deliberately, because warning at a correct project is the
+  more expensive mistake.
 
 If it fires on a project you know is correct — your ack arrives from a bundled
 dependency, or from a file type this scan doesn't open — it is a false alarm, and
-it never blocks (exit 0) unless you pass `--strict`. What it proves is narrow:
-that the message is *mentioned* in code. It cannot prove the ack ever **fires**;
-only the real host can.
+it never blocks (exit 0) unless you pass `--strict`. What it proves stays narrow
+even at its strongest: that a file your `index.html` really loads *mentions* the
+message. It cannot prove the ack ever **fires**; only the real host can.
 
 `civitai app submit` prints the same warnings before it uploads, and likewise
 does not block on them.

--- a/internal/blockproto/comments.go
+++ b/internal/blockproto/comments.go
@@ -1,0 +1,108 @@
+package blockproto
+
+// comments.go is the ONE comment stripper in this repo.
+//
+// It had three copies — `internal/validate/readyack.go`,
+// `internal/scaffold/ready_ack_contract_test.go`, and the entry-graph resolver
+// next door — asking the identical question: "does this file MENTION the token
+// outside a comment?" A predicate open-coded at N sites is typically wrong at
+// N-1 of them, so it lives here once, with the two rules that were each earned
+// by a false warning at a correct project.
+
+import "strings"
+
+// MarkupExts are the extensions whose comments are `<!-- -->`. HTML comment
+// stripping is applied ONLY to these.
+//
+// 🔴 Applying it to `.js`/`.ts` was a false-warning source: StripHTMLComments
+// has no string awareness, so a perfectly ordinary `var OPEN = '<!--';` in a
+// sanitiser started a "comment" that ran to end of file and deleted the emitter
+// below it. Reproduced live on a `static` scaffold. JS has no HTML comments
+// worth stripping here — `//` and `/* */` cover it, and Annex B's HTML-like
+// comment form is vanishingly rare next to the literal appearing in a string.
+var MarkupExts = map[string]bool{
+	".html": true, ".htm": true, ".vue": true, ".svelte": true, ".astro": true,
+}
+
+// StripCommentsForExt removes comments from src, given its file extension. JS
+// line/block comments are always stripped, leaving string and template literals
+// intact (so `'https://x'` is not read as the start of a comment, and an emitter
+// that posts from inside a string still counts). HTML comments are stripped only
+// for markup files — see MarkupExts for why that gate exists.
+func StripCommentsForExt(src, ext string) string {
+	if MarkupExts[strings.ToLower(ext)] {
+		src = StripHTMLComments(src)
+	}
+	return StripJSComments(src)
+}
+
+// StripHTMLComments removes `<!-- … -->` pairs.
+func StripHTMLComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); {
+		if strings.HasPrefix(src[i:], "<!--") {
+			end := strings.Index(src[i+4:], "-->")
+			if end < 0 {
+				// 🔴 UNTERMINATED. Keep the remainder VERBATIM rather than
+				// discarding it. Dropping the tail is lossy in the expensive
+				// direction — everything below an unclosed `<!--` disappears,
+				// including an emitter, and the author gets a warning about a
+				// correct project. There is no upside to the lossy branch: text
+				// after an unclosed marker is not evidence of a comment, it is
+				// evidence the file is not what we assumed.
+				b.WriteString(src[i:])
+				return b.String()
+			}
+			i += 4 + end + 3
+			continue
+		}
+		b.WriteByte(src[i])
+		i++
+	}
+	return b.String()
+}
+
+// StripJSComments removes // and /* */ comments while respecting string and
+// template literals, so a URL like 'https://x' is not mistaken for a comment
+// and a comment mentioning a filename cannot satisfy a wiring check.
+func StripJSComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for i := 0; i < len(src); {
+		c := src[i]
+		switch {
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			i += 2
+			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
+				i++
+			}
+			i = min(i+2, len(src))
+		case c == '\'' || c == '"' || c == '`':
+			quote := c
+			b.WriteByte(c)
+			i++
+			for i < len(src) {
+				if src[i] == '\\' && i+1 < len(src) {
+					b.WriteString(src[i : i+2])
+					i += 2
+					continue
+				}
+				b.WriteByte(src[i])
+				if src[i] == quote {
+					i++
+					break
+				}
+				i++
+			}
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}

--- a/internal/blockproto/comments.go
+++ b/internal/blockproto/comments.go
@@ -77,11 +77,19 @@ func StripJSComments(src string) string {
 				i++
 			}
 		case c == '/' && i+1 < len(src) && src[i+1] == '*':
-			i += 2
-			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
-				i++
+			// 🔴 UNTERMINATED — the same rule StripHTMLComments carries, for the
+			// same reason, which used to be documented only on that half. An
+			// unclosed `/*` swallowed the rest of the file: lossy in the
+			// EXPENSIVE direction, because everything below it disappears —
+			// including an emitter — and the author gets a warning about a
+			// correct project. Text after an unclosed marker is not evidence of
+			// a comment, it is evidence the file is not what we assumed.
+			end := strings.Index(src[i+2:], "*/")
+			if end < 0 {
+				b.WriteString(src[i:])
+				return b.String()
 			}
-			i = min(i+2, len(src))
+			i += 2 + end + 2
 		case c == '\'' || c == '"' || c == '`':
 			quote := c
 			b.WriteByte(c)

--- a/internal/blockproto/comments_test.go
+++ b/internal/blockproto/comments_test.go
@@ -1,0 +1,147 @@
+package blockproto
+
+import "testing"
+
+// The comment stripper decides whether a mention of a token is EVIDENCE or just
+// prose. Both directions are expensive:
+//
+//	strip too little -> a comment naming BLOCK_READY silences the check at a
+//	                    genuinely broken app (false negative)
+//	strip too much   -> real code disappears and a correct project is warned at
+//	                    (false positive, the one AGENTS.md item 10 exists for)
+//
+// These cases are built so a widening or narrowing of each internal branch
+// changes the ANSWER, not just the whitespace. Several exist because the audit's
+// sweep found the branch unpinned.
+
+func TestStripHTMLComments(t *testing.T) {
+	cases := []struct{ name, src, want string }{
+		{
+			// 🔴 The TERMINATOR is `-->`, three characters. Widening it to `->`
+			// ends the comment early, so everything after the arrow becomes
+			// "code" — a commented-out mention turns into evidence and the check
+			// goes silently quiet at a broken app. An `->` inside a comment is
+			// ordinary prose (and an arrow function's `=>` is one keystroke away).
+			name: "an arrow inside a comment does not terminate it",
+			src:  "<!-- the host -> block handshake posts BLOCK_READY -->after",
+			want: "after",
+		},
+		{
+			name: "a normal comment is removed",
+			src:  "a<!-- b -->c",
+			want: "ac",
+		},
+		{
+			// 🔴 UNTERMINATED: keep the tail verbatim. Dropping it is lossy in
+			// the expensive direction — everything below an unclosed marker
+			// disappears, including an emitter.
+			name: "an unterminated comment keeps the rest of the file",
+			src:  "a<!-- b\nBLOCK_READY",
+			want: "a<!-- b\nBLOCK_READY",
+		},
+		{
+			name: "two comments are both removed",
+			src:  "a<!--x-->b<!--y-->c",
+			want: "abc",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := StripHTMLComments(c.src); got != c.want {
+				t.Fatalf("StripHTMLComments(%q) = %q, want %q", c.src, got, c.want)
+			}
+		})
+	}
+}
+
+func TestStripJSComments(t *testing.T) {
+	cases := []struct{ name, src, want string }{
+		{
+			name: "a line comment goes, the code after it stays",
+			src:  "// BLOCK_READY\nkeep;",
+			want: "\nkeep;",
+		},
+		{
+			name: "a block comment goes",
+			src:  "a;/* BLOCK_READY */b;",
+			want: "a;b;",
+		},
+		{
+			// 🔴 UNTERMINATED `/*` — the same rule the HTML half carries, which
+			// used to be documented and implemented only there. Swallowing the
+			// tail deletes an emitter and warns at a correct project.
+			name: "an unterminated block comment keeps the rest of the file",
+			src:  "a;/* oops\nBLOCK_READY;",
+			want: "a;/* oops\nBLOCK_READY;",
+		},
+		{
+			// The string branch: a URL is not a comment. The ack is on the SAME
+			// LINE on purpose — with quote handling defeated the `//` in
+			// `https://` swallows everything after it.
+			name: "a URL in a string does not open a comment",
+			src:  "var u = 'https://x'; BLOCK_READY;",
+			want: "var u = 'https://x'; BLOCK_READY;",
+		},
+		{
+			// The BACKTICK branch, which nothing pinned: a template literal is a
+			// string too, and a `//` inside one is not a comment.
+			name: "a template literal protects its contents",
+			src:  "var u = `https://x`; BLOCK_READY;",
+			want: "var u = `https://x`; BLOCK_READY;",
+		},
+		{
+			// The BACKSLASH-ESCAPE branch, which nothing pinned. Without it the
+			// escaped quote is read as the string's END, so the rest of the line
+			// is parsed as code — and the `//` that follows becomes a comment
+			// that eats the ack.
+			name: "an escaped quote does not end the string early",
+			src:  `var s = 'it\'s // not a comment'; BLOCK_READY;`,
+			want: `var s = 'it\'s // not a comment'; BLOCK_READY;`,
+		},
+		{
+			// The inverse control for the branch above: an escape must not make
+			// the stripper run past a string that really does end.
+			name: "an escaped backslash still ends the string",
+			src:  `var s = 'x\\'; // gone` + "\nBLOCK_READY;",
+			want: `var s = 'x\\'; ` + "\nBLOCK_READY;",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := StripJSComments(c.src); got != c.want {
+				t.Fatalf("StripJSComments(%q) = %q, want %q", c.src, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStripCommentsForExtGate pins the extension gate in BOTH directions.
+//
+// 🔴 Running StripHTMLComments over `.js` made an ordinary `var OPEN = '<!--';`
+// open a "comment" that ran to EOF and deleted the emitter below it — a false
+// warning at a correct project, reproduced live. The inverse control matters as
+// much: without it, "don't strip HTML in .js" is indistinguishable from "don't
+// strip HTML at all", which would let a real HTML comment count as evidence.
+func TestStripCommentsForExtGate(t *testing.T) {
+	const js = "var OPEN = '<!--';\nBLOCK_READY;\nvar CLOSE = '-->';\n"
+	if got := StripCommentsForExt(js, ".js"); !contains(got, "BLOCK_READY") {
+		t.Fatalf(".js lost code between two HTML markers in strings: %q", got)
+	}
+	const html = "<!-- BLOCK_READY -->\n<script>keep;</script>"
+	if got := StripCommentsForExt(html, ".html"); contains(got, "BLOCK_READY") {
+		t.Fatalf(".html kept a real HTML comment: %q", got)
+	}
+	// The extension match is case-insensitive — an `.HTML` file is markup.
+	if got := StripCommentsForExt(html, ".HTML"); contains(got, "BLOCK_READY") {
+		t.Fatalf(".HTML was not treated as markup: %q", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/blockproto/comments_test.go
+++ b/internal/blockproto/comments_test.go
@@ -75,6 +75,17 @@ func TestStripJSComments(t *testing.T) {
 			want: "a;/* oops\nBLOCK_READY;",
 		},
 		{
+			// 🟢 The TERMINATOR is `*/`, two characters. Widening it to `*`
+			// ends the comment at the first star, so the tail of the comment
+			// becomes "code" — a commented-out mention turns into evidence and
+			// the check goes quiet at a broken app. Only a distant test in
+			// internal/validate caught this; the HTML half had a dedicated case
+			// and the JS half did not.
+			name: "a star inside a block comment does not terminate it",
+			src:  "a;/* 2 * 3 BLOCK_READY */b;",
+			want: "a;b;",
+		},
+		{
 			// The string branch: a URL is not a comment. The ack is on the SAME
 			// LINE on purpose — with quote handling defeated the `//` in
 			// `https://` swallows everything after it.

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -52,9 +52,17 @@ package blockproto
 // CORRECT project whose ack sat below the bound got the STRONG tier's warning
 // and `--strict` rc=1 — a false warning built on a graph we had stopped walking,
 // while three separate comments claimed an exhausted budget made the graph
-// incomplete. Measured at depth 10 before the fix. Only imports that are NOT
-// declared packages count as truncated: a leaf importing `react` and nothing
-// else has nothing left to see.
+// incomplete. Measured at depth 10 before the fix.
+//
+// 🔴 BUT ONLY IF SOMETHING WAS ACTUALLY TRUNCATED — see `truncatedBelow`. A
+// declared PACKAGE was never going to be followed, and a target ALREADY IN THE
+// GRAPH was read by another route. Missing that second half made the gap
+// OVER-fire and silence the very defect this check exists to catch: a DIAMOND
+// (the normal shape of any real module graph) whose deepest module re-imports an
+// already-walked file produced a gap whose message was literally false, dropped
+// the project to the presence tier, and let an orphaned emitter pass with rc=0.
+// A gap that over-fires is not "conservative"; it is the false pass wearing a
+// different hat.
 //
 // WHAT IT DELIBERATELY DOES NOT MODEL. `resolve.alias` / `tsconfig` path
 // mapping, glob imports, dynamic `import(expr)` with a computed specifier,
@@ -107,13 +115,28 @@ type EntryGraphOptions struct {
 	// Inspect, when non-nil, is called for every file the walk reads, with that
 	// file's comment-stripped contents WHILE THEY ARE IN HAND.
 	//
-	// 🔴 This is why EntryFile carries no `Code` field. Retaining every graph
-	// file's contents peaked 410 MB RSS on a 200-module graph entirely INSIDE
-	// the file-count and file-size budgets (measured; ~17 MB before the graph
-	// existed) — a check whose own caps exist because `validate` must not become
-	// a memory event, exceeding the very figure those caps were sized against.
-	// The tree scan next door deliberately holds one file at a time; so does
-	// this.
+	// 🔴 This is why EntryFile carries no `Code` field — but dropping that field
+	// was only HALF the fix, and the first version of this comment claimed a
+	// property the binary did not have. A Go substring shares its parent's
+	// backing array, so an un-cloned import specifier pins its whole file; see
+	// `strings.Clone` in the import loop. Both halves are needed.
+	//
+	// Measured on a 200-module graph entirely INSIDE the file-count and size
+	// budgets, where every module is ~2 MiB of REAL (non-comment) code AND
+	// carries an import — the shape both hazards need, and the one a fixture
+	// padded with comments or with import-less leaves silently fails to
+	// exercise:
+	//
+	//	e800129, before the graph existed   26.4 - 27.8 MB
+	//	retaining Code                       421 - 439 MB   (independently measured)
+	//	Code dropped, specifiers aliased     558 - 628 MB
+	//	both fixed                          31.4 - 33.3 MB
+	//
+	// The residual ~5 MB over the tree scan is the graph reading its files at
+	// all; the point is that it is O(one file), not O(graph). These caps exist
+	// because `validate` must not become a memory event, and the un-fixed
+	// numbers blow past the 316 MB incident that sized them. `app submit` pays
+	// this too.
 	Inspect func(f EntryFile, code string)
 }
 
@@ -255,7 +278,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue
 		}
 		g.ScriptRefs++
-		queue = append(queue, pending{spec: src, from: dir, via: 0, depth: 1,
+		queue = append(queue, pending{spec: strings.Clone(src), from: dir, via: 0, depth: 1,
 			what: "index.html <script src>", syn: syntaxURL})
 	}
 	// Inline `<script>` blocks execute too, and a module one can import the
@@ -269,7 +292,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue // external: already queued above
 		}
 		for _, im := range reJSImport.FindAllStringSubmatch(StripJSComments(m[2]), -1) {
-			queue = append(queue, pending{spec: im[1], from: dir, via: 0, depth: 1,
+			queue = append(queue, pending{spec: strings.Clone(im[1]), from: dir, via: 0, depth: 1,
 				what: "inline <script> in index.html", syn: syntaxModule})
 		}
 	}
@@ -329,15 +352,33 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue
 		}
 		for _, im := range reJSImport.FindAllStringSubmatch(code, -1) {
-			spec := im[1]
+			// 🔴 strings.Clone IS LOAD-BEARING, NOT TIDINESS. A Go substring
+			// shares its parent's backing array, so an un-cloned specifier pins
+			// this file's ENTIRE comment-stripped contents — and it is stored
+			// both in the BFS queue and in EntryFile.Spec, i.e. for the whole
+			// walk. Measured on a 200-module graph inside both caps where every
+			// module is large AND carries an import: 558-628 MB peak RSS
+			// un-cloned, against 28 MB for the same tree at e800129. Dropping
+			// EntryFile.Code fixed only the other half of this.
+			spec := strings.Clone(im[1])
 			if p.depth+1 > opts.MaxDepth {
-				// 🔴 TRUNCATION IS A GAP. A package specifier is not truncated
-				// content — it was never going to be followed — so only a
-				// reference naming something in this project counts.
-				if _, k := resolveProjectRef(dir, filepath.Dir(file), spec, opts.Dependencies, syntaxModule); k != refPackage {
-					g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
-						opts.MaxDepth, f.Rel, spec)
+				// 🔴 TRUNCATION IS A GAP — BUT ONLY IF SOMETHING WAS ACTUALLY
+				// TRUNCATED. Two things are not: a package specifier (never
+				// going to be followed) and a target ALREADY IN THE GRAPH.
+				//
+				// Missing the second check made the fix silence the very defect
+				// it exists to catch. A DIAMOND — the normal shape of any real
+				// module graph — where the deepest module re-imports a file the
+				// walk already read produced a gap whose message was literally
+				// false ("…which this check did not follow", about a file in
+				// g.Files), dropped the project to the presence tier, and an
+				// orphaned emitter went SILENT with rc=0. Measured; a
+				// self-cycle at the bound did the same.
+				if !truncatedBelow(g, dir, file, spec, opts.Dependencies) {
+					continue
 				}
+				g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
+					opts.MaxDepth, f.Rel, spec)
 				continue
 			}
 			queue = append(queue, pending{
@@ -347,6 +388,29 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		}
 	}
 	return g
+}
+
+// truncatedBelow reports whether an import sitting at the depth bound really
+// leaves something unseen.
+//
+// It answers "no" for a declared PACKAGE (never followed at any depth) and for a
+// target ALREADY IN THE GRAPH — a diamond or a cycle, where the walk read the
+// file by another route, so nothing is missing. It answers "yes" for anything
+// else, including a reference resolving to a file that is not there, which is
+// the same model disagreement the normal path treats as a gap.
+func truncatedBelow(g *EntryGraph, root, fromFile, spec string, deps map[string]bool) bool {
+	resolved, kind := resolveProjectRef(root, filepath.Dir(fromFile), spec, deps, syntaxModule)
+	switch kind {
+	case refPackage:
+		return false
+	case refUnresolved:
+		return true
+	}
+	target, err := resolveRefPath(resolved, syntaxModule)
+	if err != nil {
+		return true
+	}
+	return g.FileAt(target) < 0
 }
 
 func (g *EntryGraph) note(what, spec, resolved string, kind refKind) {
@@ -470,6 +534,12 @@ func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool, s
 	// Vite allows query/hash suffixes (`?raw`, `?url`); a URL has a real query
 	// and fragment. Neither is part of the path, and an emitter referenced as
 	// `./civitai-host.js?url` is still the emitter.
+	//
+	// The ORDER of this strip and the scheme check above is NOT load-bearing —
+	// two independent mutation sweeps swapped them and nothing failed, because
+	// a specifier that is scheme-qualified stays scheme-qualified after its
+	// query is removed. Only the `^` ANCHOR on reURLScheme matters. An earlier
+	// comment here claimed the order was the reason; it was not.
 	if i := strings.IndexAny(spec, "?#"); i >= 0 {
 		spec = spec[:i]
 	}
@@ -549,14 +619,27 @@ func srcAttrValue(attrs string) (string, bool) {
 }
 
 var (
+	// 🔴 `\b` IS NOT AN HTML NAME BOUNDARY, AND USING IT HERE PRODUCED A FALSE
+	// WARNING AT A CORRECT PROJECT — TWICE OVER. `\b` matches between `-` and
+	// `s`, so `\bsrc\s*=` reads `data-src=` and `x-src=` as `src=`, and
+	// `<script\b` reads `<script-loader>` as `<script>`. Measured: a fresh
+	// `static` scaffold with `<script data-src="./app.js" src="./civitai-host.js">`
+	// — `data-src` on a script is a real consent-manager / lazy-load pattern —
+	// resolved the WRONG reference, kept `Complete` true, and produced the
+	// STRONG tier's warning with `--strict` rc=1. HTML name characters include
+	// `-`, so a name boundary is start-of-attributes, whitespace, or `/`; RE2
+	// has no lookahead, so the tag boundary is expressed by requiring the
+	// character after `<script` to be whitespace, `/` or `>`.
+	//
 	// reScriptOpen captures a `<script …>` open tag's attribute list.
-	reScriptOpen = regexp.MustCompile(`(?is)<script\b([^>]*)>`)
+	reScriptOpen = regexp.MustCompile(`(?is)<script([\s/][^>]*)?>`)
 	// reScriptBlock captures a whole `<script …>…</script>` so an INLINE
 	// module's imports can be read. Group 1 is the attribute list, group 2 the
 	// body.
-	reScriptBlock = regexp.MustCompile(`(?is)<script\b([^>]*)>(.*?)</script>`)
-	// reSrcAttr captures a src value in any of HTML's three quoting forms.
-	reSrcAttr = regexp.MustCompile(`(?is)\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'` + "`" + `=<>]+))`)
+	reScriptBlock = regexp.MustCompile(`(?is)<script([\s/][^>]*)?>(.*?)</script\s*>`)
+	// reSrcAttr captures a src value in any of HTML's three quoting forms. The
+	// leading `(?:^|[\s/])` is the attribute-name boundary `\b` could not be.
+	reSrcAttr = regexp.MustCompile(`(?is)(?:^|[\s/])src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'` + "`" + `=<>]+))`)
 	// reJSImport captures the SPECIFIER of an import / re-export / require, so
 	// it can be resolved. Matching a basename inside the specifier is what let
 	// `import '../nonexistent/civitai-host.js'` through.

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -14,16 +14,47 @@ package blockproto
 // Guard A had before it was rewritten, regenerated at a second call site, which
 // is precisely the shape `PackageAcksReady` was consolidated here to avoid.
 //
+// 🔴 AN HTML `src` IS A URL. A JS SPECIFIER IS A MODULE SPECIFIER. THEY ARE
+// RESOLVED BY DIFFERENT RULES, AND CONFLATING THEM PRODUCED THREE SEPARATE BUGS.
+// The first version of this file ran every reference through one resolver
+// written for module specifiers. Measured consequences, each on a project one
+// character away from a shipped template:
+//
+//	<script src="app.js">         read as a BARE specifier -> "not a path in
+//	                              this project" -> gap -> presence tier -> the
+//	                              headline defect SILENT again, at ordinary HTML
+//	<script src="./civitai-host"> extension-guessed to civitai-host.js and
+//	                              ACCEPTED, on a no-build template where the
+//	                              browser fetches the literal path and 404s —
+//	                              the exact "ships a 404" shape wiring.go claims
+//	                              this resolver rejects
+//
+// So there are now two syntaxes (`refSyntax`). Under URL syntax a specifier that
+// is not scheme-qualified or protocol-relative is DOCUMENT-RELATIVE — `app.js`,
+// `./app.js` and `/app.js` all name a file in this project — and there is no
+// extension or directory-index guessing, because a browser fetches the literal
+// path. Under module syntax a bare specifier is a package, and extension/index
+// resolution applies, because a bundler does that.
+//
 // 🔴 IT IS A MODEL OF A BROWSER, NOT A BUNDLER, AND IT SAYS SO.
 // The graph carries a `Complete` flag, and every caller must branch on it. A
 // reference this resolver cannot account for — a bundler alias, a bare
 // specifier that is not a declared dependency, a CDN URL, a path that resolves
-// to a file that is not there, a file it could not read, a budget it exhausted —
-// sets `Complete = false` and records why in `Gaps`. An INCOMPLETE graph is
-// evidence about NOTHING: the emitter may well be reached through the part we
-// could not follow. Callers that would report a finding must go quiet (or fall
-// back to a weaker check that discloses itself), never treat "we did not see it"
-// as "it is not there".
+// to a file that is not there, a file it could not read, a budget it exhausted,
+// AN IMPORT BELOW ITS DEPTH BOUND — sets `Complete = false` and records why in
+// `Gaps`. An INCOMPLETE graph is evidence about NOTHING: the emitter may well be
+// reached through the part we could not follow. Callers that would report a
+// finding must go quiet (or fall back to a weaker check that discloses itself),
+// never treat "we did not see it" as "it is not there".
+//
+// 🔴 THE DEPTH BOUND IS A BUDGET LIKE ANY OTHER, AND TRUNCATING IT IS A GAP.
+// It did not used to be: `continue`-ing at MaxDepth left `Complete` true, so a
+// CORRECT project whose ack sat below the bound got the STRONG tier's warning
+// and `--strict` rc=1 — a false warning built on a graph we had stopped walking,
+// while three separate comments claimed an exhausted budget made the graph
+// incomplete. Measured at depth 10 before the fix. Only imports that are NOT
+// declared packages count as truncated: a leaf importing `react` and nothing
+// else has nothing left to see.
 //
 // WHAT IT DELIBERATELY DOES NOT MODEL. `resolve.alias` / `tsconfig` path
 // mapping, glob imports, dynamic `import(expr)` with a computed specifier,
@@ -56,7 +87,7 @@ type EntryGraphOptions struct {
 	// imports. Guard A passes 2 — index.html's scripts and their direct
 	// imports — because a template's emitter is meant to be loaded by the entry
 	// itself and a deeper chain is a template smell. `validate` passes the
-	// default, because an author's own module layout is none of our business.
+	// default, because an author's module layout is none of our business.
 	MaxDepth int
 	// MaxFiles bounds files read. Exhausting it is a Gap.
 	MaxFiles int
@@ -64,12 +95,26 @@ type EntryGraphOptions struct {
 	// the file, so we do not know what is in it.
 	MaxFileBytes int64
 	// Dependencies are the npm package names the project declares. A BARE
-	// specifier naming one is ACCOUNTED FOR (it is a package, so it is not a
-	// file in this project) and does not make the graph incomplete. A bare
-	// specifier that is NOT a declared dependency is the alias case, and DOES —
-	// `import '@/civitai-host.js'` is a real file behind a bundler alias we
-	// cannot follow. Leave nil to treat every bare specifier as a gap.
+	// MODULE specifier naming one is ACCOUNTED FOR (it is a package, so it is
+	// not a file in this project) and does not make the graph incomplete. A
+	// bare module specifier that is NOT a declared dependency is the alias
+	// case, and DOES — `import '@/civitai-host.js'` is a real file behind a
+	// bundler alias we cannot follow. Leave nil to treat every bare module
+	// specifier as a gap.
+	//
+	// It does NOT apply to an HTML `src`, which has no bare specifiers at all.
 	Dependencies map[string]bool
+	// Inspect, when non-nil, is called for every file the walk reads, with that
+	// file's comment-stripped contents WHILE THEY ARE IN HAND.
+	//
+	// 🔴 This is why EntryFile carries no `Code` field. Retaining every graph
+	// file's contents peaked 410 MB RSS on a 200-module graph entirely INSIDE
+	// the file-count and file-size budgets (measured; ~17 MB before the graph
+	// existed) — a check whose own caps exist because `validate` must not become
+	// a memory event, exceeding the very figure those caps were sized against.
+	// The tree scan next door deliberately holds one file at a time; so does
+	// this.
+	Inspect func(f EntryFile, code string)
 }
 
 func (o EntryGraphOptions) withDefaults() EntryGraphOptions {
@@ -85,15 +130,12 @@ func (o EntryGraphOptions) withDefaults() EntryGraphOptions {
 	return o
 }
 
-// EntryFile is one file the browser loads, with its comments already stripped.
+// EntryFile is one file the browser loads. Its CONTENTS are not retained — see
+// EntryGraphOptions.Inspect.
 type EntryFile struct {
 	// Path is absolute and cleaned; Rel is slash-separated, relative to Root.
 	Path string
 	Rel  string
-	// Code is the file's contents with comments stripped per its extension
-	// (see StripCommentsForExt). A mention inside a comment is not a load and
-	// not an implementation.
-	Code string
 	// Depth is 0 for index.html, 1 for a file index.html references, and so on.
 	Depth int
 	// Spec is the specifier that pulled this file in ("" for index.html);
@@ -155,6 +197,28 @@ func (g *EntryGraph) gap(format string, a ...any) {
 	g.Gaps = append(g.Gaps, fmt.Sprintf(format, a...))
 }
 
+// refSyntax picks the resolution rules. The distinction is not cosmetic — see
+// the file header for the three bugs conflating them produced.
+type refSyntax int
+
+const (
+	// syntaxURL is an HTML attribute value: a URL resolved against the
+	// document. There are NO bare specifiers, and no extension guessing.
+	syntaxURL refSyntax = iota
+	// syntaxModule is a JS/TS import specifier: bare means a package, and a
+	// bundler applies extension and directory-index resolution.
+	syntaxModule
+)
+
+type pending struct {
+	spec  string
+	from  string // directory the specifier resolves against
+	via   int
+	depth int
+	what  string
+	syn   refSyntax
+}
+
 // ResolveEntryGraph walks the project in dir the way a browser does, starting
 // at index.html. It never returns nil.
 //
@@ -175,36 +239,38 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		return g
 	}
 	html := StripHTMLComments(string(raw))
-	g.add(EntryFile{
-		Path: indexPath, Rel: "index.html", Depth: 0, Via: -1,
-		Code: StripCommentsForExt(string(raw), ".html"),
-	})
-
-	type pending struct {
-		spec  string
-		from  string // directory the specifier resolves against
-		via   int
-		depth int
-		what  string
+	index := EntryFile{Path: indexPath, Rel: "index.html", Depth: 0, Via: -1}
+	g.Files = append(g.Files, index)
+	if opts.Inspect != nil {
+		opts.Inspect(index, StripCommentsForExt(string(raw), ".html"))
 	}
+
 	var queue []pending
 
-	// `<script src=…>` resolves against the document, which sits at the root.
-	for _, m := range reScriptSrc.FindAllStringSubmatch(html, -1) {
+	// `<script src=…>` is a URL resolved against the document, which sits at
+	// the project root.
+	for _, attrs := range reScriptOpen.FindAllStringSubmatch(html, -1) {
+		src, ok := srcAttrValue(attrs[1])
+		if !ok {
+			continue
+		}
 		g.ScriptRefs++
-		queue = append(queue, pending{spec: m[1], from: dir, via: 0, depth: 1, what: "index.html <script src>"})
+		queue = append(queue, pending{spec: src, from: dir, via: 0, depth: 1,
+			what: "index.html <script src>", syn: syntaxURL})
 	}
 	// Inline `<script>` blocks execute too, and a module one can import the
 	// emitter. Without this a project whose index.html carries
 	// `<script type="module">import './civitai-host.js'</script>` would resolve
 	// to a graph that "completely" misses the emitter — a false finding at a
-	// correct project.
+	// correct project. Their specifiers are MODULE syntax, resolved against the
+	// document's directory (the project root).
 	for _, m := range reScriptBlock.FindAllStringSubmatch(html, -1) {
-		if reSrcAttr.MatchString(m[1]) {
+		if _, ok := srcAttrValue(m[1]); ok {
 			continue // external: already queued above
 		}
 		for _, im := range reJSImport.FindAllStringSubmatch(StripJSComments(m[2]), -1) {
-			queue = append(queue, pending{spec: im[1], from: dir, via: 0, depth: 1, what: "inline <script> in index.html"})
+			queue = append(queue, pending{spec: im[1], from: dir, via: 0, depth: 1,
+				what: "inline <script> in index.html", syn: syntaxModule})
 		}
 	}
 
@@ -212,7 +278,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		p := queue[0]
 		queue = queue[1:]
 
-		resolved, kind := resolveProjectRef(dir, p.from, p.spec, opts.Dependencies)
+		resolved, kind := resolveProjectRef(dir, p.from, p.spec, opts.Dependencies, p.syn)
 		g.note(p.what, p.spec, resolved, kind)
 		switch kind {
 		case refPackage:
@@ -221,10 +287,14 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			// package.json — so this is accounted for, not a gap.
 			continue
 		case refUnresolved:
-			g.gap("could not resolve %s %q — a bundler alias, a bare specifier that is not a declared dependency, or an off-project URL", p.what, p.spec)
+			if p.syn == syntaxURL {
+				g.gap("could not resolve %s %q — an off-project URL, or a path outside this project", p.what, p.spec)
+			} else {
+				g.gap("could not resolve %s %q — a bundler alias, a bare specifier that is not a declared dependency, or an off-project URL", p.what, p.spec)
+			}
 			continue
 		}
-		file, err := resolveModulePath(resolved)
+		file, err := resolveRefPath(resolved, p.syn)
 		if err != nil {
 			// A reference that points at nothing means this resolver disagrees
 			// with a project that presumably builds — our model is wrong, not
@@ -248,25 +318,36 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(file))
+		code := StripCommentsForExt(string(body), ext)
 		idx := len(g.Files)
-		g.add(EntryFile{
-			Path: file, Rel: relTo(dir, file), Depth: p.depth, Spec: p.spec, Via: p.via,
-			Code: StripCommentsForExt(string(body), ext),
-		})
-		if p.depth >= opts.MaxDepth || !entryModuleExts[ext] {
+		f := EntryFile{Path: file, Rel: relTo(dir, file), Depth: p.depth, Spec: p.spec, Via: p.via}
+		g.Files = append(g.Files, f)
+		if opts.Inspect != nil {
+			opts.Inspect(f, code)
+		}
+		if !entryModuleExts[ext] {
 			continue
 		}
-		for _, im := range reJSImport.FindAllStringSubmatch(g.Files[idx].Code, -1) {
+		for _, im := range reJSImport.FindAllStringSubmatch(code, -1) {
+			spec := im[1]
+			if p.depth+1 > opts.MaxDepth {
+				// 🔴 TRUNCATION IS A GAP. A package specifier is not truncated
+				// content — it was never going to be followed — so only a
+				// reference naming something in this project counts.
+				if _, k := resolveProjectRef(dir, filepath.Dir(file), spec, opts.Dependencies, syntaxModule); k != refPackage {
+					g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
+						opts.MaxDepth, f.Rel, spec)
+				}
+				continue
+			}
 			queue = append(queue, pending{
-				spec: im[1], from: filepath.Dir(file), via: idx, depth: p.depth + 1,
-				what: "import in " + g.Files[idx].Rel,
+				spec: spec, from: filepath.Dir(file), via: idx, depth: p.depth + 1,
+				what: "import in " + f.Rel, syn: syntaxModule,
 			})
 		}
 	}
 	return g
 }
-
-func (g *EntryGraph) add(f EntryFile) { g.Files = append(g.Files, f) }
 
 func (g *EntryGraph) note(what, spec, resolved string, kind refKind) {
 	switch kind {
@@ -307,23 +388,30 @@ func readCapped(path string, max int64) ([]byte, error) {
 
 // entryModuleExts are the extensions whose imports are followed. A `.css` a
 // module imports is still part of the graph (it is added to Files) but has no
-// imports worth chasing.
+// imports worth chasing — and widening this set would let a stylesheet pull
+// files into the graph, which no browser does.
 var entryModuleExts = map[string]bool{
 	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
 	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
 	".vue": true, ".svelte": true, ".astro": true,
 }
 
-// entryResolveExts are appended to an extensionless specifier, in the order a
-// bundler tries them.
+// entryResolveExts are appended to an extensionless MODULE specifier, in the
+// order a bundler tries them. They are never applied to a URL.
 var entryResolveExts = []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte", ".astro"}
 
-// resolveModulePath turns a resolved reference into a file that exists,
-// applying the extension and directory-index resolution a bundler does. It
-// returns an error when nothing exists there.
-func resolveModulePath(p string) (string, error) {
+// resolveRefPath turns a resolved reference into a file that exists.
+//
+// 🔴 URL syntax gets NO extension or directory-index guessing. A browser fetches
+// the literal path: `<script src="./civitai-host">` on a no-build template is a
+// 404, and guessing `.js` for it accepted exactly the "ships a 404" shape this
+// resolver exists to reject.
+func resolveRefPath(p string, syn refSyntax) (string, error) {
 	if info, err := os.Stat(p); err == nil && !info.IsDir() {
 		return filepath.Clean(p), nil
+	}
+	if syn == syntaxURL {
+		return "", os.ErrNotExist
 	}
 	for _, ext := range entryResolveExts {
 		if info, err := os.Stat(p + ext); err == nil && !info.IsDir() {
@@ -346,34 +434,42 @@ const (
 	refUnresolved refKind = iota
 	// refProject: a path inside the project.
 	refProject
-	// refPackage: a bare specifier naming a declared npm dependency.
+	// refPackage: a bare MODULE specifier naming a declared npm dependency.
 	refPackage
 )
 
-// resolveProjectRef resolves a `<script src>` or an import specifier.
+// reURLScheme matches an RFC 3986 scheme prefix. A browser treats
+// `<script src="foo:bar">` as an absolute URL rather than a relative path, so
+// this is how an HTML `src` is told apart from a document-relative one.
+var reURLScheme = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.\-]*:`)
+
+// resolveProjectRef resolves a `<script src>` (syntaxURL) or an import
+// specifier (syntaxModule).
 //
-// A root-relative ref resolves against the project root, a relative one against
-// fromDir. A bare specifier is a PACKAGE when the project declares it as a
-// dependency and unresolvable otherwise — which is what makes
+// Under MODULE syntax a bare specifier is a PACKAGE when the project declares
+// it as a dependency and unresolvable otherwise — which is what makes
 // `import 'civitai-host.js'` (a bare specifier that resolves to a package, not
 // to this file) a non-match rather than a hit.
-func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool) (string, refKind) {
+//
+// Under URL syntax there are no bare specifiers at all: `app.js` is
+// document-relative and names a file in this project, exactly as `./app.js`
+// does. Reading it as a bare specifier is what left the headline defect intact
+// for every project whose index.html omits `./`.
+func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool, syn refSyntax) (string, refKind) {
 	// A protocol-relative URL only LOOKS root-relative. Without this, the `/`
 	// case below strips one slash and `filepath.Join` cleans the rest, so
 	// `//evil.example.com/../civitai-host.js` resolves to EXACTLY the emitter's
 	// path and is accepted — measured. Pinned by the "protocol-relative URL
 	// that cleans back" corpus case.
-	//
-	// There is deliberately no `strings.Contains(spec, "://")` companion: no URI
-	// scheme can begin with `/`, `./` or `../`, so an `https://…` specifier
-	// already falls through to the bare-specifier branch, where it is not a
-	// declared dependency and reports refUnresolved — the identical answer.
 	if strings.HasPrefix(spec, "//") {
 		return "", refUnresolved
 	}
-	// Vite allows query/hash suffixes (`?raw`, `?url`); they are not part of the
-	// path, and an emitter imported as `./civitai-host.js?url` is still the
-	// emitter. Pinned by the "?url suffix" accept case.
+	if syn == syntaxURL && reURLScheme.MatchString(spec) {
+		return "", refUnresolved
+	}
+	// Vite allows query/hash suffixes (`?raw`, `?url`); a URL has a real query
+	// and fragment. Neither is part of the path, and an emitter referenced as
+	// `./civitai-host.js?url` is still the emitter.
 	if i := strings.IndexAny(spec, "?#"); i >= 0 {
 		spec = spec[:i]
 	}
@@ -385,6 +481,9 @@ func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool) (
 	case strings.HasPrefix(spec, "/"):
 		out = filepath.Clean(filepath.Join(projectDir, filepath.FromSlash(strings.TrimPrefix(spec, "/"))))
 	case strings.HasPrefix(spec, "./"), strings.HasPrefix(spec, "../"):
+		out = filepath.Clean(filepath.Join(fromDir, filepath.FromSlash(spec)))
+	case syn == syntaxURL:
+		// Document-relative. `app.js` and `./app.js` are the same URL.
 		out = filepath.Clean(filepath.Join(fromDir, filepath.FromSlash(spec)))
 	default:
 		if declaresPackage(deps, spec) {
@@ -403,6 +502,11 @@ func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool) (
 
 // declaresPackage reports whether spec names a declared dependency, allowing a
 // subpath (`react-dom/client` -> `react-dom`, `@scope/pkg/sub` -> `@scope/pkg`).
+//
+// 🔴 The boundary is a PATH SEPARATOR, never a character offset. `reactive-ui`
+// starts with `react` and is a different package; a prefix test that does not
+// split on `/` accepts it and silently classifies a real project file as a
+// dependency — which turns a gap into a confident (wrong) finding.
 func declaresPackage(deps map[string]bool, spec string) bool {
 	if len(deps) == 0 {
 		return false
@@ -420,14 +524,41 @@ func declaresPackage(deps map[string]bool, spec string) bool {
 	return deps[parts[0]]
 }
 
+// srcAttrValue extracts a `src` attribute value from a tag's attribute list,
+// accepting the three HTML forms: double-quoted, single-quoted and UNQUOTED.
+//
+// 🔴 The unquoted form is legal HTML and used to be dropped entirely. The tag
+// then looked like an INLINE script with an empty body, so the reference
+// vanished from the graph while `Complete` stayed TRUE — a correct `static`
+// scaffold written `src=./civitai-host.js` produced the strong tier's warning
+// and `--strict` rc=1. A false warning at a correct project is the outcome
+// AGENTS.md item 10 records four measured corrections to avoid.
+func srcAttrValue(attrs string) (string, bool) {
+	m := reSrcAttr.FindStringSubmatch(attrs)
+	if m == nil {
+		return "", false
+	}
+	for _, v := range m[1:] {
+		if v != "" {
+			return v, true
+		}
+	}
+	// `src=""` / `src=''`: present but empty. It IS a src attribute (so the tag
+	// is external rather than inline) and it names nothing.
+	return "", true
+}
+
 var (
-	reScriptSrc = regexp.MustCompile(`(?is)<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']`)
-	// Captures a whole `<script …>…</script>` so an INLINE module's imports can
-	// be read. Group 1 is the attribute list, group 2 the body.
+	// reScriptOpen captures a `<script …>` open tag's attribute list.
+	reScriptOpen = regexp.MustCompile(`(?is)<script\b([^>]*)>`)
+	// reScriptBlock captures a whole `<script …>…</script>` so an INLINE
+	// module's imports can be read. Group 1 is the attribute list, group 2 the
+	// body.
 	reScriptBlock = regexp.MustCompile(`(?is)<script\b([^>]*)>(.*?)</script>`)
-	reSrcAttr     = regexp.MustCompile(`(?is)\bsrc\s*=\s*["']`)
-	// Captures the SPECIFIER of an import / re-export / require, so it can be
-	// resolved. Matching a basename inside the specifier is what let
+	// reSrcAttr captures a src value in any of HTML's three quoting forms.
+	reSrcAttr = regexp.MustCompile(`(?is)\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'` + "`" + `=<>]+))`)
+	// reJSImport captures the SPECIFIER of an import / re-export / require, so
+	// it can be resolved. Matching a basename inside the specifier is what let
 	// `import '../nonexistent/civitai-host.js'` through.
 	reJSImport = regexp.MustCompile(`(?:\bimport\s*\(?\s*|\bfrom\s+|\brequire\(\s*)['"]([^'"]+)['"]`)
 )

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -1,0 +1,433 @@
+package blockproto
+
+// entrygraph.go resolves THE SET OF FILES A BROWSER ACTUALLY LOADS for a block
+// project: index.html, the scripts it references, and the modules those import.
+//
+// WHY IT LIVES HERE. It started as test-only code in
+// `internal/scaffold/ready_ack_contract_test.go`, where Guard A uses it to prove
+// a scaffolded template's vendored emitter is REACHED and not merely present.
+// `internal/validate`'s page-without-ack advisory needed exactly the same
+// question answered for an AUTHOR's project — and while it was answered by a
+// whole-tree grep instead, an author who copied `civitai-host.js` in without
+// referencing it from index.html got a green `validate` for an app that was
+// still completely broken. That is the same "presence is not reachability" hole
+// Guard A had before it was rewritten, regenerated at a second call site, which
+// is precisely the shape `PackageAcksReady` was consolidated here to avoid.
+//
+// 🔴 IT IS A MODEL OF A BROWSER, NOT A BUNDLER, AND IT SAYS SO.
+// The graph carries a `Complete` flag, and every caller must branch on it. A
+// reference this resolver cannot account for — a bundler alias, a bare
+// specifier that is not a declared dependency, a CDN URL, a path that resolves
+// to a file that is not there, a file it could not read, a budget it exhausted —
+// sets `Complete = false` and records why in `Gaps`. An INCOMPLETE graph is
+// evidence about NOTHING: the emitter may well be reached through the part we
+// could not follow. Callers that would report a finding must go quiet (or fall
+// back to a weaker check that discloses itself), never treat "we did not see it"
+// as "it is not there".
+//
+// WHAT IT DELIBERATELY DOES NOT MODEL. `resolve.alias` / `tsconfig` path
+// mapping, glob imports, dynamic `import(expr)` with a computed specifier,
+// framework-owned entry points (Next.js, SvelteKit) that have no root
+// index.html, and anything a plugin injects at transform time. Each of those
+// makes the graph INCOMPLETE rather than wrong, which is the safe direction:
+// the cost is a check that goes quiet, never a warning at a correct project.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// EntryGraph defaults. `validate` walks an author's project, so the budgets are
+// cost limits rather than correctness ones — exhausting one makes the graph
+// INCOMPLETE, which is the direction that stays quiet.
+const (
+	DefaultEntryMaxDepth     = 8
+	DefaultEntryMaxFiles     = 200
+	DefaultEntryMaxFileBytes = 2 << 20 // 2 MiB
+)
+
+// EntryGraphOptions tunes ResolveEntryGraph. The zero value is usable and takes
+// the Default* constants above.
+type EntryGraphOptions struct {
+	// MaxDepth bounds how far below index.html (depth 0) the walk follows
+	// imports. Guard A passes 2 — index.html's scripts and their direct
+	// imports — because a template's emitter is meant to be loaded by the entry
+	// itself and a deeper chain is a template smell. `validate` passes the
+	// default, because an author's own module layout is none of our business.
+	MaxDepth int
+	// MaxFiles bounds files read. Exhausting it is a Gap.
+	MaxFiles int
+	// MaxFileBytes bounds a single file. Exceeding it is a Gap: we did not read
+	// the file, so we do not know what is in it.
+	MaxFileBytes int64
+	// Dependencies are the npm package names the project declares. A BARE
+	// specifier naming one is ACCOUNTED FOR (it is a package, so it is not a
+	// file in this project) and does not make the graph incomplete. A bare
+	// specifier that is NOT a declared dependency is the alias case, and DOES —
+	// `import '@/civitai-host.js'` is a real file behind a bundler alias we
+	// cannot follow. Leave nil to treat every bare specifier as a gap.
+	Dependencies map[string]bool
+}
+
+func (o EntryGraphOptions) withDefaults() EntryGraphOptions {
+	if o.MaxDepth <= 0 {
+		o.MaxDepth = DefaultEntryMaxDepth
+	}
+	if o.MaxFiles <= 0 {
+		o.MaxFiles = DefaultEntryMaxFiles
+	}
+	if o.MaxFileBytes <= 0 {
+		o.MaxFileBytes = DefaultEntryMaxFileBytes
+	}
+	return o
+}
+
+// EntryFile is one file the browser loads, with its comments already stripped.
+type EntryFile struct {
+	// Path is absolute and cleaned; Rel is slash-separated, relative to Root.
+	Path string
+	Rel  string
+	// Code is the file's contents with comments stripped per its extension
+	// (see StripCommentsForExt). A mention inside a comment is not a load and
+	// not an implementation.
+	Code string
+	// Depth is 0 for index.html, 1 for a file index.html references, and so on.
+	Depth int
+	// Spec is the specifier that pulled this file in ("" for index.html);
+	// Via indexes the referencing file in Files (-1 for index.html).
+	Spec string
+	Via  int
+}
+
+// EntryGraph is the result of ResolveEntryGraph.
+type EntryGraph struct {
+	Root  string
+	Files []EntryFile
+	// Complete reports that every reference encountered was accounted for. A
+	// false here means the graph is a LOWER BOUND on what the browser loads and
+	// must never be read as evidence that something is absent.
+	Complete bool
+	// Gaps explains, in author-readable terms, why Complete is false.
+	Gaps []string
+	// Trace lists every reference considered and what it resolved to, for
+	// error messages that name the near-miss instead of saying "nothing".
+	Trace []string
+	// ScriptRefs counts `<script src=…>` references found in index.html,
+	// whether or not they resolved. Zero distinguishes "index.html loads
+	// nothing" from "index.html loads the wrong thing".
+	ScriptRefs int
+}
+
+// FileAt returns the index in Files of the file at the given absolute path, or
+// -1.
+func (g *EntryGraph) FileAt(abs string) int {
+	want := filepath.Clean(abs)
+	for i, f := range g.Files {
+		if f.Path == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// Chain renders how Files[i] is reached, for a human.
+func (g *EntryGraph) Chain(i int) string {
+	if i < 0 || i >= len(g.Files) {
+		return ""
+	}
+	f := g.Files[i]
+	if f.Via < 0 {
+		return f.Rel
+	}
+	parent := g.Files[f.Via]
+	verb := "imports"
+	if parent.Depth == 0 {
+		verb = "loads"
+	}
+	return g.Chain(f.Via) + " " + verb + " " + f.Spec + " -> " + f.Rel
+}
+
+func (g *EntryGraph) gap(format string, a ...any) {
+	g.Complete = false
+	g.Gaps = append(g.Gaps, fmt.Sprintf(format, a...))
+}
+
+// ResolveEntryGraph walks the project in dir the way a browser does, starting
+// at index.html. It never returns nil.
+//
+// 🔴 Read `Complete` before reading `Files`. See the file header.
+func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
+	opts = opts.withDefaults()
+	g := &EntryGraph{Root: dir, Complete: true}
+
+	indexPath := filepath.Clean(filepath.Join(dir, "index.html"))
+	raw, err := readCapped(indexPath, opts.MaxFileBytes)
+	if err != nil {
+		// No root index.html is not a broken project — it is a project whose
+		// entry point this resolver does not model (a framework-owned entry, a
+		// nested html root). There is nothing to walk, so the graph is empty
+		// AND incomplete: callers must not read "no files load the emitter"
+		// out of it.
+		g.gap("no readable index.html at the project root (%v)", err)
+		return g
+	}
+	html := StripHTMLComments(string(raw))
+	g.add(EntryFile{
+		Path: indexPath, Rel: "index.html", Depth: 0, Via: -1,
+		Code: StripCommentsForExt(string(raw), ".html"),
+	})
+
+	type pending struct {
+		spec  string
+		from  string // directory the specifier resolves against
+		via   int
+		depth int
+		what  string
+	}
+	var queue []pending
+
+	// `<script src=…>` resolves against the document, which sits at the root.
+	for _, m := range reScriptSrc.FindAllStringSubmatch(html, -1) {
+		g.ScriptRefs++
+		queue = append(queue, pending{spec: m[1], from: dir, via: 0, depth: 1, what: "index.html <script src>"})
+	}
+	// Inline `<script>` blocks execute too, and a module one can import the
+	// emitter. Without this a project whose index.html carries
+	// `<script type="module">import './civitai-host.js'</script>` would resolve
+	// to a graph that "completely" misses the emitter — a false finding at a
+	// correct project.
+	for _, m := range reScriptBlock.FindAllStringSubmatch(html, -1) {
+		if reSrcAttr.MatchString(m[1]) {
+			continue // external: already queued above
+		}
+		for _, im := range reJSImport.FindAllStringSubmatch(StripJSComments(m[2]), -1) {
+			queue = append(queue, pending{spec: im[1], from: dir, via: 0, depth: 1, what: "inline <script> in index.html"})
+		}
+	}
+
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+
+		resolved, kind := resolveProjectRef(dir, p.from, p.spec, opts.Dependencies)
+		g.note(p.what, p.spec, resolved, kind)
+		switch kind {
+		case refPackage:
+			// A declared dependency. It is not a file in this project, and
+			// whether IT acks is a separate question the caller answers from
+			// package.json — so this is accounted for, not a gap.
+			continue
+		case refUnresolved:
+			g.gap("could not resolve %s %q — a bundler alias, a bare specifier that is not a declared dependency, or an off-project URL", p.what, p.spec)
+			continue
+		}
+		file, err := resolveModulePath(resolved)
+		if err != nil {
+			// A reference that points at nothing means this resolver disagrees
+			// with a project that presumably builds — our model is wrong, not
+			// the project. That is a GAP, not "the browser 404s it": treating
+			// it as the latter would let a mis-modelled project produce a
+			// confident finding.
+			g.gap("%s %q resolves to %s, which does not exist — this resolver's model of the project is incomplete",
+				p.what, p.spec, relTo(dir, resolved))
+			continue
+		}
+		if g.FileAt(file) >= 0 {
+			continue
+		}
+		if len(g.Files) >= opts.MaxFiles {
+			g.gap("stopped after %d files — the entry graph is larger than this check reads", opts.MaxFiles)
+			return g
+		}
+		body, err := readCapped(file, opts.MaxFileBytes)
+		if err != nil {
+			g.gap("could not read %s (%v)", relTo(dir, file), err)
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(file))
+		idx := len(g.Files)
+		g.add(EntryFile{
+			Path: file, Rel: relTo(dir, file), Depth: p.depth, Spec: p.spec, Via: p.via,
+			Code: StripCommentsForExt(string(body), ext),
+		})
+		if p.depth >= opts.MaxDepth || !entryModuleExts[ext] {
+			continue
+		}
+		for _, im := range reJSImport.FindAllStringSubmatch(g.Files[idx].Code, -1) {
+			queue = append(queue, pending{
+				spec: im[1], from: filepath.Dir(file), via: idx, depth: p.depth + 1,
+				what: "import in " + g.Files[idx].Rel,
+			})
+		}
+	}
+	return g
+}
+
+func (g *EntryGraph) add(f EntryFile) { g.Files = append(g.Files, f) }
+
+func (g *EntryGraph) note(what, spec, resolved string, kind refKind) {
+	switch kind {
+	case refPackage:
+		g.Trace = append(g.Trace, fmt.Sprintf("%s %q -> a declared npm dependency, not a file in this project", what, spec))
+	case refUnresolved:
+		g.Trace = append(g.Trace, fmt.Sprintf("%s %q -> not a path in this project (bare specifier or URL)", what, spec))
+	default:
+		state := "exists"
+		if _, err := os.Stat(resolved); err != nil {
+			state = "DOES NOT EXIST"
+		}
+		g.Trace = append(g.Trace, fmt.Sprintf("%s %q -> %s (%s)", what, spec, relTo(g.Root, resolved), state))
+	}
+}
+
+func relTo(root, p string) string {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return p
+	}
+	return filepath.ToSlash(rel)
+}
+
+func readCapped(path string, max int64) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", filepath.Base(path))
+	}
+	if info.Size() > max {
+		return nil, fmt.Errorf("file is larger than %d bytes", max)
+	}
+	return os.ReadFile(path)
+}
+
+// entryModuleExts are the extensions whose imports are followed. A `.css` a
+// module imports is still part of the graph (it is added to Files) but has no
+// imports worth chasing.
+var entryModuleExts = map[string]bool{
+	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
+	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
+	".vue": true, ".svelte": true, ".astro": true,
+}
+
+// entryResolveExts are appended to an extensionless specifier, in the order a
+// bundler tries them.
+var entryResolveExts = []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts", ".vue", ".svelte", ".astro"}
+
+// resolveModulePath turns a resolved reference into a file that exists,
+// applying the extension and directory-index resolution a bundler does. It
+// returns an error when nothing exists there.
+func resolveModulePath(p string) (string, error) {
+	if info, err := os.Stat(p); err == nil && !info.IsDir() {
+		return filepath.Clean(p), nil
+	}
+	for _, ext := range entryResolveExts {
+		if info, err := os.Stat(p + ext); err == nil && !info.IsDir() {
+			return filepath.Clean(p + ext), nil
+		}
+	}
+	for _, ext := range entryResolveExts {
+		cand := filepath.Join(p, "index"+ext)
+		if info, err := os.Stat(cand); err == nil && !info.IsDir() {
+			return filepath.Clean(cand), nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+type refKind int
+
+const (
+	// refUnresolved: we cannot say what file this is. Always a gap.
+	refUnresolved refKind = iota
+	// refProject: a path inside the project.
+	refProject
+	// refPackage: a bare specifier naming a declared npm dependency.
+	refPackage
+)
+
+// resolveProjectRef resolves a `<script src>` or an import specifier.
+//
+// A root-relative ref resolves against the project root, a relative one against
+// fromDir. A bare specifier is a PACKAGE when the project declares it as a
+// dependency and unresolvable otherwise — which is what makes
+// `import 'civitai-host.js'` (a bare specifier that resolves to a package, not
+// to this file) a non-match rather than a hit.
+func resolveProjectRef(projectDir, fromDir, spec string, deps map[string]bool) (string, refKind) {
+	// A protocol-relative URL only LOOKS root-relative. Without this, the `/`
+	// case below strips one slash and `filepath.Join` cleans the rest, so
+	// `//evil.example.com/../civitai-host.js` resolves to EXACTLY the emitter's
+	// path and is accepted — measured. Pinned by the "protocol-relative URL
+	// that cleans back" corpus case.
+	//
+	// There is deliberately no `strings.Contains(spec, "://")` companion: no URI
+	// scheme can begin with `/`, `./` or `../`, so an `https://…` specifier
+	// already falls through to the bare-specifier branch, where it is not a
+	// declared dependency and reports refUnresolved — the identical answer.
+	if strings.HasPrefix(spec, "//") {
+		return "", refUnresolved
+	}
+	// Vite allows query/hash suffixes (`?raw`, `?url`); they are not part of the
+	// path, and an emitter imported as `./civitai-host.js?url` is still the
+	// emitter. Pinned by the "?url suffix" accept case.
+	if i := strings.IndexAny(spec, "?#"); i >= 0 {
+		spec = spec[:i]
+	}
+	if spec == "" {
+		return "", refUnresolved
+	}
+	var out string
+	switch {
+	case strings.HasPrefix(spec, "/"):
+		out = filepath.Clean(filepath.Join(projectDir, filepath.FromSlash(strings.TrimPrefix(spec, "/"))))
+	case strings.HasPrefix(spec, "./"), strings.HasPrefix(spec, "../"):
+		out = filepath.Clean(filepath.Join(fromDir, filepath.FromSlash(spec)))
+	default:
+		if declaresPackage(deps, spec) {
+			return "", refPackage
+		}
+		return "", refUnresolved
+	}
+	// A reference that escapes the project root is not a file in this project.
+	// A monorepo really can import one, which is exactly why it is a GAP rather
+	// than a miss: we stop modelling there.
+	if rel, err := filepath.Rel(projectDir, out); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", refUnresolved
+	}
+	return out, refProject
+}
+
+// declaresPackage reports whether spec names a declared dependency, allowing a
+// subpath (`react-dom/client` -> `react-dom`, `@scope/pkg/sub` -> `@scope/pkg`).
+func declaresPackage(deps map[string]bool, spec string) bool {
+	if len(deps) == 0 {
+		return false
+	}
+	if deps[spec] {
+		return true
+	}
+	parts := strings.Split(spec, "/")
+	if strings.HasPrefix(spec, "@") {
+		if len(parts) >= 2 && deps[parts[0]+"/"+parts[1]] {
+			return true
+		}
+		return false
+	}
+	return deps[parts[0]]
+}
+
+var (
+	reScriptSrc = regexp.MustCompile(`(?is)<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']`)
+	// Captures a whole `<script …>…</script>` so an INLINE module's imports can
+	// be read. Group 1 is the attribute list, group 2 the body.
+	reScriptBlock = regexp.MustCompile(`(?is)<script\b([^>]*)>(.*?)</script>`)
+	reSrcAttr     = regexp.MustCompile(`(?is)\bsrc\s*=\s*["']`)
+	// Captures the SPECIFIER of an import / re-export / require, so it can be
+	// resolved. Matching a basename inside the specifier is what let
+	// `import '../nonexistent/civitai-host.js'` through.
+	reJSImport = regexp.MustCompile(`(?:\bimport\s*\(?\s*|\bfrom\s+|\brequire\(\s*)['"]([^'"]+)['"]`)
+)

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -269,6 +269,9 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 	}
 
 	var queue []pending
+	// Candidate truncations, evaluated AFTER the walk — see the depth-bound
+	// branch below for why the answer is not available while it is running.
+	var pendingTrunc []truncCandidate
 
 	// `<script src=…>` is a URL resolved against the document, which sits at
 	// the project root.
@@ -363,22 +366,27 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			spec := strings.Clone(im[1])
 			if p.depth+1 > opts.MaxDepth {
 				// 🔴 TRUNCATION IS A GAP — BUT ONLY IF SOMETHING WAS ACTUALLY
-				// TRUNCATED. Two things are not: a package specifier (never
-				// going to be followed) and a target ALREADY IN THE GRAPH.
+				// TRUNCATED, AND THAT QUESTION CANNOT BE ANSWERED YET.
 				//
-				// Missing the second check made the fix silence the very defect
-				// it exists to catch. A DIAMOND — the normal shape of any real
-				// module graph — where the deepest module re-imports a file the
-				// walk already read produced a gap whose message was literally
-				// false ("…which this check did not follow", about a file in
-				// g.Files), dropped the project to the presence tier, and an
-				// orphaned emitter went SILENT with rc=0. Measured; a
-				// self-cycle at the bound did the same.
-				if !truncatedBelow(g, dir, file, spec, opts.Dependencies) {
-					continue
-				}
-				g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
-					opts.MaxDepth, f.Rel, spec)
+				// Two things are not truncation: a package specifier (never
+				// going to be followed) and a target the walk reads anyway.
+				// Missing the second silenced the very defect this check exists
+				// for — a DIAMOND, the normal shape of any real module graph,
+				// produced a gap whose message was false about a file sitting in
+				// g.Files and let an orphaned emitter pass with rc=0.
+				//
+				// 🔴 So the check is DEFERRED to the end of the walk. Asking
+				// `g.Files` here answers "has it been POPPED yet", not "is it in
+				// the graph" — a target already ENQUEUED is absent from g.Files
+				// until its turn comes. Two modules at exactly MaxDepth where
+				// the first-enqueued imports the second therefore gapped or did
+				// not depending on THE TEXTUAL ORDER OF TWO IMPORT STATEMENTS,
+				// and in the losing order an orphaned emitter shipped silently.
+				// Measured flat and nested. After the walk drains, g.Files is
+				// final and the answer cannot depend on ordering.
+				pendingTrunc = append(pendingTrunc, truncCandidate{
+					fromFile: file, spec: spec, rel: f.Rel,
+				})
 				continue
 			}
 			queue = append(queue, pending{
@@ -387,7 +395,26 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			})
 		}
 	}
+
+	// The walk has drained, so g.Files is final: now "did we actually miss
+	// anything below the bound" has an order-independent answer.
+	for _, c := range pendingTrunc {
+		if !truncatedBelow(g, dir, c.fromFile, c.spec, opts.Dependencies) {
+			continue
+		}
+		g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
+			opts.MaxDepth, c.rel, c.spec)
+	}
 	return g
+}
+
+// truncCandidate is an import seen at the depth bound, held until the walk
+// finishes. Evaluating it in place asked g.Files a question g.Files could not
+// answer yet — see the depth-bound branch in ResolveEntryGraph.
+type truncCandidate struct {
+	fromFile string // the module the import was seen in
+	spec     string // the specifier
+	rel      string // fromFile, project-relative, for the message
 }
 
 // truncatedBelow reports whether an import sitting at the depth bound really
@@ -635,11 +662,20 @@ var (
 	reScriptOpen = regexp.MustCompile(`(?is)<script([\s/][^>]*)?>`)
 	// reScriptBlock captures a whole `<script …>…</script>` so an INLINE
 	// module's imports can be read. Group 1 is the attribute list, group 2 the
-	// body.
+	// body. The close tag allows trailing whitespace (`</script >`, which a
+	// browser accepts) but NOT arbitrary characters — `</scriptx>` closes
+	// nothing, and widening to `</script[^>]*>` would make it close an inline
+	// module that is still open.
 	reScriptBlock = regexp.MustCompile(`(?is)<script([\s/][^>]*)?>(.*?)</script\s*>`)
 	// reSrcAttr captures a src value in any of HTML's three quoting forms. The
-	// leading `(?:^|[\s/])` is the attribute-name boundary `\b` could not be.
-	reSrcAttr = regexp.MustCompile(`(?is)(?:^|[\s/])src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'` + "`" + `=<>]+))`)
+	// leading `[\s/]` is the attribute-name boundary `\b` could not be.
+	//
+	// There is deliberately no `^` alternative: reScriptOpen's capture is
+	// `([\s/][^>]*)?`, so an attribute list is either EMPTY (no src to find) or
+	// begins with whitespace or `/`. An `^` arm was there and was UNREACHABLE —
+	// a mutation sweep removing it survived, which is the tell. It was dropped
+	// rather than left as a branch nothing can exercise.
+	reSrcAttr = regexp.MustCompile(`(?is)[\s/]src\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'` + "`" + `=<>]+))`)
 	// reJSImport captures the SPECIFIER of an import / re-export / require, so
 	// it can be resolved. Matching a basename inside the specifier is what let
 	// `import '../nonexistent/civitai-host.js'` through.

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -264,12 +264,96 @@ func TestReadyAckWiringPredicate(t *testing.T) {
 			wantErr: "not a path in this project",
 		},
 		{
-			// 🔴 The scheme regex is ANCHORED, and the anchor is load-bearing:
-			// the scheme check runs BEFORE the `?`/`#` strip, so an unanchored
-			// pattern matches a `https:` sitting in a QUERY STRING and throws
-			// away a perfectly ordinary local reference. Dropping the `^`
-			// survived the previous sweep. A cache-busting or proxy query with a
-			// URL in it is ordinary.
+			// 🔴 `\b` IS NOT AN HTML ATTRIBUTE-NAME BOUNDARY. It matches between
+			// `-` and `s`, so `data-src=` was read as `src=` and the WRONG
+			// reference resolved — with `Complete` still true, so the STRONG
+			// tier fired. Measured on a correct `static` scaffold: `--strict`
+			// rc=1. `data-src` on a `<script>` is a real consent-manager /
+			// lazy-load pattern, not a contrivance.
+			name: "accept: data-src before the real src does not hijack it",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script data-src="./app.js" src="./civitai-host.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "accept: x-src before the real src does not hijack it",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script x-src="./app.js" src="./civitai-host.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			// The inverse control: a tag carrying ONLY `data-src` has no src at
+			// all, so it loads nothing and cannot satisfy the wiring check.
+			// Without this, "do not match data-src" is indistinguishable from
+			// "match any attribute whose name ends in src".
+			name: "reject: data-src alone is not a load",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script data-src="./civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
+			// 🔴 The same `\b` on the TAG name: `<script-loader>` is a custom
+			// element, not a script, and a browser executes nothing in it.
+			name: "reject: a <script-loader> custom element is not a script tag",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script-loader src="./civitai-host.js"></script-loader><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
+			// 🟢 `srcAttrValue` reports an EMPTY src as PRESENT, which makes the
+			// tag EXTERNAL rather than inline. A browser ignores the body of an
+			// element that has a `src` attribute, so the import below must NOT
+			// count. Flipping that `return "", true` reproduces verbatim the
+			// hazard its own comment documents.
+			name: "reject: a body import inside a tag that has an (empty) src",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", "<script src=\"\">import './src/civitai-host.js';</script>\n<script src=\"./app.js\"></script>"},
+				{"app.js", "// app"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
+			// 🟢 The scheme class must accept a SINGLE-letter and an UPPERCASE
+			// scheme, or an off-project URL resolves as a project file.
+			name: "reject: a single-letter scheme is still a URL",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="c:/elsewhere/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "not a path in this project",
+		},
+		{
+			name: "reject: an uppercase scheme is still a URL",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="HTTPS://cdn.example.com/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "not a path in this project",
+		},
+		{
+			// 🔴 The scheme regex is ANCHORED, and THE ANCHOR is what is
+			// load-bearing here: an unanchored pattern matches a `https:`
+			// sitting in a QUERY STRING and throws away a perfectly ordinary
+			// local reference. Dropping the `^` survived the previous sweep.
+			// (An earlier comment credited the ORDER of the scheme check and
+			// the `?`/`#` strip. It does not: two independent sweeps swapped
+			// them and nothing failed, because a scheme-qualified specifier
+			// stays scheme-qualified once its query is removed.)
 			name: "accept: a local src whose query string contains a URL",
 			ack:  "civitai-host.js",
 			files: []gfile{
@@ -496,6 +580,42 @@ func TestEntryGraphCompleteness(t *testing.T) {
 			wantGap:      "stopped at import depth 2",
 		},
 		{
+			// 🔴 A DIAMOND AT THE BOUND IS NOT TRUNCATION, AND CALLING IT ONE
+			// SILENCED THE DEFECT THIS CHECK EXISTS FOR. The deepest module
+			// re-imports a file the walk ALREADY READ, so nothing is unseen —
+			// but the first version gapped anyway, with a message that was
+			// literally false about a file sitting in g.Files, and dropped the
+			// project to the presence tier. Measured end-to-end: an orphaned
+			// emitter went from `unwired`/rc=1 to SILENT/rc=0. A diamond is the
+			// normal shape of any real module graph, so this is not an edge
+			// case. A gap that over-fires is the false pass wearing a hat.
+			name: "a diamond at the depth bound is not truncation",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './shared.js';\nimport './b.js';"},
+				{"b.js", "import './shared.js';"},
+				{"shared.js", "export const s = 1;"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "a.js", "shared.js", "b.js"},
+		},
+		{
+			// The same rule for a self-cycle: `b.js` importing itself at the
+			// bound leaves nothing unseen either.
+			name: "a self-cycle at the depth bound is not truncation",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';"},
+				{"b.js", "import './b.js';"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "a.js", "b.js"},
+		},
+		{
 			// The counterpart: a leaf at the bound that imports only a declared
 			// PACKAGE has nothing left to see, so it is NOT a gap. Without this
 			// the rule above degenerates into "any project as deep as the bound
@@ -686,14 +806,19 @@ func TestEntryGraphInspectSeesEveryFile(t *testing.T) {
 	}
 }
 
-// TestEntryGraphRetainsNoContents pins the memory contract STRUCTURALLY.
+// TestEntryGraphRetainsNoContents pins ONE HALF of the memory contract.
 //
-// 🔴 The first version stored every graph file's stripped contents on EntryFile
-// and peaked 410 MB RSS on a 200-module graph entirely INSIDE the file-count and
-// size budgets — against ~17 MB before the graph existed, and past the 316 MB
-// event those budgets were sized against in the first place. A benchmark would
-// drift; this asserts the type itself cannot hold contents, which is the
-// property that made the regression possible.
+// It asserts no graph field holds a file's contents — the property whose absence
+// let a 200-module graph inside both budgets peak 421-439 MB.
+//
+// 🔴 WHAT IT CANNOT SEE, STATED BECAUSE IT WAS ONCE CITED AS IF IT COULD: the
+// ALIASING half. A Go substring shares its parent's backing array, so an
+// un-cloned import specifier pins its whole file (measured: 558-628 MB with
+// `Code` already gone). `strings.Contains` below reads the LOGICAL string, so it
+// passes identically at 558 MB and at 33 MB. Only `strings.Clone` in the walk
+// prevents that, and only a live RSS measurement on a fixture whose modules are
+// large AND carry imports can observe it — see the table in
+// EntryGraphOptions.Inspect. Do not read a green here as "memory is fine".
 func TestEntryGraphRetainsNoContents(t *testing.T) {
 	dir := writeTree(t, []gfile{
 		{"index.html", `<script src="./app.js"></script>`},
@@ -710,6 +835,49 @@ func TestEntryGraphRetainsNoContents(t *testing.T) {
 					"bytes at a time, like the tree scan", f.Rel, field)
 			}
 		}
+	}
+}
+
+// TestEntryGraphRootContainment pins BOTH arms of the containment check.
+//
+// 🟢 Dropping only the `rel == ".."` arm admits a file OUTSIDE the project with
+// `Complete` still true — the project's own emitter would then be "satisfied" by
+// a same-named file in a sibling checkout. It is reachable through directory-
+// index resolution: `import '..'` resolves to the parent DIRECTORY, and the
+// module resolver will happily take `<parent>/index.js`.
+func TestEntryGraphRootContainment(t *testing.T) {
+	base := t.TempDir()
+	// A file that exists OUTSIDE the project root, reachable only by escaping it.
+	if err := os.WriteFile(filepath.Join(base, "index.js"), []byte("// outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(base, "proj")
+	for _, f := range []gfile{
+		{"index.html", `<script type="module" src="/src/main.js"></script>`},
+		{"src/main.js", "import '../..';"},
+	} {
+		p := filepath.Join(root, filepath.FromSlash(f.path))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(f.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Positive control: the escape target really is resolvable, so a green below
+	// cannot mean "there was nothing to admit".
+	if _, err := os.Stat(filepath.Join(base, "index.js")); err != nil {
+		t.Fatalf("fixture missing its off-project target: %v", err)
+	}
+	g := ResolveEntryGraph(root, EntryGraphOptions{})
+	for _, f := range g.Files {
+		if !strings.HasPrefix(f.Path, root) {
+			t.Fatalf("the graph admitted %s, which is OUTSIDE the project root %s — a same-named file in a "+
+				"sibling checkout would satisfy this project's wiring check", f.Path, root)
+		}
+	}
+	if g.Complete {
+		t.Fatal("a reference escaping the project root must be a GAP: we stopped modelling there")
 	}
 }
 

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -312,6 +312,47 @@ func TestReadyAckWiringPredicate(t *testing.T) {
 			wantErr: "no <script src> in index.html resolves to it",
 		},
 		{
+			// 🟡 F2: `</script >` — trailing whitespace before the `>` — is a
+			// valid close tag and a browser accepts it. This commit changed the
+			// close pattern to `</script\s*>` and shipped it unpinned; without
+			// the `\s*` the block never matches, so the inline module's imports
+			// are never read and a correctly wired project is rejected.
+			name: "accept: an inline module closed by `</script >`",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", "<script type=\"module\">import './civitai-host.js';</script >"},
+			},
+			wantAccept: true,
+		},
+		{
+			// 🟡 F2, the other direction: `</scriptx>` closes NOTHING — a browser
+			// keeps parsing the script until a real `</script>`, so code AFTER
+			// the bogus tag still executes. Widening the close pattern to
+			// `</script[^>]*>` ends the block early and loses exactly that code.
+			// (My first draft of this case asserted the opposite and was simply
+			// wrong about HTML: it is an ACCEPT, and the accept is what
+			// discriminates the widening.)
+			name: "accept: an inline module continues past a bogus `</scriptx>`",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", "<script type=\"module\">var x = 1;</scriptx>\nimport './civitai-host.js';</script>"},
+			},
+			wantAccept: true,
+		},
+		{
+			// 🟡 F2: the TAG boundary again, this time for the inline path. A
+			// `<script-loader>` custom element's body is never executed, so an
+			// import inside it is not a load. Reverting the tag boundary makes
+			// this element an inline script and accepts it.
+			name: "reject: an import inside a <script-loader> body is not a load",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", "<script-loader>import './civitai-host.js';</script-loader>\n<script src=\"./app.js\"></script>"},
+				{"app.js", "// app"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
 			// 🟢 `srcAttrValue` reports an EMPTY src as PRESENT, which makes the
 			// tag EXTERNAL rather than inline. A browser ignores the body of an
 			// element that has a `src` attribute, so the import below must NOT
@@ -614,6 +655,88 @@ func TestEntryGraphCompleteness(t *testing.T) {
 			opts:         &EntryGraphOptions{MaxDepth: 2},
 			wantComplete: true,
 			wantFiles:    []string{"index.html", "a.js", "b.js"},
+		},
+		{
+			// 🔴 F1: THE ANSWER MUST NOT DEPEND ON THE TEXTUAL ORDER OF TWO
+			// IMPORT STATEMENTS. `g.Files` records files that have been POPPED,
+			// so a target already ENQUEUED is absent from it — and evaluating
+			// truncation mid-walk therefore gapped, or did not, according to
+			// which of two same-depth imports was written first. Measured
+			// end-to-end on real scaffolds, flat and nested: in the losing order
+			// an orphaned emitter shipped SILENTLY. The check is now deferred to
+			// the end of the walk. These two cases are the SAME GRAPH with the
+			// two imports swapped, and they must agree.
+			name: "the bound is order-independent (import A then B)",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';\nimport './sib.js';"},
+				{"b.js", "import './sib.js';"},
+				{"sib.js", "export const s = 1;"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "a.js", "b.js", "sib.js"},
+		},
+		{
+			name: "the bound is order-independent (import B then A)",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './sib.js';\nimport './b.js';"},
+				{"b.js", "import './sib.js';"},
+				{"sib.js", "export const s = 1;"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "a.js", "sib.js", "b.js"},
+		},
+		{
+			// 🟡 F3: truncatedBelow resolves against the IMPORTING MODULE's
+			// directory, not the project root. Every other fixture here is
+			// root-flat, where the two coincide — so only a NESTED one can tell
+			// them apart. Resolving against the root would look for
+			// `<root>/sib.js`, miss the file, and gap at a complete graph.
+			name: "the bound resolves against the importing module's directory",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/deep/a.js"></script>`},
+				{"src/deep/a.js", "import './b.js';\nimport './sib.js';"},
+				{"src/deep/b.js", "import './sib.js';"},
+				{"src/deep/sib.js", "export const s = 1;"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "src/deep/a.js", "src/deep/b.js", "src/deep/sib.js"},
+		},
+		{
+			// 🟡 F3: the refUnresolved arm. A bundler alias at the bound is
+			// something we genuinely cannot follow, so it MUST gap — otherwise
+			// the strong tier fires on a graph with a hole in it.
+			name: "a bundler alias at the depth bound is a gap",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';"},
+				{"b.js", "import '@/civitai-host.js';"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: false,
+			wantGap:      "stopped at import depth 2",
+		},
+		{
+			// 🟡 F3: the resolveRefPath-error arm. A dangling import at the
+			// bound is the same model disagreement the normal path gaps on.
+			name: "a dangling import at the depth bound is a gap",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';"},
+				{"b.js", "import './nope.js';"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: false,
+			wantGap:      "stopped at import depth 2",
 		},
 		{
 			// The counterpart: a leaf at the bound that imports only a declared

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -188,6 +188,118 @@ func TestReadyAckWiringPredicate(t *testing.T) {
 			wantAccept: true,
 		},
 		{
+			// 🔴 THE HEADLINE DEFECT'S SECOND LIFE. `<script src="app.js">` — no
+			// `./` — is entirely ordinary HTML and names the same file. Running
+			// it through MODULE rules made it a "bare specifier", so it resolved
+			// to nothing, the graph went incomplete, and validate fell to the
+			// presence tier: the shipped false pass, intact, one character away.
+			// Measured before the fix.
+			name: "accept: a document-relative src with no leading ./",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="civitai-host.js"></script><script src="app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			// 🔴 UNQUOTED ATTRIBUTE VALUES ARE LEGAL HTML. The src regex required
+			// quotes, so the tag was dropped, then re-classified as an INLINE
+			// script with an empty body — the reference vanished with `Complete`
+			// still true, and a correct `static` scaffold got the strong tier's
+			// warning plus --strict rc=1. A false warning at a correct project.
+			name: "accept: an unquoted src attribute",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src=./civitai-host.js></script><script src=app.js></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "accept: a single-quoted src attribute",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src='./civitai-host.js'></script>`},
+			},
+			wantAccept: true,
+		},
+		{
+			// 🔴 A URL IS FETCHED LITERALLY. Extension guessing belongs to a
+			// bundler resolving a MODULE specifier, never to an HTML src: on the
+			// no-build `static` template the browser asks for `/civitai-host`
+			// and gets a 404. This was REJECTED at e800129 and accepted by the
+			// first version of this resolver — the exact "ships a 404" shape
+			// wiring.go claims to reject.
+			name: "reject: an extensionless src is a 404, not an extension to guess",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="./civitai-host"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
+			// The counterpart: extension resolution IS correct for a module
+			// specifier, because a bundler does exactly that. Without this pair
+			// "no guessing" and "guess everywhere" are indistinguishable.
+			name: "accept: an extensionless MODULE import still resolves",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host';"},
+			},
+			wantAccept: true,
+		},
+		{
+			// A scheme-qualified src is a URL even without `//`. Under URL rules
+			// the default branch is document-relative, so without the scheme
+			// check `foo:bar` would resolve to a path inside the project.
+			name: "reject: a scheme-qualified src is a URL, not a relative path",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="data:text/javascript,0"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "not a path in this project",
+		},
+		{
+			// 🔴 The scheme regex is ANCHORED, and the anchor is load-bearing:
+			// the scheme check runs BEFORE the `?`/`#` strip, so an unanchored
+			// pattern matches a `https:` sitting in a QUERY STRING and throws
+			// away a perfectly ordinary local reference. Dropping the `^`
+			// survived the previous sweep. A cache-busting or proxy query with a
+			// URL in it is ordinary.
+			name: "accept: a local src whose query string contains a URL",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="./civitai-host.js?from=https://cdn.example.com"></script>`},
+			},
+			wantAccept: true,
+		},
+		{
+			// The `../` arm of the module resolver, which nothing pinned: an
+			// emitter one directory ABOVE the importing module is still inside
+			// the project and must resolve.
+			name: "accept: the entry module imports the emitter from a parent directory",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import '../civitai-host.js';"},
+			},
+			wantAccept: true,
+		},
+		{
+			// Dynamic import with a literal specifier is a real load.
+			name: "accept: a dynamic import() with a literal specifier",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "if (x) { import('./civitai-host.js'); }"},
+			},
+			wantAccept: true,
+		},
+		{
 			// NEW: pins readyAckWiringDepth. Found by a SURVIVING mutant —
 			// widening Guard A's bound from 2 to 99 passed the entire suite, so
 			// nothing was holding the "one level of imports" contract at all. A
@@ -262,6 +374,7 @@ func TestEntryGraphCompleteness(t *testing.T) {
 		name         string
 		files        []gfile
 		deps         map[string]bool
+		opts         *EntryGraphOptions
 		wantComplete bool
 		wantFiles    []string // Rel paths that must be in the graph
 		wantGap      string   // substring of the reason, when incomplete
@@ -339,6 +452,82 @@ func TestEntryGraphCompleteness(t *testing.T) {
 			wantGap:      "could not resolve",
 		},
 		{
+			// 🔴 A dependency name is matched at a PATH SEPARATOR, never at a
+			// character offset. `reactive-ui` starts with `react` and is a
+			// different package; accepting it would classify a real project file
+			// as a dependency, turning a gap into a confident wrong finding. The
+			// audit's finer-grained prefix mutant survived the old corpus.
+			name: "a bare specifier that merely starts like a dependency is still a gap",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import 'reactive-ui';"},
+			},
+			deps:         deps,
+			wantComplete: false,
+			wantGap:      "bundler alias",
+		},
+		{
+			// The positive control for the boundary: a real SUBPATH of a
+			// declared dependency is accounted for.
+			name: "a subpath of a declared dependency is accounted for",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import 'react-dom/client';\nimport '@civitai/blocks-react/dist/x.js';"},
+			},
+			deps:         deps,
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "src/main.jsx"},
+		},
+		{
+			// 🔴 TRUNCATION IS A GAP. Before this, `continue`-ing at MaxDepth
+			// left Complete TRUE, so a CORRECT project whose ack sat below the
+			// bound got the strong tier's warning and --strict rc=1 — a finding
+			// built on a graph we had stopped walking. Measured at depth 10.
+			name: "an import below MaxDepth is a gap, not an absence",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';"},
+				{"b.js", "import './c.js';"},
+				{"c.js", "// end"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: false,
+			wantGap:      "stopped at import depth 2",
+		},
+		{
+			// The counterpart: a leaf at the bound that imports only a declared
+			// PACKAGE has nothing left to see, so it is NOT a gap. Without this
+			// the rule above degenerates into "any project as deep as the bound
+			// is unobservable".
+			name: "a package import at the depth bound is not truncated content",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/a.js"></script>`},
+				{"a.js", "import './b.js';"},
+				{"b.js", "import 'react';"},
+			},
+			deps:         deps,
+			opts:         &EntryGraphOptions{MaxDepth: 2},
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "a.js", "b.js"},
+		},
+		{
+			// 🔴 `entryModuleExts` decides what can PULL files into the graph. A
+			// browser never follows imports out of a stylesheet, so widening this
+			// set would let a `.css` add reachable files — and silence the check
+			// on the strength of something that is never executed.
+			name: "a stylesheet's imports are not followed",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.js"></script>`},
+				{"src/main.js", "import './theme.css';"},
+				{"src/theme.css", "/* x */ import './civitai-host.js';"},
+				{"src/civitai-host.js", "// emitter"},
+			},
+			deps:         deps,
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "src/main.js", "src/theme.css"},
+		},
+		{
 			// An index.html with nothing to load is a COMPLETE graph of one file.
 			// It is the shape a `validate` finding is allowed to rest on, so it
 			// must not be confused with "we could not look".
@@ -352,7 +541,12 @@ func TestEntryGraphCompleteness(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := ResolveEntryGraph(writeTree(t, c.files), EntryGraphOptions{Dependencies: c.deps})
+			o := EntryGraphOptions{}
+			if c.opts != nil {
+				o = *c.opts
+			}
+			o.Dependencies = c.deps
+			g := ResolveEntryGraph(writeTree(t, c.files), o)
 			if g.Complete != c.wantComplete {
 				t.Fatalf("Complete = %v, want %v (gaps: %v)\ntrace:\n  %s",
 					g.Complete, c.wantComplete, g.Gaps, strings.Join(g.Trace, "\n  "))
@@ -436,23 +630,86 @@ func TestEntryGraphBudgetsAreGaps(t *testing.T) {
 	})
 }
 
-// TestEntryGraphCommentsAreStripped pins that the graph's Code carries no
-// comments — the check built on it asks whether a file MENTIONS a token, and a
-// comment naming it is not an implementation of it.
+// inspectAll collects every file the walk read, keyed by Rel, using the same
+// Inspect callback production uses. There is no retained `Code` field to read —
+// see TestEntryGraphRetainsNoContents.
+func inspectAll(t *testing.T, dir string, opts EntryGraphOptions) (*EntryGraph, map[string]string) {
+	t.Helper()
+	seen := map[string]string{}
+	opts.Inspect = func(f EntryFile, code string) { seen[f.Rel] = code }
+	return ResolveEntryGraph(dir, opts), seen
+}
+
+// TestEntryGraphCommentsAreStripped pins that the code handed to Inspect carries
+// no comments — the check built on it asks whether a file MENTIONS a token, and
+// a comment naming it is not an implementation of it.
 func TestEntryGraphCommentsAreStripped(t *testing.T) {
 	dir := writeTree(t, []gfile{
 		{"index.html", "<!-- BLOCK_READY lives in app.js -->\n<script src=\"./app.js\"></script>"},
 		{"app.js", "// TODO: post BLOCK_READY\nvar marker = 'KEPT_IN_A_STRING';\n"},
 	})
-	g := ResolveEntryGraph(dir, EntryGraphOptions{})
-	for _, f := range g.Files {
-		if strings.Contains(f.Code, "BLOCK_READY") {
-			t.Fatalf("%s kept a commented-out mention: %q", f.Rel, f.Code)
+	_, code := inspectAll(t, dir, EntryGraphOptions{})
+	for rel, c := range code {
+		if strings.Contains(c, "BLOCK_READY") {
+			t.Fatalf("%s kept a commented-out mention: %q", rel, c)
 		}
 	}
-	i := g.FileAt(filepath.Join(dir, "app.js"))
-	if i < 0 || !strings.Contains(g.Files[i].Code, "KEPT_IN_A_STRING") {
+	if !strings.Contains(code["app.js"], "KEPT_IN_A_STRING") {
 		t.Fatal("the strip ate code outside a comment — string literals must survive")
+	}
+}
+
+// TestEntryGraphInspectSeesEveryFile is Inspect's POSITIVE CONTROL. Every
+// assertion built on Inspect reports a NEGATIVE ("no file mentions the token"),
+// and a zero from a callback wired to nothing is indistinguishable from a zero
+// that means something. This asserts the callback fires once per graph file, in
+// a shape where the count must be non-zero.
+func TestEntryGraphInspectSeesEveryFile(t *testing.T) {
+	dir := writeTree(t, []gfile{
+		{"index.html", `<script type="module" src="/src/main.js"></script>`},
+		{"src/main.js", "import './a.js';\nimport './style.css';"},
+		{"src/a.js", "var a = 1;"},
+		{"src/style.css", "body{}"},
+	})
+	g, code := inspectAll(t, dir, EntryGraphOptions{})
+	if !g.Complete {
+		t.Fatalf("fixture should resolve completely: %v", g.Gaps)
+	}
+	want := []string{"index.html", "src/main.js", "src/a.js", "src/style.css"}
+	if len(code) != len(want) {
+		t.Fatalf("Inspect fired for %v, want exactly %v", graphRels(g), want)
+	}
+	for _, rel := range want {
+		if _, ok := code[rel]; !ok {
+			t.Fatalf("Inspect never saw %s — a callback that misses files reports a silent false negative", rel)
+		}
+	}
+}
+
+// TestEntryGraphRetainsNoContents pins the memory contract STRUCTURALLY.
+//
+// 🔴 The first version stored every graph file's stripped contents on EntryFile
+// and peaked 410 MB RSS on a 200-module graph entirely INSIDE the file-count and
+// size budgets — against ~17 MB before the graph existed, and past the 316 MB
+// event those budgets were sized against in the first place. A benchmark would
+// drift; this asserts the type itself cannot hold contents, which is the
+// property that made the regression possible.
+func TestEntryGraphRetainsNoContents(t *testing.T) {
+	dir := writeTree(t, []gfile{
+		{"index.html", `<script src="./app.js"></script>`},
+		{"app.js", "var UNIQUE_TOKEN_NOT_IN_ANY_FIELD = 1;"},
+	})
+	g, code := inspectAll(t, dir, EntryGraphOptions{})
+	if !strings.Contains(code["app.js"], "UNIQUE_TOKEN_NOT_IN_ANY_FIELD") {
+		t.Fatal("positive control failed: Inspect did not receive the file's contents")
+	}
+	for _, f := range g.Files {
+		for _, field := range []string{f.Path, f.Rel, f.Spec} {
+			if strings.Contains(field, "UNIQUE_TOKEN_NOT_IN_ANY_FIELD") {
+				t.Fatalf("%s retains file CONTENTS in a graph field (%q) — the graph must hold one file's "+
+					"bytes at a time, like the tree scan", f.Rel, field)
+			}
+		}
 	}
 }
 

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -188,6 +188,24 @@ func TestReadyAckWiringPredicate(t *testing.T) {
 			wantAccept: true,
 		},
 		{
+			// NEW: pins readyAckWiringDepth. Found by a SURVIVING mutant —
+			// widening Guard A's bound from 2 to 99 passed the entire suite, so
+			// nothing was holding the "one level of imports" contract at all. A
+			// TEMPLATE's emitter is meant to be loaded by the entry itself;
+			// burying it behind a helper module is a template smell, and this is
+			// the only case that can tell the two bounds apart. (`validate` uses
+			// the deeper default for an author's project — see
+			// TestEntryGraphBudgetsAreGaps for that bound.)
+			name: "reject: the emitter is two import levels below the entry",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './helper.js';"},
+				{"src/helper.js", "import './civitai-host.js';"},
+			},
+			wantErr: "no <script src> in index.html resolves to it",
+		},
+		{
 			// NEW: pins the ROOT CONTAINMENT guard. Without it the `..` climbs out
 			// of the project and — if a same-named file happens to sit beside it —
 			// a sibling checkout's emitter would satisfy this project's wiring.

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -1,0 +1,456 @@
+package blockproto
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type gfile struct{ path, body string }
+
+func writeTree(t *testing.T, files []gfile) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range files {
+		p := filepath.Join(dir, filepath.FromSlash(f.path))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(f.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// ---------------------------------------------------------------------------
+// The wiring predicate's control pair. MOVED here from
+// internal/scaffold/ready_ack_contract_test.go along with the predicate itself:
+// `internal/validate` needs the same resolution for an author's project, and a
+// predicate open-coded at two sites is wrong at one of them.
+//
+// It exists because the first version of this check matched a BASENAME, which
+// accepted every "wrong directory" shape. Each reject case below is a shape that
+// check accepted while shipping a broken app; the accept cases are the two real
+// templates' shapes. Ask of any future edit: can it pass while the emitter is
+// somewhere the browser will not find it?
+// ---------------------------------------------------------------------------
+
+func TestReadyAckWiringPredicate(t *testing.T) {
+	const ackRel = "src/civitai-host.js"
+
+	cases := []struct {
+		name       string
+		ack        string // where the emitter really is
+		files      []gfile
+		wantAccept bool
+		// wantErr, when set, must appear in the rejection message. It pins WHICH
+		// branch rejected — without it a case can be green because some other
+		// check happened to reject first.
+		wantErr string
+	}{
+		{
+			name: "accept: index.html loads it directly (the static shape)",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="./civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "accept: the entry module imports it (the page-vite shape)",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host.js';\nimport React from 'react';"},
+			},
+			wantAccept: true,
+		},
+		{
+			// NEW: an inline module in index.html executes exactly like an
+			// external one. Without reading inline blocks the graph would report
+			// itself COMPLETE while missing the emitter, which is a false finding
+			// at a correct project.
+			name: "accept: an inline module in index.html imports it",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", "<script type=\"module\">\nimport './civitai-host.js';\n</script>"},
+			},
+			wantAccept: true,
+		},
+		{
+			// NEW: extensionless specifiers are what a bundler resolves. Pins the
+			// extension-candidate branch.
+			name: "accept: an extensionless import resolves to the emitter",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host';"},
+			},
+			wantAccept: true,
+		},
+		{
+			name: "reject: right basename, wrong directory in the script tag",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="./vendor/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+		},
+		{
+			name: "reject: right basename, unresolvable relative import",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import '../nonexistent/civitai-host.js';"},
+			},
+		},
+		{
+			name: "reject: a BARE specifier that would resolve to a package",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import 'civitai-host.js';"},
+			},
+		},
+		{
+			name: "reject: referenced only from an HTML comment",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", "<!-- <script src=\"./civitai-host.js\"></script> -->\n<script src=\"./app.js\"></script>"},
+				{"app.js", "// app"},
+			},
+		},
+		{
+			name: "reject: the import is commented out but still greppable",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "// import './civitai-host.js';\nimport React from 'react';"},
+			},
+		},
+		{
+			name: "reject: imported by a file nothing loads",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import React from 'react';"},
+				{"src/orphan.js", "import './civitai-host.js';"},
+			},
+		},
+		{
+			// Pins the ErrNoScriptTags EARLY RETURN specifically. Without the
+			// wantErr the case passes either way — the fallthrough at the end
+			// also returns an error — so deleting that early return would go
+			// unnoticed.
+			name:    "reject: no script tags at all",
+			ack:     "civitai-host.js",
+			files:   []gfile{{"index.html", "<h1>hi</h1>"}},
+			wantErr: "no <script src> at all",
+		},
+		{
+			// Rejected by the FALLTHROUGH (an absolute URL is not a relative or
+			// root-relative path and names no declared dependency), not by a
+			// URL-specific guard — stated so the case doesn't look like it
+			// exercises one.
+			name: "reject: loaded from a CDN URL that merely ends in the name",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="https://cdn.example.com/civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "not a path in this project",
+		},
+		{
+			// 🔴 Pins the `//` half of the URL guard, which IS load-bearing:
+			// without it the leading slash is stripped, filepath.Join cleans the
+			// `..`, and this resolves to EXACTLY the emitter's path — an
+			// off-project URL would be accepted as the emitter.
+			name: "reject: protocol-relative URL that cleans back to the emitter path",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script src="//evil.example.com/../civitai-host.js"></script><script src="./app.js"></script>`},
+				{"app.js", "// app"},
+			},
+			wantErr: "not a path in this project",
+		},
+		{
+			// Pins the `?`/`#` suffix stripping: Vite's `?url` / `?raw` suffixes
+			// are not part of the path, and the emitter is still the emitter.
+			name: "accept: entry module imports it with a Vite ?url suffix",
+			ack:  ackRel,
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host.js?url';"},
+			},
+			wantAccept: true,
+		},
+		{
+			// NEW: pins the ROOT CONTAINMENT guard. Without it the `..` climbs out
+			// of the project and — if a same-named file happens to sit beside it —
+			// a sibling checkout's emitter would satisfy this project's wiring.
+			name: "reject: an import that escapes the project root",
+			ack:  "civitai-host.js",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import '../../civitai-host.js';"},
+			},
+			wantErr: "not a path in this project",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// The emitter itself always exists where `ack` says — so a rejection
+			// can only come from the REFERENCE, never from a missing file.
+			dir := writeTree(t, append([]gfile{{c.ack, "// emitter"}}, c.files...))
+			chain, err := ReadyAckWiring(dir, c.ack)
+			if c.wantAccept {
+				if err != nil {
+					t.Fatalf("wiring check REJECTED a correctly wired project: %v", err)
+				}
+				t.Logf("accepted: %s", chain)
+				return
+			}
+			if err == nil {
+				t.Fatalf("wiring check ACCEPTED a project the browser cannot load the emitter in: %q\n"+
+					"this is the basename-matching class — the reference must RESOLVE to the emitter's real path", chain)
+			}
+			if c.wantErr != "" && !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("rejected for the wrong reason — want an error mentioning %q, got:\n%v\n"+
+					"a rejection from a different branch would leave the one this case exists to pin untested",
+					c.wantErr, err)
+			}
+			t.Logf("rejected: %v", err)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Completeness — the half `internal/validate` branches on.
+//
+// 🔴 These are the cases where the graph must admit it did not see everything.
+// A caller reads `Complete == false` as "this says nothing", so a bug that
+// reports a partial graph as complete converts every one of these into a
+// confident false warning at a correct project.
+// ---------------------------------------------------------------------------
+
+func TestEntryGraphCompleteness(t *testing.T) {
+	deps := map[string]bool{"react": true, "react-dom": true, "@civitai/blocks-react": true}
+
+	cases := []struct {
+		name         string
+		files        []gfile
+		deps         map[string]bool
+		wantComplete bool
+		wantFiles    []string // Rel paths that must be in the graph
+		wantGap      string   // substring of the reason, when incomplete
+	}{
+		{
+			name: "the page-vite shape resolves completely",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import './civitai-host.js';\nimport React from 'react';\n" +
+					"import { createRoot } from 'react-dom/client';\nimport App from './App.jsx';\nimport './index.css';"},
+				{"src/civitai-host.js", "// emitter"},
+				{"src/App.jsx", "import React from 'react';"},
+				{"src/index.css", "body{}"},
+			},
+			deps:         deps,
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "src/main.jsx", "src/civitai-host.js", "src/App.jsx", "src/index.css"},
+		},
+		{
+			// 🔴 THE ALIAS CASE. A bare specifier that is not a declared
+			// dependency is a real file behind a bundler alias we cannot follow.
+			// Reporting this graph complete would warn at a correct project.
+			name: "a bundler alias makes the graph incomplete",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import '@/civitai-host.js';"},
+				{"src/civitai-host.js", "// emitter"},
+			},
+			deps:         deps,
+			wantComplete: false,
+			wantGap:      "bundler alias",
+		},
+		{
+			// The positive control for the case above: the SAME shape with the
+			// specifier declared as a dependency is accounted for, so "a bare
+			// specifier is a gap" cannot be satisfied by a resolver that treats
+			// every bare specifier as one.
+			name: "a declared dependency is accounted for, not a gap",
+			files: []gfile{
+				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
+				{"src/main.jsx", "import 'react';\nimport 'react-dom/client';\nimport '@civitai/blocks-react';"},
+			},
+			deps:         deps,
+			wantComplete: true,
+			wantFiles:    []string{"index.html", "src/main.jsx"},
+		},
+		{
+			name: "no index.html at the project root is a gap, not an empty answer",
+			files: []gfile{
+				{"src/main.jsx", "import './civitai-host.js';"},
+			},
+			deps:         deps,
+			wantComplete: false,
+			wantGap:      "index.html",
+		},
+		{
+			// A reference that points at nothing means the resolver's model
+			// disagrees with a project that presumably builds. That is a gap, not
+			// evidence the browser 404s it.
+			name: "a reference to a file that is not there is a gap",
+			files: []gfile{
+				{"index.html", `<script src="./civitai-host.js"></script>`},
+			},
+			deps:         deps,
+			wantComplete: false,
+			wantGap:      "does not exist",
+		},
+		{
+			name: "an off-project URL is a gap",
+			files: []gfile{
+				{"index.html", `<script src="https://cdn.example.com/host.js"></script>`},
+			},
+			deps:         deps,
+			wantComplete: false,
+			wantGap:      "could not resolve",
+		},
+		{
+			// An index.html with nothing to load is a COMPLETE graph of one file.
+			// It is the shape a `validate` finding is allowed to rest on, so it
+			// must not be confused with "we could not look".
+			name:         "an index.html that loads nothing is complete",
+			files:        []gfile{{"index.html", "<h1>hi</h1>"}},
+			deps:         deps,
+			wantComplete: true,
+			wantFiles:    []string{"index.html"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			g := ResolveEntryGraph(writeTree(t, c.files), EntryGraphOptions{Dependencies: c.deps})
+			if g.Complete != c.wantComplete {
+				t.Fatalf("Complete = %v, want %v (gaps: %v)\ntrace:\n  %s",
+					g.Complete, c.wantComplete, g.Gaps, strings.Join(g.Trace, "\n  "))
+			}
+			if !c.wantComplete && !strings.Contains(strings.Join(g.Gaps, "\n"), c.wantGap) {
+				t.Fatalf("gap reason does not mention %q — got %v\n"+
+					"a gap recorded by a different branch leaves the one this case pins untested", c.wantGap, g.Gaps)
+			}
+			for _, want := range c.wantFiles {
+				if !graphHasRel(g, want) {
+					t.Fatalf("graph is missing %q; it has %v", want, graphRels(g))
+				}
+			}
+			if c.wantFiles != nil && len(g.Files) != len(c.wantFiles) {
+				t.Fatalf("graph has %v, want exactly %v — an EXTRA file is as wrong as a missing one: "+
+					"it means the walk reached something the browser does not load", graphRels(g), c.wantFiles)
+			}
+		})
+	}
+}
+
+// TestEntryGraphBudgetsAreGaps pins that exhausting a budget is UNOBSERVABLE
+// rather than "nothing more is there". Both are silent-by-default outcomes for
+// callers, and reporting either as a complete graph manufactures a finding.
+func TestEntryGraphBudgetsAreGaps(t *testing.T) {
+	t.Run("a file over the size cap is a gap", func(t *testing.T) {
+		dir := writeTree(t, []gfile{
+			{"index.html", `<script src="./app.js"></script>`},
+			{"app.js", strings.Repeat("x", 4096)},
+		})
+		if g := ResolveEntryGraph(dir, EntryGraphOptions{}); !g.Complete {
+			t.Fatalf("positive control failed: a 4 KiB entry must resolve completely, gaps %v", g.Gaps)
+		}
+		// 64 bytes: index.html (32) still reads, app.js (4096) does not — so the
+		// gap is the ENTRY being unreadable, not the root.
+		g := ResolveEntryGraph(dir, EntryGraphOptions{MaxFileBytes: 64})
+		if g.Complete {
+			t.Fatal("a file the resolver refused to read was reported as a complete graph")
+		}
+		if !strings.Contains(strings.Join(g.Gaps, "\n"), "could not read") {
+			t.Fatalf("gaps do not name the unread file: %v", g.Gaps)
+		}
+	})
+
+	t.Run("the file budget is a gap", func(t *testing.T) {
+		files := []gfile{{"index.html", `<script type="module" src="/a0.js"></script>`}}
+		for i := 0; i < 5; i++ {
+			files = append(files, gfile{
+				path: "a" + string(rune('0'+i)) + ".js",
+				body: "import './a" + string(rune('0'+i+1)) + ".js';",
+			})
+		}
+		files = append(files, gfile{"a5.js", "// end"})
+		dir := writeTree(t, files)
+		if g := ResolveEntryGraph(dir, EntryGraphOptions{}); !g.Complete {
+			t.Fatalf("positive control failed: a 7-file chain must resolve completely, gaps %v", g.Gaps)
+		}
+		g := ResolveEntryGraph(dir, EntryGraphOptions{MaxFiles: 3})
+		if g.Complete {
+			t.Fatal("a walk that stopped at its file budget was reported as a complete graph")
+		}
+		if !strings.Contains(strings.Join(g.Gaps, "\n"), "stopped after") {
+			t.Fatalf("gaps do not name the budget: %v", g.Gaps)
+		}
+	})
+
+	t.Run("the depth bound is a gap only when there is more to see", func(t *testing.T) {
+		dir := writeTree(t, []gfile{
+			{"index.html", `<script type="module" src="/a.js"></script>`},
+			{"a.js", "import './b.js';"},
+			{"b.js", "import './c.js';"},
+			{"c.js", "// end"},
+		})
+		g := ResolveEntryGraph(dir, EntryGraphOptions{MaxDepth: 2})
+		if graphHasRel(g, "c.js") {
+			t.Fatal("MaxDepth=2 reached a depth-3 file — the bound does nothing")
+		}
+		if !graphHasRel(g, "b.js") {
+			t.Fatalf("MaxDepth=2 did not reach the depth-2 file; graph is %v", graphRels(g))
+		}
+	})
+}
+
+// TestEntryGraphCommentsAreStripped pins that the graph's Code carries no
+// comments — the check built on it asks whether a file MENTIONS a token, and a
+// comment naming it is not an implementation of it.
+func TestEntryGraphCommentsAreStripped(t *testing.T) {
+	dir := writeTree(t, []gfile{
+		{"index.html", "<!-- BLOCK_READY lives in app.js -->\n<script src=\"./app.js\"></script>"},
+		{"app.js", "// TODO: post BLOCK_READY\nvar marker = 'KEPT_IN_A_STRING';\n"},
+	})
+	g := ResolveEntryGraph(dir, EntryGraphOptions{})
+	for _, f := range g.Files {
+		if strings.Contains(f.Code, "BLOCK_READY") {
+			t.Fatalf("%s kept a commented-out mention: %q", f.Rel, f.Code)
+		}
+	}
+	i := g.FileAt(filepath.Join(dir, "app.js"))
+	if i < 0 || !strings.Contains(g.Files[i].Code, "KEPT_IN_A_STRING") {
+		t.Fatal("the strip ate code outside a comment — string literals must survive")
+	}
+}
+
+func graphRels(g *EntryGraph) []string {
+	out := make([]string, 0, len(g.Files))
+	for _, f := range g.Files {
+		out = append(out, f.Rel)
+	}
+	return out
+}
+
+func graphHasRel(g *EntryGraph, rel string) bool {
+	for _, f := range g.Files {
+		if f.Rel == rel {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/blockproto/wiring.go
+++ b/internal/blockproto/wiring.go
@@ -1,0 +1,64 @@
+package blockproto
+
+// wiring.go answers "is the vendored emitter at ackRel actually LOADED by this
+// project?" on top of the entry graph.
+//
+// 🔴 Every reference is RESOLVED to a path and compared with where the emitter
+// actually IS. It is deliberately NOT a basename match. A basename match is a
+// SPELLED check rather than a structural one, and it passes while the hazard
+// exists in a different shape — both of these were MEASURED surviving the
+// entire suite before the original (test-only) version of this was rewritten:
+//
+//	static/index.html    src="./vendor/civitai-host.js"          -> ships a 404
+//	page-vite/main.jsx   import '../nonexistent/civitai-host.js' -> build fails
+//
+// Both reproduce #206 with every check green.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readyAckWiringDepth keeps Guard A's original reach: index.html's `<script
+// src>` entries (depth 1) and the direct imports of those entries (depth 2).
+// One level of imports on purpose — a TEMPLATE's emitter is meant to be loaded
+// by the entry itself, and burying it behind a chain is a template smell.
+// `validate` walks an author's project and uses the deeper default instead,
+// because an author's module layout is not ours to police.
+const readyAckWiringDepth = 2
+
+// ReadyAckWiring returns a description of where the emitter at ackRel is loaded
+// from, or an error if nothing in the entry graph reaches it.
+//
+// It follows the same path a browser does — index.html's `<script>` tags, then
+// (for a module entry) that module's imports — rather than grepping the tree, so
+// an emitter referenced only from a README, a comment, or a file nothing loads
+// does not satisfy it.
+func ReadyAckWiring(dir, ackRel string) (string, error) {
+	want := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ackRel)))
+	if _, err := os.Stat(filepath.Join(dir, "index.html")); err != nil {
+		return "", err
+	}
+	g := ResolveEntryGraph(dir, EntryGraphOptions{MaxDepth: readyAckWiringDepth})
+	if i := g.FileAt(want); i >= 0 {
+		return g.Chain(i), nil
+	}
+	if g.ScriptRefs == 0 {
+		return "", ErrNoScriptTags
+	}
+	return "", readyAckWiringError(ErrNotReached.Error() + "\n  references resolved:\n    " +
+		strings.Join(g.Trace, "\n    "))
+}
+
+type readyAckWiringError string
+
+func (e readyAckWiringError) Error() string { return string(e) }
+
+// The two rejection reasons callers pin by name. A test that only asserts "an
+// error came back" is green whichever branch produced it, which is how an early
+// return gets deleted unnoticed.
+const (
+	ErrNoScriptTags = readyAckWiringError("the rendered index.html has no <script src> at all")
+	ErrNotReached   = readyAckWiringError("no <script src> in index.html resolves to it, and no import in an entry module resolves to it")
+)

--- a/internal/scaffold/ready_ack_contract_test.go
+++ b/internal/scaffold/ready_ack_contract_test.go
@@ -2,7 +2,6 @@ package scaffold
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -28,7 +27,10 @@ import (
 //   - that copy is REACHED from the template's real entry point — the rendered
 //     index.html loads it directly, or loads a module that imports it — checked
 //     after stripping comments, so a comment mentioning the filename does not
-//     satisfy it;
+//     satisfy it. The resolution itself lives in `blockproto.ReadyAckWiring`
+//     (see internal/blockproto/{entrygraph,wiring}.go) because
+//     `internal/validate` needs the same question answered for an AUTHOR's
+//     project; its control corpus moved there with it;
 //   - the canonical emitter still has the shape the host contract requires
 //     (window message listener, gated on BLOCK_INIT, `{type,payload}` envelope,
 //     addressed at `event.origin` and never `'*'`).
@@ -120,7 +122,7 @@ func ruleWhy(name string) string {
 // predicate that rejects everything, including the real emitter.
 func TestReadyAckShapePredicate(t *testing.T) {
 	t.Run("positive: the canonical emitter satisfies every rule", func(t *testing.T) {
-		bad := checkReadyAckShape(stripJSComments(string(blockproto.ReadyAckSource())))
+		bad := checkReadyAckShape(blockproto.StripJSComments(string(blockproto.ReadyAckSource())))
 		for _, name := range bad {
 			t.Errorf("blockproto's ready-ack emitter violates %q: %s", name, ruleWhy(name))
 		}
@@ -172,7 +174,7 @@ func TestReadyAckShapePredicate(t *testing.T) {
 
 	for _, c := range corpus {
 		t.Run("negative: "+c.name, func(t *testing.T) {
-			bad := checkReadyAckShape(stripJSComments(c.src))
+			bad := checkReadyAckShape(blockproto.StripJSComments(c.src))
 			if len(bad) == 0 {
 				t.Fatalf("the shape predicate ACCEPTED a snippet that does not implement the handshake:\n%s", c.src)
 			}
@@ -180,182 +182,6 @@ func TestReadyAckShapePredicate(t *testing.T) {
 				t.Fatalf("rejected for the wrong reason: got violations %v, expected %q among them — "+
 					"a green here would say nothing about %s", bad, c.wantRule, c.wantRule)
 			}
-		})
-	}
-}
-
-// TestReadyAckWiringPredicate is the wiring check's own control pair, built on
-// synthetic trees rather than the real templates so the REJECT cases can exist
-// at all.
-//
-// It exists because the first version of this check matched a BASENAME, which
-// accepted every "wrong directory" shape. Each reject case below is a shape
-// that check accepted while shipping a broken app; the accept cases are the two
-// real templates' shapes. Ask of any future edit: can it pass while the emitter
-// is somewhere the browser will not find it?
-func TestReadyAckWiringPredicate(t *testing.T) {
-	const ackRel = "src/civitai-host.js"
-
-	type file struct{ path, body string }
-	cases := []struct {
-		name       string
-		ack        string // where the emitter really is
-		files      []file
-		wantAccept bool
-		// wantErr, when set, must appear in the rejection message. It pins WHICH
-		// branch rejected — without it a case can be green because some other
-		// check happened to reject first.
-		wantErr string
-	}{
-		{
-			name: "accept: index.html loads it directly (the static shape)",
-			ack:  "civitai-host.js",
-			files: []file{
-				{"index.html", `<script src="./civitai-host.js"></script><script src="./app.js"></script>`},
-				{"app.js", "// app"},
-			},
-			wantAccept: true,
-		},
-		{
-			name: "accept: the entry module imports it (the page-vite shape)",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "import './civitai-host.js';\nimport React from 'react';"},
-			},
-			wantAccept: true,
-		},
-		{
-			name: "reject: right basename, wrong directory in the script tag",
-			ack:  "civitai-host.js",
-			files: []file{
-				{"index.html", `<script src="./vendor/civitai-host.js"></script><script src="./app.js"></script>`},
-				{"app.js", "// app"},
-			},
-		},
-		{
-			name: "reject: right basename, unresolvable relative import",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "import '../nonexistent/civitai-host.js';"},
-			},
-		},
-		{
-			name: "reject: a BARE specifier that would resolve to a package",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "import 'civitai-host.js';"},
-			},
-		},
-		{
-			name: "reject: referenced only from an HTML comment",
-			ack:  "civitai-host.js",
-			files: []file{
-				{"index.html", "<!-- <script src=\"./civitai-host.js\"></script> -->\n<script src=\"./app.js\"></script>"},
-				{"app.js", "// app"},
-			},
-		},
-		{
-			name: "reject: the import is commented out but still greppable",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "// import './civitai-host.js';\nimport React from 'react';"},
-			},
-		},
-		{
-			name: "reject: imported by a file nothing loads",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "import React from 'react';"},
-				{"src/orphan.js", "import './civitai-host.js';"},
-			},
-		},
-		{
-			// Pins the errNoScriptTags EARLY RETURN specifically. Without the
-			// wantErr the case passes either way — the fallthrough at the end
-			// also returns an error — so deleting that early return would go
-			// unnoticed.
-			name:    "reject: no script tags at all",
-			ack:     "civitai-host.js",
-			files:   []file{{"index.html", "<h1>hi</h1>"}},
-			wantErr: "no <script src> at all",
-		},
-		{
-			// Rejected by the FALLTHROUGH (an absolute URL fails the
-			// relative/root-relative switch), not by a URL-specific guard —
-			// stated so the case doesn't look like it exercises one.
-			name: "reject: loaded from a CDN URL that merely ends in the name",
-			ack:  "civitai-host.js",
-			files: []file{
-				{"index.html", `<script src="https://cdn.example.com/civitai-host.js"></script><script src="./app.js"></script>`},
-				{"app.js", "// app"},
-			},
-			wantErr: "not a path in this project",
-		},
-		{
-			// 🔴 Pins the `//` half of the URL guard, which IS load-bearing:
-			// without it the leading slash is stripped, filepath.Join cleans the
-			// `..`, and this resolves to EXACTLY the emitter's path — an
-			// off-project URL would be accepted as the emitter.
-			name: "reject: protocol-relative URL that cleans back to the emitter path",
-			ack:  "civitai-host.js",
-			files: []file{
-				{"index.html", `<script src="//evil.example.com/../civitai-host.js"></script><script src="./app.js"></script>`},
-				{"app.js", "// app"},
-			},
-			wantErr: "not a path in this project",
-		},
-		{
-			// Pins the `?`/`#` suffix stripping: Vite's `?url` / `?raw` suffixes
-			// are not part of the path, and the emitter is still the emitter.
-			name: "accept: entry module imports it with a Vite ?url suffix",
-			ack:  ackRel,
-			files: []file{
-				{"index.html", `<script type="module" src="/src/main.jsx"></script>`},
-				{"src/main.jsx", "import './civitai-host.js?url';"},
-			},
-			wantAccept: true,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			dir := t.TempDir()
-			// The emitter itself always exists where `ack` says — so a
-			// rejection can only come from the REFERENCE, never from a missing
-			// file.
-			all := append([]file{{c.ack, "// emitter"}}, c.files...)
-			for _, f := range all {
-				p := filepath.Join(dir, filepath.FromSlash(f.path))
-				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.WriteFile(p, []byte(f.body), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-			chain, err := readyAckWiring(dir, c.ack)
-			if c.wantAccept {
-				if err != nil {
-					t.Fatalf("wiring check REJECTED a correctly wired project: %v", err)
-				}
-				t.Logf("accepted: %s", chain)
-				return
-			}
-			if err == nil {
-				t.Fatalf("wiring check ACCEPTED a project the browser cannot load the emitter in: %q\n"+
-					"this is the basename-matching class — the reference must RESOLVE to the emitter's real path", chain)
-			}
-			if c.wantErr != "" && !strings.Contains(err.Error(), c.wantErr) {
-				t.Fatalf("rejected for the wrong reason — want an error mentioning %q, got:\n%v\n"+
-					"a rejection from a different branch would leave the one this case exists to pin untested",
-					c.wantErr, err)
-			}
-			t.Logf("rejected: %v", err)
 		})
 	}
 }
@@ -449,7 +275,7 @@ func TestScaffoldedPageTemplatesShipTheReadyAck(t *testing.T) {
 			// ASSERTION 2 — the copy is actually LOADED. Byte-equality of an
 			// orphan file proves nothing about the running app.
 			t.Run("reached from the rendered entry point", func(t *testing.T) {
-				chain, err := readyAckWiring(dest, rel)
+				chain, err := blockproto.ReadyAckWiring(dest, rel)
 				if err != nil {
 					t.Fatalf("%s ships %s but nothing loads it: %v\n"+
 						"Reference it from index.html (a <script src>) or from the entry module "+
@@ -573,208 +399,4 @@ func TestAckingPackagePredicate(t *testing.T) {
 				"This is the widening class (prefix/substring) the exact match exists to prevent.", name)
 		}
 	}
-}
-
-var (
-	reHTMLComment = regexp.MustCompile(`(?s)<!--.*?-->`)
-	reScriptSrc   = regexp.MustCompile(`(?is)<script\b[^>]*\bsrc\s*=\s*["']([^"']+)["']`)
-	// Captures the SPECIFIER of an import / re-export / require, so it can be
-	// resolved. Matching a basename inside the specifier is what let
-	// `import '../nonexistent/civitai-host.js'` through.
-	reJSImport = regexp.MustCompile(`(?:\bimport\s*\(?\s*|\bfrom\s+|\brequire\(\s*)['"]([^'"]+)['"]`)
-)
-
-// readyAckWiring walks the rendered entry chain and returns a description of
-// where the emitter is loaded from, or an error if nothing reaches it.
-//
-// It follows the same path a browser does — index.html's <script> tags, then
-// (for a module entry) that module's imports — rather than grepping the whole
-// tree, so an emitter referenced only from a README, a comment, or a file
-// nothing loads does not satisfy it.
-//
-// 🔴 Every reference is RESOLVED to a path and compared with where the emitter
-// actually IS. It is deliberately NOT a basename match. A basename match is a
-// SPELLED check rather than a structural one, and it passes while the hazard
-// exists in a different shape — both of these were MEASURED surviving the
-// entire suite before this was rewritten:
-//
-//	static/index.html    src="./vendor/civitai-host.js"          -> ships a 404
-//	page-vite/main.jsx   import '../nonexistent/civitai-host.js' -> build fails
-//
-// Both reproduce #206 with every check green, which is why the first version of
-// this guard did not deserve the claim that it proved the entry point REACHES
-// the emitter.
-func readyAckWiring(dir, ackRel string) (string, error) {
-	want := filepath.Clean(filepath.Join(dir, filepath.FromSlash(ackRel)))
-
-	htmlRaw, err := os.ReadFile(filepath.Join(dir, "index.html"))
-	if err != nil {
-		return "", err
-	}
-	html := reHTMLComment.ReplaceAllString(string(htmlRaw), "")
-
-	// Every reference considered, with what it resolved to and whether that
-	// file exists — reported verbatim on failure so a near-miss (right
-	// basename, wrong directory) names itself instead of reading as "nothing
-	// references it at all".
-	var tried []string
-	note := func(what, spec, resolved string) {
-		if resolved == "" {
-			tried = append(tried, fmt.Sprintf("%s %q -> not a path in this project (bare specifier or URL)", what, spec))
-			return
-		}
-		state := "exists"
-		if _, err := os.Stat(resolved); err != nil {
-			state = "DOES NOT EXIST"
-		}
-		rel, relErr := filepath.Rel(dir, resolved)
-		if relErr != nil {
-			rel = resolved
-		}
-		tried = append(tried, fmt.Sprintf("%s %q -> %s (%s)", what, spec, filepath.ToSlash(rel), state))
-	}
-
-	var entries []string
-	for _, m := range reScriptSrc.FindAllStringSubmatch(html, -1) {
-		src := m[1]
-		// A <script src> resolves against the document, which sits at the
-		// project root.
-		resolved, ok := resolveProjectRef(dir, dir, src)
-		if ok && resolved == want {
-			// Existence is pinned by the byte-equality sub-test, which reads
-			// this exact path — re-asserting it here would add a branch no
-			// mutation can reach.
-			return "index.html loads " + src + " -> " + ackRel, nil
-		}
-		note("index.html <script src>", src, resolved)
-		entries = append(entries, src)
-	}
-	if len(entries) == 0 {
-		return "", errNoScriptTags
-	}
-
-	// Not loaded directly — follow index.html's script entries and resolve
-	// every import in them. One level deep on purpose: the emitter is meant to
-	// be imported by the entry module itself, not buried behind a chain.
-	for _, src := range entries {
-		entryPath, ok := resolveProjectRef(dir, dir, src)
-		if !ok {
-			continue
-		}
-		raw, err := os.ReadFile(entryPath)
-		if err != nil {
-			continue // a <script src> that is not a file in the tree
-		}
-		code := stripJSComments(string(raw))
-		for _, m := range reJSImport.FindAllStringSubmatch(code, -1) {
-			spec := m[1]
-			// An import resolves against the IMPORTING MODULE's directory.
-			resolved, ok := resolveProjectRef(dir, filepath.Dir(entryPath), spec)
-			if ok && resolved == want {
-				return "index.html loads " + src + ", which imports " + spec + " -> " + ackRel, nil
-			}
-			note("import in "+src, spec, resolved)
-		}
-	}
-	return "", readyAckWiringError(errNotReached.Error() + "\n  references resolved:\n    " +
-		strings.Join(tried, "\n    "))
-}
-
-// resolveProjectRef resolves a <script src> or an import specifier to a path
-// inside the project. A root-relative ref resolves against the project root, a
-// relative one against fromDir. A bare specifier (a package name) or an
-// absolute URL is not a file in this project and reports false — which is what
-// makes `import 'civitai-host.js'` (a bare specifier that would resolve to a
-// PACKAGE, not this file) a rejection rather than a match.
-func resolveProjectRef(projectDir, fromDir, spec string) (string, bool) {
-	// A protocol-relative URL only LOOKS root-relative. Without this, the `/`
-	// case below strips one slash and `filepath.Join` cleans the rest, so
-	// `//evil.example.com/../civitai-host.js` resolves to EXACTLY the emitter's
-	// path and is accepted — measured. This half is load-bearing and pinned by
-	// the "protocol-relative URL that cleans back" corpus case.
-	//
-	// There is deliberately no `strings.Contains(spec, "://")` companion: no URI
-	// scheme can begin with `/`, `./` or `../`, so an `https://…` specifier
-	// already fails the switch below and returns the identical `("", false)` —
-	// it decided nothing for any URL, which is all it claimed to guard. It was
-	// removed rather than left as a branch no mutation can reach; the CDN-URL
-	// corpus case is rejected by the fallthrough, and says so.
-	//
-	// It did change the answer for a handful of NON-URLs that merely contain
-	// `://` — `/x://../civitai-host.js`, `./civitai-host.js?u=https://evil.com`
-	// — which it rejected and which now resolve to the emitter. That is the
-	// correct outcome (it is how a browser resolves them), so the removal fixes
-	// a latent false rejection rather than widening what is accepted.
-	if strings.HasPrefix(spec, "//") {
-		return "", false
-	}
-	// Vite allows query/hash suffixes (`?raw`, `?url`); they are not part of
-	// the path, and an emitter imported as `./civitai-host.js?url` is still the
-	// emitter. Pinned by the "?url suffix" accept case.
-	if i := strings.IndexAny(spec, "?#"); i >= 0 {
-		spec = spec[:i]
-	}
-	if spec == "" {
-		return "", false
-	}
-	switch {
-	case strings.HasPrefix(spec, "/"):
-		return filepath.Clean(filepath.Join(projectDir, filepath.FromSlash(strings.TrimPrefix(spec, "/")))), true
-	case strings.HasPrefix(spec, "./"), strings.HasPrefix(spec, "../"):
-		return filepath.Clean(filepath.Join(fromDir, filepath.FromSlash(spec))), true
-	}
-	return "", false
-}
-
-type readyAckWiringError string
-
-func (e readyAckWiringError) Error() string { return string(e) }
-
-const (
-	errNoScriptTags = readyAckWiringError("the rendered index.html has no <script src> at all")
-	errNotReached   = readyAckWiringError("no <script src> in index.html resolves to it, and no import in an entry module resolves to it")
-)
-
-// stripJSComments removes // and /* */ comments while respecting string and
-// template literals, so a URL like 'https://x' is not mistaken for a comment
-// and a comment mentioning a filename cannot satisfy a wiring check.
-func stripJSComments(src string) string {
-	var b strings.Builder
-	b.Grow(len(src))
-	for i := 0; i < len(src); {
-		c := src[i]
-		switch {
-		case c == '/' && i+1 < len(src) && src[i+1] == '/':
-			for i < len(src) && src[i] != '\n' {
-				i++
-			}
-		case c == '/' && i+1 < len(src) && src[i+1] == '*':
-			i += 2
-			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
-				i++
-			}
-			i = min(i+2, len(src))
-		case c == '\'' || c == '"' || c == '`':
-			quote := c
-			b.WriteByte(c)
-			i++
-			for i < len(src) {
-				if src[i] == '\\' && i+1 < len(src) {
-					b.WriteString(src[i : i+2])
-					i += 2
-					continue
-				}
-				b.WriteByte(src[i])
-				if src[i] == quote {
-					i++
-					break
-				}
-				i++
-			}
-		default:
-			b.WriteByte(c)
-			i++
-		}
-	}
-	return b.String()
 }

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -221,14 +221,17 @@ func readyAckChecks(dir string, generic any) []string {
 // resolveLoadedFiles walks the entry graph and reports whether any file the
 // BROWSER LOADS mentions the message outside a comment.
 //
-// 🔴 The answer is accumulated through `Inspect`, not read off a retained field.
-// The graph hands each file's contents over while they are in hand and keeps
-// none of them, so this costs ONE file of memory — the same discipline the tree
-// scan above follows. The first version stored every graph file's stripped
-// contents on the EntryFile and peaked 410 MB RSS on a 200-module graph entirely
-// INSIDE these budgets, against ~17 MB before the graph existed: a check whose
-// caps exist precisely so `validate` cannot become a memory event, exceeding the
-// 316 MB figure those caps were sized against. `app submit` pays this too.
+// 🔴 The answer is accumulated through `Inspect`, not read off a retained field,
+// so this costs O(one file) rather than O(graph) — the same discipline the tree
+// scan above follows. Getting there took TWO fixes, and the intermediate state
+// is why this comment now carries numbers instead of an adjective: storing every
+// file's stripped contents on EntryFile peaked 421-439 MB on a 200-module graph
+// entirely INSIDE these budgets, and dropping that field still left 558-628 MB
+// because an un-cloned import specifier pins its whole file's backing array.
+// Both fixed: 31.4-33.3 MB, against 26.4-27.8 MB at e800129 before the graph
+// existed. See blockproto's Inspect doc for the fixture — a tree padded with
+// COMMENTS, or whose leaves carry no imports, does not exercise either hazard.
+// `app submit` pays this too.
 func resolveLoadedFiles(dir string, deps map[string]bool) (*blockproto.EntryGraph, bool) {
 	found := false
 	g := blockproto.ResolveEntryGraph(dir, blockproto.EntryGraphOptions{

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -199,13 +199,9 @@ func readyAckChecks(dir string, generic any) []string {
 		return nil
 	}
 
-	graph := blockproto.ResolveEntryGraph(dir, blockproto.EntryGraphOptions{
-		MaxFiles:     maxAckGraphFiles,
-		MaxFileBytes: maxAckFileBytes,
-		Dependencies: deps,
-	})
+	graph, loadedPostsAck := resolveLoadedFiles(dir, deps)
 	if graph.Complete {
-		if graphPostsReadyAck(graph) {
+		if loadedPostsAck {
 			return nil
 		}
 		// Reachability tier: nothing the browser loads posts the message.
@@ -222,19 +218,36 @@ func readyAckChecks(dir string, generic any) []string {
 	return []string{readyAckAdvicePresenceOnly}
 }
 
-// graphPostsReadyAck reports whether any file the browser loads mentions the
-// message outside a comment. blockproto has already stripped comments per
-// extension; readyAckSourceExts decides what counts as code.
-func graphPostsReadyAck(g *blockproto.EntryGraph) bool {
-	for _, f := range g.Files {
-		if !readyAckSourceExts[strings.ToLower(filepath.Ext(f.Rel))] {
-			continue
-		}
-		if strings.Contains(f.Code, readyAckType) {
-			return true
-		}
-	}
-	return false
+// resolveLoadedFiles walks the entry graph and reports whether any file the
+// BROWSER LOADS mentions the message outside a comment.
+//
+// 🔴 The answer is accumulated through `Inspect`, not read off a retained field.
+// The graph hands each file's contents over while they are in hand and keeps
+// none of them, so this costs ONE file of memory — the same discipline the tree
+// scan above follows. The first version stored every graph file's stripped
+// contents on the EntryFile and peaked 410 MB RSS on a 200-module graph entirely
+// INSIDE these budgets, against ~17 MB before the graph existed: a check whose
+// caps exist precisely so `validate` cannot become a memory event, exceeding the
+// 316 MB figure those caps were sized against. `app submit` pays this too.
+func resolveLoadedFiles(dir string, deps map[string]bool) (*blockproto.EntryGraph, bool) {
+	found := false
+	g := blockproto.ResolveEntryGraph(dir, blockproto.EntryGraphOptions{
+		MaxFiles:     maxAckGraphFiles,
+		MaxFileBytes: maxAckFileBytes,
+		Dependencies: deps,
+		Inspect: func(f blockproto.EntryFile, code string) {
+			// readyAckSourceExts gates BOTH tiers: a `.css` an entry module
+			// imports really is loaded by the browser and really cannot
+			// implement a handshake, so it is in the graph but is not evidence.
+			if !readyAckSourceExts[strings.ToLower(filepath.Ext(f.Rel))] {
+				return
+			}
+			if strings.Contains(code, readyAckType) {
+				found = true
+			}
+		},
+	})
+	return g, found
 }
 
 // declaresPage reports whether the manifest declares a non-null `page` surface.

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -11,6 +11,18 @@ package validate
 // app scaffolded before that commit is still broken, and nothing tells its
 // author. This check is the thing that tells them.
 //
+// 🔴 PRESENCE IS NOT REACHABILITY, AND THE FIRST VERSION OF THIS CHECK ONLY
+// MEASURED PRESENCE. Its own remedy told the author to do TWO things — copy
+// `civitai-host.js` in, and LOAD it from index.html or the entry module — and it
+// verified only the first. Measured on a genuinely pre-fix scaffold: with the
+// emitter copied in and never referenced, `civitai app validate --strict`
+// printed `✓ … is valid` and exited 0, for an app that was still exactly as
+// broken as before. An orphan file containing the literal ANYWHERE in the tree
+// passed identically. A green check earned by obeying our own advice is worse
+// than the silence it replaced, so the check now RESOLVES THE ENTRY GRAPH
+// (`blockproto.ResolveEntryGraph`) wherever it can, and says which of the two
+// questions it answered.
+//
 // 🔴 IT IS A WARNING, NOT AN ERROR, AND THAT IS DELIBERATE.
 // The lockfile check next door (lockfile.go) earns hard-error status because the
 // platform PROVABLY fails: the build recipe runs `npm ci` and dies. Nothing here
@@ -23,6 +35,31 @@ package validate
 // avoiding — and unlike that one, `--strict` here would turn it into a build
 // break in somebody's CI. `Result.Warnings` costs an author nothing to ignore
 // and still puts the sentence in front of them.
+//
+// THE TWO TIERS, AND WHY THE MESSAGE NAMES WHICH ONE RAN.
+//
+//	REACHABILITY (strong). The entry graph resolved COMPLETELY: index.html is at
+//	the project root and every `<script src>` and import below it was accounted
+//	for. Then "nothing the browser loads posts BLOCK_READY" is a real finding,
+//	and an emitter sitting unreferenced in the tree is reported as the orphan it
+//	is.
+//
+//	PRESENCE ONLY (weak). The graph is INCOMPLETE — no root index.html, a
+//	bundler alias, a specifier pointing at a file that is not there, a budget
+//	exhausted. Then wiring is undecidable and the check falls back to the
+//	whole-tree scan it always did. 🔴 Its message SAYS SO, in the same breath as
+//	the remedy that tells the author to wire the emitter up. A check that
+//	silently changes strength between project shapes is how the false pass above
+//	happened in the first place.
+//
+// 🔴 "CANNOT OBSERVE" MUST NOT SILENTLY BECOME "EVERYTHING PASSES" — but it also
+// must not manufacture advice. The split: an INCOMPLETE graph never produces a
+// wiring finding (that is the AGENTS.md item 10 doctrine), yet the presence
+// finding still fires when nothing in the tree mentions the message at all, and
+// discloses its own weakness when it does. The residual, stated rather than
+// hidden: a project whose entry graph we cannot resolve AND which contains the
+// literal somewhere gets silence, exactly as before. That is a false negative,
+// and false negatives are the cheap direction here.
 //
 // EVIDENCE ORDER — THE DEPENDENCY IS CHECKED FIRST, AND THAT IS LOAD-BEARING.
 // For a project depending on `@civitai/blocks-react`, the ack comes from the
@@ -40,35 +77,33 @@ package validate
 // reproduced live on a `static` scaffold with the emitter deleted. Do not
 // re-widen this to a prefix.
 //
-// WHAT IT DOES NOT PROVE. That the ack FIRES. No static check can — an emitter
-// with an inverted `event.source` guard satisfies every assertion here (that is
-// what the scaffold's Guard B exists for, see AGENTS.md item 11). This check
-// answers one narrower question: does anything in this project's source so much
-// as MENTION the message, outside a comment. A "no" is strong evidence of the
-// #206 shape; a "yes" is weak evidence of correctness, and is treated as
-// conclusive anyway, because being generous here costs a missed warning while
-// being strict costs a false one.
+// WHAT IT STILL DOES NOT PROVE. That the ack FIRES. No static check can — an
+// emitter with an inverted `event.source` guard satisfies every assertion here
+// (that is what the scaffold's Guard B exists for, see AGENTS.md item 11). At
+// its strongest this check answers: does a file the browser actually loads so
+// much as MENTION the message, outside a comment.
 //
-// SCOPE — IT ONLY FIRES WHERE IT CAN OBSERVE, AND "OBSERVE" MEANS THE WHOLE
-// TREE. Mirroring lockfile.go's early-out shape: no `page` surface, no check;
-// unreadable package.json, no check. Beyond that, the scan concludes "this app
-// never acks" ONLY if it read every source file it could reach and found
-// nothing. Anything that leaves a gap — an unresolvable symlink, a read error, a
-// file over the size cap, the file-count budget — reports UNOBSERVABLE and stays
-// silent. A partial scan that says "absent" is manufacturing advice from a gap.
+// SCOPE OF THE PRESENCE SCAN — IT ONLY FIRES WHERE IT CAN OBSERVE, AND
+// "OBSERVE" MEANS THE WHOLE TREE. Mirroring lockfile.go's early-out shape: no
+// `page` surface, no check; unreadable package.json, no check. Beyond that, the
+// scan concludes "this app never acks" ONLY if it read every source file it
+// could reach and found nothing. Anything that leaves a gap — an unresolvable
+// symlink, a read error, a file over the size cap, the file-count budget —
+// reports UNOBSERVABLE and stays silent, and that verdict gates BOTH tiers: a
+// tree we could not read is not a tree we can draw a wiring conclusion about
+// either.
 //
-// 🔴 SKIPPING IS A COST DECISION, NEVER A CORRECTNESS ONE, because this is a
-// PRESENCE check: scanning an extra directory can only ever ADD ack evidence,
-// while skipping one can only ever CREATE a false warning. That asymmetry is why
-// the manifest's `outputDir` is NOT skipped (it was, and it was wrong — a
-// perfectly valid `"outputDir": "src"` on a page-vite app skipped the directory
-// holding the emitter and warned at a correct project; `"outputDir": "."`
-// skipped the entire tree). What remains is a fixed list of names that are
-// never source — dependencies, VCS metadata, and the conventional build
-// directories — chosen for cost. The residual trade is accepted and stated: a
-// stale committed build under a NON-conventional output directory can retain an
-// ack the source has lost, silencing a genuinely broken app. That is a false
-// negative, and false negatives are the cheap direction here.
+// 🔴 SKIPPING IS A COST DECISION, NEVER A CORRECTNESS ONE, because the tree scan
+// is a PRESENCE check: scanning an extra directory can only ever ADD ack
+// evidence, while skipping one can only ever CREATE a false warning. That
+// asymmetry is why the manifest's `outputDir` is NOT skipped (it was, and it was
+// wrong — a perfectly valid `"outputDir": "src"` on a page-vite app skipped the
+// directory holding the emitter and warned at a correct project;
+// `"outputDir": "."` skipped the entire tree). What remains is a fixed list of
+// names that are never source — dependencies, VCS metadata, and the conventional
+// build directories — chosen for cost. The residual trade is accepted and
+// stated: a stale committed build under a NON-conventional output directory can
+// retain an ack the source has lost, silencing a genuinely broken app.
 
 import (
 	"encoding/json"
@@ -89,6 +124,10 @@ const readyAckType = "BLOCK_READY"
 // handshake is not an implementation of it, and both shipped scaffold READMEs
 // describe `BLOCK_READY` at length. Including docs would silence the check for
 // exactly the apps it exists to find.
+//
+// It gates BOTH tiers: a `.css` a module imports is in the entry graph (the
+// browser really loads it) but cannot implement a handshake, so it is not read
+// as ack evidence either.
 var readyAckSourceExts = map[string]bool{
 	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
 	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
@@ -96,26 +135,17 @@ var readyAckSourceExts = map[string]bool{
 	".vue": true, ".svelte": true, ".astro": true,
 }
 
-// readyAckMarkupExts are the subset whose comments are `<!-- -->`. HTML comment
-// stripping is applied ONLY to these.
+// readyAckSkipDirs are never descended into by the TREE scan. These names are
+// never source: dependencies, VCS metadata, and the conventional build
+// directories. The list is a COST decision (see the header) — every entry can
+// only cost a false warning, so it is kept short and conventional rather than
+// expanded to every directory that might be large. `vendor` and `public` are
+// deliberately ABSENT: both routinely hold hand-written source (a vendored
+// emitter, Vite's static `public/`), and cost is bounded by the caps below
+// instead.
 //
-// 🔴 Applying it to `.js`/`.ts` was a false-warning source: `stripHTMLComments`
-// has no string awareness, so a perfectly ordinary `var OPEN = '<!--';` in a
-// sanitiser started a "comment" that ran to end of file and deleted the emitter
-// below it. Reproduced live on a `static` scaffold. JS has no HTML comments
-// worth stripping here — `//` and `/* */` cover it, and Annex B's HTML-like
-// comment form is vanishingly rare next to the literal appearing in a string.
-var readyAckMarkupExts = map[string]bool{
-	".html": true, ".htm": true, ".vue": true, ".svelte": true, ".astro": true,
-}
-
-// readyAckSkipDirs are never descended into. These names are never source:
-// dependencies, VCS metadata, and the conventional build directories. The list
-// is a COST decision (see the header) — every entry can only cost a false
-// warning, so it is kept short and conventional rather than expanded to every
-// directory that might be large. `vendor` and `public` are deliberately ABSENT:
-// both routinely hold hand-written source (a vendored emitter, Vite's static
-// `public/`), and cost is bounded by the caps below instead.
+// It does NOT apply to the entry graph: a file index.html demonstrably loads is
+// loaded whatever directory it sits in.
 var readyAckSkipDirs = map[string]bool{
 	"node_modules": true, ".git": true, "dist": true, "build": true,
 	"out": true, "coverage": true, ".vite": true, ".next": true,
@@ -135,6 +165,13 @@ const (
 	maxAckFileBytes = 2 << 20 // 2 MiB
 )
 
+// maxAckGraphFiles bounds the entry-graph walk. It is far smaller than
+// maxAckScanFiles because an entry graph is not a tree walk: a project whose
+// index.html reaches 200 modules through relative imports alone is not a shape
+// this resolver models honestly, and exhausting the budget makes the graph
+// incomplete (i.e. drops to the presence tier) rather than producing a finding.
+const maxAckGraphFiles = 200
+
 // readyAckChecks returns the ready-ack advisory for the project in dir, or nil.
 //
 // It runs in the projectState branch of validateDir (beside lockfileChecks) and
@@ -147,17 +184,57 @@ func readyAckChecks(dir string, generic any) []string {
 	}
 	// The dependency is checked FIRST — see the file header. `unknown` means the
 	// package.json is there but unreadable, i.e. we cannot answer the question
-	// that decides whether a source scan is even meaningful.
-	switch sdkDependency(dir) {
+	// that decides whether any source reading is meaningful.
+	deps, state := packageDeps(dir)
+	switch state {
 	case sdkPresent, sdkUnknown:
 		return nil
 	}
-	// Only a scan that read the WHOLE reachable tree and found nothing is
-	// evidence of absence.
-	if scanForReadyAck(dir) != ackAbsent {
+
+	// The whole-tree presence scan runs FIRST and gates everything: if we could
+	// not read the tree, we have no business drawing a conclusion from a subset
+	// of it either.
+	tree := scanForReadyAck(dir)
+	if tree == ackUnobservable {
 		return nil
 	}
-	return []string{readyAckAdvice}
+
+	graph := blockproto.ResolveEntryGraph(dir, blockproto.EntryGraphOptions{
+		MaxFiles:     maxAckGraphFiles,
+		MaxFileBytes: maxAckFileBytes,
+		Dependencies: deps,
+	})
+	if graph.Complete {
+		if graphPostsReadyAck(graph) {
+			return nil
+		}
+		// Reachability tier: nothing the browser loads posts the message.
+		if tree == ackFound {
+			return []string{readyAckAdviceUnwired}
+		}
+		return []string{readyAckAdviceMissing}
+	}
+
+	// Presence tier: wiring is undecidable for this project shape.
+	if tree == ackFound {
+		return nil
+	}
+	return []string{readyAckAdvicePresenceOnly}
+}
+
+// graphPostsReadyAck reports whether any file the browser loads mentions the
+// message outside a comment. blockproto has already stripped comments per
+// extension; readyAckSourceExts decides what counts as code.
+func graphPostsReadyAck(g *blockproto.EntryGraph) bool {
+	for _, f := range g.Files {
+		if !readyAckSourceExts[strings.ToLower(filepath.Ext(f.Rel))] {
+			continue
+		}
+		if strings.Contains(f.Code, readyAckType) {
+			return true
+		}
+	}
+	return false
 }
 
 // declaresPage reports whether the manifest declares a non-null `page` surface.
@@ -183,16 +260,24 @@ const (
 	sdkUnknown
 )
 
-func sdkDependency(dir string) sdkState {
+// packageDeps returns the project's declared dependency names and whether one of
+// them ACKS.
+//
+// The names are needed by the entry-graph resolver: a bare specifier naming a
+// declared dependency is accounted for (it is a package, not a file in this
+// project), while one that names nothing declared is a bundler alias we cannot
+// follow — which must make the graph incomplete rather than look like a dead
+// end. Both answers come from ONE read of package.json.
+func packageDeps(dir string) (map[string]bool, sdkState) {
 	raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No package.json at all: a static, no-build app. It installs
-			// nothing, so it cannot be acking through a dependency — the source
-			// scan is the whole answer for it.
-			return sdkAbsent
+			// nothing, so it cannot be acking through a dependency — reading the
+			// source is the whole answer for it.
+			return nil, sdkAbsent
 		}
-		return sdkUnknown
+		return nil, sdkUnknown
 	}
 	// json.RawMessage values, not strings: a package.json with an unusual
 	// (non-string) version entry must not make the whole decode fail and warn.
@@ -202,16 +287,26 @@ func sdkDependency(dir string) sdkState {
 		PeerDependencies map[string]json.RawMessage `json:"peerDependencies"`
 	}
 	if err := json.Unmarshal(raw, &pkg); err != nil {
-		return sdkUnknown
+		return nil, sdkUnknown
 	}
+	names := map[string]bool{}
+	state := sdkAbsent
 	for _, set := range []map[string]json.RawMessage{pkg.Dependencies, pkg.DevDependencies, pkg.PeerDependencies} {
 		for name := range set {
+			names[name] = true
 			if blockproto.PackageAcksReady(name) {
-				return sdkPresent
+				state = sdkPresent
 			}
 		}
 	}
-	return sdkAbsent
+	return names, state
+}
+
+// sdkDependency is packageDeps' verdict alone, for callers (and tests) that only
+// need to know whether a dependency acks.
+func sdkDependency(dir string) sdkState {
+	_, state := packageDeps(dir)
+	return state
 }
 
 // ackScanResult is the THREE-valued outcome of the source scan. Two values
@@ -223,7 +318,6 @@ const (
 	// ackFound: a source file mentions the message outside a comment.
 	ackFound ackScanResult = iota
 	// ackAbsent: every reachable source file was read, and none mentions it.
-	// This is the ONLY result that produces a warning.
 	ackAbsent
 	// ackUnobservable: the scan left a gap — an unresolvable symlink, a read
 	// error, a file over the size cap, the file budget, or simply no source
@@ -245,7 +339,9 @@ const (
 // send is `BLOCK_READY`"), and those comments SURVIVE deleting `civitai-host.js`.
 // Without stripping, the exact repair this check exists to demand — restore the
 // emitter — would already look satisfied, and the check would be inert on the
-// one population it was written for. Measured both ways.
+// one population it was written for. Measured both ways. The stripper itself
+// lives in blockproto, because the entry-graph resolver and the scaffold's
+// Guard A ask the identical question.
 //
 // 🔴 SYMLINKED DIRECTORIES ARE FOLLOWED. filepath.WalkDir does not follow them,
 // and it does not report them as directories either, so a monorepo whose `src`
@@ -334,105 +430,81 @@ func (s *ackScanner) walk(dir string) {
 			return
 		}
 		s.files++
-		if strings.Contains(stripComments(string(data), ext), readyAckType) {
+		if strings.Contains(blockproto.StripCommentsForExt(string(data), ext), readyAckType) {
 			s.found = true
 			return
 		}
 	}
 }
 
-// stripComments removes comments from src, given its file extension. JS
-// line/block comments are always stripped, leaving string and template literals
-// intact (so `'https://x'` is not read as the start of a comment, and an emitter
-// that posts from inside a string still counts). HTML comments are stripped only
-// for markup files — see readyAckMarkupExts for why that gate exists.
-func stripComments(src, ext string) string {
-	if readyAckMarkupExts[strings.ToLower(ext)] {
-		src = stripHTMLComments(src)
-	}
-	return stripJSComments(src)
-}
+// ---------------------------------------------------------------------------
+// The advisories.
+//
+// Three messages, built from shared fragments so the remedy cannot drift apart
+// between them, and so the ONE thing each has to add — what this run actually
+// verified — is the only thing that differs.
+// ---------------------------------------------------------------------------
 
-func stripHTMLComments(src string) string {
-	var b strings.Builder
-	b.Grow(len(src))
-	for i := 0; i < len(src); {
-		if strings.HasPrefix(src[i:], "<!--") {
-			end := strings.Index(src[i+4:], "-->")
-			if end < 0 {
-				// 🔴 UNTERMINATED. Keep the remainder VERBATIM rather than
-				// discarding it. Dropping the tail is lossy in the expensive
-				// direction — everything below an unclosed `<!--` disappears,
-				// including an emitter, and the author gets a warning about a
-				// correct project. There is no upside to the lossy branch: text
-				// after an unclosed marker is not evidence of a comment, it is
-				// evidence the file is not what we assumed.
-				b.WriteString(src[i:])
-				return b.String()
-			}
-			i += 4 + end + 3
-			continue
-		}
-		b.WriteByte(src[i])
-		i++
-	}
-	return b.String()
-}
+// readyAckWhy is the consequence. Every advisory carries it: an author who does
+// not know what breaks has no reason to act.
+const readyAckWhy = "the host will not reveal a page app until it acks the host's BLOCK_INIT, so an app that " +
+	"never sends it renders fine locally and is replaced by a failure card in the real host once the bounded " +
+	"init retries run out (issue #206)"
 
-func stripJSComments(src string) string {
-	var b strings.Builder
-	b.Grow(len(src))
-	for i := 0; i < len(src); {
-		c := src[i]
-		switch {
-		case c == '/' && i+1 < len(src) && src[i+1] == '/':
-			for i < len(src) && src[i] != '\n' {
-				i++
-			}
-		case c == '/' && i+1 < len(src) && src[i+1] == '*':
-			i += 2
-			for i+1 < len(src) && !(src[i] == '*' && src[i+1] == '/') {
-				i++
-			}
-			i = min(i+2, len(src))
-		case c == '\'' || c == '"' || c == '`':
-			quote := c
-			b.WriteByte(c)
-			i++
-			for i < len(src) {
-				if src[i] == '\\' && i+1 < len(src) {
-					b.WriteString(src[i : i+2])
-					i += 2
-					continue
-				}
-				b.WriteByte(src[i])
-				if src[i] == quote {
-					i++
-					break
-				}
-				i++
-			}
-		default:
-			b.WriteByte(c)
-			i++
-		}
-	}
-	return b.String()
-}
+// readyAckRemedy names the concrete next command, per the house rule that a
+// message must tell the author what to run.
+//
+// 🔴 IT SPELLS OUT BOTH STEPS AND SAYS THE FIRST ONE ALONE DOES NOTHING. The
+// earlier wording ("copy its civitai-host.js into this project, loading it from
+// index.html or from the entry module") read as one action with a parenthetical,
+// and a blind dogfooder did the copy, skipped the load, and got a green check.
+const readyAckRemedy = "run `civitai app init` into a scratch directory and copy its `" +
+	blockproto.ReadyAckFilename + "` into this project — then LOAD it, which is a SECOND edit in a " +
+	"DIFFERENT file: add `<script src=\"./" + blockproto.ReadyAckFilename + "\"></script>` to index.html " +
+	"above your own script tags, or `import './" + blockproto.ReadyAckFilename + "';` as the first line of " +
+	"the entry module index.html loads. Copying the file in is not enough on its own — a browser never " +
+	"fetches a file nothing references. The alternative is to adopt `@civitai/blocks-react`, whose iframe " +
+	"transport acks for you (never both: whichever answers the first BLOCK_INIT cancels the host's retry). " +
+	"Note `@civitai/app-sdk` alone does NOT ack — it is the server-side SDK and no runtime code in it posts " +
+	readyAckType
 
-// readyAckAdvice names the concrete next command, per the house rule that a
-// message must tell the author what to run. It also states its own evidentiary
-// limit — an author who knows their ack comes from a bundled dependency needs to
-// be able to recognise this as a false alarm without reading the source of the
-// CLI.
-var readyAckAdvice = "the manifest declares a \"page\" surface but nothing in this project's source posts " +
-	readyAckType + " — the host will not reveal a page app until it acks the host's BLOCK_INIT, so an app " +
-	"that never sends it renders fine locally and is replaced by a failure card in the real host once the " +
-	"bounded init retries run out (issue #206). Apps scaffolded before that fix ship no emitter: run " +
-	"`civitai app init` into a scratch directory and copy its `" + blockproto.ReadyAckFilename + "` " +
-	"into this project, loading it from index.html (a <script src>) or from the entry module — or adopt " +
-	"`@civitai/blocks-react`, whose iframe transport acks for you (never both: whichever answers the first " +
-	"BLOCK_INIT cancels the host's retry). Note `@civitai/app-sdk` alone does NOT ack — it is the " +
-	"server-side SDK and no runtime code in it posts " + readyAckType + ". This is a source-text check, so " +
-	"it is wrong about a project whose ack arrives from a bundled dependency or a file type it does not " +
-	"read; it is advisory only and never fails `civitai app validate` unless you pass --strict"
+// readyAckTail states the tier and the limit. Every advisory ends with it.
+const readyAckTail = "no static check can prove the ack FIRES — only the real host can; this is advisory only " +
+	"and never fails `civitai app validate` unless you pass --strict"
+
+// readyAckAdviceUnwired is the REACHABILITY finding for a project that has an
+// emitter nothing loads. This is the exact false pass this check was rewritten
+// to close.
+var readyAckAdviceUnwired = "the manifest declares a \"page\" surface, and this project's source DOES contain " +
+	readyAckType + " — but nothing index.html loads reaches it: resolving index.html and every script and " +
+	"module it loads found no " + readyAckType + " among them, so whatever posts it is an orphan the browser " +
+	"never fetches — " + readyAckWhy + ". Wire it up: " + readyAckRemedy + ". Caveat: " + readyAckTail
+
+// readyAckAdviceMissing is the REACHABILITY finding for a project with no
+// emitter at all — the original #206 shape, now stated with the stronger
+// evidence.
+var readyAckAdviceMissing = "the manifest declares a \"page\" surface but nothing in this project's source " +
+	"posts " + readyAckType + ", and nothing index.html loads posts it either — " + readyAckWhy + ". Apps " +
+	"scaffolded before that fix ship no emitter: " + readyAckRemedy + ". Caveat: " + readyAckTail
+
+// readyAckAdvicePresenceOnly is the PRESENCE finding, and it discloses its own
+// weakness. It fires where the entry graph could not be resolved, so it is the
+// one message that must not let an author read "valid" as "wired".
+var readyAckAdvicePresenceOnly = "the manifest declares a \"page\" surface but nothing in this project's " +
+	"source posts " + readyAckType + " — " + readyAckWhy + ". Apps scaffolded before that fix ship no " +
+	"emitter: " + readyAckRemedy + ". 🔴 What this run did NOT check: it could not resolve the files your " +
+	"index.html loads (there is no index.html at the project root, or it holds a reference this CLI cannot " +
+	"follow — a bundler alias, a generated file, an off-project URL), so it checked only whether SOME file " +
+	"in the project mentions " + readyAckType + "; it did NOT check that the file is loaded. Adding the " +
+	"emitter without referencing it will silence this warning and leave the app just as broken — verify the " +
+	"reference yourself. It is also wrong about a project whose ack arrives from a bundled dependency or a " +
+	"file type it does not read. Caveat: " + readyAckTail
+
+// readyAckAdvisories is every string this check can emit. Callers and tests
+// match against the SET rather than one variable, so a new tier cannot be
+// introduced without the tests that classify them noticing.
+var readyAckAdvisories = []string{
+	readyAckAdviceUnwired,
+	readyAckAdviceMissing,
+	readyAckAdvicePresenceOnly,
+}

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -79,17 +79,44 @@ func ackProject(t *testing.T, manifestJSON string, files map[string]string) stri
 	return dir
 }
 
-// hasReadyAckWarning compares against the advisory VALUE, not a substring of its
-// prose. A substring match would keep passing if the message were rewritten into
-// something that no longer says what to do, and would also match a different
-// warning that happened to share a phrase.
-func hasReadyAckWarning(res Result) bool {
+// hasReadyAckWarning compares against the advisory VALUES, not a substring of
+// their prose. A substring match would keep passing if a message were rewritten
+// into something that no longer says what to do, and would also match a
+// different warning that happened to share a phrase.
+//
+// It matches the SET, so a caller asking only "did the ready-ack check fire"
+// keeps working across the tiers. A caller that cares WHICH tier fired must use
+// readyAckKind — "it warned" and "it warned for the right reason" are different
+// claims, and the whole defect this file now covers was a check that answered
+// the weaker question while the message promised the stronger one.
+func hasReadyAckWarning(res Result) bool { return readyAckKind(res) != "" }
+
+// readyAckKind names the tier that fired, or "".
+func readyAckKind(res Result) string {
 	for _, w := range res.Warnings {
-		if w == readyAckAdvice {
-			return true
+		switch w {
+		case readyAckAdviceUnwired:
+			return "unwired"
+		case readyAckAdviceMissing:
+			return "missing"
+		case readyAckAdvicePresenceOnly:
+			return "presence-only"
 		}
 	}
-	return false
+	return ""
+}
+
+// wantAckKind asserts the exact tier. `want` of "" means no ready-ack warning.
+func wantAckKind(t *testing.T, dir, want string) Result {
+	t.Helper()
+	res, err := Dir(dir)
+	if err != nil {
+		t.Fatalf("Dir: %v", err)
+	}
+	if got := readyAckKind(res); got != want {
+		t.Fatalf("ready-ack advisory tier = %q, want %q\nwarnings: %v\nerrors: %v", got, want, res.Warnings, res.Errors)
+	}
+	return res
 }
 
 func wantAckWarning(t *testing.T, dir string, want bool) Result {
@@ -591,7 +618,13 @@ func TestReadyAckSkipListNeverRemovesTheRoot(t *testing.T) {
 			// Positive control on the same tree: with an emitter it goes silent,
 			// so the assertion above cannot be satisfied by a scan that warns
 			// unconditionally.
+			//
+			// 🔴 index.html has to LOAD it. Writing the file alone used to be
+			// enough here, and that is precisely the false pass this check was
+			// rewritten to close — an unreferenced emitter is now (correctly) the
+			// `unwired` finding, which this control would otherwise trip.
 			write("civitai-host.js", realEmitter())
+			write("index.html", `<!doctype html><script src="./civitai-host.js"></script><script src="./app.js"></script>`)
 			wantAckWarning(t, root, false)
 		})
 	}
@@ -768,20 +801,57 @@ func TestReadyAckAdviceIsActionable(t *testing.T) {
 		{"civitai app init", "the concrete command that produces a correct emitter"},
 		{blockproto.ReadyAckFilename, "the file to copy in"},
 		{"index.html", "where the emitter has to be referenced from"},
+		{"not enough on its own", "copying the file was the ONE step the old wording let an author stop at"},
 		{"@civitai/blocks-react", "the alternative to hand-writing it"},
 		{"never both", "adopting the SDK without deleting the emitter is strictly worse"},
 		{"#206", "the issue an author can read for the full story"},
 		{"--strict", "so nobody thinks this blocks them today"},
 	}
-	for _, r := range required {
-		if !strings.Contains(readyAckAdvice, r.substr) {
-			t.Errorf("the advisory does not mention %q — %s\ngot: %s", r.substr, r.why, readyAckAdvice)
+	if len(readyAckAdvisories) != 3 {
+		t.Fatalf("readyAckAdvisories has %d entries, want 3 — a tier added without a case here ships "+
+			"unasserted prose", len(readyAckAdvisories))
+	}
+	for _, advice := range readyAckAdvisories {
+		for _, r := range required {
+			if !strings.Contains(advice, r.substr) {
+				t.Errorf("an advisory does not mention %q — %s\ngot: %s", r.substr, r.why, advice)
+			}
+		}
+		// A message that says nothing useful is short. This is a crude floor, but
+		// it is the one thing a "something may be wrong" rewrite cannot satisfy.
+		if len(advice) < 400 {
+			t.Errorf("an advisory is %d chars — too short to carry a diagnosis and a remedy: %s", len(advice), advice)
 		}
 	}
-	// A message that says nothing useful is short. This is a crude floor, but it
-	// is the one thing a "something may be wrong" rewrite cannot satisfy.
-	if len(readyAckAdvice) < 400 {
-		t.Errorf("the advisory is %d chars — too short to carry a diagnosis and a remedy", len(readyAckAdvice))
+}
+
+// TestReadyAckAdvisoriesStateTheirOwnStrength pins the disclosure that the
+// dogfood defect turned on.
+//
+// 🔴 The presence-only tier CANNOT see wiring, and it is the tier that fires at
+// the project shapes this CLI models worst. A message that reads identically to
+// the reachability tier tells an author their app is checked when it is not —
+// which is how "copy the emitter in" became a green check for a broken app. So
+// each tier must name what it did, and the weak one must name what it did not.
+func TestReadyAckAdvisoriesStateTheirOwnStrength(t *testing.T) {
+	if !strings.Contains(readyAckAdvicePresenceOnly, "did NOT check that the file is loaded") {
+		t.Errorf("the presence-only advisory does not disclose that it cannot see wiring — an author who "+
+			"reads it as the reachability tier will copy the emitter in, be silenced, and stay broken:\n%s",
+			readyAckAdvicePresenceOnly)
+	}
+	// And the two reachability advisories must NOT carry that disclaimer: they
+	// really did resolve the entry graph, and disclaiming it would train authors
+	// to ignore the one message that is strong.
+	for name, advice := range map[string]string{
+		"unwired": readyAckAdviceUnwired,
+		"missing": readyAckAdviceMissing,
+	} {
+		if strings.Contains(advice, "did NOT check that the file is loaded") {
+			t.Errorf("the %s advisory (reachability tier) disclaims a check it DID perform:\n%s", name, advice)
+		}
+		if !strings.Contains(advice, "index.html loads") {
+			t.Errorf("the %s advisory does not say it resolved what index.html loads:\n%s", name, advice)
+		}
 	}
 }
 
@@ -795,8 +865,10 @@ func TestReadyAckIsAdvisoryOnly(t *testing.T) {
 	})
 	res := wantAckWarning(t, dir, true)
 	for _, e := range res.Errors {
-		if e == readyAckAdvice {
-			t.Fatalf("the ready-ack advisory reached Errors — it must stay a warning")
+		for _, advice := range readyAckAdvisories {
+			if e == advice {
+				t.Fatalf("a ready-ack advisory reached Errors — it must stay a warning")
+			}
 		}
 	}
 	if !res.OK() {
@@ -931,8 +1003,10 @@ func TestDeletingTheEmitterMakesTheWarningFire(t *testing.T) {
 			wantAckWarning(t, dest, true)
 
 			// The advisory must name the file the author has to restore.
-			if !strings.Contains(readyAckAdvice, blockproto.ReadyAckFilename) {
-				t.Errorf("the advisory does not name %s — an author cannot act on it", blockproto.ReadyAckFilename)
+			for _, advice := range readyAckAdvisories {
+				if !strings.Contains(advice, blockproto.ReadyAckFilename) {
+					t.Errorf("an advisory does not name %s — an author cannot act on it", blockproto.ReadyAckFilename)
+				}
 			}
 		})
 	}

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -753,9 +753,44 @@ func TestReadyAckSymlinkCycleTerminates(t *testing.T) {
 	}
 }
 
+// TestReadyAckCapValues pins the caps INDEPENDENTLY of the code under test.
+//
+// 🔴 TestReadyAckCapsAreUnobservable below sizes its fixtures FROM these
+// constants, so a mutant that raises one does not fail — it just allocates. An
+// audit mutant setting maxAckFileBytes to 1<<40 hung the suite twice instead of
+// going red. A literal here is the only thing that can see that, and it is also
+// the only record that these numbers are a deliberate cost decision rather than
+// whatever the code happens to say.
+func TestReadyAckCapValues(t *testing.T) {
+	if maxAckFileBytes != 2<<20 {
+		t.Errorf("maxAckFileBytes = %d, want %d (2 MiB) — these caps exist because `validate` must not "+
+			"become a memory event; raising one silently makes every cap fixture allocate instead of fail",
+			maxAckFileBytes, 2<<20)
+	}
+	if maxAckScanFiles != 5000 {
+		t.Errorf("maxAckScanFiles = %d, want 5000", maxAckScanFiles)
+	}
+	if maxAckGraphFiles != 200 {
+		t.Errorf("maxAckGraphFiles = %d, want 200", maxAckGraphFiles)
+	}
+}
+
 // TestReadyAckCapsAreUnobservable pins that hitting a cap stays SILENT. A scan
 // that stopped early has a gap in it, and a gap is not evidence of absence.
+//
+// It sizes its fixtures from the constants on purpose (a hardcoded 2 MiB would
+// silently stop exercising the branch if the cap moved); TestReadyAckCapValues
+// is what makes that safe.
 func TestReadyAckCapsAreUnobservable(t *testing.T) {
+	// 🔴 Sizing a fixture from the constant under test turns a raised cap into an
+	// ALLOCATION rather than a failure: a 1<<40 mutant hung this suite twice
+	// instead of going red. TestReadyAckCapValues is the real guard; this bound
+	// makes the hang a fast, readable failure instead.
+	if maxAckFileBytes > 8<<20 || maxAckScanFiles > 20000 {
+		t.Fatalf("the caps are too large to exercise (maxAckFileBytes=%d, maxAckScanFiles=%d) — this test "+
+			"builds fixtures from them, so it would allocate instead of testing. See TestReadyAckCapValues.",
+			maxAckFileBytes, maxAckScanFiles)
+	}
 	t.Run("a file over the size cap silences the check", func(t *testing.T) {
 		dir := ackProject(t, ackManifest(false), map[string]string{
 			"index.html": `<!doctype html><script src="./app.js"></script>`,
@@ -833,24 +868,65 @@ func TestReadyAckAdviceIsActionable(t *testing.T) {
 // the reachability tier tells an author their app is checked when it is not —
 // which is how "copy the emitter in" became a green check for a broken app. So
 // each tier must name what it did, and the weak one must name what it did not.
+// 🔴 AN EARLIER VERSION OF THIS TEST WAS HALF VACUOUS, and an audit mutant
+// proved it. It asserted the two strong advisories contain "index.html loads" —
+// but that phrase comes from the SHARED `readyAckRemedy` fragment, which EVERY
+// advisory carries, including the weak one. So replacing the unwired advisory's
+// entire headline with "but something is off" PASSED. That is the spelled-guard
+// class: a check satisfied by a different feature's text.
+//
+// Every literal below appears in exactly ONE tier's own diagnosis, and each is
+// paired with an INVERSE assertion that no other tier carries it — so a rewrite
+// that blurs two tiers together fails in both directions.
 func TestReadyAckAdvisoriesStateTheirOwnStrength(t *testing.T) {
-	if !strings.Contains(readyAckAdvicePresenceOnly, "did NOT check that the file is loaded") {
-		t.Errorf("the presence-only advisory does not disclose that it cannot see wiring — an author who "+
-			"reads it as the reachability tier will copy the emitter in, be silenced, and stay broken:\n%s",
-			readyAckAdvicePresenceOnly)
+	const disclosure = "did NOT check that the file is loaded"
+	// The operative half of the weak tier's disclosure: without this sentence an
+	// author reads "add the emitter", stops, and stays broken — which is the
+	// defect. Deleting it was a surviving mutant.
+	const operative = "will silence this warning"
+
+	perTier := []struct {
+		name   string
+		advice string
+		// own are literals this tier's DIAGNOSIS must carry, and which no other
+		// tier may carry.
+		own []string
+	}{
+		{"unwired", readyAckAdviceUnwired, []string{
+			"DOES contain",                        // it found the message…
+			"nothing index.html loads reaches it", // …and nothing loads it
+			"orphan",                              // named for what it is
+		}},
+		{"missing", readyAckAdviceMissing, []string{
+			"nothing index.html loads posts it either", // resolved, and absent
+		}},
+		{"presence-only", readyAckAdvicePresenceOnly, []string{
+			disclosure,
+			operative,
+			"could not resolve the files your",
+		}},
 	}
-	// And the two reachability advisories must NOT carry that disclaimer: they
-	// really did resolve the entry graph, and disclaiming it would train authors
-	// to ignore the one message that is strong.
-	for name, advice := range map[string]string{
-		"unwired": readyAckAdviceUnwired,
-		"missing": readyAckAdviceMissing,
-	} {
-		if strings.Contains(advice, "did NOT check that the file is loaded") {
-			t.Errorf("the %s advisory (reachability tier) disclaims a check it DID perform:\n%s", name, advice)
-		}
-		if !strings.Contains(advice, "index.html loads") {
-			t.Errorf("the %s advisory does not say it resolved what index.html loads:\n%s", name, advice)
+
+	for _, tier := range perTier {
+		for _, lit := range tier.own {
+			if !strings.Contains(tier.advice, lit) {
+				t.Errorf("the %s advisory no longer says %q — that literal is this tier's whole diagnosis, "+
+					"and without it the message does not tell an author WHAT WAS FOUND:\n%s",
+					tier.name, lit, tier.advice)
+			}
+			// The inverse control: no OTHER tier may claim it. This is what
+			// makes the assertion above a statement about THIS tier rather than
+			// about the shared remedy fragment every advisory carries.
+			for _, other := range perTier {
+				if other.name == tier.name {
+					continue
+				}
+				if strings.Contains(other.advice, lit) {
+					t.Errorf("the %s advisory carries %q, which belongs to the %s tier — the tiers are no "+
+						"longer distinguishable by their text, so a reader cannot tell which check ran:\n%s",
+						other.name, lit, tier.name, other.advice)
+				}
+			}
 		}
 	}
 }

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -907,6 +907,32 @@ func TestReadyAckAdvisoriesStateTheirOwnStrength(t *testing.T) {
 		}},
 	}
 
+	// 🔴 THE SHARED OPENING DIAGNOSIS, and the reason this test needed a second
+	// round. `own` literals can only pin a tier that has something UNIQUE to
+	// say — and the presence tier's three unique literals ALL live in its
+	// trailing disclosure, so replacing its OPENING ("…but nothing in this
+	// project's source posts BLOCK_READY") with vague prose survived everything
+	// below. That is the identical half-vacuous shape this test's own header
+	// records catching last round, one tier over.
+	//
+	// The sentence is shared with the `missing` tier by design — both report an
+	// absence — so it is asserted as SET MEMBERSHIP: present in exactly those
+	// two, absent from the tier that fires because the message IS present.
+	const foundNothing = "nothing in this project's source posts "
+	for _, tier := range perTier {
+		wantShared := tier.name != "unwired"
+		if got := strings.Contains(tier.advice, foundNothing); got != wantShared {
+			if wantShared {
+				t.Errorf("the %s advisory no longer opens by saying WHAT WAS FOUND (%q) — every other literal "+
+					"this test pins for it lives in the trailing disclosure, so the diagnosis itself was "+
+					"unguarded:\n%s", tier.name, foundNothing, tier.advice)
+			} else {
+				t.Errorf("the unwired advisory says nothing in the source posts the message, but that tier "+
+					"fires precisely because something DOES:\n%s", tier.advice)
+			}
+		}
+	}
+
 	for _, tier := range perTier {
 		for _, lit := range tier.own {
 			if !strings.Contains(tier.advice, lit) {

--- a/internal/validate/readyack_wiring_test.go
+++ b/internal/validate/readyack_wiring_test.go
@@ -1,0 +1,281 @@
+package validate
+
+// readyack_wiring_test.go covers the REACHABILITY tier: the half of the
+// ready-ack advisory that asks whether the browser actually loads the file
+// posting BLOCK_READY, rather than whether some file in the tree contains the
+// literal.
+//
+// 🔴 EVERY FIXTURE HERE IS A RENDERED TEMPLATE, MUTATED. The defect being
+// repaired was reproduced on a real `civitai app init` project, and a
+// hand-written string fixture cannot fail the way a real scaffold does — it
+// carries none of the template's comments, none of its import graph, and none of
+// the near-miss shapes that made the old check look green.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/blockproto"
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// renderTemplate renders tmpl into a fresh directory and returns it.
+func renderTemplate(t *testing.T, tmpl scaffold.Template) string {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), string(tmpl))
+	if _, err := scaffold.Render(tmpl, dest, scaffold.Data{Slug: "ack-block", Name: "Ack Block"}); err != nil {
+		t.Fatalf("render %s: %v", tmpl, err)
+	}
+	return dest
+}
+
+// editFile applies a replacement to a file in a rendered project and FAILS if
+// the replacement did not change anything.
+//
+// 🔴 The failure check is the point, not defensiveness. A mutation regex that
+// silently no-ops has produced false "surviving mutant" results three times in
+// this workstream; a fixture mutation that silently no-ops produces the same lie
+// in the other direction — a test that passes because the project was never
+// broken.
+func editFile(t *testing.T, dir, rel, old, new string) {
+	t.Helper()
+	p := filepath.Join(dir, filepath.FromSlash(rel))
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	if !strings.Contains(string(raw), old) {
+		t.Fatalf("fixture mutation is a no-op: %s does not contain %q — the template changed and this "+
+			"test would have passed without ever breaking the project", rel, old)
+	}
+	out := strings.Replace(string(raw), old, new, 1)
+	if err := os.WriteFile(p, []byte(out), 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE REGRESSION UNDER REPAIR.
+// ---------------------------------------------------------------------------
+
+// TestEmitterPresentButNotLoadedWarns is the defect, reproduced.
+//
+// A blind dogfooder followed this check's own remedy on a pre-fix scaffold:
+// copied `civitai-host.js` in, did not reference it from index.html, and
+// `civitai app validate --strict` printed `✓ … is valid` and exited 0 for an app
+// that was still entirely broken. Measured on the shipped CLI at 0ce0025.
+//
+// Both shapes below are that defect. They are separated because they fail
+// differently: one keeps the emitter and drops the reference (the dogfooder's),
+// the other keeps a reference to nothing and hides the ack in a file nobody
+// loads (the orphan).
+func TestEmitterPresentButNotLoadedWarns(t *testing.T) {
+	t.Run("static: the emitter is there, index.html does not load it", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.Static)
+		// Positive control: the untouched scaffold is silent, so a warning below
+		// cannot come from the template being broken to begin with.
+		wantAckKind(t, dir, "")
+
+		editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+		if _, err := os.Stat(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatalf("the emitter must still be present — this case is about the REFERENCE: %v", err)
+		}
+		wantAckKind(t, dir, "unwired")
+	})
+
+	t.Run("page-vite: the emitter is there, the entry module does not import it", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.PageVite)
+		wantAckKind(t, dir, "")
+
+		editFile(t, dir, "src/main.jsx", `import './civitai-host.js';`, "")
+		if _, err := os.Stat(filepath.Join(dir, "src", blockproto.ReadyAckFilename)); err != nil {
+			t.Fatalf("the emitter must still be present: %v", err)
+		}
+		wantAckKind(t, dir, "unwired")
+	})
+
+	t.Run("a stylesheet in the graph is not ack evidence", func(t *testing.T) {
+		// The entry graph contains files the browser loads that CANNOT implement
+		// a handshake. `src/index.css` really is loaded by page-vite's entry
+		// module, so without the readyAckSourceExts gate on the graph scan a
+		// stylesheet naming the message would silence the check.
+		dir := renderTemplate(t, scaffold.PageVite)
+		editFile(t, dir, "src/main.jsx", `import './civitai-host.js';`, "")
+		if err := os.Remove(filepath.Join(dir, "src", blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "src", "index.css"),
+			[]byte("/* x */\n.a{content:'BLOCK_READY'}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// `missing` rather than `unwired` because the whole-tree scan does not
+		// read `.css` either — the same extension policy on both tiers. What this
+		// pins is that the graph scan does NOT accept it: drop the extension gate
+		// in graphPostsReadyAck and this project goes silent.
+		wantAckKind(t, dir, "missing")
+	})
+
+	t.Run("an orphan file containing the literal does not count", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.Static)
+		// Remove the emitter AND its reference — the app is now the plain #206
+		// shape — then hide a real, correct ack in a file nothing loads.
+		editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+		if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "orphan.js"), blockproto.ReadyAckSource(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		wantAckKind(t, dir, "unwired")
+	})
+}
+
+// TestWiredEmitterIsSilent is the other half of the pair. Without it, "an
+// unreferenced emitter warns" is satisfied by a check that warns at every
+// project — which would be a false warning at every correct app on the platform,
+// the worst outcome for advisory output (AGENTS.md item 10).
+func TestWiredEmitterIsSilent(t *testing.T) {
+	t.Run("static: loaded by a <script src>", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.Static)
+		wantAckKind(t, dir, "")
+		// And the reference really is what carries it: move the emitter to a
+		// subdirectory, point the tag at the new location, and it must stay
+		// silent — so the accept above is not a basename or a fixed-path match.
+		if err := os.MkdirAll(filepath.Join(dir, "vendor"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(filepath.Join(dir, blockproto.ReadyAckFilename),
+			filepath.Join(dir, "vendor", blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		editFile(t, dir, "index.html", `src="./civitai-host.js"`, `src="./vendor/civitai-host.js"`)
+		wantAckKind(t, dir, "")
+	})
+
+	t.Run("page-vite: imported by the entry module", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.PageVite)
+		wantAckKind(t, dir, "")
+	})
+
+	t.Run("page-money: the SDK dependency acks, with no literal anywhere", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.PageMoney)
+		// Stated as evidence rather than assumed: the tree really contains no
+		// BLOCK_READY, so this template is accepted by the DEPENDENCY branch and
+		// nothing else. If that ever stopped being true, the silence below would
+		// be green for a reason that has nothing to do with the branch it covers.
+		if got := scanForReadyAck(dir); got != ackAbsent {
+			t.Fatalf("scanForReadyAck(page-money) = %v, want ackAbsent", got)
+		}
+		wantAckKind(t, dir, "")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// THE DECIDABILITY BOUNDARY, asserted explicitly.
+//
+// The check verifies reachability only when the entry graph resolves COMPLETELY.
+// Anything it cannot follow drops it to the presence tier, whose message says so.
+// These cases pin both directions of that switch — a check that changed strength
+// SILENTLY between project shapes is exactly how the defect above shipped.
+// ---------------------------------------------------------------------------
+
+func TestReadyAckDecidabilityBoundary(t *testing.T) {
+	t.Run("a bundler alias makes wiring undecidable, and the emitter is accepted on presence", func(t *testing.T) {
+		// 🔴 THE ACCEPTED RESIDUAL, stated as a test rather than left implicit.
+		// `import '@/civitai-host.js'` is a real file behind a `resolve.alias`
+		// this CLI does not read. The graph is incomplete, so no wiring finding
+		// may be made — and because the tree DOES contain the literal, the check
+		// goes quiet. A project that wired its emitter through an alias and one
+		// that left it orphaned are indistinguishable here, and quiet is the
+		// direction that never warns at a correct project.
+		dir := renderTemplate(t, scaffold.PageVite)
+		editFile(t, dir, "src/main.jsx", `import './civitai-host.js';`, `import '@/civitai-host.js';`)
+		wantAckKind(t, dir, "")
+
+		// The negative control: the SAME undecidable shape with no emitter
+		// anywhere still warns — "cannot observe" must not become "everything
+		// passes", which is the bug this whole change exists to close.
+		if err := os.Remove(filepath.Join(dir, "src", blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		wantAckKind(t, dir, "presence-only")
+	})
+
+	t.Run("no index.html at the project root is presence-only", func(t *testing.T) {
+		// A framework-owned entry point (Next.js, SvelteKit) has no root
+		// index.html to resolve. Nothing mentions the ack, so it warns — with the
+		// message that discloses it could not check wiring.
+		dir := ackProject(t, ackManifest(true), map[string]string{
+			"package.json": `{"dependencies": {"next": "^15.0.0"}}`,
+			"app/page.tsx": `export default function Page() { return null; }`,
+		})
+		wantAckKind(t, dir, "presence-only")
+	})
+
+	t.Run("a dangling reference is a gap, not a decided absence", func(t *testing.T) {
+		// Deleting the emitter from a CURRENT scaffold leaves index.html pointing
+		// at a file that is not there. That means this resolver's model of the
+		// project disagrees with a project that presumably builds, so it is a gap:
+		// the finding drops to the presence tier rather than claiming to have
+		// resolved a graph it did not.
+		dir := renderTemplate(t, scaffold.Static)
+		if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		wantAckKind(t, dir, "presence-only")
+	})
+
+	t.Run("a genuinely pre-fix project is decided on reachability", func(t *testing.T) {
+		// The shape of an app scaffolded before 4018e2c: no emitter and no
+		// reference to one. Every reference resolves, so the graph is complete and
+		// the check gets to say the strong thing.
+		dir := renderTemplate(t, scaffold.Static)
+		editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+		if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		wantAckKind(t, dir, "missing")
+	})
+}
+
+// TestShippedSDKFreeTemplatesResolveCompletely is the SEAM GUARD for the
+// boundary above, and the reason the reachability tier is not quietly dead.
+//
+// 🔴 If a template edit made the shipped scaffolds' entry graphs unresolvable,
+// every real project would silently fall to the presence tier and this whole
+// change would be inert — while every test that only asserts "no warning" stayed
+// green, because the presence tier is silent at a correct project too. Assert
+// the strength, not just the verdict.
+func TestShippedSDKFreeTemplatesResolveCompletely(t *testing.T) {
+	examined := 0
+	for _, tmpl := range []scaffold.Template{scaffold.Static, scaffold.PageVite} {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dir := renderTemplate(t, tmpl)
+			deps, _ := packageDeps(dir)
+			g := blockproto.ResolveEntryGraph(dir, blockproto.EntryGraphOptions{
+				MaxFiles: maxAckGraphFiles, MaxFileBytes: maxAckFileBytes, Dependencies: deps,
+			})
+			if !g.Complete {
+				t.Fatalf("the rendered %s template's entry graph does not resolve: %v\ntrace:\n  %s\n"+
+					"every %s app would therefore be checked on PRESENCE only, and the wiring tier would be "+
+					"dead in production while this suite stayed green",
+					tmpl, g.Gaps, strings.Join(g.Trace, "\n  "), tmpl)
+			}
+			rel := tmpl.ReadyAckPath()
+			if rel == "" {
+				t.Fatalf("%s declares no ReadyAckPath", tmpl)
+			}
+			if g.FileAt(filepath.Join(dir, filepath.FromSlash(rel))) < 0 {
+				t.Fatalf("%s's entry graph does not reach %s; it reached %v", tmpl, rel, g.Trace)
+			}
+		})
+		examined++
+	}
+	// COUNT POSITIVE CONTROL: a zero is otherwise indistinguishable from an
+	// enumeration that returned nothing.
+	if examined != 2 {
+		t.Fatalf("examined %d SDK-free templates, want 2", examined)
+	}
+}

--- a/internal/validate/readyack_wiring_test.go
+++ b/internal/validate/readyack_wiring_test.go
@@ -12,6 +12,7 @@ package validate
 // the near-miss shapes that made the old check look green.
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -170,6 +171,103 @@ func TestWiredEmitterIsSilent(t *testing.T) {
 		}
 		wantAckKind(t, dir, "")
 	})
+}
+
+// TestHTMLSrcIsAURLNotAModuleSpecifier is the end-to-end guard for the audit's
+// root cause: `<script src>` was resolved with JS module-specifier rules.
+//
+// Every case below is a real `static` scaffold with ONE character changed in
+// `index.html`, and every one is ordinary HTML that a browser resolves to
+// exactly the same file as the shipped form. Two were measured failing before
+// the fix:
+//
+//	src="app.js"           -> the emitter-not-wired defect went SILENT again
+//	src=./civitai-host.js  -> a CORRECT project got --strict rc=1
+func TestHTMLSrcIsAURLNotAModuleSpecifier(t *testing.T) {
+	// Correct projects: the reference is spelled differently, the file is the
+	// same, and the check must stay silent. A warning here is the expensive
+	// failure — advisory output that fires at a correct project.
+	for _, c := range []struct{ name, old, new string }{
+		{"unquoted src", `src="./civitai-host.js"`, `src=./civitai-host.js`},
+		{"single-quoted src", `src="./civitai-host.js"`, `src='./civitai-host.js'`},
+		{"no leading ./", `src="./civitai-host.js"`, `src="civitai-host.js"`},
+		{"root-relative", `src="./civitai-host.js"`, `src="/civitai-host.js"`},
+		{"extra attribute after src", `src="./civitai-host.js"`, `src="./civitai-host.js" defer`},
+	} {
+		t.Run("silent: "+c.name, func(t *testing.T) {
+			dir := renderTemplate(t, scaffold.Static)
+			wantAckKind(t, dir, "") // positive control on the untouched scaffold
+			editFile(t, dir, "index.html", c.old, c.new)
+			wantAckKind(t, dir, "")
+		})
+	}
+
+	// And the defect must still be caught when the SAME spellings are used for
+	// the project's own script while the emitter is unreferenced. Without this
+	// half, "stays silent" is satisfied by a check that never fires at all.
+	for _, c := range []struct{ name, old, new string }{
+		{"unquoted src", `src="./app.js"`, `src=./app.js`},
+		{"no leading ./", `src="./app.js"`, `src="app.js"`},
+	} {
+		t.Run("warns: emitter unwired, "+c.name, func(t *testing.T) {
+			dir := renderTemplate(t, scaffold.Static)
+			editFile(t, dir, "index.html", c.old, c.new)
+			editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+			wantAckKind(t, dir, "unwired")
+		})
+	}
+
+	t.Run("an extensionless src is a 404, not an extension to guess", func(t *testing.T) {
+		// 🔴 A browser fetches the literal path. On the no-build `static`
+		// template `<script src="./civitai-host">` is a 404, so the emitter is
+		// NOT loaded — guessing `.js` accepted the exact "ships a 404" shape the
+		// resolver exists to reject, and reported the strong tier's silence.
+		// Now the reference resolves to nothing, which is a GAP, so the check
+		// drops to the presence tier and (the tree does hold the literal) stays
+		// quiet WITHOUT claiming the emitter is wired.
+		dir := renderTemplate(t, scaffold.Static)
+		editFile(t, dir, "index.html", `src="./civitai-host.js"`, `src="./civitai-host"`)
+		wantAckKind(t, dir, "")
+		g, loaded := resolveLoadedFiles(dir, nil)
+		if g.Complete {
+			t.Fatalf("a src pointing at a file that does not exist must make the graph INCOMPLETE, or the "+
+				"check reports a confident finding on a model that disagrees with the project\ntrace: %v", g.Trace)
+		}
+		if loaded {
+			t.Fatal("the extensionless src resolved to the emitter — a browser would 404 that URL")
+		}
+	})
+}
+
+// TestAckBelowTheDepthBoundIsAGapNotAFinding pins the third root-cause bug: the
+// depth bound truncated the walk WITHOUT clearing Complete, so a correct project
+// whose emitter sits below it got the strong tier's warning and `--strict` rc=1.
+// Three separate comments claimed an exhausted budget made the graph incomplete;
+// none of them was true of this budget.
+func TestAckBelowTheDepthBoundIsAGapNotAFinding(t *testing.T) {
+	dir := renderTemplate(t, scaffold.Static)
+	// Rebuild the entry as a chain deeper than blockproto's default bound, with
+	// the emitter genuinely loaded at the bottom. This project WORKS.
+	editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+	editFile(t, dir, "index.html", `<script src="./app.js"></script>`, `<script type="module" src="./m0.js"></script>`)
+	const depth = blockproto.DefaultEntryMaxDepth + 3
+	for i := 0; i < depth; i++ {
+		next := fmt.Sprintf("./m%d.js", i+1)
+		if i == depth-1 {
+			next = "./" + blockproto.ReadyAckFilename
+		}
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("m%d.js", i)),
+			[]byte("import '"+next+"';\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	g, _ := resolveLoadedFiles(dir, nil)
+	if g.Complete {
+		t.Fatalf("the walk stopped at the depth bound and still reported a COMPLETE graph — every finding "+
+			"built on it is a claim about files we chose not to read\ngaps: %v", g.Gaps)
+	}
+	// The observable consequence: no strong-tier warning at a project that works.
+	wantAckKind(t, dir, "")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/validate/readyack_wiring_test.go
+++ b/internal/validate/readyack_wiring_test.go
@@ -239,6 +239,110 @@ func TestHTMLSrcIsAURLNotAModuleSpecifier(t *testing.T) {
 	})
 }
 
+// TestAttributeNameBoundary is the end-to-end guard for a regression the fix
+// round introduced in the class it had just closed: `\b` is not an HTML
+// attribute-name boundary, so `data-src=` was read as `src=`.
+//
+// 🔴 Every case is a CORRECT `static` scaffold. The failure was a false warning
+// with `--strict` rc=1, from the STRONG tier — `Complete` stayed true because a
+// reference really was found, just the wrong one, so no disclosure engaged.
+// `data-src` on a `<script>` is a real consent-manager / lazy-load pattern.
+func TestAttributeNameBoundary(t *testing.T) {
+	for _, c := range []struct{ name, old, new string }{
+		{"data-src before src", `<script src="./civitai-host.js">`,
+			`<script data-src="./app.js" src="./civitai-host.js">`},
+		{"x-src before src", `<script src="./civitai-host.js">`,
+			`<script x-src="./app.js" src="./civitai-host.js">`},
+		{"a <script-loader> custom element alongside", `<script src="./civitai-host.js">`,
+			`<script-loader src="./app.js"></script-loader><script src="./civitai-host.js">`},
+	} {
+		t.Run("silent: "+c.name, func(t *testing.T) {
+			dir := renderTemplate(t, scaffold.Static)
+			wantAckKind(t, dir, "") // positive control on the untouched scaffold
+			editFile(t, dir, "index.html", c.old, c.new)
+			wantAckKind(t, dir, "")
+		})
+	}
+
+	// The inverse control: a `data-src` carrying the ONLY reference to the
+	// emitter loads nothing, so the defect must still be reported. Without this,
+	// "ignore data-src" is indistinguishable from "ignore every src".
+	t.Run("warns: the emitter is referenced only by data-src", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.Static)
+		editFile(t, dir, "index.html", `<script src="./civitai-host.js">`, `<script data-src="./civitai-host.js">`)
+		wantAckKind(t, dir, "unwired")
+	})
+}
+
+// TestDiamondAtTheDepthBoundStillWarns is the end-to-end guard for the other
+// round-2 regression: the truncation gap OVER-fired.
+//
+// 🔴 At the depth bound the walk gapped for any non-package specifier without
+// asking whether the target was ALREADY IN THE GRAPH. A diamond — the normal
+// shape of any real module graph — therefore produced a gap whose message was
+// literally false, dropped the project to the presence tier, and let an orphaned
+// emitter pass with rc=0: the exact defect this PR exists to catch, silenced by
+// the fix for a different one.
+func TestDiamondAtTheDepthBoundStillWarns(t *testing.T) {
+	const depth = blockproto.DefaultEntryMaxDepth
+	build := func(t *testing.T, deepest string) string {
+		t.Helper()
+		dir := renderTemplate(t, scaffold.Static)
+		// Orphan the emitter: present in the tree, referenced by nothing.
+		editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+		editFile(t, dir, "index.html", `<script src="./app.js"></script>`,
+			`<script type="module" src="./m0.js"></script>`)
+		if err := os.WriteFile(filepath.Join(dir, "shared.js"), []byte("export const s = 1;\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < depth; i++ {
+			body := ""
+			if i == 0 {
+				body = "import './shared.js';\n"
+			}
+			if i < depth-1 {
+				body += fmt.Sprintf("import './m%d.js';\n", i+1)
+			} else {
+				body += deepest
+			}
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("m%d.js", i)), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// The emitter really is still there — otherwise `unwired` below would be
+		// the wrong verdict for the right-looking reason.
+		if _, err := os.Stat(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatalf("fixture lost the orphan emitter: %v", err)
+		}
+		return dir
+	}
+
+	t.Run("diamond: the deepest module re-imports an already-walked file", func(t *testing.T) {
+		wantAckKind(t, build(t, "import './shared.js';\n"), "unwired")
+	})
+	t.Run("self-cycle at the bound", func(t *testing.T) {
+		wantAckKind(t, build(t, fmt.Sprintf("import './m%d.js';\n", depth-1)), "unwired")
+	})
+	t.Run("control: the deepest module imports nothing", func(t *testing.T) {
+		// This one has genuinely nothing below the bound, so it must ALSO warn —
+		// proving the two above are not green merely because the fixture warns
+		// unconditionally.
+		wantAckKind(t, build(t, ""), "unwired")
+	})
+	t.Run("negative control: a real truncation still gaps", func(t *testing.T) {
+		// And something genuinely unseen below the bound must STILL drop to the
+		// presence tier, or the dedupe check has simply disabled the gap.
+		dir := build(t, "import './deeper.js';\n")
+		if err := os.WriteFile(filepath.Join(dir, "deeper.js"), []byte("export const d = 1;\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		g, _ := resolveLoadedFiles(dir, nil)
+		if g.Complete {
+			t.Fatalf("a genuinely unwalked module below the bound must still be a gap; gaps=%v", g.Gaps)
+		}
+	})
+}
+
 // TestAckBelowTheDepthBoundIsAGapNotAFinding pins the third root-cause bug: the
 // depth bound truncated the walk WITHOUT clearing Complete, so a correct project
 // whose emitter sits below it got the strong tier's warning and `--strict` rc=1.


### PR DESCRIPTION
`civitai app validate`'s page-without-ack advisory (#206) told authors to do
**two** things — copy `civitai-host.js` in, and **load it** from `index.html` or
the entry module — and verified only the first. A blind dogfood run of the
shipped CLI found the false pass; I reproduced it independently.

Measured on a genuinely pre-fix scaffold (`app init` from the CLI at `0ce0025`),
emitter copied in and never referenced:

```
$ grep -c 'civitai-host' index.html
0
$ civitai app validate <dir> --strict
✓ <dir> is valid          # rc=0
```

The browser never loads the file, so the app is exactly as broken as before —
and the author is told they are fine **while obeying our own advice**. That is
worse than the silence it replaced. An orphan file containing the literal
anywhere in the tree passed identically.

## What changed

The check now resolves the **entry graph** — `index.html`, its `<script src>`
tags and inline modules, and the imports below them — and asks whether a file
the *browser loads* mentions the message.

That resolution already existed in this repo, as test-only code behind scaffold
Guard A (`internal/scaffold/ready_ack_contract_test.go`). It moves to
`internal/blockproto` (`entrygraph.go` + `wiring.go`), so one predicate answers
the question for both a template and an author's project — the precedent is
exact: `PackageAcksReady` was consolidated there for the same reason, and the
second copy was wrong. The three copies of the comment stripper collapse into
`blockproto/comments.go` alongside it. Guard A's control corpus moved with the
predicate; Guard A's strength is unchanged.

**Two tiers, and the message names which one ran:**

| tier | when | what it says |
|---|---|---|
| **reachability** (strong) | the entry graph resolves **completely** | `nothing index.html loads reaches it` (orphan emitter) or `nothing index.html loads posts it either` |
| **presence only** (weak) | the graph is **incomplete** | the old whole-tree scan — *and the message states* `it did NOT check that the file is loaded` |

Still a **Warning**, never an Error, for every reason already recorded in
AGENTS.md item 18.

## The decidability boundary, and why

The obvious boundary is "static shape ⇒ decidable, bundler ⇒ not". **I did not
use it**, and the first draft that did was wrong in both directions: an ordinary
Vite project resolves perfectly (`index.html` *is* Vite's entry, which is how
Guard A has checked `page-vite` all along), while a *no-build* project can still
carry a specifier we cannot follow. Drawing the line at project type would have
left the whole `page-vite` population — half the pre-fix apps — on the broken
tier.

So the boundary is **completeness of the resolution itself**. `ResolveEntryGraph`
reports `Complete`, and *any* reference it cannot account for clears it:

- a bundler alias, or any bare specifier that is not a declared npm dependency
  (`import '@/civitai-host.js'`);
- an off-project or protocol-relative URL, or a path escaping the project root;
- a reference resolving to a file that is not there;
- a file it could not read, or an exhausted budget;
- no `index.html` at the project root at all.

A bare specifier naming a **declared dependency** is *accounted for* — it is a
package, not a file in this project — which is the only reason a React app
resolves at all. `packageDeps` therefore returns the dependency names alongside
the ack verdict, from one read of `package.json`.

🔴 **A reference to a file that is not there is a GAP, not a decided absence.**
Tempting to read it as "the browser 404s that, so it cannot be the ack" — but a
project that presumably builds having an unresolvable reference means *our model
is wrong*, and a confident finding on a wrong model is the failure this PR is
about. It also keeps two documented trades alive unchanged: deleting the emitter
from a current scaffold (leaving a dangling `<script src>`) drops to the presence
tier, and item 18's `public/`-holds-a-stale-ack false negative stays a false
negative instead of silently becoming a warning.

**"Cannot observe" does not become "everything passes."** An incomplete graph
never produces a *wiring* finding (item 10's doctrine), but the presence finding
still fires when nothing in the tree mentions the message at all, and its text
discloses its own weakness. The residual is stated rather than hidden: an
unresolvable graph **plus** the literal somewhere is silence — a false negative,
the cheap direction. An *unobservable tree scan* (unreadable file, size cap, file
budget) still gates both tiers.

## Measured before/after

`before` = `e800129` (current `main`, the shipped defect). `after` = this branch.
Projects scaffolded with the CLI at `0ce0025`, so they are genuinely pre-#206.

```
FIXTURE                BEFORE (e800129)               AFTER (this branch)
control-noemitter      WARN         rc=0 strict=1     WARN/missing   rc=0 strict=1
static-unwired         silent       rc=0 strict=0     WARN/unwired   rc=0 strict=1
static-orphan          silent       rc=0 strict=0     WARN/unwired   rc=0 strict=1
vite-unwired           silent       rc=0 strict=0     WARN/unwired   rc=0 strict=1
static-wired           silent       rc=0 strict=0     silent         rc=0 strict=0
vite-wired             silent       rc=0 strict=0     silent         rc=0 strict=0
fresh-static           silent       rc=0 strict=0     silent         rc=0 strict=0
fresh-page-vite        silent       rc=0 strict=0     silent         rc=0 strict=0
fresh-page-money       silent       rc=0 strict=0     silent         rc=0 strict=0
```

`control-noemitter` is the **harness positive control**: a pre-fix project with
no emitter anywhere, which must warn on *both* binaries. Without it, an
all-silent BEFORE column is indistinguishable from a probe wired to nothing.
`--strict` moves the exit code to 1 on exactly the warning rows and nowhere else.

## What the check now proves, and what it still cannot

Proves, on the strong tier: **a file your `index.html` actually loads mentions
`BLOCK_READY` outside a comment** — resolved, not grepped, and not basename-
matched.

Still cannot prove:

- **that the ack fires.** No static check can; an inverted `event.source` guard
  passes everything here. That is Guard B's job for templates, and there is no
  equivalent for an app the author already has.
- **wiring behind a bundler alias, a computed `import(expr)`, a plugin-injected
  entry, or a framework-owned entry with no root `index.html`.** These land on
  the presence tier, which says so in its own text.
- **anything about a project whose tree it could not fully read.** Silence, as
  before.

## Mutation results

20 mutants, restore by file-copy snapshot with a sha256 check both directions
(the first attempt restored with `git checkout` and silently left every untracked
file mutated — noted so nobody rebuilds that harness). Every mutant was confirmed
to change the file before the run; each kill is attributed to the test *and* the
assertion message.

| mutant | verdict | killed by |
|---|---|---|
| **M0 null** (comment-only) | **SURVIVED** ✓ | — (must survive) |
| M1 restore the defect (presence only) | KILLED | `TestEmitterPresentButNotLoadedWarns` — `tier = "", want "unwired"` |
| M2 old precedence (a literal anywhere wins) | KILLED | same |
| M3 every bare specifier is a package | KILLED | `TestReadyAckDecidabilityBoundary/a_bundler_alias…` |
| M4 dependency match `==` → prefix | KILLED | same |
| M5 `//` guard → `///` | KILLED | `TestReadyAckWiringPredicate/reject: protocol-relative URL…` |
| M6 drop root containment | KILLED | `…/reject: an import that escapes the project root` |
| M7 missing file is not a gap | KILLED | `TestReadyAckWarning/a_non-conventional_outputDir…` + boundary test |
| M8 stop reading inline `<script>` imports | KILLED | `…/accept: an inline module in index.html imports it` |
| M9 drop extensionless resolution | KILLED | `…/accept: an extensionless import…` |
| M10 file budget is not a gap | KILLED | `TestEntryGraphBudgetsAreGaps/the_file_budget_is_a_gap` |
| M11 drop the graph's source-extension gate | KILLED | `…/a_stylesheet_in_the_graph_is_not_ack_evidence` |
| M12 delete the presence tier's disclosure | KILLED | `TestReadyAckAdvisoriesStateTheirOwnStrength` |
| M13 unterminated `<!--` becomes lossy again | KILLED | `TestReadyAckWarning/an_unterminated_<!--_in_.html…` |
| M14 stop respecting JS string literals | KILLED | `…/a_URL_literal_does_not_swallow_the_ack_after_it` |
| M15 HTML-strip every extension | KILLED | `…/a_matched_<!--_-->_pair_in_.js_strings…` |
| M16 drop the unobservable-tree gate | KILLED | `TestReadyAckCannotObserve/a_directory_holding_only_a_manifest…` |
| M17 missing `index.html` is not a gap | KILLED | `…/an_ack_in_a_.vue_single-file_component_does_not_warn` |
| M18 make `ErrNoScriptTags` unreachable | KILLED | `…/reject: no script tags at all` |
| M19 Guard A depth `2` → `99` | **survived, then fixed** | now `…/reject: the emitter is two import levels below the entry` |

M19 is the finding worth reading: nothing in the suite held Guard A's documented
"one level of imports on purpose" contract. The corpus case that pins it is in
this PR, and re-running M19 kills it.

## Tests

New fixtures are **rendered templates, mutated** — a hand-written string fixture
carries none of the template's comments, import graph or near-miss shapes. The
mutation helper *fails* if its replacement is a no-op, so a template rename
cannot silently turn a test into "the project was never broken".

- emitter present and wired (`<script src>`, and moved to `vendor/` with the tag
  followed) → silent
- emitter present, **not** wired, on `static` **and** `page-vite` → warns
  (`unwired`)
- emitter wired via an entry-module import → silent
- orphan file containing `BLOCK_READY` → warns
- `@civitai/blocks-react` project → silent, asserted to be silent *because of the
  dependency* (`scanForReadyAck` = `ackAbsent` on that tree)
- undecidable shapes asserted explicitly: bundler alias with the emitter present
  → **silent** (documented residual), same alias with it deleted →
  `presence-only`, no root `index.html` → `presence-only`, dangling reference →
  `presence-only`, genuinely pre-fix project → `missing` (reachability)
- `TestShippedSDKFreeTemplatesResolveCompletely` — a seam guard so the strong
  tier cannot go quietly dead: if a template edit made the shipped scaffolds
  unresolvable, every real project would silently fall to the presence tier while
  every "no warning" assertion stayed green.

## `make ci`

Green. Counts from `go test ./... -v -count=1`, not an exit code:
`=== RUN 2024`, `--- PASS 2020`, `--- FAIL 0`, `--- SKIP 4`, 0 timeout panics,
18/18 packages ok, `gofmt -s -l .` silent. The 4 skips are the pre-existing
env-gated ones (`TestScanDirFromEnv`, `TestSubmissionsCapDriftAgainstLiveAPI`,
`TestScaffoldPinsSatisfyPublished`, `TestScaffoldedReadyAckActuallyFires`);
Guard B was additionally run locally with `CIVITAI_CHECK_SCAFFOLD_RUNTIME=1` and
passes, including both of its own controls.

## Docs

AGENTS.md gains **item 20** (append-only numbering, next free number) for the
tier split, the boundary and its rejected alternative, and the measured matrix.
Items **11** and **18** are corrected in place: 11 records the resolver's move
into `blockproto` and the newly-pinned depth bound; 18's "mentioned in code"
claim becomes "code the browser loads" and points at 20. README documents both
tiers plus the thing an author actually needs — that copying the emitter in is
half the fix, with the exact reference each template uses.

Refs #206, #212. No changes to `schema/`, the emitter, or any template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
