### PR TITLE
feat(generate): surface the server's silent model substitutions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -589,12 +589,84 @@ neither one's.
     **nonexistent** checkpoint id is otherwise accepted with HTTP 200, the
     ecosystem default silently substituted, and **billed** (measured on one
     ecosystem: the correct id priced 160, while a nonexistent id, a
-    foreign-ecosystem id, and no model at all ALL priced 60 — the server's own
-    comment says this correction is visible on-site and invisible through a
-    non-browser path). And `Graph.Resources` entries **require** `model:{type}`,
+    foreign-ecosystem id, and no model at all ALL priced 60). And
+    `Graph.Resources` entries **require** `model:{type}`,
     which is not derivable from a version id — a bare id and `{id}` alone are
     both 400s, while a *wrong* type is silently accepted. The type must come
     from the lookup, never a guess.
+    🔴 **CORRECTION: the substitution is no longer invisible.** An earlier
+    revision of this item said the server's own comment calls the correction
+    "visible on-site and invisible through a non-browser path". That was true
+    when written and has been **FALSE since civitai#3665** (PRs **#3692** and
+    **#3673**). The server now REPORTS every silent checkpoint swap as
+    `modelSubstitutions`, an array of
+    `{requested, applied, reason}` (`PersistedModelSubstitution` in
+    `civitai/civitai → src/shared/data-graph/generation/model-substitution.ts`;
+    `reason` ∈ `wrong-workflow` | `unrecognized` | `gated`). This **strengthens**
+    item 13 rather than contradicting it: it is a **live server signal**, not a
+    vendored table, so it is the same category as `ResolveModelVersion` — the
+    thing this item says IS allowed — and it closes the one gap that lookup
+    structurally cannot, a **real** id that is wrong for the chosen ecosystem or
+    workflow.
+    🔴 **THERE ARE THREE READ SITES AND THEY DO NOT AGREE, so the CLI reads BOTH
+    carriers.** Per the reply-contract comment on `NormalizedWorkflowMetadata`
+    (`civitai/civitai → src/server/services/orchestrator/orchestration-new.service.ts`,
+    ~line 1940-1968):
+    - `whatIfFromGraph` → **top-level `modelSubstitutions` only**. Nothing is
+      persisted on that path, so the reply is the sole carrier — and it is the
+      most valuable one, because it is the only place a caller learns *before*
+      spending, and the only signal for a SAME-PRICE swap.
+    - `generateFromGraph` → **both** top-level (authoritative for the validation
+      just performed, and present even when the graph produced no workflow
+      metadata to round-trip) **and** under `metadata`.
+    - any later read (`getWorkflow` poll / re-attach / `queryGeneratedImages`)
+      → **`metadata` only**; the top-level copy is gone.
+    A client reading only the top level sees substitutions on the submit and
+    never again; one reading only `metadata` misses the whatIf entirely.
+    `internal/genapi/substitution.go` reads both and merges, deduping exact
+    records so a two-carrier submit reply is reported once. The metadata key is
+    the literal `modelSubstitutions`
+    (`WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY`), the same on the raw
+    orchestrator workflow `getWorkflow` returns and on the normalized shape.
+    Three consequences that are easy to get wrong:
+    (a) **Every carrier is a `json.RawMessage`, parsed leniently.** A typed slice
+    would let a malformed advisory field fail the whole `json.Unmarshal` of the
+    **submit reply** — the message that hands back the workflow id for a job the
+    user has ALREADY BEEN CHARGED for. A warning we cannot parse must never cost
+    them the handle. Bad entries are skipped, mirroring the server's
+    `readModelSubstitutionsFromMetadata`.
+    (b) **`reason` is deliberately NOT narrowed against the server's union.**
+    The server narrows it because the value doubles as a bounded Prometheus
+    label; the CLI has the opposite incentive — vendoring the union means a
+    reason added server-side is DROPPED, turning a real billed substitution back
+    into the silence this closes. Unknown reasons render verbatim; the
+    `substitutionReasonGloss` table in `internal/cmd/generate_substitution.go` is
+    advisory only and **must never gate the warning**.
+    (c) **Absence is AMBIGUOUS** — "no substitution" and "a server predating
+    #3665" are indistinguishable on the wire. Never render absence as a
+    guarantee, and never print a "no substitutions" line.
+    🔴 **It WARNS and never REFUSES**, decided rather than defaulted, and the
+    same fail-soft shape as `serverQuantityClamp` above. Substitution on a
+    `modelLocked` ecosystem is legitimate graceful degradation — it keeps an app
+    pinned to a since-retired version generating instead of hard-failing — and
+    the platform has explicitly **deferred** the rejection decision ("deciding
+    whether any case should REJECT is a later phase, gated on what the counter
+    measures"), so a CLI that refused first would be vendoring a policy the
+    server has not made. A refusal would also be unenforceable, per (c), and two
+    of the four surfaces are post-spend where it buys nothing.
+    The warning must reach **every** surface that precedes or reports a spend:
+    `--dry-run` (human *and* `--json`), the TTY confirmation, `--yes`, the
+    post-submit output, and `workflows get`. It is emitted from **one call site**
+    in `runGenerate`, before every branch, precisely so none can be forgotten —
+    that is the lesson of the img2img caveat, which printed only on the
+    interactive path and so missed `--yes` (mandatory in CI) and `--dry-run`.
+    Everything goes to **stderr**, including under `--json`, where the machine
+    payload owns stdout and already carries the raw field.
+    Two deliberate NON-surfaces: `workflows list` (a paged feed — a warning block
+    per row would be noise, and `workflows get <id>` is the per-job read that
+    carries it), and the poll loop inside a waiting `generate` run, which would
+    just repeat what the submit reply already said one screen earlier. Both would
+    be cheap to add if the incidence ever justifies it; neither is an oversight.
 
 14. **Unset flags must be ABSENT from the payload, never Go zero values.** Every
     optional field on `genapi.Graph` is a pointer or carries `omitempty`. This

--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,41 @@ echoes the resolved **model name** so you approve a name rather than an integer.
 `--model` is deliberately absent: `civitai download --model` takes a *model* id,
 while this takes a *version* id.
 
+### Silent model substitutions
+
+That id check catches an id that **does not exist**. It cannot catch a **real**
+id that is wrong for the ecosystem you named — on a model-locked ecosystem the
+generator swaps it for the ecosystem default, returns HTTP 200, and bills you.
+
+The server now **reports** that swap, and this CLI surfaces it:
+
+```
+⚠ The server SUBSTITUTED a different checkpoint — the estimate below prices the
+  model it would actually run, not the one you asked for.
+  Requested:  DreamShaper — v8 (Checkpoint, id 128713)
+  Ran:        SDXL 1.0 (Checkpoint, id 999001)
+  Reason:     unrecognized — that version is in none of this ecosystem's lists …
+```
+
+It appears on **every** surface that precedes or reports a spend — `--dry-run`
+(including `--dry-run --json`), the confirmation prompt, `--yes`, the output
+after a submit, and `civitai workflows get <id>` for a job you collected later.
+Ids are resolved to model names where possible; a failed lookup shows the ids
+and never suppresses the warning. Everything goes to **stderr**, so a `--json`
+stdout stays machine-clean while still carrying the raw `modelSubstitutions`
+field.
+
+It **warns and does not refuse.** Substitution is legitimate on some
+ecosystems — it is what keeps a job pinned to a since-retired version running
+instead of failing — so blocking it would break flows that work today. Use
+`--dry-run` to see it before you spend, or branch on `modelSubstitutions` in the
+`--dry-run --json` payload if you want a script to stop.
+
+Two things absence does **not** tell you: no field means "nothing was
+substituted" *or* "this server predates the feature" — the two are
+indistinguishable — and the CLI therefore never prints a "no substitutions"
+reassurance.
+
 ### Raw graphs: `--print-input` and `--input`
 
 The five flags cover the common job. Everything else the generator understands

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -186,6 +186,16 @@ the public model-version API BEFORE submitting, so a bad id is a hard local
 error instead of a wrong charge, and it echoes the resolved model NAME in the
 confirmation so you approve a name rather than an integer.
 
+That check catches an id that does not EXIST. A real id that is wrong for the
+--ecosystem you named is swapped for the ecosystem default just as silently —
+and the server now reports that swap. When it happens, this command says so on
+every surface before and after the spend (--dry-run, the confirmation, --yes,
+the submit output, and ` + "`civitai workflows get`" + `), naming the version you
+asked for, the version that actually ran, and the server's reason. It WARNS and does
+not refuse: substitution is legitimate on some ecosystems. Note the reverse is
+not a guarantee — no report means "nothing was substituted" OR "this server
+predates the feature".
+
 WAITING AND DOWNLOADING: by default the command waits for the job to finish and
 writes every deliverable output into --out-dir as <workflow-id>-<n>.<ext>. Pass
 --no-wait to print the workflow id and exit immediately, and pick the results up
@@ -819,6 +829,16 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 		return fmt.Errorf("the server returned no cost estimate — refusing to submit a generation whose price is unknown")
 	}
 
+	// 🔴 ONE CALL SITE, DELIBERATELY PLACED BEFORE EVERY BRANCH BELOW. The
+	// surfaces that must show this are --dry-run (human AND --json), the TTY
+	// confirmation and --yes; emitting here means none of them can be forgotten,
+	// because there is no path from a successful estimate to a spend decision
+	// that does not pass through this line. printImageDisclosure learned the
+	// other lesson the hard way — it was called from the interactive path only,
+	// so `--yes` (mandatory in CI) and `--dry-run` never showed it. Do not move
+	// this into confirmGenerate.
+	printModelSubstitutions(ctx, errw, quote.ModelSubstitutions(), deps.resolveVersion, substitutionPhaseEstimate)
+
 	if o.dryRun {
 		if o.jsonOut {
 			// Raw passthrough: a script sees every field, including ones this CLI
@@ -921,6 +941,13 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 		}
 		return classifyGenerateError(err)
 	}
+
+	// 🔴 AGAIN AFTER THE SUBMIT, and not only before it. The estimate and the
+	// submit are two separate validations: a version can be gated, retired or
+	// re-scoped between them, and only this reply describes the generation that
+	// was actually CHARGED. Placed before the --no-wait branch so the fire-and-
+	// forget path reports it too — that is the path with no later output at all.
+	printModelSubstitutions(ctx, errw, result.ModelSubstitutions(), deps.resolveVersion, substitutionPhaseCharged)
 
 	workflowID := ""
 	if result != nil {

--- a/internal/cmd/generate_substitution.go
+++ b/internal/cmd/generate_substitution.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/civitai/cli/internal/genapi"
+	"github.com/civitai/cli/internal/ui"
+)
+
+// substitutionPhase selects the tense of the warning: an estimate has not been
+// charged yet, a submit or a read-back has.
+type substitutionPhase int
+
+const (
+	// substitutionPhaseEstimate is the pre-spend surface (whatIf): --dry-run,
+	// the TTY confirmation and --yes.
+	substitutionPhaseEstimate substitutionPhase = iota
+	// substitutionPhaseCharged is any surface where the money is already gone:
+	// the submit reply and `workflows get`.
+	substitutionPhaseCharged
+)
+
+// versionResolver is the model-version lookup seam. It matches
+// genapi.Client.ResolveModelVersion, and may be nil: a surface with no resolver
+// still warns, with ids instead of names.
+type versionResolver func(ctx context.Context, id int) (*genapi.ResolvedVersion, error)
+
+// substitutionReasonGloss explains the server's reason tokens in one clause.
+//
+// 🔴 IT IS ADVISORY AND FAILS SOFT, and that shape is what keeps it from being
+// the vendored table AGENTS.md item 13 forbids. An unknown token — a reason the
+// platform adds after this build — renders VERBATIM with no gloss and the
+// warning fires exactly as loudly. A map lookup here can never decide whether
+// the user is told; it only decides whether a sentence is appended. If you ever
+// make the warning conditional on a hit in this map, you have reintroduced the
+// silence this feature exists to end.
+//
+// Mirrors the doc comments on `MODEL_SUBSTITUTION_REASONS`
+// (civitai/civitai -> src/shared/data-graph/generation/model-substitution.ts).
+var substitutionReasonGloss = map[string]string{
+	"wrong-workflow": "that version exists in this ecosystem but belongs to a different workflow",
+	"unrecognized":   "that version is in none of this ecosystem's lists — a community checkpoint, or one retired since",
+	"gated":          "that version is offered here, but a gate rule hides it from your account",
+}
+
+// printModelSubstitutions is the ONE renderer for a silent model substitution
+// the server has now told us about (civitai#3665, PRs #3692 / #3673).
+//
+// 🔴 IT WARNS AND NEVER REFUSES — a deliberate decision, argued rather than
+// defaulted. Four reasons:
+//
+//   - Substitution on a `modelLocked` ecosystem is legitimate graceful
+//     degradation. It is what keeps an app pinned to a since-retired version
+//     generating instead of hard-failing, and the server documents it as such.
+//     Refusing would break flows that work today, for a class of request the
+//     platform considers correct.
+//   - The platform has DELIBERATELY NOT MADE the rejection decision. Its own
+//     module note says recording the swap "changes no behaviour" and that
+//     "deciding whether any case should REJECT is a later phase, gated on what
+//     the counter measures". A CLI that refused first would be vendoring a
+//     policy the server has explicitly deferred — item 13's anti-mirror rule,
+//     applied to a policy rather than to a table.
+//   - A refusal would be UNENFORCEABLE ANYWAY. Absence of the field means "no
+//     substitution" OR "a server predating it"; the two are indistinguishable on
+//     the wire, so a gate would bind only against servers new enough to confess.
+//   - Two of the four surfaces are POST-SPEND (the submit reply, `workflows
+//     get`) where refusing buys nothing at all. On the pre-spend surfaces the
+//     user still has --dry-run and the confirmation prompt, both of which now
+//     carry this, and a script has the raw field under --json.
+//
+// The same fail-soft shape as serverQuantityClamp (AGENTS.md item 13b): say the
+// expensive thing loudly, then let the request proceed.
+//
+// Everything goes to STDERR, unconditionally — including under --json, where the
+// machine payload owns stdout and already carries the field. A warning about a
+// wrong charge must not be the one thing a scripted surface drops.
+func printModelSubstitutions(ctx context.Context, errw io.Writer, subs []genapi.ModelSubstitution, resolve versionResolver, phase substitutionPhase) {
+	if len(subs) == 0 {
+		// The overwhelmingly common case, and it must stay SILENT — a "no
+		// substitutions" line on every run would train users past the real one.
+		// It is also not a guarantee: a server predating civitai#3665 sends
+		// nothing here either.
+		return
+	}
+	st := ui.For(errw)
+	lead := "The server SUBSTITUTED a different checkpoint — the estimate below prices the model it would actually run, not the one you asked for."
+	if phase == substitutionPhaseCharged {
+		lead = "The server SUBSTITUTED a different checkpoint — you were charged for a generation that ran a model you did not ask for."
+	}
+	fmt.Fprintln(errw, st.Warn(lead))
+
+	// One cache per call: a repeated id costs one lookup, and a surface with no
+	// resolver costs none.
+	names := map[int]string{}
+	name := func(id int) string {
+		if s, ok := names[id]; ok {
+			return s
+		}
+		s := resolveSubstitutedVersion(ctx, resolve, id)
+		names[id] = s
+		return s
+	}
+
+	for _, s := range subs {
+		fmt.Fprintf(errw, "  Requested:  %s\n", name(s.Requested))
+		fmt.Fprintf(errw, "  Ran:        %s\n", name(s.Applied))
+		reason := safeTerm(s.Reason)
+		if gloss, ok := substitutionReasonGloss[s.Reason]; ok {
+			reason += " — " + gloss
+		}
+		fmt.Fprintf(errw, "  Reason:     %s\n", reason)
+	}
+
+	tail := "This is not a server error: the request succeeds and is billed at the SUBSTITUTE's price. Pass a version this ecosystem and workflow offer, or accept the substitute."
+	if phase == substitutionPhaseCharged {
+		tail = "This is not a server error and there is no refund. Check the version against the ecosystem and workflow you named before the next run."
+	}
+	fmt.Fprintln(errw, st.Dim(tail))
+}
+
+// resolveSubstitutedVersion renders one version id as a name when it can.
+//
+// 🔴 A FAILED LOOKUP MUST NEVER SUPPRESS THE WARNING. The name is a convenience;
+// the substitution is the fact. So the id is always rendered, the failure is
+// stated inline rather than swallowed, and a nil resolver is simply a surface
+// that has no lookup wired — not a reason to say nothing.
+func resolveSubstitutedVersion(ctx context.Context, resolve versionResolver, id int) string {
+	if resolve == nil {
+		return "id " + strconv.Itoa(id)
+	}
+	rv, err := resolve(ctx, id)
+	if err != nil || rv == nil {
+		return fmt.Sprintf("id %d (could not look up the name)", id)
+	}
+	return describeVersion(rv, nil)
+}

--- a/internal/cmd/generate_substitution_test.go
+++ b/internal/cmd/generate_substitution_test.go
@@ -1,0 +1,442 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/genapi"
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// ---------------------------------------------------------------------------
+// Silent model substitutions must be surfaced on EVERY surface that precedes or
+// reports a spend (civitai#3665, PRs #3692 / #3673).
+//
+// 🔴 This mirrors a bug this codebase already shipped once: the img2img caveat
+// printed only on the interactive path, so `--yes` (mandatory in CI) and
+// `--dry-run` (the documented price-check-first workflow) never showed it. The
+// surfaces enumerated below are exactly the ones that regression missed, plus
+// the two post-spend reads.
+// ---------------------------------------------------------------------------
+
+// substWarn is the lead sentence. It is deliberately matched on the verb, not
+// on a whole line, so a wording tweak does not fail the suite while a DELETED
+// warning still does.
+const substWarn = "SUBSTITUTED a different checkpoint"
+
+const substArrayJSON = `[{"requested":128713,"applied":999001,"reason":"unrecognized"}]`
+
+// quoteWithSubs is a whatIf reply carrying one substitution, on the top-level
+// carrier — the only one that path has.
+func quoteWithSubs(total float64) (*genapi.WhatIfResult, json.RawMessage) {
+	q := okQuote(total)
+	q.RawModelSubstitutions = json.RawMessage(substArrayJSON)
+	raw := json.RawMessage(`{"ready":true,"cost":{"base":8,"total":12},"modelSubstitutions":` + substArrayJSON + `}`)
+	return q, raw
+}
+
+// subsSeams builds seams whose ESTIMATE reports a substitution.
+func subsSeams() *genSeams {
+	return &genSeams{whatIf: func(ctx context.Context, g genapi.Graph) (*genapi.WhatIfResult, json.RawMessage, error) {
+		q, raw := quoteWithSubs(12)
+		return q, raw, nil
+	}}
+}
+
+// assertSubstitutionWarning pins the three facts the user needs: that a swap
+// happened, which id was asked for, and which id ran.
+//
+// 🔴 IT PINS THE ID TO ITS LABEL, NOT JUST TO THE OUTPUT. Asserting that both
+// integers appear somewhere is satisfied by a renderer that prints them the
+// wrong way round — and "you asked for X, you got Y" is the entire content of
+// the warning, so a transposition inverts its meaning while every substring
+// check stays green. The fixture ids are deliberately distinct and neither is a
+// substring of the other.
+func assertSubstitutionWarning(t *testing.T, surface, stderr string) {
+	t.Helper()
+	if !strings.Contains(stderr, substWarn) {
+		t.Errorf("%s: the substitution warning is missing.\nstderr:\n%s", surface, stderr)
+	}
+	if !strings.Contains(stderr, "unrecognized") {
+		t.Errorf("%s: the server's reason token must be shown.\nstderr:\n%s", surface, stderr)
+	}
+	assertLabelledValue(t, surface, stderr, "Requested:", "128713")
+	assertLabelledValue(t, surface, stderr, "Ran:", "999001")
+}
+
+// assertLabelledValue requires want to appear on the SAME LINE as label.
+func assertLabelledValue(t *testing.T, surface, stderr, label, want string) {
+	t.Helper()
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.Contains(line, label) {
+			if strings.Contains(line, want) {
+				return
+			}
+			t.Errorf("%s: %q line does not carry %q — the ids may be transposed.\nline: %s\nstderr:\n%s",
+				surface, label, want, line, stderr)
+			return
+		}
+	}
+	t.Errorf("%s: no %q line at all.\nstderr:\n%s", surface, label, stderr)
+}
+
+// --- pre-spend surfaces ------------------------------------------------------
+
+func TestSubstitution_WarnsOnDryRun(t *testing.T) {
+	withStdinTTY(t, false)
+	s := subsSeams()
+	o := baseOpts()
+	o.dryRun = true
+	_, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if s.whatIfCalls != 1 {
+		t.Fatalf("POSITIVE CONTROL FAILED: whatIf reached %d times, want 1", s.whatIfCalls)
+	}
+	assertSubstitutionWarning(t, "--dry-run", errb.String())
+}
+
+// --dry-run --json: the machine payload owns stdout and must still carry the
+// field, while the human warning goes to stderr. Neither may be dropped — a
+// scripted price check is precisely where nobody reads the terminal.
+func TestSubstitution_WarnsOnDryRunJSONAndKeepsThePayloadField(t *testing.T) {
+	withStdinTTY(t, false)
+	s := subsSeams()
+	o := baseOpts()
+	o.dryRun = true
+	o.jsonOut = true
+	out, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	assertSubstitutionWarning(t, "--dry-run --json", errb.String())
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &m); err != nil {
+		t.Fatalf("stdout is not a JSON object (the warning must not have leaked into it): %v\n%s", err, out.String())
+	}
+	if _, ok := m["modelSubstitutions"]; !ok {
+		t.Errorf("--json passthrough lost `modelSubstitutions`:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), substWarn) {
+		t.Errorf("the warning must go to stderr, never into the --json payload:\n%s", out.String())
+	}
+}
+
+func TestSubstitution_WarnsOnTTYConfirm(t *testing.T) {
+	withStdinTTY(t, true)
+	s := subsSeams()
+	cmd, _, errb := genCmd("y\n")
+	if err := runGenerate(cmd, s.deps(t), baseOpts()); err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if s.submitCalls != 1 {
+		t.Fatalf("POSITIVE CONTROL FAILED: submit reached %d times, want 1", s.submitCalls)
+	}
+	assertSubstitutionWarning(t, "TTY confirm", errb.String())
+	// 🔴 Ordering: the user must read it BEFORE approving, not after.
+	stderr := errb.String()
+	if i, j := strings.Index(stderr, substWarn), strings.Index(stderr, "Generate? [y/N]"); i < 0 || j < 0 || i > j {
+		t.Errorf("the warning must precede the confirmation prompt (warn at %d, prompt at %d).\nstderr:\n%s", i, j, stderr)
+	}
+}
+
+func TestSubstitution_WarnsOnYes(t *testing.T) {
+	withStdinTTY(t, false)
+	s := subsSeams()
+	o := baseOpts()
+	o.assumeYes = true
+	_, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if s.submitCalls != 1 {
+		t.Fatalf("POSITIVE CONTROL FAILED: submit reached %d times, want 1", s.submitCalls)
+	}
+	assertSubstitutionWarning(t, "--yes", errb.String())
+}
+
+// --- post-spend surfaces -----------------------------------------------------
+
+// The SUBMIT reply is a second, independent validation: a version can be gated
+// or retired between the estimate and the submit, so this reply is the only
+// thing that describes the generation actually charged.
+func TestSubstitution_WarnsAfterSubmit(t *testing.T) {
+	withStdinTTY(t, false)
+	s := &genSeams{
+		submitReply: &genapi.SubmitResult{
+			ID: "wf_123", Status: "queued",
+			RawModelSubstitutions: json.RawMessage(substArrayJSON),
+		},
+	}
+	o := baseOpts()
+	o.assumeYes = true
+	_, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if s.submitCalls != 1 {
+		t.Fatalf("POSITIVE CONTROL FAILED: submit reached %d times, want 1", s.submitCalls)
+	}
+	assertSubstitutionWarning(t, "post-submit", errb.String())
+	// The post-spend tense: there is no refund, so it must not read like advice
+	// for a decision the user still gets to make.
+	if !strings.Contains(errb.String(), "you were charged") {
+		t.Errorf("the post-submit warning must say the charge already happened.\nstderr:\n%s", errb.String())
+	}
+}
+
+// The submit reply's OTHER carrier. The server writes both; a reader that only
+// looked at the top level would miss nothing here today, but the metadata copy
+// is the one that survives — pinning it stops a refactor from dropping it.
+func TestSubstitution_WarnsAfterSubmit_MetadataCarrier(t *testing.T) {
+	withStdinTTY(t, false)
+	s := &genSeams{
+		submitReply: &genapi.SubmitResult{
+			ID: "wf_123", Status: "queued",
+			RawMetadata: json.RawMessage(`{"params":{},"modelSubstitutions":` + substArrayJSON + `}`),
+		},
+	}
+	o := baseOpts()
+	o.assumeYes = true
+	_, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	assertSubstitutionWarning(t, "post-submit (metadata carrier)", errb.String())
+	// Reported ONCE even when both carriers hold it — see the both-carriers case
+	// in genapi's substitution_test.go for the merge itself.
+	if n := strings.Count(errb.String(), substWarn); n != 1 {
+		t.Errorf("the warning must appear exactly once per surface, got %d.\nstderr:\n%s", n, errb.String())
+	}
+}
+
+// `workflows get` is the ONLY surface for a job this process did not submit — a
+// --no-wait run collected later, a re-attach after Ctrl-C or a --timeout.
+func TestSubstitution_WarnsOnWorkflowsGet(t *testing.T) {
+	payload := `{"id":"wf_123","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":` + substArrayJSON + `},"steps":[]}`
+	for _, jsonOut := range []bool{false, true} {
+		name := "human"
+		if jsonOut {
+			name = "--json"
+		}
+		t.Run(name, func(t *testing.T) {
+			c, out, errb := genCmd("")
+			deps := wfGetDeps(payload, nil)
+			if err := runWorkflowsGet(c, deps, workflowsGetOpts{jsonOut: jsonOut, baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+				t.Fatalf("workflows get: %v", err)
+			}
+			assertSubstitutionWarning(t, "workflows get "+name, errb.String())
+			if jsonOut && strings.Contains(out.String(), substWarn) {
+				t.Errorf("the warning must not leak into the --json payload:\n%s", out.String())
+			}
+		})
+	}
+}
+
+// --- the common case: no substitution, no noise ------------------------------
+
+// 🔴 CONTRAST CONTROL WITH ITS POSITIVE CONTROL IN THE SAME TEST. A renderer
+// that printed unconditionally would pass every assertion above, and the warning
+// would become noise users learn to click past. The populated half proves the
+// same code path CAN warn, so the empty half's silence is a measurement rather
+// than a wiring failure.
+func TestSubstitution_SilentWhenNoneReported(t *testing.T) {
+	withStdinTTY(t, false)
+
+	// (A) negative: the default seams report no substitutions.
+	quiet := &genSeams{}
+	o := baseOpts()
+	o.assumeYes = true
+	_, quietErr, err := runImg(t, quiet, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if quiet.submitCalls != 1 {
+		t.Fatalf("POSITIVE CONTROL FAILED: submit reached %d times, want 1", quiet.submitCalls)
+	}
+	if strings.Contains(quietErr.String(), substWarn) {
+		t.Errorf("a run with no substitutions must print no substitution warning.\nstderr:\n%s", quietErr.String())
+	}
+	// It must not manufacture reassurance either — absence on the wire also
+	// means "a server predating civitai#3665".
+	if strings.Contains(strings.ToLower(quietErr.String()), "no substitution") {
+		t.Errorf("silence is the contract; a 'no substitutions' line would be an unfounded guarantee.\nstderr:\n%s", quietErr.String())
+	}
+
+	// (B) positive control, same path, same helper: it DOES warn when there is
+	// something to report.
+	loud := subsSeams()
+	_, loudErr, err := runImg(t, loud, o)
+	if err != nil {
+		t.Fatalf("runGenerate: %v", err)
+	}
+	if !strings.Contains(loudErr.String(), substWarn) {
+		t.Fatalf("POSITIVE CONTROL FAILED: the same path printed nothing for a populated reply.\nstderr:\n%s", loudErr.String())
+	}
+}
+
+// The same pair for `workflows get`.
+func TestSubstitution_WorkflowsGetSilentWhenNoneReported(t *testing.T) {
+	quietPayload := `{"id":"wf_123","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"params":{"seed":1}},"steps":[]}`
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(quietPayload, nil), workflowsGetOpts{}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	if strings.Contains(errb.String(), substWarn) {
+		t.Errorf("no substitutions must mean no warning.\nstderr:\n%s", errb.String())
+	}
+	// Positive control on the identical call path.
+	loudPayload := `{"id":"wf_123","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":` + substArrayJSON + `},"steps":[]}`
+	c2, _, errb2 := genCmd("")
+	if err := runWorkflowsGet(c2, wfGetDeps(loudPayload, nil), workflowsGetOpts{}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	if !strings.Contains(errb2.String(), substWarn) {
+		t.Fatalf("POSITIVE CONTROL FAILED: the same path printed nothing for a populated payload.\nstderr:\n%s", errb2.String())
+	}
+}
+
+// --- name resolution is a convenience, never a gate --------------------------
+
+// 🔴 A FAILING ResolveModelVersion MUST NOT SUPPRESS THE WARNING. The name is
+// decoration; the substitution is the fact the user is being billed for. A
+// renderer that returned early on a lookup error would be silent in exactly the
+// situation a substitution is most likely — an id the server does not recognise.
+func TestSubstitution_WarnsEvenWhenNameResolutionFails(t *testing.T) {
+	withStdinTTY(t, false)
+	s := subsSeams()
+	s.resolve = func(ctx context.Context, id int) (*genapi.ResolvedVersion, error) {
+		return nil, civitai.Tag(civitai.ErrNotFound, errors.New("no such model version"))
+	}
+	o := baseOpts()
+	o.dryRun = true
+	_, errb, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("a failed name lookup must not fail the run: %v", err)
+	}
+	assertSubstitutionWarning(t, "resolution failure", errb.String())
+	if !strings.Contains(errb.String(), "could not look up the name") {
+		t.Errorf("the failed lookup must be stated, not swallowed.\nstderr:\n%s", errb.String())
+	}
+	// POSITIVE CONTROL: the resolver was actually consulted, so the assertion
+	// above is about a failure and not about an unwired seam.
+	if s.resolveCalls == 0 {
+		t.Fatalf("POSITIVE CONTROL FAILED: the resolver was never called, so nothing failed")
+	}
+}
+
+// A surface with NO resolver wired still warns, with ids.
+func TestSubstitution_NilResolverStillWarns(t *testing.T) {
+	payload := `{"id":"wf_1","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":` + substArrayJSON + `},"steps":[]}`
+	deps := wfGetDeps(payload, nil)
+	deps.resolveVersion = nil
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, deps, workflowsGetOpts{}, "wf_1"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	assertSubstitutionWarning(t, "nil resolver", errb.String())
+}
+
+// Names are shown when the lookup works — that is the whole point of resolving.
+func TestSubstitution_ShowsResolvedNames(t *testing.T) {
+	payload := `{"id":"wf_1","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":` + substArrayJSON + `},"steps":[]}`
+	deps := wfGetDeps(payload, nil)
+	deps.resolveVersion = func(ctx context.Context, id int) (*genapi.ResolvedVersion, error) {
+		if id == 128713 {
+			return &genapi.ResolvedVersion{VersionID: id, ModelName: "AskedFor", VersionName: "v1", ModelType: "Checkpoint"}, nil
+		}
+		return &genapi.ResolvedVersion{VersionID: id, ModelName: "ActuallyRan", VersionName: "v2", ModelType: "Checkpoint"}, nil
+	}
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, deps, workflowsGetOpts{}, "wf_1"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	for _, want := range []string{"AskedFor", "ActuallyRan"} {
+		if !strings.Contains(errb.String(), want) {
+			t.Errorf("the resolved name %q must be shown so the user reads names, not integers.\nstderr:\n%s", want, errb.String())
+		}
+	}
+}
+
+// --- warn, never refuse ------------------------------------------------------
+
+// 🔴 THE DECISION, PINNED. Substitution on a modelLocked ecosystem is legitimate
+// graceful degradation and the platform has deliberately NOT decided to reject
+// it (its own module note defers that to a later phase). Refusing here would
+// block flows that work today and would vendor a policy the server has not made.
+// Fail-soft, exactly like serverQuantityClamp.
+func TestSubstitution_WarnsButNeverRefuses(t *testing.T) {
+	withStdinTTY(t, false)
+	s := subsSeams()
+	o := baseOpts()
+	o.assumeYes = true
+	_, _, err := runImg(t, s, o)
+	if err != nil {
+		t.Fatalf("a substitution must WARN, not refuse: %v", err)
+	}
+	if s.submitCalls != 1 {
+		t.Errorf("the submit must still be reached: submitCalls = %d, want 1", s.submitCalls)
+	}
+	// And it must not smuggle in a new error kind either.
+	if errors.Is(err, ErrUsage) || errors.Is(err, civitai.ErrBadRequest) {
+		t.Errorf("a substitution must not classify the run as a failure: %v", err)
+	}
+}
+
+// Exit codes stay pinned by errors.Is, not by message text: a substitution in
+// the payload must not perturb an unrelated failure's classification.
+func TestSubstitution_DoesNotDisturbExitCodes(t *testing.T) {
+	apiErr := apiErrorWithStatus(t, http.StatusNotFound)
+	c, _, _ := genCmd("")
+	err := runWorkflowsGet(c, wfGetDeps("", apiErr), workflowsGetOpts{}, "wf_missing")
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("want civitai.ErrNotFound (exit 4), got %v", err)
+	}
+}
+
+// --- the reason gloss is advisory ------------------------------------------
+
+// An unknown reason renders VERBATIM and still warns. A gloss table that gated
+// the warning would drop every reason added server-side after this build —
+// which is the silence the whole feature exists to end.
+func TestSubstitution_UnknownReasonStillWarnsVerbatim(t *testing.T) {
+	const novel = "a-reason-from-the-future"
+	payload := `{"id":"wf_1","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":[{"requested":1,"applied":2,"reason":"` + novel + `"}]},"steps":[]}`
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(payload, nil), workflowsGetOpts{}, "wf_1"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	if !strings.Contains(errb.String(), substWarn) || !strings.Contains(errb.String(), novel) {
+		t.Errorf("an unknown reason must warn and be rendered verbatim.\nstderr:\n%s", errb.String())
+	}
+}
+
+// A KNOWN reason gets its gloss. Positive control for the map: without this the
+// test above passes with an empty map, and the gloss could rot unnoticed.
+func TestSubstitution_KnownReasonIsGlossed(t *testing.T) {
+	payload := `{"id":"wf_1","status":"succeeded","createdAt":"2026-08-05T12:00:00Z",
+	  "metadata":{"modelSubstitutions":` + substArrayJSON + `},"steps":[]}`
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(payload, nil), workflowsGetOpts{}, "wf_1"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	gloss, ok := substitutionReasonGloss["unrecognized"]
+	if !ok {
+		t.Fatal("the gloss table lost `unrecognized`")
+	}
+	if !strings.Contains(errb.String(), gloss) {
+		t.Errorf("a known reason must carry its gloss.\nstderr:\n%s", errb.String())
+	}
+}

--- a/internal/cmd/workflows.go
+++ b/internal/cmd/workflows.go
@@ -60,6 +60,10 @@ type workflowsGetOpts struct {
 // every error path are testable against httptest with no live server.
 type workflowsGetDeps struct {
 	getWorkflow getWorkflowFn
+	// resolveVersion turns a model-version id into a display name for the
+	// model-substitution warning. It is ADVISORY: a nil resolver, or one that
+	// fails, renders ids instead of names and never suppresses the warning.
+	resolveVersion versionResolver
 }
 
 func newWorkflowsGetCmd() *cobra.Command {
@@ -81,6 +85,11 @@ the reason rather than omitted — a finished workflow can legitimately contain
 fewer usable results than it was charged for, and silently dropping them would
 make that invisible.
 
+If the generator silently ran a DIFFERENT checkpoint than the one the job asked
+for, that is reported here too — this is the only place to find it for a job you
+did not wait for. It names the version requested, the version that ran, and the
+server's reason.
+
 Reading a workflow SPENDS NOTHING. This needs the same personal API key with the
 AI Services scopes that ` + "`civitai generate`" + ` needs.`,
 		Example: `  civitai workflows get 01JABCXYZ
@@ -97,7 +106,10 @@ AI Services scopes that ` + "`civitai generate`" + ` needs.`,
 			}
 			o.baseURL = cfg.BaseURL()
 			gen := genapi.NewWithSource(cfg.BaseURL(), auth.New(cfg))
-			return runWorkflowsGet(cmd, workflowsGetDeps{getWorkflow: gen.GetWorkflow}, o, args[0])
+			return runWorkflowsGet(cmd, workflowsGetDeps{
+				getWorkflow:    gen.GetWorkflow,
+				resolveVersion: gen.ResolveModelVersion,
+			}, o, args[0])
 		},
 	}
 	cmd.Flags().BoolVar(&o.jsonOut, "json", false, "emit the raw server payload on stdout (scriptable)")
@@ -118,6 +130,13 @@ func runWorkflowsGet(cmd *cobra.Command, deps workflowsGetDeps, o workflowsGetOp
 	if err != nil {
 		return classifyGenerateError(err)
 	}
+	// 🔴 BEFORE the --json branch, and on stderr, so a silent substitution is
+	// reported on BOTH surfaces. This is the ONLY place a substitution shows up
+	// for a job the CLI did not submit itself — a `--no-wait` run collected
+	// later, a re-attach after Ctrl-C or a --timeout, or a workflow generated on
+	// the website. The submit reply's top-level copy is long gone by then; the
+	// record survives only on the workflow's own metadata.
+	printModelSubstitutions(ctx, cmd.ErrOrStderr(), wf.ModelSubstitutions(), deps.resolveVersion, substitutionPhaseCharged)
 	if o.jsonOut {
 		// Raw passthrough: a script sees every server field, including ones the
 		// CLI does not model. It must branch on the payload itself.

--- a/internal/genapi/generate.go
+++ b/internal/genapi/generate.go
@@ -70,6 +70,28 @@ type WhatIfResult struct {
 	AllowMatureContent *bool         `json:"allowMatureContent,omitempty"`
 	// Transactions is passed through untyped; its shape is orchestrator-owned.
 	Transactions json.RawMessage `json:"transactions,omitempty"`
+	// RawModelSubstitutions is the reply's TOP-LEVEL `modelSubstitutions` array,
+	// captured raw (see parseModelSubstitutions for why every carrier is raw).
+	//
+	// 🔴 THE WHATIF IS THE ONLY CARRIER ON THIS PATH, and the most valuable one:
+	// a whatIf spends nothing and persists no workflow, so this is where a caller
+	// can learn BEFORE committing Buzz that the model it named is not the model
+	// that will run. It is also the only signal for a SAME-PRICE substitution —
+	// cost divergence only helps if you already knew the expected price.
+	RawModelSubstitutions json.RawMessage `json:"modelSubstitutions,omitempty"`
+}
+
+// ModelSubstitutions reports the silent checkpoint swaps the server performed
+// while pricing this estimate. Empty is the overwhelmingly common case.
+//
+// 🔴 Absence is AMBIGUOUS and must not be reported as a guarantee: it means "no
+// substitution" OR "a server that predates the field" (civitai#3665). Nothing on
+// the wire distinguishes the two.
+func (r *WhatIfResult) ModelSubstitutions() []ModelSubstitution {
+	if r == nil {
+		return nil
+	}
+	return parseModelSubstitutions(r.RawModelSubstitutions)
 }
 
 // SubmitResult is the generateFromGraph reply — one normalized workflow.
@@ -92,6 +114,29 @@ type SubmitResult struct {
 	Status string        `json:"status"`
 	Cost   *WorkflowCost `json:"cost"`
 	Tags   []string      `json:"tags,omitempty"`
+	// RawModelSubstitutions is the TOP-LEVEL `modelSubstitutions` array.
+	RawModelSubstitutions json.RawMessage `json:"modelSubstitutions,omitempty"`
+	// RawMetadata is the normalized workflow metadata, which carries the SECOND
+	// copy of the same records under WorkflowMetadataModelSubstitutionsKey.
+	RawMetadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+// ModelSubstitutions reports the silent checkpoint swaps the server performed
+// for the generation that was just SUBMITTED AND CHARGED.
+//
+// 🔴 It reads BOTH carriers and unions them. `generateFromGraph` writes the same
+// records twice — top-level (authoritative for the validation it just performed,
+// and present even when the graph produced no workflow metadata to round-trip)
+// and under `metadata` (which is what survives to every later read). Reading one
+// alone misses cases; the merge is what stops the user hearing it twice.
+func (r *SubmitResult) ModelSubstitutions() []ModelSubstitution {
+	if r == nil {
+		return nil
+	}
+	return mergeModelSubstitutions(
+		parseModelSubstitutions(r.RawModelSubstitutions),
+		substitutionsFromMetadata(r.RawMetadata),
+	)
 }
 
 // SubmitOptions carries the ENVELOPE siblings of the graph — the fields that

--- a/internal/genapi/status.go
+++ b/internal/genapi/status.go
@@ -177,6 +177,27 @@ type Workflow struct {
 	// Transactions is the orchestrator's own money record, passed through
 	// untyped: its shape is orchestrator-owned and the CLI must not relabel it.
 	Transactions json.RawMessage `json:"transactions,omitempty"`
+	// RawMetadata is the workflow's own metadata, captured raw. It is the ONLY
+	// carrier of `modelSubstitutions` on a later read: the submit persists the
+	// record there precisely so a caller that polls, re-attaches or lists its
+	// history still learns it was billed for model A and given model B, and no
+	// later reply carries a top-level copy.
+	//
+	// 🔴 Raw, not a typed struct, so a metadata blob the CLI cannot interpret can
+	// never fail the whole read of a workflow the user has ALREADY PAID FOR.
+	RawMetadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+// ModelSubstitutions reports the silent checkpoint swaps recorded against this
+// workflow at submit time (civitai#3665). Empty is the common case.
+//
+// 🔴 Absence is AMBIGUOUS: it means "no substitution" OR "submitted by a server
+// that predates the field". Never render it as a guarantee that none happened.
+func (w *Workflow) ModelSubstitutions() []ModelSubstitution {
+	if w == nil {
+		return nil
+	}
+	return substitutionsFromMetadata(w.RawMetadata)
 }
 
 // Output is one workflow output with the two step-derived fields folded in.

--- a/internal/genapi/substitution.go
+++ b/internal/genapi/substitution.go
@@ -1,0 +1,126 @@
+package genapi
+
+import "encoding/json"
+
+// ModelSubstitution is one silent checkpoint swap the server performed and now
+// REPORTS (civitai/civitai issue #3665, PRs #3692 and #3673).
+//
+// It mirrors the server's `PersistedModelSubstitution`
+// (civitai/civitai -> src/shared/data-graph/generation/model-substitution.ts):
+// on a `modelLocked` ecosystem the graph replaces a checkpoint version id it
+// does not recognise for the chosen workflow with that workflow's default,
+// returns HTTP 200, and BILLS the caller. `Requested` is the id that was sent,
+// `Applied` is the id that actually ran.
+//
+// 🔴 `Reason` is a plain string and is DELIBERATELY NOT validated against the
+// server's three-value union (`wrong-workflow` / `unrecognized` / `gated`).
+// The server narrows it on its own side precisely because the value feeds a
+// bounded Prometheus label; the CLI has the opposite incentive. Vendoring the
+// union here would mean a reason added server-side is DROPPED by an older CLI —
+// turning a real, billed substitution back into the silence this whole feature
+// exists to end. An unrecognised reason is rendered verbatim instead, which is
+// the same anti-mirror judgement AGENTS.md item 13 makes about everything else
+// on this path.
+type ModelSubstitution struct {
+	// Requested is the checkpoint model-VERSION id the caller sent.
+	Requested int `json:"requested"`
+	// Applied is the model-VERSION id the server ran instead.
+	Applied int `json:"applied"`
+	// Reason is the server's own token for why. Rendered verbatim.
+	Reason string `json:"reason"`
+}
+
+// WorkflowMetadataModelSubstitutionsKey is the key silent substitutions are
+// persisted under on an orchestrator workflow's `metadata` — the literal string
+// of the server's `WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY`.
+//
+// It is the SAME key on both shapes the CLI reads: `orchestrator.getWorkflow`
+// hands back the raw orchestrator workflow whose `metadata` is byte-for-byte
+// what the submit persisted, and the normalized shape re-emits it under the
+// same name from `formatGenerationResponse2`'s allowlist.
+const WorkflowMetadataModelSubstitutionsKey = "modelSubstitutions"
+
+// parseModelSubstitutions decodes a `modelSubstitutions` array LENIENTLY.
+//
+// 🔴 EVERY CARRIER OF THIS FIELD IS A json.RawMessage, AND THAT IS THE POINT.
+// A typed slice on `SubmitResult` would make a malformed advisory field fail the
+// whole `json.Unmarshal`, and the submit reply is the message that tells a user
+// what they were just CHARGED for — an unparseable warning must never cost them
+// the workflow id. So the field is captured raw and interpreted here, where a
+// failure degrades to "no substitutions reported" instead of to an error.
+//
+// Individual entries are validated structurally and a bad one is SKIPPED, which
+// mirrors the server's own `readModelSubstitutionsFromMetadata`. The one
+// deliberate divergence is `reason`: the server narrows it against its union and
+// drops anything else; this keeps any non-empty string. See ModelSubstitution.
+//
+// Returns nil (never an empty non-nil slice) when there is nothing to report, so
+// every caller can test `len(...) > 0` and mean it.
+func parseModelSubstitutions(raw json.RawMessage) []ModelSubstitution {
+	if len(raw) == 0 {
+		return nil
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil
+	}
+	var out []ModelSubstitution
+	for _, e := range entries {
+		var v struct {
+			Requested *int   `json:"requested"`
+			Applied   *int   `json:"applied"`
+			Reason    string `json:"reason"`
+		}
+		if err := json.Unmarshal(e, &v); err != nil {
+			continue
+		}
+		if v.Requested == nil || v.Applied == nil || v.Reason == "" {
+			continue
+		}
+		out = append(out, ModelSubstitution{Requested: *v.Requested, Applied: *v.Applied, Reason: v.Reason})
+	}
+	return out
+}
+
+// substitutionsFromMetadata reads the persisted array off a workflow `metadata`
+// object. A metadata blob that is absent, null, not an object, or carries no
+// such key yields nothing — none of those is an error.
+func substitutionsFromMetadata(metadata json.RawMessage) []ModelSubstitution {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &m); err != nil {
+		return nil
+	}
+	return parseModelSubstitutions(m[WorkflowMetadataModelSubstitutionsKey])
+}
+
+// mergeModelSubstitutions concatenates carriers, dropping exact duplicates while
+// preserving first-seen order.
+//
+// 🔴 It exists because `generateFromGraph` reports the SAME records on TWO
+// carriers — top-level (authoritative for the validation it just performed) and
+// under `metadata` (what survives to every later read). A caller that reads only
+// one misses cases (the whatIf has no metadata; a poll has no top level), so the
+// CLI reads both — and then has to not tell the user twice.
+func mergeModelSubstitutions(groups ...[]ModelSubstitution) []ModelSubstitution {
+	type key struct {
+		requested int
+		applied   int
+		reason    string
+	}
+	seen := make(map[key]bool)
+	var out []ModelSubstitution
+	for _, g := range groups {
+		for _, s := range g {
+			k := key{s.Requested, s.Applied, s.Reason}
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/genapi/substitution_test.go
+++ b/internal/genapi/substitution_test.go
@@ -1,0 +1,271 @@
+package genapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Silent model substitutions (civitai#3665, PRs #3692 / #3673).
+//
+// The server reports the same records on THREE read sites that do not agree on
+// where they live, and a client that reads only one misses cases:
+//
+//	whatIfFromGraph   -> TOP-LEVEL only (nothing is persisted on that path)
+//	generateFromGraph -> BOTH top-level and under `metadata`
+//	getWorkflow       -> `metadata` only (the top-level copy is long gone)
+//
+// So every case below is paired: the carrier is exercised AND a no-substitution
+// reply on the same carrier is asserted to produce nothing. A parser wired to
+// nothing returns nil for both, which is why the populated half of each pair is
+// the positive control for the empty half.
+// ---------------------------------------------------------------------------
+
+// wantSub is the fixture record. Its three fields are pairwise distinct so a
+// transposition (requested/applied swapped) cannot pass.
+var wantSub = ModelSubstitution{Requested: 128713, Applied: 999001, Reason: "unrecognized"}
+
+const subJSON = `[{"requested":128713,"applied":999001,"reason":"unrecognized"}]`
+
+func assertSubs(t *testing.T, site string, got []ModelSubstitution, want ...ModelSubstitution) {
+	t.Helper()
+	if len(want) == 0 {
+		if len(got) != 0 {
+			t.Errorf("%s: want no substitutions, got %+v", site, got)
+		}
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s: substitutions = %+v, want %+v", site, got, want)
+	}
+}
+
+// --- carrier 1: the whatIf reply (top level, and the ONLY carrier there) -----
+
+func TestWhatIf_ReadsTopLevelModelSubstitutions(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTRPC(w, map[string]any{
+			"ready": true,
+			"cost":  map[string]any{"base": 60, "total": 60},
+			"modelSubstitutions": []any{
+				map[string]any{"requested": 128713, "applied": 999001, "reason": "unrecognized"},
+			},
+		})
+	}))
+	res, raw, err := c.WhatIfFromGraph(context.Background(), Graph{Workflow: "txt2img"})
+	if err != nil {
+		t.Fatalf("whatIf: %v", err)
+	}
+	assertSubs(t, "whatIf top-level", res.ModelSubstitutions(), wantSub)
+	// 🔴 --json passthrough: the raw payload must still carry the field, because
+	// a script branches on it rather than on our rendering.
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("raw payload is not an object: %v", err)
+	}
+	if _, ok := m["modelSubstitutions"]; !ok {
+		t.Errorf("the raw whatIf payload lost `modelSubstitutions`; --json would report nothing:\n%s", raw)
+	}
+}
+
+// The overwhelmingly common case. Paired with the test above, which drives the
+// same accessor non-empty through the same client.
+func TestWhatIf_NoSubstitutionsReportsNone(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTRPC(w, map[string]any{"ready": true, "cost": map[string]any{"base": 60, "total": 60}})
+	}))
+	res, _, err := c.WhatIfFromGraph(context.Background(), Graph{Workflow: "txt2img"})
+	if err != nil {
+		t.Fatalf("whatIf: %v", err)
+	}
+	assertSubs(t, "whatIf without the field", res.ModelSubstitutions())
+}
+
+// --- carrier 2: the submit reply (BOTH top-level and metadata) ---------------
+
+// 🔴 A submit reply carrying the record on ONE carrier only must still report
+// it. The server writes both, but the top-level copy exists precisely because a
+// graph that produced no workflow metadata round-trips nothing — so a reader
+// that requires both, or reads only `metadata`, silently loses that case.
+func TestSubmit_ReadsEitherCarrier(t *testing.T) {
+	cases := []struct {
+		name  string
+		reply map[string]any
+	}{
+		{"top-level only", map[string]any{
+			"id": "wf_1", "status": "queued",
+			"modelSubstitutions": json.RawMessage(subJSON),
+		}},
+		{"metadata only", map[string]any{
+			"id": "wf_1", "status": "queued",
+			"metadata": map[string]any{"params": map[string]any{}, "modelSubstitutions": json.RawMessage(subJSON)},
+		}},
+		{"both carriers, reported once", map[string]any{
+			"id": "wf_1", "status": "queued",
+			"modelSubstitutions": json.RawMessage(subJSON),
+			"metadata":           map[string]any{"modelSubstitutions": json.RawMessage(subJSON)},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeTRPC(w, tc.reply)
+			}))
+			res, _, _, err := c.GenerateFromGraph(context.Background(), Graph{Workflow: "txt2img"}, SubmitOptions{})
+			if err != nil {
+				t.Fatalf("submit: %v", err)
+			}
+			assertSubs(t, tc.name, res.ModelSubstitutions(), wantSub)
+		})
+	}
+}
+
+func TestSubmit_NoSubstitutionsReportsNone(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTRPC(w, map[string]any{"id": "wf_1", "status": "queued",
+			"metadata": map[string]any{"params": map[string]any{"prompt": "a cat"}}})
+	}))
+	res, _, _, err := c.GenerateFromGraph(context.Background(), Graph{Workflow: "txt2img"}, SubmitOptions{})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	assertSubs(t, "submit without the field", res.ModelSubstitutions())
+}
+
+// --- carrier 3: a later read (getWorkflow -> `metadata` ONLY) ----------------
+
+func TestGetWorkflow_ReadsMetadataModelSubstitutions(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTRPC(w, map[string]any{
+			"id": "wf_1", "status": "succeeded", "createdAt": "2026-08-05T12:00:00Z",
+			"metadata": map[string]any{"modelSubstitutions": json.RawMessage(subJSON)},
+			"steps":    []any{},
+		})
+	}))
+	wf, raw, err := c.GetWorkflow(context.Background(), "wf_1")
+	if err != nil {
+		t.Fatalf("getWorkflow: %v", err)
+	}
+	assertSubs(t, "getWorkflow metadata", wf.ModelSubstitutions(), wantSub)
+	if !json.Valid(raw) {
+		t.Fatalf("raw payload is not valid JSON: %s", raw)
+	}
+	// 🔴 The TOP-LEVEL field is absent on this path by design. Reading only
+	// there would report nothing for every job the CLI did not itself submit.
+	var m map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &m)
+	if _, ok := m["modelSubstitutions"]; ok {
+		t.Errorf("fixture drift: this path is metadata-only server-side, so the fixture must not carry a top-level copy")
+	}
+}
+
+func TestGetWorkflow_NoSubstitutionsReportsNone(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTRPC(w, map[string]any{
+			"id": "wf_1", "status": "succeeded", "createdAt": "2026-08-05T12:00:00Z",
+			"metadata": map[string]any{"params": map[string]any{"seed": 1}},
+			"steps":    []any{},
+		})
+	}))
+	wf, _, err := c.GetWorkflow(context.Background(), "wf_1")
+	if err != nil {
+		t.Fatalf("getWorkflow: %v", err)
+	}
+	assertSubs(t, "getWorkflow without the field", wf.ModelSubstitutions())
+}
+
+// --- leniency: a malformed advisory field must never break a paid reply ------
+
+// 🔴 The submit reply is the message that tells a user what they were just
+// CHARGED for. If an unparseable `modelSubstitutions` failed the whole decode,
+// a server-side shape change would cost them the workflow id — the only handle
+// to a job they have already paid for. Every one of these must still yield a
+// usable SubmitResult.
+func TestSubmit_MalformedSubstitutionsNeverBreakTheReply(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+	}{
+		{"an object instead of an array", `{"requested":1}`},
+		{"a string", `"nope"`},
+		{"null", `null`},
+		{"an array of primitives", `[1,2,3]`},
+		{"entries missing applied", `[{"requested":1,"reason":"gated"}]`},
+		{"entries missing requested", `[{"applied":2,"reason":"gated"}]`},
+		{"entries with an empty reason", `[{"requested":1,"applied":2,"reason":""}]`},
+		{"a non-numeric requested", `[{"requested":"1","applied":2,"reason":"gated"}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"id":"wf_1","status":"queued","modelSubstitutions":` + tc.field + `}`
+			c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"result":{"data":{"json":` + body + `}}}`))
+			}))
+			res, _, _, err := c.GenerateFromGraph(context.Background(), Graph{Workflow: "txt2img"}, SubmitOptions{})
+			if err != nil {
+				t.Fatalf("a malformed advisory field must not fail the submit reply: %v", err)
+			}
+			if res.ID != "wf_1" {
+				t.Fatalf("the workflow id was lost: %+v", res)
+			}
+			assertSubs(t, tc.name, res.ModelSubstitutions())
+		})
+	}
+}
+
+// 🔴 A reason the server ADDS after this build must survive. The server narrows
+// `reason` against its own union because the value doubles as a bounded metric
+// label; vendoring that union here would DROP a new reason and turn a real,
+// billed substitution back into silence. Kept verbatim instead.
+func TestParseModelSubstitutions_KeepsAnUnknownReason(t *testing.T) {
+	got := parseModelSubstitutions(json.RawMessage(
+		`[{"requested":1,"applied":2,"reason":"a-reason-invented-after-this-build"}]`))
+	assertSubs(t, "unknown reason", got,
+		ModelSubstitution{Requested: 1, Applied: 2, Reason: "a-reason-invented-after-this-build"})
+}
+
+// A bad entry is skipped; its good siblings survive. The server's own reader
+// does the same, and dropping the whole array would lose real records.
+func TestParseModelSubstitutions_SkipsOnlyTheBadEntry(t *testing.T) {
+	got := parseModelSubstitutions(json.RawMessage(
+		`[{"requested":1,"applied":2,"reason":"gated"},{"requested":3},{"requested":4,"applied":5,"reason":"wrong-workflow"}]`))
+	assertSubs(t, "mixed array", got,
+		ModelSubstitution{Requested: 1, Applied: 2, Reason: "gated"},
+		ModelSubstitution{Requested: 4, Applied: 5, Reason: "wrong-workflow"})
+}
+
+// The metadata key is a cross-repo constant. Pin its literal value: a typo here
+// is silent — every payload simply reports no substitutions, forever.
+func TestWorkflowMetadataKeyLiteral(t *testing.T) {
+	if WorkflowMetadataModelSubstitutionsKey != "modelSubstitutions" {
+		t.Errorf("metadata key = %q, want %q (civitai/civitai WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY)",
+			WorkflowMetadataModelSubstitutionsKey, "modelSubstitutions")
+	}
+}
+
+// mergeModelSubstitutions must dedupe EXACT records only. Two swaps that differ
+// in any field are two separate facts and both must be reported.
+func TestMergeModelSubstitutions_DedupesExactOnly(t *testing.T) {
+	a := ModelSubstitution{Requested: 1, Applied: 2, Reason: "gated"}
+	b := ModelSubstitution{Requested: 1, Applied: 2, Reason: "unrecognized"}
+	c := ModelSubstitution{Requested: 3, Applied: 2, Reason: "gated"}
+	got := mergeModelSubstitutions([]ModelSubstitution{a, b}, []ModelSubstitution{a, c})
+	assertSubs(t, "merge", got, a, b, c)
+}
+
+// Nil receivers are reachable: `submit` can hand back a nil result alongside a
+// nil error on a reply the CLI could not model.
+func TestModelSubstitutions_NilReceiversAreSafe(t *testing.T) {
+	var (
+		w  *WhatIfResult
+		s  *SubmitResult
+		wf *Workflow
+	)
+	assertSubs(t, "nil WhatIfResult", w.ModelSubstitutions())
+	assertSubs(t, "nil SubmitResult", s.ModelSubstitutions())
+	assertSubs(t, "nil Workflow", wf.ModelSubstitutions())
+}

--- a/internal/genapi/versions.go
+++ b/internal/genapi/versions.go
@@ -62,8 +62,24 @@ func (r *ResolvedVersion) Resource(strength *float64) Resource {
 //     into a hard local 404. Measured: on one ecosystem the correct model id
 //     priced at 160, while a nonexistent id, a foreign-ecosystem id, and no
 //     model at all ALL priced at 60 — the server substitutes the ecosystem
-//     default, and that correction is surfaced on-site but is invisible through
-//     a non-browser path.
+//     default and bills for it.
+//
+// 🔴 THE SUBSTITUTION IS NO LONGER INVISIBLE — an earlier revision of this
+// comment said the correction "is surfaced on-site but is invisible through a
+// non-browser path", and that has been FALSE since civitai#3665 (PRs #3692 /
+// #3673). The server now reports every swap as `modelSubstitutions`; see
+// substitution.go for the three read sites. That does NOT make this lookup
+// redundant, and the reasons are worth keeping straight:
+//
+//   - The report is post-hoc on the submit and only advisory on the whatIf,
+//     while this turns a bad id into a LOCAL error before any spend at all.
+//   - `ModelType` still has to come from somewhere, and no reply carries it.
+//   - Absence of the field is ambiguous — "no substitution" and "a server
+//     predating the field" are indistinguishable on the wire.
+//
+// The two are complements: this stops a NONEXISTENT id, and the server's signal
+// catches the case it structurally cannot — a REAL id that is wrong for the
+// chosen ecosystem or workflow.
 //
 // This is a live round-trip, NOT a vendored table, so it carries no drift cost
 // against the platform — the distinction that makes it the right fix under this


### PR DESCRIPTION
## What

On a `modelLocked` ecosystem the generator replaces a checkpoint version id it
does not recognise for the chosen workflow with that workflow's default, returns
HTTP 200, and **bills you**. `ResolveModelVersion` (item 13) already turns a
**nonexistent** id into a local 404 — but it cannot catch a **real** id that is
wrong for the ecosystem you named, and until now nothing did.

civitai/civitai **#3665** (PRs **#3692**, **#3673**) makes the server report every
swap as `modelSubstitutions` — `{requested, applied, reason}`. This PR reads it
and says so, plainly: *you asked for version N, the server ran version M,
reason R.*

```
⚠ The server SUBSTITUTED a different checkpoint — the estimate below prices the
  model it would actually run, not the one you asked for.
  Requested:  DreamShaper — v8 (Checkpoint, id 128713)
  Ran:        SDXL 1.0 (Checkpoint, id 999001)
  Reason:     unrecognized — that version is in none of this ecosystem's lists …
```

## 🔴 Three read sites that do not agree — both carriers are read

Per the reply-contract comment on `NormalizedWorkflowMetadata`
(`orchestration-new.service.ts` ~1940-1968):

| site | carrier |
|---|---|
| `whatIfFromGraph` | **top-level only** — nothing is persisted on that path |
| `generateFromGraph` | **both** top-level and `metadata.modelSubstitutions` |
| later reads (`getWorkflow` poll / re-attach / feed) | **`metadata` only** |

A client reading only the top level sees substitutions on the submit and never
again; one reading only `metadata` misses the whatIf entirely. `internal/genapi`
reads both and merges, deduping exact records so a two-carrier submit reply is
reported **once**.

## Surfaces

`--dry-run` (human **and** `--json`), the TTY confirmation, `--yes`, the
post-submit output, and `workflows get`. The pre-spend warning is emitted from
**one call site** in `runGenerate`, before every branch — the img2img caveat
shipped as an interactive-only print and so missed `--yes` (mandatory in CI) and
`--dry-run`; a single call site makes that class of miss unreachable. Everything
goes to **stderr**, so a `--json` stdout stays machine-clean and still carries
the raw field. Ids resolve to model names, and a **failing lookup prints the id
rather than suppressing the warning**.

## Warn, never refuse

Argued in `printModelSubstitutions` and AGENTS.md item 13, not defaulted:

- Substitution on a `modelLocked` ecosystem is **legitimate** graceful
  degradation — it keeps a job pinned to a since-retired version running instead
  of hard-failing. Refusing breaks flows that work today.
- The platform has **explicitly deferred** the rejection decision ("deciding
  whether any case should REJECT is a later phase, gated on what the counter
  measures"). Refusing first would vendor a policy the server has not made —
  item 13's anti-mirror rule applied to policy.
- A refusal would be **unenforceable**: absence of the field means "no
  substitution" *or* "a server predating #3665", indistinguishable on the wire.
- Two of the four surfaces are **post-spend**, where refusing buys nothing.

Same fail-soft shape as `serverQuantityClamp` (item 13b).

## Two things that look wrong and are not

1. **Every carrier is a `json.RawMessage`, parsed leniently.** A typed slice
   would let a malformed advisory field fail the whole `json.Unmarshal` of the
   **submit reply** — the message that hands back the workflow id for a job the
   user has already been charged for. A warning we cannot parse must never cost
   them the handle. Eight malformed shapes are pinned as tests.
2. **`reason` is deliberately NOT narrowed against the server's union.** The
   server narrows it because the value doubles as a bounded Prometheus label; the
   CLI has the opposite incentive — vendoring the union would DROP a reason added
   server-side and restore the exact silence this closes. Unknown reasons render
   verbatim; the gloss table is advisory and can never gate the warning.

## Corrections

AGENTS.md item 13 and `genapi/versions.go` both claimed the correction is
"invisible through a non-browser path". That was true when written and is now
**false**; both are corrected in place with the citation, and item 13 records all
three read sites and the read-both requirement. The signal is a **live server
read, not a vendored table**, so it *strengthens* item 13's anti-mirror thrust.

## Tests

`httptest` + `t.TempDir()`, no network, no mutation against a live server.

- All three carriers, plus **a no-substitution reply on each** with the populated
  case as its positive control in the same file.
- All five surfaces, with `submitCalls`/`whatIfCalls` positive controls.
- `--json` passthrough keeps the field; the warning never leaks into stdout.
- A failing `ResolveModelVersion` still warns (and the resolver-was-called
  counter proves the failure was reached).
- Exit codes pinned by `errors.Is`, never message text.
- The `Requested:`/`Ran:` assertion is **line-scoped**, not a substring search —
  a transposition would otherwise pass while inverting the warning's meaning.

**Mutation sweep: 18 semantic mutants, all killed, each by its own guard's
message** — branch inversion (`||`→`&&`, `== 0`→`> 0`), operand swap
(requested/applied transposed), operand drop (dedupe key ignores `reason`),
a one-character metadata-key typo, per-carrier removal, call-site removal, and
call-site *relocation* reproducing the historical img2img bug shape (warning
moved after the `--dry-run` exit / below the `--json` early return). An
**M0 no-op control survived**, proving the harness distinguishes a harmless edit
from a real one. Determinism: 8/8 runs, 41 PASS each.

## Gate

- `make ci` — green.
- `go test ./... -count=1 -v` **counted**: **2148 PASS, 0 FAIL, 4 SKIP** (the four
  by-design skips), no `panic: test timed out`.
- `gofmt -s -l .` — 0 files listed across 264 `.go` files (and it caught a real
  break earlier in this branch, so the tool is demonstrably live).
- `golangci-lint run` (v2.12.2) — **0 issues**, validated against a planted
  known-bad first: `ST1008` (error not last) reported, plus `unused` ×2 and
  `misspell` ×1; probes removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
