### PR TITLE
ci: add workflow_dispatch so a dropped run can be re-triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,21 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual trigger — the recovery path when GitHub drops a run.
+  #
+  # On 2026-08-06 an Actions incident throttled webhook triggers: push and
+  # pull_request events stopped creating workflow runs entirely (GitHub-managed
+  # workflows like CodeQL kept firing, so events WERE arriving — only user
+  # workflow runs went missing). PR #219 sat unmergeable for hours with no way
+  # to re-run anything: `gh run rerun` needs an existing run for the head sha,
+  # and empty commits and a close/reopen both produced nothing, because the
+  # trigger they rely on was the throttled thing.
+  #
+  # workflow_dispatch is the only trigger that does not depend on a webhook.
+  # It cannot be back-applied — a dispatchable workflow must already exist on
+  # the default branch — so it is only useful if it lands BEFORE the next
+  # incident. Do not remove it because it looks unused.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Adds `workflow_dispatch:` to `ci.yml`. No job, permission or step changes — 15 added lines, 14 of them comment explaining why it exists.

## Why

On 2026-08-06 a GitHub Actions incident ([status page](https://www.githubstatus.com/): *"Webhook triggers remain throttled during recovery, so many push and pull request events aren't yet triggering new workflow runs"*) stopped `ci.yml` runs from being **created** at all. For ~3.5 hours the newest `ci.yml` run repo-wide did not advance, across every branch.

Events were still arriving — GitHub-managed workflows (CodeQL) fired and completed on the same commits. Only user workflow runs went missing, which made it look like a problem with this repo's config rather than an outage.

#219 was complete, locally green, and unmergeable, with **no recovery path**. Every remedy depends on the trigger that was broken:

| attempt | event | result |
|---|---|---|
| `gh run rerun` | — | needs an existing run for the head sha; none was created |
| empty commit | `synchronize` | no run |
| close + reopen | `reopened` | no run |
| `workflow_dispatch` | — | not declared |

`workflow_dispatch` is the only trigger that does not ride a webhook.

## The catch, and why this can't wait for the next outage

It **cannot be applied retroactively** — a dispatchable workflow must already exist on the default branch. Adding it during an incident does nothing, because landing it on `main` needs the same broken CI. It only ever helps if it lands beforehand.

That also means it will look permanently unused. The comment in the file says so explicitly, so nobody prunes it as dead config.

## Verification

`actionlint` clean on the changed file **and** on the unmodified `origin/main` version, checked against a positive control — actionlint reports 16 findings on a deliberately-bad runner label, so its silence here is meaningful rather than a tool that failed to run.

Follow-up to #206 / #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
