### PR TITLE
ci(release): workflow_dispatch recovery trigger so a dropped tag-push run doesn't need a re-pushed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,29 @@ on:
   push:
     tags:
       - "v*"
+  # Manual trigger — the recovery path when GitHub drops a run.
+  #
+  # On 2026-08-06 an Actions incident throttled webhook triggers: push and
+  # pull_request events stopped creating workflow runs entirely. #228 added the
+  # same escape hatch to ci.yml. Here the stakes are higher: the only recovery
+  # from a dropped tag-push run today is to DELETE and re-push a tag that users
+  # already install from.
+  #
+  # workflow_dispatch is the only trigger that does not ride a webhook, and it
+  # cannot be back-applied — a dispatchable workflow must already exist on the
+  # default branch — so it only ever helps if it lands BEFORE the next
+  # incident. It will therefore look permanently unused. Do not prune it.
+  #
+  # Unlike ci.yml this one needs an input. goreleaser derives the version,
+  # changelog and artifact names from the git tag at HEAD, and a dispatch
+  # checks out the DEFAULT BRANCH, where that tag is the wrong one or absent.
+  # So the tag has to be named explicitly and checked out below.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release, with the leading v — e.g. v0.1.90. Must already be pushed; this does not create it."
+        required: true
+        type: string
 
 permissions:
   contents: write # create the GitHub Release + upload assets
@@ -12,9 +35,55 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      # On a tag push there is no `inputs` in the event payload, so `ref`
+      # renders as the empty string and checkout falls back to its default
+      # (github.ref = the pushed tag) — that path is unchanged. On a dispatch
+      # it resolves the supplied tag to the same detached HEAD at the same
+      # commit, so goreleaser sees identical git context either way.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.tag }}
           fetch-depth: 0 # goreleaser needs full history + tags for the changelog
+
+      # Dispatch path only — skipped entirely on a tag push.
+      #
+      # goreleaser takes the version from the git tag at HEAD, never from
+      # anything we hand it, so a dispatch that resolves to the wrong ref does
+      # not fail — it publishes the WRONG release. checkout above already fails
+      # on a tag that does not exist; this catches the case that would
+      # otherwise succeed silently, e.g. someone typing a branch name like
+      # `main`, which is a perfectly valid ref and would release from a branch.
+      - name: Verify HEAD is exactly the requested tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null; then
+            echo "::error::'${TAG}' is not a tag in this repository. Push the tag first — this workflow releases an existing tag, it does not create one."
+            exit 1
+          fi
+          head="$(git rev-parse HEAD)"
+          tagged="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+          if [ "$head" != "$tagged" ]; then
+            echo "::error::HEAD is ${head} but tag ${TAG} points at ${tagged}."
+            exit 1
+          fi
+          # The tag goreleaser will resolve for ITSELF. Mirrors its own lookup
+          # (internal/pipe/git/git.go, getTag): $GORELEASER_CURRENT_TAG, which
+          # we do not set, then `git tag --points-at HEAD` under the default
+          # `-version:refname` sort, then `git describe`. So when two tags sit
+          # on this commit the highest-sorting one wins and the release would
+          # go out under THAT name. goreleaser's own validate() does not catch
+          # this — it only asserts that some tag matching the name it picked is
+          # at HEAD, never that it matches the tag that was asked for.
+          at_head="$(git tag --points-at HEAD --sort=-version:refname)"
+          detected="${at_head%%$'\n'*}"
+          if [ "$detected" != "$TAG" ]; then
+            echo "::error::goreleaser would release '${detected}', not '${TAG}'. Refusing rather than publishing the wrong version."
+            exit 1
+          fi
+          echo "HEAD ${head} is tag ${TAG}; goreleaser will release ${detected}."
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## What

Adds `workflow_dispatch` to `release.yml` with a `tag` input, so a dropped tag-push run can be re-run **without deleting and re-pushing a published tag**. Follow-up to #228, which did the same for `ci.yml`.

63 insertions, **0 deletions** — every existing line is preserved verbatim.

## Why

On 2026-08-06 an Actions incident throttled webhook delivery and push/pull_request events stopped creating workflow runs entirely. #228 covers the reasoning; the short version is that `workflow_dispatch` is the only trigger that does not ride a webhook, and it **cannot be back-applied** (a dispatchable workflow must already exist on the default branch), so it only ever helps if it lands before the next incident. It will look permanently unused — the comment in the file says so, so nobody prunes it.

`release.yml` is the worse gap. `ci.yml` losing a run costs a merge delay; `release.yml` losing a run leaves *deleting and re-pushing a tag users install from* as the only recovery.

## Why this isn't a two-line change

`actions/checkout` on a tag push checks out the **tag**; on `workflow_dispatch` it checks out the **default branch**. GoReleaser derives version, changelog and artifact names from the git tag at HEAD, never from anything the workflow hands it. A naive `workflow_dispatch` would build from `main`.

So the trigger takes a `tag` input, checks it out explicitly, and a guard asserts HEAD really is that tag before GoReleaser runs.

### Behaviour on each path

**Tag push (unchanged).** `ref: ${{ github.event.inputs.tag }}` renders as the empty string, and `actions/checkout` treats empty and absent identically — `src/input-helper.ts:60-77` dispatches on `!result.ref`, and the vendored `@actions/core` `getInput` collapses unset and empty to `''`. `ref` has no `default:` in `action.yml`. The guard step is gated on `github.event_name == 'workflow_dispatch'` and is skipped.

**Dispatch.** Checks out the named tag → detached HEAD at the tag's commit, identical end state to the push path (`ref-helper.ts:52-63` → `git checkout --progress --force refs/tags/<tag>`, no `startPoint`, so no `-B`). Then the guard runs, then GoReleaser as before.

`fetch-depth: 0` is preserved and is load-bearing on **both** paths. Confirmed from source that it fetches all branches *and* all tags regardless of `ref`: `git-source-provider.ts:172-186` selects `getRefSpecForAllHistory()` when `fetchDepth <= 0`, which returns `['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']` and ignores `ref` entirely (`ref-helper.ts:6,69-77`). The narrow per-ref refspec can only ever run as an *additional* follow-up fetch, and for a user-supplied tag name it is skipped outright. This matters because a clone missing earlier tags does **not** fail — GoReleaser logs a warning and publishes a **truncated changelog**.

### The guard

```
Verify HEAD is exactly the requested tag   (if: github.event_name == 'workflow_dispatch')
```

Three checks, each with its own error:

1. **The input names a real tag.** Catches typos, a missing `v` prefix, a *branch* name like `main` (a valid ref that checkout happily resolves), and a **blank** input — which is the nastiest case, because a blank `ref` makes checkout fall back to `github.ref`, i.e. the branch the dispatch was launched from. That one is silent at every other layer.
2. **HEAD is that tag's commit.**
3. **The tag GoReleaser will pick is the tag that was asked for.**

Check 3 mirrors GoReleaser's own lookup rather than guessing at it. `internal/pipe/git/git.go` `getTag()` tries `$GORELEASER_CURRENT_TAG` (unset here), then **`git tag --points-at HEAD --sort=-version:refname`**, and only falls back to `git describe --tags --abbrev=0` third. GoReleaser's own `validate()` does not cover this: it runs `git describe --exact-match --tags --match <the tag it picked>`, which asserts that *some* tag matching the name it chose is at HEAD — never that it matches the tag the operator requested. With two tags on one commit those differ.

I originally wrote check 3 with `git describe --tags --abbrev=0` and it was **wrong**. On a two-tags-on-one-commit repo, `describe --abbrev=0` returns `v0.2.0` while GoReleaser resolves `v0.2.0-hotfix` — so the original guard would have passed a request to release `v0.2.0` and GoReleaser would have published `v0.2.0-hotfix`. Exactly the silent wrong-version publish the guard exists to prevent.

## Verified vs reasoned

I did **not** run the dispatch path — that would publish a release, which was explicitly out of scope. Split:

**Mechanically verified**

- `actionlint` 1.7.12 (+ shellcheck integration): **0 findings**. Validated against positive controls rather than trusting the silence — a broken copy yields `label "ubunt-latest" is unknown`, and, importantly, `property "taggg" is not defined in object type {tag: string}`, which proves actionlint parsed the `workflow_dispatch` inputs schema and type-checked the expression against it. A separate control with an unquoted expansion in the `run:` block produced `SC2086 ... [shellcheck]` at that step's line, proving the guard script itself was linted and not skipped.
- YAML parses; `on:` contains both `push.tags` and `workflow_dispatch.inputs.tag`.
- **The guard script, extracted verbatim from the committed workflow**, run against real repos. Every branch proven reachable and failing with *its own* message, not another check's:

  | input | result |
  |---|---|
  | `v0.1.89` (tag at HEAD) | pass — `goreleaser will release v0.1.89` |
  | `v0.1.88` (real tag, not HEAD) | fail — `HEAD is cae9c2a… but tag v0.1.88 points at c0672f9…` |
  | `v9.9.99` (nonexistent) | fail — `'v9.9.99' is not a tag` |
  | `main` (branch name) | fail — `'main' is not a tag` |
  | `""` (blank input) | fail — `'' is not a tag` |
  | `v0.2.0`, two tags on the commit | fail — `goreleaser would release 'v0.2.0-hotfix', not 'v0.2.0'` |
  | `v0.2.0-hotfix`, same commit | pass |

- GoReleaser and `actions/checkout` behaviour above is quoted from source at pinned versions (goreleaser v2.17.1, checked for drift against v2.0.0/v2.8.2/v2.14.3 — `git.go` is effectively unchanged across v2; actions/checkout v4.2.2, diffed across all v4 tags — the fetch/ref logic is byte-identical on every v4).

**Reasoned, not executed**

- That the dispatch path end-to-end produces a byte-identical release to a tag push. Each link is verified from source, but the composed path has not been run, and cannot be without publishing.
- That `required: true` blocks an empty submission. It is enforced in the UI form, but the API can submit `""`; that is precisely why check 1 tests for it rather than relying on the input contract.

## Separate finding: `release-npm.yml` and `GITHUB_TOKEN` — the chain works, but not for the reason it looks like

The concern was that `release.yml` creates its release with `secrets.GITHUB_TOKEN`, and GitHub deliberately does not trigger new workflow runs from events created with `GITHUB_TOKEN` — which would mean `release-npm.yml` has never fired automatically.

**It has.** Of 53 historical `release-npm.yml` runs, **50 are `event: release`** and only 3 are `workflow_dispatch` (two failed attempts on 2026-07-17 and the manual recovery after the v0.1.59 npm-sigstore failure). The automatic chain is real and is what publishes to npm.

But the mechanism is not "GITHUB_TOKEN triggered it" — **`.goreleaser.yaml` sets `release: draft: true`**, so GoReleaser creates a *draft*, and a draft does not emit `release: published` at all. A human publishes it afterwards, and *that* is what fires the event.

Evidence:

- Every release is authored by `github-actions[bot]` (GoReleaser via `GITHUB_TOKEN`), but every `release`-event npm run has `actor` and `triggering_actor` = `ZacxDev`, a human — across all 50.
- The publish always happens **after the `release.yml` run has already completed**, with a variable human-scale lag; the npm run then follows the publish by a near-constant ~2s webhook delay:

  | tag | release.yml completed | release published | lag | npm run created |
  |---|---|---|---|---|
  | v0.1.89 | 23:49:57 | 23:51:32 | +95s | 23:51:34 |
  | v0.1.88 | 19:01:00 | 19:01:10 | +10s | 19:01:12 |
  | v0.1.87 | 18:28:23 | 18:28:45 | +22s | 18:28:47 |
  | v0.1.86 | 20:26:37 | 20:27:06 | +29s | 20:27:11 |
  | v0.1.85 | 19:12:17 | 19:12:42 | +25s | 19:12:45 |
  | v0.1.82 | 18:23:30 | 18:24:31 | +61s | 18:24:33 |

  The workflow had already exited before every one of these publishes, so nothing in it could have performed them. The 10s–95s spread is human, not automated.

**So the loop-prevention rule is real and is one config flip away from biting.** Nothing today depends on `GITHUB_TOKEN` triggering anything — but if `release: draft: true` were ever flipped to `false` to "automate the last step", GoReleaser would publish the release directly with `GITHUB_TOKEN`, the `release: published` event would be suppressed, and **npm publishing would silently stop** while the GitHub release still looked perfect. Worth a comment in `.goreleaser.yaml`.

Not fixed here, per instruction — it is a separate change with its own reasoning, and there is nothing broken to fix. Recorded so the next person does not assume the chain is fully automatic (there is a manual publish step) *or* assume the draft setting is incidental (it is load-bearing).

Note npm publishing uses OIDC trusted publishing pinned to repo + workflow file, with no `NPM_TOKEN`. Nothing here changes that, and any future fix to the above should not reintroduce a long-lived token.

## Not determined

- Whether the manual publish step is deliberate (a release gate) or incidental. It is currently the only thing making the npm chain work, so it should not be automated away without replacing the trigger.
- Whether re-dispatching for a tag that already has a partial/draft release behaves cleanly. The intended use is a run that never happened; a partially-completed release may need the draft deleted first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
