### PR TITLE
fix(app): explain a store 404 on an app the caller owns

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,25 @@ the cap.
 Notes like the cap caveat go to stderr, so `--json` stdout stays pure and the
 exit code stays 0.
 
+### Deployed is not the same as listed in the store
+
+`civitai app status` and `civitai app view` read **different resources**, and an
+app can legitimately be in one and not the other:
+
+- `civitai app status <slug>` reads your **submission pipeline**
+  (`GET /api/v1/blocks/submissions`) — review status, deploy state, live URL.
+- `civitai app view <slug>` reads the **public store catalog**
+  (`GET /api/v1/apps/{slug}`) — the published store listing.
+
+So `app status` can show `approved / live` with a working `<slug>.civit.ai` URL
+while `app view <slug>` returns **not found** (exit 4). That 404 is truthful and
+says nothing about your deploy: the store lists an app only once its **store
+listing** is published (a listing needs an icon and a cover — see
+`civitai app listing status`), and the catalog itself is still gated by a launch
+flag while the store is pre-GA. When the 404 lands on a slug **you own**, the CLI
+detects that and says so, naming both next commands, instead of leaving you with
+a bare "App not found".
+
 ## App metrics
 
 `civitai app metrics <slug>` shows the owner-only analytics for one of **your**

--- a/internal/cmd/app_view_owned_test.go
+++ b/internal/cmd/app_view_owned_test.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// Issue #223: `civitai app view <slug>` 404s for an app that `civitai app status`
+// reports as approved + live and that really is serving traffic. The two commands
+// read DIFFERENT resources — the public store catalog (GET /api/v1/apps/{slug})
+// vs the author submission pipeline (GET /api/v1/blocks/submissions) — so the 404
+// is truthful and the defect is the MESSAGE. These tests pin the message, the
+// three ways it must NOT fire, and the exit-code contract on all of them.
+//
+// 🔴 The exit code is asserted with errors.Is (AGENTS.md item 7), never by
+// message text: the classification sentinels carry no visible text, so a text
+// assertion says nothing about rc=4.
+
+// appViewAdviceMarkers are the load-bearing pieces of the owned-slug advice. A
+// "plain 404" case must contain NONE of them.
+var appViewAdviceMarkers = []string{
+	"one of your own apps",
+	"civitai app listing status",
+	"civitai app status",
+}
+
+// appViewServer wires the store 404 and a submissions responder onto one
+// httptest server, returning a counter of submissions-route hits so a test can
+// prove the ownership probe ran (or did not).
+func appViewServer(t *testing.T, subs func(w http.ResponseWriter, r *http.Request)) *int32 {
+	t.Helper()
+	var probes int32
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/apps/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"App not found"}`))
+		case r.URL.Path == "/api/v1/blocks/submissions":
+			atomic.AddInt32(&probes, 1)
+			// The probe must narrow server-side by slug; a probe that asked for
+			// the whole listing would be reading someone else's newest row.
+			if got := r.URL.Query().Get("blockId"); got != "buzz-generator" {
+				t.Errorf("submissions probe should narrow by blockId, got %q", got)
+			}
+			subs(w, r)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	return &probes
+}
+
+const ownedSubmissionBody = `{"submissions":[{
+  "id":"pubreq_01H","blockId":"buzz-generator","version":"0.1.1","status":"approved",
+  "deployState":"live","submittedAt":"2026-07-28T10:00:00Z","updatedAt":"2026-07-28T10:00:00Z",
+  "createdAt":"2026-07-28T10:00:00Z","liveUrl":"https://buzz-generator.civit.ai/"}]}`
+
+// (a) 404 on a slug the caller OWNS → the actionable message, and rc is STILL 4.
+func TestAppViewNotFoundOnOwnedSlugExplains(t *testing.T) {
+	probes := appViewServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(ownedSubmissionBody))
+	})
+
+	_, _, err := run(t, "app", "view", "buzz-generator")
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	// The exit-code contract is unchanged by the richer message.
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("404 must still classify as ErrNotFound (rc=4), got %T: %v", err, err)
+	}
+	if n := atomic.LoadInt32(probes); n != 1 {
+		t.Errorf("ownership probe should run exactly once on the 404 path, ran %d times", n)
+	}
+	msg := err.Error()
+	// The original server message survives — the advice is appended, not swapped in.
+	if !strings.Contains(msg, "App not found") {
+		t.Errorf("the server's own 404 message must survive, got: %v", err)
+	}
+	for _, want := range appViewAdviceMarkers {
+		if !strings.Contains(msg, want) {
+			t.Errorf("owned-slug advice missing %q, got: %v", want, err)
+		}
+	}
+	// It must report what the submissions route actually said, and name the
+	// listing command with the slug so the next step is copy-pasteable.
+	for _, want := range []string{"approved", "live", "civitai app listing status --slug buzz-generator", "civitai app status buzz-generator"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("owned-slug advice missing %q, got: %v", want, err)
+		}
+	}
+}
+
+// (b) 404 on a slug the caller does NOT own → the plain not-found, no claim about
+// anybody's store listing.
+func TestAppViewNotFoundNotOwnedStaysPlain(t *testing.T) {
+	probes := appViewServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"submissions":[]}`))
+	})
+
+	_, _, err := run(t, "app", "view", "buzz-generator")
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("404 should classify as ErrNotFound, got %T: %v", err, err)
+	}
+	if n := atomic.LoadInt32(probes); n != 1 {
+		t.Errorf("the probe must have RUN (positive control), ran %d times", n)
+	}
+	assertNoOwnedAdvice(t, err)
+}
+
+// (b') The server ignoring ?blockId= must not be readable as ownership: a row for
+// a DIFFERENT app is not evidence about this slug.
+func TestAppViewNotFoundForeignRowIsNotOwnership(t *testing.T) {
+	probes := appViewServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"submissions":[{
+		  "id":"pubreq_02H","blockId":"someone-elses-app","version":"1.0.0","status":"approved",
+		  "deployState":"live","submittedAt":"2026-07-28T10:00:00Z","updatedAt":"2026-07-28T10:00:00Z",
+		  "createdAt":"2026-07-28T10:00:00Z"}]}`))
+	})
+
+	_, _, err := run(t, "app", "view", "buzz-generator")
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("404 should classify as ErrNotFound, got %T: %v", err, err)
+	}
+	if n := atomic.LoadInt32(probes); n != 1 {
+		t.Errorf("the probe must have RUN (positive control), ran %d times", n)
+	}
+	assertNoOwnedAdvice(t, err)
+}
+
+// (c) The ownership lookup ITSELF fails → fall back to the plain 404. Reading
+// nothing is not finding nothing: a "your listing is unpublished" claim we could
+// not check is a false diagnosis, worse than the terse 404.
+func TestAppViewNotFoundProbeFailureFallsBack(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"server error", http.StatusInternalServerError, `{"message":"boom"}`},
+		{"not an apps author", http.StatusForbidden, `{"message":"invite-only"}`},
+		{"submissions route missing", http.StatusNotFound, `{"message":"no such submission"}`},
+		{"unparseable body", http.StatusOK, `<html>gateway</html>`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			probes := appViewServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			})
+
+			_, _, err := run(t, "app", "view", "buzz-generator")
+			if err == nil {
+				t.Fatal("expected a not-found error")
+			}
+			// The 404 the USER asked about must survive — a failed probe must not
+			// re-classify the error as the probe's own failure (that would move
+			// the exit code off 4).
+			if !errors.Is(err, civitai.ErrNotFound) {
+				t.Errorf("a failed probe must leave the store 404 intact, got %T: %v", err, err)
+			}
+			if !strings.Contains(err.Error(), "App not found") {
+				t.Errorf("the store's 404 message must survive a failed probe, got: %v", err)
+			}
+			if n := atomic.LoadInt32(probes); n != 1 {
+				t.Errorf("the probe must have RUN (positive control), ran %d times", n)
+			}
+			assertNoOwnedAdvice(t, err)
+		})
+	}
+}
+
+// (d) The happy path is unchanged — and pays for NO ownership probe.
+func TestAppViewHappyPathDoesNotProbeOwnership(t *testing.T) {
+	const body = `{
+	  "id":"d1","serialId":42,"slug":"buzz-generator","kind":"onsite","name":"Buzz Generator",
+	  "tagline":"neat","description":"A longer description.","category":"generation","contentRating":"pg",
+	  "creator":{"id":7,"username":"alice","image":""},
+	  "recommend":{"recommendedCount":9,"notRecommendedCount":1,"recommendPct":0.9},"reviewCount":10,
+	  "screenshots":[],
+	  "kindData":{"kind":"onsite","appBlockId":"blk_9","hasPage":true,"liveUrl":"https://buzz-generator.civit.ai"}
+	}`
+	var probes int32
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/blocks/submissions" {
+			atomic.AddInt32(&probes, 1)
+			_, _ = w.Write([]byte(ownedSubmissionBody))
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	})
+
+	out, _, err := run(t, "app", "view", "buzz-generator")
+	if err != nil {
+		t.Fatalf("app view: %v", err)
+	}
+	if n := atomic.LoadInt32(&probes); n != 0 {
+		t.Errorf("a successful view must not pay for an ownership probe, made %d", n)
+	}
+	for _, want := range []string{"Buzz Generator", "buzz-generator", "generation", "alice", "https://buzz-generator.civit.ai"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A non-404 failure must never grow the advice (nor probe): the ownership story
+// is a claim about a MISSING store listing, and nothing else.
+func TestAppViewNon404DoesNotExplainOwnership(t *testing.T) {
+	var probes int32
+	setupAuthedAppsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/blocks/submissions" {
+			atomic.AddInt32(&probes, 1)
+			_, _ = w.Write([]byte(ownedSubmissionBody))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"kaboom"}`))
+	})
+
+	_, _, err := run(t, "app", "view", "buzz-generator")
+	if err == nil {
+		t.Fatal("expected a server error")
+	}
+	if errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("a 500 must not classify as not-found, got: %v", err)
+	}
+	if n := atomic.LoadInt32(&probes); n != 0 {
+		t.Errorf("only a 404 may trigger the ownership probe, made %d", n)
+	}
+	assertNoOwnedAdvice(t, err)
+}
+
+func assertNoOwnedAdvice(t *testing.T, err error) {
+	t.Helper()
+	for _, marker := range appViewAdviceMarkers {
+		if strings.Contains(err.Error(), marker) {
+			t.Errorf("unowned/unverifiable 404 must not claim ownership (%q), got: %v", marker, err)
+		}
+	}
+}

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/civitai/cli/internal/appapi"
 	"github.com/civitai/cli/internal/auth"
 	"github.com/civitai/cli/internal/config"
 	"github.com/civitai/cli/pkg/civitai"
@@ -154,20 +156,27 @@ external / connect target).
 
 Login is required (` + "`civitai login`" + `). A missing or out-of-scope slug returns a
 clean "not found" message. This command is useless until the backing API is
-deployed.`,
+deployed.
+
+This reads the PUBLIC STORE CATALOG, which is NOT the same thing as your
+deployment: an app can be approved, deployed and serving at <slug>.civit.ai and
+still not be in the store. When a 404 lands on a slug you own, the error says so
+and points at ` + "`civitai app listing status`" + ` / ` + "`civitai app status`" + `.`,
 		Example: `  civitai app view my-cool-app
   civitai app view my-cool-app --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jsonOut, _ := cmd.Flags().GetBool("json")
+			slug := args[0]
+			ctx := context.Background()
 
 			client, err := newLoginGatedReader()
 			if err != nil {
 				return err
 			}
-			d, raw, err := client.GetApp(context.Background(), args[0])
+			d, raw, err := client.GetApp(ctx, slug)
 			if err != nil {
-				return err
+				return explainAppViewNotFound(ctx, slug, err)
 			}
 			if jsonOut {
 				return emitJSON(cmd, raw)
@@ -178,6 +187,88 @@ deployed.`,
 	}
 	cmd.Flags().Bool("json", false, "print the raw API JSON response (for scripting)")
 	return cmd
+}
+
+// explainAppViewNotFound upgrades the bare 404 from GET /api/v1/apps/{slug} to
+// an actionable error when the caller turns out to OWN that slug (issue #223).
+//
+// The 404 is TRUTHFUL — `app view` and `app status` read genuinely DIFFERENT
+// resources. `app view` reads the PUBLIC STORE CATALOG (GET /api/v1/apps/{slug},
+// an approved+published AppListing), while `app status` reads the AUTHOR
+// SUBMISSION PIPELINE (GET /api/v1/blocks/submissions), which is what carries
+// deployState and the live URL. An app can therefore be approved, deployed and
+// serving while the store cannot show it, and the store detail route correctly
+// 404s. So the fix is the MESSAGE, not the lookup: nothing about the request
+// changes, only what we tell the author a 404 means.
+//
+// 🔴 The ownership probe runs ONLY on the 404 path, and that is deliberate. The
+// happy path must not pay a second round trip for advice it will never print,
+// and the submissions route is invite-gated (a caller who is not an Apps author
+// gets a 403 there) — so probing unconditionally would add both latency and a
+// brand-new failure mode to a command that already succeeded.
+func explainAppViewNotFound(ctx context.Context, slug string, err error) error {
+	if !errors.Is(err, civitai.ErrNotFound) {
+		return err
+	}
+	sub := ownedSubmission(ctx, slug)
+	if sub == nil {
+		// 🔴 Ownership was NOT ESTABLISHED — either the caller does not own this
+		// slug, or the probe itself could not answer (network, auth, no token,
+		// not an Apps author). Both collapse to the plain 404 on purpose:
+		// reading nothing is not finding nothing, and asserting "your store
+		// listing is not published" when we could not actually check would be a
+		// false diagnosis at a correct project — strictly worse than the terse
+		// 404 it replaced.
+		return err
+	}
+	// %w keeps the classification (and therefore the not-found exit code)
+	// attached; the advice is appended, never substituted.
+	return fmt.Errorf("%w\n\n%s", err, appViewOwnedAdvice(slug, sub))
+}
+
+// ownedSubmission answers "does the caller own <slug>?" against the author
+// submission route, returning the matching submission row or nil.
+//
+// nil means "not established" and deliberately does NOT distinguish "not yours"
+// from "could not ask" — explainAppViewNotFound must treat those identically,
+// so collapsing them here keeps the one decision in one place.
+func ownedSubmission(ctx context.Context, slug string) *appapi.Submission {
+	cfg, err := config.Load()
+	if err != nil || cfg.Token() == "" {
+		return nil
+	}
+	subs, err := appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), "").ListSubmissions(ctx, slug)
+	if err != nil {
+		return nil
+	}
+	// Match the slug HERE rather than trusting the ?blockId= narrowing: a
+	// submission's blockId IS the slug, and a server that ignored the filter
+	// would otherwise hand back someone else's newest row and turn this into a
+	// confident false claim of ownership.
+	for i := range subs {
+		if subs[i].BlockID == slug {
+			return &subs[i]
+		}
+	}
+	return nil
+}
+
+// appViewOwnedAdvice is the actionable half of the #223 message. It reports only
+// what the two endpoints actually said — the store 404ed, and the submissions
+// route holds a row for this slug with this status/deployState — and names the
+// next command for each of the two resources. It deliberately does NOT claim a
+// single cause: the CLI cannot see whether the listing is unpublished or the
+// store's launch flag is simply hiding it, and re-deriving publication rules
+// locally is exactly the vendoring this repo refuses.
+func appViewOwnedAdvice(slug string, s *appapi.Submission) string {
+	return fmt.Sprintf(
+		"`%s` IS one of your own apps (submission status: %s, deploy: %s), so this 404 is not evidence that your deploy is broken.\n"+
+			"`civitai app view` reads the PUBLIC store catalog (GET /api/v1/apps/{slug}) — a different resource from your submission, "+
+			"which is what carries the deploy state and the live URL. The store lists an app only once its store LISTING is published "+
+			"(a listing needs an icon and a cover), and the catalog itself is still gated by a launch flag: until it opens publicly you "+
+			"only see apps if your account is a moderator or app-dev-tester.\n"+
+			"Next: `civitai app listing status --slug %s` for the listing, `civitai app status %s` for the deploy state and live URL",
+		slug, dashIfEmpty(safeTerm(s.Status)), deployLabel(s.DeployState), slug, slug)
 }
 
 // newLoginGatedReader builds a civitai.Client for the App-store read endpoints,


### PR DESCRIPTION
Fixes #223.

## The mechanism (confirmed against the code, not assumed)

The 404 is **truthful** — `app view` and `app status` read genuinely different resources:

| command | route | resource |
|---|---|---|
| `civitai app view <slug>` | `GET /api/v1/apps/{slug}` (`Client.GetApp`, `pkg/civitai/apps.go`) | the **public store catalog** — `AppDetail` is documented as "the full public detail for one **approved** listing" |
| `civitai app status <slug>` | `GET /api/v1/blocks/submissions` (`internal/appapi/appblocks.go`) | the **author submission pipeline** — the only place `deployState` and `liveUrl` live |

So an app can be `approved` + `live` and serving at `<slug>.civit.ai` while the store cannot show it (its store **listing** is not published — `civitai app listing status` already models that publish floor: an icon and a cover — and the catalog itself is still gated by a launch flag, as `app list --help` already says).

The lookup is therefore correct and the defect is the **message**: a first-time author reads `Error: not found (404): App not found` as "my deploy is broken".

## The fix

On a **404 only**, probe `GET /api/v1/blocks/submissions?blockId=<slug>` for a row whose `blockId` matches the slug. When one exists, the 404 grows advice that reports *only what the two endpoints actually said*:

```
Error: not found (404): App not found

`buzz-generator` IS one of your own apps (submission status: approved, deploy: live), so this 404 is not evidence that your deploy is broken.
`civitai app view` reads the PUBLIC store catalog (GET /api/v1/apps/{slug}) — a different resource from your submission, which is what carries the deploy state and the live URL. The store lists an app only once its store LISTING is published (a listing needs an icon and a cover), and the catalog itself is still gated by a launch flag: until it opens publicly you only see apps if your account is a moderator or app-dev-tester.
Next: `civitai app listing status --slug buzz-generator` for the listing, `civitai app status buzz-generator` for the deploy state and live URL
```

Design decisions, each with a code comment:

- **The probe runs only on the 404 path.** The happy path must not pay a second round trip for advice it will never print, and the submissions route is invite-gated (a non-author gets a 403 there) — probing unconditionally would add latency *and* a new failure mode to a command that already succeeded. `TestAppViewHappyPathDoesNotProbeOwnership` pins it.
- **A probe that cannot answer falls back to the plain 404.** Network error, 403, 404, unparseable body, no token, config error — all collapse to "ownership not established", identical to "not yours". Claiming an unpublished listing we could not check would be a false diagnosis at a correct project, strictly worse than the terse 404.
- **The slug is matched client-side**, not delegated to `?blockId=`: a server that ignored the filter would otherwise hand back someone else's newest row and turn this into a confident false claim of ownership.
- **No exit-code change and no vendoring.** The advice is appended with `%w`, so `errors.Is(err, civitai.ErrNotFound)` still holds and rc stays 4. Nothing about publication rules is re-derived locally — the message names both possible causes rather than asserting one.

## Tests — red at base, green at HEAD

Base = `ba3136c` (branch base = `origin/main` at branch time). Every case was run against pre-change code with the new test file copied in.

| test | at `ba3136c` | at HEAD |
|---|---|---|
| (a) 404 + caller owns → advice **and** `errors.Is(err, ErrNotFound)` | **FAIL** | PASS |
| (b) 404 + not owned → plain 404 | **FAIL** (probe positive control: ran 0 times) | PASS |
| (b′) 404 + server returned a row for a *different* slug → plain 404 | **FAIL** (same) | PASS |
| (c) 404 + probe itself fails (500 / 403 / 404 / unparseable) → plain 404, message intact | **FAIL** ×4 (same) | PASS |
| (d) happy path unchanged **and** makes zero probes | PASS (cannot be red at base — it pins unchanged behaviour) | PASS |
| non-404 (500) never probes and never explains | PASS (same reason) | PASS |

Honest note on (b)/(b′)/(c): at base their *absence* assertions cannot fail (there is no advice to find), so their red comes from the probe-ran positive control. What actually pins the absence logic is the mutation sweep below.

## Mutation checks (each applied to the shipped code, then reverted)

| mutation | result |
|---|---|
| M1 — claim ownership unconditionally (`sub := &appapi.Submission{…}`, probe never consulted) | **killed** by (b), (b′), (c), each with `must not claim ownership` |
| M2 — treat a **failed probe** as ownership (`if err != nil { return &Submission{…} }`) | **killed** by (c), all four sub-cases, with (a)/(b)/(b′) still green — case (c) is reachable and specific |
| M3 — trust `?blockId=`, drop the client-side slug match | **killed** by (b′) alone |
| M4 — `%w` → `%v` (strips the not-found classification, message byte-identical) | **killed** by (a)'s `errors.Is` — a text-only assertion would have stayed green |
| M5 — probe unconditionally, including the happy path | **killed** by (d) |

## Also

- `README.md` gains a short "Deployed is not the same as listed in the store" subsection under **Submission status** (`app view` has no command-table entry today).
- `make ci` green (18 packages, all `ok`); `gofmt -s -l .` prints nothing over 276 `.go` files, with a negative control confirming it does flag a misformatted file.
- Touches `internal/cmd/apps.go`, a new `internal/cmd/app_view_owned_test.go`, and `README.md` — **not** `internal/appapi/appblocks.go`, so there is no overlap with the #224 work on `GetSubmission`. The probe deliberately uses `ListSubmissions` rather than `GetSubmission` for that reason (and because an empty list is a clean "not owned" instead of an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
