### PR TITLE
fix(generate): the pre-spend lead pointed at an estimate `--yes` never prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ The server now reports each swap, and `civitai generate` surfaces it:
 ```console
 $ civitai generate "a cat" --checkpoint 999999999 --dry-run
 ⚠ The server will NOT use the checkpoint you asked for. It has substituted a
-  different model, and the estimate below prices the SUBSTITUTE. Nothing has
+  different model, and this estimate prices the SUBSTITUTE. Nothing has
   been submitted or charged yet.
     requested version 999999999 -> will run version 2436219  (reason: unrecognized)
       the server does not offer that version in this model family at all …

--- a/internal/cmd/generate_substitution.go
+++ b/internal/cmd/generate_substitution.go
@@ -133,8 +133,19 @@ func reportModelSubstitutions(errw io.Writer, subs []genapi.ModelSubstitution, p
 func substitutionLead(phase substitutionPhase) string {
 	switch phase {
 	case substitutionAtEstimate:
+		// 🔴 NO POSITIONAL PROMISE — an earlier wording said "the estimate BELOW".
+		// This lead is printed on all three pre-spend surfaces, and on one of them
+		// nothing follows it: `--yes` skips the prompt, and `confirmGenerate`'s
+		// --yes arm prints the image disclosure and returns, never the cost. So the
+		// old wording pointed at an estimate that is never rendered — on the one
+		// surface that is MANDATORY non-interactively and has nobody watching.
+		// Describing the estimate that PRODUCED this warning is true everywhere;
+		// describing where it lands on screen is not. Pinned by
+		// TestConfirmGenerate_YesPathPrintsNoCost, which goes red if `--yes` ever
+		// starts printing the cost — at which point a positional wording would be
+		// honest again and this comment is the record of why it wasn't.
 		return "The server will NOT use the checkpoint you asked for. It has substituted a different model, " +
-			"and the estimate below prices the SUBSTITUTE. Nothing has been submitted or charged yet."
+			"and this estimate prices the SUBSTITUTE. Nothing has been submitted or charged yet."
 	case substitutionAfterSubmit:
 		return "The server did NOT use the checkpoint you asked for. It substituted a different model and " +
 			"this generation HAS BEEN CHARGED for the model that actually ran."

--- a/internal/cmd/generate_substitution_test.go
+++ b/internal/cmd/generate_substitution_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/civitai/cli/internal/genapi"
+	"github.com/spf13/cobra"
 )
 
 // Surfacing silent checkpoint substitutions (civitai/civitai#3665).
@@ -163,10 +164,49 @@ func TestSubstitutionLead_AllPhasesNonEmptyAndPairwiseDistinct(t *testing.T) {
 // So the whole sentence is the contract. Any edit to user-facing money wording
 // has to come here and be read, which is the point: these three sentences are the
 // only place the CLI states whether the caller's money has already moved.
+// TestConfirmGenerate_YesPathPrintsNoCost pins the FACT the estimate lead's
+// wording depends on.
+//
+// 🔴 THIS IS A RELATIONSHIP GUARD, not a test of `confirmGenerate`. The
+// pre-spend lead used to say "the estimate BELOW prices the SUBSTITUTE". That is
+// true on `--dry-run` (the quote is printed after) and on the interactive path
+// (`confirmGenerate` prints cost + balance in the prompt) — and FALSE on `--yes`,
+// where the --yes arm prints the image disclosure and returns without ever
+// rendering the cost. So the warning pointed at output that does not exist, on
+// the one pre-spend surface that is MANDATORY non-interactively and has nobody
+// watching it.
+//
+// The wording no longer makes a positional claim. This test exists so that stays
+// a deliberate choice: if `--yes` ever starts printing the cost, this goes red,
+// and whoever changed it can re-read `substitutionLead` and decide whether a
+// positional wording has become honest again. Without it, the fix is just a
+// sentence nobody can check.
+func TestConfirmGenerate_YesPathPrintsNoCost(t *testing.T) {
+	cmd := &cobra.Command{}
+	var errw bytes.Buffer
+	cmd.SetErr(&errw)
+
+	o := generateOpts{assumeYes: true}
+	if err := confirmGenerate(cmd, o, &resolvedGraph{}, 12345, 999999, true); err != nil {
+		t.Fatalf("confirmGenerate(--yes) = %v, want nil", err)
+	}
+
+	got := errw.String()
+	// The cost is 12345; `buzzAmount` renders it for the prompt and the
+	// non-TTY refusal. Neither may appear on the --yes path.
+	for _, forbidden := range []string{buzzAmount(12345), "12345"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("--yes printed the cost (%q) — the estimate lead may now legitimately "+
+				"say \"the estimate below\"; re-read substitutionLead before changing this test.\ngot:\n%s",
+				forbidden, got)
+		}
+	}
+}
+
 func TestSubstitutionLead_ExactTextPerPhase(t *testing.T) {
 	want := map[substitutionPhase]string{
 		substitutionAtEstimate: "The server will NOT use the checkpoint you asked for. It has substituted a different model, " +
-			"and the estimate below prices the SUBSTITUTE. Nothing has been submitted or charged yet.",
+			"and this estimate prices the SUBSTITUTE. Nothing has been submitted or charged yet.",
 		substitutionAfterSubmit: "The server did NOT use the checkpoint you asked for. It substituted a different model and " +
 			"this generation HAS BEEN CHARGED for the model that actually ran.",
 		substitutionOnRead: "The server did not use the checkpoint that was requested for this workflow. It substituted a " +


### PR DESCRIPTION
Follow-up to #221 (merged as `ba3136c`). Refs `civitai/civitai#3665`.

## The defect

The substitution warning's estimate-phase lead said:

> …and the estimate **below** prices the SUBSTITUTE. Nothing has been submitted or charged yet.

That holds on two of the three pre-spend surfaces:

| surface | is an estimate printed after the warning? |
|---|---|
| `--dry-run` | ✅ the quote follows |
| interactive TTY | ✅ `confirmGenerate` prints cost + balance in the prompt |
| **`--yes`** | ❌ the `--yes` arm prints the image disclosure and returns — **the cost is never rendered** |

So the warning pointed at output that does not exist, on the one pre-spend surface that is **mandatory non-interactively** and has nobody watching it — the surface this feature's own comments single out as most needing the warning.

Verified by reading the path: between the warning and `confirmGenerate`, every cost line is inside a conditional (`--max-cost` exceeded, balance exceeded); the unconditional print lives in the prompt arm only.

The lead now describes the estimate that **produced** the warning rather than where it lands on screen — true on all three surfaces.

## Why there's a test for a sentence

A wording fix is unfalsifiable on its own, so this pins the fact the wording rests on. `TestConfirmGenerate_YesPathPrintsNoCost` asserts `--yes` prints no cost. If that ever changes, it goes red and whoever changed it can re-read `substitutionLead` and decide whether a positional wording has become honest again.

Mutants, both verified:

| mutant | result |
|---|---|
| make `--yes` print the cost | new guard **red** |
| revert the lead to "the estimate below" | exact-literal lead test **red** |

## Provenance

Found by an adversarial audit of the competing implementation in #222 (since closed) — the defect was present in both, so it survived #221's three audit rounds. Worth noting as evidence that auditing the *other* implementation was what caught it.

## Verification

Suite **counted**: 2358 PASS / 0 FAIL / 4 SKIP across 2370 `=== RUN`, no timeout panics. `go vet` and `gofmt -s` clean. `golangci-lint` **0 issues** — with the instrument validated first by planting a `declared and not used`, which it reported at `generate_substitution.go:134`, then going clean on restore.

> An earlier count in my own run showed `0 PASS / 0 FAIL` — `go test` without `-v` emits no `--- PASS` lines, so the counter was reading nothing. Recounted with `-v`.

## Not fixed — flagged

`generate.go:806` (quantity clamp) and `generate_image.go:322` (image disclosure) make the same "the estimate below" claim from the same pre-spend position, so both are also wrong under `--yes`. They predate this feature; out of scope here rather than silently widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
