### PR TITLE
fix(genapi): a garbled substitution warning cost the whole workflow

### DIFF
--- a/internal/genapi/generate.go
+++ b/internal/genapi/generate.go
@@ -114,7 +114,7 @@ type SubmitResult struct {
 	// only this one survives to a later read.
 	//
 	// 🔴 Read neither directly — use Substitutions(), which fixes the precedence.
-	Metadata *substitutionMetadata `json:"metadata,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }
 
 // SubmitOptions carries the ENVELOPE siblings of the graph — the fields that

--- a/internal/genapi/status.go
+++ b/internal/genapi/status.go
@@ -185,7 +185,7 @@ type Workflow struct {
 	// 🔴 Read it via Substitutions(), not directly. This is the ONLY carrier once
 	// the submit reply is gone — which is precisely the situation
 	// `civitai generate --no-wait` creates by design.
-	Metadata *substitutionMetadata `json:"metadata,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 }
 
 // Output is one workflow output with the two step-derived fields folded in.

--- a/internal/genapi/substitution.go
+++ b/internal/genapi/substitution.go
@@ -1,5 +1,7 @@
 package genapi
 
+import "encoding/json"
+
 // Model substitution — the server's record of a checkpoint it swapped out.
 //
 // 🔴 THE FAILURE THIS EXISTS TO MAKE VISIBLE. When a submitted `model.id` is not
@@ -87,6 +89,40 @@ type substitutionMetadata struct {
 	ModelSubstitutions []ModelSubstitution `json:"modelSubstitutions,omitempty"`
 }
 
+// substitutionsFromMetadata decodes the record out of a RAW `metadata` blob.
+//
+// 🔴 WHY THE CARRIER IS json.RawMessage AND NOT A TYPED FIELD. `metadata` is an
+// orchestrator-owned free-form bag, exactly like the `transactions` field
+// declared a few lines above it in `Workflow`. Modelling it as a struct made a
+// malformed ADVISORY field fail the unmarshal of the whole reply — and the
+// replies this rides on are the ones that tell a user what they were just
+// CHARGED for. Measured on the typed version, all three shapes losing the entire
+// workflow to `unexpected orchestrator.getWorkflow payload`:
+//
+//	{"metadata":{"modelSubstitutions":[{"requested":"x",…}]}}  entry type wrong
+//	{"metadata":{"modelSubstitutions":"nope"}}                 key not an array
+//	{"metadata":"nope"}                                        bag not an object
+//
+// None is producible by today's server, which only ever writes well-formed
+// records. That is the point: a feature that exists so a user can discover they
+// were billed for the wrong model must not have a read path where a
+// garbled WARNING costs them the workflow itself. Failing soft here degrades to
+// "no substitutions reported", which is the same thing an older server produces.
+//
+// Absent / null / not-an-object / no such key all yield nil, none of them an
+// error. Entry-level validation stays where it was — a bad entry is skipped, not
+// fatal.
+func substitutionsFromMetadata(raw json.RawMessage) []ModelSubstitution {
+	if len(raw) == 0 {
+		return nil
+	}
+	var env substitutionMetadata
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil
+	}
+	return env.ModelSubstitutions
+}
+
 // Substitutions returns the substitution record for this submit, or nil.
 //
 // 🔴 IT READS TWO PLACES, AND THE ORDER MATTERS. `generateFromGraph` attaches the
@@ -108,10 +144,7 @@ func (r *SubmitResult) Substitutions() []ModelSubstitution {
 	if len(r.ModelSubstitutions) > 0 {
 		return r.ModelSubstitutions
 	}
-	if r.Metadata != nil {
-		return r.Metadata.ModelSubstitutions
-	}
-	return nil
+	return substitutionsFromMetadata(r.Metadata)
 }
 
 // Substitutions returns the substitution record persisted on this workflow, or
@@ -122,8 +155,8 @@ func (r *SubmitResult) Substitutions() []ModelSubstitution {
 // `civitai workflows get <id>`; without this, that documented path is the one
 // place a substituted run stays silent forever.
 func (w *Workflow) Substitutions() []ModelSubstitution {
-	if w == nil || w.Metadata == nil {
+	if w == nil {
 		return nil
 	}
-	return w.Metadata.ModelSubstitutions
+	return substitutionsFromMetadata(w.Metadata)
 }

--- a/internal/genapi/substitution_test.go
+++ b/internal/genapi/substitution_test.go
@@ -97,10 +97,8 @@ func TestSubmit_DecodesTopLevelAndMetadata(t *testing.T) {
 // has — Substitutions() must fall back to it rather than reporting nothing.
 func TestSubmit_FallsBackToMetadataWhenTopLevelAbsent(t *testing.T) {
 	r := &SubmitResult{
-		ID: "wf_1",
-		Metadata: &substitutionMetadata{ModelSubstitutions: []ModelSubstitution{
-			{Requested: 7, Applied: 8, Reason: SubstitutionWrongWorkflow},
-		}},
+		ID:       "wf_1",
+		Metadata: json.RawMessage(`{"modelSubstitutions":[{"requested":7,"applied":8,"reason":"wrong-workflow"}]}`),
 	}
 	subs := r.Substitutions()
 	if len(subs) != 1 || subs[0].Requested != 7 {
@@ -117,9 +115,7 @@ func TestSubmit_EmptyTopLevelArrayStillFallsBackToMetadata(t *testing.T) {
 	r := &SubmitResult{
 		ID:                 "wf_1",
 		ModelSubstitutions: []ModelSubstitution{}, // present, non-nil, EMPTY
-		Metadata: &substitutionMetadata{ModelSubstitutions: []ModelSubstitution{
-			{Requested: 9, Applied: 10, Reason: SubstitutionGated},
-		}},
+		Metadata:           json.RawMessage(`{"modelSubstitutions":[{"requested":9,"applied":10,"reason":"gated"}]}`),
 	}
 	subs := r.Substitutions()
 	if len(subs) != 1 || subs[0].Requested != 9 {
@@ -133,9 +129,7 @@ func TestSubmit_EmptyTopLevelArrayStillFallsBackToMetadata(t *testing.T) {
 func TestSubmit_TopLevelWinsOverMetadata(t *testing.T) {
 	r := &SubmitResult{
 		ModelSubstitutions: []ModelSubstitution{{Requested: 1, Applied: 2, Reason: SubstitutionUnrecognized}},
-		Metadata: &substitutionMetadata{ModelSubstitutions: []ModelSubstitution{
-			{Requested: 3, Applied: 4, Reason: SubstitutionGated},
-		}},
+		Metadata:           json.RawMessage(`{"modelSubstitutions":[{"requested":3,"applied":4,"reason":"gated"}]}`),
 	}
 	subs := r.Substitutions()
 	if len(subs) != 1 || subs[0].Applied != 2 {
@@ -204,5 +198,53 @@ func TestSubstitution_UnknownReasonIsPreservedNotDropped(t *testing.T) {
 	}
 	if out.ModelSubstitutions[0].Reason != "some-future-reason" {
 		t.Errorf("the server's own token must be preserved verbatim, got %q", out.ModelSubstitutions[0].Reason)
+	}
+}
+
+// 🔴 A GARBLED WARNING MUST NEVER COST THE WORKFLOW ITSELF.
+//
+// `metadata` is an orchestrator-owned free-form bag. While it was modelled as a
+// typed struct, a malformed ADVISORY field failed the unmarshal of the WHOLE
+// reply — and `GetWorkflow` turns that into
+// `unexpected orchestrator.getWorkflow payload`, discarding a workflow the user
+// has already been charged for. Measured before the fix: all three shapes below
+// lost the entire workflow.
+//
+// None is producible by today's server, which only writes well-formed records.
+// That is exactly why it is worth pinning: this feature exists so a user can
+// discover they were billed for the wrong model, so its read path must fail soft
+// rather than take the workflow down with the warning.
+//
+// The well-formed case is the POSITIVE CONTROL — without it, "everything decodes"
+// would also be satisfied by a decoder that silently returns nothing for every
+// input.
+func TestWorkflow_MalformedMetadataNeverCostsTheWorkflow(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  string
+		wantSubs int
+	}{
+		{"entry field has the wrong type",
+			`{"id":"wf-1","status":"succeeded","metadata":{"modelSubstitutions":[{"requested":"x","applied":2,"reason":"unrecognized"}]}}`, 0},
+		{"the key is not an array",
+			`{"id":"wf-1","status":"succeeded","metadata":{"modelSubstitutions":"nope"}}`, 0},
+		{"the metadata bag is not an object",
+			`{"id":"wf-1","status":"succeeded","metadata":"nope"}`, 0},
+		{"POSITIVE CONTROL: well-formed still decodes",
+			`{"id":"wf-1","status":"succeeded","metadata":{"modelSubstitutions":[{"requested":1,"applied":2,"reason":"unrecognized"}]}}`, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w Workflow
+			if err := json.Unmarshal([]byte(tc.payload), &w); err != nil {
+				t.Fatalf("a malformed advisory field must not fail the whole reply: %v", err)
+			}
+			if w.ID != "wf-1" {
+				t.Fatalf("workflow id lost: %q", w.ID)
+			}
+			if got := len(w.Substitutions()); got != tc.wantSubs {
+				t.Fatalf("Substitutions() = %d records, want %d", got, tc.wantSubs)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Ported from the closed #222. Follow-up to #221 / #231. Refs `civitai/civitai#3665`.

## The defect

`Workflow` carries two orchestrator-owned free-form fields, nine lines apart:

```go
Transactions json.RawMessage        `json:"transactions,omitempty"`   // :179
Metadata     *substitutionMetadata  `json:"metadata,omitempty"`       // :188
```

`transactions` is `RawMessage` *because* its shape is server-owned. `metadata` is equally server-owned and was typed — so a malformed **advisory** field failed the unmarshal of the whole reply, and `GetWorkflow` turns that into `unexpected orchestrator.getWorkflow payload`, discarding a workflow the caller **has already been charged for**.

Measured before the fix — all three lose the entire workflow:

| payload | result |
|---|---|
| `{"metadata":{"modelSubstitutions":[{"requested":"x",…}]}}` | entry type wrong → workflow lost |
| `{"metadata":{"modelSubstitutions":"nope"}}` | key not an array → workflow lost |
| `{"metadata":"nope"}` | bag not an object → workflow lost |

## Why fix something unreachable

None of these is producible by today's server, which only ever writes well-formed records. That's the argument *for* pinning it, not against: this feature exists so a user can discover they were billed for the wrong model. A read path where a garbled **warning** costs them the **workflow** inverts the whole point.

It now degrades to "no substitutions reported" — which is exactly what an older server produces, so the behaviour is already well-defined everywhere else in this code.

## Scope

`metadata` becomes `json.RawMessage` on both carriers; a small helper decodes it. **Unchanged:** entry-level validation, the precedence rule (top-level wins, metadata fallback), and the `--json` raw passthrough.

## Verification

Reverting the carrier to the typed struct **reddens all three malformed cases** while the well-formed **positive control** stays green — without that control, "everything decodes" would also be satisfied by a decoder that silently returns nothing for every input.

Suite **counted**: 2371 PASS / 0 FAIL / 4 SKIP across 2375 `=== RUN`, no timeout panics. `go vet` and `gofmt -s` clean. `golangci-lint` 0 issues.

## Deliberately not ported from #222

Its **version-name resolver**. I recommended it earlier as a UX win and was wrong: an audit measured it as an unbounded network lookup sitting between the charge and printing the workflow id — **244 s** against a stalling endpoint, with retry notices interleaving inside the warning block. It also contradicts the very principle this PR ports, since leniency covered malformed JSON but not a slow decoration. Names beat ids, but not at that price; it would need a hard timeout and a move off the post-charge path — a redesign, not a port.

Also skipped: the reason gloss (`main` already has per-reason advice) and the merge-with-dedupe carrier handling (`main`'s precedence is fine, and #222's dedupe key was itself half-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
