### PR TITLE
docs: document `app listing`, fix the ambiguous `download` example, drop 3 stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ civitai models search --base-model Illustrious --type Checkpoint --sort "Most Do
 civitai models search --type TextualInversion --base-model "SDXL 1.0"
 
 # Inspect a specific model or a specific model version:
-civitai models get 4384
-civitai model-versions get 128713
+civitai models get 618692
+civitai model-versions get 691639
 
 # Download a version's file(s) — SHA256-verified, streamed atomically.
 # `--layout` routes each file into the right app subfolder (also `a1111`);
 # `--dry-run` prints the plan without transferring. Downloads require `civitai login`.
-civitai download 128713 --layout comfyui --root ~/ComfyUI
-civitai download 128713 --dry-run
+civitai download 691639 --layout comfyui --root ~/ComfyUI
+civitai download 691639 --dry-run
 
 # Find and read articles (guides) right in the terminal:
 civitai articles search --query "comfyui workflow"
@@ -157,6 +157,13 @@ civitai app submit
 
 # 6. Check where your submission is in review / deploy.
 civitai app status
+
+# 7. Attach the store-listing media. An icon AND a cover are REQUIRED before the
+#    listing can publish — do it now, while the app is in review; it carries
+#    forward on approval. `listing status` shows what's still missing.
+civitai app listing set-icon ./assets/icon.png
+civitai app listing set-cover ./assets/cover.png
+civitai app listing status
 ```
 
 > Want to drive the **real** backend (real Buzz/compute) before submitting? Mint
@@ -208,9 +215,10 @@ README. For the end-to-end walkthrough, see
 | `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
 | `civitai app dev-token <slug> [--env] [--spend] [--budget <n>]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the invite-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). `--spend` explicitly REQUESTS `ai:write:budgeted` (real Buzz); omit it and that scope is **filtered out** of the request — the CLI never asks for budgeted spend implicitly, even when your manifest declares it (the scaffolded money app does, so a live run that used to generate now needs `--spend`). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
-| `civitai app dev-tunnel [blockId] [--port] [--tunnel-endpoint] [--idle-timeout]` | **(Pre-GA / dark)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Mints an **ephemeral in-memory ssh keypair**, opens a reverse tunnel from your dev port (start `npm run dev:tunnel` first) to the Civitai tunnel endpoint, prints the URL to open, and tears everything down on Ctrl-C or an idle timeout. Before minting it also **pre-flights whether the host can actually embed your dev server** — the host iframes it sandboxed (opaque `null` origin), so a dev server missing `Access-Control-Allow-Origin: *`, missing the `.civit.ai` entry in `allowedHosts`, or sending a framing header that excludes `civitai.com` loads as a blank iframe with no error anywhere. Those are printed as warnings (never fatal) just above the URL, with the `vite.config.ts` fix. Apps scaffolded by `civitai app init --template page-money` already satisfy all of it. Gated behind an Apps-author invite **and** a kill-switch flag that is off today, and the tunnel endpoint is not exposed yet — so it reports "not available" until it ships. |
+| `civitai app dev-tunnel [blockId] [--port] [--tunnel-endpoint] [--idle-timeout]` | **(Pre-GA / dark)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Mints an **ephemeral in-memory ssh keypair**, opens a reverse tunnel from your dev port (start `npm run dev:tunnel` first) to the Civitai tunnel endpoint, prints the URL to open, and tears everything down on Ctrl-C or an idle timeout. Before minting it also **pre-flights whether the host can actually embed your dev server** — the host iframes it sandboxed (opaque `null` origin), so a dev server missing `Access-Control-Allow-Origin: *`, missing the `.civit.ai` entry in `allowedHosts`, or sending a framing header that excludes `civitai.com` loads as a blank iframe with no error anywhere. Those are printed as warnings (never fatal) just above the URL, with the `vite.config.ts` fix. Apps scaffolded by `civitai app init --template page-money` already satisfy all of it. The tunnel endpoint (`sish.civitai.com:2224`) is **live**; access is gated behind an Apps-author invite **and** a server kill-switch flag, so if you are not enrolled the mint reports **"not available"** — ask to be added to the cohort. |
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message`) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
+| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `civitai app submit` mints your listing as a **draft**, so you can set the media *while the app is in review* and it carries forward on approval. `listing status` prints what is attached vs. what the publish floor still requires. Source images are validated locally (png/jpeg/webp; icon ≤2 MiB, cover ≤4 MiB, screenshot ≤2 MiB) before upload, then wait for the content scan. On an **already-live** listing an attach opens a **revision** for moderator re-review (`--changelog`, `-y`). App resolved from `block.manifest.json` in the CWD, or `--slug`. See [After you submit](#after-you-submit-review--approve--deploy). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
@@ -495,15 +503,15 @@ version deterministically by its numeric **version id**, or resolve a model's
 default (first) published version with `--model`:
 
 ```bash
-civitai download 128713                       # the version's primary file → ./<server-name>
+civitai download 691639                       # the version's primary file → ./<server-name>
 civitai download --model 4384                 # resolve model 4384's default version, then download its primary file
 civitai download --model 4384 --dry-run       # print the plan (files, sizes, hashes, targets) — download nothing
-civitai download 128713 --out ./dreamshaper.safetensors
-civitai download 128713 --file vae --out-dir ./models   # pick a file by name; write into a dir
+civitai download 691639 --out ./flux_dev.safetensors
+civitai download 290640 --file vae --out-dir ./models   # pick a file by name; write into a dir
 civitai download 691639 --file 1234567                  # pick one of two same-named files by its file id
-civitai download 128713 --all --out-dir ./models        # every file in the version
-civitai download 128713 --all --layout comfyui --root ~/ComfyUI   # route each file to its type folder
-civitai download 128713 --layout a1111 --for-base "SDXL 1.0"      # A1111 layout + base-model compat warning
+civitai download 290640 --all --out-dir ./models        # every file in the version
+civitai download 290640 --all --layout comfyui --root ~/ComfyUI   # route each file to its type folder
+civitai download 691639 --layout a1111 --for-base "SDXL 1.0"      # A1111 layout + base-model compat warning
 ```
 
 > **Downloads require authentication.** Every model-file download needs a token —
@@ -513,7 +521,7 @@ civitai download 128713 --layout a1111 --for-base "SDXL 1.0"      # A1111 layout
 
 Behavior:
 
-- **Identifier** — exactly one of the positional `<version-id>` or `--model <model-id>` is required (no numeric-ambiguity guessing).
+- **Identifier** — exactly one of the positional id or `--model <model-id>` is required. The positional is normally a model-**version** id, but because `models search` / `models get` print **model** ids, handing one over just works: the CLI notices it is a model id and downloads that model's default version, printing a `note: <id> is a model id — downloading its default version <v>` line. When a number is **both** a valid model id and a valid version id (common for low/mid numbers), the CLI **stops** rather than guess, naming both interpretations — re-run with `--model <id>` (that model's default version), `--version <id>` (that version as-is), or `--yes` to take the version interpretation and have it echoed back. `--version` names a version id explicitly and skips the stop entirely.
 - **`--model` resolves the default version** — the model's default (first published) version; its primary file is downloaded regardless of file type. Any model type works, including a `type: Workflows` model whose deliverable is a downloadable `Archive`.
 - **`--dry-run`** — resolve the version + selected file(s) and print the plan (each file's name, size, SHA256, resolved target path, and whether authentication will be required) then exit `0`, transferring nothing and creating no file (not even a `.part`). Works with `--file`, `--all`, `--model`, `--out`, `--out-dir`, and `--layout`/`--root` (the plan shows the routed target paths).
 - **File selection** — defaults to the version's **primary** file. `--file` selects one file by **numeric file id** (the version's `files[].id`) or by **name** (exact, else a unique case-insensitive substring; ambiguous/none errors and lists the candidate files with their ids). `--all` downloads every file.
@@ -830,6 +838,46 @@ make the subdomain serve (but `dev:live` works against a pending app — see
 walkthrough (build → submit → review → deploy), see the
 [Build your first App](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 guide.
+
+**Budget time for artwork.** Review and deploy are not the only gate: a store
+listing **cannot go live without an icon AND a cover**. `civitai app submit`
+mints your listing as a **draft** and prints this reminder inline — which is the
+moment to act on it, because the media is settable **while the app is in review**
+and carries forward when a moderator approves it. Attach it without the browser:
+
+```text
+$ civitai app listing status                        # what's attached vs. required
+App:             my-app
+Listing status:  draft
+Icon:            MISSING (required)
+Cover:           MISSING (required)
+Screenshots:     0
+
+⚠ Not publishable yet — missing icon and cover.
+  Add one:  civitai app listing set-icon <file>
+  Add one:  civitai app listing set-cover <file>
+
+$ civitai app listing set-icon ./assets/icon.png    # square-ish, ≤2 MiB
+$ civitai app listing set-cover ./assets/cover.png  # landscape hero, ≤4 MiB
+$ civitai app listing add-screenshot ./shot.png --caption "Grid view"   # optional, up to 8
+```
+
+Details worth knowing before you start:
+
+- **Source images** are png/jpeg/webp and are size-checked **locally before any
+  upload** — icon ≤2 MiB, cover ≤4 MiB, screenshot ≤2 MiB. Each attach then
+  waits for the platform content scan (a blocked image is rejected, not
+  attached).
+- **The app is resolved from `block.manifest.json`** in the current directory;
+  pass `--slug <blockId>` (with `--dir` if you prefer) to run it from anywhere.
+- **On a listing that is already LIVE**, attaching media does not edit the live
+  listing — it opens a **revision** that goes back to moderator review. Describe
+  it with `--changelog "<what changed>"`; `-y`/`--yes` skips the confirmation.
+  `civitai app listing status` on a live listing reports that in-progress
+  revision's media, and tells you when a revision is already under review.
+- **Screenshots** are managed by id (the `alsc_…` ids `listing status` prints):
+  `rm-screenshot <id>` removes one, and `reorder <id...>` takes **all** the
+  current ids in the new order — a partial set is rejected.
 
 **Need to change the bundle while a request is still `pending`?** Withdraw it
 first to free the slug, then resubmit:

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -402,6 +402,55 @@ func TestAppHelpListsDevTunnel(t *testing.T) {
 	}
 }
 
+// TestReadmeDevTunnelRowMatchesTheCommandHelp pins the two surfaces together.
+//
+// The README's dev-tunnel row said "the tunnel endpoint is not exposed yet — so
+// it reports 'not available' until it ships". That was true when the command
+// landed (#87) and was superseded by #92, which set defaultDevTunnelEndpoint to
+// the live listener and rewrote the command's own Long to say so — and left the
+// README untouched for the whole interval. This is that drift, so the guard
+// checks AGREEMENT rather than either wording alone: the README must name the
+// endpoint the code actually dials, and must not contradict the command's own
+// claim that the endpoint is live.
+func TestReadmeDevTunnelRowMatchesTheCommandHelp(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRootDir(t), "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	row := readmeCommandRefRow(t, string(raw), "civitai app dev-tunnel")
+
+	// The command's Long is the surface that was kept current; it is the anchor.
+	long := newAppDevTunnelCmd().Long
+	if !strings.Contains(long, "tunnel endpoint is live") {
+		t.Fatalf("dev-tunnel Long no longer states the endpoint is live — re-derive this "+
+			"guard against whatever the code now claims:\n%s", long)
+	}
+
+	// The README must not re-assert the superseded "endpoint isn't exposed" claim.
+	lowRow := strings.ToLower(row)
+	for _, gone := range []string{
+		"not exposed yet",
+		"until it ships",
+		"is off today",
+	} {
+		if strings.Contains(lowRow, gone) {
+			t.Errorf("README dev-tunnel row still says %q, contradicting the command's own "+
+				"help (%q):\n%s", gone, "tunnel endpoint is live", row)
+		}
+	}
+	// …and it must name the endpoint the code will actually dial, so a change to
+	// defaultDevTunnelEndpoint cannot silently orphan the README again.
+	if !strings.Contains(row, defaultDevTunnelEndpoint) {
+		t.Errorf("README dev-tunnel row should name the live endpoint %q:\n%s",
+			defaultDevTunnelEndpoint, row)
+	}
+	// The gate that IS real must survive: enrolment, not deployment.
+	if !strings.Contains(lowRow, "not available") || !strings.Contains(lowRow, "invite") {
+		t.Errorf("README dev-tunnel row should still explain the invite gate and the "+
+			"\"not available\" mint response:\n%s", row)
+	}
+}
+
 // TestAppDevTunnelForbiddenMapsToGuidance: when the server denies the mint (flag
 // off / not an author), the CLI surfaces the actionable dark/pre-GA guidance.
 // Exercises the FULL cobra path (config → api client → StartDevTunnel) against a

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -335,6 +335,94 @@ func TestSubmitFloorHeadsUp(t *testing.T) {
 	}
 }
 
+// readmeCommandRefRow returns the single command-reference TABLE ROW whose
+// command cell names `cmd`. A row is `| `civitai …` | … |`; a passing mention in
+// prose is not one, which is the distinction this helper exists to enforce.
+func readmeCommandRefRow(t *testing.T, readme, cmd string) string {
+	t.Helper()
+	var found []string
+	for _, line := range strings.Split(readme, "\n") {
+		if !strings.HasPrefix(line, "| `") {
+			continue
+		}
+		// The command cell is everything up to the first unescaped ` | `.
+		cell := line
+		if i := strings.Index(line[1:], "` | "); i >= 0 {
+			cell = line[:i+2]
+		}
+		if strings.Contains(cell, cmd) {
+			found = append(found, line)
+		}
+	}
+	switch len(found) {
+	case 0:
+		t.Fatalf("README.md has no command-reference table row for %q — it is undocumented "+
+			"in the table a reader scans to find out what the CLI can do", cmd)
+	case 1:
+		return found[0]
+	default:
+		t.Fatalf("README.md has %d command-reference rows for %q; expected exactly one", len(found), cmd)
+	}
+	return ""
+}
+
+// TestReadmeDocumentsAppListing is the regression guard for issue #227 point 1:
+// `civitai app listing` had ZERO mentions in an 80 KB README while GATING
+// publication (a listing needs an icon and a cover before it can go live), so a
+// reader planning a release budgeted no time for artwork.
+//
+// The guard is structural rather than a `strings.Contains("app listing")`: it
+// requires a real command-reference ROW, and requires that row to name EVERY
+// subcommand actually registered on the group. Adding `app listing set-banner`
+// therefore fails here until the README is updated — which is the drift that
+// produced the defect in the first place.
+func TestReadmeDocumentsAppListing(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRootDir(t), "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(raw)
+
+	row := readmeCommandRefRow(t, readme, "civitai app listing")
+
+	// Every registered subcommand must be named in that row. Reading them off the
+	// live command tree (never a hardcoded list) is what makes this catch drift.
+	subs := newAppListingCmd().Commands()
+	if len(subs) < 6 {
+		t.Fatalf("expected the `app listing` group to register >= 6 subcommands, got %d — "+
+			"if the group shrank on purpose, re-derive this floor", len(subs))
+	}
+	for _, sub := range subs {
+		if !strings.Contains(row, sub.Name()) {
+			t.Errorf("README command-reference row for `app listing` does not name the %q "+
+				"subcommand:\n%s", sub.Name(), row)
+		}
+	}
+
+	// The row must carry the fact that GATES publication — both required assets.
+	// Naming the commands without it documents the tool and not the deadline.
+	for _, want := range []string{"icon", "cover"} {
+		if !strings.Contains(strings.ToLower(row), want) {
+			t.Errorf("README command-reference row for `app listing` should name the %q "+
+				"the publish floor requires:\n%s", want, row)
+		}
+	}
+
+	// …and the publication FLOW must show the commands too, not just the table.
+	// Scoped to the text outside the row so a single mention can't satisfy both.
+	body := strings.Replace(readme, row, "", 1)
+	for _, want := range []string{
+		"civitai app listing status",
+		"civitai app listing set-icon",
+		"civitai app listing set-cover",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("README should show %q in the publication flow, not only in the "+
+				"command-reference table", want)
+		}
+	}
+}
+
 // 🔴 TestAppListingPendingReachesDraftBySlug — the whole point of draft-at-submit.
 // A first-version app pending review has NO backing appBlockId, but `civitai app
 // submit` minted its store listing as a pre-approval DRAFT, resolvable ONLY BY SLUG.

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -80,7 +80,7 @@ backs off and retries automatically).
 
 NOTE: the store is gated by a launch flag — until it opens publicly you will only
 see apps if your account is a moderator or app-dev-tester; a normal login may get
-an empty list. This command is useless until the backing API is deployed.`,
+an empty list.`,
 		Example: `  civitai app list
   civitai app list --kind onsite --sort popular --limit 10
   civitai app list --category generation --json
@@ -153,8 +153,7 @@ kind-specific action target (an on-site app's live URL, or an off-site app's
 external / connect target).
 
 Login is required (` + "`civitai login`" + `). A missing or out-of-scope slug returns a
-clean "not found" message. This command is useless until the backing API is
-deployed.`,
+clean "not found" message.`,
 		Example: `  civitai app view my-cool-app
   civitai app view my-cool-app --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cmd/apps_cmd_test.go
+++ b/internal/cmd/apps_cmd_test.go
@@ -334,3 +334,53 @@ func TestAppHelpListsDiscoveryCommands(t *testing.T) {
 		}
 	}
 }
+
+// TestAppBrowsingHelpDoesNotClaimTheAPIIsUndeployed pins the fix for issue #227's
+// stale-claim half. `app list` and `app view` both shipped a Long ending "This
+// command is useless until the backing API is deployed" — written before the
+// route existed and never revised. Both routes serve real data today (measured
+// 2026-08-06 against civitai.com: `civitai app list --limit 3` returned three
+// published apps plus a next cursor, and `civitai app view buzz` returned that
+// app's full detail), so the sentence tells a reader not to bother with a
+// command that works.
+//
+// The check is scoped to the two Longs rather than the whole help blob: the
+// GENUINE gates in that text — the launch flag on the store, the login
+// requirement — must survive, and a whole-tree phrase ban would fight them.
+func TestAppBrowsingHelpDoesNotClaimTheAPIIsUndeployed(t *testing.T) {
+	for name, long := range map[string]string{
+		"app list": newAppListCmd().Long,
+		"app view": newAppViewCmd().Long,
+	} {
+		low := strings.ToLower(long)
+		for _, gone := range []string{
+			"until the backing api is deployed",
+			"useless until",
+			"not yet deployed",
+		} {
+			if strings.Contains(low, gone) {
+				t.Errorf("%s help still claims the API is undeployed (%q) — it serves real data:\n%s",
+					name, gone, long)
+			}
+		}
+		// Positive control: the Long must still be substantive, so a green here
+		// can't be earned by emptying the field.
+		if len(strings.TrimSpace(long)) < 100 {
+			t.Errorf("%s Long is only %d chars — the phrase check would pass vacuously",
+				name, len(strings.TrimSpace(long)))
+		}
+	}
+	// The real, still-true gates must NOT have been stripped along with the
+	// stale sentence.
+	if !strings.Contains(newAppListCmd().Long, "launch flag") {
+		t.Error("app list help should still document the store's launch-flag gate")
+	}
+	for name, long := range map[string]string{
+		"app list": newAppListCmd().Long,
+		"app view": newAppViewCmd().Long,
+	} {
+		if !strings.Contains(long, "civitai login") {
+			t.Errorf("%s help should still state that login is required:\n%s", name, long)
+		}
+	}
+}

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -20,6 +20,57 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// downloadExampleVersionID is the model-VERSION id every `civitai download`
+// example uses as a BARE POSITIONAL id — in this command's help, in the root
+// command's help, and in the README.
+//
+// 🔴 It must be a number that is a valid VERSION id and NOT also a valid MODEL
+// id. A bare positional that is BOTH makes `download` stop and refuse to guess
+// (exit 2, see resolveDownloadVersion), so an ambiguous id turns the first
+// command a new user copy-pastes into an error. That is issue #227: the shipped
+// example was 128713, which is DreamShaper's v8 VERSION id *and* the MODEL id of
+// an unrelated NSFW-titled model, so the error message also sent the reader
+// there. `--version 128713` / `--model 4384` stay fine — they name the kind
+// explicitly and can never be ambiguous, which is why they are still used below.
+//
+// Verified against civitai.com on 2026-08-06 (redo this before changing it):
+//
+//	GET /api/v1/model-versions/691639 -> 200  (FLUX "Dev", model 618692)
+//	GET /api/v1/models/691639         -> 404  (so the bare id cannot be ambiguous)
+//	civitai download 691639 --dry-run -> rc=0, plans flux_dev.safetensors
+const downloadExampleVersionID = "691639"
+
+// unambiguousExampleIDs is the set of ids an example is allowed to pass as a
+// BARE POSITIONAL to `civitai download`. The invariant is NOT "must be a version
+// id" — it is "must not be BOTH", because only a number that resolves as a model
+// id *and* a version id triggers the refuse-to-guess stop. A model-id-only entry
+// is fine: `download` auto-resolves it to that model's default version and says
+// so. Values record what each one resolved as when it was verified.
+//
+// Adding an id here is a claim about the LIVE API, not a formatting choice.
+// Verify both routes before you add one — /api/v1/models/<id> AND
+// /api/v1/model-versions/<id> — and reject any id where both answer 200.
+//
+// 🔴 The keys are LITERALS, never `downloadExampleVersionID`. Keying the headline
+// entry by the constant made the allowlist self-fulfilling: repointing the
+// constant at any id moved the key with it, so the membership check passed by
+// construction. Measured — that mutant SURVIVED, and only the separate hardcoded
+// -128713 denylist caught the one case; repointing the constant at a DIFFERENT
+// ambiguous id (403131) was green. A literal key forces a human to re-verify.
+var unambiguousExampleIDs = map[string]string{
+	"691639": `version only (200) — FLUX "Dev", model 618692`,
+	// Ships a Model *and* a distinctly-named VAE, which is what makes the
+	// README's `--file vae` / `--all` / `--layout` fan-out examples runnable.
+	// 691639's two files share a name (that is the point of the `--file <id>`
+	// example), so it cannot demonstrate those.
+	"290640": `version only (200) — Pony Diffusion V6 XL "V6", model 257749`,
+	// A MODEL id on purpose: it is what the `download` help uses to show that
+	// pasting a model id from `models search` auto-resolves to the default
+	// version. Verified 2026-08-06: `civitai download 4384 --dry-run` prints
+	// "note: 4384 is a model id — downloading its default version 128713", rc=0.
+	"4384": `model only (200); /model-versions/4384 404s — DreamShaper`,
+}
+
 // downloadOpts holds the resolved flag values for `civitai download`.
 type downloadOpts struct {
 	modelID  string // --model (mutually exclusive with the positional version id)
@@ -113,10 +164,10 @@ the CLI notes this on stderr. Only download models from creators you trust.`,
 		Example: `  civitai download 691639
   civitai download --version 128713                # force a version id (skips the ambiguous-id stop)
   civitai download --model 4384 --out ./dreamshaper.safetensors
-  civitai download 691639 --file vae --out-dir ./models
+  civitai download 290640 --file vae --out-dir ./models
   civitai download 691639 --file 1234567          # pick one of two same-named files by id
-  civitai download 691639 --all --out-dir ./models
-  civitai download 691639 --all --layout comfyui --root ~/ComfyUI
+  civitai download 290640 --all --out-dir ./models
+  civitai download 290640 --all --layout comfyui --root ~/ComfyUI
   civitai download 691639 --layout a1111 --for-base "SDXL 1.0"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/download_example_id_test.go
+++ b/internal/cmd/download_example_id_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// knownAmbiguousExampleID is the id that shipped in the `download` examples until
+// issue #227. It is BOTH DreamShaper's v8 version id AND the model id of an
+// unrelated NSFW-titled model, so `civitai download 128713` refuses to guess and
+// exits 2 — the first command a new user copy-pastes, failing.
+//
+// It is named explicitly (rather than only being absent from
+// unambiguousExampleIDs) so a reader of a failure knows what the guard is about.
+const knownAmbiguousExampleID = "128713"
+
+// bareDownloadPositionalRe matches a `civitai download <digits>` example — an id
+// passed as the BARE POSITIONAL, which is the only form that can hit the
+// ambiguity stop. `civitai download --version 128713` and
+// `civitai download --model 4384` deliberately do NOT match: naming the kind
+// explicitly can never be ambiguous, which is exactly why the help still uses
+// 128713 to demonstrate the escape hatch.
+var bareDownloadPositionalRe = regexp.MustCompile(`civitai download ([0-9]+)`)
+
+// repoRootDir locates the module root from this test file's own path.
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// …/internal/cmd/download_example_id_test.go -> the repo root is two dirs up.
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+// downloadExampleSources returns every surface that teaches a `civitai download`
+// invocation: the two command helps a user reaches with --help, and the README.
+// Each entry carries the MINIMUM number of bare-positional examples it must
+// contain, so a source that stops matching (a renamed command, a moved file, a
+// regex that no longer fires) fails loudly instead of passing on zero hits.
+func downloadExampleSources(t *testing.T) map[string]struct {
+	text    string
+	minHits int
+} {
+	t.Helper()
+	root := NewRootCmd()
+	dl := newDownloadCmd()
+
+	readme, err := os.ReadFile(filepath.Join(repoRootDir(t), "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+
+	return map[string]struct {
+		text    string
+		minHits int
+	}{
+		"root Long":        {root.Long, 1},
+		"root Example":     {root.Example, 1},
+		"download Long":    {dl.Long, 2},
+		"download Example": {dl.Example, 5},
+		"README.md":        {string(readme), 8},
+	}
+}
+
+// TestDownloadExamplesUseUnambiguousIDs is the regression guard for issue #227.
+//
+// Every id handed to `civitai download` as a BARE POSITIONAL — in the root help,
+// in the download help, and in the README — must be one whose ambiguity was
+// actually checked against the live API and recorded in unambiguousExampleIDs.
+// The check is an allowlist rather than a "not 128713" denylist on purpose: the
+// hazard is the CLASS (a number that is both a model id and a version id), and a
+// denylist would wave through the next one someone picks at random.
+func TestDownloadExamplesUseUnambiguousIDs(t *testing.T) {
+	// The known-bad id must never be smuggled into the allowlist.
+	if what, ok := unambiguousExampleIDs[knownAmbiguousExampleID]; ok {
+		t.Fatalf("%s is ambiguous (both a model id and a version id) but is listed in unambiguousExampleIDs as %q",
+			knownAmbiguousExampleID, what)
+	}
+
+	total := 0
+	for name, src := range downloadExampleSources(t) {
+		hits := bareDownloadPositionalRe.FindAllStringSubmatch(src.text, -1)
+		// Positive control: a source that yields zero matches proves nothing —
+		// it is indistinguishable from a guard wired to the wrong text.
+		if len(hits) < src.minHits {
+			t.Errorf("%s: found %d `civitai download <id>` examples, want >= %d — "+
+				"the guard is reading the wrong text, or the examples were removed",
+				name, len(hits), src.minHits)
+			continue
+		}
+		total += len(hits)
+		for _, h := range hits {
+			id := h[1]
+			if id == knownAmbiguousExampleID {
+				t.Errorf("%s: `civitai download %s` is the issue-#227 example — %s is BOTH "+
+					"a model id and a version id, so it exits 2 with an ambiguity error. "+
+					"Use %s, or name the kind explicitly (--version/--model).",
+					name, id, id, downloadExampleVersionID)
+				continue
+			}
+			if _, ok := unambiguousExampleIDs[id]; !ok {
+				t.Errorf("%s: `civitai download %s` uses an id that has not been verified "+
+					"unambiguous. Check that /api/v1/models/%s and /api/v1/model-versions/%s "+
+					"do not BOTH return 200, then add it to unambiguousExampleIDs.",
+					name, id, id, id)
+			}
+		}
+	}
+	if total == 0 {
+		t.Fatal("no `civitai download <id>` examples found anywhere — the guard is inert")
+	}
+}
+
+// TestDownloadExampleVersionIDIsUsedEverywhere pins the headline example id
+// itself. downloadExampleVersionID must be in the verified allowlist, and both
+// root-help surfaces must actually render it — a constant nothing interpolates
+// would let the help drift back to a literal while the constant stayed correct.
+func TestDownloadExampleVersionIDIsUsedEverywhere(t *testing.T) {
+	if _, ok := unambiguousExampleIDs[downloadExampleVersionID]; !ok {
+		t.Fatalf("downloadExampleVersionID = %q is not listed in unambiguousExampleIDs; "+
+			"verify it against the live API and record what it resolved as",
+			downloadExampleVersionID)
+	}
+	root := NewRootCmd()
+	want := "civitai download " + downloadExampleVersionID
+	for name, text := range map[string]string{"root Long": root.Long, "root Example": root.Example} {
+		if !strings.Contains(text, want) {
+			t.Errorf("%s should show %q:\n%s", name, want, text)
+		}
+	}
+}
+
+// TestDownloadHelpKeepsTheExplicitKindEscapes proves the ambiguity ESCAPES stay
+// documented. Fixing #227 by swapping the id would be hollow if the help stopped
+// showing how to name the kind explicitly — that is what a user hitting the stop
+// on their own id needs. Both forms must survive, and the ambiguous id is the
+// right value to demonstrate --version with.
+func TestDownloadHelpKeepsTheExplicitKindEscapes(t *testing.T) {
+	dl := newDownloadCmd()
+	blob := dl.Long + "\n" + dl.Example
+	for _, want := range []string{
+		"civitai download --version " + knownAmbiguousExampleID,
+		"civitai download --model ",
+	} {
+		if !strings.Contains(blob, want) {
+			t.Errorf("download help should still document the explicit-kind escape %q:\n%s", want, blob)
+		}
+	}
+}
+
+// TestUnambiguousExampleIDsAreDocumented keeps the allowlist self-describing:
+// every entry must carry a non-empty note saying what it resolved as, so adding
+// one is a recorded measurement rather than a silent widening.
+func TestUnambiguousExampleIDsAreDocumented(t *testing.T) {
+	if len(unambiguousExampleIDs) == 0 {
+		t.Fatal("unambiguousExampleIDs is empty — the allowlist guard would reject every example")
+	}
+	ids := make([]string, 0, len(unambiguousExampleIDs))
+	for id := range unambiguousExampleIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if strings.TrimSpace(unambiguousExampleIDs[id]) == "" {
+			t.Errorf("unambiguousExampleIDs[%q] has no note recording what it resolved as", id)
+		}
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -197,7 +197,7 @@ Get started:
   # Browse & download
   civitai models search --query "pony" --limit 5
   civitai images search --sort "Most Reactions" --period Week
-  civitai download 128713 --layout comfyui --root ~/ComfyUI
+  civitai download ` + downloadExampleVersionID + ` --layout comfyui --root ~/ComfyUI
 
   # Build an App
   civitai login                    store your API token
@@ -222,7 +222,7 @@ Exit codes:
 		Example: `  # Browse & download the public catalog (no account needed to read).
   civitai models search --query "dreamshaper" --limit 5
   civitai images search --sort "Most Reactions" --period Week
-  civitai download 128713 --layout comfyui --root ~/ComfyUI
+  civitai download ` + downloadExampleVersionID + ` --layout comfyui --root ~/ComfyUI
 
   # Browse the App store.
   civitai app list


### PR DESCRIPTION
Closes #227.

Four first-impression documentation defects from a blind dogfood run, each shipped with a guard so it cannot rot back. No behaviour changes — the only non-test Go edits are help strings and one new constant.

## 1. `civitai app listing` had zero mentions in the README

`grep -c "app listing" README.md` → **0**, in an 80 KB document, for a command group that **gates publication**: a store listing needs an **icon AND a cover** before it can go live. Someone planning a release from the docs budgeted zero time for artwork.

Added, from reading `internal/cmd/app_listing.go` rather than assuming:

- a **command-reference table row** naming all six subcommands, the mandatory icon + cover, the draft-at-submit window, the local size caps and the live-listing revision path;
- **step 7** in the "Quickstart: build an App Block" block;
- a **"Budget time for artwork"** section under *After you submit: review → approve → deploy*, with real `listing status` output and the details that bite (png/jpeg/webp, icon ≤2 MiB / cover ≤4 MiB / screenshot ≤2 MiB checked **before** upload, `--slug`/`--dir` resolution, `--changelog` on a live listing, screenshot ids for `rm-screenshot`/`reorder`).

`app submit`'s existing inline nudge — which the issue rightly praises for its placement — is untouched and not duplicated; the README now points at the same commands from the planning side. It stays pinned by the pre-existing `TestSubmitFloorHeadsUp`.

Verified live (2026-08-06): `civitai app listing status --slug sensei` renders the draft listing and its `MISSING (required)` icon/cover.

## 2. The headline `download` example errored out

```
$ civitai download 128713 --layout comfyui --root ~/ComfyUI
Error: 128713 is ambiguous — it's both model "Airi Akizuki … (鬼父)" and
version 128713 (of model "DreamShaper").
rc=2
```

Reproduced before changing anything. Every **bare positional** example now uses an id checked against the live API, and each command was run end-to-end with `--dry-run` (no writes):

| example | result |
| --- | --- |
| `civitai download 691639 --dry-run` | rc=0 — FLUX "Dev", `flux_dev.safetensors` |
| `civitai download 691639 --layout comfyui --root ~/ComfyUI --dry-run` | rc=0 — `…/models/checkpoints/flux_dev.safetensors` |
| `civitai download 691639 --out ./flux_dev.safetensors --dry-run` | rc=0 |
| `civitai download 691639 --layout a1111 --for-base "SDXL 1.0" --dry-run` | rc=0 + the intended compat warning |
| `civitai download 290640 --file vae --out-dir ./models --dry-run` | rc=0 — `sdxl_vae.safetensors` |
| `civitai download 290640 --all --out-dir ./models --dry-run` | rc=0 — 2 files |
| `civitai download 290640 --all --layout comfyui --root ~/ComfyUI --dry-run` | rc=0 — checkpoint → `models/checkpoints`, VAE → `models/vae` |

Ambiguity checked directly: `/api/v1/models/691639` and `/api/v1/models/290640` both **404**, so neither bare id can hit the stop.

Two ids because one cannot teach every flag: **691639**'s two files share a name — that is precisely what the `--file <id>` example demonstrates — so it cannot show `--file vae` or `--all`. **290640** (Pony Diffusion V6 XL "V6") ships a Model plus a distinctly-named VAE, which makes the fan-out examples real. Worth noting the previous `128713` spelling of those two had **never** resolved either: that version ships exactly one file, so `--file vae` and `--all` were already fictional. The same two spellings in `download --help` were fixed with them.

`--version 128713` and `--model 4384` **stay**: naming the kind explicitly can never be ambiguous, and they are how the help teaches the escape from the stop. A guard pins that they survive.

While in there: the README's **"Identifier"** bullet still claimed *"no numeric-ambiguity guessing"*, which `f467317` superseded — it now describes the three real shapes (version id, model id auto-resolve with its note, and the refuse-to-guess stop with `--model`/`--version`/`--yes`).

## 3–4. Three stale "not deployed yet" claims

Found by sweeping README.md and every command help string for unavailability language.

- **README's `dev-tunnel` row** said the endpoint *"is not exposed yet — so it reports 'not available' until it ships"*. True at #87 (`435fb5f`); superseded by #92 (`164966a`), which set `defaultDevTunnelEndpoint = "sish.civitai.com:2224"` (commented *"the live public sish SSH listener"*) and rewrote the command's own `Long` to *"The tunnel endpoint is live; if you are not enrolled the mint reports 'not available'"* — leaving the README behind for the whole interval. The row now matches the code: endpoint live, gate is **enrolment**, not deployment.
- **`app view`** and **`app list`** both ended their `Long` with *"This command is useless until the backing API is deployed."* Measured 2026-08-06 against civitai.com: `civitai app list --limit 3` returned three published apps plus a next cursor, and `civitai app view buzz` returned that app's full detail. Both sentences removed; the **genuine** gates (the store's launch flag, the login requirement) are kept and pinned.

## Tests

Six new guards, every one watched to fail on the pre-fix text.

`TestDownloadExamplesUseUnambiguousIDs` extracts every `civitai download <digits>` from the root help, the download help **and** the README, and requires each id to be in an **allowlist** of ids whose ambiguity was actually checked. An allowlist rather than a `!= "128713"` denylist on purpose: the hazard is the class, and a denylist waves through the next id someone picks. `--version 128713` / `--model 4384` do not match the extractor and must not. Each source carries a **minimum hit count**, so a guard reading the wrong text cannot pass on zero matches.

`TestReadmeDocumentsAppListing` requires a real command-reference **row** — not a prose mention — and requires that row to name **every subcommand read off the live command tree**, so adding `app listing set-banner` fails here until the README is updated.

`TestReadmeDevTunnelRowMatchesTheCommandHelp` pins the README row to the command's own claim *and* to `defaultDevTunnelEndpoint`, which is the exact drift that produced the stale row.

Plus `TestDownloadExampleVersionIDIsUsedEverywhere`, `TestDownloadHelpKeepsTheExplicitKindEscapes`, `TestUnambiguousExampleIDsAreDocumented`, `TestAppBrowsingHelpDoesNotClaimTheAPIIsUndeployed`.

### Red-at-base matrix

Each fix mutated back on this branch; the covering guard must go red with **its own** message.

| mutation | guard | pre-fix | at HEAD |
| --- | --- | --- | --- |
| download ids in root.go + README → `128713` | `…UseUnambiguousIDs` | **RED** | GREEN |
| `downloadExampleVersionID` → `128713` | `…IsUsedEverywhere` | **RED** | GREEN |
| `downloadExampleVersionID` → `403131` (a *different* ambiguous id) | `…IsUsedEverywhere` | **RED** | GREEN |
| `downloadExampleVersionID` → `999999` (nonexistent) | `…IsUsedEverywhere` | **RED** | GREEN |
| README uses an unverified id | `…UseUnambiguousIDs` | **RED** | GREEN |
| drop the `--version 128713` escape example | `…KeepsTheExplicitKindEscapes` | **RED** | GREEN |
| blank an allowlist note | `…AreDocumented` | **RED** | GREEN |
| remove the README `app listing` row | `TestReadmeDocumentsAppListing` | **RED** | GREEN |
| row present but names only `status` | `TestReadmeDocumentsAppListing` | **RED** | GREEN |
| restore "useless until the backing API is deployed" | `…DoesNotClaimTheAPIIsUndeployed` | **RED** | GREEN |
| restore the stale dev-tunnel README row | `…RowMatchesTheCommandHelp` | **RED** | GREEN |

**One mutant SURVIVED the first sweep and the guard was rewritten.** `unambiguousExampleIDs` was originally keyed by `downloadExampleVersionID`, which made the allowlist **self-fulfilling** — repointing the constant moved the map key with it, so the membership check passed by construction. Only the separate hardcoded-`128713` denylist caught that one case; repointing at a *different* ambiguous id (`403131`) was **green**. The keys are now literals, and the three constant-repointing rows above are the re-measurement.

`make ci` green (18 packages). `gofmt -s -l .` prints nothing, with a positive control confirming it reports a deliberately misformatted file.

## Left alone, deliberately

- **`app list`, `app view` and `app pull` are also missing from the command-reference table.** Real gaps, but out of this issue's scope and they do not gate anything; flagged for a follow-up rather than widened into a docs PR that collides more with in-flight work.
- **`app_pull.go`'s "git access is not available for this app yet"** is a *runtime* message for an app with no approved version, not a stale feature claim — left as-is.
- **`app dev-tunnel`'s "not available" wording** is kept everywhere: it describes the real enrolment gate. I could **not** verify the tunnel end-to-end — two attempts against `blocks.startDevTunnel` timed out awaiting headers (exit 5), which is inconclusive rather than a "not deployed" answer — so the README was corrected only as far as the code proves (the endpoint constant is live and the command's own help says so), and no claim was made that the tunnel works for an unenrolled caller.
- **`--file vae` teaches selection by NAME, not by type.** It works on 290640 only because that VAE file is literally named `sdxl_vae.safetensors`; a version whose VAE is named otherwise would not match. Left as the shipped phrasing rather than reworded, to keep this diff scoped.

## Merge note

`README.md` overlaps open PR #221. My edits are confined to the quickstart blocks, the `dev-tunnel` / new `app listing` table rows, the download-examples block and the post-submit section; #221 touches the `generate` table row and the Generate sections. The one likely textual collision is the new table row sitting immediately above `app status`, adjacent to #221's table hunk — an independent row, trivially resolvable either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
