### PR TITLE
fix(generate): the approval summary named the superseded checkpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1243,6 +1243,52 @@ neither one's.
     money-refusal line state the substitution backwards. When you mutation-test a
     reporter, mutate the CALL SITES too, not just the function.
 
+    (h) 🔴 **The post-spend report runs AFTER the handle reaches the user, and
+    that ordering is the thing to preserve — not the line's position in the
+    file.** By the submit reply the job is CHARGED and the workflow id is the
+    user's only way back to what they paid for; the report explains a charge that
+    has already happened, so it is advisory. It used to be emitted BEFORE the id,
+    which was harmless only because it does no I/O — and the obvious next
+    improvement (resolving the substituted ids to NAMES through
+    `ResolveModelVersion`, which the estimate path already does for
+    `--checkpoint`) would have inherited `getWithRetry`'s **4 attempts**
+    (`readMaxAttempts`, `pkg/civitai/retry.go`) against a **30s**-timeout client
+    (`defaultTimeout`, `pkg/civitai/api.go`) plus backoff — minutes per id, two
+    ids per record, holding the handle for a cosmetic gain. `emitSubmitHandle`
+    exists so all four branches (--no-wait, --json, a reply with no workflow id,
+    and the waiting path) emit the handle from ONE place before any advisory, and
+    `generate_handle_order_test.go` pins it by BLOCKING the advisory's own write
+    and reading what the user already has — no wall-clock sleep is involved. If
+    you do add name enrichment, bound it and keep the ids as the fallback: the
+    report must still appear with ids rather than go quiet, which is the silence
+    the whole feature exists to end.
+    Two traps that cost a mutation round: extracting the handle emission moved
+    three control-flow decisions with it, and `||`→`&&` on either branch test
+    turns a `--no-wait` run into a POLLING run — detected at first only as a
+    **nil-seam panic**, which aborts the binary and stops the guard that would
+    have named the defect from ever running. So the `--no-wait` cases wire a
+    working poll seam they never use (`wireIdlePoll`), and the poll-count
+    assertion is deliberately NOT fatal-gated on the returned error, which every
+    one of those mutants also changes.
+
+    (i) 🔴 **The approval summary annotates the superseded checkpoint; it never
+    swaps it.** The summary echoes the checkpoint as a NAME rather than an
+    integer (item 13) so the user approves something recognisable — but with a
+    substitution in play that made the LAST model line before `Generate? [y/N]`
+    the name the server had already said it would discard, with the warning
+    scrolled above it. `substitutionCheckpointNote` appends
+    `[SUPERSEDED — the server will run version N instead; …]` to the requested
+    label at BOTH pre-spend surfaces (the confirm prompt and the `--dry-run`
+    quote), computed from one call site so the two cannot disagree. Printing the
+    applied id in the requested one's place would be a second silence, not a
+    fix: the user asked for their version and must still see it was overridden.
+    The match is on `requested`, so a substitution of anything the line does not
+    name leaves it alone — a false mark on a correct line teaches authors to
+    ignore the real one. The tense comes from `substitutionVerb(phase)`, the same
+    constant the lead uses, and is asserted structurally per (f): a call site
+    passing `substitutionAfterSubmit` would tell someone deciding whether to
+    spend that the substitute already ran.
+
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including
 the slot registry), the Vite dotenv resolution behind the dev-tunnel parent-origin

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,16 @@ $ civitai generate "a cat" --checkpoint 999999999 --dry-run
       the server does not offer that version in this model family at all …
 ```
 
+The checkpoint line in the summary you approve is annotated too, so the model
+that will *not* run is never the last one you read before saying yes:
+
+```console
+Checkpoint:   DreamShaper — 8 (Checkpoint, id 128713)  [SUPERSEDED — the server will run version 2436219 instead; see the warning above]
+```
+
+Your own id stays on the line: the CLI marks it, it never quietly substitutes
+the applied one.
+
 It is reported **on the estimate** (`--dry-run`, and before the confirmation
 prompt on a real run — while you can still back out), **again after the submit**
 (where it is the receipt for what was billed), and **on a later read** with

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -636,7 +636,13 @@ func parseLoraFlag(raw string) (loraSpec, error) {
 type resolvedGraph struct {
 	graph      genapi.Graph
 	checkpoint string
-	loras      []string
+	// checkpointNote annotates the checkpoint label when the server has already
+	// said it will not use it. It is filled in AFTER the estimate (the only
+	// place the substitution record exists) from ONE call site, so the confirm
+	// prompt and the --dry-run quote cannot disagree about it — see
+	// substitutionCheckpointNote.
+	checkpointNote string
+	loras          []string
 	// images renders the resolved reference images (dimensions + final URL) for
 	// the confirmation, so the user approves what will actually be sent rather
 	// than the paths they typed — a local file's URL is a stored blob by then.
@@ -868,6 +874,14 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 	reportModelSubstitutions(errw, quote.ModelSubstitutions, substitutionAtEstimate)
 	substitutionFlagHint(errw, o, quote.ModelSubstitutions)
 
+	// 🔴 AND THE SUMMARY BELOW MUST NOT PRESENT THE SUPERSEDED CHECKPOINT AS THE
+	// ONE THAT WILL RUN. The warning above scrolls; the summary is what the user
+	// reads at `Generate? [y/N]`, and its last model line was the name the server
+	// has already discarded. Computed HERE, from one call site, so the confirm
+	// prompt and the --dry-run quote annotate identically — the two-renderers
+	// mistake generate_charge_test.go exists to remember.
+	built.checkpointNote = substitutionCheckpointNote(built.checkpoint, o, quote.ModelSubstitutions, substitutionAtEstimate)
+
 	if o.dryRun {
 		if o.jsonOut {
 			// Raw passthrough: a script sees every field, including ones this CLI
@@ -992,10 +1006,8 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 	// the waiting path — and putting a money-relevant line in only one of them is
 	// a mistake this repo has already made and written a whole test file about
 	// (generate_charge_test.go: `Charged:` had one call site the waiting path
-	// never reached). One call site here covers --no-wait, the waiting path, and
-	// --json alike.
-	reportModelSubstitutions(errw, result.Substitutions(), substitutionAfterSubmit)
-
+	// never reached). One call site covers --no-wait, the waiting path, and
+	// --json alike, and emitSubmitHandle keeps it that way.
 	workflowID := ""
 	if result != nil {
 		workflowID = result.ID
@@ -1005,6 +1017,38 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 		_ = recordPendingWorkflowID(statePath, workflowID)
 	}
 
+	// 🔴 THE HANDLE GOES OUT BEFORE THE ADVISORY, NOT AFTER IT. By this point the
+	// job is CHARGED and the workflow id is the user's only way back to what they
+	// paid for; the substitution report explains a charge that has already
+	// happened. Nothing advisory may sit between the reply and the handle — an
+	// enrichment added to the report later (resolving the substituted ids to
+	// NAMES through ResolveModelVersion, say) would inherit getWithRetry's 4
+	// attempts on a 30s-timeout client and could hold the id for minutes, for a
+	// cosmetic gain, on a job whose money is already gone. It is the same
+	// judgement substitutionAdvice already makes on the decoding side — an
+	// unfamiliar reason still reports the ids rather than failing the record —
+	// applied to time instead of parsing. Ordering is pinned by
+	// TestGenerate_SubmitHandleReachesTheUserBeforeTheSubstitutionAdvisory.
+	terminal, handleErr := emitSubmitHandle(out, errw, o, result, workflowID, externalID, statePath, rawSubmit)
+	reportModelSubstitutions(errw, result.Substitutions(), substitutionAfterSubmit)
+	if handleErr != nil || terminal {
+		return handleErr
+	}
+	return waitAndCollect(ctx, cmd, deps, o, workflowID, externalID, statePath)
+}
+
+// emitSubmitHandle prints the handle on a job that has ALREADY BEEN CHARGED, and
+// reports whether the command is finished (nothing left to wait for).
+//
+// It is one function rather than two call sites for the reason the comment above
+// gives: every branch here — --no-wait, --json, a reply with no workflow id, and
+// the waiting path — has to emit the handle BEFORE any advisory output, and a
+// second call site is how one of those branches quietly stops doing that.
+//
+// The --json branch returns the write error rather than swallowing it, and the
+// caller still emits the substitution advisory afterwards: a broken stdout is no
+// reason to withhold the record of what was billed.
+func emitSubmitHandle(out, errw io.Writer, o generateOpts, result *genapi.SubmitResult, workflowID, externalID, statePath string, rawSubmit json.RawMessage) (bool, error) {
 	if o.noWait || workflowID == "" {
 		// Nothing more can be done without a handle to poll, so the record has
 		// served its purpose the moment the id reaches the user.
@@ -1012,10 +1056,10 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 			clearSubmitRecord(statePath)
 		}
 		if o.jsonOut {
-			return writeRawJSON(out, rawSubmit)
+			return true, writeRawJSON(out, rawSubmit)
 		}
 		printSubmitResult(out, errw, result, externalID, o.baseURL, o.noWait)
-		return nil
+		return true, nil
 	}
 
 	var submitCost *genapi.WorkflowCost
@@ -1023,7 +1067,7 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 		submitCost = result.Cost
 	}
 	printSubmitted(errw, workflowID, externalID, o.baseURL, submitCost)
-	return waitAndCollect(ctx, cmd, deps, o, workflowID, externalID, statePath)
+	return false, nil
 }
 
 // writeSubmitRecord writes the pre-submit crash-recovery record and returns its
@@ -1247,7 +1291,7 @@ func confirmGenerate(cmd *cobra.Command, o generateOpts, built *resolvedGraph, c
 		fmt.Fprintf(errw, "  Quantity:   %d\n", o.quantity)
 	}
 	if built.checkpoint != "" {
-		fmt.Fprintf(errw, "  Checkpoint: %s\n", built.checkpoint)
+		fmt.Fprintf(errw, "  Checkpoint: %s%s\n", built.checkpoint, built.checkpointNote)
 	}
 	for _, l := range built.loras {
 		fmt.Fprintf(errw, "  LoRA:       %s\n", l)
@@ -1299,7 +1343,7 @@ func printGenerateQuote(out, errw io.Writer, built *resolvedGraph, o generateOpt
 		fmt.Fprintf(tw, "Aspect ratio:\t%s\n", safeTerm(o.aspectRatio))
 	}
 	if built.checkpoint != "" {
-		fmt.Fprintf(tw, "Checkpoint:\t%s\n", built.checkpoint)
+		fmt.Fprintf(tw, "Checkpoint:\t%s%s\n", built.checkpoint, built.checkpointNote)
 	}
 	for _, l := range built.loras {
 		fmt.Fprintf(tw, "LoRA:\t%s\n", l)

--- a/internal/cmd/generate_handle_order_test.go
+++ b/internal/cmd/generate_handle_order_test.go
@@ -1,0 +1,380 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/civitai/cli/internal/genapi"
+	"github.com/spf13/cobra"
+)
+
+// The workflow id must reach the user BEFORE any advisory output.
+//
+// 🔴 THE PROPERTY, AND WHY IT IS NOT ABOUT SUBSTITUTIONS. By the time the submit
+// reply lands the job is CHARGED, and the workflow id is the user's only handle
+// on what they paid for. The post-spend substitution report explains a charge
+// that has already happened — it is advisory. An advisory step that runs BEFORE
+// the handle is emitted can delay it (an enrichment resolving the substituted
+// ids to names would inherit getWithRetry's 4 attempts against a 30s-timeout
+// client) or, if it panics or blocks, withhold it entirely.
+//
+// The tests below drive the ordering through the REAL runGenerate rather than
+// asserting it about a renderer, because "the handle comes first" is a property
+// of the path, not of either printer.
+
+// --- a writer that can stall exactly one line --------------------------------
+
+// gateWriter is an io.Writer that BLOCKS the first write containing trigger
+// until release is closed, signalling reached when it does.
+//
+// 🔴 THIS IS HOW THE ORDERING IS MEASURED WITHOUT A WALL-CLOCK SLEEP. A test
+// that slept and then looked would be timing-flaky and would prove nothing about
+// ordering; blocking the advisory's own write and then reading what is already
+// in the buffer makes "the handle was out first" an observation rather than an
+// inference. Nothing here depends on how long anything takes.
+type gateWriter struct {
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	trigger string
+	reached chan struct{}
+	release chan struct{}
+	fired   bool
+}
+
+func newGateWriter(trigger string) *gateWriter {
+	return &gateWriter{
+		trigger: trigger,
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (g *gateWriter) Write(p []byte) (int, error) {
+	// fired is only ever touched from the goroutine running the command, which is
+	// the only writer; the buffer itself is mutex-guarded because the test
+	// goroutine snapshots it while this one is parked.
+	if !g.fired && g.trigger != "" && strings.Contains(string(p), g.trigger) {
+		g.fired = true
+		close(g.reached)
+		<-g.release
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.buf.Write(p)
+}
+
+// snapshot returns everything written so far.
+func (g *gateWriter) snapshot() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.buf.String()
+}
+
+// wireIdlePoll gives a --no-wait case a WORKING poll seam it should never use.
+//
+// 🔴 IT IS THERE SO A CONTROL-FLOW MUTANT FAILS AN ASSERTION RATHER THAN
+// PANICKING. With the seam left nil, any mutant that sends a --no-wait run into
+// waitAndCollect crashes on a nil poll function — and a panic aborts the whole
+// test binary, so the guard that would have named the defect
+// (TestGenerate_NoWaitEmitsTheHandleAndNeverPolls) never runs. Measured: three
+// such mutants were detected only as a segfault until this was wired.
+func wireIdlePoll(s *genSeams) {
+	s.poll = newFakeClock().cfg()
+	s.getWorkflow = func(ctx context.Context, id string) (*genapi.Workflow, json.RawMessage, error) {
+		var wf genapi.Workflow
+		_ = json.Unmarshal([]byte(wfJSON(genapi.StatusSucceeded)), &wf)
+		return &wf, json.RawMessage(wfJSON(genapi.StatusSucceeded)), nil
+	}
+}
+
+// subSubmitReply is a submit reply carrying one top-level substitution record.
+func subSubmitReply(id string) *genapi.SubmitResult {
+	return &genapi.SubmitResult{
+		ID:     id,
+		Status: "queued",
+		ModelSubstitutions: []genapi.ModelSubstitution{
+			{Requested: 999999999, Applied: 2436219, Reason: genapi.SubstitutionUnrecognized},
+		},
+	}
+}
+
+// 🔴 THE HEADLINE ORDERING ASSERTION, on the --no-wait path.
+//
+// The advisory's own first write is stalled; while it is stalled the test reads
+// what the user has already been shown. Both ids the user needs to get back to a
+// paid-for job — the workflow id and the externalId — must already be there.
+func TestGenerate_SubmitHandleReachesTheUserBeforeTheSubstitutionAdvisory(t *testing.T) {
+	withStdinTTY(t, false)
+
+	var s genSeams
+	s.submitReply = subSubmitReply("wf_handle_1")
+	wireIdlePoll(&s)
+	o := baseOpts() // --no-wait
+	o.assumeYes = true
+	o.externalID = "ext-handle-1"
+
+	gate := newGateWriter(substitutionLead(substitutionAfterSubmit))
+	c := &cobra.Command{}
+	c.SetOut(gate)
+	c.SetErr(gate)
+	c.SetIn(strings.NewReader(""))
+	d := s.deps(t)
+
+	done := make(chan error, 1)
+	go func() { done <- runGenerate(c, d, o) }()
+
+	// POSITIVE CONTROL built into the wait: if the advisory is never emitted the
+	// command simply finishes, and this test would otherwise hang or (worse)
+	// silently assert nothing.
+	select {
+	case <-gate.reached:
+	case err := <-done:
+		t.Fatalf("POSITIVE CONTROL FAILED: the post-submit advisory was never written (run returned %v), "+
+			"so this test could not observe the ordering it claims to check.\ngot:\n%s", err, gate.snapshot())
+	}
+	atAdvisory := gate.snapshot()
+	close(gate.release)
+
+	if err := <-done; err != nil {
+		t.Fatalf("submit must succeed: %v", err)
+	}
+
+	if !strings.Contains(atAdvisory, "wf_handle_1") {
+		t.Errorf("the WORKFLOW ID must reach the user before the substitution advisory runs — "+
+			"the job is already charged and the id is the only handle on it.\nseen before the advisory:\n%s", atAdvisory)
+	}
+	if !strings.Contains(atAdvisory, "ext-handle-1") {
+		t.Errorf("the EXTERNAL ID must reach the user before the substitution advisory runs — "+
+			"it is what re-attaches to a submit without paying twice.\nseen before the advisory:\n%s", atAdvisory)
+	}
+
+	// ...and the advisory itself must still be reported, with the ids. Ordering
+	// is only an improvement if nothing was dropped to get it.
+	full := gate.snapshot()
+	assertPhase(t, full, substitutionAfterSubmit)
+	if !strings.Contains(full, "999999999") || !strings.Contains(full, "2436219") {
+		t.Errorf("the substitution must still be reported with BOTH ids after the handle; got:\n%s", full)
+	}
+}
+
+// CONTRAST CONTROL for the test above: with no substitution the gate's trigger
+// is never written, so the run completes without ever parking. This proves the
+// gate fires on the advisory specifically rather than on any output at all — if
+// it fired on something else, the ordering assertion above would be measuring
+// the wrong line.
+func TestGenerate_GateOnlyFiresOnTheAdvisory(t *testing.T) {
+	withStdinTTY(t, false)
+
+	var s genSeams
+	s.submitReply = &genapi.SubmitResult{ID: "wf_handle_2", Status: "queued"} // no substitution
+	wireIdlePoll(&s)
+	o := baseOpts()
+	o.assumeYes = true
+	o.externalID = "ext-handle-2"
+
+	gate := newGateWriter(substitutionLead(substitutionAfterSubmit))
+	c := &cobra.Command{}
+	c.SetOut(gate)
+	c.SetErr(gate)
+	c.SetIn(strings.NewReader(""))
+
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("submit must succeed: %v", err)
+	}
+	if gate.fired {
+		t.Fatal("the gate fired with no substitution in the reply — it is not keyed on the advisory")
+	}
+	got := gate.snapshot()
+	if !strings.Contains(got, "wf_handle_2") {
+		t.Fatalf("POSITIVE CONTROL FAILED: the run produced no workflow id at all; got:\n%s", got)
+	}
+	if strings.Contains(got, substitutionLead(substitutionAfterSubmit)) {
+		t.Errorf("no substitution must produce no advisory; got:\n%s", got)
+	}
+}
+
+// The same ordering on the DEFAULT (waiting) path, which uses a different
+// renderer (printSubmitted, not printSubmitResult).
+//
+// 🔴 A one-path assertion would not have caught the `Charged:` regression this
+// repo already wrote generate_charge_seam_test.go about: the claim was asserted
+// about the renderer the OTHER branch never reaches. Both branches emit the
+// handle through emitSubmitHandle, and both are checked.
+func TestGenerate_WaitingPathEmitsTheHandleBeforeTheAdvisory(t *testing.T) {
+	withStdinTTY(t, false)
+
+	clock := newFakeClock()
+	var s genSeams
+	s.poll = clock.cfg()
+	s.submitReply = subSubmitReply("wf_handle_3")
+
+	gate := newGateWriter(substitutionLead(substitutionAfterSubmit))
+	c := &cobra.Command{}
+	c.SetOut(gate)
+	c.SetErr(gate)
+	c.SetIn(strings.NewReader(""))
+
+	polls := 0
+	s.getWorkflow = func(ctx context.Context, id string) (*genapi.Workflow, json.RawMessage, error) {
+		polls++
+		var wf genapi.Workflow
+		_ = json.Unmarshal([]byte(wfJSON(genapi.StatusFailed)), &wf)
+		return &wf, json.RawMessage(wfJSON(genapi.StatusFailed)), nil
+	}
+
+	o := waitOpts(t.TempDir())
+	o.externalID = "ext-handle-3"
+	d := s.deps(t)
+
+	done := make(chan error, 1)
+	go func() { done <- runGenerate(c, d, o) }()
+
+	select {
+	case <-gate.reached:
+	case err := <-done:
+		t.Fatalf("POSITIVE CONTROL FAILED: the post-submit advisory was never written (run returned %v).\ngot:\n%s",
+			err, gate.snapshot())
+	}
+	atAdvisory := gate.snapshot()
+	pollsAtAdvisory := polls
+	close(gate.release)
+	<-done // a failed terminal status returns an error; the ordering is the claim here
+
+	if !strings.Contains(atAdvisory, "wf_handle_3") {
+		t.Errorf("waiting path: the workflow id must precede the advisory.\nseen before the advisory:\n%s", atAdvisory)
+	}
+	if !strings.Contains(atAdvisory, "ext-handle-3") {
+		t.Errorf("waiting path: the external id must precede the advisory.\nseen before the advisory:\n%s", atAdvisory)
+	}
+	// 🔴 The advisory must also run BEFORE the poll loop, not after it — a wait
+	// can last the whole --timeout, and a receipt delivered at the end of it is
+	// not a receipt. If polling had already begun, the advisory parked too late.
+	if pollsAtAdvisory != 0 {
+		t.Errorf("the advisory must be emitted before the wait begins; %d poll(s) had already run", pollsAtAdvisory)
+	}
+	// POSITIVE CONTROL for that zero: the same counter must be able to move.
+	if polls == 0 {
+		t.Fatal("POSITIVE CONTROL FAILED: the poll seam was never reached, so the zero above is not evidence of ordering")
+	}
+	if !strings.Contains(gate.snapshot(), "2436219") {
+		t.Errorf("waiting path: the substitution must still be reported; got:\n%s", gate.snapshot())
+	}
+}
+
+// 🔴 emitSubmitHandle MUST STILL DECIDE WHICH BRANCH THE RUN IS ON.
+//
+// Extracting the handle emission into one function moved three decisions with it
+// — "is this --no-wait", "is there anything left to wait for", and "did the
+// handle write fail" — and the ordering assertions above cannot see any of them:
+// three separate control-flow mutants (`||`->`&&` on the --no-wait test,
+// `return true`->`false` on the terminal branch, `||`->`&&` on the caller's
+// early return) each turned a --no-wait run into a POLLING run, and each was
+// detected only as a nil-seam panic rather than by any guard. A panic is a
+// crash, not an assertion — so this pins the behaviour those mutants break.
+//
+// Case A asserts a MEASURED zero on the poll seam; case B drives the SAME
+// counter, through the same seam constructor, above zero.
+func TestGenerate_NoWaitEmitsTheHandleAndNeverPolls(t *testing.T) {
+	withStdinTTY(t, false)
+
+	newSeams := func(polls *int) *genSeams {
+		s := &genSeams{}
+		s.poll = newFakeClock().cfg()
+		s.submitReply = subSubmitReply("wf_handle_5")
+		s.getWorkflow = func(ctx context.Context, id string) (*genapi.Workflow, json.RawMessage, error) {
+			*polls++
+			var wf genapi.Workflow
+			_ = json.Unmarshal([]byte(wfJSON(genapi.StatusSucceeded)), &wf)
+			return &wf, json.RawMessage(wfJSON(genapi.StatusSucceeded)), nil
+		}
+		return s
+	}
+
+	// (A) --no-wait: the handle is the end of the command.
+	noWaitPolls := 0
+	a := newSeams(&noWaitPolls)
+	o := baseOpts() // --no-wait
+	o.assumeYes = true
+	o.externalID = "ext-handle-5"
+
+	c, out, errb := genCmd("")
+	err := runGenerate(c, a.deps(t), o)
+
+	// 🔴 THE POLL-SEAM ASSERTION COMES FIRST, AND IS NOT FATAL-GATED ON err.
+	// Every mutant that sends --no-wait into the wait ALSO changes the returned
+	// error, so a `t.Fatalf` on err above would kill the test before this line
+	// and the failure would be attributed to the wrong guard — a green-for-the-
+	// wrong-reason inversion of the same trap.
+	if noWaitPolls != 0 {
+		t.Errorf("🔴 --no-wait reached the poll seam %d time(s) — the run did not stop at the handle", noWaitPolls)
+	}
+	if err != nil {
+		t.Errorf("--no-wait submit must succeed: %v", err)
+	}
+	if !strings.Contains(out.String(), "wf_handle_5") || !strings.Contains(out.String(), "ext-handle-5") {
+		t.Errorf("--no-wait must print both ids:\nstdout:\n%s", out.String())
+	}
+	if !strings.Contains(errb.String(), "--no-wait") {
+		t.Errorf("--no-wait must say it is not waiting and how to collect:\nstderr:\n%s", errb.String())
+	}
+
+	// (B) POSITIVE CONTROL: the waiting path drives the same counter above zero,
+	// so the zero above is a measurement rather than an unwired seam.
+	waitPolls := 0
+	b := newSeams(&waitPolls)
+	// The wait's own outcome is irrelevant here (a workflow with no output steps
+	// ends in an error); the counter is the claim.
+	_ = runGenerate(mustGenCmd(), b.deps(t), waitOpts(t.TempDir()))
+	if waitPolls == 0 {
+		t.Fatal("POSITIVE CONTROL FAILED: the poll seam is never reached at all, so case A's zero proves nothing")
+	}
+}
+
+// mustGenCmd is genCmd with the streams discarded — used where only a seam
+// counter is being read.
+func mustGenCmd() *cobra.Command {
+	c, _, _ := genCmd("")
+	return c
+}
+
+// --json is a raw stdout passthrough, and the reorder must not have changed
+// either half of that contract: the record still reaches stderr, and stdout is
+// still exactly one parseable document.
+func TestGenerate_JSONStillReportsTheSubstitutionAfterTheHandle(t *testing.T) {
+	withStdinTTY(t, false)
+
+	var s genSeams
+	s.submitReply = subSubmitReply("wf_handle_4")
+	wireIdlePoll(&s)
+	s.submitRaw = json.RawMessage(`{"id":"wf_handle_4","status":"queued","modelSubstitutions":[{"requested":999999999,"applied":2436219,"reason":"unrecognized"}]}`)
+	o := baseOpts()
+	o.assumeYes = true
+	o.jsonOut = true
+
+	c, out, errb := genCmd("")
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("submit must succeed: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("stdout must stay one parseable document: %v\n%s", err, out.String())
+	}
+	if doc["id"] != "wf_handle_4" {
+		t.Errorf("stdout must be the raw submit reply; got %v", doc)
+	}
+	assertPhase(t, errb.String(), substitutionAfterSubmit)
+}
+
+// 🔴 SIGNATURE LEDGER. The ordering above is what makes it SAFE to enrich the
+// post-spend report later (resolving the substituted ids to names, say). This
+// assignment fails to compile the moment reportModelSubstitutions grows a
+// context or a resolver — which is precisely the change that would make it able
+// to block — and sends whoever makes it to the ordering comment in runGenerate
+// before they wire it up.
+var _ func(io.Writer, []genapi.ModelSubstitution, substitutionPhase) = reportModelSubstitutions

--- a/internal/cmd/generate_substitution.go
+++ b/internal/cmd/generate_substitution.go
@@ -165,6 +165,46 @@ func substitutionVerb(phase substitutionPhase) string {
 	return "ran"
 }
 
+// substitutionCheckpointNote is the annotation the approval summary appends to
+// its `Checkpoint:` line, or "" when there is nothing to annotate.
+//
+// 🔴 THE SUMMARY MUST NOT NAME THE MODEL THAT WILL NOT RUN. The summary echoes
+// the checkpoint as a NAME rather than an integer (AGENTS.md item 13) precisely
+// so the user approves something they can recognise — but with a substitution in
+// play the LAST model line before `Generate? [y/N]` was the requested one, which
+// is the one the server has already said it is discarding. So a user approved a
+// name that would not be used, with the warning scrolled several lines above.
+//
+// 🔴 IT ANNOTATES, IT NEVER SWAPS. Printing the applied id in place of the
+// requested one would erase the fact that the user's own input was overridden,
+// which is a second silence rather than a fix. The requested label stays, and
+// the note says it has been superseded and by what.
+//
+// 🔴 THE TENSE COMES FROM THE PHASE, via substitutionVerb — the same constant
+// the lead and the id line already key off (AGENTS.md item 21(f)), not a
+// parallel notion of "before/after the money". Both call sites are pre-spend,
+// so a wrong argument here would tell someone deciding whether to spend that
+// the substitute already ran.
+//
+// The match is by REQUESTED ID, deliberately. The record names the id the caller
+// sent, so a substitution of something other than the checkpoint on this line
+// leaves it un-annotated — the line is then accurate, and the warning block above
+// still carries the ids. `label` is empty on the --input path (the CLI does not
+// interpret that graph, so it prints no checkpoint line at all), and an
+// annotation with no line to hang on would be lost.
+func substitutionCheckpointNote(label string, o generateOpts, subs []genapi.ModelSubstitution, phase substitutionPhase) string {
+	if label == "" || !o.checkpointSet || len(subs) == 0 {
+		return ""
+	}
+	for _, s := range subs {
+		if s.Requested == o.checkpoint {
+			return fmt.Sprintf("  [SUPERSEDED — the server %s version %d instead; see the warning above]",
+				substitutionVerb(phase), s.Applied)
+		}
+	}
+	return ""
+}
+
 // substitutionFlagHint suggests --fail-on-substitution, and ONLY when the caller
 // has not already passed it.
 //

--- a/internal/cmd/generate_substitution_summary_test.go
+++ b/internal/cmd/generate_substitution_summary_test.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/genapi"
+)
+
+// The approval summary must not present the SUPERSEDED checkpoint as the one
+// that will run.
+//
+// 🔴 THE DEFECT. The summary echoes the checkpoint as a NAME rather than an
+// integer, deliberately, so the user approves something recognisable. With a
+// substitution reported on the estimate that made the LAST model line before
+// `Generate? [y/N]` the name the server had already said it would discard —
+// observed live:
+//
+//	⚠ The server will NOT use the checkpoint you asked for …
+//	  …
+//	Checkpoint:   DreamShaper — 8 (Checkpoint, id 128713)
+//
+// The warning scrolls; the summary is what is on screen at the moment of
+// approval. It is now annotated, never swapped: the user asked for the requested
+// version and must still see that their own input was overridden.
+
+// checkpointLine returns the summary's `Checkpoint:` line from a captured
+// stream, or "".
+//
+// 🔴 THE ASSERTIONS BELOW ARE SCOPED TO THIS LINE ON PURPOSE. The substitution
+// warning block a few lines above carries the same applied id and the same tense
+// verb, so a whole-buffer Contains() would be satisfied by the warning and could
+// not see whether the summary line was annotated at all — which is the entire
+// bug.
+func checkpointLine(t *testing.T, got string) string {
+	t.Helper()
+	for _, ln := range strings.Split(got, "\n") {
+		if strings.Contains(ln, "Checkpoint:") {
+			return ln
+		}
+	}
+	return ""
+}
+
+// subCheckpointOpts is an invocation with --checkpoint set to the id the fixture
+// substitution reports as `requested`.
+func subCheckpointOpts() generateOpts {
+	o := baseOpts()
+	o.checkpoint = 999999999
+	o.checkpointSet = true
+	return o
+}
+
+// 🔴 THE HEADLINE ASSERTION, on the interactive confirmation — the surface where
+// the user is actually approving the spend.
+func TestGenerate_ConfirmSummaryMarksTheSupersededCheckpoint(t *testing.T) {
+	withStdinTTY(t, true)
+
+	var s genSeams
+	withQuote(&s, subQuote(genapi.SubstitutionUnrecognized), okQuoteRaw(12))
+	c, _, errb := genCmd("n\n") // decline: the summary is printed before the prompt
+	if err := runGenerate(c, s.deps(t), subCheckpointOpts()); err == nil {
+		t.Fatal("declining must return an error")
+	}
+	if s.submitCalls != 0 {
+		t.Fatalf("declining must never submit; got %d", s.submitCalls)
+	}
+
+	line := checkpointLine(t, errb.String())
+	if line == "" {
+		t.Fatalf("POSITIVE CONTROL FAILED: the confirmation printed no Checkpoint line, so nothing below is being checked:\n%s", errb.String())
+	}
+	// The user's own input is still there — the annotation supplements it.
+	if !strings.Contains(line, "DreamShaper") {
+		t.Errorf("the REQUESTED checkpoint must still be named — silently swapping in the applied one hides that the user was overridden; got %q", line)
+	}
+	if !strings.Contains(line, "SUPERSEDED") {
+		t.Errorf("the checkpoint the server will NOT use must be marked at the moment of approval; got %q", line)
+	}
+	// ...and it names what supersedes it, or the mark is not actionable.
+	if !strings.Contains(line, "2436219") {
+		t.Errorf("the annotation must name the version that will run instead; got %q", line)
+	}
+}
+
+// CONTRAST CONTROL: with no substitution the same line is UNCHANGED. Without
+// this, an annotation printed unconditionally would pass every assertion above.
+func TestGenerate_ConfirmSummaryUnchangedWithoutASubstitution(t *testing.T) {
+	withStdinTTY(t, true)
+
+	var s genSeams
+	withQuote(&s, okQuote(12), okQuoteRaw(12)) // no ModelSubstitutions
+	c, _, errb := genCmd("n\n")
+	if err := runGenerate(c, s.deps(t), subCheckpointOpts()); err == nil {
+		t.Fatal("declining must return an error")
+	}
+
+	line := checkpointLine(t, errb.String())
+	if line == "" {
+		t.Fatalf("POSITIVE CONTROL FAILED: no Checkpoint line at all:\n%s", errb.String())
+	}
+	if !strings.Contains(line, "DreamShaper") {
+		t.Fatalf("POSITIVE CONTROL FAILED: the Checkpoint line carries no model name, so the check below is vacuous; got %q", line)
+	}
+	if strings.Contains(line, "SUPERSEDED") {
+		t.Errorf("a run with no reported substitution must print the checkpoint unannotated; got %q", line)
+	}
+}
+
+// The --dry-run quote is the OTHER surface that echoes the checkpoint, and it is
+// the documented price-check-first workflow. A fix applied to only one of the two
+// renderers is the mistake generate_charge_seam_test.go exists to remember.
+func TestGenerate_DryRunQuoteMarksTheSupersededCheckpoint(t *testing.T) {
+	withStdinTTY(t, false)
+
+	var s genSeams
+	withQuote(&s, subQuote(genapi.SubstitutionGated), okQuoteRaw(12))
+	o := subCheckpointOpts()
+	o.dryRun = true
+
+	c, out, _ := genCmd("")
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("dry run must succeed: %v", err)
+	}
+
+	line := checkpointLine(t, out.String())
+	if line == "" {
+		t.Fatalf("POSITIVE CONTROL FAILED: the quote printed no Checkpoint line:\n%s", out.String())
+	}
+	if !strings.Contains(line, "DreamShaper") {
+		t.Errorf("the requested checkpoint must still be named in the quote; got %q", line)
+	}
+	if !strings.Contains(line, "SUPERSEDED") {
+		t.Errorf("the --dry-run quote must mark a superseded checkpoint too; got %q", line)
+	}
+	if s.submitCalls != 0 {
+		t.Fatalf("a dry run must never submit; got %d", s.submitCalls)
+	}
+}
+
+// 🔴 THE PHASE THE CALL SITE PASSES, ASSERTED STRUCTURALLY (AGENTS.md item
+// 21(f)). Both summary call sites are PRE-spend, so the annotation must be in
+// the future tense: telling someone deciding whether to spend that the
+// substitute already "ran" is the same class of defect as a lead announcing "HAS
+// BEEN CHARGED" on --dry-run.
+//
+// The expected and forbidden texts are DERIVED from substitutionVerb, so a wrong
+// phase argument at the call site moves the expectation instead of leaving a
+// spelled word that some other line also happens to print.
+func TestGenerate_CheckpointAnnotationUsesTheEstimateTense(t *testing.T) {
+	withStdinTTY(t, true)
+
+	var s genSeams
+	withQuote(&s, subQuote(genapi.SubstitutionUnrecognized), okQuoteRaw(12))
+	c, _, errb := genCmd("n\n")
+	_ = runGenerate(c, s.deps(t), subCheckpointOpts())
+
+	line := checkpointLine(t, errb.String())
+	if line == "" {
+		t.Fatalf("POSITIVE CONTROL FAILED: no Checkpoint line:\n%s", errb.String())
+	}
+
+	want := fmt.Sprintf("the server %s version 2436219", substitutionVerb(substitutionAtEstimate))
+	if !strings.Contains(line, want) {
+		t.Errorf("the annotation must carry the ESTIMATE tense derived from the phase constant.\n  want: %q\n  line: %q", want, line)
+	}
+	// The other phases share one verb ("ran"); its rendering must be absent.
+	for _, other := range []substitutionPhase{substitutionAfterSubmit, substitutionOnRead} {
+		bad := fmt.Sprintf("the server %s version 2436219", substitutionVerb(other))
+		if bad == want {
+			t.Fatalf("phase %d renders identically to the estimate phase, so this assertion cannot discriminate", other)
+		}
+		if strings.Contains(line, bad) {
+			t.Errorf("the annotation carries the WRONG phase's tense (%d): %q", other, line)
+		}
+	}
+}
+
+// --- the note function itself -------------------------------------------------
+
+// The note is matched on the REQUESTED id. A substitution of something the
+// summary line does not name must not annotate it — the line is accurate then,
+// and a false mark on a correct line teaches the user to ignore the real one.
+func TestSubstitutionCheckpointNote_MatchesOnTheRequestedID(t *testing.T) {
+	o := baseOpts()
+	o.checkpoint = 128713
+	o.checkpointSet = true
+
+	match := []genapi.ModelSubstitution{{Requested: 128713, Applied: 2154472, Reason: genapi.SubstitutionGated}}
+	got := substitutionCheckpointNote("DreamShaper — 8", o, match, substitutionAtEstimate)
+	if got == "" {
+		t.Fatal("POSITIVE CONTROL FAILED: a record naming this very id produced no note")
+	}
+	if !strings.Contains(got, "2154472") {
+		t.Errorf("the note must name the APPLIED version; got %q", got)
+	}
+	if strings.Contains(got, "128713") {
+		t.Errorf("the note must not repeat the requested id — the label it hangs on already carries it; got %q", got)
+	}
+
+	// A record about a DIFFERENT id must leave the line alone.
+	other := []genapi.ModelSubstitution{{Requested: 999, Applied: 2154472, Reason: genapi.SubstitutionGated}}
+	if n := substitutionCheckpointNote("DreamShaper — 8", o, other, substitutionAtEstimate); n != "" {
+		t.Errorf("a substitution of another id must not annotate this checkpoint; got %q", n)
+	}
+}
+
+// Guard rails on the inputs that make an annotation meaningless or lost.
+func TestSubstitutionCheckpointNote_SilentWhenThereIsNoLineToAnnotate(t *testing.T) {
+	subs := []genapi.ModelSubstitution{{Requested: 128713, Applied: 2154472, Reason: genapi.SubstitutionGated}}
+
+	set := baseOpts()
+	set.checkpoint = 128713
+	set.checkpointSet = true
+
+	// POSITIVE CONTROL first: the fully-populated call DOES produce a note, so
+	// every empty expectation below is a real discrimination.
+	if substitutionCheckpointNote("DreamShaper — 8", set, subs, substitutionAtEstimate) == "" {
+		t.Fatal("POSITIVE CONTROL FAILED: the note is never produced, so the cases below prove nothing")
+	}
+
+	// No label: the --input path prints no Checkpoint line at all, so an
+	// annotation would be dropped on the floor.
+	if n := substitutionCheckpointNote("", set, subs, substitutionAtEstimate); n != "" {
+		t.Errorf("no checkpoint line means no annotation; got %q", n)
+	}
+	// --checkpoint not passed: the id in the record is not this caller's input.
+	unset := baseOpts()
+	unset.checkpoint = 128713
+	if n := substitutionCheckpointNote("DreamShaper — 8", unset, subs, substitutionAtEstimate); n != "" {
+		t.Errorf("no --checkpoint means no annotation; got %q", n)
+	}
+	// An empty record is AMBIGUOUS (AGENTS.md item 21(b)) — it may mean the
+	// server predates the field. Nothing may be claimed from it in either
+	// direction, so the line is printed exactly as it would be without the
+	// feature.
+	if n := substitutionCheckpointNote("DreamShaper — 8", set, nil, substitutionAtEstimate); n != "" {
+		t.Errorf("an empty record must annotate nothing; got %q", n)
+	}
+}


### PR DESCRIPTION
Two audit follow-ups to #221, both about the substitution report telling the user something that is not true at the moment they read it. Based directly on `main` (rebased onto #231).

## 1. The approval summary named the model that will NOT run

`Checkpoint: <requested>` is echoed as a **name** rather than an integer, deliberately (AGENTS item 13), so the user approves something recognisable. With a substitution in play that made the **last model line before `Generate? [y/N]`** the name the server had already said it would discard — the warning having scrolled several lines above.

Both pre-spend surfaces (the confirm prompt and the `--dry-run` quote) now append an annotation:

```
Checkpoint:   DreamShaper — 8 (Checkpoint, id 128713)  [SUPERSEDED — the server will run version 2436219 instead; see the warning above]
```

- It **annotates, it never swaps.** The user asked for their version and must still see it was overridden; printing the applied id in its place would be a second silence rather than a fix.
- **One call site** computes it (`built.checkpointNote`), so the prompt and the quote cannot disagree — the two-renderers mistake `generate_charge_seam_test.go` exists to remember.
- **Matched on `requested`**, so a substitution of anything the line does not name leaves it alone; a false mark on a correct line teaches authors to ignore the real one.
- **Tense from `substitutionVerb(phase)`** — the same constant the lead uses, not a parallel notion of before/after the money — and asserted structurally per item 21(f).

`--yes` prints no checkpoint summary at all (`confirmGenerate`'s `--yes` arm returns after the image disclosure), so the "see the warning above" reference is true on every surface where the annotation can appear.

## 2. The post-spend report ran before the workflow id reached the user

Harmless *today* because the report does no I/O — but the obvious next improvement, resolving the substituted ids to names through `ResolveModelVersion` (which the estimate path already does for `--checkpoint`), would inherit `getWithRetry`'s **4 attempts** (`readMaxAttempts`, `pkg/civitai/retry.go`) against a **30s**-timeout client (`defaultTimeout`, `pkg/civitai/api.go`) plus backoff. Minutes per id, two ids per record, holding the **only handle on an already-charged job** for a cosmetic gain.

`emitSubmitHandle` now emits the handle from one place across all four branches (`--no-wait`, `--json`, a reply with no workflow id, the waiting path) **before** any advisory output, so nothing added later can get in front of it.

> ⚠️ **The audit brief said the name lookups were already there. They are not.** `reportModelSubstitutions` prints raw ids and performs no lookup at `ba3136c` — measured. So no `context.WithTimeout` was added for a call that does not exist. What is fixed is the ordering that would make such a lookup dangerous, plus a signature ledger (`var _ func(io.Writer, []genapi.ModelSubstitution, substitutionPhase) = reportModelSubstitutions`) that fails to compile the moment the renderer grows a context or a resolver, sending whoever does that to the ordering comment first.

## Tests

`httptest`/stub-seam only; no mutation call reaches a server. Ordering is measured by **blocking the advisory's own write** and reading what the user already has — no wall-clock sleep. Deterministic: 10 runs under `-race`, 10 PASS each.

**13 semantic mutants, all killed with the guard's own message:**

| # | Mutant | Killed by |
| --- | --- | --- |
| M1 | advisory moved back before the handle | `…SubmitHandleReachesTheUserBeforeTheSubstitutionAdvisory`, `…WaitingPathEmitsTheHandleBeforeTheAdvisory` |
| M2 | `o.noWait \|\| workflowID == ""` → `&&` | `…NoWaitEmitsTheHandleAndNeverPolls` ("reached the poll seam 1 time(s)") |
| M3 | terminal branch returns `false` | same |
| M4 | `handleErr != nil \|\| terminal` → `&&` | same |
| M5 | advisory call commented out | 5 tests, incl. both POSITIVE CONTROL guards |
| M6 | match on `Applied` not `Requested` | 5 summary tests |
| M7 | call site passes `substitutionAfterSubmit` | `…CheckpointAnnotationUsesTheEstimateTense` |
| M8 | note prints `Requested` not `Applied` | 3 tests |
| M9 | note guard `\|\|` → `&&` | `…SilentWhenThereIsNoLineToAnnotate` |
| M10 | annotation dropped from the confirm summary | `…ConfirmSummaryMarksTheSupersededCheckpoint` |
| M11 | annotation dropped from the `--dry-run` quote | `…DryRunQuoteMarksTheSupersededCheckpoint` |
| M12 | nil record passed at the call site | 3 tests |
| M13 | `range subs[1:]` (off-by-one) | 5 tests |

🔴 **M2/M3/M4 were at first detected ONLY as a nil-seam panic**, which aborts the test binary before the guard that names the defect ever runs. Fixed two ways: the `--no-wait` cases wire a working poll seam they never use (`wireIdlePoll`), and the poll-count assertion is deliberately **not** fatal-gated on the returned error, which every one of those mutants also changes.

Every asserted zero has a positive control in the same test.

## Verification

Ran the **built binary** against a local stub with no spend route (`do_POST` returns 500) — both the `--dry-run` quote and the real pty-driven `Generate? [y/N]` confirmation print the annotated checkpoint line, and declining cancels with no POST.

- Suite **counted**: 2377 PASS / 0 FAIL / 4 SKIP (the four by-design skips), no `panic: test timed out`.
- `make ci` green.
- `gofmt -s -l .` clean — instrument validated against a planted defect it listed.
- `golangci-lint run` **0 issues** — same instrument validated against the same planted defect (2 issues reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
