### PR TITLE
fix(validate): carry a field on every finding, in one notation (#225)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,8 @@ deliberate *non*-mirrors); items 5–9 cover `civitai app metrics`, the CLI's on
 analytics read path; items 12–17 and 19 cover `civitai generate`, the CLI's only
 path that **spends the user's money irreversibly** (19 is img2img); item 18
 covers the two checks that tell an author their EXISTING app is missing the
-item-11 handshake. The durable fix for the mirroring is a server-side
+item-11 handshake; item 21 covers the SHAPE of a validation finding — the
+`field` every `--json` consumer groups on. The durable fix for the mirroring is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
 
@@ -1164,6 +1165,103 @@ neither one's.
       CONTROL — a pre-fix project with no emitter warns on BOTH binaries — so
       the silent cells are real false passes rather than a probe wired to
       nothing.
+
+21. **A validation finding is a `Finding{Field, Message}`, and the Field is
+    carried from the CHECK — never re-derived at the printer.** `validate.Result`
+    holds `[]Finding`, not `[]string`, and every check function in
+    `internal/validate` returns `[]Finding`. This looks like ceremony around what
+    used to be a string; it is the fix for issue #225, and the string version is
+    what made that bug unfixable in place.
+    - **What broke.** `--json` promised `errors`/`warnings` each with
+      `field`/`message`. The field was recovered in `internal/cmd/app_validate.go`
+      by string-parsing a schema-style `"<path>: <reason>"` prefix. Schema errors
+      parse; the ported semantic checks of item 1 emit PROSE, so they parsed to
+      nothing. Measured on a six-ways-broken manifest at `e9a44c4`: **7 of 11
+      findings came back `field: null`, and they were precisely the semantic ones**
+      — the checks a local pre-check exists for. Grouping by field in CI, the one
+      thing `--json` is for, did not work for the findings that matter most.
+    - 🔴 **DO NOT "FIX" A FUTURE GAP HERE WITH MORE PREFIX HEURISTICS.** A parser
+      at the printer regenerates the bug at every check added afterwards: the new
+      check emits prose, the parser finds no path, the null is back, and nothing
+      fails. The field has to come from the producer. `newFinding(field, message)`
+      is the only constructor, and `Finding{…}` composite literals outside
+      `finding.go` are rejected by `TestFindingsAreConstructedWithAField`.
+    - **ONE NOTATION: DOTTED.** `blockId`, `iframe.sandbox`, `scopes[1]`,
+      `targets[0].slotId`. Three notations used to coexist — `(root)` and JSON
+      Pointer `/blockId` in `--json`, dotted `iframe.sandbox` in the text output.
+      Dotted won because it is what every other surface already speaks (the
+      semantic messages' own prose, this file, the README, the schema
+      descriptions), so unifying on JSON Pointer would have meant rewriting every
+      author-facing message to `/iframe/sandbox` to buy escaping rigour a manifest
+      whose keys are all identifiers does not need. **This changed the wire
+      values** (`/scopes/1` → `scopes[1]`) and the text output's leading path;
+      it is a deliberate break, called out in the README.
+    - **TWO SENTINELS, NOT ONE, AND THEY ARE NOT INTERCHANGEABLE.** `(root)`
+      (`FieldDocument`) is the manifest DOCUMENT — absent, unparseable, or a
+      schema violation the library locates at the top-level object. `(project)`
+      (`FieldProject`) is repository state OUTSIDE the manifest — the committed
+      lockfile, the source tree the item-20 advisory reads. Collapsing them would
+      send a CI job looking in `block.manifest.json` for a missing lockfile. Note
+      the lockfile remedy *does* offer a `buildCommand` edit as one option; the
+      finding still is not ABOUT that field, and pinning it there would mis-group
+      every project that takes the other remedy.
+    - **Field assignment is mechanical, not taste.** A finding names the location
+      it is ABOUT — the field whose presence, absence or value the rule reports
+      on. For an "X is set but Y is missing" pair rule that is **Y**, which reads
+      straight off the sentence and stays symmetric across the pair. Per-element
+      and per-key rules carry the index or key (`targets[0].slotId`,
+      `scopeJustifications.<scope>`), because `targets` alone is useless on the
+      only manifests where those rules fire more than once.
+    - 🔴 **`dedupe` KEYS ON THE (field, message) PAIR.** The value being deduped
+      grew a second axis and collapsing on either alone loses real findings: an
+      iframe is routinely wrong several ways at once (same field, different
+      messages), and `scopeJustifications` emits one finding per offending key
+      (same message shape, different fields). Pinned by
+      `TestDedupeFindingsKeysOnTheFieldMessagePAIR`.
+    - 🔴 **`findingSiteHook` IS A TEST SEAM IN PRODUCTION CODE, AND IT IS THERE
+      BECAUSE "EVERY FINDING I SAW HAD A FIELD" IS A CLAIM ABOUT THE CORPUS, NOT
+      ABOUT THE CHECKS.** A corpus that never trips the sandbox rule reports a
+      serene pass for a sandbox rule that emits nothing — the reassuring-zero
+      shape. `TestEveryCheckEmitsAField` therefore AST-enumerates every
+      finding-producing function in the package and, through the hook, requires
+      the corpus to have REACHED each one; a check added without a fixture fails
+      by name and source line. Measured: deleting the `targets` fixture failed
+      with `targetChecks (targets.go:89) was never reached`. The hook is nil in
+      every production run — one nil compare per finding, and `runtime.Caller` is
+      not entered unless a test installed it. Do not delete it to "clean up"; the
+      coverage claim becomes vacuous the moment it goes.
+    - **Three guards, and none subsumes the others.**
+      `TestFindingsAreConstructedWithAField` (structural, AST) fires on the
+      SOURCE, so it catches a new check nobody wrote a test for — but cannot see a
+      field computed to `""` at runtime. `TestEveryCheckEmitsAField`
+      (behavioural + ledger) catches exactly that — but only for checks a fixture
+      reaches. `TestValidateJSONEveryFindingCarriesAField` /
+      `…SemanticChecksAreFieldTagged` (in `internal/cmd`) assert on the DECODED
+      `map[string]any` of real `--json` stdout, per AGENTS item 14's reasoning: a
+      `strings.Contains(out, "field")` is satisfied by the word appearing inside a
+      MESSAGE and cannot see `"field": null` at all. Mutation results: a literal
+      `""` field kills guard A at its site; a runtime-computed `""` kills guard B
+      and the per-check cmd guard; a `Finding{…}` literal kills guard A's funnel
+      rule; reverting `fieldPath` to JSON Pointer kills all four notation guards;
+      deleting one corpus fixture kills guard B's ledger by name. Five mutants,
+      five kills, each with the intended guard's own message.
+    - **The `issues()` empty-field fallback in `app_validate.go` maps `""` →
+      `(root)`, and it is DEFENCE IN DEPTH, not a working path.** It upholds the
+      README's "never null" for a case the guards missed. 🔴 State the cost with
+      it, because it is what makes a per-SHAPE assertion insufficient: measured on
+      the runtime-empty mutant, `TestValidateJSONEveryFindingCarriesAField`
+      **passed** — the fallback supplied a non-null value — while
+      `TestValidateJSONSemanticChecksAreFieldTagged`, which asks for the SPECIFIC
+      field, failed on `(root)`. Assert the field a check must carry, never merely
+      that it carried one. The unrestricted claim over every check stays with
+      `TestEveryCheckEmitsAField`, which sees findings before the fallback.
+    - **The human-readable output is `Finding.Message` verbatim**, which is why
+      `Message` is the complete line rather than a reason fragment to compose with
+      `Field`: the semantic messages name their field inside prose
+      ("iframe.sandbox MUST NOT combine …") and composing would stutter. Sorting
+      is by Message first, Field second, so the text output's order is unchanged
+      from the string era. `validate.Messages()` is the projection the three text
+      consumers (`app validate`, `app submit`, `app init`'s self-check) use.
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1291,7 +1291,13 @@ neither one's.
       straight off the sentence and stays symmetric across the pair. Per-element
       and per-key rules carry the index or key (`targets[0].slotId`,
       `scopeJustifications.<scope>`), because `targets` alone is useless on the
-      only manifests where those rules fire more than once.
+      only manifests where those rules fire more than once. All three clauses are
+      ASSERTED, not merely stated: the pair-rule convention by
+      `TestPairRuleNamesTheMissingField` (which also requires the message to name
+      BOTH sides, so "the missing one" is a claim about a pair that exists), the
+      per-element/per-key ones by rows in `findingFieldLedger()`. It was stated
+      here and asserted nowhere for one release, and an inverted pair survived a
+      green suite.
     - 🔴 **`dedupe` KEYS ON THE (field, message) PAIR.** The value being deduped
       grew a second axis and collapsing on either alone loses real findings: an
       iframe is routinely wrong several ways at once (same field, different
@@ -1310,21 +1316,84 @@ neither one's.
       every production run — one nil compare per finding, and `runtime.Caller` is
       not entered unless a test installed it. Do not delete it to "clean up"; the
       coverage claim becomes vacuous the moment it goes.
-    - **Three guards, and none subsumes the others.**
+    - 🔴 **`make fmt` ONCE DISARMED GUARD A, AND THE FIX IS THAT THE FUNNEL RULE
+      IS SPELLING-INDEPENDENT.** The first version of the AST scan matched only a
+      composite literal that NAMES ITS OWN TYPE (`Finding{…}` — an
+      `*ast.CompositeLit` whose `Type` is an `*ast.Ident`). An element with its
+      type ELIDED — `[]Finding{{Message: …}}` — has `Type == nil`, so the scan
+      skipped it. That is not an exotic spelling: **`gofmt -s` REWRITES the
+      caught form into the uncaught one**, and this repo runs `gofmt -s -w .` in
+      `make fmt` and enforces `gofmt -s -l .` in CI. The repo's own formatter
+      converted every literal the guard could see into one it could not.
+      Measured on the merged tree: a new check returning
+      `[]Finding{{Message: …}}` with NO Field, wired into the real pipeline and
+      with no corpus fixture, passed the ENTIRE suite (18/18 packages `ok`,
+      `gofmt -s -l .` clean over 278 files) — guard B could not see it either,
+      because its ledger is built from `newFinding` call sites and this check
+      never calls `newFinding`. `findingLitDepth` now resolves the element type
+      from the ENCLOSING literal (`[]Finding`, `[]*Finding`, `map[k]Finding`,
+      `[][]Finding`), and `TestFindingFunnelScannerSeesEveryLiteralSpelling`
+      drives the scanner against a control corpus of 15 spellings — both the
+      forms that MUST be flagged and the forms that must NOT — so a future
+      narrowing of the guard fails loudly instead of silently.
+      **Do not describe the funnel rule as being about `Finding{…}`**; an earlier
+      revision of this item and of the test's own doc comment both did, and both
+      were true only for the spelling gofmt deletes.
+      Related hole closed in the same change: the scan iterated `f.Decls` and
+      skipped everything that was not an `*ast.FuncDecl`, so a package-level
+      `var x = newFinding("", …)` was invisible to BOTH guards. It now walks the
+      whole file and rejects any construction outside a function body by name —
+      such a site runs at init, before a test can install `findingSiteHook`, so
+      the reachability ledger can never attribute it.
+    - **Four guards, and none subsumes the others.**
       `TestFindingsAreConstructedWithAField` (structural, AST) fires on the
       SOURCE, so it catches a new check nobody wrote a test for — but cannot see a
       field computed to `""` at runtime. `TestEveryCheckEmitsAField`
       (behavioural + ledger) catches exactly that — but only for checks a fixture
-      reaches. `TestValidateJSONEveryFindingCarriesAField` /
+      reaches. `TestEveryFindingCarriesItsDocumentedField` +
+      `TestPairRuleNamesTheMissingField` (`finding_fields_test.go`) pin the
+      field's VALUE — see the bullet below. `TestValidateJSONEveryFindingCarriesAField` /
       `…SemanticChecksAreFieldTagged` (in `internal/cmd`) assert on the DECODED
       `map[string]any` of real `--json` stdout, per AGENTS item 14's reasoning: a
       `strings.Contains(out, "field")` is satisfied by the word appearing inside a
       MESSAGE and cannot see `"field": null` at all. Mutation results: a literal
       `""` field kills guard A at its site; a runtime-computed `""` kills guard B
-      and the per-check cmd guard; a `Finding{…}` literal kills guard A's funnel
-      rule; reverting `fieldPath` to JSON Pointer kills all four notation guards;
-      deleting one corpus fixture kills guard B's ledger by name. Five mutants,
-      five kills, each with the intended guard's own message.
+      and the per-check cmd guard; an elided-type `[]Finding{{…}}` literal kills
+      guard A's funnel rule with its own message; a package-level `newFinding`
+      kills guard A's attribution rule; reverting `fieldPath` to JSON Pointer
+      kills all four notation guards; deleting one corpus fixture kills guard B's
+      ledger by name.
+    - 🔴 **A NON-EMPTY FIELD IS NOT THE CONTRACT — THE SPECIFIC FIELD IS, AND
+      MUTATING ONE TO A *WRONG BUT PLAUSIBLE* VALUE IS THE SHAPE THE FIRST SWEEP
+      NEVER TRIED.** Every guard above answers "is the field non-empty / in the
+      right notation?", and the original sweep only ever mutated a field to `""`
+      or to JSON Pointer — both of which those guards see. It never mutated one
+      to another real field name, which is what a refactor actually produces. An
+      audit found three such mutants surviving the full green suite:
+      `buildCoherence`'s two pair rules INVERTED; the budgeted-scope-no-page
+      warning moved `page` → `scopes`; and **both lockfile findings moved
+      `(project)` → `(root)`**, i.e. exactly the sentinel collapse this item
+      already marked 🔴, undetected. Note the near miss that let the last one
+      through: guard B's positive control asserts the corpus produced *a*
+      `(project)` finding, and `readyack.go` still produced one — a control
+      satisfied by a bystander.
+      `findingFieldLedger()` closes it with a BIDIRECTIONAL ledger over every
+      finding the corpus produces: each finding must match exactly ONE entry (a
+      new check with no row fails, naming itself), and each entry must match at
+      least one finding (a stale row cannot sit there looking like coverage).
+      Each row records the field AND `why` that field — derived from what the
+      check MEANS, never copied from the implementation, or the test is a
+      restatement of the thing it constrains.
+    - **The residual `dedupe`'s second axis knowingly ships with.** Two
+      `targets[]` entries carrying the SAME unknown `slotId` now print two
+      identical-looking lines in the human output, because the message
+      interpolates the slot id but not the index, and the (field, message) key
+      keeps both. Measured. Under the old message-keyed dedupe they collapsed to
+      one. `--json` is unaffected and is arguably *more* correct — the two
+      findings carry `targets[0].slotId` and `targets[1].slotId` and a consumer
+      can point at both lines. Fixing the text would mean interpolating the index
+      into the message, which changes author-facing copy for a cosmetic
+      duplicate; it is left alone deliberately rather than by oversight.
     - **The `issues()` empty-field fallback in `app_validate.go` maps `""` →
       `(root)`, and it is DEFENCE IN DEPTH, not a working path.** It upholds the
       README's "never null" for a case the guards missed. 🔴 State the cost with

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
 | `civitai app dev-token <slug> [--env] [--spend] [--budget <n>]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the invite-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). `--spend` explicitly REQUESTS `ai:write:budgeted` (real Buzz); omit it and that scope is **filtered out** of the request — the CLI never asks for budgeted spend implicitly, even when your manifest declares it (the scaffolded money app does, so a live run that used to generate now needs `--spend`). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
 | `civitai app dev-tunnel [blockId] [--port] [--tunnel-endpoint] [--idle-timeout]` | **(Pre-GA / dark)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Mints an **ephemeral in-memory ssh keypair**, opens a reverse tunnel from your dev port (start `npm run dev:tunnel` first) to the Civitai tunnel endpoint, prints the URL to open, and tears everything down on Ctrl-C or an idle timeout. Before minting it also **pre-flights whether the host can actually embed your dev server** — the host iframes it sandboxed (opaque `null` origin), so a dev server missing `Access-Control-Allow-Origin: *`, missing the `.civit.ai` entry in `allowedHosts`, or sending a framing header that excludes `civitai.com` loads as a blank iframe with no error anywhere. Those are printed as warnings (never fatal) just above the URL, with the `vite.config.ts` fix. Apps scaffolded by `civitai app init --template page-money` already satisfy all of it. Gated behind an Apps-author invite **and** a kill-switch flag that is off today, and the tunnel endpoint is not exposed yet — so it reports "not available" until it ships. |
-| `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message`) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity). |
+| `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message` — **`field` is always present and never `null`**) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity) and [The `--json` result shape](#the---json-result-shape). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
@@ -756,6 +756,45 @@ The **durable fix** is a server-side `civitai app validate` endpoint that calls
 the real `BlockManifestValidator` (the faithful contract), with this schema
 published as the syntactic half. See [`AGENTS.md`](AGENTS.md) for the full
 caveat and how the vendored schema + Go checks are kept in sync.
+
+### The `--json` result shape
+
+```jsonc
+{
+  "ok": false,
+  "dir": "./my-block",
+  "errors":   [ { "field": "iframe.sandbox", "message": "…" } ],
+  "warnings": [ { "field": "page.buzzBudgetPerGen", "message": "…" } ]
+}
+```
+
+Two guarantees, both of which the previous release broke:
+
+- **`field` is present on every finding, and is never `null` or empty.** It used
+  to be recovered by parsing the message text, which worked only for the JSON
+  Schema errors — so every *semantic* finding (the sandbox rules, the
+  justification rules, the money-path warnings: the ones a local pre-check exists
+  for) arrived as `"field": null`, and grouping by field in CI silently dropped
+  them. Findings now carry their field from where they are produced.
+- **One notation: dotted paths.** `blockId`, `iframe.sandbox`, `scopes[1]`,
+  `targets[0].slotId`, `scopeJustifications.<scope>` — the same way the
+  human-readable messages, this README and the schema all name fields. Earlier
+  releases mixed JSON Pointer (`/blockId`, `/scopes/1`) into `--json` while the
+  text output used dotted; **if you were matching on `/`-prefixed fields, update
+  your scripts.**
+
+Two findings have no single manifest field, and say so explicitly rather than
+omitting the key:
+
+| `field` | meaning |
+| --- | --- |
+| `(root)` | the manifest **document** — it is missing, unparseable, or the schema reports a violation at the top level (e.g. `missing property 'contentRating'`). |
+| `(project)` | **repository state outside the manifest** — the committed lockfile, or the source tree the `BLOCK_READY` advisory reads. No manifest edit alone resolves these. |
+
+`ok` already accounts for `--strict`: it is `false` when there are hard errors,
+and also when `--strict` is passed and there are warnings. The process exit code
+matches, and the JSON still goes to **stdout** while the failure is reported on
+**stderr** — so `civitai app validate --json | jq` works on a failing project.
 
 ## Submit & auth
 

--- a/internal/cmd/app_init.go
+++ b/internal/cmd/app_init.go
@@ -178,7 +178,7 @@ init and copy the upstream files in manually`)
 		return verr
 	}
 	if !res.OK() {
-		return fmt.Errorf("internal error: scaffolded manifest failed validation:\n  %s", joinLines(res.Errors))
+		return fmt.Errorf("internal error: scaffolded manifest failed validation:\n  %s", joinLines(validate.Messages(res.Errors)))
 	}
 
 	printScaffoldResult(out, display, slug, tmpl, destDir, abs, written)

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -75,7 +75,7 @@ Defaults to the current directory.`,
 					errw := cmd.ErrOrStderr()
 					fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("validation failed (%d error(s)) — fix before submitting, or pass --skip-validate:", len(res.Errors))))
 					for _, e := range res.Errors {
-						fmt.Fprintf(errw, "  - %s\n", e)
+						fmt.Fprintf(errw, "  - %s\n", e.Message)
 					}
 					// Warnings are useful context on a failure too, and this is
 					// the last moment before the app would have gone to review.

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/civitai/cli/internal/ui"
 	"github.com/civitai/cli/internal/validate"
@@ -100,7 +99,7 @@ Defaults to the current directory.`,
 			if !res.OK() {
 				fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("%d validation error(s) in %s:", len(res.Errors), dir)))
 				for _, e := range res.Errors {
-					fmt.Fprintf(errw, "  - %s\n", e)
+					fmt.Fprintf(errw, "  - %s\n", e.Message)
 				}
 				// Surface warnings too — they're useful context even on a failure.
 				printWarnings(errw, res)
@@ -126,35 +125,31 @@ Defaults to the current directory.`,
 	return cmd
 }
 
-// issues converts the flat validation messages into structured objects with a
-// machine-readable field (when one can be derived) plus the full message. Schema
-// errors are formatted "<json/path>: <reason>"; we surface the leading path as
-// the field. Messages with no derivable path carry field "" (omitted).
-func issues(msgs []string) []map[string]string {
-	out := make([]map[string]string, 0, len(msgs))
-	for _, m := range msgs {
-		item := map[string]string{"message": m}
-		if field, ok := deriveField(m); ok {
-			item["field"] = field
+// issues renders findings as the `--json` objects README promises: `field` plus
+// `message`, on EVERY finding.
+//
+// 🔴 The field is READ OFF the finding, never re-derived from the message. It
+// used to be recovered by string-parsing a schema-style "<path>: <reason>"
+// prefix, which worked for schema errors and produced `field: null` for every
+// ported semantic check — the prose ones, i.e. the findings a local pre-check
+// exists for (issue #225). Do not reintroduce a parser here: a new check that
+// emits prose would silently go back to null, with nothing failing.
+//
+// The empty-field fallback is defence in depth for the README's "every finding
+// carries a field" promise, not a working path — `TestFindingsAreConstructedWithAField`
+// rejects an empty field at the construction site, and
+// `TestEveryCheckEmitsAField` drives the checks and asserts it end to end. If it
+// ever fires, the finding is at least grouped somewhere honest instead of null.
+func issues(fs []validate.Finding) []map[string]string {
+	out := make([]map[string]string, 0, len(fs))
+	for _, f := range fs {
+		field := f.Field
+		if field == "" {
+			field = validate.FieldDocument
 		}
-		out = append(out, item)
+		out = append(out, map[string]string{"field": field, "message": f.Message})
 	}
 	return out
-}
-
-// deriveField pulls the JSON-path field out of a schema-style "<path>: <reason>"
-// message. It only treats the prefix as a field when it looks like a path
-// (starts with "/" or is the literal "(root)") so prose messages aren't split.
-func deriveField(msg string) (string, bool) {
-	i := strings.Index(msg, ": ")
-	if i <= 0 {
-		return "", false
-	}
-	prefix := msg[:i]
-	if prefix == "(root)" || strings.HasPrefix(prefix, "/") {
-		return prefix, true
-	}
-	return "", false
 }
 
 func printWarnings(w io.Writer, res validate.Result) {
@@ -163,6 +158,6 @@ func printWarnings(w io.Writer, res validate.Result) {
 	}
 	fmt.Fprintln(w, ui.For(w).Warn(fmt.Sprintf("%d warning(s):", len(res.Warnings))))
 	for _, warn := range res.Warnings {
-		fmt.Fprintf(w, "  - %s\n", warn)
+		fmt.Fprintf(w, "  - %s\n", warn.Message)
 	}
 }

--- a/internal/cmd/app_validate_json_field_test.go
+++ b/internal/cmd/app_validate_json_field_test.go
@@ -1,0 +1,312 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// app_validate_json_field_test.go pins the `--json` contract README states:
+// "`--json` emits the structured result (`ok`, plus `errors`/`warnings` each
+// with `field`/`message`)".
+//
+// 🔴 EVERY ASSERTION HERE IS ON A DECODED map[string]any, NEVER ON THE RAW TEXT.
+// A `strings.Contains(out, "field")` would be satisfied by the literal appearing
+// anywhere — including inside a MESSAGE, and several of these messages contain
+// the word — so a text search cannot tell a present key from a mentioned word,
+// and cannot see `"field": null` at all. Same reasoning as
+// `TestGraph_UnsetFieldsAreAbsent` (AGENTS.md item 14): `"cfg"` substring-matches
+// `"cfgScale"`, so key identity is a question only the decoder can answer.
+//
+// 🔴 WHAT THIS FILE CAN AND CANNOT SEE, stated so a green here is not over-read.
+// `issues()` maps an empty field to `(root)` as a last line of defence for the
+// README's "never null" promise, so a check that computes its field to "" at
+// RUNTIME reaches the wire looking well-formed. Measured against exactly that
+// mutant (the sandbox-escape rule rewired to an empty field):
+// TestValidateJSONEveryFindingCarriesAField PASSED — it only asks that the value
+// is non-null, and the fallback supplied one — while
+// TestValidateJSONSemanticChecksAreFieldTagged FAILED, because it asks for the
+// SPECIFIC field and got `(root)`. That is the whole argument for asserting
+// per-check rather than per-shape. The general claim over ALL checks still
+// belongs to `TestEveryCheckEmitsAField` in internal/validate, which sees the
+// finding before the fallback.
+//
+// RED/GREEN at base (`origin/main` @ e9a44c4, this file copied in verbatim):
+//   - TestValidateJSONEveryFindingCarriesAField    RED  (7 of 11 findings had no field key)
+//   - TestValidateJSONSemanticChecksAreFieldTagged RED  (all 6 semantic fields "", both schema fields JSON Pointer)
+//   - TestValidateJSONFieldsUseDottedNotation      RED  (/blockId, /scopes/2)
+//   - TestValidateJSONStreamSeparation             GREEN — an INVARIANT GUARD, not
+//     regression coverage: stream separation was already correct and the issue
+//     asked that it stay that way. Labelled rather than counted.
+//   - TestValidateJSONCleanManifestHasEmptyBuckets GREEN — the NEGATIVE CONTROL,
+//     green on purpose in both directions.
+
+// brokenSixWays is the manifest from issue #225 — the one whose 7 findings came
+// back with 4 `field: null`. The four nulls were the SEMANTIC checks:
+// sandbox escape, disallowed sandbox token, unjustified sensitive scope, and the
+// budgeted-page warning.
+const brokenSixWays = `{
+  "blockId": "Bad_Id",
+  "name": "Six Ways Broken",
+  "version": "1.0.0",
+  "scopes": ["user:read:self", "ai:write:budgeted", "not-a-real-scope"],
+  "page": {"path": "/", "title": "Broken"},
+  "iframe": {"sandbox": "allow-same-origin allow-scripts allow-popups"},
+  "contentRating": "g"
+}`
+
+// decodeValidateJSON runs `app validate --json` and decodes stdout GENERICALLY,
+// so key presence and JSON null are both observable. It returns the decoded
+// object plus stderr and the command error.
+func decodeValidateJSON(t *testing.T, dir string, extraArgs ...string) (map[string]any, string, error) {
+	t.Helper()
+	args := append([]string{"app", "validate", dir, "--json"}, extraArgs...)
+	out, errOut, err := run(t, args...)
+	var got map[string]any
+	if uerr := json.Unmarshal([]byte(out), &got); uerr != nil {
+		t.Fatalf("--json stdout is not valid JSON: %v\nstdout:\n%s", uerr, out)
+	}
+	return got, errOut, err
+}
+
+// findingObjects pulls the errors+warnings arrays out of the decoded payload
+// WITHOUT typing them, so a missing key and a null value stay distinguishable.
+func findingObjects(t *testing.T, payload map[string]any, key string) []map[string]any {
+	t.Helper()
+	raw, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload has no %q key: %v", key, payload)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("%q is not an array: %T", key, raw)
+	}
+	out := make([]map[string]any, 0, len(arr))
+	for i, e := range arr {
+		obj, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("%s[%d] is not an object: %T", key, i, e)
+		}
+		out = append(out, obj)
+	}
+	return out
+}
+
+// TestValidateJSONEveryFindingCarriesAField is the direct regression test for
+// issue #225.
+//
+// It asserts, on the DECODED object:
+//   - the "field" KEY IS PRESENT on every finding (the old code omitted it),
+//   - its value is NOT JSON null and NOT the empty string,
+//   - "message" likewise.
+//
+// The positive control is the count: the fixture must produce a minimum number
+// of findings in BOTH buckets, so "zero findings had a null field" cannot mean
+// "there were no findings".
+func TestValidateJSONEveryFindingCarriesAField(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, brokenSixWays)
+
+	payload, _, err := decodeValidateJSON(t, dir)
+	if err == nil {
+		t.Fatal("a manifest this broken must still exit non-zero in --json mode")
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		t.Errorf("broken manifest reported ok:true: %v", payload)
+	}
+
+	errs := findingObjects(t, payload, "errors")
+	warns := findingObjects(t, payload, "warnings")
+
+	// Positive control. The issue's manifest produced 7 findings; requiring
+	// several in each bucket means a harness that observed nothing cannot pass.
+	if len(errs) < 5 {
+		t.Fatalf("expected at least 5 errors from the six-ways-broken manifest, got %d: %v", len(errs), errs)
+	}
+	if len(warns) < 1 {
+		t.Fatalf("expected at least 1 warning from the six-ways-broken manifest, got %d: %v", len(warns), warns)
+	}
+
+	for _, bucket := range []struct {
+		name  string
+		items []map[string]any
+	}{{"errors", errs}, {"warnings", warns}} {
+		for i, item := range bucket.items {
+			raw, present := item["field"]
+			if !present {
+				t.Errorf("%s[%d] has NO \"field\" key — issue #225 is back: %v", bucket.name, i, item)
+				continue
+			}
+			if raw == nil {
+				t.Errorf("%s[%d] has \"field\": null — issue #225 is back: %v", bucket.name, i, item)
+				continue
+			}
+			s, ok := raw.(string)
+			if !ok {
+				t.Errorf("%s[%d] \"field\" is %T, want string: %v", bucket.name, i, raw, item)
+				continue
+			}
+			if s == "" {
+				t.Errorf("%s[%d] has an EMPTY \"field\": %v", bucket.name, i, item)
+			}
+			msg, ok := item["message"].(string)
+			if !ok || msg == "" {
+				t.Errorf("%s[%d] has no usable \"message\": %v", bucket.name, i, item)
+			}
+		}
+	}
+}
+
+// TestValidateJSONSemanticChecksAreFieldTagged is the SHARP version of the test
+// above: it names the four findings that came back null and requires each to
+// carry a SPECIFIC field.
+//
+// "at least one finding has a field" — which is what this file's predecessor
+// asserted — was green throughout the entire life of the bug, because the schema
+// errors always had one. The claim that matters is per-check, so it is asserted
+// per-check.
+func TestValidateJSONSemanticChecksAreFieldTagged(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, brokenSixWays)
+
+	payload, _, err := decodeValidateJSON(t, dir)
+	if err == nil {
+		t.Fatal("broken manifest must exit non-zero")
+	}
+
+	byMessageFragment := map[string]string{}
+	for _, item := range append(findingObjects(t, payload, "errors"), findingObjects(t, payload, "warnings")...) {
+		msg, _ := item["message"].(string)
+		field, _ := item["field"].(string)
+		byMessageFragment[msg] = field
+	}
+
+	// Each entry: a fragment identifying ONE finding, and the field it must
+	// carry. These are the exact four the issue reported as null, plus the two
+	// schema findings whose notation changed.
+	want := []struct {
+		fragment string
+		field    string
+	}{
+		{"MUST NOT combine allow-same-origin with allow-scripts", "iframe.sandbox"},
+		{`sandbox token "allow-popups" is not allowed`, "iframe.sandbox"},
+		{"sensitive scopes require a justification", "scopeJustifications"},
+		{"page.buzzBudgetPerGen is not set", "page.buzzBudgetPerGen"},
+		{"iframe.minHeight is required", "iframe.minHeight"},
+		{"iframe.resizable is required", "iframe.resizable"},
+		// Schema findings: dotted, not JSON Pointer.
+		{"does not match pattern", "blockId"},
+		{"value must be one of", "scopes[2]"},
+	}
+	for _, w := range want {
+		var found bool
+		for msg, field := range byMessageFragment {
+			if !strings.Contains(msg, w.fragment) {
+				continue
+			}
+			found = true
+			if field != w.field {
+				t.Errorf("finding %q carries field %q, want %q", w.fragment, field, w.field)
+			}
+		}
+		if !found {
+			t.Errorf("the fixture did not produce the finding %q at all — this test is not "+
+				"checking what it claims to. Findings seen: %v", w.fragment, byMessageFragment)
+		}
+	}
+}
+
+// TestValidateJSONFieldsUseDottedNotation pins the SECONDARY defect: three
+// notations used to coexist (`(root)`, `/blockId`, `iframe.sandbox`). Exactly
+// one survives on the wire.
+//
+// It asserts the NEGATIVE — no field is a JSON Pointer — because that is the
+// notation that was there. A positive-only assertion ("some field is dotted")
+// was true before the fix too.
+func TestValidateJSONFieldsUseDottedNotation(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, brokenSixWays)
+
+	payload, _, _ := decodeValidateJSON(t, dir)
+	var sawNested, sawIndexed bool
+	items := append(findingObjects(t, payload, "errors"), findingObjects(t, payload, "warnings")...)
+	for _, item := range items {
+		field, _ := item["field"].(string)
+		if strings.HasPrefix(field, "/") || strings.Contains(field, "/") {
+			t.Errorf("field %q is a JSON Pointer; --json is unified on dotted paths: %v", field, item)
+		}
+		switch {
+		case field == "(root)" || field == "(project)":
+			// A documented sentinel, not a path — see the README --json table.
+		case strings.Contains(field, "["):
+			sawIndexed = true
+		case strings.Contains(field, "."):
+			sawNested = true
+		}
+	}
+	// Positive controls: the fixture really does produce the shapes whose
+	// notation is being asserted, so the negative above had something to catch.
+	if !sawNested {
+		t.Error("positive control: no nested field (e.g. iframe.sandbox) in the payload")
+	}
+	if !sawIndexed {
+		t.Error("positive control: no array-indexed field (e.g. scopes[2]) in the payload")
+	}
+}
+
+// TestValidateJSONStreamSeparation pins what the issue explicitly asked be kept:
+// the JSON goes to STDOUT and nothing else does, while the failure is signalled
+// out of band. `main` prints "Error: …" to stderr; at this level that is the
+// non-nil error, and stdout must stay machine-parseable in full.
+func TestValidateJSONStreamSeparation(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, brokenSixWays)
+
+	out, errOut, err := run(t, "app", "validate", dir, "--json")
+	if err == nil {
+		t.Fatal("broken manifest must exit non-zero")
+	}
+	// The WHOLE of stdout must decode. A single stray human line would break a
+	// consumer piping stdout into jq, and would not be caught by decoding a
+	// prefix.
+	var payload map[string]any
+	if uerr := json.Unmarshal([]byte(out), &payload); uerr != nil {
+		t.Fatalf("stdout is not pure JSON — stream separation broken: %v\nstdout:\n%s", uerr, out)
+	}
+	if strings.TrimSpace(errOut) != "" {
+		t.Errorf("--json mode wrote to stderr; the human summary must be suppressed:\n%s", errOut)
+	}
+}
+
+// TestValidateJSONCleanManifestHasEmptyBuckets is the negative control for the
+// tests above: on a manifest with nothing wrong, the same code path must produce
+// ZERO findings and ok:true. Without it, a harness that fabricated a field on
+// everything would look identical.
+func TestValidateJSONCleanManifestHasEmptyBuckets(t *testing.T) {
+	tmp := t.TempDir()
+	chdir(t, tmp)
+	if _, _, err := run(t, "app", "init", "clean-field-block"); err != nil {
+		t.Fatalf("app init: %v", err)
+	}
+	dir := filepath.Join(tmp, "clean-field-block")
+
+	payload, _, err := decodeValidateJSON(t, dir)
+	if err != nil {
+		t.Fatalf("clean project should exit 0: %v", err)
+	}
+	if ok, _ := payload["ok"].(bool); !ok {
+		t.Errorf("clean project should report ok:true: %v", payload)
+	}
+	if n := len(findingObjects(t, payload, "errors")); n != 0 {
+		t.Errorf("clean project should have no errors, got %d", n)
+	}
+}
+
+func writeManifest(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cmd/app_validate_test.go
+++ b/internal/cmd/app_validate_test.go
@@ -47,8 +47,14 @@ func TestAppValidateJSONOK(t *testing.T) {
 }
 
 // TestAppValidateJSONErrors asserts a bad manifest yields ok:false, a non-empty
-// errors list (each carrying a message, with a field on schema-path errors), AND
-// a non-zero exit so scripts still detect failure.
+// errors list (each carrying a message AND a field), and a non-zero exit so
+// scripts still detect failure.
+//
+// 🔴 This test's "at least one error carries a field" assertion was GREEN
+// throughout the entire life of issue #225, because the schema errors always had
+// one while every semantic finding was null. It is kept for the exit-code and
+// shape coverage; the per-finding and per-check claims live in
+// app_validate_json_field_test.go, which asserts on the decoded object.
 func TestAppValidateJSONErrors(t *testing.T) {
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "block.manifest.json"), []byte(`{"blockId":"x"}`), 0o600); err != nil {
@@ -74,17 +80,11 @@ func TestAppValidateJSONErrors(t *testing.T) {
 			t.Errorf("every error must carry a message: %+v", e)
 		}
 	}
-	// Schema-path errors should surface a field (e.g. a missing required prop at
-	// the root, or a bad /version). At least one error should be field-tagged.
-	var anyField bool
+	// EVERY error carries a field now, not just the schema-path ones.
 	for _, e := range got.Errors {
-		if e.Field != "" {
-			anyField = true
-			break
+		if e.Field == "" {
+			t.Errorf("every error must carry a field (issue #225): %+v", e)
 		}
-	}
-	if !anyField {
-		t.Errorf("expected at least one schema-path error with a field: %+v", got.Errors)
 	}
 }
 

--- a/internal/validate/finding.go
+++ b/internal/validate/finding.go
@@ -100,10 +100,19 @@ const (
 // question about ONE call rather than about a struct literal somewhere.
 //
 // TestFindingsAreConstructedWithAField enforces that structurally — it parses
-// every non-test file in the package, rejects a bare `Finding{…}` composite
-// literal, and rejects a `newFinding("" , …)`. That is the guard that a NEWLY
-// ADDED check cannot ship without a field: it fires on the construction site
-// itself, so it does not depend on the new check being exercised by any test.
+// every non-test file in the package and rejects a composite literal that
+// constructs a Finding IN ANY SPELLING, a `newFinding("", …)`, and a
+// construction outside any function body. That is the guard that a NEWLY ADDED
+// check cannot ship without a field: it fires on the construction site itself,
+// so it does not depend on the new check being exercised by any test.
+//
+// 🔴 "IN ANY SPELLING" is not decoration. The first version of that guard
+// matched only a literal that names its own type (`Finding{…}`), and `gofmt -s`
+// — which `make fmt` runs and CI enforces — rewrites `[]Finding{Finding{…}}`
+// into the ELIDED `[]Finding{{…}}`, whose AST node carries no type at all. So
+// the repo's own formatter converted the one caught form into an uncaught one,
+// and a fieldless finding shipped past the whole suite. Never describe or
+// re-narrow this rule to the `Finding{…}` spelling.
 func newFinding(field, message string) Finding {
 	if h := findingSiteHook; h != nil {
 		recordFindingSite(h)

--- a/internal/validate/finding.go
+++ b/internal/validate/finding.go
@@ -1,0 +1,249 @@
+package validate
+
+import (
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// finding.go defines the ONE shape every validation finding has, and the ONE
+// notation every finding names its location in.
+//
+// WHY THIS IS A STRUCT AND NOT A STRING (issue #225). `--json` promised
+// `errors`/`warnings` each with `field`/`message`, and the field was
+// reverse-engineered at the PRINTER by string-parsing a schema-style
+// "<path>: <reason>" prefix. The schema errors parsed; the SEMANTIC checks —
+// the ported BlockManifestValidator rules of AGENTS.md item 1, i.e. exactly the
+// findings a local pre-check exists for — emit prose, so 4 of 7 findings on a
+// six-ways-broken manifest came back `field: null`. Grouping findings by field
+// in CI, the one thing `--json` is for, did not work for the findings that
+// matter most.
+//
+// 🔴 The fix has to be that a finding CARRIES its field from where it is
+// PRODUCED. Adding more prefix heuristics to the printer regenerates the same
+// bug at every check added afterwards: a new check emits prose, the parser
+// finds no path, and the null is back with nothing failing. That is why every
+// check function in this package returns []Finding rather than []string.
+
+// Finding is a single validation error or warning.
+type Finding struct {
+	// Field is the manifest location this finding is about, in DOTTED notation
+	// (see the notation contract below). It is NEVER empty: a finding with no
+	// single natural field carries one of the two documented sentinels.
+	Field string
+
+	// Message is the COMPLETE human-readable line — byte-for-byte what the text
+	// renderer prints. It is deliberately not a reason fragment to be composed
+	// with Field: the semantic messages name their field inside prose
+	// ("iframe.sandbox MUST NOT combine …"), so composing would stutter, and
+	// the schema messages already carry a "<field>: <reason>" shape.
+	Message string
+}
+
+// ---------------------------------------------------------------------------
+// The notation contract.
+// ---------------------------------------------------------------------------
+//
+// Findings used to mix THREE notations: `(root)` and JSON Pointer `/blockId`
+// in `--json`, and dotted `iframe.sandbox` in the human-readable text. They are
+// unified on DOTTED — `iframe.sandbox`, `scopes[1]`, `targets[0].slotId`.
+//
+// Dotted rather than JSON Pointer because dotted is what every other surface
+// already speaks: the ported semantic messages ("iframe.minHeight is required",
+// "page.buzzBudgetPerGen is not set"), the README, AGENTS.md, and the schema's
+// own descriptions. Unifying on JSON Pointer would have meant rewriting every
+// prose message to `/iframe/sandbox` — a far larger change to the output
+// authors read, to buy an escaping rigour a manifest whose keys are all
+// identifiers does not need. Dotted is also what an author types to find the
+// key in their file.
+//
+// Residuals, stated rather than hidden. A member name containing `.` or `[`
+// renders ambiguously (`scopeJustifications` keys are author-supplied; a key
+// "a.b" renders as `scopeJustifications.a.b`), and a numeric OBJECT key renders
+// like an array index. Neither is reachable from this schema's own fields — the
+// manifest's keys are fixed identifiers and scope names use `:`, not `.` — and
+// a consumer grouping by field is unharmed by either.
+
+const (
+	// FieldDocument is the Field of a finding about the manifest AS A WHOLE:
+	// the manifest is absent or unparseable, or the schema reports a violation
+	// at the document root (a missing top-level required property is located at
+	// the object that lacks it, not at the key that is not there).
+	//
+	// It is the literal the previous JSON output already used for schema root
+	// errors, kept so existing consumers keep grouping the same way.
+	FieldDocument = "(root)"
+
+	// FieldProject is the Field of a finding about PROJECT STATE OUTSIDE the
+	// manifest — the committed lockfile, the source tree. These are real
+	// findings with no manifest field to name: the lockfile check reports on a
+	// file that is or is not committed, and the ready-ack advisory reports on
+	// what the browser loads.
+	//
+	// 🔴 It is a SECOND sentinel rather than reusing FieldDocument on purpose.
+	// Both would be "not a manifest field", but they are not the same kind of
+	// finding and a consumer routes them differently: `(root)` says "your
+	// manifest document is wrong", `(project)` says "your repository state is
+	// wrong, and no manifest edit alone fixes it". Collapsing them would tell a
+	// CI job to go looking in block.manifest.json for a missing lockfile.
+	//
+	// Some of these findings DO offer a manifest edit as one remedy — the
+	// lockfile error suggests setting `buildCommand` to match the lockfile you
+	// already have — but the finding is not ABOUT that field, and pinning it
+	// there would mis-group every project that takes the other remedy.
+	FieldProject = "(project)"
+)
+
+// newFinding builds a Finding. 🔴 It is the ONLY constructor: every finding in
+// this package goes through it, so "does this check carry a field?" is a
+// question about ONE call rather than about a struct literal somewhere.
+//
+// TestFindingsAreConstructedWithAField enforces that structurally — it parses
+// every non-test file in the package, rejects a bare `Finding{…}` composite
+// literal, and rejects a `newFinding("" , …)`. That is the guard that a NEWLY
+// ADDED check cannot ship without a field: it fires on the construction site
+// itself, so it does not depend on the new check being exercised by any test.
+func newFinding(field, message string) Finding {
+	if h := findingSiteHook; h != nil {
+		recordFindingSite(h)
+	}
+	return Finding{Field: field, Message: message}
+}
+
+// findingSiteHook is a TEST SEAM, nil in every production run: one nil compare
+// per finding, and `recordFindingSite` (the only thing that pays for a
+// `runtime.Caller`) is not entered unless a test installed it.
+//
+// 🔴 It exists because a corpus test that only asserts "every finding I saw
+// carried a field" cannot distinguish a thorough corpus from one that never
+// reached the check in question — the reassuring-zero shape. With the hook,
+// TestEveryCheckEmitsAField compares the finding-producing functions the corpus
+// ACTUALLY REACHED against the set the AST finds in the source, so a newly
+// added check with no fixture fails loudly instead of passing unobserved.
+//
+// A test that installs it must not run in parallel with another that does.
+var findingSiteHook func(fn string)
+
+func recordFindingSite(h func(fn string)) {
+	pc, _, _, ok := runtime.Caller(2) // 0=recordFindingSite, 1=newFinding, 2=the check
+	if !ok {
+		return
+	}
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return
+	}
+	h(f.Name())
+}
+
+// Messages returns just the human-readable lines, in order. Callers that render
+// text (the validate/submit printers, `app init`'s self-check) want this;
+// callers that render JSON want the Findings themselves.
+func Messages(fs []Finding) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.Message
+	}
+	return out
+}
+
+// sortFindings orders findings by MESSAGE first, Field second.
+//
+// Message-first is deliberate: the text output prints messages and nothing
+// else, so ordering on the message keeps that output's order exactly what it
+// was when findings were bare strings. Field is the tiebreak so the order is
+// total (two checks can legitimately produce the same sentence about two
+// different fields — see dedupeFindings).
+func sortFindings(fs []Finding) {
+	sort.SliceStable(fs, func(i, j int) bool {
+		if fs[i].Message != fs[j].Message {
+			return fs[i].Message < fs[j].Message
+		}
+		return fs[i].Field < fs[j].Field
+	})
+}
+
+// dedupeFindings collapses findings that are identical in BOTH field and
+// message, and only those.
+//
+// The semantics are the point, so they are stated: two findings with the same
+// MESSAGE and different FIELDS are two findings and both survive (the
+// scopeJustifications key rule emits one sentence per offending key, and a
+// per-key field is the only thing that distinguishes them once the key is
+// interpolated out of the sentence — which it is not today, but a message that
+// stopped naming the key would silently collapse into one). Two findings with
+// the same FIELD and different messages are likewise both kept: an iframe can
+// be wrong in several ways at once. Only the exact pair collapses, which is
+// what the string dedupe did before, restricted to the axis that used to be the
+// whole value.
+func dedupeFindings(in []Finding) []Finding {
+	seen := make(map[Finding]struct{}, len(in))
+	var out []Finding
+	for _, f := range in {
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	return out
+}
+
+// fieldPath renders a schema InstanceLocation (raw, UNESCAPED JSON Pointer
+// tokens — the jsonschema library escapes only when it prints) as a dotted
+// path. An empty location is the document itself.
+//
+// A token that is entirely ASCII digits is rendered as an array subscript,
+// which is what it is everywhere in this schema (`scopes`, `targets`,
+// `permissions` are the only arrays and none holds objects with numeric keys).
+func fieldPath(tokens []string) string {
+	if len(tokens) == 0 {
+		return FieldDocument
+	}
+	var b strings.Builder
+	for i, tok := range tokens {
+		if isIndexToken(tok) {
+			b.WriteByte('[')
+			b.WriteString(tok)
+			b.WriteByte(']')
+			continue
+		}
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(tok)
+	}
+	// A location that starts with an index (impossible for an object-rooted
+	// manifest, but not for a hypothetical array document) would render
+	// "[0]…"; that is still a usable path, so no special case.
+	return b.String()
+}
+
+func isIndexToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for i := 0; i < len(tok); i++ {
+		if tok[i] < '0' || tok[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// childField joins a parent path with a member name: childField("iframe",
+// "sandbox") is "iframe.sandbox". Kept as a function so the notation lives in
+// one place rather than in a dozen string concatenations.
+func childField(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "." + name
+}
+
+// indexField renders an element of an array field: indexField("targets", 0) is
+// "targets[0]".
+func indexField(parent string, i int) string {
+	return parent + "[" + strconv.Itoa(i) + "]"
+}

--- a/internal/validate/finding_contract_test.go
+++ b/internal/validate/finding_contract_test.go
@@ -1,0 +1,762 @@
+package validate
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// finding_contract_test.go is the guard set for issue #225: `--json` promised a
+// `field` on every finding and delivered `null` for every ported semantic check,
+// because the field was reverse-engineered from the message at the printer.
+//
+// THREE guards, and none subsumes the others.
+//
+//	(A) TestFindingsAreConstructedWithAField — STRUCTURAL. Parses the package and
+//	    fails on a construction that cannot carry a field. It fires on the SOURCE,
+//	    so it catches a new check nobody wrote a test for.
+//	(B) TestEveryCheckEmitsAField — BEHAVIOURAL, with a REACHABILITY LEDGER. Drives
+//	    a corpus through the real entry points and asserts every finding carries a
+//	    field — and, via the findingSiteHook, that the corpus reached every
+//	    finding-producing function the AST finds. Without the ledger a green here
+//	    would be indistinguishable from a corpus that never ran the check.
+//	(C) TestFindingFieldsUseOneNotation — the SECONDARY defect. Three notations
+//	    used to coexist; this pins that exactly one survives.
+//
+// (A) cannot see a field computed to "" at runtime; (B) cannot see a check no
+// fixture reaches that (A) already rejected statically; (C) says nothing about
+// presence. Keep all three.
+
+// packageGoFiles returns the non-test .go files of this package.
+func packageGoFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	if len(out) < 5 {
+		// Positive control on the scanner itself: this package has semantic.go,
+		// targets.go, warnings.go, lockfile.go, readyack.go, validate.go and
+		// finding.go. A short list means we are scanning the wrong directory, and
+		// every assertion below would pass vacuously.
+		t.Fatalf("scanner found only %d package files (%v) — it is looking at the wrong tree", len(out), out)
+	}
+	return out
+}
+
+// findingSite is one `newFinding(...)` call in the package source.
+type findingSite struct {
+	file string
+	fn   string // enclosing function, closures normalised to their parent
+	line int
+	// fieldIsEmptyLiteral is set when the first argument is a literal "" — the
+	// one shape a static check can call out with certainty.
+	fieldIsEmptyLiteral bool
+}
+
+// normaliseFuncName reduces a runtime function name to the bare identifier the
+// AST scan produces. A closure (`schemaErrors`'s `walk`) is folded into its
+// parent, because "which function constructs findings" is the granularity the
+// ledger needs and the only one the two sources can agree on.
+func normaliseFuncName(name string) string {
+	// runtime names look like "github.com/civitai/cli/internal/validate.schemaErrors.func1".
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	if i := strings.Index(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	if i := strings.Index(name, ".func"); i >= 0 {
+		name = name[:i]
+	}
+	return name
+}
+
+// collectFindingSites parses the package and returns every newFinding call site,
+// plus every bare `Finding{...}` composite literal it finds (which must be
+// empty outside finding.go).
+func collectFindingSites(t *testing.T) (sites []findingSite, compositeLits []string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	for _, name := range packageGoFiles(t) {
+		f, err := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		// Track the enclosing top-level func for each node.
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			fnName := fd.Name.Name
+			ast.Inspect(fd, func(n ast.Node) bool {
+				switch v := n.(type) {
+				case *ast.CallExpr:
+					id, ok := v.Fun.(*ast.Ident)
+					if !ok || id.Name != "newFinding" {
+						return true
+					}
+					pos := fset.Position(v.Lparen)
+					site := findingSite{file: name, fn: fnName, line: pos.Line}
+					if len(v.Args) == 0 {
+						t.Errorf("%s:%d: newFinding called with no arguments", name, pos.Line)
+						return true
+					}
+					if lit, ok := v.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING &&
+						(lit.Value == `""` || lit.Value == "``") {
+						site.fieldIsEmptyLiteral = true
+					}
+					sites = append(sites, site)
+				case *ast.CompositeLit:
+					id, ok := v.Type.(*ast.Ident)
+					if !ok || id.Name != "Finding" {
+						return true
+					}
+					if name != "finding.go" {
+						compositeLits = append(compositeLits,
+							fset.Position(v.Lbrace).String())
+					}
+				}
+				return true
+			})
+		}
+	}
+	return sites, compositeLits
+}
+
+// TestFindingsAreConstructedWithAField is GUARD A — the structural one.
+//
+// It is the answer to "how does a NEWLY ADDED check fail to ship without a
+// field?". It fires at the construction site, in the source, so it does not
+// depend on anybody writing a fixture for the new check first.
+//
+// It enforces two properties:
+//
+//  1. `Finding{...}` is never written as a composite literal outside finding.go.
+//     That is what makes newFinding the single funnel — a struct literal can
+//     omit Field and compile, and no amount of arguing about conventions stops
+//     the next one.
+//  2. No newFinding call passes an empty string literal as the field.
+//
+// Residual, stated: a field computed to "" at runtime is invisible here. That is
+// what GUARD B covers.
+func TestFindingsAreConstructedWithAField(t *testing.T) {
+	sites, compositeLits := collectFindingSites(t)
+
+	if len(compositeLits) > 0 {
+		t.Errorf("Finding{...} composite literal(s) outside finding.go at %v —\n"+
+			"every finding must be built by newFinding(field, message) so that "+
+			"\"does this check carry a field?\" is a question about one call. "+
+			"See finding.go and issue #225.", compositeLits)
+	}
+
+	// Positive control on the parser: this package HAS finding sites. A zero here
+	// would make every assertion below vacuous, and is exactly what a scanner
+	// wired to nothing reports.
+	const minSites = 20
+	if len(sites) < minSites {
+		t.Fatalf("found only %d newFinding call sites; expected at least %d — "+
+			"the AST scan is not matching what it should", len(sites), minSites)
+	}
+
+	for _, s := range sites {
+		if s.fieldIsEmptyLiteral {
+			t.Errorf("%s:%d (%s): newFinding called with an EMPTY field — "+
+				"every finding must name a manifest location, or one of the documented "+
+				"sentinels FieldDocument / FieldProject. See finding.go.", s.file, s.line, s.fn)
+		}
+	}
+}
+
+// TestEveryCheckEmitsAField is GUARD B — behavioural, with a reachability
+// ledger.
+//
+// 🔴 THE LEDGER IS THE POINT. "Every finding I observed carried a field" is a
+// claim about the corpus, not about the checks: a corpus that never trips the
+// sandbox rule reports a serene pass for a sandbox rule that emits nothing at
+// all. So the test ALSO derives, from the AST, the set of functions that
+// construct findings, and requires the corpus to have reached every one of
+// them. A check added without a fixture fails here by name.
+//
+// The reached set is observed through findingSiteHook, which is nil in every
+// production run.
+func TestEveryCheckEmitsAField(t *testing.T) {
+	sites, _ := collectFindingSites(t)
+
+	want := map[string]string{} // funcName -> "file:line" of one of its sites
+	for _, s := range sites {
+		if _, ok := want[s.fn]; !ok {
+			want[s.fn] = s.file + ":" + itoaTest(s.line)
+		}
+	}
+
+	reached := map[string]bool{}
+	findingSiteHook = func(fn string) { reached[normaliseFuncName(fn)] = true }
+	defer func() { findingSiteHook = nil }()
+
+	var allFindings []Finding
+	var corpusNames []string
+	for _, fx := range fieldCoverageCorpus() {
+		dir := writeFixture(t, fx.files)
+		res, err := Dir(dir)
+		if err != nil {
+			t.Fatalf("%s: Dir: %v", fx.name, err)
+		}
+		got := append(append([]Finding{}, res.Errors...), res.Warnings...)
+		if len(got) == 0 {
+			t.Errorf("fixture %q produced NO findings — it is not exercising what it "+
+				"claims to, so it contributes nothing to this test", fx.name)
+		}
+		allFindings = append(allFindings, got...)
+		corpusNames = append(corpusNames, fx.name)
+	}
+
+	// --- Positive control -------------------------------------------------
+	// A reassuring "no finding had an empty field" is indistinguishable from a
+	// harness that observed nothing. Prove the harness CAN see fields, and that
+	// the number moves: assert a floor on the findings observed AND that a known
+	// dotted field and both sentinels actually turned up.
+	const minFindings = 25
+	if len(allFindings) < minFindings {
+		t.Fatalf("corpus produced only %d findings across %d fixtures; expected at least %d — "+
+			"the harness is not exercising the checks", len(allFindings), len(corpusNames), minFindings)
+	}
+	seenField := map[string]bool{}
+	for _, f := range allFindings {
+		seenField[f.Field] = true
+	}
+	for _, control := range []string{"iframe.sandbox", "blockId", FieldDocument, FieldProject} {
+		if !seenField[control] {
+			t.Errorf("positive control: the corpus never produced a finding with field %q, "+
+				"so a pass here says nothing about that shape of field", control)
+		}
+	}
+
+	// --- The actual assertion --------------------------------------------
+	for _, f := range allFindings {
+		if f.Field == "" {
+			t.Errorf("finding with an EMPTY field (issue #225 is back):\n  %s", f.Message)
+		}
+	}
+
+	// --- The reachability ledger -----------------------------------------
+	var missing []string
+	for fn, at := range want {
+		if !reached[fn] {
+			missing = append(missing, fn+" ("+at+")")
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("these finding-producing functions were never reached by the corpus, so this "+
+			"test proves nothing about them:\n  %s\n"+
+			"Add a fixture to fieldCoverageCorpus() that trips each one.",
+			strings.Join(missing, "\n  "))
+	}
+	// The mirror direction: a function reached but absent from the AST set would
+	// mean the scanner missed a construction site.
+	for fn := range reached {
+		if _, ok := want[fn]; !ok {
+			t.Errorf("the corpus reached finding-producer %q, which the AST scan did not find — "+
+				"the scanner is missing construction sites", fn)
+		}
+	}
+}
+
+// TestFindingFieldsUseOneNotation pins the SECONDARY defect of issue #225: the
+// three notations (`(root)`, JSON Pointer `/blockId`, dotted `iframe.sandbox`)
+// are unified on DOTTED.
+//
+// It asserts the negative — no field is a JSON Pointer — because that is the
+// notation that was actually there and would come back if schemaErrors were
+// reverted. Asserting only that dotted fields exist would stay green with both
+// notations present.
+func TestFindingFieldsUseOneNotation(t *testing.T) {
+	findingSiteHook = nil
+	var all []Finding
+	for _, fx := range fieldCoverageCorpus() {
+		dir := writeFixture(t, fx.files)
+		res, err := Dir(dir)
+		if err != nil {
+			t.Fatalf("%s: Dir: %v", fx.name, err)
+		}
+		all = append(all, res.Errors...)
+		all = append(all, res.Warnings...)
+	}
+	if len(all) == 0 {
+		t.Fatal("no findings to check the notation of")
+	}
+	sentinels := map[string]bool{FieldDocument: true, FieldProject: true}
+	var sawDotted, sawIndexed bool
+	for _, f := range all {
+		if sentinels[f.Field] {
+			continue
+		}
+		if strings.Contains(f.Field, "/") {
+			t.Errorf("field %q uses JSON Pointer notation; findings are unified on dotted "+
+				"paths (issue #225). Message: %s", f.Field, f.Message)
+		}
+		if strings.HasPrefix(f.Field, "(") {
+			t.Errorf("field %q looks like a sentinel but is not one of the two documented "+
+				"values (%q, %q)", f.Field, FieldDocument, FieldProject)
+		}
+		if strings.Contains(f.Field, ".") {
+			sawDotted = true
+		}
+		if strings.Contains(f.Field, "[") {
+			sawIndexed = true
+		}
+	}
+	// Positive control: the corpus really does contain both notation shapes, so
+	// the negative assertions above had something to be wrong about.
+	if !sawDotted {
+		t.Error("positive control: no nested (dotted) field in the corpus at all")
+	}
+	if !sawIndexed {
+		t.Error("positive control: no array-indexed field in the corpus at all")
+	}
+}
+
+// TestFieldPathRendersDottedPaths pins the schema-location renderer directly,
+// including the two shapes the JSON-Pointer version got wrong for a reader:
+// the root, and an array element.
+func TestFieldPathRendersDottedPaths(t *testing.T) {
+	cases := []struct {
+		tokens []string
+		want   string
+	}{
+		{nil, FieldDocument},
+		{[]string{}, FieldDocument},
+		{[]string{"blockId"}, "blockId"},
+		{[]string{"iframe", "sandbox"}, "iframe.sandbox"},
+		{[]string{"scopes", "1"}, "scopes[1]"},
+		{[]string{"targets", "0", "slotId"}, "targets[0].slotId"},
+		{[]string{"a", "10", "b", "2"}, "a[10].b[2]"},
+		// A member name that merely LOOKS numeric-adjacent is not an index.
+		{[]string{"v2"}, "v2"},
+		{[]string{"page", "1x"}, "page.1x"},
+	}
+	for _, tc := range cases {
+		if got := fieldPath(tc.tokens); got != tc.want {
+			t.Errorf("fieldPath(%v) = %q, want %q", tc.tokens, got, tc.want)
+		}
+	}
+}
+
+// TestDedupeFindingsKeysOnTheFieldMessagePAIR pins the semantics the string
+// dedupe could not have: the value being deduped grew a second axis, and
+// collapsing on either one alone loses real findings.
+//
+// It is not a restatement of the implementation — each case is a shape the
+// checks genuinely produce (scopeJustifications emits one message per key; an
+// iframe is routinely wrong in several ways at once).
+func TestDedupeFindingsKeysOnTheFieldMessagePAIR(t *testing.T) {
+	sameMsgDifferentFields := []Finding{
+		{Field: "scopeJustifications.a", Message: "unknown justification key"},
+		{Field: "scopeJustifications.b", Message: "unknown justification key"},
+	}
+	if got := dedupeFindings(sameMsgDifferentFields); len(got) != 2 {
+		t.Errorf("two findings with the same message and DIFFERENT fields must both survive, got %d: %v", len(got), got)
+	}
+
+	sameFieldDifferentMsgs := []Finding{
+		{Field: "iframe.sandbox", Message: "token not allowed"},
+		{Field: "iframe.sandbox", Message: "sandbox escape combination"},
+	}
+	if got := dedupeFindings(sameFieldDifferentMsgs); len(got) != 2 {
+		t.Errorf("two findings on the same field with DIFFERENT messages must both survive, got %d: %v", len(got), got)
+	}
+
+	exactDupes := []Finding{
+		{Field: "iframe.sandbox", Message: "token not allowed"},
+		{Field: "iframe.sandbox", Message: "token not allowed"},
+		{Field: "iframe.sandbox", Message: "token not allowed"},
+	}
+	got := dedupeFindings(exactDupes)
+	if len(got) != 1 {
+		t.Errorf("identical findings must collapse to one, got %d: %v", len(got), got)
+	}
+	if len(got) == 1 && got[0] != exactDupes[0] {
+		t.Errorf("dedupe kept the wrong value: %v", got[0])
+	}
+}
+
+// TestMessagesPreservesOrderAndText pins the text seam: the human-readable
+// renderers print Message and nothing else, so Messages must be a pure
+// projection. If this ever needed to compose Field into the line, the byte-for-
+// byte human output promise would be the thing that broke.
+func TestMessagesPreservesOrderAndText(t *testing.T) {
+	in := []Finding{
+		{Field: "b", Message: "second"},
+		{Field: "a", Message: "first"},
+	}
+	got := Messages(in)
+	if len(got) != 2 || got[0] != "second" || got[1] != "first" {
+		t.Errorf("Messages must project Message in order, got %v", got)
+	}
+	if len(Messages(nil)) != 0 {
+		t.Error("Messages(nil) must be empty")
+	}
+}
+
+func itoaTest(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// The corpus.
+// ---------------------------------------------------------------------------
+
+type fieldFixture struct {
+	name  string
+	files map[string]string
+}
+
+func writeFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// goodBase is a manifest that validates clean, used as the starting point for
+// fixtures that need exactly one thing wrong.
+const goodBase = `{
+  "blockId": "cov-block",
+  "name": "Coverage Block",
+  "version": "1.0.0",
+  "description": "a manifest used by the field-coverage corpus",
+  "author": "tester",
+  "contentRating": "g",
+  "renderMode": "iframe",
+  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false},
+  "entry": "index.html"
+}`
+
+// fieldCoverageCorpus returns one fixture per finding-producing site. It is the
+// input to the reachability ledger — if a check is added and no fixture here
+// trips it, TestEveryCheckEmitsAField names it.
+func fieldCoverageCorpus() []fieldFixture {
+	return []fieldFixture{
+		{
+			name:  "no manifest at all (validateDir, FieldDocument)",
+			files: map[string]string{"README.md": "nothing here"},
+		},
+		{
+			name:  "unparseable manifest (validateDir, FieldDocument)",
+			files: map[string]string{"block.manifest.json": `{"blockId": `},
+		},
+		{
+			name: "schema violations at the root and inside an array (schemaErrors)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "Bad_Id",
+			  "name": "x",
+			  "version": "1.0.0",
+			  "scopes": ["user:read:self", "totally-not-a-scope"],
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "server-owned fields set (serverOwnedFieldChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "server-owned fields",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "trustTier": "verified",
+			  "iframe": {"src": "https://example.com/x.html", "sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "buildCommand not on the allowlist, and no outputDir (buildCoherence)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "bad build command",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "buildCommand": "rm -rf /",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "outputDir escapes the project root, with no buildCommand (buildCoherence)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "stray outputDir",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "outputDir": "../escape",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "outputDir is absolute (buildCoherence)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "absolute outputDir",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "buildCommand": "npm run build",
+			  "outputDir": "/abs",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "buildCommand set with no outputDir (buildCoherence)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "build with no output",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "buildCommand": "npm run build",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "buildCommand over the length cap (buildCoherence)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "long build command",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "outputDir": "dist",
+			  "buildCommand": "npm run ` + strings.Repeat("x", 140) + `",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "renderMode tier gate, and no iframe block (semanticChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "inline render mode",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "renderMode": "inline"
+			}`},
+		},
+		{
+			name: "page without an iframe block (semanticChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "page without iframe",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "page": {"path": "/", "title": "App"}
+			}`},
+		},
+		{
+			name: "iframe missing minHeight and resizable (iframeRequiredFields)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "bare iframe",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "iframe": {"sandbox": "allow-scripts"}
+			}`},
+		},
+		{
+			name: "iframe minHeight above the ceiling (iframeRequiredFields)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "over-tall iframe",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 99999, "resizable": false}
+			}`},
+		},
+		{
+			name: "sandbox escape combination and a disallowed token (sandboxChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "bad sandbox",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "iframe": {"sandbox": "allow-same-origin allow-scripts allow-popups", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "sandbox is whitespace only (sandboxChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "empty sandbox",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "iframe": {"sandbox": "   ", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "justification for a scope that is not declared (scopeJustificationChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "stray justification",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "scopes": ["user:read:self"],
+			  "scopeJustifications": {"models:read:self": "not declared"},
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "sensitive scope with no justification (sensitiveScopeJustificationChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "unjustified sensitive scope",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "scopes": ["buzz:read:self"],
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "unknown slot and the page slot in targets (targetChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "bad targets",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "targets": [
+			    {"slotId": "model.not_a_real_slot"},
+			    {"slotId": "app.page"}
+			  ],
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "budgeted scope on a page with no per-gen budget (warningChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "budgeted page, no budget",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "scopes": ["ai:write:budgeted"],
+			  "scopeJustifications": {"ai:write:budgeted": "the app generates images for the viewer"},
+			  "page": {"path": "/", "title": "App"},
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "budgeted scope with no page at all (warningChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "budgeted, no page",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "scopes": ["ai:write:budgeted"],
+			  "scopeJustifications": {"ai:write:budgeted": "the app generates images for the viewer"},
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "inert budget: a per-gen budget with no budgeted scope (warningChecks)",
+			files: map[string]string{"block.manifest.json": `{
+			  "blockId": "cov-block",
+			  "name": "Coverage Block",
+			  "version": "1.0.0",
+			  "description": "inert budget",
+			  "author": "tester",
+			  "contentRating": "g",
+			  "page": {"path": "/", "title": "App", "buzzBudgetPerGen": 40},
+			  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false}
+			}`},
+		},
+		{
+			name: "package.json with no lockfile (lockfileChecks, hard error)",
+			files: map[string]string{
+				"block.manifest.json": goodBase,
+				"package.json":        `{"name":"cov-block","private":true}`,
+			},
+		},
+		{
+			name: "two lockfiles committed (lockfileChecks, advisory)",
+			files: map[string]string{
+				"block.manifest.json": goodBase,
+				"package.json":        `{"name":"cov-block","private":true}`,
+				"package-lock.json":   "{}\n",
+				"pnpm-lock.yaml":      "lockfileVersion: '9.0'\n",
+			},
+		},
+		{
+			name: "a page app whose source never posts the ready ack (readyAckChecks)",
+			files: map[string]string{
+				"block.manifest.json": `{
+				  "blockId": "cov-block",
+				  "name": "Coverage Block",
+				  "version": "1.0.0",
+				  "description": "page app with no ack",
+				  "author": "tester",
+				  "contentRating": "g",
+				  "page": {"path": "/", "title": "App"},
+				  "iframe": {"sandbox": "allow-scripts", "minHeight": 400, "resizable": false},
+				  "entry": "index.html"
+				}`,
+				"index.html": `<!doctype html><script src="./app.js"></script>`,
+				"app.js":     `document.title = 'hello';`,
+			},
+		},
+	}
+}

--- a/internal/validate/finding_contract_test.go
+++ b/internal/validate/finding_contract_test.go
@@ -31,6 +31,15 @@ import (
 // (A) cannot see a field computed to "" at runtime; (B) cannot see a check no
 // fixture reaches that (A) already rejected statically; (C) says nothing about
 // presence. Keep all three.
+//
+// 🔴 AND NONE OF THE THREE PINS THE FIELD'S VALUE — every one of them asks only
+// "non-empty / right notation". That is a fourth question, and it lives in
+// finding_fields_test.go, which exists because three mutants moving a field to a
+// WRONG BUT PLAUSIBLE value survived all of the above with the suite green.
+//
+// (A)'s own scanner is validated by TestFindingFunnelScannerSeesEveryLiteralSpelling,
+// because (A)'s green is a claim about the spellings it can SEE — and that claim
+// was false for the one spelling `gofmt -s` produces.
 
 // packageGoFiles returns the non-test .go files of this package.
 func packageGoFiles(t *testing.T) []string {
@@ -61,7 +70,10 @@ func packageGoFiles(t *testing.T) []string {
 // findingSite is one `newFinding(...)` call in the package source.
 type findingSite struct {
 	file string
-	fn   string // enclosing function, closures normalised to their parent
+	// fn is the enclosing function, closures normalised to their parent. It is
+	// EMPTY for a construction outside any function body (a package-level `var`
+	// initialiser), which Guard A rejects outright — see below.
+	fn   string
 	line int
 	// fieldIsEmptyLiteral is set when the first argument is a literal "" — the
 	// one shape a static check can call out with certainty.
@@ -86,55 +98,170 @@ func normaliseFuncName(name string) string {
 	return name
 }
 
+// findingLitDepth reports how many levels of COMPOSITE-LITERAL NESTING separate
+// a type expression from a `Finding` value:
+//
+//	Finding                            -> 0  (a literal of this type IS a Finding)
+//	*Finding                           -> 0  (`&Finding{…}` / an elided `{…}`)
+//	[]Finding / [3]Finding / map[k]Finding -> 1  (its ELEMENTS are Findings)
+//	[][]Finding                        -> 2
+//	anything else                      -> -1
+//
+// 🔴 THE DEPTH IS THE WHOLE POINT, AND IT IS WHY THE FIRST VERSION OF THIS GUARD
+// WAS DISARMED BY `make fmt`. An element written with its type elided —
+// `[]Finding{{Message: "x"}}` — is an `*ast.CompositeLit` whose `Type` is NIL, so
+// a scanner that asks the literal for its own type finds none and skips it. That
+// is not an exotic spelling: `gofmt -s` REWRITES the caught form
+// `[]Finding{Finding{…}}` into exactly that uncaught one, and this repo runs
+// `gofmt -s -w .` in `make fmt` and enforces `gofmt -s -l .` in CI. So the
+// repo's own formatter converted every literal the guard could see into one it
+// could not. The element type therefore has to come from the ENCLOSING literal,
+// which is what this depth carries.
+func findingLitDepth(t ast.Expr) int {
+	switch e := t.(type) {
+	case *ast.Ident:
+		if e.Name == "Finding" {
+			return 0
+		}
+	case *ast.StarExpr:
+		return findingLitDepth(e.X)
+	case *ast.ArrayType:
+		if d := findingLitDepth(e.Elt); d >= 0 {
+			return d + 1
+		}
+	case *ast.MapType:
+		if d := findingLitDepth(e.Value); d >= 0 {
+			return d + 1
+		}
+	}
+	return -1
+}
+
+// findingScan accumulates one package's worth of scan results.
+type findingScan struct {
+	t     *testing.T
+	fset  *token.FileSet
+	file  string
+	sites []findingSite
+	lits  []string
+	seen  map[string]bool
+}
+
+func (sc *findingScan) flagLit(pos token.Pos, what string) {
+	if sc.file == "finding.go" {
+		return // the one authority, where the literal is allowed to live
+	}
+	at := sc.fset.Position(pos).String()
+	if sc.seen[at] {
+		return
+	}
+	sc.seen[at] = true
+	sc.lits = append(sc.lits, at+" ("+what+")")
+}
+
+// checkComposite flags a composite literal that constructs Finding(s). depth is
+// the element depth of the CONTEXT the literal appears in (see findingLitDepth):
+// 0 means this literal is itself a Finding, >0 means its elements are.
+func (sc *findingScan) checkComposite(cl *ast.CompositeLit, depth int) {
+	if depth < 0 {
+		return
+	}
+	if depth == 0 {
+		what := "Finding{…} composite literal"
+		if cl.Type == nil {
+			what = "elided-type Finding literal `{…}` inside a []Finding/map literal — the form `gofmt -s` produces"
+		}
+		sc.flagLit(cl.Lbrace, what)
+		return
+	}
+	for _, el := range cl.Elts {
+		if kv, ok := el.(*ast.KeyValueExpr); ok {
+			el = kv.Value
+		}
+		inner, ok := el.(*ast.CompositeLit)
+		if !ok {
+			continue // a newFinding(...) call, an identifier, anything else
+		}
+		if inner.Type != nil {
+			continue // it names its own type; the walk visits it in its own right
+		}
+		sc.checkComposite(inner, depth-1)
+	}
+}
+
+// findingWalker carries the enclosing function name down the AST. It is a VALUE
+// so a nested func gets its own name without mutating the parent's.
+type findingWalker struct {
+	sc *findingScan
+	fn string // "" == not inside any function body
+}
+
+func (w findingWalker) Visit(n ast.Node) ast.Visitor {
+	switch v := n.(type) {
+	case *ast.FuncDecl:
+		// A method is named by its own identifier; the ledger normalises the
+		// runtime name to the same thing.
+		return findingWalker{sc: w.sc, fn: v.Name.Name}
+	case *ast.CompositeLit:
+		if v.Type != nil {
+			w.sc.checkComposite(v, findingLitDepth(v.Type))
+		}
+	case *ast.CallExpr:
+		id, ok := v.Fun.(*ast.Ident)
+		if !ok || id.Name != "newFinding" {
+			break
+		}
+		pos := w.sc.fset.Position(v.Lparen)
+		site := findingSite{file: w.sc.file, fn: w.fn, line: pos.Line}
+		if len(v.Args) == 0 {
+			w.sc.t.Errorf("%s:%d: newFinding called with no arguments", w.sc.file, pos.Line)
+			break
+		}
+		if lit, ok := v.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING &&
+			(lit.Value == `""` || lit.Value == "``") {
+			site.fieldIsEmptyLiteral = true
+		}
+		w.sc.sites = append(w.sc.sites, site)
+	}
+	return w
+}
+
+// scanFindingSource parses one file — from disk when src is nil, otherwise from
+// src — and returns its newFinding sites plus every Finding-constructing
+// composite literal in it.
+//
+// It is factored out of collectFindingSites so the scanner itself can be driven
+// by a CONTROL CORPUS of known-good and known-bad spellings
+// (TestFindingFunnelScannerSeesEveryLiteralSpelling). A funnel guard that cannot
+// be shown to go red on the spelling it exists to catch is a claim about the
+// guard, not about the package.
+func scanFindingSource(t *testing.T, fset *token.FileSet, name string, src any) ([]findingSite, []string) {
+	t.Helper()
+	f, err := parser.ParseFile(fset, name, src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+	sc := &findingScan{t: t, fset: fset, file: name, seen: map[string]bool{}}
+	ast.Walk(findingWalker{sc: sc}, f)
+	return sc.sites, sc.lits
+}
+
 // collectFindingSites parses the package and returns every newFinding call site,
-// plus every bare `Finding{...}` composite literal it finds (which must be
-// empty outside finding.go).
+// plus every composite literal that constructs a Finding (which must be none
+// outside finding.go).
+//
+// 🔴 IT WALKS THE WHOLE FILE, NOT ONLY `*ast.FuncDecl`s. An earlier version
+// iterated `f.Decls` and skipped everything that was not a function, so a
+// package-level `var x = newFinding("", …)` was invisible to BOTH guards: Guard
+// A never saw the empty field, and Guard B never listed it in the reachability
+// ledger. Such a site is now collected with an EMPTY `fn` and rejected by name.
 func collectFindingSites(t *testing.T) (sites []findingSite, compositeLits []string) {
 	t.Helper()
 	fset := token.NewFileSet()
 	for _, name := range packageGoFiles(t) {
-		f, err := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
-		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
-		}
-		// Track the enclosing top-level func for each node.
-		for _, decl := range f.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok {
-				continue
-			}
-			fnName := fd.Name.Name
-			ast.Inspect(fd, func(n ast.Node) bool {
-				switch v := n.(type) {
-				case *ast.CallExpr:
-					id, ok := v.Fun.(*ast.Ident)
-					if !ok || id.Name != "newFinding" {
-						return true
-					}
-					pos := fset.Position(v.Lparen)
-					site := findingSite{file: name, fn: fnName, line: pos.Line}
-					if len(v.Args) == 0 {
-						t.Errorf("%s:%d: newFinding called with no arguments", name, pos.Line)
-						return true
-					}
-					if lit, ok := v.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING &&
-						(lit.Value == `""` || lit.Value == "``") {
-						site.fieldIsEmptyLiteral = true
-					}
-					sites = append(sites, site)
-				case *ast.CompositeLit:
-					id, ok := v.Type.(*ast.Ident)
-					if !ok || id.Name != "Finding" {
-						return true
-					}
-					if name != "finding.go" {
-						compositeLits = append(compositeLits,
-							fset.Position(v.Lbrace).String())
-					}
-				}
-				return true
-			})
-		}
+		fileSites, fileLits := scanFindingSource(t, fset, name, nil)
+		sites = append(sites, fileSites...)
+		compositeLits = append(compositeLits, fileLits...)
 	}
 	return sites, compositeLits
 }
@@ -145,24 +272,52 @@ func collectFindingSites(t *testing.T) (sites []findingSite, compositeLits []str
 // field?". It fires at the construction site, in the source, so it does not
 // depend on anybody writing a fixture for the new check first.
 //
-// It enforces two properties:
+// It enforces three properties:
 //
-//  1. `Finding{...}` is never written as a composite literal outside finding.go.
-//     That is what makes newFinding the single funnel — a struct literal can
-//     omit Field and compile, and no amount of arguing about conventions stops
-//     the next one.
+//  1. No composite literal outside finding.go CONSTRUCTS a Finding — in ANY
+//     spelling. That is what makes newFinding the single funnel: a struct
+//     literal can omit Field and compile, and no amount of arguing about
+//     conventions stops the next one.
+//
+//     🔴 "IN ANY SPELLING" IS LOAD-BEARING, AND SAYING LESS THAN THAT IS HOW
+//     THIS GUARD WAS ONCE DISARMED BY `make fmt`. The first version matched
+//     only a literal that names its own type (`Finding{…}`), and `gofmt -s`
+//     rewrites `[]Finding{Finding{…}}` into the ELIDED `[]Finding{{…}}`, whose
+//     `Type` is nil — so the repo's own formatter, run by `make fmt` and
+//     enforced by CI's `gofmt -s -l .`, converted the one caught form into an
+//     uncaught one. Measured: a new check returning `[]Finding{{Message: …}}`
+//     with no Field, wired into the real pipeline and with NO corpus fixture,
+//     passed the entire suite. Do not narrow this back to a form; see
+//     findingLitDepth, and TestFindingFunnelScannerSeesEveryLiteralSpelling for
+//     the spellings both directions are pinned on.
+//
 //  2. No newFinding call passes an empty string literal as the field.
 //
+//  3. Every construction sits INSIDE a function, so Guard B's reachability
+//     ledger can attribute it. A package-level `var x = newFinding(…)` runs at
+//     init, before any test can install the hook, and was invisible to both
+//     guards.
+//
 // Residual, stated: a field computed to "" at runtime is invisible here. That is
-// what GUARD B covers.
+// what GUARD B covers. So is a Finding built without a literal at all (`var f
+// Finding; f.Message = …`), which no spelling-based funnel can see.
 func TestFindingsAreConstructedWithAField(t *testing.T) {
 	sites, compositeLits := collectFindingSites(t)
 
 	if len(compositeLits) > 0 {
-		t.Errorf("Finding{...} composite literal(s) outside finding.go at %v —\n"+
+		t.Errorf("Finding-constructing composite literal(s) outside finding.go at %v —\n"+
 			"every finding must be built by newFinding(field, message) so that "+
 			"\"does this check carry a field?\" is a question about one call. "+
 			"See finding.go and issue #225.", compositeLits)
+	}
+
+	for _, s := range sites {
+		if s.fn == "" {
+			t.Errorf("%s:%d: newFinding called OUTSIDE any function body (a package-level "+
+				"initialiser) — construct findings inside the check that reports them, or "+
+				"Guard B's reachability ledger cannot attribute them and the site is "+
+				"unobserved by every test in this file.", s.file, s.line)
+		}
 	}
 
 	// Positive control on the parser: this package HAS finding sites. A zero here
@@ -183,6 +338,141 @@ func TestFindingsAreConstructedWithAField(t *testing.T) {
 	}
 }
 
+// TestFindingFunnelScannerSeesEveryLiteralSpelling VALIDATES THE INSTRUMENT
+// Guard A reads its verdict from.
+//
+// 🔴 Guard A's green is a claim about the SPELLINGS ITS SCANNER CAN SEE, and
+// that claim was FALSE for the one spelling `gofmt -s` produces. So the scanner
+// is driven here against a corpus of synthetic sources with a known answer:
+// every literal form that constructs a Finding must be flagged, and the forms
+// that do not construct one must NOT be (a guard that flagged everything would
+// be equally useless and equally green on the real tree).
+//
+// The two rows that matter most are the gofmt PAIR: `[]Finding{Finding{…}}` is
+// what a person writes, `[]Finding{{…}}` is what `make fmt` leaves behind, and
+// the second is the form that shipped a fieldless finding past the whole suite.
+// If you ever change findingLitDepth or checkComposite, this table is the thing
+// that says whether you narrowed the guard.
+func TestFindingFunnelScannerSeesEveryLiteralSpelling(t *testing.T) {
+	const preamble = "package validate\n\ntype Finding struct{ Field, Message string }\n\nfunc newFinding(a, b string) Finding { panic(\"stub\") }\n"
+
+	cases := []struct {
+		name     string
+		body     string
+		wantLits int
+		// wantSites is the number of newFinding calls, and wantFnEmpty the
+		// number of them attributed to no function (a package-level init).
+		wantSites   int
+		wantFnEmpty int
+	}{
+		{
+			name:     "elided element in a []Finding literal (what `gofmt -s` produces)",
+			body:     "func c() []Finding { return []Finding{{Message: \"x\"}} }",
+			wantLits: 1,
+		},
+		{
+			name:     "explicitly typed element in a []Finding literal (what a person writes)",
+			body:     "func c() []Finding { return []Finding{Finding{Message: \"x\"}} }",
+			wantLits: 1,
+		},
+		{
+			name:     "bare Finding literal",
+			body:     "func c() Finding { return Finding{Field: \"a\"} }",
+			wantLits: 1,
+		},
+		{
+			name:     "address-of a Finding literal",
+			body:     "func c() *Finding { return &Finding{} }",
+			wantLits: 1,
+		},
+		{
+			name:     "elided element in a []*Finding literal",
+			body:     "func c() []*Finding { return []*Finding{{Message: \"x\"}} }",
+			wantLits: 1,
+		},
+		{
+			name:     "elided value in a map[string]Finding literal",
+			body:     "func c() map[string]Finding { return map[string]Finding{\"k\": {Message: \"x\"}} }",
+			wantLits: 1,
+		},
+		{
+			name:     "two elided elements are two literals",
+			body:     "func c() []Finding { return []Finding{{Message: \"a\"}, {Message: \"b\"}} }",
+			wantLits: 2,
+		},
+		{
+			name:     "elided element nested two deep",
+			body:     "func c() [][]Finding { return [][]Finding{{{Message: \"x\"}}} }",
+			wantLits: 1,
+		},
+		{
+			name:     "a var declaration is not a hiding place",
+			body:     "func c() { var f = []Finding{{Message: \"x\"}}; _ = f }",
+			wantLits: 1,
+		},
+		// --- the NEGATIVE side: these must NOT be flagged ------------------
+		{
+			name:      "the sanctioned funnel",
+			body:      "func c() []Finding { return []Finding{newFinding(\"a\", \"b\")} }",
+			wantSites: 1,
+		},
+		{
+			name: "an unrelated composite literal",
+			body: "func c() []string { return []string{\"x\"} }",
+		},
+		{
+			name:      "a struct that merely CONTAINS findings",
+			body:      "type R struct{ E []Finding }\n\nfunc c() R { return R{E: []Finding{newFinding(\"a\", \"b\")}} }",
+			wantSites: 1,
+		},
+		// --- attribution ---------------------------------------------------
+		{
+			name:      "a closure is attributed to its enclosing function",
+			body:      "func outer() []Finding { f := func() Finding { return newFinding(\"a\", \"b\") }; return []Finding{f()} }",
+			wantSites: 1,
+		},
+		{
+			name:      "a method is attributed to the method name",
+			body:      "type T struct{}\n\nfunc (T) m() Finding { return newFinding(\"a\", \"b\") }",
+			wantSites: 1,
+		},
+		{
+			name:        "a package-level initialiser is attributed to NO function",
+			body:        "var pkgLevel = newFinding(\"\", \"x\")",
+			wantSites:   1,
+			wantFnEmpty: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sites, lits := scanFindingSource(t, token.NewFileSet(), "subject.go", preamble+"\n"+tc.body+"\n")
+			if len(lits) != tc.wantLits {
+				t.Errorf("flagged %d Finding literal(s), want %d: %v", len(lits), tc.wantLits, lits)
+			}
+			if len(sites) != tc.wantSites {
+				t.Errorf("found %d newFinding site(s), want %d: %v", len(sites), tc.wantSites, sites)
+			}
+			var empty int
+			for _, s := range sites {
+				if s.fn == "" {
+					empty++
+				}
+			}
+			if empty != tc.wantFnEmpty {
+				t.Errorf("%d site(s) attributed to no function, want %d: %v", empty, tc.wantFnEmpty, sites)
+			}
+		})
+	}
+
+	// The file the funnel LIVES in is exempt, and that exemption must be
+	// file-scoped rather than global — otherwise the guard is off everywhere.
+	if _, lits := scanFindingSource(t, token.NewFileSet(), "finding.go",
+		preamble+"\nfunc c() []Finding { return []Finding{{Message: \"x\"}} }\n"); len(lits) != 0 {
+		t.Errorf("finding.go must be exempt from the funnel rule, got %v", lits)
+	}
+}
+
 // TestEveryCheckEmitsAField is GUARD B — behavioural, with a reachability
 // ledger.
 //
@@ -200,6 +490,13 @@ func TestEveryCheckEmitsAField(t *testing.T) {
 
 	want := map[string]string{} // funcName -> "file:line" of one of its sites
 	for _, s := range sites {
+		if s.fn == "" {
+			// A package-level construction. It has no enclosing function to
+			// reach, so it cannot enter the ledger; Guard A rejects it by name
+			// and line instead. Listing it here would only add a second,
+			// misleading "add a fixture" failure for the same defect.
+			continue
+		}
 		if _, ok := want[s.fn]; !ok {
 			want[s.fn] = s.file + ":" + itoaTest(s.line)
 		}

--- a/internal/validate/finding_fields_test.go
+++ b/internal/validate/finding_fields_test.go
@@ -1,0 +1,313 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+// finding_fields_test.go pins the VALUE of the field every check carries, not
+// merely that it carried one.
+//
+// 🔴 WHY THIS FILE EXISTS, stated because the gap it closes was invisible to a
+// full green suite AND to a mutation sweep. The three guards in
+// finding_contract_test.go and `TestValidateJSONEveryFindingCarriesAField` all
+// answer "is the field non-empty?"; only eight sites had their SPECIFIC field
+// asserted anywhere. The original sweep mutated a field to `""` or to JSON
+// Pointer — both of which those guards see — and never to a WRONG BUT PLAUSIBLE
+// value, which is the shape a real refactor produces. Three such mutants
+// survived the whole suite:
+//
+//   - buildCoherence's two pair rules INVERTED, so "buildCommand is set but
+//     outputDir is missing" reported `buildCommand`;
+//   - the budgeted-scope-no-page warning moved from `page` to `scopes`;
+//   - BOTH lockfile findings moved from `(project)` to `(root)` — the exact
+//     sentinel collapse AGENTS.md item 22 marks 🔴, because it sends a CI job
+//     looking in block.manifest.json for a missing lockfile.
+//
+// The ledger below is BIDIRECTIONAL, which is what makes it a gate rather than a
+// sample: every finding the corpus produces must match exactly ONE entry (a new
+// check with no entry fails), and every entry must match at least one finding (a
+// stale entry cannot sit there looking like coverage).
+//
+// 🔴 EACH `field` IS DERIVED FROM WHAT THE CHECK MEANS, NOT FROM WHAT THE CODE
+// DOES — that is what `why` records. Copying the value out of the implementation
+// would make this test a restatement of the thing it is supposed to constrain.
+
+// fieldExpectation is one finding the corpus produces, the field it MUST carry,
+// and the reason that field is the right one.
+type fieldExpectation struct {
+	// fragment identifies exactly one finding. It is matched with Contains
+	// against the message, and the test fails if it matches more than one
+	// distinct finding or none.
+	fragment string
+	field    string
+	why      string
+}
+
+// findingFieldLedger is the whole contract, one row per finding the corpus
+// produces. Ordered by the file that emits it.
+func findingFieldLedger() []fieldExpectation {
+	return []fieldExpectation{
+		// --- validate.go: the document itself ---------------------------
+		{"not found at project root", FieldDocument,
+			"there is no manifest, so no key inside one can be named"},
+		{"is not valid JSON", FieldDocument,
+			"the document did not decode; nothing inside it is addressable"},
+
+		// --- validate.go: schemaErrors ----------------------------------
+		{"(root): missing property 'contentRating'", FieldDocument,
+			"a missing top-level required property is located at the object that lacks it"},
+		{"(root): missing property 'scopes'", FieldDocument,
+			"same: the object is what is incomplete, not the absent key"},
+		{"(root): missing property 'outputDir'", FieldDocument,
+			"same, via the schema's buildCommand=>outputDir allOf"},
+		{"blockId: 'Bad_Id' does not match pattern", "blockId",
+			"the offending value is blockId's"},
+		{"scopes[1]: value must be one of", "scopes[1]",
+			"an array violation names the ELEMENT; `scopes` alone cannot point at a line"},
+		{"buildCommand: 'rm -rf /' does not match pattern", "buildCommand",
+			"the schema's pattern is on buildCommand's own value"},
+		{"buildCommand: maxLength", "buildCommand",
+			"the length constraint is on buildCommand's own value"},
+		{"outputDir: not failed", "outputDir",
+			"the schema locates this `not` violation at outputDir"},
+		{"iframe.minHeight: maximum", "iframe.minHeight",
+			"the range constraint is on iframe.minHeight's own value"},
+
+		// --- validate.go: serverOwnedFieldChecks ------------------------
+		{"trustTier is server-owned", "trustTier",
+			"the remedy is to delete this key; it is the key that must not be there"},
+		{"iframe.src is server-owned", "iframe.src",
+			"same, nested — the sub-key is what must be deleted, not the iframe block"},
+
+		// --- validate.go: buildCoherence --------------------------------
+		{"buildCommand is too long", "buildCommand",
+			"the rule reports on buildCommand's own length"},
+		{"is not an allowed build invocation", "buildCommand",
+			"the rule reports on buildCommand's own value"},
+		{"buildCommand is set but outputDir is missing", "outputDir",
+			"PAIR RULE: the finding names the MISSING side (AGENTS.md item 22) — " +
+				"buildCommand is correct as written; outputDir is the edit"},
+		{"outputDir is set but buildCommand is missing", "buildCommand",
+			"PAIR RULE, the mirror: outputDir is correct as written; buildCommand is the edit"},
+		{"must be a relative path under the project root", "outputDir",
+			"the rule reports on outputDir's own value"},
+		{"must not escape the project root", "outputDir",
+			"the rule reports on outputDir's own value"},
+
+		// --- semantic.go ------------------------------------------------
+		{"requires a verified/internal trust tier", "renderMode",
+			"the gate is on the renderMode value the author chose; trustTier is server-owned " +
+				"and not an edit the author can make"},
+		{"must also declare an iframe block", "iframe",
+			"PAIR RULE: `page` is set and correct; the missing side is the iframe block"},
+		{"iframe block is required for renderMode=iframe", "iframe",
+			"the missing block is the finding's subject"},
+		{"iframe.minHeight is required and must be a number", "iframe.minHeight",
+			"the required sub-field that is absent"},
+		{"iframe.minHeight must be a number in", "iframe.minHeight",
+			"the sub-field whose value is out of range"},
+		{"iframe.resizable is required and must be a boolean", "iframe.resizable",
+			"the required sub-field that is absent"},
+		{"iframe.sandbox must contain at least one token", "iframe.sandbox",
+			"the sandbox string's own content"},
+		{`sandbox token "allow-popups" is not allowed`, "iframe.sandbox",
+			"a disallowed token lives INSIDE the sandbox string; there is no finer location"},
+		{`sandbox token "allow-same-origin" is not allowed`, "iframe.sandbox",
+			"same — one finding per token, all on the one string that holds them"},
+		{"MUST NOT combine allow-same-origin with allow-scripts", "iframe.sandbox",
+			"the escape combo is an interaction of two TOKENS in one string value, " +
+				"not of two manifest fields"},
+		{"is not one of the manifest's declared scopes", "scopeJustifications.models:read:self",
+			"PER-KEY rule: the offending KEY, because `scopeJustifications` alone is " +
+				"useless on the only manifests where this fires more than once"},
+		{"sensitive scopes require a justification", "scopeJustifications",
+			"the map the author must ADD entries to. Not `scopes` — the declared scopes " +
+				"are correct — and not per-scope, because the server emits ONE message " +
+				"naming them all and this mirror is byte-identical on purpose"},
+
+		// --- targets.go -------------------------------------------------
+		{"is not a known slot", "targets[0].slotId",
+			"PER-ELEMENT rule: the index plus the sub-key, so a consumer can point at a line"},
+		{"is the page slot", "targets[1].slotId",
+			"same — and the two findings in this fixture must land on DIFFERENT fields"},
+
+		// --- warnings.go ------------------------------------------------
+		{"page.buzzBudgetPerGen is not set", "page.buzzBudgetPerGen",
+			"PAIR RULE: the budgeted scope is deliberate; the missing budget is the edit"},
+		{`but no "page" block is declared`, "page",
+			"PAIR RULE: the scope is deliberate; the missing `page` block is the edit. " +
+				"NOT `scopes` — that would tell the author to drop the scope they meant to declare"},
+		{"the budget is inert", "scopes",
+			"PAIR RULE, the mirror: the budget is deliberate; the missing scope is the edit"},
+
+		// --- lockfile.go ------------------------------------------------
+		{"package.json is present but no lockfile is committed", FieldProject,
+			"🔴 repository state, not a manifest key: the manifest can be byte-perfect " +
+				"and still trip this. `(root)` would send a CI job looking inside " +
+				"block.manifest.json for a file that is missing from the repo"},
+		{"more than one lockfile is committed", FieldProject,
+			"same: the finding is about which files are committed"},
+
+		// --- readyack.go ------------------------------------------------
+		{"nothing in this project's source posts BLOCK_READY", FieldProject,
+			"the finding is about what the browser loads. `page` is what makes the check " +
+				"APPLY and is the one field that is CORRECT — reporting it there would " +
+				"send a consumer to the wrong file entirely"},
+	}
+}
+
+// corpusFindings runs every fixture and returns the DISTINCT findings produced,
+// each with the fixture that produced it (for the failure message).
+func corpusFindings(t *testing.T) map[Finding]string {
+	t.Helper()
+	findingSiteHook = nil
+	out := map[Finding]string{}
+	for _, fx := range fieldCoverageCorpus() {
+		dir := writeFixture(t, fx.files)
+		res, err := Dir(dir)
+		if err != nil {
+			t.Fatalf("%s: Dir: %v", fx.name, err)
+		}
+		for _, f := range append(append([]Finding{}, res.Errors...), res.Warnings...) {
+			// The "no manifest" fixture interpolates a temp path; normalise so
+			// the distinct set is stable.
+			if _, ok := out[f]; !ok {
+				out[f] = fx.name
+			}
+		}
+	}
+	return out
+}
+
+// TestEveryFindingCarriesItsDocumentedField is the field-VALUE gate.
+//
+// It is deliberately bidirectional. A one-directional version — "for each entry,
+// find the finding and check it" — is what `TestValidateJSONSemanticChecksAreFieldTagged`
+// already does for eight sites, and it cannot see a check that has no entry:
+// that is precisely how fifteen sites went unpinned while the suite stayed green.
+func TestEveryFindingCarriesItsDocumentedField(t *testing.T) {
+	ledger := findingFieldLedger()
+	found := corpusFindings(t)
+
+	// Positive control on the harness. A ledger that matched nothing would report
+	// a serene pass in exactly the same shape as a correct one.
+	const minFindings = 30
+	if len(found) < minFindings {
+		t.Fatalf("the corpus produced only %d distinct findings, expected at least %d — "+
+			"the harness is not exercising the checks, and every assertion below is vacuous",
+			len(found), minFindings)
+	}
+	if len(ledger) < minFindings {
+		t.Fatalf("the ledger holds only %d entries, expected at least %d", len(ledger), minFindings)
+	}
+
+	matched := make([]int, len(ledger))
+	for f, fixture := range found {
+		var hits []int
+		for i, e := range ledger {
+			if strings.Contains(f.Message, e.fragment) {
+				hits = append(hits, i)
+			}
+		}
+		switch len(hits) {
+		case 0:
+			t.Errorf("this finding matches NO ledger entry, so its field is pinned by nothing:\n"+
+				"  fixture: %s\n  field:   %q\n  message: %s\n"+
+				"Add a row to findingFieldLedger() naming the field this check must carry "+
+				"and WHY that is the right field — derived from what the check means, not "+
+				"from what the code currently does.", fixture, f.Field, f.Message)
+			continue
+		case 1:
+			// The intended case.
+		default:
+			var frags []string
+			for _, i := range hits {
+				frags = append(frags, ledger[i].fragment)
+			}
+			t.Errorf("finding %q matches %d ledger entries (%v) — the fragments are ambiguous, "+
+				"so one entry could shadow another and go untested. Make them distinguishing.",
+				f.Message, len(hits), frags)
+			continue
+		}
+		e := ledger[hits[0]]
+		matched[hits[0]]++
+		if f.Field != e.field {
+			t.Errorf("WRONG FIELD.\n  finding:  %s\n  fixture:  %s\n  carries:  %q\n  must be: %q\n  because:  %s",
+				f.Message, fixture, f.Field, e.field, e.why)
+		}
+	}
+
+	for i, e := range ledger {
+		if matched[i] == 0 {
+			t.Errorf("ledger entry %q matched NO finding — it is stale (the check changed its "+
+				"message or was deleted), so it has been asserting nothing.", e.fragment)
+		}
+	}
+}
+
+// TestPairRuleNamesTheMissingField pins the CONVENTION AGENTS.md item 22 states
+// as a contract and nothing asserted: "for an 'X is set but Y is missing' pair
+// rule the field is **Y** (the missing one)".
+//
+// It is separate from the ledger above on purpose. The ledger says WHAT each
+// field is; this says WHY that set of values is not arbitrary, and it is the
+// test that fails with the right explanation when someone flips a pair. Four
+// pair rules exist across two files, and an inversion of any of them is a
+// plausible-looking refactor that changes nothing else observable.
+func TestPairRuleNamesTheMissingField(t *testing.T) {
+	pairs := []struct {
+		fragment string
+		present  string // the field whose PRESENCE triggered the rule
+		missing  string // the field whose ABSENCE the rule reports — the expected Field
+	}{
+		{"buildCommand is set but outputDir is missing", "buildCommand", "outputDir"},
+		{"outputDir is set but buildCommand is missing", "outputDir", "buildCommand"},
+		{`but no "page" block is declared`, "scopes", "page"},
+		{"the budget is inert", "page.buzzBudgetPerGen", "scopes"},
+		{"page.buzzBudgetPerGen is not set", "scopes", "page.buzzBudgetPerGen"},
+		{"must also declare an iframe block", "page", "iframe"},
+	}
+
+	found := corpusFindings(t)
+	for _, p := range pairs {
+		if p.present == p.missing {
+			t.Fatalf("pair %q names the same field on both sides — the assertion below would be vacuous", p.fragment)
+		}
+		var hits int
+		for f := range found {
+			if !strings.Contains(f.Message, p.fragment) {
+				continue
+			}
+			hits++
+			// The rule really is ABOUT both fields — otherwise "name the missing
+			// one" is a claim about a pair that does not exist.
+			for _, name := range []string{p.present, p.missing} {
+				if !strings.Contains(f.Message, lastSegment(name)) {
+					t.Errorf("pair rule %q does not mention %q in its message, so it is not the "+
+						"pair this test claims it is:\n  %s", p.fragment, name, f.Message)
+				}
+			}
+			if f.Field != p.missing {
+				t.Errorf("PAIR RULE INVERTED: %q reports field %q.\n"+
+					"  %q is the side that is SET and correct; %q is the side that is MISSING "+
+					"and is the edit that resolves the finding. AGENTS.md item 22: the field is "+
+					"the missing one.\n  %s", p.fragment, f.Field, p.present, p.missing, f.Message)
+			}
+		}
+		if hits != 1 {
+			t.Errorf("the corpus produced %d findings matching %q, want exactly 1 — this test "+
+				"is not checking what it claims to", hits, p.fragment)
+		}
+	}
+}
+
+// lastSegment returns the member name of a dotted path ("page.buzzBudgetPerGen"
+// -> "buzzBudgetPerGen"), which is how the prose messages spell a nested field
+// when they do not spell the whole path.
+func lastSegment(field string) string {
+	if i := strings.LastIndex(field, "."); i >= 0 {
+		return field[i+1:]
+	}
+	return field
+}

--- a/internal/validate/lockfile.go
+++ b/internal/validate/lockfile.go
@@ -107,7 +107,14 @@ func packageManagerFor(buildCommand string) packageManager {
 
 // lockfileChecks reports the lockfile ↔ buildCommand inconsistencies for the
 // project in dir. Hard errors are returned first, advisories second.
-func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []string) {
+//
+// FIELD: FieldProject on both. These are findings about a FILE that is or is
+// not committed, not about a manifest key — the manifest can be byte-perfect
+// and still trip them. `buildCommand` appears in the remedy (one way out is to
+// set it to match the lockfile you already have) but the other way out touches
+// no manifest field at all, so pinning the finding there would mis-group every
+// project that runs the install instead.
+func lockfileChecks(dir string, m *manifest.Manifest) (errs []Finding, warns []Finding) {
 	// A block with no package.json is STATIC: the recipe's `if [ -f package.json ]`
 	// guard is false, it never installs anything, and the bundle is served as-is.
 	// Never flag it.
@@ -140,7 +147,7 @@ func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []st
 	}
 
 	if !haveWanted {
-		return []string{missingLockfileError(want, foreign, build)}, nil
+		return []Finding{newFinding(FieldProject, missingLockfileError(want, foreign, build))}, nil
 	}
 	// The required lockfile IS there, so the build installs strictly and
 	// reproducibly — any extra lockfile is unused by the platform. That is not
@@ -148,7 +155,7 @@ func lockfileChecks(dir string, m *manifest.Manifest) (errs []string, warns []st
 	// an unused lockfile drifts, and the next contributor who runs the other
 	// package manager lands right back in the mismatch above.
 	if len(foreign) > 0 {
-		warns = append(warns, extraLockfileWarning(want, committed, build))
+		warns = append(warns, newFinding(FieldProject, extraLockfileWarning(want, committed, build)))
 	}
 	return nil, warns
 }

--- a/internal/validate/lockfile_test.go
+++ b/internal/validate/lockfile_test.go
@@ -48,8 +48,8 @@ func project(t *testing.T, manifestJSON string, files map[string]string) Result 
 func lockErrors(res Result) []string {
 	var out []string
 	for _, e := range res.Errors {
-		if strings.Contains(e, "lockfile") || strings.Contains(e, "-lock.") {
-			out = append(out, e)
+		if strings.Contains(e.Message, "lockfile") || strings.Contains(e.Message, "-lock.") {
+			out = append(out, e.Message)
 		}
 	}
 	return out
@@ -407,7 +407,7 @@ func TestLockfileMultipleWithRequiredPresentIsWarning(t *testing.T) {
 	if !res.HasWarnings() {
 		t.Fatal("extra lockfiles should raise an advisory")
 	}
-	joined := strings.Join(res.Warnings, "\n")
+	joined := strings.Join(Messages(res.Warnings), "\n")
 	for _, want := range []string{"more than one lockfile is committed", "package-lock.json and pnpm-lock.yaml", "installs only from package-lock.json"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("warning missing %q:\n%s", want, joined)

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -178,7 +178,12 @@ const maxAckGraphFiles = 200
 // NOT in warningChecks: warningChecks is reached under ManifestOnly, which
 // `civitai app init` uses to self-check the template it just wrote, and a check
 // that reads `src/` has no business running there.
-func readyAckChecks(dir string, generic any) []string {
+//
+// FIELD: FieldProject on every tier. The manifest's `page` is what makes the
+// check APPLY, but the finding is about what the browser loads — the remedy is
+// two edits in source files and the manifest is not one of them. Reporting it
+// against `page` would send a consumer to the one field that is correct.
+func readyAckChecks(dir string, generic any) []Finding {
 	if !declaresPage(generic) {
 		return nil
 	}
@@ -206,16 +211,16 @@ func readyAckChecks(dir string, generic any) []string {
 		}
 		// Reachability tier: nothing the browser loads posts the message.
 		if tree == ackFound {
-			return []string{readyAckAdviceUnwired}
+			return []Finding{newFinding(FieldProject, readyAckAdviceUnwired)}
 		}
-		return []string{readyAckAdviceMissing}
+		return []Finding{newFinding(FieldProject, readyAckAdviceMissing)}
 	}
 
 	// Presence tier: wiring is undecidable for this project shape.
 	if tree == ackFound {
 		return nil
 	}
-	return []string{readyAckAdvicePresenceOnly}
+	return []Finding{newFinding(FieldProject, readyAckAdvicePresenceOnly)}
 }
 
 // resolveLoadedFiles walks the entry graph and reports whether any file the

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -94,7 +94,7 @@ func hasReadyAckWarning(res Result) bool { return readyAckKind(res) != "" }
 // readyAckKind names the tier that fired, or "".
 func readyAckKind(res Result) string {
 	for _, w := range res.Warnings {
-		switch w {
+		switch w.Message {
 		case readyAckAdviceUnwired:
 			return "unwired"
 		case readyAckAdviceMissing:
@@ -968,7 +968,7 @@ func TestReadyAckIsAdvisoryOnly(t *testing.T) {
 	res := wantAckWarning(t, dir, true)
 	for _, e := range res.Errors {
 		for _, advice := range readyAckAdvisories {
-			if e == advice {
+			if e.Message == advice {
 				t.Fatalf("a ready-ack advisory reached Errors — it must stay a warning")
 			}
 		}

--- a/internal/validate/semantic.go
+++ b/internal/validate/semantic.go
@@ -40,12 +40,22 @@ const (
 
 // semanticChecks runs the ported BlockManifestValidator semantic rules over the
 // decoded manifest map.
-func semanticChecks(generic any) []string {
+//
+// 🔴 EVERY finding here carries a Field, and that is the whole point of issue
+// #225: these are the checks the JSON Schema cannot express, so they are the
+// ones `--json` exists to surface — and they were also the four that came back
+// `field: null`, because their messages are prose with no parseable path
+// prefix. A field derived at the printer could never have worked for them.
+//
+// FIELD ASSIGNMENT: a finding names the manifest location it is ABOUT — the
+// field whose presence, absence, or value the rule reports on. For an
+// "X requires Y" rule that is Y, the thing that must appear.
+func semanticChecks(generic any) []Finding {
 	m, ok := generic.(map[string]any)
 	if !ok {
 		return nil
 	}
-	var errs []string
+	var errs []Finding
 
 	// renderMode defaults to "iframe" (validator ~L280).
 	renderMode := "iframe"
@@ -58,9 +68,9 @@ func semanticChecks(generic any) []string {
 	// always rejected. The schema can't express this (it's a cross-field gate
 	// on the server-owned trustTier).
 	if renderMode == "inline" || renderMode == "hybrid" {
-		errs = append(errs, fmt.Sprintf(
+		errs = append(errs, newFinding("renderMode", fmt.Sprintf(
 			"renderMode %q requires a verified/internal trust tier (INLINE_REQUIRES_VERIFIED_TIER); "+
-				"a submitted block is always unverified, so use renderMode \"iframe\"", renderMode))
+				"a submitted block is always unverified, so use renderMode \"iframe\"", renderMode)))
 	}
 
 	iframe, hasIframe := m["iframe"].(map[string]any)
@@ -69,12 +79,13 @@ func semanticChecks(generic any) []string {
 	// page ⇒ iframe required (validator ~L504): a manifest declaring a page
 	// must also ship an iframe block (the bundle the page mounts).
 	if hasPage && !hasIframe {
-		errs = append(errs, "a manifest declaring \"page\" must also declare an iframe block (the bundle the page mounts)")
+		errs = append(errs, newFinding("iframe",
+			"a manifest declaring \"page\" must also declare an iframe block (the bundle the page mounts)"))
 	}
 
 	// renderMode=iframe ⇒ iframe block required (validator ~L375-377).
 	if renderMode == "iframe" && !hasIframe {
-		errs = append(errs, "iframe block is required for renderMode=iframe")
+		errs = append(errs, newFinding("iframe", "iframe block is required for renderMode=iframe"))
 	}
 
 	// iframe required sub-fields when an iframe block is present (validator
@@ -162,15 +173,20 @@ func unjustifiedSensitiveScopes(generic map[string]any) []string {
 // sensitiveScopeJustificationChecks emits ONE hard error naming every declared
 // sensitive scope that lacks a non-empty justification, using the server's exact
 // message so the local failure is byte-identical to the submit-time 400.
-func sensitiveScopeJustificationChecks(generic map[string]any) []string {
+//
+// FIELD: `scopeJustifications` — the map the author must add entries to. Not
+// `scopes` (the declared scopes are correct; it is the justifications that are
+// missing) and not one entry per scope (the server emits ONE message naming
+// them all, and the mirror is byte-identical on purpose).
+func sensitiveScopeJustificationChecks(generic map[string]any) []Finding {
 	unjustified := unjustifiedSensitiveScopes(generic)
 	if len(unjustified) == 0 {
 		return nil
 	}
-	return []string{
-		"sensitive scopes require a justification — add a non-empty scopeJustifications entry for: " +
+	return []Finding{newFinding("scopeJustifications",
+		"sensitive scopes require a justification — add a non-empty scopeJustifications entry for: "+
 			strings.Join(unjustified, ", "),
-	}
+	)}
 }
 
 // scopeJustificationChecks enforces that every key in scopeJustifications is a
@@ -180,7 +196,12 @@ func sensitiveScopeJustificationChecks(generic map[string]any) []string {
 // ONLY the keys⊆scopes rule the schema cannot express. Absent map or empty map
 // yields no error (backward-compatible). Scope names are canonical lowercase, so
 // the comparison is an exact match with no case-folding (mirroring the server).
-func scopeJustificationChecks(generic map[string]any) []string {
+//
+// FIELD: `scopeJustifications.<key>` — ONE finding per offending key, each
+// naming that key. This is the check whose findings would collapse into each
+// other if the message ever stopped interpolating the key, which is why
+// dedupeFindings keys on the (field, message) PAIR rather than the message.
+func scopeJustificationChecks(generic map[string]any) []Finding {
 	just, ok := generic["scopeJustifications"].(map[string]any)
 	if !ok || len(just) == 0 {
 		// Absent, wrong-typed (schema-handled), or empty → nothing to check.
@@ -195,11 +216,11 @@ func scopeJustificationChecks(generic map[string]any) []string {
 	}
 	sort.Strings(keys)
 
-	var errs []string
+	var errs []Finding
 	for _, key := range keys {
 		if _, declared := scopes[key]; !declared {
-			errs = append(errs, fmt.Sprintf(
-				"scopeJustifications key %q is not one of the manifest's declared scopes", key))
+			errs = append(errs, newFinding(childField("scopeJustifications", key), fmt.Sprintf(
+				"scopeJustifications key %q is not one of the manifest's declared scopes", key)))
 		}
 	}
 	return errs
@@ -209,22 +230,24 @@ func scopeJustificationChecks(generic map[string]any) []string {
 // resizable on a present iframe block (validator ~L387-415). Range bounds when
 // present are already covered by the JSON Schema; here we add the required-ness
 // the schema omits, with the same bounds for a clear single message.
-func iframeRequiredFields(iframe map[string]any) []string {
-	var errs []string
+func iframeRequiredFields(iframe map[string]any) []Finding {
+	var errs []Finding
 
+	minHeightField := childField("iframe", "minHeight")
 	mh, ok := iframe["minHeight"]
 	if !ok {
-		errs = append(errs, fmt.Sprintf(
-			"iframe.minHeight is required and must be a number in [%d, %d]", heightMinFloor, heightMaxCeiling))
+		errs = append(errs, newFinding(minHeightField, fmt.Sprintf(
+			"iframe.minHeight is required and must be a number in [%d, %d]", heightMinFloor, heightMaxCeiling)))
 	} else if n, isNum := toNumber(mh); !isNum || n < heightMinFloor || n > heightMaxCeiling {
-		errs = append(errs, fmt.Sprintf(
-			"iframe.minHeight must be a number in [%d, %d]", heightMinFloor, heightMaxCeiling))
+		errs = append(errs, newFinding(minHeightField, fmt.Sprintf(
+			"iframe.minHeight must be a number in [%d, %d]", heightMinFloor, heightMaxCeiling)))
 	}
 
+	resizableField := childField("iframe", "resizable")
 	if rz, ok := iframe["resizable"]; !ok {
-		errs = append(errs, "iframe.resizable is required and must be a boolean")
+		errs = append(errs, newFinding(resizableField, "iframe.resizable is required and must be a boolean"))
 	} else if _, isBool := rz.(bool); !isBool {
-		errs = append(errs, "iframe.resizable must be a boolean")
+		errs = append(errs, newFinding(resizableField, "iframe.resizable must be a boolean"))
 	}
 
 	return errs
@@ -234,7 +257,12 @@ func iframeRequiredFields(iframe map[string]any) []string {
 // tier — the only tier a submitted block can hold. Any token outside the
 // unverified allowlist is rejected, and the allow-same-origin + allow-scripts
 // sandbox-escape combo is rejected explicitly (defense in depth).
-func sandboxChecks(iframe map[string]any) []string {
+//
+// FIELD: `iframe.sandbox` on every finding — including the sandbox-escape combo
+// rule, which is genuinely about the interaction of two TOKENS inside one
+// string value rather than about two fields, so the string is the location.
+func sandboxChecks(iframe map[string]any) []Finding {
+	sandboxField := childField("iframe", "sandbox")
 	raw, ok := iframe["sandbox"]
 	if !ok {
 		// sandbox required-ness / type is handled by the schema (minLength 1).
@@ -248,10 +276,10 @@ func sandboxChecks(iframe map[string]any) []string {
 
 	tokens := strings.Fields(sandbox)
 	if len(tokens) == 0 {
-		return []string{"iframe.sandbox must contain at least one token"}
+		return []Finding{newFinding(sandboxField, "iframe.sandbox must contain at least one token")}
 	}
 
-	var errs []string
+	var errs []Finding
 	seen := make(map[string]struct{}, len(tokens))
 	// Iterate deterministically over deduped tokens so error order is stable.
 	var order []string
@@ -264,10 +292,10 @@ func sandboxChecks(iframe map[string]any) []string {
 	}
 	for _, tok := range order {
 		if _, allowed := sandboxUnverifiedAllowlist[tok]; !allowed {
-			errs = append(errs, fmt.Sprintf(
+			errs = append(errs, newFinding(sandboxField, fmt.Sprintf(
 				"sandbox token %q is not allowed for unverified blocks "+
 					"(trustTier is server-forced to unverified at submit; "+
-					"only allow-scripts and allow-forms are permitted)", tok))
+					"only allow-scripts and allow-forms are permitted)", tok)))
 		}
 	}
 
@@ -276,9 +304,9 @@ func sandboxChecks(iframe map[string]any) []string {
 	_, hasSameOrigin := seen["allow-same-origin"]
 	_, hasScripts := seen["allow-scripts"]
 	if hasSameOrigin && hasScripts {
-		errs = append(errs,
+		errs = append(errs, newFinding(sandboxField,
 			"iframe.sandbox MUST NOT combine allow-same-origin with allow-scripts (sandbox escape) — "+
-				"forbidden outside the internal trust tier")
+				"forbidden outside the internal trust tier"))
 	}
 
 	return errs

--- a/internal/validate/semantic_test.go
+++ b/internal/validate/semantic_test.go
@@ -50,7 +50,7 @@ func TestUnknownSlotErrorEnumeratesKnownSlots(t *testing.T) {
 	if len(errs) != 1 {
 		t.Fatalf("want exactly 1 error, got %d: %v", len(errs), errs)
 	}
-	got := errs[0]
+	got := errs[0].Message
 	if !strings.Contains(got, "value must be one of ") {
 		t.Errorf("error missing the enum phrasing: %q", got)
 	}
@@ -165,8 +165,8 @@ func TestScopeJustificationChecks(t *testing.T) {
 				t.Fatalf("got %d errors %v, want %d %v", len(got), got, len(tc.want), tc.want)
 			}
 			for i := range tc.want {
-				if got[i] != tc.want[i] {
-					t.Errorf("error[%d] = %q, want %q", i, got[i], tc.want[i])
+				if got[i].Message != tc.want[i] {
+					t.Errorf("error[%d] = %q, want %q", i, got[i].Message, tc.want[i])
 				}
 			}
 		})
@@ -273,8 +273,8 @@ func TestSensitiveScopeJustificationChecks(t *testing.T) {
 				t.Fatalf("got %d errors %v, want %d %v", len(got), got, len(tc.want), tc.want)
 			}
 			for i := range tc.want {
-				if got[i] != tc.want[i] {
-					t.Errorf("error[%d] = %q, want %q", i, got[i], tc.want[i])
+				if got[i].Message != tc.want[i] {
+					t.Errorf("error[%d] = %q, want %q", i, got[i].Message, tc.want[i])
 				}
 			}
 		})

--- a/internal/validate/targets.go
+++ b/internal/validate/targets.go
@@ -54,7 +54,12 @@ func knownSlotIDList() string {
 // (array of objects with a non-empty string slotId, ≤16 entries) is already
 // enforced by the JSON Schema; here we add the registry-membership + page-slot
 // semantic the schema cannot express.
-func targetChecks(generic any) []string {
+//
+// FIELD: `targets[i].slotId`, carrying the ELEMENT INDEX. `targets` alone would
+// be useless on a manifest with several targets — which is the only shape where
+// this check fires more than once — and the index is exactly what a consumer
+// grouping findings needs in order to point at a line.
+func targetChecks(generic any) []Finding {
 	m, ok := generic.(map[string]any)
 	if !ok {
 		return nil
@@ -69,8 +74,8 @@ func targetChecks(generic any) []string {
 		return nil
 	}
 
-	var errs []string
-	for _, t := range arr {
+	var errs []Finding
+	for i, t := range arr {
 		obj, ok := t.(map[string]any)
 		if !ok {
 			continue // shape handled by the schema.
@@ -79,14 +84,15 @@ func targetChecks(generic any) []string {
 		if !ok || slotID == "" {
 			continue // shape handled by the schema.
 		}
+		field := childField(indexField("targets", i), "slotId")
 		if !isKnownSlotID(slotID) {
-			errs = append(errs, fmt.Sprintf(
-				"target slotId %q is not a known slot — value must be one of %s", slotID, knownSlotIDList()))
+			errs = append(errs, newFinding(field, fmt.Sprintf(
+				"target slotId %q is not a known slot — value must be one of %s", slotID, knownSlotIDList())))
 			continue
 		}
 		if isPageSlotID(slotID) {
-			errs = append(errs, fmt.Sprintf(
-				"target slotId %q is the page slot — declare a full page via the \"page\" field, not targets", slotID))
+			errs = append(errs, newFinding(field, fmt.Sprintf(
+				"target slotId %q is the page slot — declare a full page via the \"page\" field, not targets", slotID)))
 		}
 	}
 	return errs

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 
 	cli "github.com/civitai/cli"
@@ -34,14 +33,19 @@ const buildCommandMaxLength = 128
 var printer = message.NewPrinter(language.English)
 
 // Result is the outcome of validating a project directory.
+//
+// Both slices hold Findings — a field PLUS a message — rather than bare
+// strings. See finding.go for why (issue #225): the field has to be carried
+// from where a finding is produced, because it cannot be recovered from prose
+// afterwards.
 type Result struct {
 	// Errors are hard failures: the server will reject the manifest. Non-empty
 	// Errors means validation failed.
-	Errors []string
+	Errors []Finding
 	// Warnings are non-fatal money-path / footgun advisories the schema can't
 	// express as hard errors (e.g. a budgeted page with no per-gen budget).
 	// They do not fail validation unless --strict is requested.
-	Warnings []string
+	Warnings []Finding
 }
 
 // OK reports whether validation passed (no hard errors).
@@ -93,20 +97,22 @@ func ManifestOnly(dir string) (Result, error) { return validateDir(dir, false) }
 func validateDir(dir string, projectState bool) (Result, error) {
 	var res Result
 
-	// Structural: manifest must exist at the project root.
+	// Structural: manifest must exist at the project root. There is no manifest
+	// to name a field IN, so this is a document-level finding.
 	if _, err := os.Stat(manifest.Path(dir)); err != nil {
 		if os.IsNotExist(err) {
-			return Result{Errors: []string{
+			return Result{Errors: []Finding{newFinding(FieldDocument,
 				fmt.Sprintf("%s not found at project root %s", manifest.Filename, dir),
-			}}, nil
+			)}}, nil
 		}
 		return res, err
 	}
 
 	generic, m, err := manifest.LoadRaw(dir)
 	if err != nil {
-		// A parse error is a validation failure, not a CLI error.
-		return Result{Errors: []string{err.Error()}}, nil
+		// A parse error is a validation failure, not a CLI error. The document
+		// did not decode, so no field inside it can be named.
+		return Result{Errors: []Finding{newFinding(FieldDocument, err.Error())}}, nil
 	}
 
 	// Schema validation.
@@ -160,34 +166,44 @@ func validateDir(dir string, projectState bool) (Result, error) {
 	// caller opts into --strict.
 	res.Warnings = append(res.Warnings, warningChecks(generic)...)
 
-	sort.Strings(res.Errors)
-	res.Errors = dedupe(res.Errors)
-	sort.Strings(res.Warnings)
-	res.Warnings = dedupe(res.Warnings)
+	sortFindings(res.Errors)
+	res.Errors = dedupeFindings(res.Errors)
+	sortFindings(res.Warnings)
+	res.Warnings = dedupeFindings(res.Warnings)
 	return res, nil
 }
 
 // serverOwnedFieldChecks rejects manifest fields the platform assigns. Devs
 // must not set them; doing so is a hard error with a clear, actionable message.
-func serverOwnedFieldChecks(generic any) []string {
-	var errs []string
+func serverOwnedFieldChecks(generic any) []Finding {
+	var errs []Finding
 	m, ok := generic.(map[string]any)
 	if !ok {
 		return nil
 	}
 	if _, set := m["trustTier"]; set {
-		errs = append(errs, "trustTier is server-owned — remove it from your manifest; the platform assigns the trust tier during review")
+		errs = append(errs, newFinding("trustTier",
+			"trustTier is server-owned — remove it from your manifest; the platform assigns the trust tier during review"))
 	}
 	if iframe, ok := m["iframe"].(map[string]any); ok {
 		if _, set := iframe["src"]; set {
-			errs = append(errs, "iframe.src is server-owned — remove it; the platform stamps the canonical bundle URL during build/approve")
+			errs = append(errs, newFinding(childField("iframe", "src"),
+				"iframe.src is server-owned — remove it; the platform stamps the canonical bundle URL during build/approve"))
 		}
 	}
 	return errs
 }
 
-func buildCoherence(dir string, m *manifest.Manifest) []string {
-	var errs []string
+// buildCoherence checks buildCommand/outputDir.
+//
+// FIELD ASSIGNMENT for the two PAIR rules: the finding names the field the
+// message reports as MISSING, not the one whose presence triggered the rule.
+// "buildCommand is set but outputDir is missing" is a finding about
+// `outputDir`; its mirror is a finding about `buildCommand`. That is mechanical
+// (it reads straight off the sentence), symmetric across the pair, and it puts
+// the finding on the field a consumer would have to edit.
+func buildCoherence(dir string, m *manifest.Manifest) []Finding {
+	var errs []Finding
 	build := strings.TrimSpace(m.BuildCommand)
 	hasBuild := build != ""
 	out := strings.TrimSpace(m.OutputDir)
@@ -200,19 +216,19 @@ func buildCoherence(dir string, m *manifest.Manifest) []string {
 	// BUILD_COMMAND_RE / BUILD_COMMAND_MAX_LENGTH exactly.
 	if hasBuild {
 		if len(build) > buildCommandMaxLength {
-			errs = append(errs, fmt.Sprintf("buildCommand is too long (%d chars) — it must be at most %d characters", len(build), buildCommandMaxLength))
+			errs = append(errs, newFinding("buildCommand", fmt.Sprintf("buildCommand is too long (%d chars) — it must be at most %d characters", len(build), buildCommandMaxLength)))
 		} else if !buildCommandRe.MatchString(build) {
-			errs = append(errs, fmt.Sprintf("buildCommand %q is not an allowed build invocation — use \"npm run <script>\", \"pnpm run <script>\", \"yarn run <script>\", \"vite build\", or \"npx vite build\"", build))
+			errs = append(errs, newFinding("buildCommand", fmt.Sprintf("buildCommand %q is not an allowed build invocation — use \"npm run <script>\", \"pnpm run <script>\", \"yarn run <script>\", \"vite build\", or \"npx vite build\"", build)))
 		}
 	}
 
 	switch {
 	case hasBuild && !hasOut:
-		errs = append(errs, "buildCommand is set but outputDir is missing — the platform needs to know where the build output lands (e.g. \"dist\")")
+		errs = append(errs, newFinding("outputDir", "buildCommand is set but outputDir is missing — the platform needs to know where the build output lands (e.g. \"dist\")"))
 	case !hasBuild && hasOut:
 		// Not fatal, but almost always a mistake: an outputDir with no build
 		// to produce it. Warn as an error so it surfaces.
-		errs = append(errs, "outputDir is set but buildCommand is missing — a no-build (static) app should omit outputDir; a built app must set buildCommand")
+		errs = append(errs, newFinding("buildCommand", "outputDir is set but buildCommand is missing — a no-build (static) app should omit outputDir; a built app must set buildCommand"))
 	}
 
 	// outputDir must be a SAFE RELATIVE path. The server companion validates
@@ -223,34 +239,38 @@ func buildCoherence(dir string, m *manifest.Manifest) []string {
 	// message.
 	if hasOut {
 		if strings.HasPrefix(out, "/") {
-			errs = append(errs, fmt.Sprintf("outputDir %q must be a relative path under the project root — remove the leading \"/\"", out))
+			errs = append(errs, newFinding("outputDir", fmt.Sprintf("outputDir %q must be a relative path under the project root — remove the leading \"/\"", out)))
 		} else if out == ".." || strings.HasPrefix(out, "../") || strings.Contains(out, "/../") || strings.HasSuffix(out, "/..") {
-			errs = append(errs, fmt.Sprintf("outputDir %q must not escape the project root — remove the \"..\" path traversal", out))
+			errs = append(errs, newFinding("outputDir", fmt.Sprintf("outputDir %q must not escape the project root — remove the \"..\" path traversal", out)))
 		}
 	}
 	return errs
 }
 
 // schemaErrors flattens a jsonschema validation error into clear, per-field
-// messages keyed by the offending JSON path.
-func schemaErrors(err error) []string {
+// findings keyed by the offending JSON path.
+//
+// The path used to be rendered as a JSON Pointer ("/scopes/1"), which was one
+// of the three notations issue #225 was about. It is now dotted
+// ("scopes[1]") — the same notation the ported semantic checks and the human
+// output use. The MESSAGE still leads with the path, so the text output reads
+// the same way it always did; only the notation inside it changed.
+func schemaErrors(err error) []Finding {
 	ve, ok := err.(*jsonschema.ValidationError)
 	if !ok {
-		return []string{err.Error()}
+		// Not a jsonschema error at all — we have no location to report, so the
+		// finding is about the document.
+		return []Finding{newFinding(FieldDocument, err.Error())}
 	}
-	var out []string
+	var out []Finding
 	var walk func(e *jsonschema.ValidationError)
 	walk = func(e *jsonschema.ValidationError) {
 		// Only emit leaf errors (those with no children carry the concrete
 		// reason); intermediate nodes just describe the path.
 		if len(e.Causes) == 0 {
-			loc := strings.Join(e.InstanceLocation, "/")
-			if loc == "" {
-				loc = "(root)"
-			} else {
-				loc = "/" + loc
-			}
-			out = append(out, fmt.Sprintf("%s: %s", loc, e.ErrorKind.LocalizedString(printer)))
+			field := fieldPath(e.InstanceLocation)
+			out = append(out, newFinding(field,
+				fmt.Sprintf("%s: %s", field, e.ErrorKind.LocalizedString(printer))))
 			return
 		}
 		for _, c := range e.Causes {
@@ -259,20 +279,7 @@ func schemaErrors(err error) []string {
 	}
 	walk(ve)
 	if len(out) == 0 {
-		out = append(out, ve.Error())
-	}
-	return out
-}
-
-func dedupe(in []string) []string {
-	seen := make(map[string]struct{}, len(in))
-	var out []string
-	for _, s := range in {
-		if _, ok := seen[s]; ok {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
+		out = append(out, newFinding(fieldPath(ve.InstanceLocation), ve.Error()))
 	}
 	return out
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -94,7 +94,7 @@ func mustReject(t *testing.T, name, json, wantSubstr string) {
 	if wantSubstr != "" {
 		found := false
 		for _, e := range res.Errors {
-			if strings.Contains(e, wantSubstr) {
+			if strings.Contains(e.Message, wantSubstr) {
 				found = true
 				break
 			}

--- a/internal/validate/warnings.go
+++ b/internal/validate/warnings.go
@@ -32,12 +32,18 @@ package validate
 const budgetedScope = "ai:write:budgeted"
 
 // warningChecks runs the advisory rules over the decoded manifest map.
-func warningChecks(generic any) []string {
+//
+// FIELD ASSIGNMENT: each of these three rules is a relationship between
+// `scopes` and something on `page`, and each names the side that is MISSING —
+// the edit that resolves it. That keeps the assignment mechanical (it reads off
+// the sentence) rather than a judgement call per rule, and it means the three
+// warnings land on three different fields instead of collapsing onto `scopes`.
+func warningChecks(generic any) []Finding {
 	m, ok := generic.(map[string]any)
 	if !ok {
 		return nil
 	}
-	var warns []string
+	var warns []Finding
 
 	page, hasPage := m["page"].(map[string]any)
 	scopes := stringSet(m["scopes"])
@@ -49,14 +55,14 @@ func warningChecks(generic any) []string {
 	//     before it runs. The headline footgun the dogfood found.
 	if hasBudgeted && hasPage {
 		if _, hasBudget := page["buzzBudgetPerGen"]; !hasBudget {
-			warns = append(warns,
+			warns = append(warns, newFinding(childField("page", "buzzBudgetPerGen"),
 				"scopes include \"ai:write:budgeted\" but page.buzzBudgetPerGen is not set — "+
 					"tokens fall back to a 10 Buzz budget, below almost any real generation, so "+
 					"every submit is rejected with insufficient budget before it runs. Set "+
 					"page.buzzBudgetPerGen: it is a SAFETY CEILING on what one generation may "+
 					"cost, not a cost estimate — size it several times your worst-case run "+
 					"(headroom is free; you are charged the real price, and the server clamps "+
-					"the budget at the per-gen cap)")
+					"the budget at the per-gen cap)"))
 		}
 	}
 
@@ -65,10 +71,10 @@ func warningChecks(generic any) []string {
 	//     meant to be a page (declare a `page` field). Not a hard error (the
 	//     server gates the spend), but worth surfacing.
 	if hasBudgeted && !hasPage {
-		warns = append(warns,
+		warns = append(warns, newFinding("page",
 			"scopes include \"ai:write:budgeted\" but no \"page\" block is declared — "+
 				"budgeted Buzz spend is a full-page (W10) affordance; declare a \"page\" field, "+
-				"or drop the scope if this isn't a money-path page app")
+				"or drop the scope if this isn't a money-path page app"))
 	}
 
 	// (3) A page app that declares neither model targets nor a money scope and no
@@ -76,9 +82,9 @@ func warningChecks(generic any) []string {
 	//     a generation budget but no budgeted scope can never spend.
 	if hasPage && !hasBudgeted {
 		if _, hasBudget := page["buzzBudgetPerGen"]; hasBudget {
-			warns = append(warns,
+			warns = append(warns, newFinding("scopes",
 				"page.buzzBudgetPerGen is set but scopes do not include \"ai:write:budgeted\" — "+
-					"the budget is inert; add the scope to enable budgeted generation, or remove the budget")
+					"the budget is inert; add the scope to enable budgeted generation, or remove the budget"))
 		}
 	}
 

--- a/internal/validate/warnings_test.go
+++ b/internal/validate/warnings_test.go
@@ -7,7 +7,7 @@ import (
 
 func hasWarningContaining(res Result, substr string) bool {
 	for _, w := range res.Warnings {
-		if strings.Contains(w, substr) {
+		if strings.Contains(w.Message, substr) {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes #225.

## The defect

`README.md` promised: *"`--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message`)"*. The field was recovered **at the printer** (`internal/cmd/app_validate.go`, `deriveField`) by string-parsing a schema-style `"<path>: <reason>"` prefix. The JSON Schema errors parse; the ported **semantic** checks (AGENTS.md item 1 — the rules deliberately written in Go *because the schema cannot express them*) emit prose, so there was nothing to parse.

Reproduced on the issue's manifest at `origin/main` (`e9a44c4`) — **7 of 11 findings came back `field: null`, and they were precisely the semantic ones**:

```
$ civitai app validate ./broken --json     # BEFORE (e9a44c4)
  error '(root)'     | (root): missing property 'contentRating'
  error '/blockId'   | /blockId: 'Bad_Id' does not match pattern …
  error '/page'      | /page: missing properties 'path', 'title'
  error '/scopes/2'  | /scopes/2: value must be one of …
  error None         | iframe.minHeight is required and must be a number in [40, 4000]
  error None         | iframe.resizable is required and must be a boolean
  error None         | iframe.sandbox MUST NOT combine allow-same-origin with allow-scripts
  error None         | sandbox token "allow-popups" is not allowed for unverified blocks
  error None         | sandbox token "allow-same-origin" is not allowed for unverified blocks
  error None         | sensitive scopes require a justification …
  warning None       | scopes include "ai:write:budgeted" but page.buzzBudgetPerGen is not set
```

```
$ civitai app validate ./broken --json     # AFTER
  error '(root)'                  | (root): missing property 'contentRating'
  error 'blockId'                 | blockId: 'Bad_Id' does not match pattern …
  error 'iframe.minHeight'        | iframe.minHeight is required and must be a number in [40, 4000]
  error 'iframe.resizable'        | iframe.resizable is required and must be a boolean
  error 'iframe.sandbox'          | iframe.sandbox MUST NOT combine allow-same-origin with allow-scripts
  error 'page'                    | page: missing properties 'path', 'title'
  error 'iframe.sandbox'          | sandbox token "allow-popups" is not allowed …
  error 'iframe.sandbox'          | sandbox token "allow-same-origin" is not allowed …
  error 'scopes[2]'               | scopes[2]: value must be one of …
  error 'scopeJustifications'     | sensitive scopes require a justification …
  warning 'page.buzzBudgetPerGen' | scopes include "ai:write:budgeted" but page.buzzBudgetPerGen is not set
```

## The shape of the fix

**Findings carry their field from where they are PRODUCED.** Not a printer heuristic — a printer heuristic regenerates the bug at every check added afterwards: the new check emits prose, the parser finds no path, the null is back, and nothing fails.

- New `validate.Finding{Field, Message}` (`internal/validate/finding.go`).
- `validate.Result.Errors`/`.Warnings` are `[]Finding`, not `[]string`.
- All 23 check returns across `validate.go`, `semantic.go`, `targets.go`, `warnings.go`, `lockfile.go`, `readyack.go` return `[]Finding`.
- `newFinding(field, message)` is the **only** constructor; `Finding{…}` composite literals outside `finding.go` are rejected by a test.
- `validate.Messages([]Finding) []string` is the projection the three text consumers use.

### Notation: dotted — and why

`blockId`, `iframe.sandbox`, `scopes[1]`, `targets[0].slotId`, `scopeJustifications.<scope>`.

Three notations used to coexist: `(root)` and JSON Pointer `/blockId` in `--json`, dotted `iframe.sandbox` in the human output. **Dotted** wins because it is what every other surface already speaks — the semantic checks' own prose (`"iframe.minHeight is required"`), the README, `AGENTS.md`, the schema's descriptions — and it is what an author types to find the key in their file. Unifying on JSON Pointer would have meant rewriting every author-facing message to `/iframe/sandbox` to buy escaping rigour a manifest whose keys are all identifiers does not need.

🔴 **This is a deliberate output change, called out in the README:** `--json` field values move from `/scopes/1` to `scopes[1]`, and the text output's leading path loses its `/`. **Consumers matching on `/`-prefixed fields must update.** No test in the repo pinned the old form.

### Findings with no single natural field

Two documented sentinels, never null, never empty:

| `field` | meaning | used by |
| --- | --- | --- |
| `(root)` | the manifest **document** — absent, unparseable, or a schema violation located at the top-level object | manifest-missing, parse error, root schema errors |
| `(project)` | **repository state outside the manifest** — no manifest edit alone fixes it | lockfile checks, the `BLOCK_READY` advisory |

They are two, not one, on purpose: `(root)` says "your manifest document is wrong", `(project)` says "your repository is wrong". Collapsing them would send a CI job looking in `block.manifest.json` for a missing lockfile.

Field assignment elsewhere is **mechanical, not taste**: a finding names the location it is *about*. For an *"X is set but Y is missing"* pair rule that is **Y** — it reads straight off the sentence and stays symmetric across the pair. Per-element and per-key rules carry the index/key (`targets[0].slotId`, `scopeJustifications.<scope>`), because `targets` alone is useless on the only manifests where those rules fire twice.

### `dedupe` semantics — decided and tested

Keys on the **(field, message) PAIR**, and only that. Two findings with the same message and different fields both survive (`scopeJustifications` emits one per offending key); same field, different messages both survive (an iframe is routinely wrong several ways at once). Pinned by `TestDedupeFindingsKeysOnTheFieldMessagePAIR`. Sorting is Message-first, Field-second, so the text output's order is unchanged from the string era.

## What did NOT change

- **Human output is byte-identical** apart from the deliberate notation change. Diffed base vs HEAD on the issue's manifest: stdout identical; stderr differs only in the three schema lines (`/blockId:` → `blockId:`, `/scopes/2:` → `scopes[2]:`) and their sort position.
- **Stream separation** — JSON on stdout, failure on stderr — preserved and now pinned by `TestValidateJSONStreamSeparation` (which asserts the *whole* of stdout decodes and stderr is empty).
- **Exit codes** unchanged; nothing here touches the classification path.
- **Which checks run in which mode** unchanged — `readyAckChecks` stays in the `projectState` branch, `warningChecks` still runs under `ManifestOnly` (AGENTS.md item 18 placement constraint). `TestReadyAckSkippedByManifestOnly` still passes.
- `examples_test.go` green — the shipped examples still validate clean.

## Test coverage

Three guards, none subsuming the others (`internal/validate/finding_contract_test.go`, `internal/cmd/app_validate_json_field_test.go`):

**(A) `TestFindingsAreConstructedWithAField` — structural.** Parses every non-test file in the package; rejects a bare `Finding{…}` literal outside `finding.go`, and rejects `newFinding("", …)`. It fires on the **source**, so a newly added check cannot ship without a field *even if nobody writes a fixture for it*. Positive control: ≥20 call sites and ≥5 package files, or it fails as "wired to nothing".

**(B) `TestEveryCheckEmitsAField` — behavioural, with a REACHABILITY LEDGER.** 24 fixtures driven through the real `validate.Dir`. "Every finding I saw carried a field" is a claim about the *corpus*, not the checks — so the test also AST-enumerates every finding-producing function and, through a nil-in-production `findingSiteHook`, requires the corpus to have **reached each one**. Deleting a fixture fails by name: `targetChecks (targets.go:89) was never reached`. Positive controls: ≥25 findings observed, and the fields `iframe.sandbox`, `blockId`, `(root)`, `(project)` must all actually turn up.

**(C) The `--json` wire tests — asserted on the DECODED `map[string]any`, never `strings.Contains`.** Per AGENTS.md item 14's reasoning: the word "field" appears inside several *messages*, and a text search cannot see `"field": null` at all. `TestValidateJSONEveryFindingCarriesAField` checks key presence / non-null / non-empty per finding; `TestValidateJSONSemanticChecksAreFieldTagged` names the four findings that were null and requires each to carry a **specific** field.

### Red/green matrix

New tests copied verbatim into a clean `origin/main` (`e9a44c4`) checkout:

| test | at `e9a44c4` | at HEAD |
| --- | --- | --- |
| `TestValidateJSONEveryFindingCarriesAField` | **RED** (7/11 findings had no `field` key) | GREEN |
| `TestValidateJSONSemanticChecksAreFieldTagged` | **RED** (6 semantic fields `""`, 2 schema fields JSON Pointer) | GREEN |
| `TestValidateJSONFieldsUseDottedNotation` | **RED** (`/blockId`, `/scopes/2`) | GREEN |
| `TestValidateJSONStreamSeparation` | GREEN — **invariant guard**, labelled as such, not counted as regression coverage | GREEN |
| `TestValidateJSONCleanManifestHasEmptyBuckets` | GREEN — **negative control**, green in both directions by design | GREEN |
| `TestFindingsAreConstructedWithAField`, `TestEveryCheckEmitsAField`, `TestFindingFieldsUseOneNotation`, `TestFieldPathRendersDottedPaths`, `TestDedupeFindingsKeysOnTheFieldMessagePAIR`, `TestMessagesPreservesOrderAndText` | **cannot compile** — they name a type that does not exist at base. Stated rather than claimed as red; their strength is established by mutation instead. | GREEN |

### Mutation sweep — 5 mutants, 5 kills, each by the intended guard

| mutant | killed by | survivors that should survive |
| --- | --- | --- |
| field reverted to a literal `""` (`semanticChecks`) | **A** (`semantic.go:71 (semanticChecks): newFinding called with an EMPTY field`) + B | notation guards, cmd guards |
| field computed to `""` at **runtime** (invisible to A) | **B** (`finding with an EMPTY field (issue #225 is back)`) + the per-check cmd guard | A (documented: it cannot see runtime values) |
| `Finding{Message: …}` composite literal | **A** (`Finding{...} composite literal(s) outside finding.go at [validate.go:185:30]`) + B | others |
| `fieldPath` reverted to JSON Pointer | all four notation guards | A, `…EveryFindingCarriesAField` |
| one corpus fixture deleted | **B's ledger**, by function and source line | all others |

🔴 **One measured correction worth recording.** On the runtime-empty mutant, `TestValidateJSONEveryFindingCarriesAField` **passed** — `issues()` maps an empty field to `(root)` as defence in depth for the "never null" promise, so the fallback supplied a plausible value — while `TestValidateJSONSemanticChecksAreFieldTagged`, which asks for the *specific* field, failed on `(root)`. That is the argument for asserting per-check rather than per-shape, and it is written into both the test file and AGENTS.md item 21 so nobody re-derives it.

The mutation sweep also found two real defects in my own first-draft fixtures (uppercase `contentRating`, a `minHeight` inside the valid range on a fixture named "out of range"), both fixed.

### Instrument validation

- `gofmt -s -l .` — negative control: a deliberately misformatted file **was** listed, then removed and the run went clean. 274 `.go` files present.
- `make ci` — read by counting output lines, not the exit code: **18 `ok`, 0 `FAIL`, 0 `panic: test timed out`**. Across the two touched packages: **876 `--- PASS`, 0 `--- FAIL`**.

## Consumers touched

`internal/cmd/app_validate.go` (`issues()` reads the field off the finding; `deriveField` **deleted**; printers use `.Message`), `internal/cmd/app_submit.go`, `internal/cmd/app_init.go` (via `validate.Messages`), plus the assertion sites in `lockfile_test.go`, `readyack_test.go`, `semantic_test.go`, `validate_test.go`, `warnings_test.go`, `app_validate_test.go`. `examples_test.go` needed no change.

## Docs

- `README.md` — new **"The `--json` result shape"** section: the guarantees, the sentinel table, and an explicit "if you were matching on `/`-prefixed fields, update your scripts".
- `AGENTS.md` — **item 21**, covering the anti-pattern (do not re-add a printer parser), the notation decision, the two sentinels, the dedupe axis, the `findingSiteHook` test seam and why deleting it makes the coverage claim vacuous, and the measured mutation results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
