### PR TITLE
docs(login): stop a comment tripping GitGuardian's CLI-option detector

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -146,12 +146,20 @@ account with ` + "`civitai whoami`" + `.)`,
 			//
 			// 🔴 THIS MUST PRECEDE THE bare-`--token` MINT-HELP RETURN BELOW. It used
 			// to sit after it, which made the guard partial in exactly the two
-			// spellings where --token carries NO value: `login --token --scopes
-			// generate` and `login --scopes generate --token` both took the early
-			// return, printed the mint help and exited 0 with --scopes silently
-			// dropped — while the two value-carrying spellings were rejected. A guard
-			// that fires for some spellings of the same mistake is worse than none,
-			// because the exit-0 ones read as acceptance.
+			// spellings where --token carries NO value: `login --token
+			// --scopes generate` and `login --scopes generate --token` both took
+			// the early return, printed the mint help and exited 0 with --scopes
+			// silently dropped — while the two value-carrying spellings were
+			// rejected. A guard that fires for some spellings of the same mistake
+			// is worse than none, because the exit-0 ones read as acceptance.
+			//
+			// The line break after `--token` above is deliberate — do not reflow
+			// it. With `--token` immediately followed on the SAME line by another
+			// flag, GitGuardian's Generic CLI Option Secret detector reads that
+			// following flag NAME as the option's secret VALUE. It alerted on
+			// this exact line — a comment, in a repo with no secret in it — on
+			// 2026-08-07. Keep the two on separate lines here (and in any new
+			// prose spelling the same mistake) so the scanner stays quiet.
 			if cmd.Flags().Changed("scopes") && cmd.Flags().Changed("token") {
 				return asUsageError(fmt.Errorf(
 					"--scopes applies only to the browser device login and cannot be combined with --token: " +


### PR DESCRIPTION
## What

Reflows one comment in `internal/cmd/login.go` so `--token` is not immediately followed by another flag on the same line. Comment-only; no behaviour change.

## Why

GitGuardian alerted on 2026-08-06 (Good Samaritan program) — **`[civitai/cli] Generic CLI Option Secret exposed on GitHub`**, pinned by the email's link to commit e9a44c4 (#220), `internal/cmd/login.go` line 149:

```go
// spellings where --token carries NO value: `login --token --scopes
```

The detector reads the flag name `--scopes` as the secret VALUE of `--token`.

## The alert is a false positive — no secret to rotate

The flagged line is a code comment inside the block explaining why the `--scopes` + `--token` guard must precede the bare-`--token` early return.

I scanned all 2,710 added lines of e9a44c4 for credential-shaped assignments and high-entropy literals. Three hits, all fixtures:

| Literal | Location | What it is |
|---|---|---|
| `7f3c9a21b8e04d5fa1c2e6d90b4a8f13` | `login_scopes_test.go:213` | `const theKey` — its own comment says it is *"deliberately secret-shaped: any case that rejects an invocation containing it must not put it in the error text"* |
| `"dev-secret-code"` | `oauth_test.go` | device-flow fixture |
| `access_token: at-1` / `refresh_token: rt-1` | config test | fixture |

Everything else matching `token|secret|key` is error-message prose or flag documentation.

## The change

The paragraph is rewrapped so `--token` ends a line, plus a note recording why — without it, the next person to reflow the paragraph re-triggers the alert, and this PR is pure churn.

The prose is **byte-identical modulo whitespace** (verified by normalising the comment block on both sides and comparing).

Note the explanatory comment had to be written carefully: the first draft of it said ``` `--token --scopes` trips … ``` and reintroduced the exact pattern it was documenting.

## Not changed

Two other sites have the same adjacency and were left alone — neither was flagged, and both use self-evident placeholders rather than a real flag name as the "value":

- `internal/cmd/login.go:204` — `` `login --token --bogus` ``
- `internal/cmd/login_token_deeplink_test.go:152` — `login --token --someUnknownFlag`

## Verification

- `make ci` green — tidy + vet + 18/18 packages `ok` + build.
- `gofmt -s -l .` clean, with a positive control (2,536 Go files present, tool scanned the tree) and a negative control (gofmt went red on a deliberately misformatted file) so "clean" cannot mean "scanned nothing".
- `grep -- '--token[[:space:]]\+--[a-z]'` no longer matches the flagged line.

Marking the incident a false positive on the GitGuardian dashboard is a separate manual step (needs GitHub auth there) and is not done by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
