### PR TITLE
fix(retry): a filesystem error is not a transient network error (#244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,8 +166,10 @@ is model substitution, and 22 is the one gate on that path that guards CONTENT
 rather than money); items 18 and 20 cover the checks that tell an author their
 EXISTING app is missing the item-11 handshake (20 is the reachability repair to
 18's presence-only scan); item 23 covers the SHAPE of a validation finding — the
-`field` every `--json` consumer groups on; and item 24 covers the CLI-wide
-exit-code classifier, which every command's published exit code funnels through.
+`field` every `--json` consumer groups on; and item 24 covers the ONE
+transport-vs-filesystem predicate now shared by the CLI-wide exit-code
+classifier (which every command's published exit code funnels through) and
+`pkg/civitai`'s read-GET retry loop.
 The durable fix for the mirroring is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
@@ -1537,7 +1539,8 @@ neither one's.
       consumers (`app validate`, `app submit`, `app init`'s self-check) use.
 24. **`syscall.Errno` IS a `net.Error`, so the obvious spelling of the transport
     check silently classified EVERY filesystem failure in the CLI as a network
-    failure.** `cmd/civitai/main.go`'s `isNetworkErr` used to end
+    failure — in TWO places, and the first fix reached only one of them.**
+    `cmd/civitai/main.go`'s `isNetworkErr` used to end
     `var netErr net.Error; return errors.As(err, &netErr)` — the spelling anyone
     would write, and the spelling anyone will "simplify" it back to. Do not.
     `syscall.Errno` declares both `Timeout() bool` and `Temporary() bool` and so
@@ -1568,9 +1571,43 @@ neither one's.
       be false on arrival. `1` promises nothing it cannot keep. The contract is
       published from `exitCodeDocs` (codes 1, 2 and 5 all say it), so the README
       and `--help` moved together.
+    - 🔴 **THERE WERE TWO COPIES, AND FIXING ONE IS WHAT THIS ITEM NOW EXISTS
+      TO PREVENT.** `pkg/civitai/retry.go`'s `isTransientNetErr` carried the
+      IDENTICAL unfixed spelling through #242, and `syscall.Errno.Timeout()` is
+      **true** for `ETIMEDOUT`, `EAGAIN` and `EWOULDBLOCK` — so a FILESYSTEM
+      failure carrying one of those entered the bounded retry loop. Reachable,
+      not theoretical: `internal/auth/source.go` returns
+      `persist refreshed tokens: %w` when writing rotated OAuth tokens fails,
+      `Tokens.Token(ctx)` feeds that straight into `getWithRetry`'s transient
+      arm, and a config dir on NFS-soft / sshfs / CIFS fails with exactly those
+      errnos. Measured through the real `getWithRetry`: **Token() calls=4,
+      server hits=0, retry notices=3** — the user watches three
+      `network error from Civitai, retrying (n/4)…` lines plus backoff for a
+      problem that never clears. Issue #244.
+      **The walk now lives in ONE place**, `pkg/civitai/transport_error.go`, and
+      both callers ask it: `cmd/civitai`'s classifier through the exported
+      `civitai.IsTransportError` (presence), `isTransientNetErr` through the
+      unexported `transportError` (the matched `net.Error`, whose `Timeout()`
+      it needs). It is in `pkg/civitai` because the dependency only runs one
+      way — `cmd/` and `internal/` import `pkg/civitai`, and `pkg/civitai`
+      imports nothing of ours — so putting it in `internal/` would have reversed
+      that for the public SDK. Exactly ONE new exported symbol, a bool: a caller
+      needing the `net.Error` itself uses the unexported form, so the SDK does
+      not owe compatibility on a `net.Error` return. The two callers keep
+      DIFFERENT answers — `exitCode` asks "is this exit 5?", the loop asks
+      "should I retry?", and `context.Canceled` (never retried, not a filesystem
+      error) and a non-timeout `*net.DNSError` (exit 5, not retried) are where
+      they diverge. What is shared is the EVIDENCE, not the verdict.
     - 🔴 **The guard is TWO rules and neither subsumes the other.**
-      `hasTransportError` walks the error tree — both `Unwrap() error` and
-      `Unwrap() []error`, so it sees everything `errors.As` would. (1) A bare
+      `transportError` walks the error tree — both `Unwrap() error` and
+      `Unwrap() []error`. 🔴 It does **not** "see everything `errors.As` would",
+      which is what this bullet used to claim and what `hasTransportError`'s own
+      doc comment claimed: `errors.As` ALSO calls a matched type's own
+      `As(any) bool` method, which the walk never consults. Measured — zero
+      `As(any) bool` / `As(interface{}) bool` declarations in the repo and
+      across all 119 dependency package directories (1445 `.go` files, scanner
+      positive-controlled against both spellings) — so it is UNREACHABLE here,
+      not equivalent. (1) A bare
       `syscall.Errno` is SKIPPED, not stopped at, so a genuine net.Error
       elsewhere in a multi-error tree is still found; the skip is a type
       ASSERTION on the matched value, never `errors.As`, because `errors.As`
@@ -1583,15 +1620,26 @@ neither one's.
       itself. `*os.SyscallError` is deliberately NOT a terminator: the net stack
       nests one inside `*net.OpError` on every dial failure, and the OpError is
       found first.
-    - **The residual, stated rather than hidden.** A network errno arriving with
-      NO net-stack wrapper at all (a bare `syscall.ETIMEDOUT`) now falls to 1.
-      Nothing in this CLI produces that shape — `net/http` surfaces a dial
-      failure as `*url.Error` → `*net.OpError` → …, both real `net.Error`s — and
-      the alternative is to keep reading an errno's `Timeout()`/`Temporary()` as
-      evidence, which is what mis-sorted every filesystem failure. `ECONNREFUSED`
-      and `ECONNRESET` keep their explicit bare-form `errors.Is` checks precisely
-      because both their `Timeout()` and `Temporary()` are **false**, so the
-      interface test never caught them anyway.
+    - 🔴 **The residual, stated rather than hidden — and it is WIDER than the
+      "a bare `syscall.ETIMEDOUT`" this bullet used to name.** State the RULE,
+      not a list, because the list is what went stale: **every network errno
+      except `ECONNREFUSED` and `ECONNRESET`** (which keep explicit sentinels)
+      now falls to 1 when it arrives with no net-stack wrapper — and equally
+      when wrapped in an `*os.SyscallError` with no `*net.OpError` above it,
+      since an `*os.SyscallError` is not itself a `net.Error` and the walk
+      unwraps to the Errno and skips it. Measured on go1.25.12, `isNetworkErr`
+      is false for all ten of bare `ETIMEDOUT`, `EHOSTUNREACH`, `ENETUNREACH`,
+      `EPIPE`, `ECONNABORTED`, `ENETDOWN`, `ENETRESET`, `EHOSTDOWN`, `EAGAIN`,
+      `EWOULDBLOCK` and for each under `os.NewSyscallError`; each becomes exit 5
+      again the moment a `*net.OpError` sits above it — the only shape the net
+      stack produces. Nothing in this CLI produces the bare shapes: `net/http`
+      surfaces a dial failure as `*url.Error` → `*net.OpError` → …, both real
+      `net.Error`s — and the alternative is to keep reading an errno's
+      `Timeout()`/`Temporary()` as evidence, which is what mis-sorted every
+      filesystem failure. `ECONNREFUSED` and `ECONNRESET` keep their explicit
+      bare-form `errors.Is` checks precisely because both their `Timeout()` and
+      `Temporary()` are **false**, so the interface test never caught them
+      anyway.
     - 🔴 **The tests must keep BOTH directions, because either half alone is
       satisfiable by a broken fix.** Delete exit 5 outright and the whole
       filesystem table stays green; leave the classifier alone and the positive
@@ -1605,14 +1653,53 @@ neither one's.
       classified by it rather than by a sentinel shortcut (`viaNetErrorBranch`),
       or gutting the walk leaves them green on `errors.Is` alone.
       Mutation-measured, three ways: reverting `isNetworkErr` to the base
-      spelling reddens 24 subtests; disabling the `net.Error` branch reddens the
-      real read-deadline / `*net.DNSError` / `*url.Error` / multi-error rows;
-      dropping the three explicit sentinels reddens the bare-errno rows. Two
-      known survivors, recorded so nobody re-derives them as holes: a refused
-      dial survives the branch mutation (it is caught by the ECONNREFUSED
-      sentinel) and `context.DeadlineExceeded` survives the sentinel mutation
-      (`deadlineExceededError` is itself a `net.Error`) — both are redundancy
-      working, not a gap.
+      spelling reddens 24 failures (20 leaf subtests + 4 parents) — re-measured
+      after the table grew, unchanged; disabling the `net.Error` branch reddens
+      the real read-deadline / `*net.DNSError` / `*url.Error` / multi-error rows
+      (8 leaf subtests here, 8 more in `pkg/civitai`); dropping the three
+      explicit sentinels reddens the bare-errno rows.
+      🔴 **One recorded survivor MOVED and the old wording is retracted.** This
+      bullet used to say "a refused dial survives the branch mutation (it is
+      caught by the ECONNREFUSED sentinel)". Half true, and the half that
+      changed is the half that mattered: its exit-5 assertion still passes on
+      the sentinel, but the row now ALSO asserts `civitai.IsTransportError` saw
+      it, so the ROW fails. Do not read the surviving exit code as the row
+      surviving. The genuine survivor is `context.DeadlineExceeded` under the
+      sentinel mutation (`deadlineExceededError` is itself a `net.Error`) —
+      redundancy working, not a gap.
+      🔴 **AND ONE OF THOSE BATTERIES RESTED ON A SINGLE ROW.** The mutation
+      that re-spells the Errno skip as `errors.As` — the exact mistake the doc
+      comment warns against, and the one that rejects every real dial failure —
+      reddened **exactly one** subtest at `050d401`
+      (`*net.OpError nesting *os.SyscallError(ECONNRESET)`); the real-refused-dial
+      row survived it because the `ECONNREFUSED` sentinel carried the row, so
+      deleting or reshaping that one row made the regression invisible. Fixed by
+      making the backstop plural rather than by trusting the row: the real
+      refused dial now ALSO asserts the walk saw it (independent of its exit-5
+      assertion, which still comes from the sentinel), two sentinel-free
+      `*net.OpError` rows were added, `sentinelFree` rows ASSERT their own
+      premise (`errors.Is` finds none of the three sentinels — a row that
+      quietly gained one stops being evidence), and a count floor fails if fewer
+      than four rows pin the walk without a sentinel. Re-measured after: that
+      mutant now reddens **9 leaf subtests across both packages** (4 in
+      `TestTransportErrorsStillExitFive`, 5 in `pkg/civitai`), up from 1.
+    - 🔴 **THE RETRY LOOP'S GUARD IS `pkg/civitai/retry_fs_test.go`, AND IT
+      ASSERTS THE ATTEMPT COUNT — not that "an error came back".** The buggy
+      loop also returns an error; the only observable that separates it is what
+      it DID. The harness drives the REAL `getRaw` → `getWithRetry` (never a
+      reimplementation) with a failing `TokenSource`, counting Token() calls,
+      requests that reached a live `httptest` server, and retry-notice LINES
+      (counted, not matched — the wording is pinned elsewhere), and it asserts
+      the loop handed the error back by IDENTITY, which is the structural form
+      of "it was not re-wrapped as `failed after N attempts`". Mutation-measured
+      both ways: restoring the `errors.As` spelling of `isTransientNetErr`
+      reddens 8 leaf subtests with their own message (`Token() was called 4
+      times, want 1` / `3 retry notice(s) printed`), while every positive
+      control stays green; disabling the `net.Error` branch outright reddens 8
+      leaf subtests across the two packages and leaves the filesystem table
+      green. The `EACCES` / `ENOENT` / `EIO` / `ENOSPC` rows are labelled in the
+      table as CONTROLS — `Timeout()` is false for them, so they passed at base
+      too and are invariant guards, not regression coverage.
     - **Classification is asserted through the exit code, never through message
       text** (item 7), and message PRESERVATION is asserted separately: the six
       invocations' stderr is byte-for-byte identical base vs HEAD, verified with

--- a/cmd/civitai/fs_not_network_test.go
+++ b/cmd/civitai/fs_not_network_test.go
@@ -15,6 +15,12 @@ package main
 // untagged os.ReadFile / os.Stat / os.MkdirAll failure in the CLI therefore
 // exited 5 — the code the README tells scripts to RETRY on.
 //
+// The walk that fixes it now lives in pkg/civitai (transport_error.go), reached
+// through civitai.IsTransportError, because the identical spelling was ALSO
+// open-coded in that package's retry loop and only this copy got fixed — see
+// issue #244. These tests drive the CLI's classifier; pkg/civitai's
+// retry_fs_test.go drives the retry loop through the same predicate.
+//
 // Three tests, and NONE subsumes the others:
 //
 //   - TestSyscallErrnoStillSatisfiesNetError pins the TRAP itself, so a later
@@ -76,8 +82,8 @@ func naivelyLooksLikeANetError(err error) bool {
 // TestSyscallErrnoStillSatisfiesNetError pins the stdlib fact the whole guard
 // is built on, and the three NEGATIVE facts that make it bite.
 //
-// 🔴 Do not "simplify" hasTransportError back to a bare errors.As because the
-// wrapper types look like they would stop it. They do not: measured on
+// 🔴 Do not "simplify" civitai.IsTransportError back to a bare errors.As because
+// the wrapper types look like they would stop it. They do not: measured on
 // go1.25.12, NONE of *fs.PathError, *os.LinkError or *os.SyscallError declares
 // Temporary(), so none of them satisfies net.Error and errors.As walks
 // straight through to the Errno. That asymmetry is the entire bug.
@@ -86,7 +92,7 @@ func TestSyscallErrnoStillSatisfiesNetError(t *testing.T) {
 		t.Fatal("syscall.Errno no longer satisfies net.Error.\n" +
 			"That is GOOD NEWS, not a test failure to silence: the hazard this file guards has\n" +
 			"left the standard library. Re-measure before removing anything — the Errno skip in\n" +
-			"hasTransportError becomes dead code, but the *fs.PathError/*os.LinkError terminators\n" +
+			"pkg/civitai's transportError becomes dead code, but the *fs.PathError/*os.LinkError terminators\n" +
 			"do NOT, they guard the mirror-image hazard of a wrapper GAINING Temporary().")
 	}
 
@@ -101,7 +107,7 @@ func TestSyscallErrnoStillSatisfiesNetError(t *testing.T) {
 		{"*os.SyscallError", os.NewSyscallError("read", syscall.EACCES)},
 	} {
 		if _, ok := tc.err.(net.Error); ok {
-			t.Errorf("%s now satisfies net.Error directly. hasTransportError's Errno skip no longer\n"+
+			t.Errorf("%s now satisfies net.Error directly. The Errno skip in transportError no longer\n"+
 				"covers this shape — the wrapper itself matches. Verify the terminator list still\n"+
 				"stops it (it covers *fs.PathError and *os.LinkError, NOT *os.SyscallError).", tc.name)
 		}
@@ -270,7 +276,7 @@ type multiErr struct{ errs []error }
 func (m multiErr) Error() string   { return "joined" }
 func (m multiErr) Unwrap() []error { return m.errs }
 
-// TestPathErrorTerminatesTheWalk pins the SECOND rule in hasTransportError,
+// TestPathErrorTerminatesTheWalk pins the SECOND rule in transportError,
 // which the Errno skip cannot cover: an error ABOUT A PATH is a filesystem
 // error, and nothing beneath it is transport evidence.
 //
@@ -306,6 +312,19 @@ func TestPathErrorTerminatesTheWalk(t *testing.T) {
 //
 // 🔴 INVARIANT GUARD, not regression coverage — every row passes at base too.
 // That is exactly its job.
+//
+// 🔴 viaNetErrorBranch IS THE BACKSTOP, AND IT USED TO REST ON ONE ROW. The
+// mutation that matters here is re-spelling transportError's Errno skip as
+// `errors.As(ne, &errno)` — precisely the mistake the doc comment warns about,
+// because errors.As unwraps a *net.OpError down to its errno and then rejects
+// the OpError. Measured before this file was widened, that mutant reddened
+// exactly ONE subtest (`*net.OpError nesting *os.SyscallError(ECONNRESET)`);
+// the real refused dial survived it because the ECONNREFUSED sentinel carried
+// the row. Deleting or reshaping that single row would have made the whole
+// regression invisible. So: the real refused dial now ALSO asserts the walk saw
+// it (its exit 5 still comes from the sentinel — the two assertions are
+// independent), and two sentinel-free *net.OpError rows were added, whose exit
+// 5 has no sentinel to fall back on at all.
 func TestTransportErrorsStillExitFive(t *testing.T) {
 	realRefused := realRefusedDial(t)
 	realDeadline := realReadDeadlineExceeded(t)
@@ -315,26 +334,47 @@ func TestTransportErrorsStillExitFive(t *testing.T) {
 		err  error
 		// viaNetErrorBranch requires the row to be classified by the net.Error
 		// walk rather than by one of the three explicit sentinel checks. Without
-		// it, gutting hasTransportError would leave rows green on the sentinels
-		// alone.
+		// it, gutting the walk would leave rows green on the sentinels alone.
 		viaNetErrorBranch bool
+		// sentinelFree additionally requires that NO sentinel could have carried
+		// the row, so its exit-5 assertion is itself evidence about the walk.
+		// Asserted, not just declared — see the check below.
+		sentinelFree bool
 	}{
-		{"REAL refused dial (*net.OpError from net.Dial)", realRefused, false},
-		{"REAL read deadline exceeded (*net.OpError from conn.Read)", realDeadline, true},
-		{"REAL 503 after retries (pkg/civitai read GET)", real503AfterRetries(t), false},
+		{"REAL refused dial (*net.OpError from net.Dial)", realRefused, true, false},
+		{"REAL read deadline exceeded (*net.OpError from conn.Read)", realDeadline, true, true},
+		{"REAL 503 after retries (pkg/civitai read GET)", real503AfterRetries(t), false, false},
 
-		{"bare syscall.ECONNREFUSED", syscall.ECONNREFUSED, false},
-		{"bare syscall.ECONNRESET", syscall.ECONNRESET, false},
-		{"wrapped syscall.ECONNREFUSED", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), false},
-		{"context.DeadlineExceeded", fmt.Errorf("request: %w", context.DeadlineExceeded), false},
+		{"bare syscall.ECONNREFUSED", syscall.ECONNREFUSED, false, false},
+		{"bare syscall.ECONNRESET", syscall.ECONNRESET, false, false},
+		{"wrapped syscall.ECONNREFUSED", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), false, false},
+		{"context.DeadlineExceeded", fmt.Errorf("request: %w", context.DeadlineExceeded), false, false},
 
 		{"*net.OpError nesting *os.SyscallError(ECONNRESET)",
-			&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, true},
-		{"*net.DNSError", &net.DNSError{Err: "no such host", Name: "civitai.com", IsNotFound: true}, true},
+			&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, true, false},
+		{"*net.OpError nesting *os.SyscallError(ETIMEDOUT)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}, true, true},
+		{"*net.OpError nesting *os.SyscallError(EHOSTUNREACH)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.EHOSTUNREACH)}, true, true},
+		{"*net.DNSError", &net.DNSError{Err: "no such host", Name: "civitai.com", IsNotFound: true}, true, true},
 		{"*url.Error wrapping *net.OpError",
 			&url.Error{Op: "Get", URL: "https://civitai.com/api/v1/models",
-				Err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")}}, true},
-		{"civitai.ErrNetwork sentinel", civitai.ErrNetwork, false},
+				Err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")}}, true, true},
+		{"civitai.ErrNetwork sentinel", civitai.ErrNetwork, false, false},
+	}
+
+	// A count floor, so a table someone trimmed cannot report a serene pass with
+	// the backstop back down to one row.
+	var sentinelFreeWalkRows int
+	for _, tc := range cases {
+		if tc.viaNetErrorBranch && tc.sentinelFree {
+			sentinelFreeWalkRows++
+		}
+	}
+	if sentinelFreeWalkRows < 4 {
+		t.Fatalf("only %d row(s) pin the walk with no sentinel to fall back on; want >= 4.\n"+
+			"This backstop was ONE row once, and the errors.As mutant it exists to catch was\n"+
+			"one row-deletion away from invisible.", sentinelFreeWalkRows)
 	}
 
 	for _, tc := range cases {
@@ -347,10 +387,20 @@ func TestTransportErrorsStillExitFive(t *testing.T) {
 					"A real transport failure must stay retryable — the filesystem fix must not\n"+
 					"have disabled exit 5. err = %#v", got, exitNetwork, tc.err)
 			}
-			if tc.viaNetErrorBranch && !hasTransportError(tc.err) {
+			if tc.viaNetErrorBranch && !civitai.IsTransportError(tc.err) {
 				t.Errorf("this row is meant to be classified by the net.Error walk, but\n" +
-					"hasTransportError said false — it is passing on a sentinel shortcut instead,\n" +
-					"so it cannot see a regression in the walk itself")
+					"civitai.IsTransportError said false — it is passing on a sentinel shortcut\n" +
+					"instead, so it cannot see a regression in the walk itself")
+			}
+			if tc.sentinelFree {
+				// The row's own premise. A "sentinel-free" row that quietly
+				// gained a sentinel would stop being evidence about the walk.
+				for _, s := range []error{context.DeadlineExceeded, syscall.ECONNREFUSED, syscall.ECONNRESET} {
+					if errors.Is(tc.err, s) {
+						t.Fatalf("row is marked sentinel-free but errors.Is finds %v — its exit 5 no longer\n"+
+							"depends on the walk, so it cannot back the errors.As mutation up", s)
+					}
+				}
 			}
 		})
 	}

--- a/cmd/civitai/main.go
+++ b/cmd/civitai/main.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
-	"net"
 	"os"
 	"syscall"
 
@@ -112,7 +110,7 @@ func isDeviceFlowErr(err error) bool {
 // that startlingly easy to get wrong. `syscall.Errno` carries both
 // `Timeout() bool` and `Temporary() bool`, so it satisfies `net.Error` — while
 // `*fs.PathError`, `*os.LinkError` and `*os.SyscallError` do NOT (measured on
-// go1.25: none of the three declares `Temporary()`). A plain
+// go1.25.12: none of the three declares `Temporary()`). A plain
 // `errors.As(err, &netErr)` therefore unwraps straight PAST the filesystem
 // wrapper and matches the bare Errno underneath it, so EVERY untagged
 // os.ReadFile / os.Stat / os.MkdirAll failure in the CLI landed on exit 5 —
@@ -126,69 +124,38 @@ func isDeviceFlowErr(err error) bool {
 // published contract already says in so many words that an unreadable-but-
 // present file does not exit 2.
 //
-// The residual, stated rather than hidden: a network errno that reaches us
-// with NO net-stack wrapper at all now falls to 1 as well (a bare
-// syscall.ETIMEDOUT, say). Nothing in this CLI produces that shape —
-// net/http surfaces a dial failure as *url.Error → *net.OpError → …, and both
-// of those are real net.Errors — and the alternative is to keep reading an
-// errno's Timeout()/Temporary() as evidence, which is what mis-sorted every
-// filesystem failure in the first place. ECONNREFUSED/ECONNRESET keep their
-// explicit bare-form checks above, because their Timeout() and Temporary() are
-// BOTH false and the interface test never caught them anyway.
+// 🔴 The walk itself lives in pkg/civitai (transport_error.go) and is reached
+// through civitai.IsTransportError, because the SAME predicate was open-coded
+// in this file and in that package's retry loop — and only this copy got fixed
+// (issue #241 → PR #242), leaving the retry loop retrying filesystem failures
+// until issue #244. One rule, one place. Do not re-inline it here.
+//
+// 🔴 The residual, stated rather than hidden — and it is WIDER than the "a bare
+// syscall.ETIMEDOUT, say" this comment used to name. The rule, not a list:
+// EVERY network errno except ECONNREFUSED and ECONNRESET (which keep explicit
+// sentinels below) now falls to 1 when it reaches us with no net-stack wrapper,
+// and equally when wrapped in an `*os.SyscallError` with no `*net.OpError`
+// above it — an `*os.SyscallError` is not itself a net.Error, so the walk
+// unwraps to the Errno and skips it. Measured on go1.25.12, `isNetworkErr` is
+// false for all ten of bare ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, EPIPE,
+// ECONNABORTED, ENETDOWN, ENETRESET, EHOSTDOWN, EAGAIN and EWOULDBLOCK, and for
+// each of them under `os.NewSyscallError`; each becomes exit 5 again the moment
+// a `*net.OpError` sits above it, which is the only shape the net stack
+// produces. Do not re-narrow this to a list of four — an enumerated set is what
+// went stale here the first time.
+//
+// Nothing in this CLI produces those shapes — net/http surfaces a
+// dial failure as *url.Error → *net.OpError → …, and both of those are real
+// net.Errors — and the alternative is to keep reading an errno's
+// Timeout()/Temporary() as evidence, which is what mis-sorted every filesystem
+// failure in the first place. ECONNREFUSED/ECONNRESET keep their explicit
+// bare-form checks above, because their Timeout() and Temporary() are BOTH
+// false and the interface test never caught them anyway.
 func isNetworkErr(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.ECONNRESET) {
 		return true
 	}
-	return hasTransportError(err)
-}
-
-// hasTransportError walks err's tree — both the `Unwrap() error` and
-// `Unwrap() []error` shapes, so it sees everything errors.As would — looking
-// for a net.Error that the NET STACK contributed.
-//
-// Two rules, and neither subsumes the other:
-//
-//   - A bare `syscall.Errno` is not evidence. It satisfies net.Error by
-//     accident of having Timeout()/Temporary(); the walk SKIPS it and keeps
-//     going rather than stopping, so a genuine net.Error elsewhere in a
-//     multi-error tree is still found.
-//   - An error ABOUT A PATH is a filesystem error, full stop. `*fs.PathError`
-//     and `*os.LinkError` terminate the walk, so nothing beneath one can be
-//     read as transport evidence. Today that is belt-and-braces (they bottom
-//     out in an Errno the first rule already rejects); it is here because a
-//     future Go release adding `Temporary()` to either type would otherwise
-//     re-open this exact hole silently, matching the wrapper itself instead of
-//     the Errno. No net API returns either type.
-//
-// `*os.SyscallError` is deliberately NOT a terminator: the net stack nests one
-// inside *net.OpError on every dial failure, and the OpError — a real
-// net.Error — is found before the walk ever reaches it.
-func hasTransportError(err error) bool {
-	for err != nil {
-		switch err.(type) {
-		case *fs.PathError, *os.LinkError:
-			return false
-		}
-		if ne, ok := err.(net.Error); ok {
-			if _, isErrno := ne.(syscall.Errno); !isErrno {
-				return true
-			}
-		}
-		switch x := err.(type) {
-		case interface{ Unwrap() error }:
-			err = x.Unwrap()
-		case interface{ Unwrap() []error }:
-			for _, e := range x.Unwrap() {
-				if hasTransportError(e) {
-					return true
-				}
-			}
-			return false
-		default:
-			return false
-		}
-	}
-	return false
+	return civitai.IsTransportError(err)
 }

--- a/pkg/civitai/retry.go
+++ b/pkg/civitai/retry.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -60,6 +59,19 @@ func isRetriableStatus(status int) bool {
 // isTransientNetErr reports whether a request error is a transient network
 // condition worth retrying (timeout, connection refused, connection reset). A
 // context cancellation (user SIGINT) is NOT transient and is never retried.
+//
+// 🔴 The timeout question is asked of the net.Error that transportError found,
+// NOT of `errors.As(err, &netErr)`. This is issue #244, the second copy of
+// issue #241: `syscall.Errno` satisfies net.Error, and `Timeout()` is TRUE for
+// ETIMEDOUT, EAGAIN and EWOULDBLOCK — so the errors.As spelling fed a
+// FILESYSTEM failure carrying one of those into the retry loop. Reachable
+// through the TokenSource: internal/auth returns `persist refreshed tokens: %w`
+// when writing rotated OAuth tokens fails, and a config dir on NFS-soft, sshfs
+// or CIFS can fail with exactly those errnos. Measured before the fix: four
+// Token() calls, zero requests on the wire, and three
+// `network error from Civitai, retrying (n/4)…` lines plus backoff, for a
+// problem that never clears. See transport_error.go — do not re-spell this as
+// errors.As.
 func isTransientNetErr(err error) bool {
 	if err == nil {
 		return false
@@ -70,8 +82,7 @@ func isTransientNetErr(err error) bool {
 	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
 		return true
 	}
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := transportError(err); ok {
 		return netErr.Timeout()
 	}
 	return false

--- a/pkg/civitai/retry_fs_test.go
+++ b/pkg/civitai/retry_fs_test.go
@@ -1,0 +1,491 @@
+package civitai
+
+// A FILESYSTEM ERROR IS NOT A TRANSIENT NETWORK ERROR.
+//
+// This file is the retry-loop half of the guard AGENTS.md item 24 describes for
+// the exit-code classifier. It is issue #244, a SECOND COPY of issue #241: PR
+// #242 fixed `cmd/civitai/main.go`'s isNetworkErr, while isTransientNetErr here
+// still ended with the identical spelling —
+//
+//	var netErr net.Error
+//	if errors.As(err, &netErr) { return netErr.Timeout() }
+//
+// — and `syscall.Errno.Timeout()` is TRUE for ETIMEDOUT, EAGAIN and EWOULDBLOCK.
+// So a filesystem failure carrying one of those (a config write on NFS-soft,
+// sshfs or CIFS) entered the retry loop: reachable through the TokenSource seam,
+// because internal/auth's Token() returns `persist refreshed tokens: %w` when
+// writing rotated OAuth tokens fails, and that error flows straight into
+// getWithRetry's isTransientNetErr arm.
+//
+// Three batteries, and none subsumes the others:
+//
+//   - TestFilesystemErrorsAreNotRetried drives the REAL getWithRetry and asserts
+//     the observed ATTEMPT COUNT (1 token call, 0 server hits, 0 retry notices).
+//     Asserting only "an error came back" cannot see the defect at all — the
+//     buggy loop also returns an error, after burning four attempts.
+//   - TestTransientTransportErrorsStillRetry is the POSITIVE CONTROL battery.
+//     Without it, a "fix" that deleted the isTransientNetErr net.Error branch
+//     outright would leave the first battery green.
+//   - TestSyscallErrnoTimeoutIsStillTrue pins the stdlib fact the whole thing
+//     rests on, so a row that stops exercising the trap cannot go green quietly.
+//
+// Classification is asserted through OBSERVED BEHAVIOUR (attempt counts, errors.Is)
+// and never through message text, per AGENTS.md item 7.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// The trap
+// ---------------------------------------------------------------------------
+
+// TestSyscallErrnoTimeoutIsStillTrue pins the two stdlib facts that make the
+// naive spelling wrong, so a Go release that changes either fails HERE with an
+// explanation rather than silently making the rows below vacuous.
+func TestSyscallErrnoTimeoutIsStillTrue(t *testing.T) {
+	if _, ok := any(syscall.ETIMEDOUT).(net.Error); !ok {
+		t.Fatal("syscall.Errno no longer satisfies net.Error.\n" +
+			"GOOD NEWS, not a failure to silence: the hazard has left the standard library.\n" +
+			"Re-measure before deleting anything — the *fs.PathError/*os.LinkError terminators\n" +
+			"guard the mirror-image hazard of a WRAPPER gaining Temporary().")
+	}
+	for _, e := range []syscall.Errno{syscall.ETIMEDOUT, syscall.EAGAIN, syscall.EWOULDBLOCK} {
+		if !e.Timeout() {
+			t.Errorf("%v.Timeout() is no longer true — the rows built on it no longer exercise the trap", e)
+		}
+	}
+	// The controls' half: these were never mis-sorted, because Timeout() is false.
+	for _, e := range []syscall.Errno{syscall.EACCES, syscall.ENOENT, syscall.EIO, syscall.ENOSPC} {
+		if e.Timeout() {
+			t.Errorf("%v.Timeout() is now true — this errno moved from the control group into the trap", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// failingTokenSource is the seam the reachable defect arrives through:
+// internal/auth's Tokens.Token(ctx) returns `persist refreshed tokens: %w` when
+// persisting rotated OAuth tokens fails, and authedDoHdr surfaces that error
+// verbatim into getWithRetry's transient arm.
+type failingTokenSource struct {
+	err   error
+	calls int32
+}
+
+func (s *failingTokenSource) Token(context.Context) (string, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return "", s.err
+}
+
+func (s *failingTokenSource) Refresh(context.Context) (string, error) { return "", ErrNoRefresh }
+
+// roundTripperFunc injects a transport-layer error into the REAL http.Client, so
+// the error getWithRetry sees is the one net/http hands us (a *url.Error around
+// the transport's error) rather than a constructed shape.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// observation is what the retry loop DID, which is the only thing that can tell
+// a retried failure from a terminal one.
+type observation struct {
+	tokenCalls int
+	serverHits int
+	notices    int
+	err        error
+}
+
+// noticeCount counts the one-line retry notices without depending on their
+// wording: the loop emits exactly one line per retry.
+func noticeCount(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	return len(strings.Split(s, "\n"))
+}
+
+// driveReadWithTokenError runs the REAL read GET path (getRaw → getWithRetry)
+// against a live server, with a TokenSource that fails with tokenErr. The server
+// counts hits so "0 requests reached the wire" is measured, not assumed.
+func driveReadWithTokenError(t *testing.T, tokenErr error) observation {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	src := &failingTokenSource{err: tokenErr}
+	c, buf := retryClient(srv)
+	c.Tokens = src
+	c.HTTP = srv.Client()
+
+	_, _, err := c.getRaw(context.Background(), "/api/v1/probe", nil)
+	return observation{
+		tokenCalls: int(atomic.LoadInt32(&src.calls)),
+		serverHits: int(atomic.LoadInt32(&hits)),
+		notices:    noticeCount(buf.String()),
+		err:        err,
+	}
+}
+
+// driveReadWithTransportError runs the same real path with a healthy token and a
+// transport that always fails with transportErr.
+func driveReadWithTransportError(t *testing.T, transportErr error) observation {
+	t.Helper()
+	var hits int32
+	c := New("http://civitai.invalid", "tok")
+	d := time.Duration(0)
+	c.RetryBackoffBase = &d
+	var sb strings.Builder
+	c.Stderr = &sb
+	c.HTTP = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(&hits, 1)
+		return nil, transportErr
+	})}
+
+	_, _, err := c.getRaw(context.Background(), "/api/v1/probe", nil)
+	return observation{
+		tokenCalls: 1,
+		serverHits: int(atomic.LoadInt32(&hits)),
+		notices:    noticeCount(sb.String()),
+		err:        err,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression: a filesystem error must never enter the retry loop
+// ---------------------------------------------------------------------------
+
+// TestFilesystemErrorsAreNotRetried is the regression coverage.
+//
+// RED AT BASE (origin/main, 050d401): the three Timeout()==true rows observe
+// tokenCalls=4 / notices=3 instead of 1 / 0.
+// GREEN AT HEAD: every row observes exactly one attempt.
+//
+// The EACCES/ENOENT/EIO/ENOSPC rows are CONTROLS that already passed at base —
+// invariant guards, not regression coverage. They are here so a future change to
+// the walk that starts retrying them fails loudly.
+func TestFilesystemErrorsAreNotRetried(t *testing.T) {
+	cases := []struct {
+		name string
+		// errno is the errno the filesystem failure carries.
+		errno syscall.Errno
+		// trapped records whether this errno's Timeout() is true, i.e. whether
+		// the row exercises the defect or is a control that never could.
+		trapped bool
+	}{
+		{"ETIMEDOUT (Timeout()==true — the reachable defect)", syscall.ETIMEDOUT, true},
+		{"EAGAIN (Timeout()==true — the reachable defect)", syscall.EAGAIN, true},
+		{"EWOULDBLOCK (Timeout()==true — the reachable defect)", syscall.EWOULDBLOCK, true},
+
+		{"EACCES (control: Timeout()==false, correct at base)", syscall.EACCES, false},
+		{"ENOENT (control: Timeout()==false, correct at base)", syscall.ENOENT, false},
+		{"EIO (control: Timeout()==false, correct at base)", syscall.EIO, false},
+		{"ENOSPC (control: Timeout()==false, correct at base)", syscall.ENOSPC, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Half one: the row's premise. A row whose errno stopped being
+			// trapped (or started being) says nothing about the guard.
+			if got := tc.errno.Timeout(); got != tc.trapped {
+				t.Fatalf("%v.Timeout() = %v, want %v — this row no longer exercises what it claims", tc.errno, got, tc.trapped)
+			}
+
+			// The shape internal/auth/source.go really produces: a persist
+			// failure wrapped around the *fs.PathError os.WriteFile returns.
+			tokenErr := fmt.Errorf("persist refreshed tokens: %w",
+				&fs.PathError{Op: "write", Path: "/cfg/config.yaml", Err: tc.errno})
+
+			got := driveReadWithTokenError(t, tokenErr)
+
+			if got.tokenCalls != 1 {
+				t.Errorf("Token() was called %d times, want 1.\n"+
+					"A filesystem failure was fed to the transient-retry loop: the user watches\n"+
+					"%d `network error from Civitai, retrying (n/4)…` lines plus backoff for a\n"+
+					"problem that never clears.", got.tokenCalls, got.notices)
+			}
+			if got.serverHits != 0 {
+				t.Errorf("%d request(s) reached the server, want 0 — the failure is before the wire", got.serverHits)
+			}
+			if got.notices != 0 {
+				t.Errorf("%d retry notice(s) printed, want 0 — nothing about a filesystem failure is retriable", got.notices)
+			}
+			// The loop must hand the error back UNTOUCHED on the first attempt.
+			// Identity is the structural form of "it was not re-wrapped as
+			// `failed after N attempts`", asserted without reading any message.
+			if got.err != tokenErr {
+				t.Errorf("the returned error is not the one the TokenSource produced (%T) — it was\n"+
+					"re-wrapped, which only the exhausted-retry path does", got.err)
+			}
+			if !errors.Is(got.err, tc.errno) {
+				t.Errorf("the returned error no longer carries %v — the fixture is not exercising the errno path", tc.errno)
+			}
+		})
+	}
+}
+
+// TestFilesystemErrorShapesAreNotRetried covers the wrapper shapes the CLI's
+// filesystem call sites actually return, beyond the *fs.PathError of the
+// reachable case: a bare errno, an *os.LinkError, and an *os.SyscallError.
+//
+// RED AT BASE for every row (all three carry ETIMEDOUT, whose Timeout() is true).
+func TestFilesystemErrorShapesAreNotRetried(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"bare syscall.ETIMEDOUT", syscall.ETIMEDOUT},
+		{"*fs.PathError", &fs.PathError{Op: "write", Path: "/cfg/config.yaml", Err: syscall.ETIMEDOUT}},
+		{"*os.LinkError", &os.LinkError{Op: "rename", Old: "/cfg/.tmp", New: "/cfg/config.yaml", Err: syscall.ETIMEDOUT}},
+		{"*os.SyscallError", os.NewSyscallError("fsync", syscall.ETIMEDOUT)},
+		{"multi-error tree (prose, *fs.PathError)", errors.Join(
+			errors.New("persisting rotated tokens"),
+			&fs.PathError{Op: "write", Path: "/cfg/config.yaml", Err: syscall.ETIMEDOUT})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := driveReadWithTokenError(t, tc.err)
+			if got.tokenCalls != 1 || got.notices != 0 || got.serverHits != 0 {
+				t.Errorf("tokenCalls=%d notices=%d serverHits=%d, want 1/0/0 — a %T entered the retry loop",
+					got.tokenCalls, got.notices, got.serverHits, tc.err)
+			}
+		})
+	}
+}
+
+// TestContextCancelledIsNeverRetried pins the one exclusion that predates this
+// fix: a user SIGINT is not transient. INVARIANT GUARD — green at base.
+func TestContextCancelledIsNeverRetried(t *testing.T) {
+	got := driveReadWithTokenError(t, fmt.Errorf("token: %w", context.Canceled))
+	if got.tokenCalls != 1 || got.notices != 0 {
+		t.Errorf("tokenCalls=%d notices=%d, want 1/0 — a cancelled context was retried", got.tokenCalls, got.notices)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: what MUST still retry
+// ---------------------------------------------------------------------------
+
+// TestTransientTransportErrorsStillRetry is the other half of the guard. Without
+// it, a "fix" that simply deleted isTransientNetErr's net.Error branch would
+// leave every filesystem row above green.
+//
+// 🔴 INVARIANT GUARD, not regression coverage — every row passes at base too.
+// That is exactly its job.
+//
+// Rows carrying an errno that is NOT one of the two explicit sentinels
+// (ECONNREFUSED / ECONNRESET) are the ones that pin the WALK rather than the
+// shortcut: gutting the walk leaves a sentinel-backed row green.
+func TestTransientTransportErrorsStillRetry(t *testing.T) {
+	realDeadline := realReadDeadlineExceeded(t)
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		// sentinelFree marks a row no errors.Is sentinel can carry, so its
+		// green is evidence about the net.Error walk itself.
+		sentinelFree bool
+	}{
+		{"*net.OpError nesting *os.SyscallError(ECONNRESET)",
+			&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, false},
+		{"*net.OpError nesting *os.SyscallError(ETIMEDOUT)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}, true},
+		{"*net.OpError nesting *os.SyscallError(EAGAIN)",
+			&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.EAGAIN)}, true},
+		{"REAL read deadline exceeded (*net.OpError from conn.Read)", realDeadline, true},
+		{"*net.DNSError (IsTimeout)",
+			&net.DNSError{Err: "i/o timeout", Name: "civitai.com", IsTimeout: true}, true},
+		{"*url.Error wrapping a timeout *net.OpError",
+			&url.Error{Op: "Get", URL: "https://civitai.com/api/v1/models",
+				Err: &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}}, true},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+		{"bare syscall.ECONNREFUSED", syscall.ECONNREFUSED, false},
+		{"bare syscall.ECONNRESET", syscall.ECONNRESET, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := driveReadWithTransportError(t, tc.err)
+			if got.serverHits != readMaxAttempts {
+				t.Errorf("the transport was tried %d time(s), want %d.\n"+
+					"A genuine transport failure must stay retryable — the filesystem fix must not\n"+
+					"have disabled the retry loop. err = %#v", got.serverHits, readMaxAttempts, tc.err)
+			}
+			if got.notices != readMaxAttempts-1 {
+				t.Errorf("%d retry notice(s), want %d", got.notices, readMaxAttempts-1)
+			}
+			if got.err == nil {
+				t.Fatal("exhausted retries returned no error")
+			}
+			if tc.sentinelFree {
+				// Independent of the loop: the shared predicate itself must see
+				// this shape. A row that only passes because errors.Is found
+				// ECONNREFUSED/ECONNRESET cannot report a regression in the walk.
+				if errors.Is(tc.err, syscall.ECONNREFUSED) || errors.Is(tc.err, syscall.ECONNRESET) {
+					t.Fatalf("row is marked sentinel-free but carries a sentinel — it cannot pin the walk")
+				}
+				if !isTransientNetErr(tc.err) {
+					t.Errorf("isTransientNetErr said false for a sentinel-free transport failure — the\n" +
+						"net.Error walk is not seeing it, so the loop above is passing for some other reason")
+				}
+			}
+		})
+	}
+}
+
+// TestRealRefusedDialStillRetries drives the retry loop with a genuinely refused
+// loopback dial — the error net/http really produces, rather than a constructed
+// one. INVARIANT GUARD.
+func TestRealRefusedDialStillRetries(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind a loopback listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("could not release the listener: %v", err)
+	}
+
+	c := New("http://"+addr, "tok")
+	d := time.Duration(0)
+	c.RetryBackoffBase = &d
+	var sb strings.Builder
+	c.Stderr = &sb
+	c.HTTP = &http.Client{Timeout: 5 * time.Second}
+
+	_, _, gerr := c.getRaw(context.Background(), "/api/v1/probe", nil)
+	if gerr == nil {
+		t.Skip("something else grabbed the port between close and dial — the refusal is not observable here")
+	}
+	if n := noticeCount(sb.String()); n != readMaxAttempts-1 {
+		t.Errorf("a refused dial produced %d retry notice(s), want %d", n, readMaxAttempts-1)
+	}
+	// It is classified by the shared predicate, not only by a sentinel: assert
+	// both, so gutting the walk cannot hide behind errors.Is(ECONNREFUSED).
+	var ue *url.Error
+	if !errors.As(gerr, &ue) {
+		t.Fatalf("expected net/http's *url.Error, got %T", gerr)
+	}
+	if _, ok := transportError(ue); !ok {
+		t.Error("transportError did not see a real refused dial — the walk is broken and this row\n" +
+			"is only green because errors.Is found ECONNREFUSED")
+	}
+}
+
+// TestRetriableStatusesStillRetry pins that the STATUS side of the loop is
+// untouched by the error-classification fix. INVARIANT GUARD.
+func TestRetriableStatusesStillRetry(t *testing.T) {
+	for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var hits int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"error":"transient"}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			c, buf := retryClient(srv)
+			c.HTTP = srv.Client()
+			_, _, err := c.getRaw(context.Background(), "/api/v1/probe", nil)
+			if err == nil {
+				t.Fatal("a server answering only this status produced no error")
+			}
+			if got := int(atomic.LoadInt32(&hits)); got != readMaxAttempts {
+				t.Errorf("%d request(s) reached the server, want %d", got, readMaxAttempts)
+			}
+			if n := noticeCount(buf.String()); n != readMaxAttempts-1 {
+				t.Errorf("%d retry notice(s), want %d", n, readMaxAttempts-1)
+			}
+			if !errors.Is(err, ErrNetwork) {
+				t.Errorf("exhausted retries on HTTP %d must stay tagged ErrNetwork (exit 5)", status)
+			}
+		})
+	}
+}
+
+// TestTransportErrorFromTheTokenSourceStillRetries is the positive control for
+// the INJECTION POINT the regression uses. Without it, "no filesystem error is
+// retried" would also be satisfied by never retrying anything a TokenSource
+// returns — and internal/auth's refresh really does make an HTTP call, so a
+// transport failure genuinely arrives through this seam.
+//
+// INVARIANT GUARD — green at base.
+func TestTransportErrorFromTheTokenSourceStillRetries(t *testing.T) {
+	tokenErr := fmt.Errorf("refreshing tokens: %w", &url.Error{
+		Op:  "Post",
+		URL: "https://civitai.com/api/auth/token",
+		Err: &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)},
+	})
+	got := driveReadWithTokenError(t, tokenErr)
+	if got.tokenCalls != readMaxAttempts {
+		t.Errorf("Token() was called %d times, want %d — a transport failure from the token source\n"+
+			"must still be retried", got.tokenCalls, readMaxAttempts)
+	}
+	if got.notices != readMaxAttempts-1 {
+		t.Errorf("%d retry notice(s), want %d", got.notices, readMaxAttempts-1)
+	}
+}
+
+// realReadDeadlineExceeded produces a genuine timeout *net.OpError from the net
+// stack: a live loopback connection whose read deadline has already passed. A
+// constructed *net.OpError proves nothing about what the net stack really hands
+// us; this cannot flake on a slow box or a sandbox with no route out.
+func realReadDeadlineExceeded(t *testing.T) error {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind a loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			accepted <- c
+		}
+		close(accepted)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("could not dial the loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if c := <-accepted; c != nil {
+		t.Cleanup(func() { _ = c.Close() })
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("could not set a read deadline: %v", err)
+	}
+	_, rerr := conn.Read(make([]byte, 1))
+	if rerr == nil {
+		t.Fatal("a read past its deadline returned no error")
+	}
+	var ne net.Error
+	if !errors.As(rerr, &ne) || !ne.Timeout() {
+		t.Fatalf("expected a timeout net.Error, got %T: %v", rerr, rerr)
+	}
+	return rerr
+}

--- a/pkg/civitai/transport_error.go
+++ b/pkg/civitai/transport_error.go
@@ -1,0 +1,113 @@
+package civitai
+
+import (
+	"io/fs"
+	"net"
+	"os"
+	"syscall"
+)
+
+// 🔴 A FILESYSTEM ERROR IS NOT A NETWORK ERROR, and the standard library makes
+// that startlingly easy to get wrong. `syscall.Errno` carries both
+// `Timeout() bool` and `Temporary() bool`, so it satisfies `net.Error` — while
+// `*fs.PathError`, `*os.LinkError` and `*os.SyscallError` do NOT (measured on
+// go1.25.12: none of the three declares `Temporary()`). A plain
+// `errors.As(err, &netErr)` therefore unwraps straight PAST the filesystem
+// wrapper and matches the bare Errno underneath it.
+//
+// That single spelling was wrong in TWO places — `exitCode`'s classifier in
+// cmd/civitai (issue #241, fixed by #242) and the read-GET retry loop in this
+// package (issue #244). One rule, one place: the filesystem-exclusion walk now
+// lives here and both callers ask it, because a predicate open-coded at two
+// sites is how the second copy survived the first fix.
+//
+// The two callers deliberately do NOT want the same ANSWER — `exitCode` asks
+// "is this exit 5?", `isTransientNetErr` asks "should I retry?", and those
+// differ (context.Canceled is never retried but is not a filesystem error;
+// a *net.DNSError that is not a timeout is exit 5 but is not retried). So what
+// is shared is the EVIDENCE — which net.Error, if any, the net stack
+// contributed — and each caller draws its own conclusion from it.
+
+// transportError returns the net.Error that the NET STACK contributed to err's
+// tree, if there is one. It walks both the `Unwrap() error` and `Unwrap() []error`
+// shapes.
+//
+// It is close to, but deliberately not, `errors.As(err, &netErr)`. Two rules,
+// and neither subsumes the other:
+//
+//   - A bare `syscall.Errno` is not evidence. It satisfies net.Error by
+//     accident of having Timeout()/Temporary(); the walk SKIPS it and keeps
+//     going rather than stopping, so a genuine net.Error elsewhere in a
+//     multi-error tree is still found. The skip is a type ASSERTION on the
+//     matched value, never `errors.As`, because `errors.As` unwraps a
+//     *net.OpError down to its ECONNREFUSED and would reject every real dial
+//     failure.
+//   - An error ABOUT A PATH is a filesystem error, full stop. `*fs.PathError`
+//     and `*os.LinkError` terminate the walk, so nothing beneath one can be
+//     read as transport evidence. Today that is belt-and-braces (they bottom
+//     out in an Errno the first rule already rejects); it is here because a
+//     future Go release adding `Temporary()` to either type would otherwise
+//     re-open this exact hole silently, matching the wrapper itself instead of
+//     the Errno. No net API returns either type.
+//
+// `*os.SyscallError` is deliberately NOT a terminator: the net stack nests one
+// inside *net.OpError on every dial failure, and the OpError — a real
+// net.Error — is found before the walk ever reaches it.
+//
+// 🔴 It does NOT "see everything errors.As would", and the earlier wording in
+// cmd/civitai saying so was simply wrong. This walk consults only the two Unwrap
+// shapes; `errors.As` ALSO calls a matched type's own `As(any) bool` method, and
+// a type that implements one can hand errors.As a target the walk never reaches.
+// Measured on this module: zero `func (…) As(any) bool` / `As(interface{}) bool`
+// declarations in the repo and across all 119 dependency package directories
+// (1445 .go files scanned; the scanner's pattern was positive-controlled against
+// both spellings), so no error tree reachable from this CLI is classified
+// differently today. It is unreachable, not equivalent — a dependency that adds
+// an `As` method could hide a net.Error from this walk.
+func transportError(err error) (net.Error, bool) {
+	for err != nil {
+		switch err.(type) {
+		case *fs.PathError, *os.LinkError:
+			return nil, false
+		}
+		if ne, ok := err.(net.Error); ok {
+			if _, isErrno := ne.(syscall.Errno); !isErrno {
+				return ne, true
+			}
+		}
+		switch x := err.(type) {
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+		case interface{ Unwrap() []error }:
+			for _, e := range x.Unwrap() {
+				if ne, ok := transportError(e); ok {
+					return ne, true
+				}
+			}
+			return nil, false
+		default:
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+// IsTransportError reports whether err is (or wraps) a transport failure that
+// the NET STACK contributed — a *net.OpError, *net.DNSError, *url.Error, a
+// deadline, and so on — as opposed to a filesystem failure whose bare
+// `syscall.Errno` merely satisfies net.Error by accident. See transportError
+// for the two rules and why they are not `errors.As`.
+//
+// It is the thin exported seam over that walk, and exists so `cmd/civitai`'s
+// exit-code classifier and this package's retry loop share ONE copy of the
+// filesystem-exclusion rule rather than two. It answers only the presence
+// question; a caller that needs the matched error's Timeout() (the retry loop
+// does) uses the unexported transportError, so the public surface stays one
+// boolean rather than a net.Error the SDK would then owe compatibility on.
+//
+// It is NOT a retry predicate: a *net.DNSError for a host that does not exist is
+// a transport error and is not worth retrying.
+func IsTransportError(err error) bool {
+	_, ok := transportError(err)
+	return ok
+}


### PR DESCRIPTION
Closes #244.

PR #242 fixed `cmd/civitai/main.go`'s `isNetworkErr` — `syscall.Errno` accidentally satisfies `net.Error`, so `errors.As(err, &netErr)` unwrapped straight past `*fs.PathError` and matched the Errno underneath. It did not fix the **second copy**: `pkg/civitai/retry.go`'s `isTransientNetErr` carried the identical spelling, and `syscall.Errno.Timeout()` is **true** for `ETIMEDOUT`, `EAGAIN` and `EWOULDBLOCK` — so a filesystem failure carrying one of those entered the bounded read-GET retry loop.

Reachable, not theoretical: `internal/auth/source.go` returns `persist refreshed tokens: %w` when persisting rotated OAuth tokens fails, and that flows from `Tokens.Token(ctx)` into `getWithRetry`'s transient arm. Measured through the real `getWithRetry`:

```
Token() calls=4  server hits=0  retry notices=3
err=request to /api/v1/probe failed after 4 attempts: persist refreshed tokens: write /cfg/config.yaml: connection timed out
```

Three `network error from Civitai, retrying (n/4)…` lines plus exponential backoff, for a config write on NFS-soft / sshfs / CIFS that will never clear.

## Where the shared predicate went, and why

**`pkg/civitai/transport_error.go`** — an unexported `transportError(err) (net.Error, bool)` doing the walk, plus one exported `IsTransportError(err) bool`.

- **`pkg/civitai`, not `internal/`**, because the dependency currently runs one way: `cmd/` and `internal/` import `pkg/civitai`, and `pkg/civitai` imports nothing of ours (verified: zero `civitai/cli/internal` imports in that package). Putting the predicate in `internal/` would have made the public SDK depend on an internal package — legal in Go, but it reverses the layering for the one package we publish.
- **One new exported symbol, and it is a bool.** The retry loop needs the matched `net.Error`'s `Timeout()`, so it uses the *unexported* `transportError`; only the presence question is exported. That keeps the SDK from owing compatibility on a `net.Error` return value it would otherwise have published. "Is this error a transport failure?" is also a genuinely useful question for an SDK consumer deciding whether to retry, so the one export is not dead weight.
- **The two callers keep different answers, deliberately.** `exitCode` asks *"is this exit 5?"*; `isTransientNetErr` asks *"should I retry?"*. Those diverge — `context.Canceled` is never retried but is not a filesystem error; a non-timeout `*net.DNSError` is exit 5 but is not retried; `ECONNREFUSED` is both. What is shared is the **evidence** (which `net.Error`, if any, the net stack contributed), not the verdict. `cmd/civitai`'s `hasTransportError` is deleted rather than kept as a wrapper — a shadow name invites re-implementation.

## Behaviour that did not change

Genuine transport failures still retry and still exit 5; `context.Canceled` still never retries; `ECONNREFUSED`/`ECONNRESET` still retry; 502/503/504 still retry and stay tagged `ErrNetwork`.

**Message preservation**, base (`050d401`) vs HEAD, byte-for-byte on stderr across all 8 invocations (the six filesystem ones plus a refused-dial and a usage control) — 0 differences. The differ carries its own negative controls (an injected one-word change, and two genuinely different invocations) so a `0` cannot mean "wired to nothing".

The one *intended* output change: a filesystem error from the token source now surfaces on the first attempt, without the `request to %s failed after 4 attempts:` prefix and without the three retry notices. The underlying error text is preserved verbatim — the test asserts the loop returns it by **identity**.

## Red/green matrix

`pkg/civitai/retry_fs_test.go` (new) drives the **real** `getRaw` → `getWithRetry` — never a reimplementation — and asserts the observed **attempt count**, because the buggy loop also returns an error and only what it *did* separates the two.

| Test | At base | At HEAD | Kind |
|---|---|---|---|
| `TestFilesystemErrorsAreNotRetried` — `ETIMEDOUT`/`EAGAIN`/`EWOULDBLOCK` | **RED** (Token()=4, notices=3) | green (1/0/0) | regression |
| `TestFilesystemErrorsAreNotRetried` — `EACCES`/`ENOENT`/`EIO`/`ENOSPC` | green | green | **invariant guard** (labelled as such in the table) |
| `TestFilesystemErrorShapesAreNotRetried` — bare errno, `*fs.PathError`, `*os.LinkError`, `*os.SyscallError`, multi-error tree | **RED** (all 5) | green | regression |
| `TestContextCancelledIsNeverRetried` | green | green | **invariant guard** |
| `TestTransientTransportErrorsStillRetry` (9 rows) | green | green | **invariant guard / positive control** |
| `TestRealRefusedDialStillRetries` | green | green | **invariant guard** |
| `TestRetriableStatusesStillRetry` (502/503/504) | green | green | **invariant guard** |
| `TestTransportErrorFromTheTokenSourceStillRetries` | green | green | **invariant guard** (positive control on the *injection point*) |
| `TestSyscallErrnoTimeoutIsStillTrue` | green | green | trap pin |

Honest note on how "base" was measured: the new file references the shared predicate, so it cannot compile against a literal `050d401` tree. The base column is measured by reverting **only** `isTransientNetErr`'s body to the base spelling on this branch — which is the more precise instrument anyway, and is mutation direction 1 below.

## Mutation, both directions

**1. Restore the old `isTransientNetErr` (`errors.As` + `Timeout()`)** → **10 subtests red** (8 leaf + 2 parents), with their own message:

```
retry_fs_test.go:224: Token() was called 4 times, want 1.
    A filesystem failure was fed to the transient-retry loop: the user watches
    3 `network error from Civitai, retrying (n/4)…` lines plus backoff for a
    problem that never clears.
retry_fs_test.go:233: 3 retry notice(s) printed, want 0
retry_fs_test.go:239: the returned error is not the one the TokenSource produced
```

Every positive control stayed green (22 PASS), so the guard is not satisfiable by "stop retrying anything".

**2. Break the transport side** — disable the `net.Error` branch in `transportError` entirely → **8 leaf subtests red in `pkg/civitai`** (`TestTransientTransportErrorsStillRetry` ×6, `TestRealRefusedDialStillRetries`, `TestTransportErrorFromTheTokenSourceStillRetries`) and **8 more in `cmd/civitai`** (7 rows of `TestTransportErrorsStillExitFive` + `TestFilesystemErrorUnderAMultiErrorTree`). The filesystem table stayed green — which is why both halves have to exist.

**3. The `errors.As` mutant on the Errno skip** — the third item this PR fixes. Measured at `050d401` with the mutant applied: **exactly ONE** subtest red (`*net.OpError nesting *os.SyscallError(ECONNRESET)`); the real-refused-dial row survived because the `ECONNREFUSED` sentinel carried it, so deleting or reshaping that single row would have made the whole regression invisible.

Fixed by making the backstop plural: the real refused dial now also asserts `civitai.IsTransportError` saw it (independent of its exit-5 assertion, which still comes from the sentinel); two sentinel-free `*net.OpError` rows added (`ETIMEDOUT`, `EHOSTUNREACH`); `sentinelFree` rows **assert their own premise** (`errors.Is` finds none of the three sentinels, so a row that quietly gains one fails instead of going quiet); and a count floor fails the test if fewer than four rows pin the walk with no sentinel. **Re-measured with the same mutant: 9 leaf subtests red across both packages** (4 in `TestTransportErrorsStillExitFive`, 5 in `pkg/civitai`), up from 1.

**4. Re-measured the two claims item 24 already recorded**, because widening the table can invalidate them. Reverting `isNetworkErr` to the base spelling still reddens **24 failures** (20 leaf + 4 parents) — unchanged. But one recorded *survivor* moved and is retracted in the file: item 24 said "a refused dial survives the branch mutation (it is caught by the ECONNREFUSED sentinel)". Its exit-5 assertion still passes on the sentinel, but the row now also asserts the walk saw it, so the **row fails**. The genuine survivor is `context.DeadlineExceeded` under the sentinel mutation.

## Also fixed (both CONFIRMED, both from the same audit)

- **The documented residual was narrower than the real one.** The comment and AGENTS.md item 24 said "a bare `syscall.ETIMEDOUT`". Measured on go1.25.12, `isNetworkErr` is false for all **ten** of bare `ETIMEDOUT`, `EHOSTUNREACH`, `ENETUNREACH`, `EPIPE`, `ECONNABORTED`, `ENETDOWN`, `ENETRESET`, `EHOSTDOWN`, `EAGAIN`, `EWOULDBLOCK`, and for each under `os.NewSyscallError` with no `*net.OpError` above it. Each becomes exit 5 again the moment a `*net.OpError` sits above — the only shape the net stack produces. Both places now state the **rule** ("every network errno except the two sentinels") rather than a list, because an enumerated set is what went stale here the first time.
- **A false claim in a comment.** `hasTransportError`'s doc comment and item 24 said the walk "sees everything `errors.As` would". It does not — `errors.As` also calls a matched type's own `As(any) bool` method. Re-verified independently: **zero** `As(any) bool` / `As(interface{}) bool` declarations in the repo and across all **119** dependency package directories (**1445** `.go` files scanned; the scanner's pattern was positive-controlled against both spellings). Unreachable here, but not equivalent, and the sentence was wrong.

## AGENTS.md

**Extended item 24 rather than adding a new item** — this is literally the same defect, second copy, and splitting it would put half the reasoning where nobody fixing the first half would read it. Three bullets added/rewritten: the two-copies + consolidation fact, the corrected `errors.As` claim, the widened residual, the single-row backstop and its re-measurement, and the retry-loop guard's own bullet. The section preamble now says item 24 covers the one predicate both callers share.

## Found but deliberately NOT changed

Two other `errors.As(err, &net.Error)` sites carry the same spelling but different reachability and stakes — changing them unmeasured would be exactly the mistake this PR is about:

- `internal/appapi/appblocks.go`'s `isTimeoutErr` (decides whether an `app submit` timed out and should be recovery-polled). It *already* calls `os.IsTimeout(err)` first, which matches `*fs.PathError{ETIMEDOUT}` too, so its intent arguably spans os timeouts by design; the cost of a false positive is an extra poll, not user-visible retry noise.
- `internal/cmd/app_dev_tunnel.go`'s `classifyProbeErr` — a cosmetic label on a progress line (`"timeout"` vs `"unreachable"`).

Both are noted in #244 for a separate look.

## Verification

`make ci` green, read by **counting**: 18 packages `ok`, 0 `FAIL`, 0 build errors, 0 `panic: test timed out`. `gofmt -s -l .` prints nothing over 288 `.go` files, with a positive control confirming it can flag (a deliberately misformatted file in a scratch dir was reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
