### PR TITLE
fix(transport): a filesystem error is not a request timeout (#246)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1704,6 +1704,107 @@ neither one's.
       text** (item 7), and message PRESERVATION is asserted separately: the six
       invocations' stderr is byte-for-byte identical base vs HEAD, verified with
       a differ that was itself shown to go red on an injected one-word change.
+    - 🔴 **THERE WERE FOUR COPIES, NOT TWO — AND THE THIRD TAUGHT THAT THE
+      SPELLING IS ONLY HALF OF THE HAZARD.** Issue #246 closed the two remaining
+      `errors.As(err, &netErr)` sites: `isTimeoutErr` in
+      `internal/appapi/appblocks.go` (the `app submit` upload) and
+      `classifyProbeErr` in `internal/cmd/app_dev_tunnel.go` (the readiness
+      probe's progress tag). Both now gate their `net.Error` branch on
+      `civitai.IsTransportError`, so that predicate has **four** callers:
+      `cmd/civitai`'s `exitCode`, `pkg/civitai`'s retry loop, and these two.
+      - 🔴 **`os.IsTimeout` AND `errors.As` ARE COMPLEMENTARY HALVES, so a
+        spelling-only fix is a HALF-FIX — and the gate's PLACEMENT is what
+        carries it.** `isTimeoutErr` began
+        `errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err)`, which
+        reads like a stricter check that the `errors.As` below it merely
+        widens. It is not: the two lines are filesystem-broad over DIFFERENT
+        SHAPES, because `os.IsTimeout` unwraps `*fs.PathError` /
+        `*os.LinkError` / `*os.SyscallError` at the **top level only** while
+        `errors.As` walks a `fmt.Errorf` wrapper. Measured on go1.25.12:
+        `os.IsTimeout(&fs.PathError{Err: ETIMEDOUT})` is **true** and
+        `os.IsTimeout(fmt.Errorf("x: %w", <that>))` is **false**, while
+        `errors.As` matches the Errno under the wrapper and reports
+        `Timeout()` **true**. Same for `EAGAIN`/`EWOULDBLOCK`;
+        `EACCES`/`ENOENT`/`EIO`/`ENOSPC` are false in both halves and were
+        never mis-sorted. So the gate sits **above `os.IsTimeout`**, not merely
+        above the `errors.As`, and `internal/appapi/submit_fs_not_timeout_test.go`
+        carries BOTH shapes with each row recording which half of the old
+        predicate caught it — and the halves are DISJOINT by assertion, an
+        `errors.As only` row requiring `os.IsTimeout` NOT to match it — plus a
+        per-half count floor. Mutation-measured: reverting `isTimeoutErr` to the
+        base spelling reddens **16 leaf subtests** (8 rows × the predicate table
+        and the flow table) plus 3 parents, while moving the gate ONE LINE DOWN
+        — the half-fix — reddens **8** of those, exactly the `os.IsTimeout`
+        rows, and leaves every `errors.As only` row green. A table built on one
+        shape cannot see that second mutant at all.
+      - 🔴 **THE SUBMIT SITE WAS LIVE, AND ITS FAILURE MODE WAS A LIE ABOUT AN
+        UPLOAD THAT NEVER HAPPENED.** `internal/cmd/app_submit.go` wires
+        `auth.New(cfg)` into `SubmitVersion` → `authedDoWith` →
+        `auth.Source.Token(ctx)` → `refreshLocked` → `cfg.SetOAuthTokens` →
+        `config.save()`, a real filesystem write, and `internal/auth/source.go`
+        returns `persist refreshed tokens: %w` when it fails — the exact
+        `fmt.Errorf`-wrapped shape above, and the same seam issue #244 came
+        through. A config dir on NFS-soft / sshfs / CIFS fails with those
+        errnos, so `isTimeoutErr` said "the upload timed out" about a POST that
+        was never built. Measured through the real `SubmitVersion`: **Token()
+        calls=4, submit POSTs=0, recovery polls=3** — three wasted
+        `ListSubmissions` round-trips and then `timedOutSubmitError`, telling
+        the author "submit timed out and the upload may not have completed …
+        run `civitai app status` to check whether it landed" about zero bytes
+        sent. The guard asserts that count and that the error comes back by
+        IDENTITY (`errors.Is`), which is the structural form of "it was not
+        re-wrapped"; `timedOutSubmitError` interpolates its cause with `%v`, so
+        `errors.Is` cannot find it through one.
+      - 🔴 **THE PROBE SITE IS REACHABLE — the handoff's "may not even be
+        reachable with a filesystem error" is RETRACTED — but KEEP THE CLAIM AT
+        THE MEASURED SIZE.** `internal/dnsprobe` imports no fs packages and
+        `DialClient` only ever returns `ErrNotPublished`, so the resolver call
+        site really is clean. The other two take whatever `client.Do` returns
+        on an **https** URL, and the x509 system-roots load surfaces an
+        unreadable CA bundle as `x509.SystemRootsError` wrapping an
+        `*fs.PathError`. Reproduced live against an `httptest` TLS server with
+        `SSL_CERT_FILE` at a mode-000 bundle:
+        `errors.As(clientDoErr, &pathErr)` = **true**.
+        What is NOT true — and an earlier draft of this bullet said it —
+        is that today's shape mislabels. It does not, for a reason two layers
+        away from `classifyProbeErr`: `url.Error.Timeout()` **type-asserts on
+        its immediate `.Err`** instead of unwrapping, so the errno is never
+        consulted. Measured with an ETIMEDOUT bundle: bare
+        `x509.SystemRootsError` tags **timeout**,
+        `*tls.CertificateVerificationError` around it tags **timeout**, and only
+        the outer `*url.Error` drops it back to **unreachable**; with EACCES
+        every shape tags unreachable. So the correct tag is one stdlib
+        implementation detail from being wrong, on an input measured arriving
+        here, and the gate makes it structural rather than accidental. The
+        `*url.Error` row is labelled a CONTROL in
+        `app_dev_tunnel_probe_class_test.go` for exactly that reason — reading
+        it as the regression would be reading an invariant guard as coverage.
+        Mutation-measured: reverting `classifyProbeErr` to the base spelling
+        reddens **9 leaf subtests**, every trapped row and no control;
+        flattening it to a constant `"unreachable"` reddens **8** in the
+        transport battery plus the real-DNS test, so neither battery is
+        satisfiable by the other's fix.
+        Why it is worth closing at all: the tag is the only thing telling an
+        author whether to WAIT (DNS propagation, a slow route) or go looking,
+        so a manufactured "timeout" is the false-advice failure item 10 spent
+        four measured corrections avoiding.
+      - **The `*net.DNSError` and `context.DeadlineExceeded` checks stay AHEAD
+        of the gate at both sites.** Neither is reachable from a filesystem
+        error, and `context.DeadlineExceeded` is not a `net.Error` the walk
+        would find — gating it would delete a real timeout.
+      - **Both guards keep BOTH directions, and the positive controls are what
+        make the fs rows mean anything.** `TestSubmitVersionStillRecoversFromA
+        RealTimeout` drives a REAL `http.Client.Timeout` against a hung handler
+        and requires ≥1 recovery poll; its sibling requires the full
+        `submitPollAttempts` budget plus the actionable message when nothing
+        landed; a `context.DeadlineExceeded` from the TokenSource pins the
+        INJECTION POINT itself (otherwise "no filesystem error recovers" is
+        also satisfied by never recovering from anything a TokenSource
+        returns). Mutation-measured: deleting the recovery branch entirely
+        reddens **5 top-level tests** — the three positive controls plus the two
+        pre-existing `submit_recover_test.go` cases — with the whole filesystem
+        table still green, which is what makes those rows evidence rather than a
+        build that refuses everything.
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -501,15 +501,55 @@ func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte, slug, versi
 	return &out, nil
 }
 
-// isTimeoutErr reports whether err is a request timeout / deadline-exceeded /
-// no-response condition (as opposed to a clean HTTP error response). It matches
-// context.DeadlineExceeded, os timeouts, and any net.Error whose Timeout() is
-// true (which is what http.Client.Timeout surfaces when awaiting headers).
+// isTimeoutErr reports whether err is a REQUEST timeout — the POST went out and
+// no response came back inside the deadline — as opposed to a clean HTTP error
+// status or any other failure. It matches context.DeadlineExceeded, an os
+// timeout, and any net.Error whose Timeout() is true (which is what
+// http.Client.Timeout surfaces while awaiting response headers).
+//
+// 🔴 A FILESYSTEM ERROR IS NEVER A REQUEST TIMEOUT, BECAUSE NOTHING WAS SENT.
+// That is what civitai.IsTransportError gates, and the gate must stay ABOVE
+// os.IsTimeout — see the two halves below. This is the third instance of the
+// trap AGENTS.md item 24 documents (issues #241, #244, #246): syscall.Errno
+// declares Timeout() and Temporary(), so it IS a net.Error, and Timeout() is
+// TRUE for ETIMEDOUT, EAGAIN and EWOULDBLOCK.
+//
+// Reachable, not theoretical. internal/cmd/app_submit.go wires auth.New(cfg)
+// into SubmitVersion → authedDoWith → auth.Source.Token(ctx) → refreshLocked →
+// cfg.SetOAuthTokens → config.save(), a real filesystem write, and
+// internal/auth/source.go returns `persist refreshed tokens: %w` when it fails.
+// A config dir on NFS-soft / sshfs / CIFS fails with exactly those errnos. Route
+// that into recoverTimedOutSubmit and the CLI polls /submissions three times for
+// a submission that never existed — zero bytes ever left the machine — and then
+// tells the author "submit timed out and the upload may not have completed …
+// check whether it landed", about an upload that was never attempted.
+//
+// The predicate is filesystem-broad through TWO COMPLEMENTARY LINES, and fixing
+// only the errors.As spelling is a HALF-FIX. Measured on go1.25.12:
+//
+//   - os.IsTimeout unwraps *fs.PathError / *os.LinkError / *os.SyscallError at
+//     the TOP LEVEL only, so os.IsTimeout(&fs.PathError{Err: ETIMEDOUT}) is
+//     TRUE — the direct shape a filesystem call site returns.
+//   - errors.As walks through a fmt.Errorf wrapper, so os.IsTimeout of
+//     `persist refreshed tokens: %w` around that same PathError is FALSE while
+//     errors.As matches the Errno underneath and reports Timeout() TRUE — the
+//     exact shape the submit path above produces.
+//
+// EACCES / ENOENT / EIO / ENOSPC are false in both halves and were never
+// mis-sorted. Guard: internal/appapi/submit_fs_not_timeout_test.go.
 func isTimeoutErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// A filesystem error is never a request timeout — see the doc comment. This
+	// must gate BOTH halves below, not only the errors.As one.
+	if !civitai.IsTransportError(err) {
+		return false
+	}
+	if os.IsTimeout(err) {
 		return true
 	}
 	var netErr net.Error

--- a/internal/appapi/submit_fs_not_timeout_test.go
+++ b/internal/appapi/submit_fs_not_timeout_test.go
@@ -1,0 +1,603 @@
+package appapi
+
+// A FILESYSTEM ERROR IS NOT A REQUEST TIMEOUT, BECAUSE NOTHING WAS SENT.
+//
+// This file is the submit-path half of the guard AGENTS.md item 24 describes —
+// issue #246, the THIRD copy of issues #241 and #244. isTimeoutErr used to read
+//
+//	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) { return true }
+//	var netErr net.Error
+//	if errors.As(err, &netErr) { return netErr.Timeout() }
+//
+// and `syscall.Errno.Timeout()` is TRUE for ETIMEDOUT, EAGAIN and EWOULDBLOCK.
+//
+// 🔴 IT WAS FILESYSTEM-BROAD THROUGH TWO COMPLEMENTARY LINES, SO FIXING THE
+// errors.As SPELLING ALONE IS A HALF-FIX. Measured on go1.25.12:
+//
+//   - os.IsTimeout unwraps *fs.PathError / *os.LinkError / *os.SyscallError at
+//     the TOP LEVEL only. os.IsTimeout(&fs.PathError{Err: ETIMEDOUT}) is TRUE
+//     while errors.As is what catches the same PathError under a fmt.Errorf
+//     wrapper (os.IsTimeout of that is FALSE).
+//
+// So the table below carries BOTH shapes — DIRECT (only os.IsTimeout sees it)
+// and WRAPPED (only errors.As sees it) — and each row records which half of the
+// old predicate matched it. A gate placed above only one line leaves the other
+// shape's rows red.
+//
+// The defect is reachable through the real submit path, not theoretical:
+// internal/cmd/app_submit.go wires auth.New(cfg) into SubmitVersion →
+// authedDoWith → auth.Source.Token(ctx) → refreshLocked → cfg.SetOAuthTokens →
+// config.save(), and internal/auth/source.go:115 returns
+// `persist refreshed tokens: %w` when that filesystem write fails. A config dir
+// on NFS-soft / sshfs / CIFS fails with exactly those errnos, and the CLI then
+// polls /submissions three times for a submission that never existed before
+// telling the author the upload "may not have completed".
+//
+// Three batteries, and none subsumes the others:
+//
+//   - TestIsTimeoutErrRejectsFilesystemErrors asserts the PREDICATE, so a
+//     failure names isTimeoutErr rather than only the flow around it.
+//   - TestSubmitVersionDoesNotRecoverFromAFilesystemError drives the REAL
+//     SubmitVersion and asserts what it DID (attempts, polls, error identity).
+//     "An error came back" cannot see the defect — the buggy version also
+//     returns an error, after three wasted polls and a misleading message.
+//   - TestSubmitVersionStillRecoversFromARealTimeout is the POSITIVE CONTROL
+//     battery. Without it, deleting the recovery branch outright would leave
+//     both batteries above green.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// ---------------------------------------------------------------------------
+// The trap
+// ---------------------------------------------------------------------------
+
+// naivelyLooksLikeATimeout is the predicate isTimeoutErr USED to be. Rows assert
+// against it so a fixture that stops exercising the trap cannot go green
+// quietly — and, because it reports WHICH half matched, so the table can pin
+// that the gate covers both lines rather than only the errors.As one.
+func naivelyLooksLikeATimeout(err error) (viaOsIsTimeout, viaErrorsAs bool) {
+	if err == nil {
+		return false, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false, false
+	}
+	viaOsIsTimeout = os.IsTimeout(err)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		viaErrorsAs = netErr.Timeout()
+	}
+	return viaOsIsTimeout, viaErrorsAs
+}
+
+// TestOsIsTimeoutAndErrorsAsAreComplementaryHalves pins the two stdlib facts the
+// gate's PLACEMENT rests on. If either changes, the rows built on it stop
+// exercising what they claim and this fails HERE with an explanation.
+func TestOsIsTimeoutAndErrorsAsAreComplementaryHalves(t *testing.T) {
+	if _, ok := any(syscall.ETIMEDOUT).(net.Error); !ok {
+		t.Fatal("syscall.Errno no longer satisfies net.Error.\n" +
+			"GOOD NEWS, not a failure to silence: the hazard has left the standard library.\n" +
+			"Re-measure before deleting the gate — os.IsTimeout's own unwrapping of\n" +
+			"*fs.PathError/*os.LinkError/*os.SyscallError is a SEPARATE half and does not go away.")
+	}
+	direct := &fs.PathError{Op: "write", Path: "/cfg/config.yaml", Err: syscall.ETIMEDOUT}
+	wrapped := fmt.Errorf("persist refreshed tokens: %w", direct)
+
+	if !os.IsTimeout(direct) {
+		t.Error("os.IsTimeout no longer unwraps a *fs.PathError to its errno — the DIRECT rows below\n" +
+			"no longer exercise the os.IsTimeout half of the trap")
+	}
+	if os.IsTimeout(wrapped) {
+		t.Error("os.IsTimeout now walks through a fmt.Errorf wrapper — the WRAPPED rows below no longer\n" +
+			"isolate the errors.As half, so the table stops pinning the gate's placement")
+	}
+	var ne net.Error
+	if !errors.As(wrapped, &ne) || !ne.Timeout() {
+		t.Error("errors.As no longer reaches the errno under a fmt.Errorf wrapper — the WRAPPED rows\n" +
+			"no longer exercise the trap at all")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The table
+// ---------------------------------------------------------------------------
+
+// half records which line of the OLD predicate a fixture was caught by, and the
+// two values are DISJOINT by construction:
+//
+//   - halfOsIsTimeout: os.IsTimeout matched it, so a gate placed BELOW that line
+//     leaves this row broken.
+//   - halfErrorsAs: os.IsTimeout did NOT match and errors.As did, so this row is
+//     evidence about the errors.As line ALONE.
+//
+// Both premises are asserted per row, which is what makes the table able to tell
+// a complete fix from a gate placed above the wrong line.
+type half int
+
+const (
+	halfNone half = iota // a CONTROL: neither line matched, correct at base
+	halfOsIsTimeout
+	halfErrorsAs
+)
+
+func (h half) String() string {
+	switch h {
+	case halfOsIsTimeout:
+		return "os.IsTimeout"
+	case halfErrorsAs:
+		return "errors.As only"
+	default:
+		return "neither (control)"
+	}
+}
+
+// fsErrCases is the shared corpus: the filesystem error shapes the submit path's
+// TokenSource seam really produces, plus the errnos that were never mis-sorted.
+func fsErrCases() []struct {
+	name string
+	err  error
+	half half
+} {
+	pathErr := func(e syscall.Errno) error {
+		return &fs.PathError{Op: "write", Path: "/cfg/civitai/config.yaml", Err: e}
+	}
+	return []struct {
+		name string
+		err  error
+		half half
+	}{
+		// WRAPPED — the exact shape internal/auth/source.go:115 produces. Only
+		// errors.As saw these.
+		{"persist refreshed tokens: *fs.PathError(ETIMEDOUT)",
+			fmt.Errorf("persist refreshed tokens: %w", pathErr(syscall.ETIMEDOUT)), halfErrorsAs},
+		{"persist refreshed tokens: *fs.PathError(EAGAIN)",
+			fmt.Errorf("persist refreshed tokens: %w", pathErr(syscall.EAGAIN)), halfErrorsAs},
+		{"persist refreshed tokens: *fs.PathError(EWOULDBLOCK)",
+			fmt.Errorf("persist refreshed tokens: %w", pathErr(syscall.EWOULDBLOCK)), halfErrorsAs},
+		{"multi-error tree (prose, *fs.PathError(ETIMEDOUT))",
+			errors.Join(errors.New("persisting rotated tokens"), pathErr(syscall.ETIMEDOUT)), halfErrorsAs},
+
+		// DIRECT — os.IsTimeout matches these on its own, so a gate placed only
+		// above errors.As leaves them broken.
+		{"bare syscall.ETIMEDOUT", syscall.ETIMEDOUT, halfOsIsTimeout},
+		{"*fs.PathError(ETIMEDOUT), unwrapped", pathErr(syscall.ETIMEDOUT), halfOsIsTimeout},
+		{"*os.SyscallError(ETIMEDOUT)", os.NewSyscallError("fsync", syscall.ETIMEDOUT), halfOsIsTimeout},
+		{"*os.LinkError(ETIMEDOUT)",
+			&os.LinkError{Op: "rename", Old: "/cfg/.tmp", New: "/cfg/config.yaml", Err: syscall.ETIMEDOUT}, halfOsIsTimeout},
+
+		// CONTROLS — Timeout() is false for these errnos, so they were sorted
+		// correctly at base too. Invariant guards, not regression coverage.
+		{"control: *fs.PathError(EACCES)", pathErr(syscall.EACCES), halfNone},
+		{"control: *fs.PathError(ENOENT)", pathErr(syscall.ENOENT), halfNone},
+		{"control: persist refreshed tokens: *fs.PathError(ENOSPC)",
+			fmt.Errorf("persist refreshed tokens: %w", pathErr(syscall.ENOSPC)), halfNone},
+	}
+}
+
+// TestIsTimeoutErrRejectsFilesystemErrors asserts the PREDICATE directly, so a
+// regression names isTimeoutErr rather than only the flow.
+//
+// RED AT BASE (origin/main, 592a8a9): every non-control row returns true.
+func TestIsTimeoutErrRejectsFilesystemErrors(t *testing.T) {
+	cases := fsErrCases()
+
+	// A count floor per half, so a trimmed table cannot leave one line of the
+	// old predicate unpinned and still report a serene pass.
+	var viaOs, viaAs int
+	for _, tc := range cases {
+		switch tc.half {
+		case halfOsIsTimeout:
+			viaOs++
+		case halfErrorsAs:
+			viaAs++
+		}
+	}
+	if viaOs < 2 || viaAs < 3 {
+		t.Fatalf("the table pins %d os.IsTimeout row(s) and %d errors.As row(s); want >= 2 and >= 3.\n"+
+			"The old predicate was filesystem-broad through BOTH lines — a table covering only one\n"+
+			"cannot tell a complete fix from a gate placed above the wrong line.", viaOs, viaAs)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Half one: the row's own premise. Which line of the OLD predicate
+			// matched is what makes this row evidence about the gate's placement.
+			gotOs, gotAs := naivelyLooksLikeATimeout(tc.err)
+			switch tc.half {
+			case halfOsIsTimeout:
+				if !gotOs {
+					t.Fatalf("os.IsTimeout no longer matches %T — this row no longer pins that the gate\n"+
+						"sits ABOVE os.IsTimeout, which is the half a spelling-only fix misses", tc.err)
+				}
+			case halfErrorsAs:
+				if !gotAs {
+					t.Fatalf("the naive errors.As no longer reports a timeout for %T — this row no longer\n"+
+						"exercises the trap", tc.err)
+				}
+				if gotOs {
+					t.Fatalf("os.IsTimeout now ALSO matches %T — this row was the errors.As line's own\n"+
+						"evidence, and it no longer isolates it", tc.err)
+				}
+			default:
+				if gotOs || gotAs {
+					t.Fatalf("control row %T is now matched by the old predicate (os=%v as=%v) — it moved\n"+
+						"out of the control group and into the trap", tc.err, gotOs, gotAs)
+				}
+			}
+
+			// Half two: the real predicate rejects it.
+			if isTimeoutErr(tc.err) {
+				t.Errorf("isTimeoutErr said TRUE for a filesystem failure (%T: %v).\n"+
+					"Nothing was sent, so there is no request to have timed out: this routes the submit\n"+
+					"into recoverTimedOutSubmit, which polls for a submission that never existed and then\n"+
+					"reports that the upload \"may not have completed\".\n"+
+					"The old predicate caught this via %s.", tc.err, tc.err, tc.half)
+			}
+			// The predicate must not touch the message.
+			before := tc.err.Error()
+			_ = isTimeoutErr(tc.err)
+			if after := tc.err.Error(); after != before {
+				t.Errorf("classification changed the message: %q -> %q", before, after)
+			}
+		})
+	}
+}
+
+// TestIsTimeoutErrStillAcceptsRealTimeouts is the predicate-level positive
+// control. Without it, `return false` would pass the whole table above.
+//
+// 🔴 INVARIANT GUARD — every row passes at base too. That is exactly its job.
+func TestIsTimeoutErrStillAcceptsRealTimeouts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"context.DeadlineExceeded", context.DeadlineExceeded},
+		{"wrapped context.DeadlineExceeded", fmt.Errorf("submit: %w", context.DeadlineExceeded)},
+		{"REAL http.Client.Timeout (*url.Error)", realClientTimeoutErr(t)},
+		{"REAL read deadline exceeded (*net.OpError)", realReadDeadlineErr(t)},
+		{"*net.OpError nesting *os.SyscallError(ETIMEDOUT)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}},
+		{"*net.DNSError (IsTimeout)",
+			&net.DNSError{Err: "i/o timeout", Name: "civitai.com", IsTimeout: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isTimeoutErr(tc.err) {
+				t.Errorf("isTimeoutErr said FALSE for a genuine request timeout (%T: %v) — the filesystem\n"+
+					"gate has disabled the recovery this predicate exists to trigger", tc.err, tc.err)
+			}
+		})
+	}
+	if isTimeoutErr(nil) {
+		t.Error("nil is not a timeout")
+	}
+	if isTimeoutErr(errors.New("boom")) {
+		t.Error("a plain error is not a timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Harness: the REAL SubmitVersion, driven through the real TokenSource seam
+// ---------------------------------------------------------------------------
+
+// fsTokenSource is the seam the reachable defect arrives through: internal/auth's
+// Token(ctx) returns `persist refreshed tokens: %w` when persisting rotated
+// OAuth tokens fails, and authedDoWith surfaces that verbatim into
+// SubmitVersion's isTimeoutErr arm.
+type fsTokenSource struct {
+	err   error
+	calls int32
+}
+
+func (s *fsTokenSource) Token(context.Context) (string, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return "", s.err
+}
+
+func (s *fsTokenSource) Refresh(context.Context) (string, error) { return "", civitai.ErrNoRefresh }
+
+// submitObservation is what SubmitVersion DID. A returned error alone cannot
+// tell a refusal from a recovery — the buggy version also returns an error.
+type submitObservation struct {
+	tokenCalls int
+	submitPOST int
+	listCalls  int
+	err        error
+	res        *SubmitResult
+}
+
+// countingSubmitServer answers the submit POST and the submissions GET, counting
+// both, so "0 requests reached the wire" and "0 recovery polls" are MEASURED
+// rather than assumed. hangPOST makes the POST block past the client's
+// SubmitTimeout, producing a real http.Client.Timeout *url.Error.
+func countingSubmitServer(t *testing.T, hangPOST bool, submissions func() []Submission) (*httptest.Server, *int32, *int32) {
+	t.Helper()
+	release := make(chan struct{})
+	var posts, lists int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "submit-version"):
+			atomic.AddInt32(&posts, 1)
+			if hangPOST {
+				<-release
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"publishRequestId": "pubreq_live"})
+		case r.Method == http.MethodGet && r.URL.Path == SubmissionsPath:
+			atomic.AddInt32(&lists, 1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"submissions": submissions()})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	return srv, &posts, &lists
+}
+
+// driveSubmitWithTokenError runs the REAL SubmitVersion with a TokenSource that
+// fails with tokenErr, against a live server that counts what reached it.
+func driveSubmitWithTokenError(t *testing.T, tokenErr error) submitObservation {
+	t.Helper()
+	srv, posts, lists := countingSubmitServer(t, false, func() []Submission {
+		// A row that WOULD satisfy the recovery matcher, so a run that reaches
+		// the poll is unmistakable: it returns a success rather than an error.
+		return []Submission{{ID: "pubreq_recovered", BlockID: "my-block", Version: "0.2.0", Status: "pending"}}
+	})
+
+	src := &fsTokenSource{err: tokenErr}
+	c := NewWithSource(srv.URL, src, "")
+	zero := time.Duration(0)
+	c.SubmitPollDelay = &zero
+
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	return submitObservation{
+		tokenCalls: int(atomic.LoadInt32(&src.calls)),
+		submitPOST: int(atomic.LoadInt32(posts)),
+		listCalls:  int(atomic.LoadInt32(lists)),
+		err:        err,
+		res:        res,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression: a filesystem error must never enter the recovery poll
+// ---------------------------------------------------------------------------
+
+// TestSubmitVersionDoesNotRecoverFromAFilesystemError is the regression coverage,
+// through the real command path rather than the predicate alone.
+//
+// RED AT BASE (origin/main, 592a8a9): every non-control row observes
+// tokenCalls=4 (one submit + three recovery polls, each re-asking the source)
+// and comes back with the misleading timedOutSubmitError.
+// GREEN AT HEAD: exactly one attempt, and the filesystem error itself.
+func TestSubmitVersionDoesNotRecoverFromAFilesystemError(t *testing.T) {
+	for _, tc := range fsErrCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			got := driveSubmitWithTokenError(t, tc.err)
+
+			if got.tokenCalls != 1 {
+				t.Errorf("Token() was called %d times, want 1.\n"+
+					"A filesystem failure was routed into recoverTimedOutSubmit: the CLI polled for a\n"+
+					"submission that never existed, on an upload where ZERO bytes were sent.",
+					got.tokenCalls)
+			}
+			if got.submitPOST != 0 {
+				t.Errorf("%d submit POST(s) reached the server, want 0 — the failure is before the wire", got.submitPOST)
+			}
+			if got.listCalls != 0 {
+				t.Errorf("%d recovery poll(s) of %s, want 0 — nothing was submitted, so there is nothing\n"+
+					"to recover", got.listCalls, SubmissionsPath)
+			}
+			if got.res != nil {
+				t.Errorf("SubmitVersion reported SUCCESS (%+v) for a failure that never left the machine —\n"+
+					"the recovery poll matched an unrelated pending row", got.res)
+			}
+			// The error must be handed back untouched. Identity is the structural
+			// form of "it was not re-wrapped as timedOutSubmitError", asserted
+			// without reading any message: timedOutSubmitError interpolates its
+			// cause with %v, so errors.Is cannot find it through one.
+			if !errors.Is(got.err, tc.err) {
+				t.Errorf("the returned error is not the one the TokenSource produced (%T: %v) — it was\n"+
+					"re-wrapped, which only the post-timeout recovery path does", got.err, got.err)
+			}
+		})
+	}
+}
+
+// TestSubmitVersionFilesystemErrorMessageIsNotTheTimeoutAdvice pins the
+// USER-VISIBLE cost separately from the classification: the misleading sentence
+// must not appear at all. Classification itself is asserted structurally above,
+// per AGENTS.md item 7 — this row is about the advice, not the code path.
+func TestSubmitVersionFilesystemErrorMessageIsNotTheTimeoutAdvice(t *testing.T) {
+	tokenErr := fmt.Errorf("persist refreshed tokens: %w",
+		&fs.PathError{Op: "write", Path: "/cfg/civitai/config.yaml", Err: syscall.ETIMEDOUT})
+	got := driveSubmitWithTokenError(t, tokenErr)
+	if got.err == nil {
+		t.Fatal("a failing token source produced no error")
+	}
+	for _, forbidden := range []string{"may not have completed", "civitai app status"} {
+		if strings.Contains(got.err.Error(), forbidden) {
+			t.Errorf("the error tells the author %q about an upload that was never attempted.\n"+
+				"full message: %s", forbidden, got.err)
+		}
+	}
+	// Positive control on this assertion: the real timeout path DOES say it, so
+	// a green above cannot mean the sentence was simply deleted from the product.
+	if !strings.Contains(timedOutSubmitError("my-block", context.DeadlineExceeded).Error(), "may not have completed") {
+		t.Fatal("timedOutSubmitError no longer carries the sentence this test asserts is absent —\n" +
+			"the assertion above is now vacuous")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: what MUST still recover
+// ---------------------------------------------------------------------------
+
+// TestSubmitVersionStillRecoversFromARealTimeout is the other half of the guard.
+// Without it, deleting the recovery branch at SubmitVersion outright would leave
+// every filesystem row above green.
+//
+// 🔴 INVARIANT GUARD — green at base. It drives a REAL http.Client.Timeout
+// against a server that hangs the POST, because a constructed error proves
+// nothing about what net/http hands SubmitVersion.
+func TestSubmitVersionStillRecoversFromARealTimeout(t *testing.T) {
+	landed := Submission{ID: "pubreq_01KVY45JGYSAXK7DKMQ19T2HGE", BlockID: "my-block", Version: "0.2.0", Status: "pending"}
+	srv, posts, lists := countingSubmitServer(t, true, func() []Submission { return []Submission{landed} })
+
+	c := New(srv.URL, "tok", "")
+	c.SubmitTimeout = 50 * time.Millisecond
+	zero := time.Duration(0)
+	c.SubmitPollDelay = &zero
+
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err != nil {
+		t.Fatalf("a REAL request timeout must still recover, got error: %v", err)
+	}
+	if res == nil || res.PublishRequestID != landed.ID {
+		t.Fatalf("recovered result = %+v, want the landed pubreq id %q", res, landed.ID)
+	}
+	if got := int(atomic.LoadInt32(posts)); got != 1 {
+		t.Errorf("%d submit POST(s) reached the server, want 1 — the upload really was attempted", got)
+	}
+	if got := int(atomic.LoadInt32(lists)); got < 1 {
+		t.Errorf("%d recovery poll(s), want >= 1 — the recovery branch is gone, so the filesystem rows\n"+
+			"above would pass against a build that never recovers anything", got)
+	}
+}
+
+// TestSubmitVersionStillRecoversFromARealTimeoutWithNothingLanded is the second
+// positive control: the same real timeout with NO matching submission must burn
+// the full poll budget and end in the actionable timeout error. It pins the
+// EXHAUSTED branch, which the recovering control above never reaches.
+//
+// 🔴 INVARIANT GUARD — green at base.
+func TestSubmitVersionStillRecoversFromARealTimeoutWithNothingLanded(t *testing.T) {
+	srv, _, lists := countingSubmitServer(t, true, func() []Submission { return nil })
+
+	c := New(srv.URL, "tok", "")
+	c.SubmitTimeout = 50 * time.Millisecond
+	zero := time.Duration(0)
+	c.SubmitPollDelay = &zero
+
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err == nil {
+		t.Fatal("a real timeout with nothing landed produced no error")
+	}
+	if got := int(atomic.LoadInt32(lists)); got != submitPollAttempts {
+		t.Errorf("%d recovery poll(s), want %d — the bounded poll is what distinguishes a lost response\n"+
+			"from a failure that never reached the wire", got, submitPollAttempts)
+	}
+	if !strings.Contains(err.Error(), "may not have completed") {
+		t.Errorf("a genuinely lost response must still carry the actionable advice, got: %v", err)
+	}
+}
+
+// TestSubmitVersionRecoversFromADeadlineExceededTokenError is the positive
+// control on the INJECTION POINT the regression uses. Without it, "no filesystem
+// error recovers" would also be satisfied by never recovering from anything a
+// TokenSource returns — and a ctx deadline really does arrive through that seam,
+// because internal/auth's refresh makes its own HTTP call.
+//
+// The recovery poll re-enters the same failing source, so the observable is the
+// ATTEMPT COUNT (1 submit + submitPollAttempts polls), not a server hit.
+//
+// 🔴 INVARIANT GUARD — green at base.
+func TestSubmitVersionRecoversFromADeadlineExceededTokenError(t *testing.T) {
+	got := driveSubmitWithTokenError(t, fmt.Errorf("refreshing tokens: %w", context.DeadlineExceeded))
+	want := 1 + submitPollAttempts
+	if got.tokenCalls != want {
+		t.Errorf("Token() was called %d times, want %d (one submit + %d recovery polls) — a genuine\n"+
+			"deadline must still enter the recovery poll", got.tokenCalls, want, submitPollAttempts)
+	}
+	if got.err == nil {
+		t.Fatal("an exhausted recovery produced no error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Real errors from the net stack
+// ---------------------------------------------------------------------------
+
+// realClientTimeoutErr produces the error net/http really returns when
+// http.Client.Timeout fires: a *url.Error whose Timeout() is true. A constructed
+// one proves nothing about what the client hands isTimeoutErr.
+func realClientTimeoutErr(t *testing.T) error {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-release }))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	c := &http.Client{Timeout: 50 * time.Millisecond}
+	resp, err := c.Get(srv.URL + "/")
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("a hung handler answered inside the client timeout — no timeout error to test with")
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) || !ne.Timeout() {
+		t.Fatalf("expected a timeout net.Error from http.Client.Timeout, got %T: %v", err, err)
+	}
+	return err
+}
+
+// realReadDeadlineErr produces a genuine timeout *net.OpError from the net stack:
+// a live loopback connection whose read deadline has already passed. It cannot
+// flake on a slow box or in a sandbox with no route out.
+func realReadDeadlineErr(t *testing.T) error {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind a loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			accepted <- c
+		}
+		close(accepted)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("could not dial the loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if c := <-accepted; c != nil {
+		t.Cleanup(func() { _ = c.Close() })
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("could not set a read deadline: %v", err)
+	}
+	_, rerr := conn.Read(make([]byte, 1))
+	if rerr == nil {
+		t.Fatal("a read past its deadline returned no error")
+	}
+	return rerr
+}

--- a/internal/cmd/app_dev_tunnel.go
+++ b/internal/cmd/app_dev_tunnel.go
@@ -1462,6 +1462,41 @@ func isDNSPending(detail string, err error) bool {
 
 // classifyProbeErr gives a short human tag for a transport-level probe failure,
 // for the progress line ("dns", "timeout", "unreachable").
+//
+// 🔴 The net.Error branch is gated on civitai.IsTransportError because a
+// FILESYSTEM error can reach here, and tagging one "timeout" is the manufactured
+// claim AGENTS.md item 10 forbids for this command's advisory output — the tag
+// is the only thing telling an author whether to wait (DNS propagation, a slow
+// route) or to go looking. Same trap as #241/#244, AGENTS.md item 24:
+// syscall.Errno satisfies net.Error and its Timeout() is TRUE for
+// ETIMEDOUT/EAGAIN/EWOULDBLOCK, so a plain errors.As walks past the filesystem
+// wrapper and matches the errno underneath.
+//
+// A prior handoff guessed this site "may not even be reachable with a filesystem
+// error". RETRACTED — reachability is measured. internal/dnsprobe imports no fs
+// packages and DialClient only ever returns ErrNotPublished, so the
+// probeLocalHopTunnel resolver call site really is clean; but the two call sites
+// in probePublicURL / probeLocalHopURL take whatever client.Do returns on an
+// https URL, and the x509 system-roots load surfaces an unreadable CA bundle as
+// x509.SystemRootsError wrapping an *fs.PathError. Reproduced live against an
+// httptest TLS server with SSL_CERT_FILE pointing at a mode-000 bundle:
+// errors.As(clientDoErr, &pathErr) is TRUE.
+//
+// 🔴 STATE THE CLAIM AT THE SIZE IT WAS MEASURED. Today's live shape does NOT
+// mislabel, and the reason is an accident two layers away rather than anything
+// this function does: url.Error.Timeout() TYPE-ASSERTS on its immediate .Err
+// (the tls error) instead of unwrapping, so the errno never gets consulted.
+// Measured with an ETIMEDOUT (or EAGAIN) CA bundle: bare x509.SystemRootsError
+// tags "timeout", *tls.CertificateVerificationError around it tags "timeout",
+// and only the outer *url.Error drops it back to "unreachable"; with EACCES
+// every shape tags "unreachable". So the correct answer is one stdlib
+// implementation detail from being wrong, on an input we have measured arriving
+// here. The gate makes it structural instead of accidental — that is the whole
+// value, and it is not a report of a live wrong label.
+//
+// The *net.DNSError and context.DeadlineExceeded checks stay AHEAD of the gate:
+// neither is reachable from a filesystem error, and DeadlineExceeded is not a
+// net.Error the walk would find. Guard: app_dev_tunnel_probe_class_test.go.
 func classifyProbeErr(err error) string {
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
@@ -1469,6 +1504,9 @@ func classifyProbeErr(err error) string {
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "timeout"
+	}
+	if !civitai.IsTransportError(err) {
+		return "unreachable"
 	}
 	var nerr net.Error
 	if errors.As(err, &nerr) && nerr.Timeout() {

--- a/internal/cmd/app_dev_tunnel_probe_class_test.go
+++ b/internal/cmd/app_dev_tunnel_probe_class_test.go
@@ -1,0 +1,299 @@
+package cmd
+
+// A FILESYSTEM ERROR IS NOT A PROBE TIMEOUT.
+//
+// This file is the dev-tunnel half of the guard AGENTS.md item 24 describes —
+// issue #246, alongside internal/appapi/submit_fs_not_timeout_test.go.
+// classifyProbeErr used to end
+//
+//	var nerr net.Error
+//	if errors.As(err, &nerr) && nerr.Timeout() { return "timeout" }
+//	return "unreachable"
+//
+// and `syscall.Errno.Timeout()` is TRUE for ETIMEDOUT, EAGAIN and EWOULDBLOCK,
+// so errors.As walked past a filesystem wrapper and read the errno underneath.
+//
+// The tag is advisory output, which is precisely why it matters: it is the only
+// thing telling an author whether to WAIT (DNS propagation, a slow route) or to
+// go looking. Manufacturing "timeout" for a problem on their own disk is the
+// false-advice failure AGENTS.md item 10 spent four measured corrections
+// avoiding.
+//
+// 🔴 REACHABILITY IS MEASURED, AND THE CLAIM IS KEPT AT THE MEASURED SIZE. A
+// filesystem error DOES reach classifyProbeErr: probePublicURL and
+// probeLocalHopURL pass whatever client.Do returns on an https URL, and the x509
+// system-roots load surfaces an unreadable CA bundle as x509.SystemRootsError
+// wrapping an *fs.PathError (reproduced live against an httptest TLS server with
+// SSL_CERT_FILE at a mode-000 bundle). But today's outermost shape does NOT
+// mislabel, for a reason two layers away from this function: url.Error.Timeout()
+// TYPE-ASSERTS on its immediate .Err rather than unwrapping, so the errno is
+// never consulted. Measured with an ETIMEDOUT bundle — bare
+// x509.SystemRootsError tags "timeout", *tls.CertificateVerificationError around
+// it tags "timeout", and only the outer *url.Error drops it to "unreachable".
+// The gate makes the right answer structural instead of accidental; the rows
+// below are labelled with which of those they are, so nobody reads an invariant
+// guard as regression coverage.
+//
+// Two batteries, and neither subsumes the other: the filesystem table, and the
+// transport table that would stay green if the fix simply deleted "timeout".
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// naivelyLooksLikeAProbeTimeout is the branch classifyProbeErr USED to end with.
+// Rows assert against it so a fixture that stopped exercising the trap cannot go
+// green quietly.
+func naivelyLooksLikeAProbeTimeout(err error) bool {
+	var nerr net.Error
+	return errors.As(err, &nerr) && nerr.Timeout()
+}
+
+// TestClassifyProbeErrRejectsFilesystemErrors is the filesystem table.
+//
+// trapped marks a row the OLD spelling mislabelled "timeout" — RED AT BASE
+// (origin/main, 592a8a9). The others are CONTROLS: correct at base, kept so a
+// future widening that starts mislabelling them fails loudly.
+func TestClassifyProbeErrRejectsFilesystemErrors(t *testing.T) {
+	caBundle := func(e syscall.Errno) error {
+		return &fs.PathError{Op: "open", Path: "/etc/ssl/certs/ca-bundle.crt", Err: e}
+	}
+	// The real chain, rebuilt from its own types: url.Error → tls verification
+	// error → x509.SystemRootsError → *fs.PathError → errno. It is constructed
+	// rather than produced by SSL_CERT_FILE so the suite carries no dependency on
+	// process-wide env or on the host's cert layout.
+	systemRoots := func(e syscall.Errno) error { return x509.SystemRootsError{Err: caBundle(e)} }
+
+	cases := []struct {
+		name string
+		err  error
+		// trapped: the OLD predicate said "timeout" for this row.
+		trapped bool
+	}{
+		// The reachable shape, at each layer of the real chain.
+		{"x509.SystemRootsError(*fs.PathError ETIMEDOUT)", systemRoots(syscall.ETIMEDOUT), true},
+		{"x509.SystemRootsError(*fs.PathError EAGAIN)", systemRoots(syscall.EAGAIN), true},
+		{"tls.CertificateVerificationError(x509.SystemRootsError ETIMEDOUT)",
+			&tls.CertificateVerificationError{Err: systemRoots(syscall.ETIMEDOUT)}, true},
+
+		// Other filesystem shapes an error tree reaching here can carry.
+		{"*fs.PathError(ETIMEDOUT)", caBundle(syscall.ETIMEDOUT), true},
+		{"wrapped *fs.PathError(ETIMEDOUT)", fmt.Errorf("loading roots: %w", caBundle(syscall.ETIMEDOUT)), true},
+		{"*os.SyscallError(ETIMEDOUT)", os.NewSyscallError("read", syscall.ETIMEDOUT), true},
+		{"*os.LinkError(EWOULDBLOCK)",
+			&os.LinkError{Op: "rename", Old: "/a", New: "/b", Err: syscall.EWOULDBLOCK}, true},
+		{"bare syscall.ETIMEDOUT", syscall.ETIMEDOUT, true},
+		{"multi-error tree (prose, *fs.PathError ETIMEDOUT)",
+			errors.Join(errors.New("loading roots"), caBundle(syscall.ETIMEDOUT)), true},
+
+		// CONTROLS — Timeout() is false for these errnos, so they tagged
+		// "unreachable" at base too. Invariant guards, not regression coverage.
+		{"control: x509.SystemRootsError(*fs.PathError EACCES)", systemRoots(syscall.EACCES), false},
+		{"control: *fs.PathError(ENOENT)", caBundle(syscall.ENOENT), false},
+		{"control: bare syscall.EIO", syscall.EIO, false},
+
+		// The LIVE outermost shape. It tagged "unreachable" at base too — not
+		// because classifyProbeErr was right, but because url.Error.Timeout()
+		// type-asserts on its immediate .Err. Recorded as the invariant guard it
+		// is, so nobody counts it as the regression.
+		{"control (shielded by url.Error): *url.Error(tls(x509(*fs.PathError ETIMEDOUT)))",
+			&url.Error{Op: "Get", URL: "https://dev-0123456789abcdef.civit.ai/",
+				Err: &tls.CertificateVerificationError{Err: systemRoots(syscall.ETIMEDOUT)}}, false},
+	}
+
+	var trappedRows int
+	for _, tc := range cases {
+		if tc.trapped {
+			trappedRows++
+		}
+	}
+	if trappedRows < 6 {
+		t.Fatalf("only %d row(s) exercise the trap; want >= 6 — a table trimmed down to controls\n"+
+			"reports a serene pass while pinning nothing", trappedRows)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Half one: the row's own premise.
+			if got := naivelyLooksLikeAProbeTimeout(tc.err); got != tc.trapped {
+				t.Fatalf("the naive `errors.As(err, &net.Error) && Timeout()` said %v for %T, want %v —\n"+
+					"this row no longer exercises what it claims", got, tc.err, tc.trapped)
+			}
+			// Half two: the real classifier.
+			if got := classifyProbeErr(tc.err); got != "unreachable" {
+				t.Errorf("classifyProbeErr = %q for a filesystem failure (%T: %v), want \"unreachable\".\n"+
+					"\"timeout\" points the author at the network for a problem on their own disk — the\n"+
+					"manufactured-advice failure AGENTS.md item 10 forbids for this output.",
+					got, tc.err, tc.err)
+			}
+		})
+	}
+}
+
+// TestClassifyProbeErrStillTagsTransportFailures is the POSITIVE CONTROL
+// battery. Without it, a "fix" that returned "unreachable" unconditionally would
+// leave the whole table above green.
+//
+// 🔴 INVARIANT GUARD — every row passes at base too. That is exactly its job.
+// It mixes REAL errors from the net stack with constructed ones, because a
+// constructed *net.OpError proves nothing about what net/http hands us.
+func TestClassifyProbeErrStillTagsTransportFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"REAL http.Client.Timeout (*url.Error)", realProbeClientTimeout(t), "timeout"},
+		{"REAL read deadline exceeded (*net.OpError from conn.Read)", realProbeReadDeadline(t), "timeout"},
+		{"REAL refused dial (*url.Error from http.Client.Do)", realProbeRefusedDial(t), "unreachable"},
+
+		{"context.DeadlineExceeded", context.DeadlineExceeded, "timeout"},
+		{"wrapped context.DeadlineExceeded", fmt.Errorf("probe: %w", context.DeadlineExceeded), "timeout"},
+		{"*net.DNSError (not found)",
+			&net.DNSError{Err: "no such host", Name: "dev-0123456789abcdef.civit.ai", IsNotFound: true}, "dns"},
+		{"*url.Error wrapping *net.DNSError",
+			&url.Error{Op: "Get", URL: "https://dev-0123456789abcdef.civit.ai/",
+				Err: &net.DNSError{Err: "no such host", Name: "dev-0123456789abcdef.civit.ai", IsNotFound: true}}, "dns"},
+		{"*net.OpError nesting *os.SyscallError(ETIMEDOUT)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}, "timeout"},
+		{"*url.Error wrapping a timeout *net.OpError",
+			&url.Error{Op: "Get", URL: "https://dev-0123456789abcdef.civit.ai/",
+				Err: &net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ETIMEDOUT)}}, "timeout"},
+		{"*net.OpError nesting *os.SyscallError(ECONNREFUSED)",
+			&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}, "unreachable"},
+		{"a plain error", errors.New("boom"), "unreachable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyProbeErr(tc.err); got != tc.want {
+				t.Errorf("classifyProbeErr = %q, want %q for %T: %v.\n"+
+					"A genuine transport failure must keep its tag — the filesystem gate must not have\n"+
+					"flattened the classification.", got, tc.want, tc.err, tc.err)
+			}
+		})
+	}
+}
+
+// TestClassifyProbeErrRealDNSFailure uses a REAL resolver failure when one is
+// observable. `.invalid` is reserved by RFC 2606 and can never resolve, but a
+// sandbox with no resolver at all answers differently — so the row SKIPS rather
+// than asserting something the environment is not doing. It never depends on
+// reaching the public internet.
+func TestClassifyProbeErrRealDNSFailure(t *testing.T) {
+	c := &http.Client{Timeout: 5 * time.Second}
+	resp, err := c.Get("http://dev-0123456789abcdef.invalid/")
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Skip("a reserved .invalid name resolved here — this environment cannot show a real DNS failure")
+	}
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		t.Skipf("the resolver did not produce a *net.DNSError here (%T: %v) — nothing real to assert", err, err)
+	}
+	if got := classifyProbeErr(err); got != "dns" {
+		t.Errorf("classifyProbeErr = %q for a REAL resolver failure, want \"dns\": %v", got, err)
+	}
+}
+
+// realProbeClientTimeout produces the error net/http really returns when
+// http.Client.Timeout fires against a hung handler.
+func realProbeClientTimeout(t *testing.T) error {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-release }))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	c := &http.Client{Timeout: 50 * time.Millisecond}
+	resp, err := c.Get(srv.URL + "/")
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("a hung handler answered inside the client timeout — no timeout error to test with")
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) || !ne.Timeout() {
+		t.Fatalf("expected a timeout net.Error from http.Client.Timeout, got %T: %v", err, err)
+	}
+	return err
+}
+
+// realProbeRefusedDial produces the *url.Error http.Client.Do really returns for
+// a refused connection — the commonest not-ready state of a dev tunnel.
+func realProbeRefusedDial(t *testing.T) error {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind a loopback listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("could not release the listener: %v", err)
+	}
+	c := &http.Client{Timeout: 5 * time.Second}
+	resp, derr := c.Get("http://" + addr + "/")
+	if derr == nil {
+		_ = resp.Body.Close()
+		t.Skipf("something else grabbed %s between close and dial — the refusal is not observable here", addr)
+	}
+	var op *net.OpError
+	if !errors.As(derr, &op) {
+		t.Fatalf("expected a *net.OpError from a refused dial, got %T: %v", derr, derr)
+	}
+	return derr
+}
+
+// realProbeReadDeadline produces a genuine timeout *net.OpError from the net
+// stack: a live loopback connection whose read deadline has already passed.
+func realProbeReadDeadline(t *testing.T) error {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not bind a loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			accepted <- c
+		}
+		close(accepted)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("could not dial the loopback listener: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if c := <-accepted; c != nil {
+		t.Cleanup(func() { _ = c.Close() })
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("could not set a read deadline: %v", err)
+	}
+	_, rerr := conn.Read(make([]byte, 1))
+	if rerr == nil {
+		t.Fatal("a read past its deadline returned no error")
+	}
+	var ne net.Error
+	if !errors.As(rerr, &ne) || !ne.Timeout() {
+		t.Fatalf("expected a timeout net.Error, got %T: %v", rerr, rerr)
+	}
+	return rerr
+}


### PR DESCRIPTION
Closes #246. Third and fourth copies of the trap AGENTS.md item 24 documents (issues #241, #244): `syscall.Errno` declares `Timeout()` and `Temporary()`, so it satisfies `net.Error`, and `errors.As(err, &netErr)` walks straight past a filesystem wrapper to the errno underneath. `Errno.Timeout()` is **true** for `ETIMEDOUT`, `EAGAIN` and `EWOULDBLOCK`.

Both remaining sites now gate their `net.Error` branch on `civitai.IsTransportError`, which therefore has **four** callers: `cmd/civitai`'s `exitCode`, `pkg/civitai`'s retry loop, and these two.

Rebased onto `bea523a` (current `main`); `TestEveryAgentsItemIsNamedByTheIndex` from #247 is green — item 24 is extended, N stays 24, no index edit needed.

## Per-site decision

### `internal/appapi/appblocks.go` — `isTimeoutErr` (the `app submit` upload)

**Fixed, and it was LIVE.** `internal/cmd/app_submit.go:132` wires `auth.New(cfg)` into `SubmitVersion` → `authedDoWith` → `auth.Source.Token(ctx)` → `refreshLocked` → `cfg.SetOAuthTokens` → `config.save()` (a real filesystem write), and `internal/auth/source.go:115` returns `persist refreshed tokens: %w` when it fails. A config dir on NFS-soft / sshfs / CIFS fails with exactly those errnos — the #244 scenario, arriving through the same seam.

So `SubmitVersion` believed the upload had timed out and routed into `recoverTimedOutSubmit` for a POST that was never built. Measured through the real `SubmitVersion`: **Token() calls=4, submit POSTs=0, recovery polls=3**, then `timedOutSubmitError` — "submit timed out and the upload may not have completed … run `civitai app status` to check whether it landed" — about **zero bytes sent**.

🔴 **The gate sits ABOVE `os.IsTimeout`, not only above the `errors.As`, and that placement is the whole point.** The predicate was filesystem-broad through **two complementary lines**. Measured on go1.25.12:

| shape | `os.IsTimeout` | naive `errors.As` + `Timeout()` |
|---|---|---|
| `&fs.PathError{Err: ETIMEDOUT}` | **true** | true |
| `fmt.Errorf("x: %w", <that>)` | false | **true** |
| `os.NewSyscallError("fsync", ETIMEDOUT)` | **true** | true |
| `&os.LinkError{Err: ETIMEDOUT}` | **true** | true |
| `errors.Join(prose, <PathError>)` | false | **true** |
| `EACCES` / `ENOENT` / `EIO` / `ENOSPC` (any shape) | false | false |

`os.IsTimeout` unwraps `*fs.PathError` / `*os.LinkError` / `*os.SyscallError` at the **top level only**; `errors.As` walks a `fmt.Errorf` wrapper. Fixing the spelling alone leaves half the hole — and the half it leaves is the DIRECT shape every filesystem call site returns.

### `internal/cmd/app_dev_tunnel.go` — `classifyProbeErr` (the readiness progress tag)

**Fixed, and the reachability guess in the handoff is retracted — but the claim is kept at the size it was measured.**

Reachability is confirmed: `internal/dnsprobe` imports no fs packages and `DialClient` only ever returns `ErrNotPublished`, so the resolver call site is clean — but the two `client.Do` call sites take whatever an **https** request returns, and the x509 system-roots load surfaces an unreadable CA bundle as `x509.SystemRootsError` wrapping an `*fs.PathError`. Reproduced live against an `httptest` TLS server with `SSL_CERT_FILE` at a mode-000 file: `errors.As(clientDoErr, &pathErr)` = **true**.

What is **not** claimed: that today's outermost shape mislabels. It does not, and the reason is two layers away from this function — `url.Error.Timeout()` type-asserts on its immediate `.Err` rather than unwrapping, so the errno is never consulted. Measured with an ETIMEDOUT bundle: bare `x509.SystemRootsError` → `timeout`, `*tls.CertificateVerificationError` around it → `timeout`, and only the outer `*url.Error` drops it to `unreachable`; with EACCES every shape is `unreachable`. The correct tag is one stdlib implementation detail from being wrong, on an input measured arriving here. The gate makes it structural instead of accidental. The `*url.Error` row is labelled a CONTROL in the test for exactly that reason.

Worth closing because the tag is the only thing telling an author whether to WAIT (DNS propagation, a slow route) or go looking — a manufactured "timeout" is the false-advice failure item 10 spent four measured corrections avoiding.

The `*net.DNSError` and `context.DeadlineExceeded` checks stay **ahead** of the gate at both sites: neither is reachable from a filesystem error, and `context.DeadlineExceeded` is not a `net.Error` the walk would find.

## Tests

Both directions, per item 24's doctrine — either half alone is satisfiable by a broken fix.

- **`internal/appapi/submit_fs_not_timeout_test.go`** drives the **REAL** `SubmitVersion` against an `httptest` server with an injected `civitai.TokenSource`, counting Token() calls, submit POSTs that reached the wire and `ListSubmissions` recovery polls. Filesystem rows must observe **1 / 0 / 0** and get the error back by **identity** (`errors.Is` — `timedOutSubmitError` interpolates its cause with `%v`, so identity is the structural form of "not re-wrapped"). Each row records which half of the old predicate caught it, and the halves are **disjoint by assertion** (an `errors.As only` row requires `os.IsTimeout` NOT to match), with a per-half count floor. A separate table asserts `isTimeoutErr` directly, so a failure names the predicate rather than only the flow.
- **Positive controls (invariant guards, green at base):** a REAL `http.Client.Timeout` against a hung handler must still recover and surface the landed pubreq id; the same with nothing landed must burn the full `submitPollAttempts` budget and keep the actionable message; a `context.DeadlineExceeded` from the TokenSource pins the **injection point** itself, so "no filesystem error recovers" is not also satisfied by never recovering from anything a TokenSource returns.
- **`internal/cmd/app_dev_tunnel_probe_class_test.go`** is the `classifyProbeErr` table: REAL errors where they can be produced (a real refused dial, a real `http.Client.Timeout` `*url.Error`, a real read-deadline `*net.OpError`, and a real resolver failure that **skips** rather than depending on the network), plus the constructed x509 / tls / `*url.Error` chain. `EACCES`/`ENOENT`/`EIO` rows are labelled CONTROLS.
- Both files pin the stdlib trap itself and assert **per row** that the naive predicate still matches — a row the trap no longer reaches proves nothing about the guard.

## Verification

`make ci` green on the rebased tree, **counted**: **18 `ok` packages, 0 `--- FAIL`, 0 `FAIL` packages, 0 `build failed`, 0 `no test files`, 0 timeout panics.** `gofmt -s -l .` silent over **292** `.go` files (count asserted, so a silent scan of zero files cannot read as clean).

## Mutation matrix

Each mutation applied, affected packages run with `-v`, leaf subtests counted by name, then reverted. Re-run after `make fmt` (which rewrote nothing).

| # | mutation | reddened | which |
|---|---|---|---|
| 1 | `isTimeoutErr` reverted to the base spelling | **16 leaf** + 3 parents | all 8 trapped rows × `TestIsTimeoutErrRejectsFilesystemErrors` and `TestSubmitVersionDoesNotRecoverFromAFilesystemError`, plus `…MessageIsNotTheTimeoutAdvice`. Controls and all positive controls green. |
| 2 | gate moved ONE LINE DOWN (`os.IsTimeout` left ungated — the half-fix) | **8 leaf** + 2 parents | exactly the four `os.IsTimeout` rows (`bare ETIMEDOUT`, `*fs.PathError`, `*os.SyscallError`, `*os.LinkError`) × both tables. Every `errors.As only` row stayed green — the placement is load-bearing, and a table built on one shape could not see this. |
| 3 | recovery branch at `SubmitVersion` deleted | **5 top-level** | `…StillRecoversFromARealTimeout`, `…WithNothingLanded`, `…RecoversFromADeadlineExceededTokenError`, plus the two pre-existing `submit_recover_test.go` cases. Filesystem table fully green — the controls are not vacuous. |
| 4 | `classifyProbeErr` reverted to the base spelling | **9 leaf** + 1 parent | every trapped row; no control, and the `*url.Error` shielded row correctly stayed green. |
| 5 | `classifyProbeErr` flattened to a constant `"unreachable"` | **8 leaf** + 2 parents | the whole transport battery plus the real-DNS test — neither battery is satisfiable by the other's fix. |

No mutation reddened zero subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
