### PR TITLE
test(neterr): assert the set of errors.As(&net.Error) sites instead of asking for a comment (#246)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1805,6 +1805,50 @@ neither one's.
         pre-existing `submit_recover_test.go` cases — with the whole filesystem
         table still green, which is what makes those rows evidence rather than a
         build that refuses everything.
+    - 🔴 **THE SET OF SITES IS NOW AN ASSERTED LEDGER, SO ADDING ONE IS A CODE
+      CHANGE A TEST REFUSES — NOT A CONVENTION SOMEONE MAY NOT HAVE READ.**
+      #246's fourth suggestion was "leave no bare `errors.As(err, &netErr)`
+      without an adjacent comment". That is unenforceable, and unenforceability
+      is the ENTIRE history of this item: four copies, found one at a time,
+      across #241, #244 and #246, each looking fine in isolation because nothing
+      ever counted them. `neterr_ledger_test.go` (module root) AST-walks every
+      non-test `.go` file for `errors.As` calls whose target is typed
+      `net.Error`, and asserts the set equals a ledger carrying a one-line
+      justification per entry. **It fails when the set GROWS, when it SHRINKS,
+      and when a ledgered function's COUNT changes** — a guard that only caught
+      growth would let a silent removal turn the ledger into a false map. So a
+      new site costs a ledger entry AND the behavioural test that entry cites;
+      neither a comment nor a reviewer's memory is load-bearing any more.
+      - **It keys on the TYPE, never the identifier.** The two ledgered sites
+        already spell the variable `netErr` and `nerr`; a matcher keyed on
+        either is a spelled guard that a third site named anything else walks
+        straight past. Mutation-measured, each mutation **checksum-gated** so an
+        edit that silently failed to apply cannot read as a survivor: a new bare
+        site, the same with the variable renamed, and the same after `make fmt`
+        each redden it with `UNLEDGERED …`; deleting a ledgered site reddens it
+        with `LEDGERED site(s) no longer present`; a comment-only null mutant
+        survives. The `make fmt` mutant is not paranoia — it is the #238 trap,
+        where `gofmt -s` rewrote the literal shape a guard keyed on and CI then
+        enforced the rewritten form, disarming it.
+      - 🔴 **DO NOT READ ITS GREEN AS "THE SITES ARE FINE".** It cannot see a
+        gate at all — not whether one exists, and not whether it sits in the
+        right PLACE. Deleting `civitai.IsTransportError` from either site, or
+        sliding it one line down at `isTimeoutErr` (the half-fix the bullet
+        above measured), leaves this file byte-for-byte green. It answers
+        exactly one question — has a site appeared or vanished — and the
+        behavioural guards answer the other. Both are needed.
+      - **It is deliberately blind to `_test.go` files and to comments, and both
+        exclusions are load-bearing.** `cmd/civitai/fs_not_network_test.go`
+        IMPLEMENTS the naive predicate on purpose, as the control that pins the
+        stdlib trap; and `transport_error.go`, `retry.go` and `main.go` all
+        QUOTE the pattern in prose to explain why they avoid it — which is why
+        this is an AST walk rather than a `git grep`, since a text matcher
+        counts all four as sites. The cost is stated rather than hidden: a new
+        bare site inside a `_test.go` file is invisible to it. Its syntactic
+        blind spots (`:=` with no spelled type, a local type alias, a
+        dot-imported `net`) are listed in the file's own header; there is no
+        full type resolution because `golang.org/x/tools/go/packages` would be a
+        new dependency, which is an "ask first" below.
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/neterr_ledger_test.go
+++ b/neterr_ledger_test.go
@@ -1,0 +1,549 @@
+package cli_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// neterr_ledger_test.go is the structural guard for issue #246's point 4, and
+// it replaces a rule that could not enforce itself.
+//
+// THE RULE IT REPLACES. #246's suggested resolution ended "leave no bare
+// `errors.As(err, &netErr)` in the tree without an adjacent comment explaining
+// why that spelling is correct there". #248 closed the two sites the issue was
+// about; this closes the point the issue could not close by writing it down.
+// A convention decays the moment somebody adds a site without reading it —
+// which is exactly how #244 survived #242, and how #246's pair survived #244:
+// the spelling looked fine at every site, and nothing counted the sites. Four
+// copies were found one at a time, over four issues.
+//
+// WHAT THIS DOES INSTEAD. It parses every non-test .go file in the module,
+// finds every `errors.As(x, &v)` whose target `v` is typed as the `net.Error`
+// INTERFACE, and asserts that set equals a ledger written out below with a
+// one-line justification per entry. It fails when the set GROWS (a new site
+// nobody justified) and when it SHRINKS (a ledgered site silently removed, so
+// the ledger stops describing the tree). A guard that only catches growth is
+// half a guard.
+//
+// 🔴 WHAT IT DOES NOT PROVE — read this before trusting a green run.
+//
+//   - 🔴 It does not prove any ledgered site is CORRECT — it proves the SET has
+//     not moved. In particular it CANNOT see whether a site's
+//     `civitai.IsTransportError` gate is still there, or still in the right
+//     PLACE. #248 measured that placement is load-bearing at `isTimeoutErr`:
+//     gating only the `errors.As` and leaving `os.IsTimeout` above it is a
+//     half-fix, because the two lines are filesystem-broad over different
+//     shapes. Deleting a gate outright, or sliding it one line down, leaves
+//     THIS file byte-for-byte green. The behavioural guards are what catch
+//     that: internal/appapi/submit_fs_not_timeout_test.go and
+//     internal/cmd/app_dev_tunnel_probe_class_test.go. Do not read a green here
+//     as "the sites are fine"; read it as "no site appeared or vanished".
+//   - It does not see a site whose target's type it cannot resolve
+//     SYNTACTICALLY. The module has no `golang.org/x/tools/go/packages`
+//     dependency and adding one is an "ask first" in AGENTS.md, so there is no
+//     full type resolution here. Specifically blind to: `nerr := someFunc()`
+//     returning a net.Error (no type is spelled), a local type alias
+//     (`type ne = net.Error`), a dot-imported `net`, and a target reached
+//     through an intermediate variable (`p := &nerr; errors.As(err, p)`).
+//     Every one of those is a shape nobody in this tree writes, and each would
+//     be a deliberate evasion rather than an accident — which is the shape of
+//     mistake this guard is not trying to catch.
+//   - It is deliberately blind to COMMENTS, and that is load-bearing rather
+//     than incidental: `pkg/civitai/transport_error.go`, `pkg/civitai/retry.go`
+//     and `cmd/civitai/main.go` all QUOTE `errors.As(err, &netErr)` in prose to
+//     explain why they do not use it. A text matcher counts those as sites; an
+//     AST walk cannot see them at all, because a comment never becomes a
+//     CallExpr.
+//   - It is deliberately blind to _test.go FILES. `cmd/civitai/fs_not_network_test.go`
+//     IMPLEMENTS the naive predicate on purpose, as the control that pins the
+//     stdlib trap itself ("assert the naive spelling STILL matches this
+//     fixture, or the row proves nothing"). Ledgering test files would either
+//     force that control into the ledger or force it to be written obscurely.
+//     The cost is real and stated: a new bare site in a _test.go file is
+//     invisible here.
+//
+// 🔴 IT KEYS ON THE TYPE, NOT ON THE NAME. The two ledgered sites spell the
+// variable `netErr` and `nerr`; a matcher keyed on either identifier would be a
+// spelled guard that a third site named `ne` walks straight past. The scanner's
+// own claim about which spellings it can SEE is validated separately by
+// TestNetErrorAsScannerSeesEverySpelling — including the `gofmt -s` question
+// that disarmed the analogous guard in #238, since `make fmt` rewrites the tree
+// and CI enforces `gofmt -s -l .`.
+
+// netErrorAsSite is one `errors.As(_, &<net.Error>)` call in the module source.
+type netErrorAsSite struct {
+	// File is slash-separated and relative to the module root.
+	File string
+	// Func is the enclosing top-level function or method, closures normalised to
+	// their parent. It is "<file-level>" for a call outside any function body.
+	Func string
+}
+
+func (s netErrorAsSite) String() string { return s.File + ":" + s.Func }
+
+// netErrorAsLedger is the ASSERTED SET. Every bare `errors.As(_, &<net.Error>)`
+// in a non-test file must appear here, with a count, and every entry here must
+// still exist. Adding an entry is how you justify a new site; the justification
+// belongs on the entry, not in a comment three screens away, because a comment
+// somewhere else is what #246 found does not survive.
+var netErrorAsLedger = []struct {
+	netErrorAsSite
+	// Count is how many such calls the function holds. Pinned so a SECOND site
+	// smuggled into an already-ledgered function is still caught.
+	Count int
+	// Why is the one-line justification. Keep it one line; the full argument
+	// belongs in the function's doc comment, which is where a reader who is
+	// about to change the code will actually be.
+	Why string
+}{
+	{
+		netErrorAsSite: netErrorAsSite{File: "internal/appapi/appblocks.go", Func: "isTimeoutErr"},
+		Count:          1,
+		Why: "GATED, NOT BARE (#246/#248): unreachable unless civitai.IsTransportError(err) already returned " +
+			"true, and that gate sits ABOVE os.IsTimeout because the two lines are filesystem-broad over " +
+			"different shapes. Guard: internal/appapi/submit_fs_not_timeout_test.go.",
+	},
+	{
+		netErrorAsSite: netErrorAsSite{File: "internal/cmd/app_dev_tunnel.go", Func: "classifyProbeErr"},
+		Count:          1,
+		Why: "GATED, NOT BARE (#246/#248): unreachable unless civitai.IsTransportError(err) already returned " +
+			"true; it only reads Timeout() off an error the walk accepted, which IsTransportError (a presence " +
+			"answer) cannot give. Guard: internal/cmd/app_dev_tunnel_probe_class_test.go.",
+	},
+}
+
+func TestNetErrorAsSitesMatchTheLedger(t *testing.T) {
+	files := moduleGoFiles(t)
+	// Positive control on the WALKER: this module has ~110 non-test .go files.
+	// A short list means the walk is looking at the wrong tree and every
+	// assertion below would pass vacuously — the "harness wired to nothing"
+	// failure whose reassuring answer is a zero.
+	if len(files) < 60 {
+		t.Fatalf("walker found only %d non-test .go files — it is scanning the wrong tree, so a "+
+			"clean result says nothing", len(files))
+	}
+
+	found := map[netErrorAsSite]int{}
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		rel := filepath.ToSlash(f)
+		for _, s := range scanNetErrorAs(t, rel, src) {
+			found[s]++
+		}
+	}
+
+	want := map[netErrorAsSite]int{}
+	why := map[netErrorAsSite]string{}
+	for _, e := range netErrorAsLedger {
+		if e.Count < 1 {
+			t.Fatalf("ledger entry %s has Count %d — an entry is a site that EXISTS", e, e.Count)
+		}
+		if strings.TrimSpace(e.Why) == "" {
+			t.Fatalf("ledger entry %s carries no justification — that is the whole point of the entry", e)
+		}
+		want[e.netErrorAsSite] = e.Count
+		why[e.netErrorAsSite] = e.Why
+	}
+
+	// GROWTH: a site the ledger does not name.
+	var grown []string
+	for s, n := range found {
+		if w, ok := want[s]; !ok {
+			grown = append(grown, fmt.Sprintf("%s (%d call(s))", s, n))
+		} else if n != w {
+			grown = append(grown, fmt.Sprintf("%s has %d call(s), ledger says %d", s, n, w))
+		}
+	}
+	sort.Strings(grown)
+	if len(grown) > 0 {
+		t.Errorf("UNLEDGERED `errors.As(_, &<net.Error>)` site(s):\n  %s\n\n"+
+			"`syscall.Errno` satisfies net.Error (it declares Timeout() and Temporary()) while "+
+			"*fs.PathError / *os.LinkError / *os.SyscallError do not, so errors.As unwraps PAST the "+
+			"filesystem wrapper and matches the bare errno — and Errno.Timeout() is TRUE for "+
+			"ETIMEDOUT / EAGAIN / EWOULDBLOCK. See AGENTS.md item 24.\n"+
+			"Either call `civitai.IsTransportError` instead, or add an entry to netErrorAsLedger in "+
+			"this file with a one-line justification AND a test that pins the behaviour you are "+
+			"claiming is correct.", strings.Join(grown, "\n  "))
+	}
+
+	// SHRINK: a ledgered site that no longer exists. The ledger is documentation
+	// that other files' doc comments point at; a stale entry is a false map.
+	var gone []string
+	for s := range want {
+		if _, ok := found[s]; !ok {
+			gone = append(gone, fmt.Sprintf("%s — justified as: %s", s, why[s]))
+		}
+	}
+	sort.Strings(gone)
+	if len(gone) > 0 {
+		t.Errorf("LEDGERED site(s) no longer present:\n  %s\n\n"+
+			"If the site was legitimately removed or renamed, delete/update its netErrorAsLedger "+
+			"entry in the same commit — and check whether the doc comment that referenced it "+
+			"(and AGENTS.md item 24) still describes the tree.", strings.Join(gone, "\n  "))
+	}
+}
+
+// TestNetErrorAsScannerSeesEverySpelling validates the SCANNER, not the tree.
+// TestNetErrorAsSitesMatchTheLedger's green is a claim about the spellings this
+// scanner can see, and in #238 the analogous claim was false for exactly one
+// spelling — the one `gofmt -s` produces, which `make fmt` writes and CI
+// enforces. So each row here is a negative or positive control fed to the same
+// function the ledger test uses.
+func TestNetErrorAsScannerSeesEverySpelling(t *testing.T) {
+	const preamble = "package p\n\nimport (\n\t\"errors\"\n\t\"net\"\n)\n\nvar err error\n\n"
+
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "the canonical spelling",
+			src:  preamble + "func f() bool {\n\tvar netErr net.Error\n\treturn errors.As(err, &netErr)\n}\n",
+			want: 1,
+		},
+		{
+			name: "SAME SHAPE, DIFFERENT NAME — the spelled-guard control",
+			src:  preamble + "func f() bool {\n\tvar wibble net.Error\n\treturn errors.As(err, &wibble)\n}\n",
+			want: 1,
+		},
+		{
+			name: "single-line var decl inside an if",
+			src:  preamble + "func f() bool {\n\tvar ne net.Error\n\tif errors.As(err, &ne) && ne.Timeout() {\n\t\treturn true\n\t}\n\treturn false\n}\n",
+			want: 1,
+		},
+		{
+			name: "grouped var decl",
+			src:  preamble + "func f() bool {\n\tvar (\n\t\tx int\n\t\tne net.Error\n\t)\n\t_ = x\n\treturn errors.As(err, &ne)\n}\n",
+			want: 1,
+		},
+		{
+			name: "aliased net import",
+			src:  "package p\n\nimport (\n\t\"errors\"\n\tgonet \"net\"\n)\n\nvar err error\n\nfunc f() bool {\n\tvar ne gonet.Error\n\treturn errors.As(err, &ne)\n}\n",
+			want: 1,
+		},
+		{
+			name: "aliased errors import",
+			src:  "package p\n\nimport (\n\tgoerrors \"errors\"\n\t\"net\"\n)\n\nvar err error\n\nfunc f() bool {\n\tvar ne net.Error\n\treturn goerrors.As(err, &ne)\n}\n",
+			want: 1,
+		},
+		{
+			name: "target is a function parameter",
+			src:  preamble + "func f(target net.Error) bool {\n\treturn errors.As(err, &target)\n}\n",
+			want: 1,
+		},
+		{
+			name: "target is new(net.Error) — no named variable at all",
+			src:  preamble + "func f() bool {\n\treturn errors.As(err, new(net.Error))\n}\n",
+			want: 1,
+		},
+		{
+			name: "package-level target, call inside a closure",
+			src:  preamble + "var ne net.Error\n\nfunc f() func() bool {\n\treturn func() bool { return errors.As(err, &ne) }\n}\n",
+			want: 1,
+		},
+		{
+			name: "two sites in one function are counted as two",
+			src:  preamble + "func f() bool {\n\tvar a net.Error\n\tvar b net.Error\n\treturn errors.As(err, &a) || errors.As(err, &b)\n}\n",
+			want: 2,
+		},
+		// NEGATIVE CONTROLS.
+		{
+			name: "NEGATIVE *net.DNSError is a concrete type, not the interface",
+			src:  preamble + "func f() bool {\n\tvar d *net.DNSError\n\treturn errors.As(err, &d)\n}\n",
+			want: 0,
+		},
+		{
+			name: "NEGATIVE *net.OpError is a concrete type, not the interface",
+			src:  preamble + "func f() bool {\n\tvar o *net.OpError\n\treturn errors.As(err, &o)\n}\n",
+			want: 0,
+		},
+		{
+			name: "NEGATIVE errors.Is is a different function",
+			src:  preamble + "func f() bool {\n\tvar ne net.Error\n\t_ = ne\n\treturn errors.Is(err, nil)\n}\n",
+			want: 0,
+		},
+		{
+			name: "NEGATIVE the pattern quoted in a doc comment (how transport_error.go explains itself)",
+			src:  preamble + "// It is close to, but deliberately not, `errors.As(err, &netErr)`.\n//\n//\tvar netErr net.Error\n//\treturn errors.As(err, &netErr)\nfunc f() bool {\n\treturn false\n}\n",
+			want: 0,
+		},
+		{
+			name: "NEGATIVE a same-named local of a DIFFERENT type in another file",
+			src:  preamble + "type myErr struct{}\n\nfunc f() bool {\n\tvar ne *myErr\n\treturn errors.As(err, &ne)\n}\n",
+			want: 0,
+		},
+		{
+			name: "NEGATIVE net.Error used as a type but never an errors.As target",
+			src:  preamble + "func f(ne net.Error) bool {\n\treturn ne.Timeout()\n}\n",
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanNetErrorAs(t, "synthetic.go", []byte(tc.src))
+			if len(got) != tc.want {
+				t.Fatalf("scanner found %d site(s), want %d\n--- source ---\n%s", len(got), tc.want, tc.src)
+			}
+		})
+	}
+}
+
+// TestNetErrorAsScannerSurvivesGofmt is the #238 lesson made into a test. That
+// guard was disarmed because `gofmt -s` REWROTE the literal spelling it keyed
+// on, and CI then enforced the rewritten form. So: take every positive row's
+// source, run it through the same printer `gofmt` uses, and require the scanner
+// to still see it.
+func TestNetErrorAsScannerSurvivesGofmt(t *testing.T) {
+	srcs := []string{
+		"package p\n\nimport (\n\"errors\"\n\"net\"\n)\n\nvar err error\n\nfunc f() bool {\nvar netErr net.Error\nreturn errors.As( err , &netErr )\n}\n",
+		"package p\n\nimport (\n\"errors\"\n\"net\"\n)\n\nvar err error\n\nfunc f() bool {\nvar ne net.Error\nif errors.As(err,&ne)&&ne.Timeout(){return true}\nreturn false\n}\n",
+		"package p\n\nimport (\n\"errors\"\n\"net\"\n)\n\nvar err error\n\nfunc f() bool { return errors.As(err, new(net.Error)) }\n",
+	}
+	for i, src := range srcs {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			before := scanNetErrorAs(t, "synthetic.go", []byte(src))
+			if len(before) != 1 {
+				t.Fatalf("pre-format: scanner found %d site(s), want 1 — the row is not a positive control", len(before))
+			}
+			formatted := gofmtSimplify(t, []byte(src))
+			after := scanNetErrorAs(t, "synthetic.go", formatted)
+			if len(after) != 1 {
+				t.Fatalf("POST-`gofmt -s`: scanner found %d site(s), want 1. The repo's own formatter "+
+					"disarmed the guard — this is exactly what happened in #238.\n--- formatted ---\n%s",
+					len(after), formatted)
+			}
+		})
+	}
+}
+
+// gofmtSimplify runs the module's real `gofmt -s` over src. It shells out to the
+// same binary `make fmt` and CI use rather than reimplementing the simplifier,
+// because a reimplementation would be a fourth thing to keep in lockstep and the
+// whole point of the check is "what does the tool actually do".
+func gofmtSimplify(t *testing.T, src []byte) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.go")
+	if err := os.WriteFile(p, src, 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	bin, err := exec.LookPath("gofmt")
+	if err != nil {
+		// `go test` always runs with a toolchain, so gofmt should be next to it;
+		// fall back to `go fmt`'s binary location before giving up.
+		if goroot := os.Getenv("GOROOT"); goroot != "" {
+			bin = filepath.Join(goroot, "bin", "gofmt")
+		} else {
+			t.Fatalf("gofmt not on PATH (%v) — this control cannot run, and a SKIP here would "+
+				"read as a pass; install the toolchain or fix PATH", err)
+		}
+	}
+	out, err := exec.Command(bin, "-s", p).Output()
+	if err != nil {
+		t.Fatalf("gofmt -s %s: %v", p, err)
+	}
+	if len(out) == 0 {
+		t.Fatal("gofmt -s produced empty output — the control is measuring nothing")
+	}
+	return out
+}
+
+// moduleGoFiles returns every non-test .go file in the module, relative to the
+// module root, sorted. Hidden dirs, testdata and the scaffold's template trees
+// are excluded; nothing else is.
+func moduleGoFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if path != "." && (strings.HasPrefix(name, ".") || name == "testdata" || name == "node_modules" || name == "dist" || name == "bin") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// scanNetErrorAs parses src and returns one site per `errors.As(_, target)` call
+// whose target is typed as the `net.Error` INTERFACE.
+//
+// Resolution is syntactic and scoped to the file, which over-approximates: a
+// name declared `net.Error` anywhere in a file makes every `errors.As(_, &name)`
+// in that file a site, even if the second one is a different variable that
+// happens to share the name. Over-approximation is the safe direction — it can
+// only produce a spurious FAILURE, which is a stop-and-read, never a spurious
+// pass. The under-approximations are listed in this file's header comment.
+func scanNetErrorAs(t *testing.T, rel string, src []byte) []netErrorAsSite {
+	t.Helper()
+	fset := token.NewFileSet()
+	// Comments are not parsed: a quoted `errors.As(err, &netErr)` in prose must
+	// never become a site, and three files in this repo quote it deliberately.
+	file, err := parser.ParseFile(fset, rel, src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", rel, err)
+	}
+
+	netPkg := importedAs(file, "net")
+	errorsPkg := importedAs(file, "errors")
+	if netPkg == "" || errorsPkg == "" {
+		// A file that imports neither cannot hold the pattern in the shapes this
+		// scanner understands.
+		return nil
+	}
+
+	// Phase 1: every identifier in this file declared with the type `net.Error`
+	// (var specs at any level, function parameters, results, struct fields).
+	targets := map[string]bool{}
+	isNetError := func(e ast.Expr) bool {
+		sel, ok := e.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Error" {
+			return false
+		}
+		id, ok := sel.X.(*ast.Ident)
+		return ok && id.Name == netPkg
+	}
+	addNames := func(names []*ast.Ident, typ ast.Expr) {
+		if typ == nil || !isNetError(typ) {
+			return
+		}
+		for _, n := range names {
+			targets[n.Name] = true
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.ValueSpec:
+			addNames(x.Names, x.Type)
+		case *ast.Field:
+			addNames(x.Names, x.Type)
+		}
+		return true
+	})
+
+	// Phase 2: the calls. Walk top-level declarations so the enclosing function
+	// name is known; closures normalise to their parent FuncDecl.
+	var sites []netErrorAsSite
+	collect := func(node ast.Node, fnName string) {
+		ast.Inspect(node, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "As" {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != errorsPkg {
+				return true
+			}
+			if !isNetErrorTarget(call.Args[1], targets, isNetError) {
+				return true
+			}
+			sites = append(sites, netErrorAsSite{File: rel, Func: fnName})
+			return true
+		})
+	}
+	for _, d := range file.Decls {
+		switch x := d.(type) {
+		case *ast.FuncDecl:
+			collect(x, funcLabel(x))
+		default:
+			collect(x, "<file-level>")
+		}
+	}
+	return sites
+}
+
+// isNetErrorTarget reports whether an `errors.As` second argument is a net.Error
+// target: `&someNetErrorVar` or `new(net.Error)`.
+func isNetErrorTarget(arg ast.Expr, targets map[string]bool, isNetError func(ast.Expr) bool) bool {
+	switch x := arg.(type) {
+	case *ast.UnaryExpr:
+		if x.Op != token.AND {
+			return false
+		}
+		id, ok := x.X.(*ast.Ident)
+		return ok && targets[id.Name]
+	case *ast.CallExpr:
+		id, ok := x.Fun.(*ast.Ident)
+		if !ok || id.Name != "new" || len(x.Args) != 1 {
+			return false
+		}
+		return isNetError(x.Args[0])
+	}
+	return false
+}
+
+// funcLabel names a FuncDecl the way the ledger spells it: `Name` for a
+// function, `Recv.Name` for a method.
+func funcLabel(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return fd.Name.Name
+	}
+	recv := fd.Recv.List[0].Type
+	if star, ok := recv.(*ast.StarExpr); ok {
+		recv = star.X
+	}
+	if id, ok := recv.(*ast.Ident); ok {
+		return id.Name + "." + fd.Name.Name
+	}
+	return fd.Name.Name
+}
+
+// importedAs returns the local name a file imports importPath under ("" if it
+// does not import it). This is what keeps the scanner off a spelling: an aliased
+// `gonet "net"` is still net.
+func importedAs(file *ast.File, importPath string) string {
+	for _, imp := range file.Imports {
+		p, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || p != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name == "_" {
+				continue
+			}
+			return imp.Name.Name
+		}
+		return importBase(importPath)
+	}
+	return ""
+}
+
+// importBase is filepath.Base for an import path, which is always slash-separated.
+func importBase(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}


### PR DESCRIPTION
Follow-up to #246, on top of #248 (which merged while this was being built). #248 closed the two sites; this closes the issue's **fourth** point, which #248 did not:

> 4. Either way, leave no bare `errors.As(err, &netErr)` in the tree without an adjacent comment explaining why that spelling is correct there — the whole cost of #241 and #244 was that the spelling looked fine at every site.

A comment is not enforcement, and unenforceability is the entire history of AGENTS.md item 24: **four copies, found one at a time, across #241, #244 and #246** — each looking fine in isolation because nothing ever *counted* them. `--- ` **No behaviour change. Test + docs only.**

## Per-site decision — and a retraction

My brief said to **keep** `isTimeoutErr`'s breadth on a cost-asymmetry argument: "a false positive costs one bounded recovery poll that finds nothing; a false negative skips `recoverTimedOutSubmit` after a real timeout, so the author resubmits a landed upload."

**That premise was wrong on the facts, and #248 measured why.** At this site the failure arrives from `Token()`, *before* the POST is built — so the false positive is not a harmless poll. It is `Token() calls=4, submit POSTs=0, recovery polls=3` and then "submit timed out and the upload may not have completed … check whether it landed", **about zero bytes sent**, with the real cause (a config-dir write failure) buried. And the false negative I was protecting against is not created by the gate at all: a genuine `http.Client.Timeout` *is* a transport error, so it still passes `IsTransportError` and still recovers — #248 pins that with positive controls.

#248 also caught something the "keep the breadth" framing would have hidden entirely: at that site the gate has to sit **above `os.IsTimeout`**, because the two lines are filesystem-broad over *different shapes*. So both sites are correct as merged, and this PR touches neither. Recording it here because "I was told X, the evidence said not-X" is the part worth not losing.

## What the ledger is

`neterr_ledger_test.go` (module root) AST-walks every non-test `.go` file for `errors.As` calls whose second argument is typed as the **`net.Error` interface**, and asserts the set equals a ledger carrying a one-line justification per entry.

- Fails when the set **GROWS** (a site nobody justified), when it **SHRINKS** (a ledgered site silently removed — otherwise the ledger becomes a false map), and when a ledgered function's call **COUNT** changes (so a second site smuggled into an already-ledgered function is still caught).
- **Keys on the TYPE, not the identifier.** The two ledgered sites already spell the variable `netErr` and `nerr`; a check keyed on either is a spelled guard that a third site named anything else walks straight past.
- Adding a site now costs a **ledger entry plus the behavioural test that entry cites**. Neither a comment nor a reviewer's memory is load-bearing any more.

Current ledger — both entries justified as *gated, not bare* (each is unreachable unless `civitai.IsTransportError` already returned true):

| site | justification |
|---|---|
| `internal/appapi/appblocks.go` `isTimeoutErr` | gate sits ABOVE `os.IsTimeout` because the two lines are fs-broad over different shapes. Guard: `submit_fs_not_timeout_test.go` |
| `internal/cmd/app_dev_tunnel.go` `classifyProbeErr` | reads `Timeout()` off an error the walk accepted; `IsTransportError` is a presence answer and cannot give that. Guard: `app_dev_tunnel_probe_class_test.go` |

## Mutation matrix

Each mutation is **checksum-gated** — the file's sha256 must change, or the run is reported NOT-APPLIED rather than as a survivor. A mutation that silently fails to apply reads exactly like a survivor. Baseline asserted green first, so every kill is attributable. Every kill is by **this guard's own message**, not a neighbour's.

| # | mutation | verdict | attributed to |
|---|---|---|---|
| 1 | new bare `errors.As(err, &netErr)` in a non-test file | **KILLED** | `neterr_ledger_test.go:172: UNLEDGERED \`errors.As(_, &<net.Error>)\` site(s)` |
| 2 | same, variable renamed `zzOpaque` — the **spelled-guard** control | **KILLED** | same message — proves it is not keyed on the identifier |
| 3 | same, written unformatted then run through **`make fmt`** | **KILLED** | same message — the #238 trap, where `gofmt -s` rewrote the shape a guard keyed on and CI then enforced the rewritten form |
| 4 | delete a ledgered site (`classifyProbeErr`'s `net.Error` branch) | **KILLED** | `neterr_ledger_test.go:192: LEDGERED site(s) no longer present` |
| 5 | null mutant (comment-only append) | **SURVIVED** (expected) | — |

Tree restored to base checksums after the run (asserted, not assumed).

The scanner has its own controls, because the ledger's green is a claim about the spellings it can *see*: `TestNetErrorAsScannerSeesEverySpelling` (16 rows — aliased `net`/`errors` imports, grouped var decls, func params, `new(net.Error)`, two-in-one-function, plus **negative** controls for `*net.DNSError`, `*net.OpError`, `errors.Is`, and the pattern quoted in a doc comment) and `TestNetErrorAsScannerSurvivesGofmt` (runs the real `gofmt -s` binary over each positive row and re-scans). The walker also asserts a **file-count floor**, so a walk pointed at the wrong tree cannot report a reassuring zero.

## 🔴 What the ledger does NOT prove

- **It cannot see a gate — not whether one exists, nor whether it is in the right place.** Deleting `civitai.IsTransportError` from either site, or sliding it one line down at `isTimeoutErr` (the half-fix #248 measured), leaves this file **byte-for-byte green**. It answers exactly one question: has a site appeared or vanished. #248's behavioural guards answer the other one. Both are needed.
- **Deliberately blind to `_test.go` files** — `cmd/civitai/fs_not_network_test.go` *implements* the naive predicate on purpose, as the control that pins the stdlib trap itself. Cost stated rather than hidden: a new bare site inside a test file is invisible here.
- **Deliberately blind to comments** — `transport_error.go`, `retry.go` and `main.go` all *quote* `errors.As(err, &netErr)` in prose to explain why they avoid it. A text matcher counts all four as sites; an AST walk cannot see them at all. That is why this is not a `git grep`.
- **Syntactic blind spots**, listed in the file's own header: `nerr := someFunc()` (no type spelled), a local type alias, a dot-imported `net`, a target reached through an intermediate variable. There is no full type resolution because `golang.org/x/tools/go/packages` would be a new dependency — an "ask first" in AGENTS.md. Each blind spot is a deliberate evasion rather than the accident this guard exists to catch.

## Verification

`make ci` green. Counted, not read off an exit code: **2669 `=== RUN`, 2665 `--- PASS`, 0 `--- FAIL`, 4 `--- SKIP`** (all four pre-existing environment-gated: `TestScanDirFromEnv`, `TestSubmissionsCapDriftAgainstLiveAPI`, `TestScaffoldPinsSatisfyPublished`, `TestScaffoldedReadyAckActuallyFires`), **18 `ok` packages, 0 `FAIL` packages, 0 `no test files`, 0 timeout panics**. `gofmt -s -l .` silent over **293** `.go` files (count asserted, so a scan of zero files cannot read as clean). `TestEveryAgentsItemIsNamedByTheIndex` and the xref guards green — item 24 is extended, N stays 24, no index edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
