### PR TITLE
fix(generate): --print-input without --image needs no credential (#257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,11 +1174,20 @@ civitai generate --input graph.json --dry-run
 (`civitai login`, no `--scopes`) does **not** carry them and is refused.
 `civitai whoami` shows the capability as **Spend Buzz (AI Services)**.
 
-The one exception is `--print-input` **without** `--image`: it assembles the
-graph and exits before any authenticated route, so it needs no credential and
-works offline — useful for building a graph to edit before you have logged in.
-`--print-input` **with** `--image` still needs one, because it uploads each local
-file first and that upload is authenticated.
+The one exception is `--print-input`: it assembles the graph and exits before the
+estimator, the submit and the balance read, so it needs no credential — useful
+for building a graph to edit before you have logged in. Two caveats, and they are
+**not** the same caveat:
+
+- `--print-input` **with `--image`** does need a credential, because it uploads
+  each local file first and that upload is authenticated.
+- `--print-input` **with `--checkpoint` or `--lora`** needs none — the
+  model-version lookup is a public read — but it is **not offline**: that lookup
+  is a real request, and with no network it fails (exit `5`) rather than printing
+  a graph. Measured against a dead endpoint: bare `--print-input` exits `0`;
+  `--print-input --checkpoint <id>` exits `5` after the read's retries.
+
+So only a **bare** `--print-input` needs neither a credential nor a network.
 
 ### 🔴 `--max-cost` is an estimate check, not a spending cap
 

--- a/README.md
+++ b/README.md
@@ -1174,6 +1174,12 @@ civitai generate --input graph.json --dry-run
 (`civitai login`, no `--scopes`) does **not** carry them and is refused.
 `civitai whoami` shows the capability as **Spend Buzz (AI Services)**.
 
+The one exception is `--print-input` **without** `--image`: it assembles the
+graph and exits before any authenticated route, so it needs no credential and
+works offline — useful for building a graph to edit before you have logged in.
+`--print-input` **with** `--image` still needs one, because it uploads each local
+file first and that upload is authenticated.
+
 ### 🔴 `--max-cost` is an estimate check, not a spending cap
 
 The cost this command shows is an **estimate, not a quote**: the server's

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -179,10 +179,13 @@ CREDENTIAL: generation needs the AI Services scopes. Two credentials carry them:
 (` + "`civitai login`" + ` with no --scopes) does NOT carry them and is refused — and
 re-running plain ` + "`civitai login`" + ` will not fix that. Check yours with
 ` + "`civitai whoami`" + `.
-The ONE exception is --print-input WITHOUT --image: it assembles the graph and
-exits before any authenticated route, so it needs no credential and works
-offline. --print-input WITH --image still needs one, because it uploads each
-local file first and the upload is authenticated.
+The ONE exception is --print-input: it assembles the graph and exits before the
+estimator, the submit and the balance read, so it needs no credential. Two
+caveats, and they are NOT the same caveat. With --image it does need one, because
+it uploads each local file first and that upload is authenticated. With
+--checkpoint or --lora it still needs none — the model-version lookup is a public
+read — but it is not OFFLINE: that lookup is a real request and fails without a
+network. Only a bare --print-input needs neither a credential nor a network.
 
 --max-cost IS AN ESTIMATE CHECK, NOT A SPENDING CAP. The cost this command shows
 is an estimate, not a quote: the server's estimator returns no quote id, no
@@ -319,11 +322,24 @@ interpreted, so nothing in it is checked before you pay for it.`,
 			}
 			// 🔴 ONE credential gate, and it stays here — before every seam is
 			// built, not pushed down into the call sites. `--print-input` is the
-			// single exception, and only when it reaches no authed request at
-			// all: it assembles the graph and exits before the estimator, the
-			// submit and the balance read, so with no `--image` it makes NO
-			// request of any kind and refusing it contradicted the invariant
+			// single exception, and only when it reaches no AUTHED request: it
+			// assembles the graph and exits before the estimator, the submit and
+			// the balance read, so with no `--image` it sends nothing that
+			// carries a credential, and refusing it contradicted the invariant
 			// stated at the --print-input short-circuit below. Issue #257.
+			//
+			// 🔴 "NO AUTHED REQUEST" IS NOT "NO REQUEST", AND THE TWO MUST NOT
+			// BE COLLAPSED — an earlier revision of this comment said "makes NO
+			// request of any kind", which is the wording that belongs at the
+			// short-circuit (where it is guarded by "with no
+			// --checkpoint/--lora") and is false here. `--checkpoint`/`--lora`
+			// still perform the public model-version READ, so they need no
+			// credential but DO need a network. Measured against a dead
+			// endpoint, no credential: bare `--print-input` returns nil and
+			// prints the graph; `--print-input --checkpoint <id>` and
+			// `--print-input --lora <id>` both fail as transport errors (exit 5)
+			// after the read's 4 attempts. Only a bare `--print-input` needs
+			// neither.
 			//
 			// 🔴 The condition is `--image`, NOT `--checkpoint`/`--lora`, and
 			// the difference is which hop needs a credential. `--image` with a

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -179,6 +179,10 @@ CREDENTIAL: generation needs the AI Services scopes. Two credentials carry them:
 (` + "`civitai login`" + ` with no --scopes) does NOT carry them and is refused — and
 re-running plain ` + "`civitai login`" + ` will not fix that. Check yours with
 ` + "`civitai whoami`" + `.
+The ONE exception is --print-input WITHOUT --image: it assembles the graph and
+exits before any authenticated route, so it needs no credential and works
+offline. --print-input WITH --image still needs one, because it uploads each
+local file first and the upload is authenticated.
 
 --max-cost IS AN ESTIMATE CHECK, NOT A SPENDING CAP. The cost this command shows
 is an estimate, not a quote: the server's estimator returns no quote id, no

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -313,7 +313,29 @@ interpreted, so nothing in it is checked before you pay for it.`,
 			if err != nil {
 				return err
 			}
-			if cfg.Token() == "" {
+			// 🔴 ONE credential gate, and it stays here — before every seam is
+			// built, not pushed down into the call sites. `--print-input` is the
+			// single exception, and only when it reaches no authed request at
+			// all: it assembles the graph and exits before the estimator, the
+			// submit and the balance read, so with no `--image` it makes NO
+			// request of any kind and refusing it contradicted the invariant
+			// stated at the --print-input short-circuit below. Issue #257.
+			//
+			// 🔴 The condition is `--image`, NOT `--checkpoint`/`--lora`, and
+			// the difference is which hop needs a credential. `--image` with a
+			// local file UPLOADS before printing (item 19(f)) and hop 1 of that
+			// upload — `getConsumerBlobUploadUrl` — is AUTHED (item 19(e)), so
+			// the flag genuinely needs a token even on this path. An https
+			// `--image` reaches only the credential-free fetch, but a token is
+			// still required for the whole flag rather than per value: the
+			// narrower rule buys nothing, and "some --image values need a
+			// credential" is a worse contract than "--image does".
+			// `--checkpoint`/`--lora` resolve through the PUBLIC
+			// `GET /api/v1/model-versions/{id}` (item 13, "free,
+			// unauthenticated-capable"), so gating on them would keep refusing
+			// a case that demonstrably works with no credential.
+			needsCredential := !o.printInput || len(o.images) > 0
+			if needsCredential && cfg.Token() == "" {
 				return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf(
 					"no token configured — generation needs a credential with the AI Services scopes: "+
 						spendCredentialRoutes+". Or set CIVITAI_TOKEN"))
@@ -850,6 +872,10 @@ func runGenerate(cmd *cobra.Command, deps generateDeps, o generateOpts) error {
 		// make --print-input emit a document that --input then cannot submit,
 		// destroying the round-trip that is the whole feature. With no
 		// --checkpoint/--lora there is no request of any kind.
+		//
+		// That last sentence is what the credential gate in RunE now honours:
+		// `--print-input` without `--image` needs no token, because nothing on
+		// this path sends one. Issue #257 — the command used to refuse offline.
 		return printAssembledGraph(out, built.graph)
 	}
 

--- a/internal/cmd/generate_print_input_auth_test.go
+++ b/internal/cmd/generate_print_input_auth_test.go
@@ -266,30 +266,49 @@ func TestGeneratePrintInput_WithImageStillNeedsACredential(t *testing.T) {
 	// built), parseImageFlag (inside resolveImages) and resolveLocalImage's
 	// stat (deepest, one step before the upload). A change that silences any
 	// ONE of those sites cannot silence the other two.
-	for _, tc := range []struct {
+	// 🔴 AND THE THREE-SITE PROPERTY IS ASSERTED, NOT ASSERTED-IN-A-COMMENT.
+	// An audit demonstrated the gap: `via` was interpolated only into FAILURE
+	// messages, so a passing row never printed it — collapse rows 2 and 3 onto
+	// row 1's site and the suite stayed fully green at 16 RUN / 0 FAIL, in a
+	// file whose central thesis is that one row is not a battery. Each row now
+	// carries a `fingerprint` of its site's message and a PREMISE subtest that
+	// runs the same invocation WITH a credential — the gate does not fire, the
+	// run falls through to the site the row names, and the fingerprint is
+	// checked. `assertPairwiseDistinctSites` then requires each row's error to
+	// carry its OWN fingerprint and NONE of the others', so two rows that
+	// collapse onto one site fail by name.
+	rows := []struct {
 		name string
 		args []string
 		// via names the usage-error site the row reaches when the gate is
-		// ABSENT. Recorded so a row that stops exercising its site is visible
-		// as a documentation mismatch rather than as a quiet duplicate.
+		// ABSENT.
 		via string
+		// fingerprint is a substring unique to that site's message. It is used
+		// ONLY to identify WHICH check answered — never to assert the
+		// classification, which stays errors.Is per item 7.
+		fingerprint string
 	}{
 		{
-			name: "no --ecosystem",
-			args: []string{"a cat", "--print-input", "--image", img},
-			via:  "validateImageOpts (item 19(b): --image requires --ecosystem)",
+			name:        "no --ecosystem",
+			args:        []string{"a cat", "--print-input", "--image", img},
+			via:         "validateImageOpts (item 19(b): --image requires --ecosystem)",
+			fingerprint: "--image requires --ecosystem",
 		},
 		{
-			name: "empty --image value",
-			args: []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", ""},
-			via:  "parseImageFlag (an empty value is not a path or an https URL)",
+			name:        "empty --image value",
+			args:        []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", ""},
+			via:         "parseImageFlag (an empty value is not a path or an https URL)",
+			fingerprint: "the value is empty",
 		},
 		{
-			name: "--image is a directory",
-			args: []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", dir},
-			via:  "resolveLocalImage (os.Stat says directory, one step before the upload)",
+			name:        "--image is a directory",
+			args:        []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", dir},
+			via:         "resolveLocalImage (os.Stat says directory, one step before the upload)",
+			fingerprint: "is a directory, not an image file",
 		},
-	} {
+	}
+
+	for _, tc := range rows {
 		t.Run("and it is THIS gate that refuses: "+tc.name, func(t *testing.T) {
 			// Credential-less AND usage-invalid. ErrUnauthorized means the gate
 			// won the race; ErrUsage means the gate is gone and tc.via got there
@@ -298,6 +317,44 @@ func TestGeneratePrintInput_WithImageStillNeedsACredential(t *testing.T) {
 			assertRefusedByTheGate(t, r, tc.via)
 		})
 	}
+
+	// The premise of every row above: with the gate out of the way, this
+	// invocation really does reach the site it names. Without this, the rows
+	// are three spellings of one claim and nobody would know.
+	t.Run("each row reaches the DISTINCT site it names", func(t *testing.T) {
+		seen := make(map[string]string, len(rows))
+		for _, tc := range rows {
+			r := runGenerateCLI(t, "not-a-real-token-000", tc.args...)
+			if !errors.Is(r.err, ErrUsage) {
+				t.Fatalf("%s: with a credential the run must fall through to %s and fail as ErrUsage, got %v",
+					tc.name, tc.via, r.err)
+			}
+			if !strings.Contains(r.err.Error(), tc.fingerprint) {
+				t.Fatalf("%s: expected the error from %s (fingerprint %q), got %v",
+					tc.name, tc.via, tc.fingerprint, r.err)
+			}
+			// Pairwise distinctness, both directions: this row's error must
+			// carry NO other row's fingerprint, and no two rows may share one.
+			for _, other := range rows {
+				if other.via == tc.via {
+					continue
+				}
+				if strings.Contains(r.err.Error(), other.fingerprint) {
+					t.Fatalf("%s reached %s as well as %s — the rows are not independent sites",
+						tc.name, other.via, tc.via)
+				}
+			}
+			if prev, dup := seen[tc.fingerprint]; dup {
+				t.Fatalf("%s and %s share the fingerprint %q, so one of them is not pinning its own site",
+					prev, tc.name, tc.fingerprint)
+			}
+			seen[tc.fingerprint] = tc.name
+			assertOffline(t, r)
+		}
+		if len(seen) != len(rows) {
+			t.Fatalf("expected %d distinct sites, saw %d", len(rows), len(seen))
+		}
+	})
 }
 
 // TestGenerateDryRun_StillNeedsACredential — --dry-run reaches the estimator, an
@@ -377,23 +434,38 @@ func TestGeneratePrintInput_SkipsTheGateNotTheValidation(t *testing.T) {
 //
 // The server answers 404, so the run fails; that is fine and deliberate. The
 // claim is about WHERE it got to, not that it succeeded.
+// 🔴 BOTH FLAGS GET A ROW. `--checkpoint` alone was pinned, and an audit
+// measured the consequence: an ADDITIVE `|| len(o.loras) > 0` widening survived
+// all 1324 subtests in this package. The gate's own comment treats the two
+// identically, so pinning one and not the other made half of that comment a
+// claim nothing held.
 func TestGeneratePrintInput_WithCheckpointNeedsNoCredential(t *testing.T) {
-	r := runGenerateCLI(t, "", "a cat", "--print-input", "--checkpoint", "128713")
+	for _, tc := range []struct {
+		flag, value string
+	}{
+		{"--checkpoint", "128713"},
+		{"--lora", "128713"},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			r := runGenerateCLI(t, "", "a cat", "--print-input", tc.flag, tc.value)
 
-	if errors.Is(r.err, civitai.ErrUnauthorized) {
-		t.Fatalf("--print-input --checkpoint needs no credential (the version read is public), but it was refused: %v", r.err)
-	}
-	var public int
-	for _, h := range r.hits {
-		if strings.Contains(h.path, "/model-versions/") {
-			if h.hasAuth {
-				t.Errorf("the model-version read carried an Authorization header: %s", h)
+			if errors.Is(r.err, civitai.ErrUnauthorized) {
+				t.Fatalf("--print-input %s needs no credential (the version read is public), but it was refused: %v",
+					tc.flag, r.err)
 			}
-			public++
-		}
-	}
-	if public == 0 {
-		t.Fatalf("the run never reached the public model-version read; hits=%v err=%v", r.hits, r.err)
+			var public int
+			for _, h := range r.hits {
+				if strings.Contains(h.path, "/model-versions/") {
+					if h.hasAuth {
+						t.Errorf("the model-version read carried an Authorization header: %s", h)
+					}
+					public++
+				}
+			}
+			if public == 0 {
+				t.Fatalf("the run never reached the public model-version read; hits=%v err=%v", r.hits, r.err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/generate_print_input_auth_test.go
+++ b/internal/cmd/generate_print_input_auth_test.go
@@ -16,8 +16,9 @@ package cmd
 // `--print-input` really does upload local files (item 19(f)). `--checkpoint` /
 // `--lora` resolve through the PUBLIC model-version route (item 13), so gating on
 // those would keep refusing a case that works with no credential. The rows below
-// are therefore three refusals (--image, --dry-run, plain submit) against one
-// permission, so "delete the gate" fails rather than passes.
+// therefore pin BOTH directions — three refusals (--image, --dry-run, plain
+// submit) and two permissions (bare --print-input, --print-input --checkpoint) —
+// so neither "delete the gate" nor "widen the gate" passes.
 //
 // 🔴 CLASSIFICATION IS ASSERTED WITH errors.Is, NEVER MESSAGE TEXT (item 7). The
 // sentinels leave Error() byte-identical, so a message assertion says nothing at
@@ -33,8 +34,12 @@ package cmd
 // rather than by message. The gate runs BEFORE validateGenerateOpts, so an
 // invocation that is credential-less AND usage-invalid comes back
 // ErrUnauthorized today and flips to ErrUsage the moment the gate is gone.
-// Those rows carry `wantsGateAheadOfValidation`, and they are what makes
-// deleting the gate a failing change rather than a passing one.
+// Those rows call `assertRefusedByTheGate`, and they are what makes deleting
+// the gate a failing change rather than a passing one. There are THREE of them
+// on the --image path alone, reached through three different usage-error sites:
+// an audit measured the single-row version and found all three WIDENING mutants
+// reddening exactly one leaf, so reshaping that row would have unguarded the
+// `--image` half of the condition entirely.
 //
 // 🔴 "NO NETWORK" IS MEASURED, NOT INFERRED. Every run points CIVITAI_BASE_URL at
 // a live httptest server that RECORDS each request, and the offline rows assert
@@ -60,9 +65,10 @@ import (
 	"github.com/civitai/cli/pkg/civitai"
 )
 
-// recordedReq is one request that reached the base-URL server. hasAuth is kept
-// because the `--checkpoint` row's whole claim is that the model-version read is
-// PUBLIC — "a request went out" cannot distinguish that from an authed one.
+// recordedReq is one request that reached the base-URL server. hasAuth catches a
+// hardcoded credential appearing on the model-version read; see the note on
+// TestGeneratePrintInput_WithCheckpointNeedsNoCredential for what it does and
+// does not establish.
 type recordedReq struct {
 	method  string
 	path    string
@@ -153,13 +159,16 @@ func assertOffline(t *testing.T, r cliRun) {
 // Neither branch dials, and both would satisfy a plain "is it ErrUnauthorized?"
 // check via the token source — which is precisely why that check cannot pin the
 // gate and this one can.
-func assertRefusedByTheGate(t *testing.T, r cliRun) {
+//
+// `via` names the usage-error site the row falls through to when the gate is
+// absent; it is printed on failure so the message says WHICH check won the race.
+func assertRefusedByTheGate(t *testing.T, r cliRun, via string) {
 	t.Helper()
 	if errors.Is(r.err, ErrUsage) {
-		t.Fatalf("refused as a USAGE error, so the credential gate no longer runs ahead of validateGenerateOpts: %v", r.err)
+		t.Fatalf("refused as a USAGE error by %s, so the credential gate no longer runs ahead of it: %v", via, r.err)
 	}
 	if !errors.Is(r.err, civitai.ErrUnauthorized) {
-		t.Fatalf("want ErrUnauthorized from the credential gate, got %v", r.err)
+		t.Fatalf("want ErrUnauthorized from the credential gate (ahead of %s), got %v", via, r.err)
 	}
 	assertOffline(t, r)
 }
@@ -242,13 +251,53 @@ func TestGeneratePrintInput_WithImageStillNeedsACredential(t *testing.T) {
 		}
 	})
 
-	t.Run("and it is THIS gate that refuses", func(t *testing.T) {
-		// Credential-less AND usage-invalid: --image without --ecosystem is a
-		// hard usage error (item 19(b)). ErrUnauthorized means the gate won the
-		// race; ErrUsage means the gate is gone.
-		r := runGenerateCLI(t, "", "a cat", "--print-input", "--image", img)
-		assertRefusedByTheGate(t, r)
-	})
+	// 🔴 THREE discriminators, reached through THREE DIFFERENT usage-error
+	// sites, because one row is not a battery.
+	//
+	// An audit measured the first version: all three widening mutants — dropping
+	// `len(o.images) > 0`, swapping it for `len(o.loras) > 0`, replacing it with
+	// `false` — reddened EXACTLY ONE leaf subtest in the whole package, and the
+	// sibling "the refusal itself" survived every one of them (carried by the
+	// genapi token-source bystander). Delete or reshape that single row and the
+	// `--image` half of the condition is unguarded. That is AGENTS item 24's
+	// recorded "battery rested on a single row" shape, regenerated here.
+	//
+	// So the rows are routed through validateImageOpts (before the graph is
+	// built), parseImageFlag (inside resolveImages) and resolveLocalImage's
+	// stat (deepest, one step before the upload). A change that silences any
+	// ONE of those sites cannot silence the other two.
+	for _, tc := range []struct {
+		name string
+		args []string
+		// via names the usage-error site the row reaches when the gate is
+		// ABSENT. Recorded so a row that stops exercising its site is visible
+		// as a documentation mismatch rather than as a quiet duplicate.
+		via string
+	}{
+		{
+			name: "no --ecosystem",
+			args: []string{"a cat", "--print-input", "--image", img},
+			via:  "validateImageOpts (item 19(b): --image requires --ecosystem)",
+		},
+		{
+			name: "empty --image value",
+			args: []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", ""},
+			via:  "parseImageFlag (an empty value is not a path or an https URL)",
+		},
+		{
+			name: "--image is a directory",
+			args: []string{"a cat", "--print-input", "--ecosystem", "Qwen", "--image", dir},
+			via:  "resolveLocalImage (os.Stat says directory, one step before the upload)",
+		},
+	} {
+		t.Run("and it is THIS gate that refuses: "+tc.name, func(t *testing.T) {
+			// Credential-less AND usage-invalid. ErrUnauthorized means the gate
+			// won the race; ErrUsage means the gate is gone and tc.via got there
+			// first.
+			r := runGenerateCLI(t, "", tc.args...)
+			assertRefusedByTheGate(t, r, tc.via)
+		})
+	}
 }
 
 // TestGenerateDryRun_StillNeedsACredential — --dry-run reaches the estimator, an
@@ -268,7 +317,7 @@ func TestGenerateDryRun_StillNeedsACredential(t *testing.T) {
 		// --quantity 0 is a usage error (the server would silently clamp it to 1
 		// and charge), so it is the second half of the discriminator.
 		r := runGenerateCLI(t, "", "a cat", "--dry-run", "--quantity", "0")
-		assertRefusedByTheGate(t, r)
+		assertRefusedByTheGate(t, r, "validateGenerateOpts (--quantity must be at least 1)")
 	})
 }
 
@@ -284,7 +333,7 @@ func TestGenerateSubmit_StillNeedsACredential(t *testing.T) {
 
 	t.Run("and it is THIS gate that refuses", func(t *testing.T) {
 		r := runGenerateCLI(t, "", "a cat", "--yes", "--quantity", "0")
-		assertRefusedByTheGate(t, r)
+		assertRefusedByTheGate(t, r, "validateGenerateOpts (--quantity must be at least 1)")
 	})
 }
 
@@ -316,10 +365,15 @@ func TestGeneratePrintInput_SkipsTheGateNotTheValidation(t *testing.T) {
 //
 // `--checkpoint` resolves through `GET /api/v1/model-versions/{id}`, which is
 // PUBLIC (AGENTS.md item 13 calls it "free, unauthenticated-capable"). So the
-// run must be let through, and it must reach that route carrying NO
-// Authorization header — "a request went out" alone cannot tell a public read
-// from an authed one, and the whole argument for excluding --checkpoint from the
-// gate rests on which of the two it is.
+// run must be let through and must actually reach that route.
+//
+// 🔴 KEEP THE hasAuth ASSERTION'S CLAIM AT ITS MEASURED SIZE. Every row in this
+// file runs with token == "", and `doOnceHdr` attaches no header on an empty
+// token — so this can only catch a HARDCODED credential appearing on the
+// version read (mutation-checked: forcing `Authorization: Bearer …` into
+// `doOnceHdr` does redden it, so it is a real guard, not a decoration). It does
+// NOT establish that the route is public: that is item 13's claim, established
+// server-side, and this row consumes it rather than proving it.
 //
 // The server answers 404, so the run fails; that is fine and deliberate. The
 // claim is about WHERE it got to, not that it succeeded.
@@ -381,11 +435,11 @@ func TestGeneratePrintInput_NetworkRecorderPositiveControl(t *testing.T) {
 		t.Fatal("the recorder saw ZERO requests on an invocation that must reach the estimator — " +
 			"the harness is wired to nothing and every offline assertion in this file is vacuous")
 	}
-	// The server answers 500, so this must fail — but never as ErrUnauthorized:
+	// The server answers 404, so this must fail — but never as ErrUnauthorized:
 	// the refusal in the rows above came from the local gate, not from a shape
 	// this run also produces.
 	if r.err == nil {
-		t.Fatal("a 500 from the estimator must surface as an error")
+		t.Fatal("a 404 from the estimator must surface as an error")
 	}
 	if errors.Is(r.err, civitai.ErrUnauthorized) {
 		t.Fatalf("the credentialed run must not be refused for lack of a credential: %v", r.err)

--- a/internal/cmd/generate_print_input_auth_test.go
+++ b/internal/cmd/generate_print_input_auth_test.go
@@ -1,0 +1,393 @@
+package cmd
+
+// `--print-input` WITHOUT `--image` REACHES NO REQUEST, SO IT MUST NOT DEMAND A
+// CREDENTIAL — ISSUE #257.
+//
+// `generate`'s RunE refused unconditionally when no token was configured, before
+// runGenerate was ever entered. That contradicted the invariant stated in the
+// command's OWN comment at the --print-input short-circuit: "With no
+// --checkpoint/--lora there is no request of any kind." The reporter measured it
+// from the other side — with a garbage token the same invocation completes fully
+// offline, which is what proves the credential was never used on that path.
+//
+// 🔴 THE GATE IS NARROWED, NOT DELETED, AND THIS FILE HAS TO SEE THE DIFFERENCE.
+// Only `--image` genuinely needs a credential on the print path: hop 1 of the
+// upload (`getConsumerBlobUploadUrl`) is AUTHED (AGENTS.md item 19(e)) and
+// `--print-input` really does upload local files (item 19(f)). `--checkpoint` /
+// `--lora` resolve through the PUBLIC model-version route (item 13), so gating on
+// those would keep refusing a case that works with no credential. The rows below
+// are therefore three refusals (--image, --dry-run, plain submit) against one
+// permission, so "delete the gate" fails rather than passes.
+//
+// 🔴 CLASSIFICATION IS ASSERTED WITH errors.Is, NEVER MESSAGE TEXT (item 7). The
+// sentinels leave Error() byte-identical, so a message assertion says nothing at
+// all about the published exit code.
+//
+// 🔴 "STILL ErrUnauthorized" IS NOT ENOUGH TO PIN THE GATE, AND THAT WAS
+// MEASURED. `internal/auth`'s token source refuses a credential-less request too,
+// with its own ErrUnauthorized tag and without dialing — so with the top-level
+// gate DELETED OUTRIGHT, every refusal row below still exits 3 and still records
+// zero requests. The whole "delete the gate" mutation survived a table built on
+// exit code plus offline-ness alone: a control satisfied by a bystander.
+// The discriminator is the gate's PLACE IN THE ORDER, asserted structurally
+// rather than by message. The gate runs BEFORE validateGenerateOpts, so an
+// invocation that is credential-less AND usage-invalid comes back
+// ErrUnauthorized today and flips to ErrUsage the moment the gate is gone.
+// Those rows carry `wantsGateAheadOfValidation`, and they are what makes
+// deleting the gate a failing change rather than a passing one.
+//
+// 🔴 "NO NETWORK" IS MEASURED, NOT INFERRED. Every run points CIVITAI_BASE_URL at
+// a live httptest server that RECORDS each request, and the offline rows assert
+// the recorder saw zero. A zero from a recorder wired to nothing would look
+// identical, so TestGeneratePrintInput_NetworkRecorderPositiveControl drives the
+// SAME recorder above zero through the same command and the same wiring.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// recordedReq is one request that reached the base-URL server. hasAuth is kept
+// because the `--checkpoint` row's whole claim is that the model-version read is
+// PUBLIC — "a request went out" cannot distinguish that from an authed one.
+type recordedReq struct {
+	method  string
+	path    string
+	hasAuth bool
+}
+
+func (r recordedReq) String() string {
+	auth := "no-auth"
+	if r.hasAuth {
+		auth = "AUTHED"
+	}
+	return r.method + " " + r.path + " (" + auth + ")"
+}
+
+// cliRun is one end-to-end invocation of the REAL command through NewRootCmd.
+type cliRun struct {
+	stdout string
+	stderr string
+	err    error
+	// hits is every request that reached the base-URL server. It is the whole
+	// point of the harness: the offline claim is a measured zero rather than an
+	// assumption about which seams got built.
+	hits []recordedReq
+}
+
+// runGenerateCLI drives `civitai generate …` with an isolated config dir and a
+// recording server standing in for civitai.com.
+//
+// token == "" means NO credential is configured: XDG_CONFIG_HOME is a fresh
+// t.TempDir() (so no config file exists) and CIVITAI_TOKEN is explicitly set to
+// the empty string, which clears any ambient value the developer's shell holds.
+func runGenerateCLI(t *testing.T, token string, args ...string) cliRun {
+	t.Helper()
+
+	var mu sync.Mutex
+	var hits []recordedReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits = append(hits, recordedReq{
+			method:  r.Method,
+			path:    r.URL.Path,
+			hasAuth: r.Header.Get("Authorization") != "",
+		})
+		mu.Unlock()
+		// Deliberately unhelpful: no row here wants a successful round-trip.
+		// Either the request should never have happened (the offline rows) or
+		// the row only needs proof that one arrived. 404 rather than 5xx on
+		// purpose — pkg/civitai's read loop RETRIES a 5xx with backoff, which
+		// would make every row that does reach the server slow for no gain.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"the test server answers nothing"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_TOKEN", token)
+
+	root := NewRootCmd()
+	var out, errBuf bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errBuf)
+	// --no-update-check keeps the release poll (a real network call to GitHub,
+	// not to srv) out of the run entirely.
+	root.SetArgs(append([]string{"generate", "--no-update-check"}, args...))
+	err := root.Execute()
+
+	mu.Lock()
+	defer mu.Unlock()
+	return cliRun{stdout: out.String(), stderr: errBuf.String(), err: err, hits: append([]recordedReq(nil), hits...)}
+}
+
+// assertOffline fails loudly, naming every request, if anything reached the
+// server.
+func assertOffline(t *testing.T, r cliRun) {
+	t.Helper()
+	if len(r.hits) != 0 {
+		t.Fatalf("expected NO request, got %d: %v", len(r.hits), r.hits)
+	}
+}
+
+// assertRefusedByTheGate is the discriminating assertion. Its input is an
+// invocation that is BOTH credential-less and usage-invalid, so:
+//
+//	gate present -> ErrUnauthorized (the gate ran first)
+//	gate absent  -> ErrUsage        (validateGenerateOpts got there instead)
+//
+// Neither branch dials, and both would satisfy a plain "is it ErrUnauthorized?"
+// check via the token source — which is precisely why that check cannot pin the
+// gate and this one can.
+func assertRefusedByTheGate(t *testing.T, r cliRun) {
+	t.Helper()
+	if errors.Is(r.err, ErrUsage) {
+		t.Fatalf("refused as a USAGE error, so the credential gate no longer runs ahead of validateGenerateOpts: %v", r.err)
+	}
+	if !errors.Is(r.err, civitai.ErrUnauthorized) {
+		t.Fatalf("want ErrUnauthorized from the credential gate, got %v", r.err)
+	}
+	assertOffline(t, r)
+}
+
+// writeTinyPNG writes a real 1x1 PNG, so the --image row stays meaningful if the
+// credential gate ever moves below the file read.
+func writeTinyPNG(t *testing.T, dir string) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, "ref.png")
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestGeneratePrintInput_NoCredentialNeeded is the regression: RED at 8ed4d69
+// with `errors.Is(err, civitai.ErrUnauthorized)` where nil was wanted.
+func TestGeneratePrintInput_NoCredentialNeeded(t *testing.T) {
+	r := runGenerateCLI(t, "", "a cat", "--print-input", "--quantity", "2")
+
+	if r.err != nil {
+		t.Fatalf("--print-input with no credential must succeed, got %v (unauthorized=%v)",
+			r.err, errors.Is(r.err, civitai.ErrUnauthorized))
+	}
+	assertOffline(t, r)
+
+	// 🔴 DECODED, NEVER strings.Contains — a substring search cannot tell "cfg"
+	// from "cfgScale" (AGENTS.md item 14), so it cannot assert a key at all.
+	var m map[string]any
+	if err := json.Unmarshal([]byte(r.stdout), &m); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, r.stdout)
+	}
+	if got := m["workflow"]; got != "txt2img" {
+		t.Errorf("workflow = %v, want txt2img", got)
+	}
+	if got := m["prompt"]; got != "a cat" {
+		t.Errorf("prompt = %v, want %q", got, "a cat")
+	}
+	// --quantity 2 was passed, so the key must be PRESENT and 2 — otherwise a
+	// document that decodes fine could still be an empty graph.
+	if got, ok := m["quantity"]; !ok || got != float64(2) {
+		t.Errorf("quantity = %v (present=%v), want 2", got, ok)
+	}
+	// And an unset lever must be ABSENT rather than a zero the server would
+	// price as a degenerate job (item 14).
+	if _, ok := m["steps"]; ok {
+		t.Errorf("steps must be absent from the printed graph, got %v", m["steps"])
+	}
+}
+
+// TestGeneratePrintInput_WithImageStillNeedsACredential is the POSITIVE CONTROL
+// on the gate itself: without it, deleting the credential check outright would
+// pass every other row in this file.
+//
+// It is also the reason the narrowing is `--image` and not "--print-input is
+// always free": the local file is UPLOADED before the graph is printed
+// (item 19(f)) and the presign hop is authed (item 19(e)).
+func TestGeneratePrintInput_WithImageStillNeedsACredential(t *testing.T) {
+	dir := t.TempDir()
+	img := writeTinyPNG(t, dir)
+
+	t.Run("the refusal itself", func(t *testing.T) {
+		// --ecosystem is supplied so the invocation is otherwise VALID: with the
+		// gate deleted this run proceeds to reading and decoding the file and on
+		// towards the presign, so the row is about a real path rather than an
+		// invocation that would be refused anyway.
+		r := runGenerateCLI(t, "", "a cat", "--print-input", "--image", img, "--ecosystem", "Qwen")
+		if !errors.Is(r.err, civitai.ErrUnauthorized) {
+			t.Fatalf("--print-input --image with no credential must be ErrUnauthorized, got %v", r.err)
+		}
+		assertOffline(t, r)
+		if strings.TrimSpace(r.stdout) != "" {
+			t.Errorf("nothing may be printed on a refusal, got %q", r.stdout)
+		}
+	})
+
+	t.Run("and it is THIS gate that refuses", func(t *testing.T) {
+		// Credential-less AND usage-invalid: --image without --ecosystem is a
+		// hard usage error (item 19(b)). ErrUnauthorized means the gate won the
+		// race; ErrUsage means the gate is gone.
+		r := runGenerateCLI(t, "", "a cat", "--print-input", "--image", img)
+		assertRefusedByTheGate(t, r)
+	})
+}
+
+// TestGenerateDryRun_StillNeedsACredential — --dry-run reaches the estimator, an
+// authed tRPC query. CONTROL: green at base, so the plain half is an invariant
+// guard rather than regression coverage. The second half is not: it is what
+// makes deleting the gate visible.
+func TestGenerateDryRun_StillNeedsACredential(t *testing.T) {
+	t.Run("the refusal itself", func(t *testing.T) {
+		r := runGenerateCLI(t, "", "a cat", "--dry-run")
+		if !errors.Is(r.err, civitai.ErrUnauthorized) {
+			t.Fatalf("--dry-run with no credential must be ErrUnauthorized, got %v", r.err)
+		}
+		assertOffline(t, r)
+	})
+
+	t.Run("and it is THIS gate that refuses", func(t *testing.T) {
+		// --quantity 0 is a usage error (the server would silently clamp it to 1
+		// and charge), so it is the second half of the discriminator.
+		r := runGenerateCLI(t, "", "a cat", "--dry-run", "--quantity", "0")
+		assertRefusedByTheGate(t, r)
+	})
+}
+
+// TestGenerateSubmit_StillNeedsACredential — the money path.
+func TestGenerateSubmit_StillNeedsACredential(t *testing.T) {
+	t.Run("the refusal itself", func(t *testing.T) {
+		r := runGenerateCLI(t, "", "a cat", "--yes")
+		if !errors.Is(r.err, civitai.ErrUnauthorized) {
+			t.Fatalf("a plain submit with no credential must be ErrUnauthorized, got %v", r.err)
+		}
+		assertOffline(t, r)
+	})
+
+	t.Run("and it is THIS gate that refuses", func(t *testing.T) {
+		r := runGenerateCLI(t, "", "a cat", "--yes", "--quantity", "0")
+		assertRefusedByTheGate(t, r)
+	})
+}
+
+// TestGeneratePrintInput_SkipsTheGateNotTheValidation is the mirror image of
+// assertRefusedByTheGate, and it is what stops the narrowing from being read as
+// "--print-input bypasses the front of the command".
+//
+// The SAME usage-invalid invocation that comes back ErrUnauthorized on every
+// other path must come back ErrUsage here, because the gate is skipped and
+// validateGenerateOpts is reached. A widening of the skip (say, dropping the
+// `len(o.images) > 0` term and letting --image through) is caught by the row
+// above; a narrowing back to the unconditional gate is caught by this one.
+func TestGeneratePrintInput_SkipsTheGateNotTheValidation(t *testing.T) {
+	r := runGenerateCLI(t, "", "a cat", "--print-input", "--quantity", "0")
+
+	if errors.Is(r.err, civitai.ErrUnauthorized) {
+		t.Fatalf("the credential gate still fired on a --print-input run that needs no credential: %v", r.err)
+	}
+	if !errors.Is(r.err, ErrUsage) {
+		t.Fatalf("want ErrUsage from validateGenerateOpts, got %v", r.err)
+	}
+	assertOffline(t, r)
+}
+
+// TestGeneratePrintInput_WithCheckpointNeedsNoCredential is the row that pins
+// the NARROWING, and it was added because the obvious wider gate — the one
+// issue #257 proposes, refusing whenever --image OR --checkpoint OR --lora is
+// present — survived every other assertion in this file.
+//
+// `--checkpoint` resolves through `GET /api/v1/model-versions/{id}`, which is
+// PUBLIC (AGENTS.md item 13 calls it "free, unauthenticated-capable"). So the
+// run must be let through, and it must reach that route carrying NO
+// Authorization header — "a request went out" alone cannot tell a public read
+// from an authed one, and the whole argument for excluding --checkpoint from the
+// gate rests on which of the two it is.
+//
+// The server answers 404, so the run fails; that is fine and deliberate. The
+// claim is about WHERE it got to, not that it succeeded.
+func TestGeneratePrintInput_WithCheckpointNeedsNoCredential(t *testing.T) {
+	r := runGenerateCLI(t, "", "a cat", "--print-input", "--checkpoint", "128713")
+
+	if errors.Is(r.err, civitai.ErrUnauthorized) {
+		t.Fatalf("--print-input --checkpoint needs no credential (the version read is public), but it was refused: %v", r.err)
+	}
+	var public int
+	for _, h := range r.hits {
+		if strings.Contains(h.path, "/model-versions/") {
+			if h.hasAuth {
+				t.Errorf("the model-version read carried an Authorization header: %s", h)
+			}
+			public++
+		}
+	}
+	if public == 0 {
+		t.Fatalf("the run never reached the public model-version read; hits=%v err=%v", r.hits, r.err)
+	}
+}
+
+// TestGeneratePrintInput_WithCredentialUnchanged — the credentialed print path
+// behaved this way before the change and must keep doing so: a token present
+// changes nothing about what --print-input does, including that it sends
+// nothing.
+func TestGeneratePrintInput_WithCredentialUnchanged(t *testing.T) {
+	r := runGenerateCLI(t, "not-a-real-token-000", "a cat", "--print-input")
+	if r.err != nil {
+		t.Fatalf("--print-input with a credential must succeed, got %v", r.err)
+	}
+	assertOffline(t, r)
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(r.stdout), &m); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, r.stdout)
+	}
+	if got := m["prompt"]; got != "a cat" {
+		t.Errorf("prompt = %v, want %q", got, "a cat")
+	}
+}
+
+// TestGeneratePrintInput_NetworkRecorderPositiveControl is what stops every
+// `assertOffline` above from being a reassuring zero.
+//
+// It drives the SAME recorder, through the SAME NewRootCmd wiring and the same
+// CIVITAI_BASE_URL, with a credential and --dry-run — an invocation that MUST
+// reach the estimator. If this ever reports zero hits, the harness is observing
+// nothing and none of the offline rows mean anything.
+//
+// It doubles as the discriminator for the three refusal rows: it proves they are
+// refused BY THE CREDENTIAL GATE (same command, credential added, request goes
+// out) rather than by something else that would refuse regardless.
+func TestGeneratePrintInput_NetworkRecorderPositiveControl(t *testing.T) {
+	r := runGenerateCLI(t, "not-a-real-token-000", "a cat", "--dry-run")
+
+	if len(r.hits) == 0 {
+		t.Fatal("the recorder saw ZERO requests on an invocation that must reach the estimator — " +
+			"the harness is wired to nothing and every offline assertion in this file is vacuous")
+	}
+	// The server answers 500, so this must fail — but never as ErrUnauthorized:
+	// the refusal in the rows above came from the local gate, not from a shape
+	// this run also produces.
+	if r.err == nil {
+		t.Fatal("a 500 from the estimator must surface as an error")
+	}
+	if errors.Is(r.err, civitai.ErrUnauthorized) {
+		t.Fatalf("the credentialed run must not be refused for lack of a credential: %v", r.err)
+	}
+}


### PR DESCRIPTION
Fixes #257.

## The defect

`internal/cmd/generate.go`'s `RunE` checked `cfg.Token() == ""` and returned a `civitai.ErrUnauthorized`-tagged error **unconditionally**, before `runGenerate` was ever entered. The `--print-input` short-circuit sits inside `runGenerate` and returns `printAssembledGraph` before the estimator, the submit and the balance read.

The strongest evidence is not the README — it is the code's own comment at that short-circuit, which already asserts:

> With no `--checkpoint`/`--lora` there is no request of any kind.

So the command contradicted its own documented invariant. The reporter measured the same thing from the other side: with a garbage token (`CIVITAI_TOKEN=not-a-real-token-000`) `--print-input` succeeds fully offline, which is what proves the credential is never used on that path.

## The fix

One line, at the existing gate — narrowed, **not** pushed down into the call sites (moving it would invite a "gate deleted for every path" mutation the tests would have to re-cover from scratch):

```go
needsCredential := !o.printInput || len(o.images) > 0
if needsCredential && cfg.Token() == "" { … }
```

`o.images` is bound by `StringArrayVar`, so it is already populated at this point in `RunE` — no `Flags().Changed` dance needed.

### Why `--image` and not the issue's `--image`/`--checkpoint`/`--lora`

The issue proposes gating on all three. That is too wide:

- `--image` **does** need a credential even here. `--print-input` really uploads local files (AGENTS.md item 19(f)), and hop 1 of that upload — `getConsumerBlobUploadUrl` — is authed (item 19(e)).
- `--checkpoint`/`--lora` resolve through the **public** `GET /api/v1/model-versions/{id}`, which `generate.go`'s own comment calls "free, unauthenticated-capable" (item 13). Gating on them would keep refusing a case that demonstrably works with no credential.

An https `--image` value only reaches the credential-free fetch, so it does not strictly need a token. The gate still covers the whole flag: "some `--image` values need a credential" is a worse contract than "`--image` does", and the narrower rule buys nothing. Stated as a residual in the code comment rather than hidden.

## Tests — `internal/cmd/generate_print_input_auth_test.go`

Every row drives the **real** command through `NewRootCmd()` + `SetArgs`, with an isolated `XDG_CONFIG_HOME` (`t.TempDir()`), `CIVITAI_TOKEN` explicitly cleared, and `CIVITAI_BASE_URL` pointed at a live `httptest` server that **records every request**. "No network" is therefore a measured zero, and `TestGeneratePrintInput_NetworkRecorderPositiveControl` drives that same recorder above zero through the same wiring so the zeros are not a recorder wired to nothing.

Classification is asserted with `errors.Is`, never message text (item 7). The JSON in the permitted case is decoded to `map[string]any` and checked key-by-key — a `strings.Contains` cannot tell `cfg` from `cfgScale` (item 14) — including that `quantity` is present and `2` and that unset `steps` is **absent**.

### 🔴 "Still ErrUnauthorized" was not enough to pin the gate, and that was measured

The first version of this table asserted exit code plus offline-ness on the three refusal rows. **The whole "delete the gate" mutation survived it**: `internal/auth`'s token source refuses a credential-less request too, with its own `ErrUnauthorized` tag and without dialing. A control satisfied by a bystander — the exact near-miss shape AGENTS item 23 records.

The discriminator is the gate's **place in the order**, asserted structurally rather than by message: it runs ahead of `validateGenerateOpts`, so an invocation that is *both* credential-less and usage-invalid answers `ErrUnauthorized` today and flips to `ErrUsage` the moment the gate is gone. Those rows carry `assertRefusedByTheGate`.

The `--checkpoint` row exists for the same reason in the other direction: the issue's wider gate survived everything else, because nothing exercised `--print-input --checkpoint` offline. That row asserts the run reaches `/api/v1/model-versions/` **carrying no `Authorization` header** — "a request went out" alone cannot distinguish a public read from an authed one, and the whole argument for excluding `--checkpoint` rests on which it is.

## Mutation matrix

Each mutant is checksum-gated (md5 must move, gate line must occur exactly once) so an edit that silently failed to apply cannot read as a survivor. `M0` is the unmutated null control.

| mutant | production change | reddens | failure message |
|---|---|---|---|
| **M1** | `needsCredential := true` (revert the fix — base `8ed4d69`) | 3 tests | `--print-input with no credential must succeed, got no token configured … (unauthorized=true)`; `the credential gate still fired on a --print-input run that needs no credential`; `--print-input --checkpoint needs no credential …, but it was refused` |
| **M2** | `needsCredential := false` (delete the gate) | 3 leaf subtests + 3 parents | `refused as a USAGE error, so the credential gate no longer runs ahead of validateGenerateOpts: --image requires --ecosystem …` / `… --quantity must be at least 1, got 0` (×2) |
| **M3** | `needsCredential := !o.printInput` (drop the `--image` term) | 1 leaf + 1 parent | `refused as a USAGE error, so the credential gate no longer runs ahead of validateGenerateOpts: --image requires --ecosystem …` |
| **M4** | `… \|\| o.checkpointSet \|\| len(o.loras) > 0` (the issue's wider gate) | 1 test | `--print-input --checkpoint needs no credential (the version read is public), but it was refused: …` |
| **M0** | none | 0 | all green |

Note recorded honestly: under M2 and M3 the *plain* `--image` refusal subtest stays green — the downstream token source carries it. That is why the discriminating subtest sits beside it rather than replacing it.

## Gate

`make ci` — **rc=0, `--- FAIL` count = 0, `build failed` count = 0**, 18 packages `ok` (positive control on the count: 18 ≥ 1). `gofmt -s -l .` prints nothing over **297** Go files found (positive control: the tool found files).

## Not done, deliberately

- **No new AGENTS.md item** (six agents are working in parallel and would collide on the number). Nothing in the existing text became inaccurate: item 19(f) still describes the `--image` upload correctly, and item 13's "free, unauthenticated-capable" is now *load-bearing* for the gate rather than merely descriptive. If a maintainer wants an item, the substance is the "still ErrUnauthorized was not enough" measurement above.
- **README untouched** (outside this PR's file ownership). It is not made inaccurate by this change — it says `--print-input` "reaches **no money seam**", which stays true — but it also never says the command works without a credential. Suggested addition to the `Raw graphs` section, for whoever owns README next:

  > Without `--image`, `--print-input` needs no credential at all: it reaches no authenticated route, so it works offline and before `civitai login`.
- **No standalone-binary reproduction.** The symptom is reproduced in-process through the real `NewRootCmd()` (which is exactly what `main` executes; `main` only maps the returned error to an exit code, and that mapping is pinned elsewhere). The sandbox refuses `HOME`/`XDG_CONFIG_HOME` overrides in a shell, so running `./bin/civitai` against an isolated config was not possible here — flagged rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Audit round 2 — `ccf31d0`

Independently audited at `035afbc`: **safe to merge, no 🔴**. The auditor established structurally that no money seam is reachable without a credential (`runGenerate` returns at the `--print-input` short-circuit; every money seam is control-flow after it; `runGenerate` has exactly one caller), confirmed `doOnceHdr` attaches no header on an empty token, and closed the flag-spelling attack empirically — `--image <path>`, `--image=<path>`, repeated, comma-joined, empty value, http/https URL, nonexistent path, over-cap: **all rc 3**. `--input` cannot smuggle an upload. Three 🟡, none blocking, all addressed below.

The standalone-binary caveat from the original body is **closed**: the coordinator ran it (`--print-input` rc 0 emitting valid JSON, `--dry-run` still rc 3).

### 🟡1 — the widening direction rested on ONE leaf subtest (fixed)

All three **widening** mutants — dropping `len(o.images) > 0`, swapping it for `len(o.loras) > 0`, replacing it with `false` — reddened exactly one leaf and nothing else in the package, and the sibling "the refusal itself" row survived all three, carried by the `genapi` token-source bystander. That is the same bystander problem this PR already documents, regenerated one level down, and AGENTS item 24's recorded "battery rested on a single row" shape.

The discriminator is now **plural and routed through three different usage-error sites**, so silencing any one cannot silence the others:

| row | usage-error site reached when the gate is absent |
|---|---|
| `--image` with no `--ecosystem` | `validateImageOpts` (item 19(b)) |
| `--image ""` | `parseImageFlag` (empty value is not a path or an https URL) |
| `--image <directory>` | `resolveLocalImage`'s `os.Stat` — deepest, one step before the upload |

Each row now passes its site name into `assertRefusedByTheGate`, so the failure message says which check won the race.

### 🟡2 — published text stated the credential requirement unconditionally (fixed)

`README.md` and `generate`'s `Long` help both now name the exception and why `--image` is excluded from it. This is the mirror image of the defect the PR fixes, so leaving it would have been the same class of bug.

The README guards that landed on `main` after this branch (`readme_nav_test.go`, `app_listing_help_test.go`) do **not** constrain this text — verified on the merged tree, see below.

### 🟡3 — undisclosed exit-code shift (disclosed; `exitCodeDocs` needs no change)

Beyond the headline fix, three invocations move **3 → 2** with no credential. Measured at HEAD through the real command (`errors.Is`, never message text):

| invocation | base | HEAD | HEAD error |
|---|---|---|---|
| `--print-input --quantity 0` | 3 | **2** | `--quantity must be at least 1, got 0` |
| `--print-input` (no prompt) | 3 | **2** | `a prompt is required — quote it as one argument…` |
| `--print-input --lora bogus` | 3 | **2** | `invalid --lora "bogus" — the id is not an integer…` |

These are correct, and they are the discriminator the tests rely on. **`exitCodeDocs` needs no word**: its code-2 summary already promises exit 2 for "a bad flag **value** (`--limit` out of range, a non-integer id …)", so the shift moves behaviour *toward* the published contract — the old `3` was the credential gate masking a usage error, not a documented promise. A sibling branch owns that file; flagging rather than editing.

### 🟢4, 🟢5 (both taken)

- The positive control said "the server answers 500" while the harness sends **404**; corrected. (Also caught two more stale claims the audit did not flag: the file header named a helper that no longer exists, `wantsGateAheadOfValidation`.)
- The `hasAuth` comment claimed to establish the route is public. It cannot — every row runs with `token == ""`, so it only catches a **hardcoded** header. Reworded to its measured size, citing the auditor's mutation (forcing `Authorization: Bearer MUTANT` into `doOnceHdr` **does** redden it, so it is a real guard) and noting that "the route is public" is item 13's claim, consumed here rather than proven.

### Re-measured mutation matrix (`ccf31d0`, my own runs — checksum-gated, `=== RUN` floor asserted)

| mutant | leaf fails | top-level fails | vs round 1 |
|---|---|---|---|
| **W1** drop `len(o.images) > 0` | **3** | 1 | was 1 leaf |
| **W2** `len(o.loras) > 0` for images | **3** | 1 | was 1 leaf |
| **W3** images term → `false` | **3** | 1 | was 1 leaf |
| **M1** revert (`true`) | 0 | 3 | unchanged |
| **M2** delete the gate (`false`) | **5** | 3 | was 3 leaves |
| **M4** issue's wider gate | 0 | 1 | unchanged |
| **M0** null control | 0 | 0 | green |

### Gate

- `make ci` on the branch — **rc=0, `--- FAIL` = 0, `build failed` = 0**, 18 packages `ok`; `gofmt -s -l .` empty.
- `make ci` on the **merged tree** (integration branch off `origin/main` at `fbb36df`, clean merge) — **rc=0, `--- FAIL` = 0, `build failed` = 0**, 18 packages `ok`; every `TestREADME*` guard green, including the ones that exist only on `main`.
- `golangci-lint` **v2.12.2** (`nix-shell -p golangci-lint`) — **rc=0, "0 issues"**. 🔴 Instrument validated first: `errcheck` is disabled in `.golangci.yml` (enabled set is `govet, ineffassign, misspell, staticcheck, unused`), so the negative control was built from two slips *this file could realistically contain* — a `t.Fatalf` verb/arg mismatch and `occured` in a comment. Injected, it reported **rc=1 and named both, in this PR's own new file**; restored, back to 0.


---

## Audit round 3 — `c1c0a0c`

Delta re-audit of `ccf31d0` verified the substantive fix independently: the three-site battery is real (under the delete-gate mutant the rows fail with three *distinct* error strings), every "was N → now N" number reproduced, and both structural checks passed (dropping each row in turn still leaves every widening mutant killed by ≥2 leaves; neutering each production site in turn likewise). Three 🟡, all on the doc surface round 2 newly took ownership of. All three fixed.

### 🟡1 — "works offline" was measurably false (fixed)

The mirror of the bug this PR exists to fix, turned inward: round 2 scoped the exception on `--image` only, but `--checkpoint`/`--lora` perform a real public model-version read. So the claim was false for exactly the use the README advertised it for, contradicted the accurate wording forty lines away at the `--print-input` short-circuit, and contradicted this PR's own test asserting a request **does** go out.

**Four-way matrix, measured through the real command against a dead endpoint (listener opened then closed → ECONNREFUSED, with a control proving the endpoint really is dead), no credential:**

| invocation | result | exit |
|---|---|---|
| `--print-input` | `nil` error, 49 bytes of JSON on stdout, **zero requests** | 0 |
| `--print-input --checkpoint 128713` | transport error, `failed after 4 attempts` | **5** |
| `--print-input --lora 128713` | transport error, identical shape | **5** |
| `--print-input --image <png>` | `ErrUnauthorized` (gate fires first) | 3 |

Both published surfaces now separate the two claims — *needs no credential* vs *needs no network* — and say only a **bare** `--print-input` needs neither. The gate comment no longer says "makes NO request of any kind"; that sentence is true only at the short-circuit, where it is guarded by "with no `--checkpoint`/`--lora`", and the comment now records why the two wordings differ so the next edit does not re-merge them.

### 🟡2 — the `via` field's stated guard did not exist (fixed)

`via` was interpolated only into **failure** messages, so a passing row never printed it. Confirmed reproducible: collapsing rows 2 and 3 onto row 1's site left the suite fully green.

Each row now carries a `fingerprint` of its site's message plus a **premise subtest** that runs the same invocation *with* a credential — the gate does not fire, the run falls through to the site the row names — and asserts bidirectional pairwise distinctness (this row's error carries its own fingerprint and **none** of the others'; no two rows share one; the distinct-site count must equal the row count).

Classification stays `errors.Is` per item 7. The fingerprint identifies *which check answered*, never the exit code — a different claim, and the only signal available, since all three sites are `ErrUsage`.

### 🟡3 — `--lora` had no permission row (fixed)

The additive `|| len(o.loras) > 0` widening survived every subtest in the package while the file header claimed the widen direction was covered. `TestGeneratePrintInput_WithCheckpointNeedsNoCredential` is now a table over **both** flags; `--print-input --lora 128713` reaches `/api/v1/model-versions/128713` with no `Authorization` header, exactly like the checkpoint row.

### 🟢4 — corrected

The claim-3 justification quoted only code-2's "a bad flag **value**" clause. That covers `--quantity 0` and `--lora bogus`; the **no-prompt** shift is covered by the sibling "**missing required flag or argument**" clause. Conclusion unchanged: `exitCodeDocs` still needs no edit, since both clauses already promise exit 2 for these.

### Re-measured mutation matrix (`c1c0a0c`, all checksum-gated, `=== RUN` floor asserted)

| mutant | leaf fails | top-level | note |
|---|---|---|---|
| **W1** drop `len(o.images) > 0` | 3 | 1 | |
| **W2** `len(o.loras) > 0` for images | **4** | 2 | +1: the new `--lora` row also dies |
| **W3** images term → `false` | 3 | 1 | |
| **W4** additive `\|\| len(o.loras) > 0` | **1** | 1 | **was a full survivor** (all 1324 subtests) |
| **M1** revert (`true`) | 2 | 3 | |
| **M2** delete the gate (`false`) | 5 | 3 | |
| **M4** issue's wider gate | 2 | 1 | |
| **C1** *(test mutant)* collapse the 3 rows onto one site | **1** | 1 | **was fully green** — this is 🟡2's guard |
| **M0** null control | 0 | 0 | green |

C1's failure names the defect precisely: `empty --image value: expected the error from parseImageFlag (…fingerprint "the value is empty"), got --image requires --ecosystem …`.

### Gate

- `make ci` **branch** — rc=0, `--- FAIL` = **0**, `build failed` = **0**, `panic: test timed out` = **0**, 18 packages `ok`; `gofmt -s -l .` empty.
- `make ci` **merged tree** (integration branch off `origin/main` at `fbb36df`, clean merge, worktree removed after) — rc=0, all three counts **0**, 18 packages `ok`, 10 `TestREADME*` guards pass, `gofmt` clean.
- `golangci-lint` **v2.12.2** — rc=0, "0 issues", with the instrument **re-validated for this round** (round 2's validation does not carry — different files changed): injecting a `t.Fatalf` verb/arg mismatch and `occured` into this PR's own test file reported **rc=1 naming both**; restored, back to 0.
