### PR TITLE
fix(login): stop `login --help` emitting a raw NUL byte

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -39,7 +39,28 @@ const spendCredentialRoutes = "`civitai login --scopes generate` (a browser logi
 // non-empty; without it, `--token` alone errors "flag needs an argument". We set
 // this sentinel so the no-value form parses, then detect it (or an explicitly
 // empty value) and print where to mint a key instead of attempting a login.
-const tokenFlagNoValue = "\x00civitai-token-no-value"
+//
+// 🔴 IT MUST CONTAIN NO CONTROL BYTES, AND ABOVE ALL NO NUL (issue #253). The
+// sentinel is USER-VISIBLE: pflag interpolates NoOptDefVal into the help row's
+// flag column as `[="%s"]`, so `civitai login --help` prints it verbatim. It
+// used to be prefixed with "\x00" to make collision with a real key literally
+// impossible (argv cannot carry a NUL) — and that prefix escaped into stdout.
+// pflag's FlagUsagesWrapped builds each row as `<flag part>\x00<usage part>` and
+// splits on the FIRST \x00 to align the two columns; ours came first, so pflag
+// aligned on it and its own separator survived into the output. Any captured
+// copy of `civitai login --help` then became BINARY: `file(1)` said `data`,
+// `grep` said "binary file matches", and `git diff` refused to render it — which
+// silently ended human review of the CLI-reference snapshot in
+// civitai-developer-docs.
+//
+// The sentinel's only real requirements are that it be non-empty and not
+// collide with a plausible API key. "(no value)" satisfies both while reading,
+// in the help row, as the description it is rather than as a magic string
+// someone should type: `--token string[="(no value)"]`. A Civitai personal key
+// is an alphanumeric string, so the space and parentheses make a collision
+// implausible; and were one ever passed, the effect is only that the mint
+// guidance prints instead of that literal being stored.
+const tokenFlagNoValue = "(no value)"
 
 func newLoginCmd() *cobra.Command {
 	var tokenFlag string

--- a/internal/cmd/login_help_bytes_test.go
+++ b/internal/cmd/login_help_bytes_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestLoginHelpEmitsNoControlBytes is the regression guard for issue #253:
+// `civitai login --help` wrote a raw NUL to stdout, because --token's
+// NoOptDefVal sentinel started with "\x00" and pflag interpolates NoOptDefVal
+// into the help row it then SPLITS on the first "\x00" to align its two
+// columns. The failure is invisible in a terminal and only shows up once the
+// output is captured — `file(1)` calls it `data`, `grep` says "binary file
+// matches", and `git diff` refuses to render it.
+//
+// 🔴 POSITIVE CONTROLS ARE MANDATORY HERE. "contains no NUL" is satisfied by
+// empty output, and it is also satisfied by a build that dropped NoOptDefVal
+// altogether (which would break bare `login --token` — the very feature the
+// sentinel exists for). So this test additionally requires that the help it
+// examined is real AND that it rendered the sentinel-carrying `--token` row
+// CONTIGUOUSLY, which is the exact text that used to carry the stray byte.
+func TestLoginHelpEmitsNoControlBytes(t *testing.T) {
+	out, errOut, err := run(t, "login", "--help")
+	if err != nil {
+		t.Fatalf("login --help: %v", err)
+	}
+	help := out + errOut
+
+	// --- Positive control 1: the help is real, not an empty buffer. -----------
+	if len(help) < 200 {
+		t.Fatalf("login --help produced %d bytes — too short to be real help; "+
+			"the no-NUL assertion below would pass vacuously:\n%s", len(help), help)
+	}
+	if !strings.Contains(help, "Flags:") {
+		t.Fatalf("login --help has no Flags: section — nothing to check:\n%s", help)
+	}
+
+	// --- Positive control 2: the row that carried the byte is present. --------
+	// pflag renders an optional-value flag as `--token string[="<NoOptDefVal>"]`.
+	// This half is deliberately independent of the sentinel's BYTES — it fires
+	// only if NoOptDefVal was dropped altogether, which would break bare
+	// `civitai login --token` ("flag needs an argument"). It must stay ahead of
+	// the NUL scan and must NOT depend on the sentinel's value, or a build that
+	// reintroduces the NUL fails here instead of at the assertion that names the
+	// actual defect.
+	const optionalValueMarker = `--token string[="`
+	if !strings.Contains(help, optionalValueMarker) {
+		t.Fatalf("login --help has no %q row — --token's NoOptDefVal is gone, so bare "+
+			"`civitai login --token` would error \"flag needs an argument\". "+
+			"Nothing renders the sentinel, so the NUL scan below would pass vacuously.\n%s",
+			optionalValueMarker, help)
+	}
+
+	// --- The assertion itself. ------------------------------------------------
+	if i := strings.IndexByte(help, 0x00); i >= 0 {
+		t.Errorf("login --help emitted a raw NUL at byte offset %d (issue #253): "+
+			"any captured copy of this output is BINARY to file(1), grep and git.\n"+
+			"context: %q", i, help[max(0, i-40):min(len(help), i+40)])
+	}
+
+	// The row must also render CONTIGUOUSLY. With the NUL present pflag aligned
+	// its two help columns on OUR byte rather than its own, padding the row
+	// apart into `--token string[="` + spaces + the rest — so the contiguous
+	// form did not exist in the broken output. This catches column corruption
+	// from any future separator byte, not just 0x00.
+	wantRow := fmt.Sprintf(`--token string[=%q]`, tokenFlagNoValue)
+	if !strings.Contains(help, wantRow) {
+		t.Errorf("login --help does not render the --token row contiguously as %q — "+
+			"pflag split the row, which means the sentinel carries a byte pflag "+
+			"treats as a column separator.\n%s", wantRow, help)
+	}
+
+	// A NUL is the byte that broke a real consumer, but every other C0 control
+	// byte poisons a captured snapshot the same way. Newline and tab are the
+	// only ones help output legitimately contains.
+	for i := 0; i < len(help); i++ {
+		b := help[i]
+		if b < 0x20 && b != '\n' && b != '\t' {
+			t.Errorf("login --help emitted control byte %#02x at offset %d — "+
+				"help output must stay plain text.\ncontext: %q",
+				b, i, help[max(0, i-40):min(len(help), i+40)])
+			break
+		}
+	}
+}
+
+// TestTokenFlagNoValueSentinelIsPlainText pins the constant itself, so the
+// defect cannot come back through a code path this package's help rendering
+// does not happen to exercise. The sentinel is USER-VISIBLE (pflag prints it in
+// the help row), and pflag's own column alignment uses "\x00" as its separator,
+// so a control byte here is never merely cosmetic.
+//
+// It must also stay non-empty: pflag only permits the no-argument form
+// (`civitai login --token`) when NoOptDefVal is non-empty.
+func TestTokenFlagNoValueSentinelIsPlainText(t *testing.T) {
+	if tokenFlagNoValue == "" {
+		t.Fatal("tokenFlagNoValue must be non-empty — pflag rejects bare `--token` without a NoOptDefVal")
+	}
+	for i := 0; i < len(tokenFlagNoValue); i++ {
+		if b := tokenFlagNoValue[i]; b < 0x20 || b == 0x7f {
+			t.Errorf("tokenFlagNoValue contains control byte %#02x at index %d (%q); "+
+				"it is rendered verbatim into `civitai login --help` — see issue #253",
+				b, i, tokenFlagNoValue)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #253.

## The defect

`civitai login --help` wrote a raw `\x00` to stdout, so any **captured** copy of that output was classified as binary — `file(1)` said `data`, `grep` said `binary file matches`, and `git diff` refused to render it. Invisible in a terminal; only bites once the output is piped into a file, a pager, a test fixture or a doc generator.

Reproduced on a clean build of `origin/main` @ `8ed4d69`:

```console
$ civitai login --help | tr -dc '\000' | wc -c
1
$ civitai login --help > out.txt && file -b out.txt
data
$ grep -c token out.txt
grep: out.txt: binary file matches
```

## Cause

`internal/cmd/login.go` set `--token`'s `NoOptDefVal` to `"\x00civitai-token-no-value"`.

pflag's `FlagUsagesWrapped` builds each help row as `<flag part>\x00<usage part>` and splits on the **first** `\x00` to align its two columns. `NoOptDefVal` is interpolated into the flag part as `[="%s"]`, so the row held *two* NULs — pflag aligned on ours and its own separator survived into stdout. Visible in the broken render, where the flag column truncates mid-string:

```
      --token string[="                            civitai-token-no-value"]<NUL>store a personal API key instead of ...
```

## The fix

**The sentinel stays** — pflag only permits the no-argument form (`civitai login --token`) when `NoOptDefVal` is non-empty; without it, bare `--token` errors *"flag needs an argument"*, which is the whole feature it exists for. Only the byte was wrong.

The sentinel is **user-visible** (pflag prints it verbatim in the help row), so the replacement was chosen to read as the description it is rather than as a magic string someone should type:

```
--token string[="(no value)"]   store a personal API key instead of the browser device login (pass with no value to print where to create one)
```

`civitai-token-no-value` minus the NUL was the smaller diff, but it is opaque — it reads like a literal a user might be expected to supply — and at 22 characters it widened the flag column for every row. `(no value)` is short, self-explanatory, and obviously prose.

The original `\x00` prefix did buy something real: argv cannot carry a NUL, so collision with a user-supplied value was *impossible*. `(no value)` gives that up, and the cost is bounded and benign — a Civitai personal key is alphanumeric, so it cannot contain a space or parentheses; and if someone did pass `--token='(no value)'`, the only effect is that the mint guidance prints instead of that literal being stored, i.e. exactly what bare `--token` already does. Nothing is lost and nothing is overwritten. Verified end to end below.

The constant's doc comment now records the mechanism and states the no-control-bytes requirement, so the byte cannot come back as a "harmless" tweak.

## Verification

**`--token` is the only `NoOptDefVal` in the CLI** — confirmed by grep across `internal/`, `cmd/` and `pkg/`; every other hit is prose in a comment or test. `--scopes` deliberately has none (documented in `login.go`). So there is no sibling instance of this hazard.

Swept `--help` across the whole command tree on both binaries, with the pre-fix build as the positive control so a zero cannot mean "the sweep was wired to nothing":

| build | commands with a NUL | total NULs |
|---|---|---|
| `origin/main` @ `8ed4d69` | `login` | 1 |
| this branch | none | 0 |

On the fixed binary: `file -b` → `Unicode text, UTF-8 text`; `grep -c token` → `9` (was `binary file matches`); 0 NUL and 0 other C0 control bytes.

**The no-argument form still works** (this is what the sentinel exists to preserve, and a help-text assertion cannot see it) — run against the built binary with a throwaway `XDG_CONFIG_HOME`:

| invocation | result |
|---|---|
| `login --token` | prints where to mint a key, `rc=0`, **no config written** |
| `login --token=` | same |
| `login --token=(no value)` (sentinel collision spelling) | same — mint help, nothing stored |
| `login --token abc123` | `✓ Token saved`, key persisted |

## Tests

`internal/cmd/login_help_bytes_test.go`, two guards, both with positive controls — "contains no NUL" passes trivially against empty output *and* against a build that dropped `NoOptDefVal` altogether:

- **`TestLoginHelpEmitsNoControlBytes`** — asserts the help it examined is real (length + a `Flags:` section) and that the optional-value `--token string[="` row is present *before* scanning; then asserts no NUL, no other C0 byte (newline/tab excepted), and that the row renders **contiguously** — pflag padded it apart when it aligned on our byte, so the contiguous form did not exist in the broken output.
- **`TestTokenFlagNoValueSentinelIsPlainText`** — pins the constant itself as non-empty and control-byte-free, so the defect cannot return through a path this package's help rendering does not happen to exercise.

**Mutation-tested** (a test not watched to fail proves nothing):

*Mutant 1 — restore the `\x00` prefix:*

```
    login_help_bytes_test.go:57: login --help emitted a raw NUL at byte offset 2769 (issue #253): any captured copy of this output is BINARY to file(1), grep and git.
    login_help_bytes_test.go:69: login --help does not render the --token row contiguously as "--token string[=\"\x00(no value)\"]" — pflag split the row, which means the sentinel carries a byte pflag treats as a column separator.
    login_help_bytes_test.go:80: login --help emitted control byte 0x00 at offset 2769 — help output must stay plain text.
--- FAIL: TestLoginHelpEmitsNoControlBytes (0.00s)
    login_help_bytes_test.go:102: tokenFlagNoValue contains control byte 0x00 at index 0 ("\x00(no value)"); it is rendered verbatim into `civitai login --help` — see issue #253
--- FAIL: TestTokenFlagNoValueSentinelIsPlainText (0.00s)
```

*Mutant 2 — drop the `NoOptDefVal` assignment (proves the positive control is live, not decorative):*

```
    login_help_bytes_test.go:49: login --help has no "--token string[=\"" row — --token's NoOptDefVal is gone, so bare `civitai login --token` would error "flag needs an argument". Nothing renders the sentinel, so the NUL scan below would pass vacuously.
--- FAIL: TestLoginHelpEmitsNoControlBytes (0.00s)
```

Both mutants reverted; both tests green.

Note the first draft of the test had the row control ahead of the NUL scan as a `Fatalf` **derived from the sentinel**, so mutant 1 failed at the control rather than at the assertion naming the actual defect. Restructured so the byte-independent control gates first and the NUL scan always runs.

## `make ci`

Counted, not inferred: **18 packages `ok`, 0 `FAIL`, 0 `no test files`, 0 `panic: test timed out`.** `go mod tidy` left `go.mod`/`go.sum` unchanged.

`gofmt -s -l .` prints nothing — confirmed **live** rather than trusted, since a formatter checking zero files prints the same nothing as one checking everything: planted a deliberately misformatted `internal/cmd/zz_gofmt_canary.go`, saw it listed, removed it, re-ran clean. 297 `.go` files in the tree were available to check.

## 🔴 Cross-repo consequence — `civitai-developer-docs`

`civitai-developer-docs` commits a snapshot of this CLI's `--help` output at `appblocks-snapshots/civitai-cli-help.txt` and generates its published CLI reference from it. **This change alters the rendered `--token` row**, so that snapshot is now stale and needs re-capturing on the docs side:

```
node scripts/gen-appblocks-cli.mjs --write-snapshot
```

That is out of scope here and this PR does not touch the docs repo.

Worth stating precisely, because it is easy to misread: the docs repo currently carries a **repair at its capture seam** for this exact NUL. After this fix that repair becomes a harmless no-op for current CLI builds — but it **must stay**, because it is still doing real work for every older CLI version anyone captures from (`v0.1.90`-era builds reproduce the NUL). This is not a request to remove it.

## Not verified

- No new binary has been released; the fix is verified against a local build of this branch, not against a published artifact.
- The docs-side re-capture has not been run — that repo was deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
