### PR TITLE
fix(scaffold): starter-comfy-txt2img IS registered — drop the stale "not shipped yet" claim

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -297,6 +297,54 @@ func TestRenderPageMoney(t *testing.T) {
 		mustNotContain(t, comfyReadme, stale)
 	}
 
+	// The SECOND false invariant, same defect class, found the same way (a blind
+	// dogfooder). The scaffold used to tell the developer that
+	// `starter-comfy-txt2img` was not registered server-side "yet" and to print an
+	// inventory of the recipe registry alongside it. The recipe IS registered; the
+	// published web docs said so; the developer believed the generated README over
+	// them and spent a real generation attempt resolving the contradiction.
+	//
+	// Same SPELLED-guard caveat as above — these match phrasings, so they are a
+	// floor, not a proof, and a retraction that quotes the old wording verbatim
+	// will trip them. Describe the old claim; don't restate it.
+	genTS := readFile(t, filepath.Join(dest, "src", "generation.ts"))
+	genTest := readFile(t, filepath.Join(dest, "src", "generation.test.ts"))
+	comfySurfaces := []string{comfy, app, comfyReadme, genTS, genTest}
+	for _, stale := range []string{
+		"not registered server-side yet",
+		"registry currently holds only",
+		"Until it ships",
+		"is **not runnable yet**",
+	} {
+		for _, surface := range comfySurfaces {
+			mustNotContain(t, surface, stale)
+		}
+	}
+
+	// The STRUCTURAL half, and the one that survives a rephrasing: the generated
+	// app must not enumerate the server-owned recipe registry at all. Every stale
+	// claim above was anchored to a hardcoded inventory of it — a list of recipe
+	// ids this app does not send, written into a file that ships on a different
+	// cadence than the registry does. `seamless-pano-360` is the id that inventory
+	// named; the app's own id is the only recipe id that belongs in here.
+	//
+	// This is deliberately NOT phrasing-matched: it fails on any reintroduction of
+	// a foreign recipe id, in a comment, a doc, or a test fixture, however worded.
+	for _, surface := range comfySurfaces {
+		mustNotContain(t, surface, "seamless-pano-360")
+	}
+
+	// Positive control for the two loops above: they assert ABSENCE, so they are
+	// green against a surface that is empty, misread, or wired to the wrong path.
+	// Pin something that MUST be present on each surface, so a mis-wired read
+	// cannot pass the absence checks vacuously.
+	for i, surface := range comfySurfaces {
+		if !strings.Contains(surface, "starter-comfy-txt2img") {
+			t.Errorf("comfySurfaces[%d] does not mention the app's own recipe id — "+
+				"the stale-claim guards above would pass vacuously against it", i)
+		}
+	}
+
 	// generation.ts threads the chosen checkpoint into modelId/modelVersionId
 	// instead of a hardcoded constant, AND emits the selected LoRAs as
 	// additionalResources (only when non-empty).

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -130,7 +130,13 @@ graph, the resource allowlist, the checkpoint policy, and a hard per-job
 `maxBuzz` ceiling; the block picks only the recipe + a small, per-recipe-
 validated `params` object (here just a prompt, plus the shared account picker —
 no checkpoint/LoRA axis). This sample invokes **`starter-comfy-txt2img`** — a
-cheap, minimal Z-Image txt2img starter recipe (per-job Buzz ceiling 30).
+cheap, minimal Z-Image txt2img starter recipe, and it is **registered
+server-side**, so the id in this scaffold resolves to a real recipe.
+
+Its per-job Buzz ceiling is owned by the **registry**, not by your app, and can be
+changed server-side without a scaffold release (it was raised once already, to
+cover cold-start). Treat any ceiling number printed in this README as indicative
+and the server's own response as authoritative.
 
 Note that `mode` is **omitted**, not set to `'recipe'`. The server declares it an
 optional literal precisely so a body without the key parses as a recipe, which is
@@ -233,7 +239,7 @@ an app-developer account. It only affects the offline mock harness.
 **Two different numbers, and they are not the same quantity.** It is easy to
 read one off the other; don't.
 
-- A recipe's **`maxBuzz` ceiling** (30 here) is what the *server* enforces on a
+- A recipe's **`maxBuzz` ceiling** is what the *server* enforces on a
   single job. The step runs under a timeout that physically bounds GPU-seconds,
   so the job cannot accrue more than that no matter what the graph does — and
   you settle down to the *real* runtime cost anyway. You don't choose this
@@ -244,13 +250,18 @@ read one off the other; don't.
   bundle compromised.
 
 The ceiling constrains the budget in exactly one direction: a submit is rejected
-when the recipe's ceiling exceeds the token budget, so 30 is a hard **floor**
-here. A floor is not a sizing method. "Ceiling plus a margin" pegs your blast
-radius to whatever the cheapest recipe you currently call happens to cost, which
-is an estimate wearing a safety hat — and it re-breaks the app the moment you
-call something pricier. Size the budget from how much damage you are willing to
-absorb, then check it clears the floor. The scaffold ships **300**, ~10× its own
-worst case.
+when the recipe's ceiling exceeds the token budget, so the recipe's ceiling is a
+hard **floor** on your budget. A floor is not a sizing method. "Ceiling plus a
+margin" pegs your blast radius to whatever the cheapest recipe you currently call
+happens to cost, which is an estimate wearing a safety hat — and it re-breaks the
+app the moment you call something pricier, *or* the moment the registry raises
+that recipe's ceiling underneath you (which has happened). Size the budget from
+how much damage you are willing to absorb, then check it clears the floor. The
+scaffold ships **300**, several times the starter recipe's ceiling.
+
+If you do hit the floor, the server says so precisely — `insufficient buzz
+budget: recipe ceiling <N> exceeds budget <M>` names the live ceiling. That
+message, not this README, is the current value.
 
 > **One budget serves both modes, and it is a CEILING — not an estimate.**
 > `page.buzzBudgetPerGen` is the safety ceiling on what a SINGLE generation your
@@ -287,28 +298,42 @@ On **live** civitai.com:
 - **Inline** requires an **app-developer** account (and a page token). With one,
   the path is live; without one the submit is rejected by the same app-blocks
   gate below.
-- **The recipe sample** is **not runnable yet**, for two reasons, and its
-  graceful panel is best-effort:
-  - `customComfy` is **invite-only beta** — a submit by a non-tester is rejected
-    by the app-blocks gate (`"Apps are not enabled"` / `"Apps authoring is not
-    enabled for this account"`).
-  - The recipe `starter-comfy-txt2img` is **not registered server-side yet** (the
-    registry currently holds only `seamless-pano-360`). Until it ships, a submit
-    is rejected even earlier — at the workflow-schema **enum** boundary
-    (`Invalid enum value … received 'starter-comfy-txt2img'`).
+- **The recipe sample** names a **registered** recipe — `starter-comfy-txt2img`
+  resolves server-side and prices an estimate. What gates it is the **cohort, not
+  the recipe**: `customComfy` is **invite-only beta**, so a submit by a
+  non-tester is rejected by the app-blocks gate (`"Apps are not enabled"` /
+  `"Apps authoring is not enabled for this account"`).
 
-The app tries to degrade both of these to a friendly **invite-only beta** panel:
-`isFeatureGated` matches those three specific strings and, **in Comfy mode only**,
+🔴 **An earlier revision of this README claimed the opposite** — that this recipe
+had not shipped, and it printed a hardcoded inventory of the registry alongside
+that claim. Both were wrong by the time anyone read them, and a developer who
+trusted this file over the published docs burned a real generation attempt
+finding out which one to believe. The lesson is structural, not a typo: **the
+recipe registry is server-owned and changes without a scaffold release**, so this
+README no longer tries to enumerate it.
+
+**To discover what is registered right now, ask the server.** Send an id and read
+the rejection: an unregistered id is refused at the workflow-schema **enum**
+boundary, and the message enumerates the ids that ARE registered —
+`Invalid enum value. Expected …, received '<the id you sent>'`. That list is
+generated from the live registry, so it cannot go stale the way a README can.
+
+The app degrades the gate signals to a friendly **invite-only beta** panel:
+`isFeatureGated` matches three specific strings — the two app-blocks gate strings
+above, plus that enum rejection. Note what the enum case means **now**: "this
+server's registry has no such id", i.e. you pointed `STARTER_COMFY_RECIPE` at
+something else, or you are running against a deployment that predates the recipe.
+It is no longer the expected state of the shipped sample. **In Comfy mode only**,
 the App renders the beta panel instead of a raw error. **Caveat (honest):** this
 only works if the host relays the raw server message into the block's submit
 rejection — the host→block error relay is host-dependent and can't be verified
 locally, so **a live Comfy submit may still surface a raw error** rather than the
-panel until the recipe is registered + deployed. The persistent "invite-only beta"
-note above the prompt frames the sample honestly regardless. The txt2img path is
-unaffected — the gate strings are Comfy-scoped and never change its behaviour.
+panel. The persistent "invite-only beta" note above the prompt frames the sample
+honestly regardless. The txt2img path is unaffected — the gate strings are
+Comfy-scoped and never change its behaviour.
 
-So: **mock works now**; a real Comfy run needs the invite-only beta cohort (+
-`civitai app dev-tunnel` in that cohort) **and** the deployed recipe.
+So: **mock works now**; a real Comfy run on live civitai.com needs the
+invite-only beta cohort (+ `civitai app dev-tunnel` in that cohort).
 
 ### Buzz balance + account picker (per-account spend)
 

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -60,9 +60,11 @@ import { STARTER_COMFY_RECIPE, buildComfyBody } from './comfy.js';
  *  - `txt2img` — the PRIMARY, runnable-today path (hardcoded-default checkpoint +
  *    host checkpoint/LoRA pickers).
  *  - `comfy`  — the SECONDARY Comfy on Civitai (customComfy) sample: a
- *    server-registered, code-reviewed recipe (`starter-comfy-txt2img`). The app
- *    can't ship a graph; it sends only the recipe id + a prompt. Invite-only beta
- *    on live civitai.com (works end-to-end against the mock host).
+ *    code-reviewed recipe (`starter-comfy-txt2img`), which IS registered
+ *    server-side. On THIS arm the app sends only the recipe id + a prompt and
+ *    the server owns the graph — but an app CAN ship its own graph;
+ *    that is the separate INLINE arm, built and unit-tested in comfy.ts. Comfy is
+ *    invite-only beta on live civitai.com (works end-to-end against the mock host).
  */
 type GenMode = 'txt2img' | 'comfy';
 

--- a/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/comfy.ts.tmpl
@@ -49,10 +49,17 @@ export type ComfyParams = ComfyRecipeBody['params'];
 
 /**
  * The starter recipe the RECIPE sample invokes: a cheap, minimal Z-Image txt2img
- * recipe (per-job Buzz ceiling 30). It is SERVER-registered — a recipe id must
- * exist in the server registry for a real run to resolve, and an unknown id is
- * rejected fail-closed at the schema enum. To run a graph that is NOT in the
- * registry, use the inline arm below instead of waiting for a review.
+ * recipe. It IS server-registered — a recipe id must exist in the server registry
+ * for a real run to resolve, and an unknown id is rejected fail-closed at the
+ * schema enum (whose message lists the ids that ARE registered — that list, not a
+ * constant written here, is how you find out what the registry currently holds).
+ *
+ * Its per-job Buzz ceiling is declared by the REGISTRY, not by this file, and can
+ * be raised server-side without a scaffold release. Don't mirror it into a
+ * constant here: a stale copy of a spend limit is worse than no copy.
+ *
+ * To run a graph that is NOT in the registry, use the inline arm below instead of
+ * waiting for a review.
  */
 export const STARTER_COMFY_RECIPE = 'starter-comfy-txt2img';
 

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -158,10 +158,19 @@ describe('isFeatureGated', () => {
     expect(isFeatureGated('UNAUTHORIZED: Apps are not enabled')).toBe(true);
     // (b) author gate — assertViewerIsAppDeveloper.
     expect(isFeatureGated('Apps authoring is not enabled for this account')).toBe(true);
-    // (c) unknown-recipe Zod enum rejection (pre-deploy; recipe not yet registered).
+    // (c) unknown-recipe Zod enum rejection — the server's registry holds no such
+    //     id. `starter-comfy-txt2img` IS registered, so this is the "you pointed
+    //     STARTER_COMFY_RECIPE somewhere else" case, not a pre-deploy state.
+    //
+    //     🔴 The `Expected …` side is a PLACEHOLDER on purpose. An earlier fixture
+    //     wrote the real registry's contents in here; the registry is server-owned,
+    //     it changed, and the fixture became a false claim that a reader took for
+    //     documentation. What the predicate actually keys on is the enum signature
+    //     plus THIS app's recipe id — that is what these fixtures pin, and it does
+    //     not depend on what else is registered.
     expect(
       isFeatureGated(
-        "Invalid enum value. Expected 'seamless-pano-360', received 'starter-comfy-txt2img'",
+        "Invalid enum value. Expected 'some-registered-id', received 'starter-comfy-txt2img'",
       ),
     ).toBe(true);
   });
@@ -203,7 +212,7 @@ describe('phaseForError', () => {
     expect(phaseForError('Apps are not enabled')).toBe('failed');
     expect(
       phaseForError(
-        "Invalid enum value. Expected 'seamless-pano-360', received 'starter-comfy-txt2img'",
+        "Invalid enum value. Expected 'some-registered-id', received 'starter-comfy-txt2img'",
       ),
     ).toBe('failed');
   });
@@ -213,8 +222,10 @@ describe('phaseForSubmitError (comfy-mode-scoped gating)', () => {
   // The three real gate strings (verified against civitai/civitai).
   const FLAG_GATE = 'Apps are not enabled';
   const AUTHOR_GATE = 'Apps authoring is not enabled for this account';
+  // Placeholder `Expected` side — see the note in the isFeatureGated block above:
+  // this fixture must not encode an inventory of the server-owned recipe registry.
   const ENUM_REJECT =
-    "Invalid enum value. Expected 'seamless-pano-360', received 'starter-comfy-txt2img'";
+    "Invalid enum value. Expected 'some-registered-id', received 'starter-comfy-txt2img'";
 
   it('COMFY mode: each gate string -> gated', () => {
     expect(phaseForSubmitError(FLAG_GATE, true)).toBe('gated');

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -154,10 +154,18 @@ const STARTER_COMFY_RECIPE_ID = 'starter-comfy-txt2img';
  *       UNAUTHORIZED `"Apps are not enabled"`.
  *   (b) the author gate — `assertViewerIsAppDeveloper` throws FORBIDDEN
  *       `"Apps authoring is not enabled for this account"`.
- *   (c) the unknown-recipe rejection — before the recipe is registered server-side
- *       (`REGISTERED_RECIPE_IDS = ['seamless-pano-360']`), a customComfy submit is
- *       rejected at the Zod enum boundary with
- *       `"Invalid enum value. Expected 'seamless-pano-360', received 'starter-comfy-txt2img'"`.
+ *   (c) the unknown-recipe rejection — a customComfy submit naming a recipe id
+ *       the server's registry does not hold is rejected at the Zod enum boundary:
+ *       `"Invalid enum value. Expected <the registered ids>, received '<sent id>'"`.
+ *
+ *       🔴 This is NOT the shipped sample's expected state. `starter-comfy-txt2img`
+ *       IS registered server-side. (c) fires when you point
+ *       {@link STARTER_COMFY_RECIPE_ID} at an id the server doesn't have, or run
+ *       against a deployment older than the recipe. An earlier version of this
+ *       comment asserted the reverse AND hardcoded the registry's contents; both
+ *       went stale, and a developer believed them over the published docs. The
+ *       registry is server-owned and changes without a scaffold release — read
+ *       the `Expected …` list in the rejection, never a list written down here.
  *
  * It INTENTIONALLY no longer matches the broad tokens `forbidden` / `not allowed`
  * / `restricted` / bare `invite`: those over-matched dev misconfig (a generic
@@ -178,8 +186,8 @@ export function isFeatureGated(message: string | null | undefined): boolean {
     m.includes('apps are not enabled') ||
     // (b) author gate — exact server string.
     m.includes('apps authoring is not enabled') ||
-    // (c) unknown-recipe Zod enum rejection (pre-deploy) — the enum signature
-    //     AND the recipe id, so a *different* enum rejection can't match.
+    // (c) unknown-recipe Zod enum rejection — the enum signature AND this app's
+    //     own recipe id, so a *different* enum rejection can't match.
     (m.includes('invalid enum value') && m.includes(STARTER_COMFY_RECIPE_ID))
   );
 }


### PR DESCRIPTION
## The problem

`internal/scaffold/templates/page-money/README.md.tmpl` told the developer that
`starter-comfy-txt2img` was **"not registered server-side yet"** and that the
recipe registry **"currently holds only `seamless-pano-360`"**.

Both claims are false. The recipe is registered and resolves.

A developer dogfooding the CLI blind hit a direct contradiction: the published
web docs named `starter-comfy-txt2img` as the starter recipe, while the README
they had just generated said it did not exist. They believed the README — a
scaffold README is read as authoritative by the person holding it — and **spent
a real generation attempt to establish which of the two docs to trust.**

## What was stale, and where

Six instances across five files, in three groups:

| # | Group | Site |
|---|---|---|
| 1 | availability | `README.md.tmpl` — "is **not runnable yet**" |
| 2 | availability + inventory | `README.md.tmpl` — "not registered server-side yet (the registry currently holds only …)" |
| 3 | availability | `README.md.tmpl` — "…may still surface a raw error … until the recipe is registered + deployed" / "needs … **and** the deployed recipe" |
| 4 | availability + inventory | `generation.ts.tmpl` — sniff comment (c), which asserted the recipe was unregistered *and* hardcoded `REGISTERED_RECIPE_IDS = [...]` |
| 5 | availability + inventory | `generation.test.ts.tmpl` — "(pre-deploy; recipe not yet registered)" plus 3 fixtures encoding the registry |
| 6 | ceiling | `README.md.tmpl` ×3 + `comfy.ts.tmpl` ×1 — a per-job Buzz ceiling of **30** |

Group 6 was found while reading the neighbours, as instructed. The registry
raised that ceiling (30 no longer covered cold start), which also silently
falsified the README's derived arithmetic: "the scaffold ships **300**, ~10× its
own worst case" — it is not 10×. Leaving a wrong money number in a passage this
PR otherwise vouches for would have shipped a new false claim.

Bonus find, same defect class, different claim: `App.tsx.tmpl` still carried the
**previously-retracted** "the app can't ship a graph" sentence. The README and
`comfy.ts` had both been corrected for that; this file was missed.

## The fix, and why it is shaped this way

**It does not write a corrected inventory.** An enumeration nobody can keep
current is precisely how this passage rotted. The docs now describe how to
**discover** the registry instead: send an id, and the workflow schema's enum
rejection enumerates the ids that *are* registered. That list is generated from
the live registry, so it cannot go stale the way a README can.

Same treatment for the ceiling — the server's own
`insufficient buzz budget: recipe ceiling <N> exceeds budget <M>` names the live
value, so no number is mirrored into the scaffold. `comfy.ts` now says outright:
*don't mirror a spend limit into a constant here.*

**The enum-rejection branch in `isFeatureGated` is kept, not deleted.** It is not
dead code — it just means something different now. It no longer means "the
starter recipe hasn't shipped"; it means **"this server's registry has no such
id"**, which is exactly what a developer who repoints `STARTER_COMFY_RECIPE`, or
who runs against an older deployment, will hit. That reading is true regardless
of what the registry contains.

### Claims I did and did not make

I verified from the server source on the deployed branch that
`starter-comfy-txt2img` is registered, and that its ceiling is 90 rather than 30.
The production check that it returns a cost estimate came from the dogfood
report, so the README asserts only the durable fact (it is registered; the
registry is server-owned; ask the server) and does not restate a dated
measurement that would itself rot.

## Tests

There is precedent in this repo for tests that encoded a doc claim. The existing
stale-claim block in `TestRenderPageMoney` is extended rather than duplicated:

- **Spelled guards** for the four stale phrasings, across five generated
  surfaces (`comfy.ts`, `App.tsx`, `README.md`, `generation.ts`,
  `generation.test.ts`).
- **A structural guard that survives rephrasing** — no foreign recipe id may
  appear in the generated app at all. Every stale claim above was anchored to a
  hardcoded inventory; this fires on any reintroduction of one, in a comment, a
  doc, or a fixture, however worded.
- **A positive control.** The two loops above assert *absence*, so they are green
  against a surface that is empty or read from the wrong path. The control
  requires each surface to mention the app's own recipe id.

The updated JS fixtures assert something **true**, not re-pinned wording: the
`Expected …` side is now an explicit placeholder, so they pin the predicate's
real contract (enum signature + this app's own recipe id) without encoding an
inventory again — which is the exact mistake being fixed.

### Results

**Mutation matrix** — guard is **RED at `origin/main`**: 7 assertions fire in
`TestRenderPageMoney`, each with this guard's own
`expected NOT to contain "<specific string>"` message. **GREEN at HEAD.**

> Worth recording: the first mutation run reported a confident `ok`. `-run
> TestScaffold` matches `TestScaffolded…` / `TestScaffoldHeaders…` and never
> executed `TestRenderPageMoney` at all — a real pass of the wrong tests. The
> guard was fine; the command line was not.

The positive control was itself mutation-tested: stripping the recipe id from one
surface fires it by name, at its own line.

| Suite | Result |
|---|---|
| Go (`go test ./...`) | **2686 passed, 0 failed, 4 skipped**, 0 timeout panics, 18/18 packages ok |
| Generated app (scaffold + `npm test`) | **11 test files, 148 tests passed, 0 failed** |
| Generated app typecheck / build | clean |

The edited `isFeatureGated` / `phaseForSubmitError` specs were confirmed to
actually execute (not silently skipped) before the pass was believed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
