### PR TITLE
docs(#260): document app list/view/pull, scope the anonymous-reads claim, add a TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # civitai CLI
 
 > **Browse and download Civitai models, images, and articles — and author,
-> validate, and submit App Blocks.** Two paths in one static binary: an
-> anonymous **read/download client** for the public API, and the toolchain for
-> shipping **Apps**.
+> validate, and submit App Blocks.** Two paths in one static binary: a
+> **read/download client** for the public API (reads are anonymous; downloads
+> need a token), and the toolchain for shipping **Apps** (every `civitai app`
+> command needs one).
 
 > ⚠️ **Apps is in a limited, invite-only beta (pre-GA).** You can install this
 > CLI, `login`, scaffold, validate, and run an app locally right now — but
@@ -17,8 +18,11 @@
 
 The command-line interface for [Civitai](https://civitai.com) — a single static
 binary that does two things: it's a thin **read/download client** for Civitai's
-public API (browse and fetch models, images, and articles — no account needed to
-read), and it's the toolchain to **author, validate, and ship Apps**.
+**public** API (browse and fetch models, images, and articles — no account needed
+to read those), and it's the toolchain to **author, validate, and ship Apps**.
+Everything under `civitai app` needs a credential, including the App-store
+browse commands `app list` / `app view` — see
+[Browse the App store](#browse-the-app-store).
 
 An **App** is a small, sandboxed web app that runs inside Civitai
 surfaces (it's served in an iframe; the platform owns the build and the
@@ -29,6 +33,52 @@ contract, and **packages/submits** it for review.
 > New here? The
 > [Build your first App](https://github.com/civitai/civitai-app-starters/blob/main/docs/build-your-first-app-block.md)
 > guide is the full end-to-end walkthrough.
+
+## Contents
+
+- [Install](#install)
+- [Quickstart: browse & download](#quickstart-browse--download)
+- [Quickstart: build an App Block](#quickstart-build-an-app-block)
+- [SDK packages](#sdk-packages)
+- [Command reference](#command-reference)
+  - [Templates](#templates)
+  - [The host handshake (`BLOCK_READY`)](#the-host-handshake-block_ready)
+  - [Local dev loop (harness: mock vs live)](#local-dev-loop-harness-mock-vs-live)
+  - [Preview in the real host (`app dev-tunnel`)](#preview-in-the-real-host-app-dev-tunnel)
+  - [Examples](#examples)
+- [Browse the public API](#browse-the-public-api)
+- [Download model files](#download-model-files)
+- [Scripting with `--json`](#scripting-with---json)
+  - [Cursor pagination loop](#cursor-pagination-loop)
+  - [Clean output for pipelines](#clean-output-for-pipelines)
+  - [Generation `--json`](#generation---json)
+  - [Gotchas](#gotchas)
+  - [Worked example — top LoRAs for a base model, then plan a download](#worked-example--top-loras-for-a-base-model-then-plan-a-download)
+- [Validate fidelity](#validate-fidelity)
+  - [The `--json` result shape](#the---json-result-shape)
+- [Submit & auth](#submit--auth)
+  - [After you submit: review → approve → deploy](#after-you-submit-review--approve--deploy)
+- [Submission status](#submission-status)
+  - [Deployed is not the same as listed in the store](#deployed-is-not-the-same-as-listed-in-the-store)
+- [Pull your app's repository (`app pull`)](#pull-your-apps-repository-app-pull)
+- [Browse the App store](#browse-the-app-store)
+- [App metrics](#app-metrics)
+- [Generate](#generate)
+  - [`--max-cost` is an estimate check, not a spending cap](#---max-cost-is-an-estimate-check-not-a-spending-cap)
+  - [Silent model substitution](#-silent-model-substitution)
+  - [Confirmation](#confirmation)
+  - [Image-to-image: `--image` and `--ecosystem`](#image-to-image---image-and---ecosystem)
+  - [The content flags, and why there aren't twelve](#the-content-flags-and-why-there-arent-twelve)
+  - [Raw graphs: `--print-input` and `--input`](#raw-graphs---print-input-and---input)
+  - [Waiting, downloading, and re-attaching](#waiting-downloading-and-re-attaching)
+  - [Listing and cancelling workflows](#listing-and-cancelling-workflows)
+  - [Exit codes specific to `generate`](#exit-codes-specific-to-generate)
+- [Configuration](#configuration)
+- [Exit codes](#exit-codes)
+- [Troubleshooting](#troubleshooting)
+- [Development](#development)
+- [Releasing](#releasing)
+- [License](#license)
 
 ## Install
 
@@ -102,8 +152,17 @@ go install github.com/civitai/cli/cmd/civitai@latest
 
 ## Quickstart: browse & download
 
-Reads are **anonymous** — no `login` needed. Every command takes `--json` to
-emit the raw API response for scripting.
+Reads of the **public catalog** — models, model versions, images, tags,
+creators, users, articles, collections — are **anonymous**: no `login` needed
+for the commands in this section. Every one of them takes `--json` to emit the
+raw API response for scripting.
+
+> **What is *not* anonymous.** `civitai download` needs a token, and so does
+> every `civitai app …` command — **including the App-store browse commands**
+> `civitai app list` and `civitai app view`, which exit `3` with
+> `no token configured` when you have not logged in. The store endpoint keys the
+> visible catalog off your identity, so there is no anonymous view of it. See
+> [Browse the App store](#browse-the-app-store).
 
 ```bash
 # Search models — filter by base model, type, and sort:
@@ -212,17 +271,20 @@ README. For the end-to-end walkthrough, see
 | `civitai login [--scopes <set>] [--token [<t>]] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens). The default scope set grants identity + Apps submit + dev-tunnel and **not** Buzz-spend; `--scopes generate` additively grants generation + Buzz **spend** (needed by `civitai generate` and money-path `dev:live`). `--token <t>` stores a personal API key instead (not combinable with `--scopes`). `--token` with **no value** prints where to create a personal key (`civitai.com/user/account`) and how to re-run — handy when you know you want a personal key but haven't minted one yet. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
 | `civitai whoami [--scopes] [--json]` | Verify the stored token; print the authenticated user **and a Capabilities section** — credential type (**OAuth login** vs **personal API key**), **Read Buzz balance**, and **Spend Buzz** — decoded from the token's scope, so a money-path dead end (a default OAuth login can't spend) is visible before `dev:live` — and when it can't, the output names the fix for that credential (`login --scopes generate` for an OAuth login, a full-scope key otherwise). `--scopes` also lists every granted scope; `--json` emits the user + `credentialType`/`canReadBalance`/`canSpend`/`scopes` (scriptable). |
 | `civitai buzz [--json]` | Show your spendable Buzz balance (**blue / green / yellow**, plus a **total**). Needs the BuzzRead scope — a full-scope personal API key or `civitai login --scopes generate`; a **default** OAuth login token can't read it, and gets a clear message naming both fixes. `--json` emits `{blue,green,yellow,total}` (scriptable — handy for before/after diffing a `dev:live` spend). |
+| `civitai app list [--kind <k>] [--category <c>] [--sort <s>] [--limit <n>] [--cursor <c>] [--json]` | **Discover published Apps in the store** (`GET /api/v1/apps`) — filter-based discovery, not free-text search. **Needs a credential** (`civitai login` or `CIVITAI_TOKEN`): the endpoint keys the visible catalog off your identity, so this is *not* one of the anonymous reads. Cursor-paged. See [Browse the App store](#browse-the-app-store). |
+| `civitai app view <slug> [--json]` | **Show one published App's store detail** (`GET /api/v1/apps/{slug}`) — description, category, rating, gallery, live/external target. **Needs a credential**, same as `app list`. Reads the *public store catalog*, which is a different resource from your own deploy — a not-found here says nothing about `<slug>.civit.ai`. See [Browse the App store](#browse-the-app-store). |
 | `civitai app create [name] [dir] [--template static\|page-vite\|page-money] [--dir <path>] [--name <display>]` | **The friendly happy path.** Scaffold a ready-to-build App, defaulting to the batteries-included `page-money` SDK template (default dir `./<slug>`). |
 | `civitai app init [name] [dir] [...]` | Same scaffolder as `create` with a no-build `static` default (back-compat alias). |
-| `civitai app dev-token <slug> [--env] [--spend] [--budget <n>]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`** — calls the invite-gated mint route with your stored credential, reading scopes from your local `block.manifest.json` (so it works on an unsubmitted slug). `--spend` explicitly REQUESTS `ai:write:budgeted` (real Buzz); omit it and that scope is **filtered out** of the request — the CLI never asks for budgeted spend implicitly, even when your manifest declares it (the scaffolded money app does, so a live run that used to generate now needs `--spend`). Prints the token (`--env` prints `VITE_LIVE_BLOCK_TOKEN=<token>`, paste-ready); warns at mint time if the token is read-only (can't spend). See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
-| `civitai app dev-tunnel [blockId] [--port] [--tunnel-endpoint] [--idle-timeout]` | **(Pre-GA / invite-gated)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Mints an **ephemeral in-memory ssh keypair**, opens a reverse tunnel from your dev port (start `npm run dev:tunnel` first) to the Civitai tunnel endpoint, prints the URL to open, and tears everything down on Ctrl-C or an idle timeout. Before minting it also **pre-flights whether the host can actually embed your dev server** — the host iframes it sandboxed (opaque `null` origin), so a dev server missing `Access-Control-Allow-Origin: *`, missing the `.civit.ai` entry in `allowedHosts`, or sending a framing header that excludes `civitai.com` loads as a blank iframe with no error anywhere. Those are printed as warnings (never fatal) **twice** — once the moment the checks run, so you still get them if you Ctrl-C the DNS wait, and again just above the URL, with the `vite.config.ts` fix. Apps scaffolded by `civitai app init --template page-money` already satisfy all of it. The tunnel endpoint (`sish.civitai.com:2224`) is **live**; access is gated behind an Apps-author invite **and** a server kill-switch flag, so if you are not enrolled the mint reports **"not available"** — ask to be added to the cohort. Publishing the tunnel host through external-dns + Cloudflare usually takes 1–3 min (occasionally longer); the command waits for it and prints the elapsed time. |
+| `civitai app dev-token <slug> [--env] [--spend] [--budget <n>]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`.** `--spend` must be asked for explicitly to request real-Buzz spend — without it the CLI filters `ai:write:budgeted` out of the mint request. `--env` prints a paste-ready `VITE_LIVE_BLOCK_TOKEN=<token>`. See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
+| `civitai app dev-tunnel [blockId] [--port] [--tunnel-endpoint] [--idle-timeout]` | **(Pre-GA / invite-gated)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Pre-flights whether the host can actually **embed** your dev server and warns (never fatally) when it cannot. See [Preview in the real host](#preview-in-the-real-host-app-dev-tunnel). |
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message` — **`field` is always present and never `null`**) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity) and [The `--json` result shape](#the---json-result-shape). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
-| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `civitai app submit` mints your listing as a **draft**, so you can set the media *while the app is in review* and it carries forward on approval. `listing status` prints what is attached vs. what the publish floor still requires. Source images are validated locally (png/jpeg/webp; icon ≤2 MiB, cover ≤4 MiB, screenshot ≤2 MiB) before upload, then wait for the content scan. On an **already-live** listing an attach opens a **revision** for moderator re-review (`--changelog`, `-y`). App resolved from `block.manifest.json` in the CWD, or `--slug`. See [After you submit](#after-you-submit-review--approve--deploy). |
+| `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
+| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires. See [After you submit](#after-you-submit-review--approve--deploy). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
-| `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results into `--out-dir` as `<workflow-id>-<n>.<ext>`. `--no-wait` prints the workflow id and exits; `--timeout` bounds the **wait** (never the job and never the charge); `--no-download` waits but prints URLs instead of writing files. `--dry-run` estimates and exits without submitting (`--dry-run --json` emits the raw estimate). `--print-input` prints the assembled graph and exits **without reaching any money seam** (no submit, no estimate, no balance read) — note that with `--image` it still **uploads** local files first, because the printed graph has to reference real blob URLs for `--input` to be able to submit it; uploading spends nothing; `--input <file>` (or `-` for stdin) sends a raw graph as-is — txt2img only, and mutually exclusive with the content flags. `--image <path-or-url>` (repeatable) attaches a reference image for **image-to-image** — a local png/jpeg is uploaded, an https URL is passed through — and **requires `--ecosystem`**, because without one the server ignores the images, generates from the prompt alone and charges anyway. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. `--max-cost` is an **estimate check, not a spending cap**. If the server **substitutes a different checkpoint** for the one you asked for it says so — on the estimate, after the submit, and in `--json` — and `--fail-on-substitution` refuses the run instead — though only when the server *reports* one, so it is **not** a spend guard against an older deployment (see [Silent model substitution](#-silent-model-substitution)). See [Generate](#generate). |
+| `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
 | `civitai workflows list [--limit <n>] [--cursor <c>] [--tag <t>] [--json]` | **List the generation workflows you have submitted**, newest first — status, when, cost, and `deliverable/total` outputs. Cursor-paged: the next cursor is printed on stdout when more results exist. Reading spends nothing. See [Generate](#listing-and-cancelling-workflows). |
 | `civitai workflows get <workflow-id> [--json]` | **Look up one generation workflow** — status, steps and outputs. This is how you re-attach after `--no-wait`, a `--timeout` expiry or a Ctrl-C. Outputs that are blocked, unavailable or hidden are listed **with the reason** rather than omitted. Output URLs are presigned and expire; re-run for fresh links. Reading spends nothing. See [Generate](#waiting-downloading-and-re-attaching). |
 | `civitai workflows cancel <workflow-id> [--yes] [--json]` | **Stop a running generation.** 🔴 **This does not refund anything** — a mid-run cancel bills the accrued cost, non-refundably. Cancel because you no longer want the output, never to save money. Asks for confirmation (default **no**); `--yes` skips the prompt and a non-TTY without it refuses. See [Generate](#listing-and-cancelling-workflows). |
@@ -343,13 +405,19 @@ civitai app dev-token my-block --env >> .env.development.local
 npm run dev:live
 ```
 
+`dev-token` reads the scopes to request from your **local**
+`block.manifest.json`, so it works on a slug you have never submitted.
 `.env.development*` is never committed (`submit` excludes it) and the token is
 short-lived (~4h) — re-run `dev-token` when it expires. For real generation mint
 with a spend-capable credential (**full-scope personal API key** or
-`civitai login --scopes generate`) **and** add `--spend`: the scope is requested
-only when you ask for it, so without the flag the mint drops it and dev:live
-refuses to generate with `block lacks ai:write:budgeted scope`. A default OAuth
-login mints a read-only token either way (the command warns you at mint time). With no token, `dev:live` **fails safe**
+`civitai login --scopes generate`) **and** add `--spend`: the CLI never asks for
+budgeted spend implicitly — **even when your manifest declares it** (the
+scaffolded money app does) — so without the flag the mint filters
+`ai:write:budgeted` out and dev:live refuses to generate with `block lacks
+ai:write:budgeted scope`. `--budget <n>` sets the token's **per-generation** Buzz
+budget (1–250; omit it and the server picks one — 50 for an unsubmitted app). A
+default OAuth login mints a read-only token either way (the command warns you at
+mint time). With no token, `dev:live` **fails safe**
 (renders a notice, never spends). Live v1 covers the money path
 (`estimate`/`submit`/`poll`/`cancel`); pickers, checkpoint-set, App-Storage KV,
 and in-band Buzz purchase are mock-only.
@@ -391,6 +459,39 @@ Env vars (`VITE_BLOCK_ALLOWED_PARENT_ORIGINS`, `VITE_HARNESS_MODE`,
 `VITE_LIVE_BLOCK_TOKEN`, …) and the scenario knobs are documented in depth in the
 scaffolded project's own `README.md` and `.env.example` — see
 [`internal/scaffold/templates/page-money/README.md.tmpl`](internal/scaffold/templates/page-money/README.md.tmpl).
+
+### Preview in the real host (`app dev-tunnel`)
+
+> **(Pre-GA / invite-gated.)** Access is gated behind an Apps-author invite
+> **and** a server kill-switch flag, so if you are not enrolled the mint reports
+> **"not available"** — ask to be added to the cohort.
+
+The harness is a *mock* of the host. `civitai app dev-tunnel` is the other end of
+that trade: it previews your **local** dev server inside the **real** Civitai
+host at `civitai.com/apps/dev/<blockId>`, so you see prod chrome, prod sandbox
+and the prod handshake against the code in your editor.
+
+```bash
+npm run dev:tunnel                 # start your dev server first
+civitai app dev-tunnel my-block    # then open the tunnel
+```
+
+It mints an **ephemeral in-memory ssh keypair**, opens a reverse tunnel from your
+dev port to the Civitai tunnel endpoint (`sish.civitai.com:2224`, live), prints
+the URL to open, and tears everything down on Ctrl-C or an idle timeout.
+Publishing the tunnel host through external-dns + Cloudflare usually takes 1–3
+min (occasionally longer); the command waits for it and prints the elapsed time.
+
+**Embeddability preflight.** Before minting, the command checks whether the host
+can actually *embed* your dev server. The host iframes it sandboxed, at an opaque
+`null` origin, so a dev server that is missing `Access-Control-Allow-Origin: *`,
+missing the `.civit.ai` entry in `allowedHosts`, or sending a framing header that
+excludes `civitai.com` loads as a **blank iframe with no error anywhere** — the
+worst kind of failure to debug. Those are printed as **warnings, never fatal**,
+and deliberately **twice**: once the moment the checks run, so you still get them
+if you Ctrl-C the DNS wait, and again just above the URL, with the
+`vite.config.ts` fix. Apps scaffolded by `civitai app create` (the `page-money`
+template) already satisfy all of it.
 
 ### Examples
 
@@ -1008,6 +1109,84 @@ flag while the store is pre-GA. When the 404 lands on a slug **you own**, the CL
 detects that and says so, naming both next commands, instead of leaving you with
 a bare "App not found".
 
+## Pull your app's repository (`app pull`)
+
+`civitai app pull` is the **read side of git authoring**: it clones (or, if
+`[dir]` is already a checkout, syncs) the canonical repository backing one of
+**your** approved Apps, so you can edit locally and then `civitai app submit` or
+push.
+
+```bash
+civitai app pull --app my-block                # clone into ./my-block
+civitai app pull ./my-block --app my-block     # clone/sync into ./my-block
+civitai app pull . --app my-block              # sync the current directory
+```
+
+`--app` is required (the slug or `appBlockId`; find it with `civitai app
+status`). Authentication uses your stored credential (`civitai login` or a
+personal API key) — the command calls an owner-only endpoint that **lazily
+provisions a scoped, read-only Forgejo identity** for you and returns a clone URL
+with a pull token embedded.
+
+The repo only exists once your **first version has been submitted as a ZIP and
+approved**; before then the command tells you so rather than failing obscurely.
+
+> ⚠️ **SECURITY — TOKEN-IN-URL LEAKAGE.** The clone URL embeds your access token
+> as HTTP-Basic credentials (`https://<user>:<token>@…`).
+>
+> - On a fresh **CLONE**, git writes the remote URL into `.git/config`, so **the
+>   token lands on disk** in the checkout. Treat the directory as sensitive: do
+>   **not** commit `.git/config` or share the directory. To drop the token, point
+>   the remote at the credential-less HTTPS URL —
+>   `git -C <dir> remote set-url origin <httpUrl>` — which is exactly the command
+>   the CLI prints for you after a clone.
+> - On a **SYNC** (pull into an existing checkout) the URL is passed explicitly
+>   and is **not** persisted to `.git/config`. The token still appears
+>   transiently in the git child process's arguments, so it is briefly visible to
+>   other local processes via `ps` / `/proc/<pid>/cmdline`.
+>
+> The CLI prints the applicable half of this warning to stderr after every run.
+
+A sync is `git fetch` + `git merge --ff-only`, so it never creates a merge commit
+and refuses rather than clobbering diverged history or a conflicting dirty tree.
+
+## Browse the App store
+
+`civitai app list` and `civitai app view <slug>` read the **public App store
+catalog** (`GET /api/v1/apps` and `GET /api/v1/apps/{slug}`).
+
+> 🔴 **These are not anonymous reads.** Unlike the model/image/article commands
+> in [Browse the public API](#browse-the-public-api), both **require a
+> credential** and exit `3` with
+> `no token configured — run 'civitai login' (or set CIVITAI_TOKEN) to browse the App store`
+> without one. The store endpoint keys the **visible catalog off your identity**,
+> so an anonymous call would see nothing; the CLI refuses up front rather than
+> presenting an empty catalog as the whole store.
+
+```bash
+civitai app list
+civitai app list --kind onsite --sort popular --limit 10
+civitai app list --category generation --json
+civitai app list --cursor '<next-cursor-from-a-previous-page>'
+civitai app view my-cool-app
+civitai app view my-cool-app --json
+```
+
+- **Filter-based discovery, not search.** There is no free-text query — the store
+  service does not expose one, which is why there is no `civitai app search`.
+  Filter with `--kind` (`all`, `onsite`, `offsite`), `--category` (`generation`,
+  `games`, `utility`, `discovery`, `moderation`, `analytics`, `other`) and
+  `--sort` (`top-rated`, `popular`, `newest`, `name`).
+- **Keyset cursor pagination**, not page numbers: the next cursor is printed
+  after the results, and you pass it back with `--cursor`. `--limit` is 1–50.
+- **The store is gated by a launch flag.** Until it opens publicly you only see
+  apps if your account is a moderator or an app-dev-tester, so a perfectly valid
+  login may get an **empty list**. That is the pre-GA state, not a broken login.
+- **Rate-limited per caller** — a tight scripted loop may see `429`s, which the
+  CLI backs off and retries automatically.
+- `app view` reads the **store catalog**, which is *not* your deploy: see
+  [Deployed is not the same as listed in the store](#deployed-is-not-the-same-as-listed-in-the-store).
+
 ## App metrics
 
 `civitai app metrics <slug>` shows the owner-only analytics for one of **your**
@@ -1069,8 +1248,11 @@ believable-but-wrong reading:
   `civitai app status <slug>` instead — a silently-empty dashboard that looks
   like real data is the failure mode this command is built to avoid.
 - **It needs a personal API key.** The query is full-scope, so an OAuth
-  `civitai login` token gets a 403; the error names the fix
-  (`civitai login --token <key>`).
+  `civitai login` token gets a 403. Both refusals — the 403 *and* the
+  no-token-at-all case — name the route that actually works
+  (`civitai login --token <key>`, created at `civitai.com/user/account`) rather
+  than the generic "run `civitai login`", which here is the one route that
+  cannot succeed.
 
 Two data caveats.
 

--- a/internal/cmd/app_dev_tunnel_cmd_test.go
+++ b/internal/cmd/app_dev_tunnel_cmd_test.go
@@ -412,12 +412,20 @@ func TestAppHelpListsDevTunnel(t *testing.T) {
 // checks AGREEMENT rather than either wording alone: the README must name the
 // endpoint the code actually dials, and must not contradict the command's own
 // claim that the endpoint is live.
+//
+// 🔴 SCOPE: "the README" here is the row PLUS the section(s) the row links to.
+// The detail used to sit inside the table cell — 222 words in one markdown
+// column, which GitHub renders unreadably — and moved into a dedicated section
+// (issue #260). Keeping the assertions pinned to the CELL would have made the
+// relocation look like deletion; following the row's own cross-reference keeps
+// the anti-drift claim intact AND fails if that link ever breaks.
 func TestReadmeDevTunnelRowMatchesTheCommandHelp(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join(repoRootDir(t), "README.md"))
 	if err != nil {
 		t.Fatalf("read README.md: %v", err)
 	}
-	row := readmeCommandRefRow(t, string(raw), "civitai app dev-tunnel")
+	row := readmeRowPlusLinkedSections(t, string(raw),
+		readmeCommandRefRow(t, string(raw), "civitai app dev-tunnel"))
 
 	// The command's Long is the surface that was kept current; it is the anchor.
 	long := newAppDevTunnelCmd().Long

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -29,6 +29,19 @@ const wireTimeLayout = "2006-01-02T15:04:05.000Z"
 // regardless of where they run the CLI.
 const dateOnlyLayout = "2006-01-02"
 
+// appMetricsCredentialRoute names the ONE credential that works for this
+// command, and it is deliberately NOT login.go's spendCredentialRoutes.
+//
+// 🔴 That constant names BOTH routes because generation accepts either. The
+// analytics proc does not: it is full-scope, so an OAuth browser login is
+// refused with 403 (see the Long text, and item 5 in AGENTS.md). Until issue
+// #260 the no-token error here was the generic "run `civitai login`" — which is
+// the ONE route this command cannot use, so following the CLI's own advice
+// landed the author on a second refusal. `generate` and `workflows` already name
+// their working routes; this mirrors that shape for the route that works here.
+const appMetricsCredentialRoute = "a full-scope personal API key " +
+	"(`civitai login --token <key>`, created at " + accountAPIKeysURL + ")"
+
 // appMetricsDeps are the two network seams `app metrics` needs: slug →
 // appBlockId resolution (the existing submissions route) and the analytics query
 // itself. Bundled so the command core is exercisable without a live server.
@@ -58,8 +71,8 @@ command therefore always prints the window the SERVER served (echoed from the
 response), not the one you asked for. Pass --from / --to as a plain YYYY-MM-DD
 date (midnight UTC) or a full RFC3339 timestamp to widen it.
 
-CREDENTIAL: the analytics query is full-scope, so it needs a personal API key
-(` + "`civitai login --token <key>`" + `); an OAuth browser login is refused with 403.
+CREDENTIAL: the analytics query is full-scope, so it needs ` + appMetricsCredentialRoute + `;
+an OAuth browser login is refused with 403.
 
 DATA CAVEAT: engagement counts only AUTHENTICATED, scope-gated API calls. An app
 that ships no scoped API surface will show real installs and revenue with a flat
@@ -80,7 +93,12 @@ engagement section — that is expected, not a bug.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
+				// Name the route that WORKS, not the generic one: an OAuth
+				// browser login is refused here with 403 (see
+				// appMetricsCredentialRoute).
+				return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf(
+					"no token configured — app analytics need %s; a browser login (`civitai login`) is full-scope-refused with 403 here. Or set CIVITAI_TOKEN to that key",
+					appMetricsCredentialRoute))
 			}
 
 			client := appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")

--- a/internal/cmd/app_metrics_credential_test.go
+++ b/internal/cmd/app_metrics_credential_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// TestAppMetricsNoTokenNamesTheRouteThatWorks is the issue-#260 guard.
+//
+// The no-token branch used to return the house-standard "run `civitai login`"
+// — which is the ONE credential this command cannot use. The analytics proc is
+// full-scope, so an OAuth browser login is refused with 403 (item 5 in
+// AGENTS.md, and TestAppMetricsForbiddenAsksForPersonalAPIKey pins that half).
+// Following the CLI's own advice therefore landed an author on a SECOND
+// refusal.
+//
+// The exit code is pinned with errors.Is and never from the text (AGENTS item
+// 7): stripping the ErrUnauthorized tag leaves every character of this message
+// intact and silently degrades exit 3 to exit 1. The MESSAGE assertions are
+// separate, and they ask for the specific route — "some login advice" is
+// satisfied by exactly the wording this test exists to reject.
+func TestAppMetricsNoTokenNamesTheRouteThatWorks(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+
+	_, _, err := run(t, "app", "metrics", "my-block")
+	if err == nil {
+		t.Fatal("expected an error with no token configured")
+	}
+
+	// Exit 3. Asserted structurally.
+	if !errors.Is(err, civitai.ErrUnauthorized) {
+		t.Errorf("a missing token must classify as ErrUnauthorized (exit 3), got %T: %v", err, err)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		"no token configured",
+		"personal API key",
+		"civitai login --token <key>",
+		accountAPIKeysURL, // where to actually mint one
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the no-token error must name %q so the advice is followable, got: %v", want, err)
+		}
+	}
+
+	// And it must SAY that the obvious route is refused — otherwise a reader who
+	// already has a browser login has no reason to mint a key.
+	if !strings.Contains(msg, "403") {
+		t.Errorf("the no-token error should say a browser login is refused with 403, got: %v", err)
+	}
+}
+
+// TestAppMetricsCredentialRouteIsNotTheSpendRoute is the discriminating check.
+//
+// login.go's spendCredentialRoutes names BOTH credentials because `generate`
+// accepts either, and it is the obvious constant to reach for here. It is the
+// WRONG one: `civitai login --scopes generate` does not make an OAuth token
+// full-scope, so offering it would be the same "walk them into a second
+// refusal" defect in a new spelling. Every message assertion above stays green
+// under that substitution, so the divergence is asserted directly.
+func TestAppMetricsCredentialRouteIsNotTheSpendRoute(t *testing.T) {
+	if appMetricsCredentialRoute == spendCredentialRoutes {
+		t.Fatal("appMetricsCredentialRoute has been collapsed into spendCredentialRoutes — " +
+			"the analytics proc is full-scope and refuses an OAuth login however it was scoped")
+	}
+	if strings.Contains(appMetricsCredentialRoute, "--scopes generate") {
+		t.Errorf("appMetricsCredentialRoute offers `login --scopes generate`, which cannot satisfy "+
+			"a full-scope proc: %q", appMetricsCredentialRoute)
+	}
+	if !strings.Contains(appMetricsCredentialRoute, accountAPIKeysURL) {
+		t.Errorf("appMetricsCredentialRoute does not say where to mint the key: %q", appMetricsCredentialRoute)
+	}
+
+	// The command's own --help must carry the same route, from the same
+	// constant — two hand-copied answers are how the 403 branch and the
+	// no-token branch drifted apart in the first place.
+	long := newAppMetricsCmd().Long
+	if !strings.Contains(long, appMetricsCredentialRoute) {
+		t.Errorf("`app metrics --help` does not render appMetricsCredentialRoute:\n%s", long)
+	}
+}

--- a/internal/cmd/exitcodes_doc_test.go
+++ b/internal/cmd/exitcodes_doc_test.go
@@ -85,10 +85,15 @@ func TestREADMEExitCodeTableIsGenerated(t *testing.T) {
 // requires the freshly built command to carry it. A hand-written copy pasted
 // back into root.go passes an equality check on the current text and fails
 // this one.
+//
+// It reads the RENDERED `civitai --help` output rather than `cmd.Long`. The
+// section moved OUT of Long and into the help TEMPLATE so it renders after
+// Usage/Available Commands (see rootHelpTemplate) — and the rendered text is the
+// stronger claim anyway: it is what the user actually sees.
 func TestRootHelpExitCodesAreGenerated(t *testing.T) {
 	const sentinel = "ZZ-EXIT-DOC-SENTINEL-ZZ"
 
-	before := NewRootCmd().Long
+	before := renderRootHelp(t)
 	if !strings.Contains(before, rootExitCodeHelp()) {
 		t.Fatalf("root --help does not carry the rendered exit-code section:\n%s", before)
 	}
@@ -104,7 +109,7 @@ func TestRootHelpExitCodesAreGenerated(t *testing.T) {
 	swapped[4].Summary = sentinel
 	exitCodeDocs = swapped
 
-	after := NewRootCmd().Long
+	after := renderRootHelp(t)
 	if !strings.Contains(after, sentinel) {
 		t.Errorf("root --help is not rendered from exitCodeDocs: changing code 4's summary did not change the help text.\n%s", after)
 	}

--- a/internal/cmd/readme_nav_test.go
+++ b/internal/cmd/readme_nav_test.go
@@ -1,0 +1,365 @@
+package cmd
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// The README is ~1.6k lines and is navigated almost entirely through in-document
+// anchor links (a table of contents, plus ~20 cross-references between the
+// command table and the sections that hold the detail). A broken anchor is
+// invisible: GitHub renders it as an ordinary link that silently goes nowhere.
+// These guards make the navigation checkable.
+
+// readmeHeadingRe matches a `##`/`###` ATX heading. Fenced code blocks are
+// stripped before this runs — a `# comment` line inside a bash block is not a
+// heading, and counting one would invent an anchor that does not exist.
+var readmeHeadingRe = regexp.MustCompile(`(?m)^(#{2,3})[ \t]+(.+?)[ \t]*$`)
+
+// readmeAnchorRe matches an in-document link target: the `#foo` in `[x](#foo)`.
+var readmeAnchorRe = regexp.MustCompile(`\]\(#([^)]*)\)`)
+
+// readmeAnchorSlug reproduces GitHub's heading→anchor algorithm: lowercase,
+// drop every character that is not a letter, digit, space, hyphen or
+// underscore (so emoji, em dashes, arrows, backticks, parentheses, colons,
+// commas, apostrophes and `&` all vanish), then turn each remaining space into
+// a hyphen. Runs of dropped punctuation therefore leave DOUBLED hyphens
+// (`Submit & auth` → `submit--auth`), which is exactly what GitHub produces and
+// what the README's pre-existing links already spell.
+//
+// 🔴 This is a REIMPLEMENTATION of somebody else's rule, so it is only worth
+// what its control corpus is worth — see
+// TestREADMEAnchorSlugMatchesKnownGitHubAnchors, which pins it against anchors
+// that shipped and worked before this file existed. Without that control, this
+// function and the TOC could agree with each other and both be wrong.
+func readmeAnchorSlug(heading string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(heading)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// stripFencedCode removes ``` blocks so headings and links inside sample output
+// are not mistaken for real ones.
+func stripFencedCode(md string) string {
+	var out []string
+	fenced := false
+	for _, line := range strings.Split(md, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			fenced = !fenced
+			continue
+		}
+		if !fenced {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// readmeHeadings returns slug → heading text for every `##`/`###` heading, and
+// fails on a duplicate slug: two headings that collide get `-1` suffixes from
+// GitHub, which this model does not reproduce, so a collision would make every
+// anchor claim below unreliable rather than merely incomplete.
+func readmeHeadings(t *testing.T, md string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, m := range readmeHeadingRe.FindAllStringSubmatch(stripFencedCode(md), -1) {
+		slug := readmeAnchorSlug(m[2])
+		if prev, dup := out[slug]; dup {
+			t.Fatalf("two README headings share the anchor %q (%q and %q). "+
+				"GitHub disambiguates with a -1 suffix, which this guard does not model — rename one.",
+				slug, prev, m[2])
+		}
+		out[slug] = m[2]
+	}
+	if len(out) < 20 {
+		t.Fatalf("found only %d README headings — the heading regex is reading the wrong text", len(out))
+	}
+	return out
+}
+
+// anyHeadingRe matches an ATX heading of ANY level, capturing its `#` run and
+// its text. Used to bound a section at the next same-or-higher-level heading.
+var anyHeadingRe = regexp.MustCompile(`^(#{1,6})[ \t]+(.+?)[ \t]*$`)
+
+// readmeSectionByAnchor returns the body of the README section whose heading
+// slugs to `slug`, up to the next heading at the same or a higher level.
+//
+// It exists so a guard can follow a command-table row's OWN cross-reference and
+// assert against the text a reader reaches, rather than against the row alone.
+// That makes relocating detail out of an unreadable table cell a supported move
+// instead of a silent loss of coverage — and it fails when the link is broken,
+// which is the failure mode the relocation introduces.
+func readmeSectionByAnchor(t *testing.T, md, slug string) string {
+	t.Helper()
+	lines := strings.Split(stripFencedCode(md), "\n")
+	start, level := -1, 0
+	for i, line := range lines {
+		m := anyHeadingRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if readmeAnchorSlug(m[2]) == slug {
+			start, level = i+1, len(m[1])
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("README.md has no heading anchored at #%s", slug)
+	}
+	for i := start; i < len(lines); i++ {
+		if m := anyHeadingRe.FindStringSubmatch(lines[i]); m != nil && len(m[1]) <= level {
+			return strings.Join(lines[start:i], "\n")
+		}
+	}
+	return strings.Join(lines[start:], "\n")
+}
+
+// readmeRowPlusLinkedSections returns a command-table row concatenated with
+// every README section its cross-reference links point at — i.e. everything a
+// reader who follows the row actually reads.
+func readmeRowPlusLinkedSections(t *testing.T, md, row string) string {
+	t.Helper()
+	parts := []string{row}
+	for _, m := range readmeAnchorRe.FindAllStringSubmatch(row, -1) {
+		parts = append(parts, readmeSectionByAnchor(t, md, m[1]))
+	}
+	if len(parts) == 1 {
+		t.Fatalf("command-table row carries no cross-reference to follow:\n%s", row)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// TestREADMEAnchorSlugMatchesKnownGitHubAnchors is the positive control for the
+// slug algorithm. Every pair below is a heading plus the anchor the README
+// ALREADY linked it by before this guard existed — i.e. anchors observed to
+// work on github.com. They exercise the four cases the algorithm gets wrong if
+// it is written naively: a dropped `&` leaving a double hyphen, backticks
+// around a `--flag`, a leading emoji, and an underscore that must SURVIVE.
+func TestREADMEAnchorSlugMatchesKnownGitHubAnchors(t *testing.T) {
+	cases := map[string]string{
+		"Submit & auth":                                  "submit--auth",
+		"The `--json` result shape":                      "the---json-result-shape",
+		"🔴 Silent model substitution":                    "-silent-model-substitution",
+		"The host handshake (`BLOCK_READY`)":             "the-host-handshake-block_ready",
+		"Local dev loop (harness: mock vs live)":         "local-dev-loop-harness-mock-vs-live",
+		"After you submit: review → approve → deploy":    "after-you-submit-review--approve--deploy",
+		"Exit codes specific to `generate`":              "exit-codes-specific-to-generate",
+		"The content flags, and why there aren't twelve": "the-content-flags-and-why-there-arent-twelve",
+	}
+	for heading, want := range cases {
+		if got := readmeAnchorSlug(heading); got != want {
+			t.Errorf("readmeAnchorSlug(%q) = %q, want %q", heading, got, want)
+		}
+	}
+}
+
+// TestREADMEAnchorLinksResolve is the guard that keeps the table of contents —
+// and every cross-reference in the command table — honest. Every `](#…)` target
+// in the README must be a heading that exists in the README.
+//
+// Mutation-verified when it landed: adding a single `[x](#no-such-heading)` line
+// reddens it by name; removing that line greens it again.
+func TestREADMEAnchorLinksResolve(t *testing.T) {
+	md := readREADME(t)
+	headings := readmeHeadings(t, md)
+
+	links := readmeAnchorRe.FindAllStringSubmatch(stripFencedCode(md), -1)
+	// Positive control: a zero-link result is indistinguishable from a guard
+	// wired to nothing. The README carries a full TOC plus the command table's
+	// cross-references, so the real number is far above this floor.
+	if len(links) < 40 {
+		t.Fatalf("found only %d in-document anchor links — the link regex is reading the wrong text", len(links))
+	}
+
+	var broken []string
+	for _, m := range links {
+		if _, ok := headings[m[1]]; !ok {
+			broken = append(broken, m[1])
+		}
+	}
+	if len(broken) > 0 {
+		sort.Strings(broken)
+		var known []string
+		for slug := range headings {
+			known = append(known, slug)
+		}
+		sort.Strings(known)
+		t.Errorf("README anchor link(s) point at no heading: %v\n\nheadings that DO exist:\n  %s",
+			broken, strings.Join(known, "\n  "))
+	}
+}
+
+// TestREADMETableOfContentsCoversEverySection requires each top-level (`##`)
+// section to be reachable from the "## Contents" list. A TOC that silently stops
+// covering the document is the state this whole change set exists to end, and it
+// degrades one section at a time rather than all at once — so the check has to
+// be per-section, not "a TOC exists".
+func TestREADMETableOfContentsCoversEverySection(t *testing.T) {
+	md := stripFencedCode(readREADME(t))
+
+	const heading = "\n## Contents\n"
+	i := strings.Index(md, heading)
+	if i < 0 {
+		t.Fatal("README.md has no `## Contents` section — the table of contents is gone")
+	}
+	toc := md[i+len(heading):]
+	if j := strings.Index(toc, "\n## "); j >= 0 {
+		toc = toc[:j]
+	}
+
+	linked := map[string]bool{}
+	for _, m := range readmeAnchorRe.FindAllStringSubmatch(toc, -1) {
+		linked[m[1]] = true
+	}
+	if len(linked) < 20 {
+		t.Fatalf("the Contents section holds only %d links — the extractor is reading the wrong block", len(linked))
+	}
+
+	var missing []string
+	sections := 0
+	for _, m := range readmeHeadingRe.FindAllStringSubmatch(md, -1) {
+		if m[1] != "##" {
+			continue
+		}
+		slug := readmeAnchorSlug(m[2])
+		if slug == "contents" {
+			continue // the TOC does not list itself
+		}
+		sections++
+		if !linked[slug] {
+			missing = append(missing, m[2]+"  (#"+slug+")")
+		}
+	}
+	if sections < 15 {
+		t.Fatalf("found only %d top-level sections — the heading scan is wrong", sections)
+	}
+	if len(missing) > 0 {
+		t.Errorf("README sections missing from `## Contents`:\n  %s", strings.Join(missing, "\n  "))
+	}
+}
+
+// readmeCommandTableSubjects returns the first-column cell of every
+// `| `civitai …` |` row inside the "## Command reference" table.
+//
+// Scoped to that table on purpose: the strings `civitai app list` and
+// `civitai app pull` also appear in prose and in shell examples, so a
+// whole-file search would report a command as "documented in the table" when it
+// is merely mentioned somewhere.
+func readmeCommandTableSubjects(t *testing.T, md string) []string {
+	t.Helper()
+	const heading = "\n## Command reference\n"
+	i := strings.Index(md, heading)
+	if i < 0 {
+		t.Fatal("README.md has no `## Command reference` heading")
+	}
+	body := md[i+len(heading):]
+	if j := strings.Index(body, "\n### "); j >= 0 {
+		body = body[:j]
+	}
+
+	var subjects []string
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "| `civitai") {
+			continue
+		}
+		cells := strings.Split(line, "|")
+		if len(cells) < 3 {
+			continue
+		}
+		subjects = append(subjects, strings.TrimSpace(cells[1]))
+	}
+	return subjects
+}
+
+// TestREADMECommandTableDocumentsEveryAppSubcommand derives the expected rows
+// from the COBRA TREE rather than a hardcoded list, so a command cannot be added
+// to `civitai app` without being documented.
+//
+// It exists because three already had been: `app list`, `app view` and
+// `app pull` were all shipped and reachable from `civitai app --help` while the
+// README's command table named none of them (issue #260). `app pull` in
+// particular carries a token-in-URL security warning that a README-only reader
+// had no way to reach.
+func TestREADMECommandTableDocumentsEveryAppSubcommand(t *testing.T) {
+	root := NewRootCmd()
+	appCmd, _, err := root.Find([]string{"app"})
+	if err != nil {
+		t.Fatalf("the `app` command group is not in the tree: %v", err)
+	}
+
+	subjects := readmeCommandTableSubjects(t, readREADME(t))
+	// Positive control: zero extracted rows would make every lookup below fail
+	// for the wrong reason (or, with a Contains-any check, pass for one).
+	if len(subjects) < 15 {
+		t.Fatalf("extracted only %d command-reference rows — the table extractor is reading the wrong block", len(subjects))
+	}
+
+	documented := func(want string) bool {
+		for _, s := range subjects {
+			if strings.Contains(s, want) {
+				return true
+			}
+		}
+		return false
+	}
+
+	checked := 0
+	for _, sub := range appCmd.Commands() {
+		name := sub.Name()
+		if sub.Hidden || sub.IsAdditionalHelpTopicCommand() || name == "help" || name == "completion" {
+			continue
+		}
+		checked++
+		want := "civitai app " + name
+		if !documented(want) {
+			t.Errorf("`%s` is registered on the app command tree but has no row in the README's "+
+				"command-reference table. Add one (and a section it can link to) — a command a "+
+				"README-only reader cannot see is a command that does not exist for them.", want)
+		}
+	}
+	// A tree that resolved to nothing would report a serene pass above.
+	if checked < 10 {
+		t.Fatalf("only %d app subcommands were checked — the tree walk is wrong", checked)
+	}
+}
+
+// TestREADMEDocumentsTheAppStoreCredentialRequirement pins the specific false
+// claim from issue #260: the README told readers that "reads are anonymous"
+// while `civitai app list` / `app view` exit 3 without a token. The correction
+// has to survive future edits to the quickstart, so it is asserted where a
+// reader meets it — a dedicated section, reachable from the TOC.
+func TestREADMEDocumentsTheAppStoreCredentialRequirement(t *testing.T) {
+	md := readREADME(t)
+	headings := readmeHeadings(t, md)
+	if _, ok := headings["browse-the-app-store"]; !ok {
+		t.Fatal("README.md has no `Browse the App store` section — `app list` / `app view` " +
+			"and their login requirement have nowhere to be documented")
+	}
+
+	i := strings.Index(md, "\n## Browse the App store\n")
+	body := md[i:]
+	if j := strings.Index(body[1:], "\n## "); j >= 0 {
+		body = body[:j+1]
+	}
+	for _, want := range []string{"civitai app list", "civitai app view", "civitai login"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the App-store section does not mention %q:\n%s", want, body)
+		}
+	}
+	// The claim that matters: these reads are NOT anonymous.
+	if !strings.Contains(body, "not anonymous") && !strings.Contains(body, "require a\ncredential") {
+		t.Errorf("the App-store section does not state that these reads need a credential:\n%s", body)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -166,6 +166,54 @@ func isDevDefault(v string) bool {
 	return v == "" || v == "dev"
 }
 
+// rootHelpTemplate renders `civitai --help` with the exit-code taxonomy AFTER
+// the usage/commands block instead of before it.
+//
+// WHY A TEMPLATE AND NOT `Long`. Cobra's help template prints Long, then the
+// usage string (Usage / Examples / Available Commands / Flags). The exit-code
+// section is ~60 lines, so appending it to Long — which is where it lived — put
+// the whole taxonomy AHEAD of "Available Commands": a first-time user running
+// `civitai --help` had to scroll past a reference table to find the list of
+// things the binary can do. Moving the section is the only way to fix the order,
+// because Long has no "render me last" slot.
+//
+// 🔴 THE `{{if not .HasParent}}` GATE IS LOAD-BEARING. Command.HelpTemplate()
+// walks UP to the parent when a command sets none of its own, so a template set
+// on the root is inherited by every subcommand — without the gate,
+// `civitai app validate --help` would grow a copy of the root's exit-code
+// taxonomy. The gate is evaluated per command, so only the root renders it.
+//
+// The block is still GENERATED from exitCodeDocs at NewRootCmd() time, which is
+// what keeps `--help` unable to drift from the README (exitcodes_doc.go). The
+// rest of the template is cobra v1.8.1's default, copied verbatim.
+func rootHelpTemplate() string {
+	return `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}{{if not .HasParent}}
+` + rootExitCodeHelp() + `
+{{end}}`
+}
+
+// flagErrorWithHelpHint appends the next step to cobra's own flag-parse error.
+//
+// Cobra answers a mistyped FLAG with a bare `unknown flag: --stict` and no next
+// step, while a mistyped COMMAND already gets `Run 'civitai app --help' …` from
+// unknownSubcommandError — the same class of typo got two different qualities of
+// answer (issue #260). The hint names the command whose flags were ACTUALLY
+// being parsed, so `civitai app validate --stict` points at
+// `civitai app validate --help` rather than at the root's flag list.
+//
+// Cobra's own wording is APPENDED to, never replaced: its shorthand and
+// `--flag=value` diagnostics are what a user greps for. The error is wrapped
+// with %w so the caller's asUsageError tag (and therefore exit code 2) is
+// unaffected by this function.
+func flagErrorWithHelpHint(c *cobra.Command, err error) error {
+	if c == nil || err == nil {
+		return err
+	}
+	return fmt.Errorf("%w\nRun '%s --help' for the available flags.", err, c.CommandPath())
+}
+
 // NewRootCmd builds the root command with all subcommands attached.
 func NewRootCmd() *cobra.Command {
 	var noUpdateCheck bool
@@ -177,21 +225,25 @@ func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "civitai",
 		Short: "Civitai CLI — browse & download models, and build Apps",
-		// The "Exit codes:" block is APPENDED, not written here: it is rendered
-		// from exitCodeDocs (exitcodes_doc.go), the one source this help section
-		// and the README's exit-code table both come from. Hand-writing it back
-		// in is what let the two drift — see the file header there.
+		// 🔴 The "Exit codes:" block is NOT part of Long — see rootHelpTemplate
+		// below for why it is appended by the help TEMPLATE instead. It is still
+		// rendered from exitCodeDocs (exitcodes_doc.go), the one source this help
+		// section and the README's exit-code table both come from. Hand-writing
+		// it back in is what let the two drift — see the file header there.
 		Long: `civitai is the command-line interface for Civitai (https://civitai.com).
 
 It does three things from one static binary:
 
   • Browse & download the public catalog — search models, list images and
-    articles, and fetch model files. Reading is anonymous; downloading a
-    model file needs a token (civitai login). --layout routes each file into
-    the right folder for ComfyUI / A1111.
+    articles, and fetch model files. Reading the PUBLIC catalog is anonymous;
+    downloading a model file needs a token (civitai login). --layout routes
+    each file into the right folder for ComfyUI / A1111.
   • Build & submit Apps — small, sandboxed web apps that run inside Civitai
     surfaces. Scaffold a correct project, validate it against the platform
-    contract, and package it for submission.
+    contract, and package it for submission. EVERY civitai app command needs a
+    token, including the App-store browse commands app list / app view: that
+    endpoint keys the visible catalog off your identity, so it has no
+    anonymous view.
   • Generate images — civitai generate "<prompt>". This SPENDS REAL BUZZ and
     needs the AI Services scopes (civitai login --scopes generate, or a
     full-scope personal API key); price a job with --dry-run first.
@@ -206,15 +258,13 @@ Get started:
   # Build an App
   civitai login                    store your API token
   civitai app create my-app        scaffold a ready-to-build App
-  civitai app submit               package + submit for review
-
-` + rootExitCodeHelp(),
+  civitai app submit               package + submit for review`,
 		Example: `  # Browse & download the public catalog (no account needed to read).
   civitai models search --query "dreamshaper" --limit 5
   civitai images search --sort "Most Reactions" --period Week
   civitai download ` + downloadExampleVersionID + ` --layout comfyui --root ~/ComfyUI
 
-  # Browse the App store.
+  # Browse the App store (needs civitai login — this is NOT an anonymous read).
   civitai app list
   civitai app view <slug>
 
@@ -253,6 +303,7 @@ Get started:
 		},
 	}
 	root.SetVersionTemplate("civitai {{.Version}}\n")
+	root.SetHelpTemplate(rootHelpTemplate())
 
 	// A persistent flag so every command honours --no-update-check, and the
 	// post-run hook can read its resolved value.
@@ -270,11 +321,13 @@ Get started:
 	_ = colorViper.BindEnv("no_color", "CIVITAI_NO_COLOR")
 	_ = colorViper.BindEnv("color", "CIVITAI_COLOR")
 
-	// Classify Cobra's own flag-parsing failures as usage errors (message left
-	// untouched) so the entrypoint can map them to a dedicated exit code. Applies
-	// to every subcommand via cobra's flag-error propagation.
-	root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-		return asUsageError(err)
+	// Classify Cobra's own flag-parsing failures as usage errors so the
+	// entrypoint can map them to a dedicated exit code, and append the next step
+	// (see flagErrorWithHelpHint). Applies to every subcommand via cobra's
+	// flag-error propagation — cobra passes the command whose flags failed to
+	// parse, not the root.
+	root.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		return asUsageError(flagErrorWithHelpHint(c, err))
 	})
 
 	root.AddCommand(newAppCmd())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -211,7 +211,7 @@ func flagErrorWithHelpHint(c *cobra.Command, err error) error {
 	if c == nil || err == nil {
 		return err
 	}
-	return fmt.Errorf("%w\nRun '%s --help' for the available flags.", err, c.CommandPath())
+	return fmt.Errorf("%w\nRun '%s --help' for the available flags", err, c.CommandPath())
 }
 
 // NewRootCmd builds the root command with all subcommands attached.

--- a/internal/cmd/root_help_order_test.go
+++ b/internal/cmd/root_help_order_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// renderRootHelp returns what a user actually sees from `civitai --help`.
+//
+// It renders through cobra's help path (template + UsageString), NOT cmd.Long,
+// because the exit-code section deliberately no longer lives in Long — see
+// rootHelpTemplate in root.go. Reading Long would silently stop observing it.
+func renderRootHelp(t *testing.T) string {
+	t.Helper()
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	if err := root.Help(); err != nil {
+		t.Fatalf("render root help: %v", err)
+	}
+	got := buf.String()
+	// Positive control: an empty (or usage-less) render would make every
+	// ordering assertion below vacuously true.
+	if !strings.Contains(got, "Available Commands:") {
+		t.Fatalf("root help render produced no command list — the harness is reading the wrong text:\n%s", got)
+	}
+	return got
+}
+
+// TestRootHelpShowsUsageBeforeExitCodes is the ordering guard for issue #260.
+//
+// `civitai --help` used to open with the ~60-line exit-code taxonomy (it was
+// appended to Long, and cobra prints Long before the usage block), so the list
+// of things the binary can DO sat below the fold for a first-time reader. The
+// taxonomy is still published in full — it just comes last now.
+//
+// The assertion is on INDICES, not on presence: "the help contains both" is
+// satisfied by the broken order too.
+func TestRootHelpShowsUsageBeforeExitCodes(t *testing.T) {
+	help := renderRootHelp(t)
+
+	usage := strings.Index(help, "Usage:")
+	commands := strings.Index(help, "Available Commands:")
+	exits := strings.Index(help, "Exit codes:")
+
+	if usage < 0 {
+		t.Fatalf("root help has no %q block:\n%s", "Usage:", help)
+	}
+	if exits < 0 {
+		t.Fatalf("root help no longer publishes the exit-code contract:\n%s", help)
+	}
+	if usage > exits {
+		t.Errorf("`Usage:` (index %d) comes AFTER the exit-code section (index %d) — "+
+			"the taxonomy is back above the fold", usage, exits)
+	}
+	if commands > exits {
+		t.Errorf("`Available Commands:` (index %d) comes AFTER the exit-code section (index %d) — "+
+			"a first-time reader has to scroll past a reference table to find the commands", commands, exits)
+	}
+	// The section must still be the GENERATED one, byte for byte. Without this a
+	// "fix" that simply deleted it from Long would pass the ordering checks by
+	// having nothing left to order.
+	if !strings.Contains(help, rootExitCodeHelp()) {
+		t.Errorf("root help does not carry the rendered exit-code section verbatim:\n%s", help)
+	}
+}
+
+// TestSubcommandHelpDoesNotRepeatTheExitCodeSection pins the `{{if not
+// .HasParent}}` gate in rootHelpTemplate.
+//
+// Command.HelpTemplate() walks UP to the parent when a command sets none of its
+// own, so a template set on the root is inherited by every subcommand. Without
+// the gate, moving the section into the template would have stapled the whole
+// ~60-line taxonomy onto `civitai app validate --help` and every other
+// subcommand help — strictly worse than the problem it fixes.
+func TestSubcommandHelpDoesNotRepeatTheExitCodeSection(t *testing.T) {
+	// Positive control first: the ROOT must carry it, so a green here cannot
+	// mean "the section does not exist anywhere".
+	if !strings.Contains(renderRootHelp(t), "Exit codes:") {
+		t.Fatal("the root help does not carry the exit-code section — the control is broken")
+	}
+
+	for _, path := range [][]string{{"app"}, {"app", "validate"}, {"login"}, {"generate"}} {
+		name := strings.Join(path, " ")
+		t.Run(name, func(t *testing.T) {
+			out, _, err := run(t, append(path, "--help")...)
+			if err != nil {
+				t.Fatalf("%s --help: %v", name, err)
+			}
+			if !strings.Contains(out, "Usage:") {
+				t.Fatalf("%s --help produced no usage block — the probe is reading the wrong text:\n%s", name, out)
+			}
+			if strings.Contains(out, "Exit codes:") {
+				t.Errorf("`civitai %s --help` inherited the ROOT's exit-code section — "+
+					"the {{if not .HasParent}} gate in rootHelpTemplate is gone:\n%s", name, out)
+			}
+		})
+	}
+}
+
+// TestUnknownFlagNamesTheHelpCommandForThatCommand is the issue-#260 guard for
+// the unknown-FLAG path.
+//
+// A mistyped flag used to print a bare `unknown flag: --stict` with no next
+// step, while a mistyped COMMAND already got `Run 'civitai app --help' …`. The
+// hint must name the command whose flags were being parsed — pointing a user at
+// the ROOT's flag list for a subcommand's typo is the wrong answer, so the test
+// asserts the FULL command path rather than merely "some --help".
+//
+// The exit code is pinned with errors.Is, never by message text (AGENTS item 7):
+// stripping the ErrUsage tag leaves every character of the message intact.
+func TestUnknownFlagNamesTheHelpCommandForThatCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"app subcommand", []string{"app", "validate", "--stict"}, "Run 'civitai app validate --help'"},
+		{"top-level command", []string{"models", "search", "--quiry", "x"}, "Run 'civitai models search --help'"},
+		{"root", []string{"--nocolour"}, "Run 'civitai --help'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := run(t, tc.args...)
+			if err == nil {
+				t.Fatalf("%v: expected a flag-parse error", tc.args)
+			}
+			// Exit code 2 (usage). Asserted structurally, not from the text.
+			if !errors.Is(err, ErrUsage) {
+				t.Errorf("a bad flag must classify as ErrUsage (exit 2), got %T: %v", err, err)
+			}
+			// Cobra's own diagnosis is APPENDED to, never replaced.
+			if !strings.Contains(err.Error(), "unknown flag") {
+				t.Errorf("cobra's own wording was lost: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the error must name the next step %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestUnknownFlagHintDoesNotNameTheWrongCommand is the discriminating half of
+// the test above: a hint hard-coded to the root would satisfy every "contains
+// --help" assertion while sending a user to the wrong flag list.
+func TestUnknownFlagHintDoesNotNameTheWrongCommand(t *testing.T) {
+	_, _, err := run(t, "app", "validate", "--stict")
+	if err == nil {
+		t.Fatal("expected a flag-parse error")
+	}
+	if strings.Contains(err.Error(), "Run 'civitai --help'") {
+		t.Errorf("a subcommand's bad flag was answered with the ROOT's help command: %v", err)
+	}
+}


### PR DESCRIPTION
Four of the seven sub-items in the #260 dogfood umbrella, plus the navigation
work. The other three (`app_init.go`'s scaffold-validation and `--from` leak;
the icon/cover on-ramp) are elsewhere or blocked.

## The false claims (issue #260 A1–A4)

These are not cosmetics — the docs asserted things the binary does not do.

**A1 — three commands existed and the README documented none of them.**
`civitai app --help` lists `list`, `view` and `pull`; the command-reference table
had rows for none. `app pull` is the significant one: its own `--help` calls it
"the read side of git authoring", it lazily provisions a Forgejo identity, and it
carries a 10-line **⚠ SECURITY — TOKEN-IN-URL LEAKAGE** warning. A README-only
reader did not know a git authoring path existed, let alone its hazards.

All three now have rows. `app pull` and the App-store commands get sections; the
security warning is mirrored from the real `--help` text (both halves — the
clone path persists the token to `.git/config`, the sync path only exposes it
transiently in the git child's argv).

**A2 — the README contradicted the binary on anonymous reads.** `Reads are
**anonymous** — no `login` needed` and root `--help`'s "Reading is anonymous"
were both false for `civitai app list` / `app view`, which exit **3** with
`no token configured — … to browse the App store`. Verified against the source
(`newLoginGatedReader` in `internal/cmd/apps.go`), not assumed: the public
model/image/article commands genuinely are anonymous, and only these two store
reads are not. The claim is now scoped to the public catalog on all three
surfaces, and the App-store section says so at the top.

**A3 — `app metrics` recommended a login that will be refused.** The no-token
branch returned the generic `run 'civitai login'` — the one credential the
full-scope analytics proc refuses with 403 — so following the CLI's own advice
landed the author on a second refusal. It now names the personal-API-key route
and where to mint one, from a constant `app metrics --help` renders too.

**A4 — `unknown flag` offered no next step.** `civitai app validate --stict`
printed only `unknown flag: --stict`, while an unknown *command* already said
`Run '… --help'`. `SetFlagErrorFunc` now appends the help command for the
command actually being parsed:

```
$ civitai app validate --stict
Error: unknown flag: --stict
Run 'civitai app validate --help' for the available flags.
$ echo $?
2
```

## Navigation (issue #260 B)

- A **table of contents** with verified anchors.
- The four essay-length table cells — `generate` (280 words / 1859 chars in one
  markdown column), `app dev-tunnel` (222), `app listing` (124), `app dev-token`
  (105) — condensed to a one-line summary plus a link. **Content was relocated,
  not deleted**: `generate`'s detail was already fully covered by `## Generate`;
  `dev-tunnel` got a new section; `dev-token`'s unique bits (`--budget`, the
  manifest-scope read) went into the Local dev loop section.
- `civitai --help` now shows `Usage:` and `Available Commands:` **before** the
  ~60-line exit-code taxonomy, which used to sit above the fold.

### ⚠ Reconciliation note for the exit-code work

The exit-code section moved **out of** root's `Long` and into a help
**template**. Its text is untouched and still generated from `exitCodeDocs`, and
the README's generated exit-code table is untouched — but
`TestRootHelpExitCodesAreGenerated` had to change from reading `cmd.Long` to
reading the rendered `--help` output (a strictly stronger assertion: it is what
the user sees). If `exitcodes_doc.go` is being edited concurrently, that is the
one point of contact.

The `{{if not .HasParent}}` gate is load-bearing: cobra's `HelpTemplate()` walks
up to the parent, so without it every subcommand help would grow a copy of the
root taxonomy. `TestSubcommandHelpDoesNotRepeatTheExitCodeSection` pins it.

## Guards

| Guard | What it pins |
| --- | --- |
| `TestREADMEAnchorLinksResolve` | every `](#…)` target is a heading that exists |
| `TestREADMEAnchorSlugMatchesKnownGitHubAnchors` | the slug algorithm, against 8 anchors that already worked on github.com |
| `TestREADMETableOfContentsCoversEverySection` | every `##` section is reachable from the TOC |
| `TestREADMECommandTableDocumentsEveryAppSubcommand` | derived from the **cobra tree**, so a new `app` subcommand cannot ship undocumented |
| `TestAppMetricsNoTokenNamesTheRouteThatWorks` | `errors.Is(civitai.ErrUnauthorized)` for the exit code, the specific route substrings for the message |
| `TestAppMetricsCredentialRouteIsNotTheSpendRoute` | that the constant is not collapsed into `spendCredentialRoutes`, which would reintroduce the defect |
| `TestUnknownFlagNamesTheHelpCommandForThatCommand` | `errors.Is(ErrUsage)`, plus a case a root-hardcoded hint would fail |
| `TestRootHelpShowsUsageBeforeExitCodes` | **indices**, not presence — "contains both" is satisfied by the broken order |

Every exit-code assertion is `errors.Is`, never message text (AGENTS item 7).

**Mutation results** (each injected, watched red, reverted):

- an injected `[x](#no-such-heading-zz)` → `TestREADMEAnchorLinksResolve` fails,
  naming the dangling slug;
- deleting the `civitai app pull` table row →
  `TestREADMECommandTableDocumentsEveryAppSubcommand` fails, naming the command.

`TestReadmeDevTunnelRowMatchesTheCommandHelp` was widened to follow the row's own
cross-reference into the section it links to, so relocating detail out of a table
cell is a supported move — and a broken link now fails it.

## Gate

`make ci` green. Counted from `go test ./... -count=1 -v`, not the exit code:
**2708 `=== RUN`, 2704 `--- PASS`, 0 `--- FAIL`, 4 `--- SKIP`, 0 `build failed`,
0 timeout panics.** `gofmt -s -l .` clean over 299 `.go` files.

Behaviour verified against the built binary (`./bin/civitai`), not only tests:
the `--stict` invocation above, `civitai app --help` carrying zero copies of the
exit-code block, and `civitai --help` showing `Usage:` at line 32 with
`Exit codes:` after the flag list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
