### PR TITLE
fix(validate): the ready-ack advisory names the reason it fell back, and wraps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1045,11 +1045,17 @@ neither one's.
       Issue #258. The gaps are now spliced between
       `readyAckAdvicePresenceOnlyHead` and `…Tail` by `presenceOnlyAdvice`.
       - **The fix is GENERAL, and that is the point.** It surfaces `Gaps`
-        wholesale rather than special-casing the dangling reference, so all six
-        kinds (dangling reference, bare specifier, off-project URL, unreadable
-        file, file budget, depth truncation) reach the author from one change.
+        wholesale rather than special-casing the dangling reference, so every
+        kind reaches the author from one change.
         `TestEveryGapKindReachesTheAuthor` covers four of them; a fifth would
         have been a special case nobody wrote.
+        🔴 **There are SEVEN `g.gap(...)` call sites, not six** — an earlier
+        revision of this bullet said six and omitted the root-`index.html` one,
+        which is the kind `TestEveryGapKindReachesTheAuthor` covers explicitly.
+        Count them (`grep -n 'g.gap(' internal/blockproto/entrygraph.go`) rather
+        than trusting the prose: no root index.html, an unresolvable URL, an
+        unresolvable module specifier, a dangling reference, the file budget, an
+        unreadable file, and the depth bound.
       - 🔴 **THE TIERING DID NOT CHANGE, AND MUST NOT.** The bullet below —
         a reference to a file that is not there is a GAP, not a decided
         absence — is why #258's project is on the weak tier at all, and it
@@ -1070,17 +1076,58 @@ neither one's.
         (`readyAckGapCap`). A silently truncated list reads as "that was all of
         them" — the same class of lie as the guess it replaced: the author
         fixes what they were shown, re-runs, and meets reasons that were there
-        the whole time.
+        the whole time. 🔴 **The VALUE was unpinned for a round**: every
+        assertion in `TestGapReportUnitCap` is written relative to the constant,
+        so `= 99` reddened **0** subtests and the wall of gaps came back under a
+        green suite. `TestGapReportCapValue` pins the literal AND that it bounds
+        the output.
+      - 🔴 **THE CAP CAN BURY THE ACTUAL CAUSE, AND THAT IS THIS ITEM'S OWN
+        THESIS FAILING IN A NEW SHAPE.** Measured on an index.html carrying
+        three CDN `<script src>` tags above a dangling `./civitai-host.js`: the
+        report listed the three off-project URLs and withheld the dangling
+        reference — the real bug — beneath a lead-in asserting "one of these is
+        usually the actual bug". Order was document order and deterministic, so
+        it was a stable wrong emphasis, not a flake. TWO fixes, because either
+        alone is insufficient: `blockproto.rankGaps` orders gaps
+        most-likely-cause-first (a dangling LOCAL reference ahead of a CDN URL,
+        which is routine in a working project, ahead of a budget THIS CHECK
+        imposes), and `readyAckGapLeadTruncated` stops claiming the cause is
+        present whenever anything was withheld — ranking is a heuristic, so the
+        list may still not contain it. The sort is STABLE, so two gaps of one
+        kind keep the author's own document order. Pinned by
+        `TestTheActualCauseSurvivesTheCap` and, at the resolver,
+        `TestGapsAreRankedMostLikelyCauseFirst` /
+        `TestGapRankingIsStableWithinAKind`.
       - **The gap strings are AUTHOR-FACING NOW.** They used to be read only in
         a test failure message, and one carried "this resolver's model of the
         project is incomplete" — a fact about US. Word a new gap for the person
         who has to fix it (referencing file, specifier, edit), and keep it to a
         SINGLE LINE: it rides in a `--json` `message` field. `readyAckGapReport`
         collapses whitespace rather than trusting a `%v`-interpolated OS error.
+        🔴 **AND IT MUST CARRY NO ABSOLUTE PATH.** The first copy pass fixed ONE
+        of the seven sites. The root-`index.html` gap interpolated a raw `%v`,
+        the only site not going through `relTo`, so it printed
+        `stat /abs/…/index.html: no such file or directory` — machine-specific
+        noise AND a single unbreakable token that no greedy wrap can split.
+        Measured on a deep fixture path: a **120-rune** token producing a
+        **136-rune** line under a 79-rune budget. `readableErr` now renders a
+        `*fs.PathError` relative. `TestGapsCarryNoAbsolutePaths` checks the root
+        and a 60-rune token ceiling across four fixtures, so a NEW site cannot
+        reintroduce it — the hazard is interpolating anything unbounded, and a
+        path is only the instance that shipped.
+        Two budget gaps also still read as facts about us
+        ("larger than this check reads" / "which this check did not follow") and
+        were reworded to say what it means for the author: the part of their
+        project that was not examined.
       - **Layout is the PRINTER's, not the message's** — the inverse of item 23.
-        The advisory is ~2 kB and `app validate` printed it as ONE
-        1938-character line; `internal/cmd/validate_print.go`'s `printFinding`
-        now wraps EVERY finding to 79 columns with a hanging indent, which fixes
+        🔴 **Quote the two lengths and say which is which**: PRE-fix, `app
+        validate` printed the advisory as ONE **1847**-rune line (the message
+        itself **1843** chars); POST-fix the message is **1936** chars — longer,
+        because the gap report was added — wrapped over 29 lines with no line
+        over 79. An earlier revision of this bullet gave "1938" as the pre-fix
+        number; it was neither, and the pre/post distinction is the whole point
+        of quoting it. `internal/cmd/validate_print.go`'s `printFinding`
+        wraps EVERY finding to 79 columns with a hanging indent, which fixes
         every long message rather than the one that provoked it. Wrapping in the
         message would corrupt `--json` for exactly the consumers item 23 exists
         to serve, so both directions are asserted:
@@ -1092,6 +1139,30 @@ neither one's.
         substring assertion on `validate`'s stderr is really an assertion about
         where the layout broke — one in `app_validate_lockfile_test.go` had to
         go through `unwrapFinding` the moment wrapping landed.
+        🔴 **THERE ARE FOUR PRINT SITES, AND THE FIRST ROUND FIXED THREE.**
+        `app_submit.go`'s ERROR loop kept its raw `Fprintf`, so one `app submit`
+        run printed a **412**-rune unwrapped error AND a wrapped warning — two
+        layouts in a single run, on the highest-traffic path, which made this
+        item's own "one place fixes every long message" false.
+        `TestAppSubmitWrapsItsErrorsToo` covers it. **Headers are deliberately
+        NOT wrapped**: `✗ N validation error(s) in <dir>:` interpolates the
+        directory the user typed, so its width is theirs to control and wrapping
+        would break a path they may need to copy — measured, it is the only
+        >79-rune line either command still emits, at 136 runes on a deep path.
+      - 🔴 **THE WRAP ITSELF REGRESSED PASTEABLE REMEDY TEXT, AND THAT NEEDED A
+        SECOND FIX.** A greedy wrap split `"pnpm run build"` — a value the
+        lockfile message tells the author to put in their manifest — into
+        `"pnpm` / `run build"`, where the unwrapped base printed it whole. So
+        `findingTokens` keeps a DOUBLE-QUOTED span as one wrap unit. Two
+        fallbacks make that safe and both are load-bearing: an overlong span is
+        split back into words (an atomic span wider than the budget would blow
+        the width contract wrapping exists to hold), and an UNBALANCED quote
+        flushes at end of input rather than swallowing the tail, so the worst
+        case is exactly the old greedy behaviour. Only `"` is grouped — an
+        apostrophe would open a span that never closes, and these messages are
+        full of `project's`. Residual, stated: `"buildCommand": "pnpm run
+        build"` can still break between the balanced `"buildCommand":` token and
+        the span; the pasteable unit is whole, the sentence around it is not.
       - **Mutation matrix**, `--- FAIL` leaf lines counted from output (never an
         exit code), each mutation checksum-gated: discard the gaps 11; restore
         the guess 1; remove the cap 2; truncate silently 2; drop the one-line
@@ -1104,6 +1175,20 @@ neither one's.
         strength test structurally cannot make because it reads the FIXED bases
         and this text is appended at runtime). A comment-only null mutant
         survives.
+      - 🔴 **TWO OF THIS ITEM'S GUARDS CANNOT FAIL, AND ARE LABELLED SO NOBODY
+        COUNTS THEM AS COVERAGE.** `TestGapReportDoesNotLeakIntoTheStrongTiers`
+        is an INVARIANT guard: a strong tier implies `Complete` implies zero
+        gaps, so even appending `readyAckGapReport(graph.Gaps)` to
+        `readyAckAdviceUnwired` on purpose reddens **0** subtests — the appended
+        text is empty. The invariant it rests on is now asserted where it can
+        actually break, in `blockproto`'s completeness corpus (`Complete` iff no
+        gaps, plus the two parallel gap slices being the same length). And
+        `TestGapReportCannotSatisfyAnotherTiersStrengthAssertion` is
+        FIXTURE-SCOPED, not structural: gaps interpolate author-chosen
+        filenames, so a project referencing `./orphan.js` genuinely produces a
+        presence-tier report containing `orphan`, the unwired tier's own
+        literal. The tiers are told apart by their fixed halves
+        (`isPresenceOnlyAdvice`), never by keyword.
     - 🔴 **AN HTML `src` IS A URL; A JS SPECIFIER IS A MODULE SPECIFIER. THE
       FIRST VERSION CONFLATED THEM, AND THAT ONE MISTAKE PRODUCED THREE BUGS,
       TWO OF THEM OPPOSITES.** Measured, each on a project one character from a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1119,6 +1119,26 @@ neither one's.
         ("larger than this check reads" / "which this check did not follow") and
         were reworded to say what it means for the author: the part of their
         project that was not examined.
+        🔴 **AND ONE BRANCH CONFLATED OUR OWN LIMIT WITH A DEFECT IN THE
+        AUTHOR'S PROJECT — WRONG IN THE WORDING *AND* IN THE RANK.** `readCapped`
+        returns the same error shape for a genuine read failure and for the
+        per-file SIZE CAP, so an over-cap file produced `could not read big.js
+        (…) — make it readable`: false advice about a perfectly readable file,
+        and ranked `gapUnreadable`, so a limit WE impose outranked a real
+        dangling reference in the capped list — the exact ranking hazard
+        `gapKind` exists to close, in the one branch that had not been separated
+        from it. `errOverCap` / `errIsDirectory` are now sentinels (never
+        message-text matching, which would be a spelled guard) and `readGapFor`
+        sorts them to `gapBudget` with "did not read … so anything it loads was
+        not examined". Pinned in both packages, and the two rows are
+        deliberately separate so neither can drift into the other.
+        🔴 **The leak guard's `unreadable` row was testing the wrong half too**:
+        it forced `MaxFileBytes: 64`, which returns a plain `fmt.Errorf` and so
+        never reaches `readableErr`'s `*fs.PathError` branch at all. Both
+        packages now carry a **chmod-000** row for that branch — with a
+        `Geteuid() == 0` skip and a positive control that the file really is
+        unreadable, because root bypasses mode bits and would silently turn the
+        row into a third different test.
       - **Layout is the PRINTER's, not the message's** — the inverse of item 23.
         🔴 **Quote the two lengths and say which is which**: PRE-fix, `app
         validate` printed the advisory as ONE **1847**-rune line (the message
@@ -1144,11 +1164,24 @@ neither one's.
         run printed a **412**-rune unwrapped error AND a wrapped warning — two
         layouts in a single run, on the highest-traffic path, which made this
         item's own "one place fixes every long message" false.
-        `TestAppSubmitWrapsItsErrorsToo` covers it. **Headers are deliberately
-        NOT wrapped**: `✗ N validation error(s) in <dir>:` interpolates the
-        directory the user typed, so its width is theirs to control and wrapping
-        would break a path they may need to copy — measured, it is the only
-        >79-rune line either command still emits, at 136 runes on a deep path.
+        `TestAppSubmitWrapsItsErrorsToo` covers it.
+        🔴 **NON-FINDING LINES STAY UNWRAPPED, AND AN EARLIER REVISION OF THIS
+        BULLET MISATTRIBUTED WHY.** It claimed one exempt header, "the only
+        >79-rune line either command still emits", justified by its
+        interpolating the user's directory. Re-measured, there are THREE lines
+        and only one is about a path: `app validate`'s header at **130** runes
+        DOES interpolate `<dir>` (so its width is the user's to control, and
+        wrapping would break a path they may need to copy); `app submit`'s
+        header is a **CONSTANT 82** runes with no path in it at all
+        (byte-identical at a short and a deep path — it is simply a long
+        sentence); and `Error: refusing to submit without --yes …` is **184**
+        runes and is not a header at all, because `cmd/civitai/main.go` prints
+        `Error: %v` for every error returned by every command. Wrapping that
+        last one is a deliberate NON-change: it is a CLI-wide error path rather
+        than a validation printer, so it would alter every command's stderr at
+        once, and item 24 pins error-message preservation byte-for-byte across
+        it. Worth doing as its own change, measured against that contract —
+        not as a side effect of this one.
       - 🔴 **THE WRAP ITSELF REGRESSED PASTEABLE REMEDY TEXT, AND THAT NEEDED A
         SECOND FIX.** A greedy wrap split `"pnpm run build"` — a value the
         lockfile message tells the author to put in their manifest — into
@@ -1181,8 +1214,12 @@ neither one's.
         gaps, so even appending `readyAckGapReport(graph.Gaps)` to
         `readyAckAdviceUnwired` on purpose reddens **0** subtests — the appended
         text is empty. The invariant it rests on is now asserted where it can
-        actually break, in `blockproto`'s completeness corpus (`Complete` iff no
-        gaps, plus the two parallel gap slices being the same length). And
+        actually break — the `Complete == (len(Gaps) == 0)` assertion inside
+        `blockproto`'s `TestEntryGraphCompleteness` corpus loop, plus the two
+        parallel gap slices being the same length. (It is an assertion in that
+        loop, NOT a test of its own: an earlier revision cited a
+        `TestIncompleteIsExactlyHavingGaps` that does not exist anywhere in the
+        repo. Cite what you can grep.) And
         `TestGapReportCannotSatisfyAnotherTiersStrengthAssertion` is
         FIXTURE-SCOPED, not structural: gaps interpolate author-chosen
         filenames, so a project referencing `./orphan.js` genuinely produces a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -888,7 +888,8 @@ neither one's.
       before touching `readyack.go`: the whole-tree presence scan described
       above is now the WEAK tier, reached only when the entry graph cannot be
       resolved, and the advisory it emits is a different string that discloses
-      the difference.
+      the difference — and, since #258, NAMES the resolver's own reason for
+      falling back instead of guessing at it. See item 20.
 
 19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
     `--ecosystem`, and uploads with NO credential — three things that each read
@@ -1030,6 +1031,79 @@ neither one's.
       project shapes is exactly how the false pass above shipped, so the
       strength is part of the output, not an implementation detail.
       `TestReadyAckAdvisoriesStateTheirOwnStrength` pins both directions.
+    - 🔴 **AND THE WEAK TIER NAMES ITS REASON RATHER THAN GUESSING AT IT — THE
+      RESOLVER ALREADY KNEW, AND THE CHECK THREW IT AWAY.** Every gap kind
+      writes a precise, per-reference reason into `EntryGraph.Gaps`;
+      `readyAckChecks` returned the CONSTANT `readyAckAdvicePresenceOnly` and
+      discarded the slice, so the message offered a fixed list of plausible
+      causes instead — "there is no index.html at the project root, or it holds
+      a reference this CLI cannot follow — a bundler alias, a generated file, an
+      off-project URL". In the canonical #206 shape, a `static` scaffold whose
+      `civitai-host.js` has been deleted, **not one of those is true**: the
+      reason is that `<script src="./civitai-host.js">` points at a file that is
+      not there, and a five-file no-build app has no bundler to alias anything.
+      Issue #258. The gaps are now spliced between
+      `readyAckAdvicePresenceOnlyHead` and `…Tail` by `presenceOnlyAdvice`.
+      - **The fix is GENERAL, and that is the point.** It surfaces `Gaps`
+        wholesale rather than special-casing the dangling reference, so all six
+        kinds (dangling reference, bare specifier, off-project URL, unreadable
+        file, file budget, depth truncation) reach the author from one change.
+        `TestEveryGapKindReachesTheAuthor` covers four of them; a fifth would
+        have been a special case nobody wrote.
+      - 🔴 **THE TIERING DID NOT CHANGE, AND MUST NOT.** The bullet below —
+        a reference to a file that is not there is a GAP, not a decided
+        absence — is why #258's project is on the weak tier at all, and it
+        stands. **The message was the defect.** A reading of #258 as "promote
+        the dangling case to the strong tier" walks straight into the confident
+        finding built on a wrong model that this item exists to prevent.
+      - 🔴 **"NAMES THE CAUSE" IS ONLY HALF; THE SPECULATION HAS TO BE GONE,
+        AND A REPORT-SCOPED ASSERTION CANNOT SEE THAT.** Measured: the first
+        version asserted the absence of "bundler alias" within the GAP REPORT
+        only, and the most likely regression — restoring the guess to
+        `…PresenceOnlyHead` while keeping the real reasons — reddened **0**
+        subtests across `internal/validate` and `internal/cmd`.
+        `TestPresenceAdviceNoLongerSpeculates` reads the WHOLE emitted message
+        at a fixture where every quoted phrase is provably impossible, with a
+        positive control that the real cause is present so "says none of the
+        wrong things" is not satisfied by a message that says nothing.
+      - **The cap is 3 and the overflow is COUNTED OUT LOUD**
+        (`readyAckGapCap`). A silently truncated list reads as "that was all of
+        them" — the same class of lie as the guess it replaced: the author
+        fixes what they were shown, re-runs, and meets reasons that were there
+        the whole time.
+      - **The gap strings are AUTHOR-FACING NOW.** They used to be read only in
+        a test failure message, and one carried "this resolver's model of the
+        project is incomplete" — a fact about US. Word a new gap for the person
+        who has to fix it (referencing file, specifier, edit), and keep it to a
+        SINGLE LINE: it rides in a `--json` `message` field. `readyAckGapReport`
+        collapses whitespace rather than trusting a `%v`-interpolated OS error.
+      - **Layout is the PRINTER's, not the message's** — the inverse of item 23.
+        The advisory is ~2 kB and `app validate` printed it as ONE
+        1938-character line; `internal/cmd/validate_print.go`'s `printFinding`
+        now wraps EVERY finding to 79 columns with a hanging indent, which fixes
+        every long message rather than the one that provoked it. Wrapping in the
+        message would corrupt `--json` for exactly the consumers item 23 exists
+        to serve, so both directions are asserted:
+        `TestValidateJSONMessagesAreOneLine` DECODES the payload (a
+        `strings.Contains` over raw stdout cannot tell a real newline from the
+        `\n` escape) and `TestValidateTextOutputIsWrapped` requires the advisory
+        to occupy ≥10 lines, since a width assertion alone is satisfied by a
+        build that prints nothing long. Consequence for anyone adding a test: a
+        substring assertion on `validate`'s stderr is really an assertion about
+        where the layout broke — one in `app_validate_lockfile_test.go` had to
+        go through `unwrapFinding` the moment wrapping landed.
+      - **Mutation matrix**, `--- FAIL` leaf lines counted from output (never an
+        exit code), each mutation checksum-gated: discard the gaps 11; restore
+        the guess 1; remove the cap 2; truncate silently 2; drop the one-line
+        collapse 1; put a newline in the message 2 (including the `--json`
+        guard); revert the printer to one line 1; revert the gap wording to the
+        maintainer form 3; splice the report after the tail instead of before
+        24 (the bracketing matchers); weak tier loses its disclosure 2; a strong
+        tier gains it 1; the report leaks another tier's own literal 1
+        (`TestGapReportCannotSatisfyAnotherTiersStrengthAssertion`, the case the
+        strength test structurally cannot make because it reads the FIXED bases
+        and this text is appended at runtime). A comment-only null mutant
+        survives.
     - 🔴 **AN HTML `src` IS A URL; A JS SPECIFIER IS A MODULE SPECIFIER. THE
       FIRST VERSION CONFLATED THEM, AND THAT ONE MISTAKE PRODUCED THREE BUGS,
       TWO OF THEM OPPOSITES.** Measured, each on a project one character from a

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -176,6 +176,16 @@ type EntryGraph struct {
 	// must never be read as evidence that something is absent.
 	Complete bool
 	// Gaps explains, in author-readable terms, why Complete is false.
+	//
+	// 🔴 THESE STRINGS ARE PRINTED TO AUTHORS, not just to a test failure
+	// message. `internal/validate`'s presence-tier advisory renders them
+	// (issue #258: it used to GUESS at why it had fallen back — "a bundler
+	// alias, a generated file, an off-project URL" — while the real reason sat
+	// here and was discarded, so a five-file no-build app was sent hunting for
+	// a bundler alias that cannot exist in it). Word a new gap for the author
+	// who has to fix it: name the referencing file, the specifier, and the
+	// edit. Each one must be a SINGLE LINE — the advisory rides in a
+	// `--json` message field.
 	Gaps []string
 	// Trace lists every reference considered and what it resolved to, for
 	// error messages that name the near-miss instead of saying "nothing".
@@ -327,7 +337,15 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			// the project. That is a GAP, not "the browser 404s it": treating
 			// it as the latter would let a mis-modelled project produce a
 			// confident finding.
-			g.gap("%s %q resolves to %s, which does not exist — this resolver's model of the project is incomplete",
+			//
+			// 🔴 THE WORDING IS AUTHOR-FACING, because `Gaps` is rendered into
+			// the ready-ack advisory an author reads (issue #258). This is the
+			// gap the canonical #206 shape produces — a `static` scaffold whose
+			// `civitai-host.js` was deleted — so it must name the referencing
+			// file, the specifier and the missing target, and say what to do.
+			// "this resolver's model of the project is incomplete", the tail it
+			// used to carry, is a fact about US that an author cannot act on.
+			g.gap("%s %q points at %s, which does not exist — restore that file or fix the reference",
 				p.what, p.spec, relTo(dir, resolved))
 			continue
 		}

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -72,10 +72,13 @@ package blockproto
 // the cost is a check that goes quiet, never a warning at a correct project.
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -185,8 +188,19 @@ type EntryGraph struct {
 	// a bundler alias that cannot exist in it). Word a new gap for the author
 	// who has to fix it: name the referencing file, the specifier, and the
 	// edit. Each one must be a SINGLE LINE — the advisory rides in a
-	// `--json` message field.
+	// `--json` message field, and must carry NO absolute path: it is one
+	// unbreakable token, and the printer wraps at 79 columns.
+	//
+	// 🔴 THE ORDER IS MOST-LIKELY-CAUSE FIRST, NOT DOCUMENT ORDER — see
+	// rankGaps. A consumer that renders only the first few (the advisory caps
+	// at three) would otherwise bury the actual bug behind whatever happened
+	// to appear earlier in index.html.
 	Gaps []string
+	// gapKinds is the rank of each entry in Gaps, parallel and same length.
+	// Unexported because it is an ordering input, not a contract: callers
+	// consume the ordered Gaps. `gap` is the only writer of either, which is
+	// what keeps the two slices in step.
+	gapKinds []gapKind
 	// Trace lists every reference considered and what it resolved to, for
 	// error messages that name the near-miss instead of saying "nothing".
 	Trace []string
@@ -225,9 +239,76 @@ func (g *EntryGraph) Chain(i int) string {
 	return g.Chain(f.Via) + " " + verb + " " + f.Spec + " -> " + f.Rel
 }
 
-func (g *EntryGraph) gap(format string, a ...any) {
+// gapKind ranks a gap by how likely it is to be the thing the author must fix.
+// Lower sorts first.
+//
+// 🔴 THIS EXISTS BECAUSE THE CAP CAN BURY THE ACTUAL CAUSE, WHICH IS THE DEFECT
+// ISSUE #258 WAS ABOUT, IN A NEW SHAPE. The advisory renders at most three gaps.
+// Measured on an index.html carrying three CDN `<script src>` tags above a
+// dangling `./civitai-host.js`: in document order the report listed the three
+// off-project URLs and withheld the dangling reference — the real bug — under a
+// lead-in claiming "one of these is usually the actual bug". Order is
+// deterministic (no map iteration in the gap path), so that was a stable wrong
+// emphasis rather than a flake.
+//
+// The ranking is a claim about LIKELIHOOD, not about correctness: every gap is
+// equally real, and each still clears `Complete`. A CDN reference is expected in
+// a working project and is a gap only because we do not follow it; a local
+// reference to a file that is not there is the #206 population.
+type gapKind int
+
+const (
+	// gapDangling: a project-LOCAL reference that resolves to nothing, and the
+	// missing-entry-point case. Nearly always the author's actual bug.
+	gapDangling gapKind = iota
+	// gapUnreadable: a file we could not read. Real, and usually local.
+	gapUnreadable
+	// gapUnresolved: a bare specifier, a CDN URL, a path outside the project.
+	// Routine in a working project.
+	gapUnresolved
+	// gapBudget: a limit THIS CHECK imposes. Never the author's bug.
+	gapBudget
+)
+
+func (g *EntryGraph) gap(kind gapKind, format string, a ...any) {
 	g.Complete = false
 	g.Gaps = append(g.Gaps, fmt.Sprintf(format, a...))
+	g.gapKinds = append(g.gapKinds, kind)
+}
+
+// rankGaps reorders Gaps most-likely-cause first. The sort is STABLE, so
+// document order is preserved within a kind — two dangling references stay in
+// the order the author's index.html lists them.
+func (g *EntryGraph) rankGaps() {
+	if len(g.Gaps) < 2 {
+		return
+	}
+	idx := make([]int, len(g.Gaps))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return g.gapKinds[idx[a]] < g.gapKinds[idx[b]] })
+	texts := make([]string, len(g.Gaps))
+	kinds := make([]gapKind, len(g.Gaps))
+	for i, src := range idx {
+		texts[i], kinds[i] = g.Gaps[src], g.gapKinds[src]
+	}
+	g.Gaps, g.gapKinds = texts, kinds
+}
+
+// readableErr renders err for an AUTHOR.
+//
+// 🔴 A `*fs.PathError` carries the ABSOLUTE path, and that breaks two contracts
+// at once now that gaps are printed: it leaks a machine-specific path into a
+// user-facing message, and it is a single unbreakable token — measured at 130
+// runes against the printer's 79-rune budget, which `wrapRunes` cannot split.
+// Every other gap site goes through relTo; this one interpolated a raw error.
+func readableErr(root string, err error) string {
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		return fmt.Sprintf("%s: %v", relTo(root, pe.Path), pe.Err)
+	}
+	return err.Error()
 }
 
 // refSyntax picks the resolution rules. The distinction is not cosmetic — see
@@ -256,7 +337,18 @@ type pending struct {
 // at index.html. It never returns nil.
 //
 // 🔴 Read `Complete` before reading `Files`. See the file header.
+//
+// The walk itself is `resolveEntryGraph`; this wrapper exists so `rankGaps` runs
+// on EVERY return path. The walk has three (no index.html, the file budget, and
+// the normal drain), and a ranking applied at only some of them would order the
+// gaps differently depending on which limit a project happened to hit.
 func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
+	g := resolveEntryGraph(dir, opts)
+	g.rankGaps()
+	return g
+}
+
+func resolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 	opts = opts.withDefaults()
 	g := &EntryGraph{Root: dir, Complete: true}
 
@@ -268,7 +360,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		// nested html root). There is nothing to walk, so the graph is empty
 		// AND incomplete: callers must not read "no files load the emitter"
 		// out of it.
-		g.gap("no readable index.html at the project root (%v)", err)
+		g.gap(gapDangling, "no readable index.html at the project root (%s) — this check starts there, so it followed nothing", readableErr(dir, err))
 		return g
 	}
 	html := StripHTMLComments(string(raw))
@@ -324,9 +416,9 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue
 		case refUnresolved:
 			if p.syn == syntaxURL {
-				g.gap("could not resolve %s %q — an off-project URL, or a path outside this project", p.what, p.spec)
+				g.gap(gapUnresolved, "could not resolve %s %q — an off-project URL, or a path outside this project", p.what, p.spec)
 			} else {
-				g.gap("could not resolve %s %q — a bundler alias, a bare specifier that is not a declared dependency, or an off-project URL", p.what, p.spec)
+				g.gap(gapUnresolved, "could not resolve %s %q — a bundler alias, a bare specifier that is not a declared dependency, or an off-project URL", p.what, p.spec)
 			}
 			continue
 		}
@@ -345,7 +437,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			// file, the specifier and the missing target, and say what to do.
 			// "this resolver's model of the project is incomplete", the tail it
 			// used to carry, is a fact about US that an author cannot act on.
-			g.gap("%s %q points at %s, which does not exist — restore that file or fix the reference",
+			g.gap(gapDangling, "%s %q points at %s, which does not exist — restore that file or fix the reference",
 				p.what, p.spec, relTo(dir, resolved))
 			continue
 		}
@@ -353,12 +445,12 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 			continue
 		}
 		if len(g.Files) >= opts.MaxFiles {
-			g.gap("stopped after %d files — the entry graph is larger than this check reads", opts.MaxFiles)
+			g.gap(gapBudget, "stopped after %d files — this project loads more than this check follows, so anything past that point was not examined", opts.MaxFiles)
 			return g
 		}
 		body, err := readCapped(file, opts.MaxFileBytes)
 		if err != nil {
-			g.gap("could not read %s (%v)", relTo(dir, file), err)
+			g.gap(gapUnreadable, "could not read %s (%s) — make it readable, or this check cannot tell what it contains", relTo(dir, file), readableErr(dir, err))
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(file))
@@ -420,7 +512,7 @@ func ResolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		if !truncatedBelow(g, dir, c.fromFile, c.spec, opts.Dependencies) {
 			continue
 		}
-		g.gap("stopped at import depth %d: %s imports %q, which this check did not follow",
+		g.gap(gapBudget, "stopped at import depth %d: %s imports %q, and this check does not follow imports deeper than that, so anything below it was not examined",
 			opts.MaxDepth, c.rel, c.spec)
 	}
 	return g

--- a/internal/blockproto/entrygraph.go
+++ b/internal/blockproto/entrygraph.go
@@ -450,7 +450,7 @@ func resolveEntryGraph(dir string, opts EntryGraphOptions) *EntryGraph {
 		}
 		body, err := readCapped(file, opts.MaxFileBytes)
 		if err != nil {
-			g.gap(gapUnreadable, "could not read %s (%s) — make it readable, or this check cannot tell what it contains", relTo(dir, file), readableErr(dir, err))
+			g.gap(readGapFor(dir, file, err))
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(file))
@@ -573,18 +573,45 @@ func relTo(root, p string) string {
 	return filepath.ToSlash(rel)
 }
 
+// errOverCap and errIsDirectory mark the two readCapped failures that are NOT
+// the file's fault.
+//
+// 🔴 THEY ARE SENTINELS BECAUSE THE CALLER MUST RANK THEM DIFFERENTLY, AND
+// TELLING THEM APART BY MESSAGE TEXT WOULD BE A SPELLED GUARD. `errOverCap` is a
+// limit THIS CHECK imposes: the file is perfectly readable and a human opening
+// it sees nothing wrong. Reported as an unreadable file it both gave false
+// advice ("make it readable") and outranked genuine gaps in the capped advisory
+// — the exact ranking hazard gapKind exists to close, in the one branch that had
+// not been separated.
+var (
+	errOverCap     = errors.New("this check does not read files that large")
+	errIsDirectory = errors.New("it is a directory, not a file")
+)
+
 func readCapped(path string, max int64) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
 	if info.IsDir() {
-		return nil, fmt.Errorf("%s is a directory", filepath.Base(path))
+		return nil, errIsDirectory
 	}
 	if info.Size() > max {
-		return nil, fmt.Errorf("file is larger than %d bytes", max)
+		return nil, fmt.Errorf("%w (over %d bytes)", errOverCap, max)
 	}
 	return os.ReadFile(path)
+}
+
+// readGapFor classifies a readCapped failure into the kind and the sentence the
+// author should read. Our own limits are budgets and say so; anything else is a
+// real problem with the file and names an edit.
+func readGapFor(root, file string, err error) (gapKind, string) {
+	rel := relTo(root, file)
+	if errors.Is(err, errOverCap) || errors.Is(err, errIsDirectory) {
+		return gapBudget, fmt.Sprintf("did not read %s (%s), so anything it loads was not examined", rel, err)
+	}
+	return gapUnreadable, fmt.Sprintf("could not read %s (%s) — make it readable, or this check cannot tell "+
+		"what it contains", rel, readableErr(root, err))
 }
 
 // entryModuleExts are the extensions whose imports are followed. A `.css` a

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -1,6 +1,7 @@
 package blockproto
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -842,13 +843,30 @@ func TestEntryGraphBudgetsAreGaps(t *testing.T) {
 			t.Fatalf("positive control failed: a 4 KiB entry must resolve completely, gaps %v", g.Gaps)
 		}
 		// 64 bytes: index.html (32) still reads, app.js (4096) does not — so the
-		// gap is the ENTRY being unreadable, not the root.
+		// gap is the ENTRY being skipped, not the root.
 		g := ResolveEntryGraph(dir, EntryGraphOptions{MaxFileBytes: 64})
 		if g.Complete {
 			t.Fatal("a file the resolver refused to read was reported as a complete graph")
 		}
-		if !strings.Contains(strings.Join(g.Gaps, "\n"), "could not read") {
-			t.Fatalf("gaps do not name the unread file: %v", g.Gaps)
+		joined := strings.Join(g.Gaps, "\n")
+		if !strings.Contains(joined, "did not read") || !strings.Contains(joined, "app.js") {
+			t.Fatalf("gaps do not name the skipped file: %v", g.Gaps)
+		}
+		// 🔴 THE SIZE CAP IS OUR OWN LIMIT, NOT A PROBLEM WITH THE FILE, and the
+		// wording and the RANK both have to say so. It used to report
+		// "could not read app.js … make it readable" — false advice about a
+		// perfectly readable file — and it was ranked gapUnreadable, so a limit
+		// WE impose outranked a genuine dangling reference in the capped
+		// advisory. That is the ranking hazard gapKind exists to close, in the
+		// one branch that had not been separated from it.
+		if strings.Contains(joined, "make it readable") {
+			t.Errorf("the size-cap gap gives advice about a file that is perfectly readable: %v", g.Gaps)
+		}
+		for i, k := range g.gapKinds {
+			if strings.Contains(g.Gaps[i], "app.js") && k != gapBudget {
+				t.Errorf("the size-cap gap is ranked %v, want gapBudget — a limit this check imposes must "+
+					"never outrank a real defect in the author's project: %s", k, g.Gaps[i])
+			}
 		}
 	})
 
@@ -1097,32 +1115,95 @@ func TestGapsAreRankedMostLikelyCauseFirst(t *testing.T) {
 }
 
 // TestGapRankingIsStableWithinAKind keeps the ranking from scrambling the order
-// an author reads their own file in. Two dangling references must stay in
-// document order — a sort that is merely "grouped" would make the first thing
-// they see depend on nothing they can predict.
+// an author reads their own file in. Gaps of one kind must stay in document
+// order — a sort that is merely "grouped" would make the first thing they see
+// depend on nothing they can predict.
+//
+// 🔴 STABILITY IS LOAD-BEARING, NOT TIDINESS: it decides WHICH THREE gaps the
+// capped advisory shows, so `TestTheActualCauseSurvivesTheCap`'s whole argument —
+// that the withheld gaps are the least likely — rests on it.
+//
+// 🔴 AND THE FIRST VERSION OF THIS GUARD COULD NOT FAIL. It used a 2-gap
+// fixture, and Go's `sort.Slice` switches to INSERTION SORT below n=13, which is
+// stable by accident. Measured: `sort.SliceStable` → `sort.Slice` reddened **0
+// subtests across the entire suite**. The fixture is now deliberately larger
+// than that threshold — that is the only reason the mutant dies — and the
+// constant is named so nobody "simplifies" the fixture back under it.
 func TestGapRankingIsStableWithinAKind(t *testing.T) {
-	dir := writeTree(t, []gfile{
-		{"index.html", `<!doctype html>` +
-			`<script src="./first-gone.js"></script>` +
-			`<script src="./second-gone.js"></script>`},
-	})
+	// 🔴 TWO PROPERTIES THE FIXTURE MUST HAVE, AND MISSING EITHER MAKES THE
+	// MUTANT SURVIVE. Both were measured, not reasoned about.
+	//
+	//  1. MORE THAN ~12 ELEMENTS. Go's `sort.Slice` runs insertion sort below
+	//     that, which is stable by accident. The first version used 2, and the
+	//     `sort.SliceStable` -> `sort.Slice` mutant reddened 0 subtests.
+	//  2. MIXED KINDS. With one kind the comparator is all-equal, and pdqsort
+	//     detects an all-equal partition and leaves it alone — so widening to 40
+	//     of a single kind ALSO reddened 0. The sort has to actually move
+	//     something before instability can show.
+	//
+	// So: 30 gaps alternating between two kinds. After ranking, the 15 dangling
+	// ones come first and the 15 unresolved ones follow, and within each run the
+	// author's document order must survive.
+	const pairs = 15
+
+	var html strings.Builder
+	html.WriteString(`<!doctype html>`)
+	for i := 0; i < pairs; i++ {
+		// Zero-padded so lexical order matches document order — otherwise a
+		// failure is ambiguous between "unstable" and "sorted by name".
+		fmt.Fprintf(&html, `<script src="./gone-%03d.js"></script>`, 2*i)
+		fmt.Fprintf(&html, `<script src="https://cdn.example.com/off-%03d.js"></script>`, 2*i+1)
+	}
+	dir := writeTree(t, []gfile{{"index.html", html.String()}})
 	g := ResolveEntryGraph(dir, EntryGraphOptions{})
-	first, second := -1, -1
+
+	if len(g.Gaps) < 2*pairs {
+		t.Fatalf("fixture produced %d gaps, want >= %d — below Go's insertion-sort threshold an unstable "+
+			"sort passes by accident and this test proves nothing", len(g.Gaps), 2*pairs)
+	}
+	// Positive control on the SHAPE: both kinds must really be present, or the
+	// comparator is all-equal and pdqsort never moves anything — the second way
+	// this guard measured green while testing nothing.
+	kinds := map[gapKind]int{}
+	for _, k := range g.gapKinds {
+		kinds[k]++
+	}
+	if len(kinds) < 2 {
+		t.Fatalf("the fixture produced only one gap kind (%v); with an all-equal comparator pdqsort leaves "+
+			"the slice alone, so an unstable sort is indistinguishable from a stable one", kinds)
+	}
+
+	// Within each KIND, the numbers must ascend — i.e. document order survived.
+	last := map[gapKind]int{}
 	for i, s := range g.Gaps {
-		if strings.Contains(s, "first-gone.js") {
-			first = i
+		n := gapNumberIn(t, s)
+		k := g.gapKinds[i]
+		if prev, seen := last[k]; seen && n <= prev {
+			t.Fatalf("gaps of kind %v are out of document order (%d after %d) — the sort is not STABLE, so "+
+				"WHICH THREE the capped advisory shows depends on nothing the author can predict:\n%v",
+				k, n, prev, g.Gaps)
 		}
-		if strings.Contains(s, "second-gone.js") {
-			second = i
+		last[k] = n
+	}
+}
+
+// gapNumberIn pulls the NNN out of a `gone-NNN.js` / `off-NNN.js` token, so the
+// assertion does not depend on the gap's wording.
+func gapNumberIn(t *testing.T, gap string) int {
+	t.Helper()
+	for _, tok := range strings.FieldsFunc(gap, func(r rune) bool {
+		return r == ' ' || r == '"' || r == ',' || r == '/'
+	}) {
+		var n int
+		if _, err := fmt.Sscanf(tok, "gone-%03d.js", &n); err == nil {
+			return n
+		}
+		if _, err := fmt.Sscanf(tok, "off-%03d.js", &n); err == nil {
+			return n
 		}
 	}
-	if first < 0 || second < 0 {
-		t.Fatalf("fixture did not produce both gaps: %v", g.Gaps)
-	}
-	if first > second {
-		t.Errorf("two gaps of the same kind were reordered (%d > %d); the sort must be STABLE so the report "+
-			"follows the author's own file:\n%v", first, second, g.Gaps)
-	}
+	t.Fatalf("could not read a file number out of gap %q", gap)
+	return -1
 }
 
 // TestGapsCarryNoAbsolutePaths is the general form of the leak that shipped.
@@ -1138,10 +1219,19 @@ func TestGapsCarryNoAbsolutePaths(t *testing.T) {
 	trees := map[string][]gfile{
 		"no index.html": {{"package.json", `{}`}},
 		"dangling ref":  {{"index.html", `<!doctype html><script src="./gone.js"></script>`}},
-		"unreadable/oversize": {
+		"over the size cap (a BUDGET, not a defect)": {
 			{"index.html", `<!doctype html><script type="module" src="./e.js"></script>`},
 			{"e.js", "import './big.css';\n"},
 			{"big.css", strings.Repeat("/*pad*/\n", 300)},
+		},
+		// 🔴 THE ONLY ROW THAT REACHES readableErr. The size-cap row above
+		// returns a plain fmt.Errorf, NOT a *fs.PathError, so it never enters
+		// the branch this test exists to guard — it was labelled
+		// "unreadable/oversize" and tested the wrong half. A chmod-000 file is
+		// the shape that produces a *fs.PathError carrying an absolute path.
+		"genuinely unreadable": {
+			{"index.html", `<!doctype html><script type="module" src="./locked.js"></script>`},
+			{"locked.js", "export const x = 1;\n"},
 		},
 		"off-project": {{"index.html", `<!doctype html><script src="../../outside.js"></script>`}},
 	}
@@ -1150,8 +1240,24 @@ func TestGapsCarryNoAbsolutePaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			dir := writeTree(t, files)
 			opts := EntryGraphOptions{}
-			if name == "unreadable/oversize" {
-				opts.MaxFileBytes = 64 // force the read to fail on big.css
+			switch name {
+			case "over the size cap (a BUDGET, not a defect)":
+				opts.MaxFileBytes = 64 // force the read to be DECLINED on big.css
+			case "genuinely unreadable":
+				if os.Geteuid() == 0 {
+					t.Skip("running as root: mode 0000 does not deny, so this row cannot fail a read")
+				}
+				locked := filepath.Join(dir, "locked.js")
+				if err := os.Chmod(locked, 0o000); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(locked, 0o600) })
+				// Positive control on the FIXTURE: an unreadable row that is
+				// still readable proves nothing, which is how the size-cap row
+				// passed while exercising a different branch entirely.
+				if _, err := os.ReadFile(locked); err == nil {
+					t.Skip("this filesystem ignores mode 0000")
+				}
 			}
 			g := ResolveEntryGraph(dir, opts)
 			if g.Complete {

--- a/internal/blockproto/entrygraph_test.go
+++ b/internal/blockproto/entrygraph_test.go
@@ -798,6 +798,24 @@ func TestEntryGraphCompleteness(t *testing.T) {
 				t.Fatalf("gap reason does not mention %q — got %v\n"+
 					"a gap recorded by a different branch leaves the one this case pins untested", c.wantGap, g.Gaps)
 			}
+			// 🔴 `Complete` AND `Gaps` MUST AGREE, over this whole corpus.
+			// `internal/validate` relies on it in two places that CANNOT fail
+			// on their own: the strong tiers append `Gaps` and are quiet only
+			// because a complete graph has none, and the presence tier's
+			// "reasons" would be empty for an incomplete graph that recorded
+			// none. Both would go silently wrong here rather than there, so
+			// this is where it is asserted. `gap` is the only writer of either
+			// field; a second writer, or a `gap` that stopped clearing
+			// Complete, breaks this row.
+			if g.Complete != (len(g.Gaps) == 0) {
+				t.Fatalf("Complete = %v but len(Gaps) = %d — the flag and the reasons disagree, so a caller "+
+					"branching on Complete and a caller rendering Gaps see different graphs", g.Complete, len(g.Gaps))
+			}
+			if len(g.Gaps) != len(g.gapKinds) {
+				t.Fatalf("Gaps (%d) and gapKinds (%d) are out of step — the parallel slices rankGaps sorts "+
+					"together have drifted, so gaps would be reordered under the wrong ranks",
+					len(g.Gaps), len(g.gapKinds))
+			}
 			for _, want := range c.wantFiles {
 				if !graphHasRel(g, want) {
 					t.Fatalf("graph is missing %q; it has %v", want, graphRels(g))
@@ -1019,4 +1037,143 @@ func graphHasRel(g *EntryGraph, rel string) bool {
 		}
 	}
 	return false
+}
+
+// TestGapsAreRankedMostLikelyCauseFirst pins the ORDER of Gaps.
+//
+// 🔴 A CONSUMER THAT RENDERS ONLY THE FIRST FEW BURIES THE ACTUAL BUG WITHOUT
+// IT. `internal/validate`'s advisory caps at three. Measured before ranking, on
+// an index.html carrying three CDN `<script src>` tags above a dangling
+// `./civitai-host.js`: the report showed the three off-project URLs and withheld
+// the dangling reference, under a lead-in claiming the cause was among them.
+//
+// The ranking is a claim about LIKELIHOOD, not correctness — every gap is
+// equally real and each still clears Complete. A CDN reference is expected in a
+// working project; a local reference to a file that is not there is the #206
+// population.
+func TestGapsAreRankedMostLikelyCauseFirst(t *testing.T) {
+	dir := writeTree(t, []gfile{
+		// Document order is the LOSING order: the off-project references come
+		// first and the dangling local one last.
+		{"index.html", `<!doctype html>` +
+			`<script src="https://cdn.example.com/a.js"></script>` +
+			`<script src="//proto.example.com/b.js"></script>` +
+			`<script type="module" src="./entry.js"></script>` +
+			`<script src="./gone.js"></script>`},
+		{"entry.js", "import '@alias/x.js';\nexport const e = 1;\n"},
+	})
+	g := ResolveEntryGraph(dir, EntryGraphOptions{})
+	if g.Complete {
+		t.Fatalf("fixture must be incomplete; gaps=%v", g.Gaps)
+	}
+	if len(g.Gaps) < 4 {
+		t.Fatalf("fixture produced %d gaps, want >= 4 — it does not exercise ordering: %v", len(g.Gaps), g.Gaps)
+	}
+	// The dangling LOCAL reference must sort ahead of every unresolved one.
+	dangling, firstUnresolved := -1, -1
+	for i, s := range g.Gaps {
+		if strings.Contains(s, `"./gone.js"`) && dangling < 0 {
+			dangling = i
+		}
+		if strings.Contains(s, "could not resolve") && firstUnresolved < 0 {
+			firstUnresolved = i
+		}
+	}
+	if dangling < 0 || firstUnresolved < 0 {
+		t.Fatalf("fixture did not produce both gap kinds (dangling=%d unresolved=%d): %v",
+			dangling, firstUnresolved, g.Gaps)
+	}
+	if dangling > firstUnresolved {
+		t.Errorf("a dangling local reference (index %d) sorts BELOW an off-project one (index %d); a "+
+			"consumer that shows the first three would bury the actual bug:\n%v", dangling, firstUnresolved, g.Gaps)
+	}
+	// The kinds themselves must be non-decreasing — the sort really ran, rather
+	// than the fixture happening to be in order.
+	for i := 1; i < len(g.gapKinds); i++ {
+		if g.gapKinds[i] < g.gapKinds[i-1] {
+			t.Fatalf("gapKinds are not sorted at %d: %v (%v)", i, g.gapKinds, g.Gaps)
+		}
+	}
+}
+
+// TestGapRankingIsStableWithinAKind keeps the ranking from scrambling the order
+// an author reads their own file in. Two dangling references must stay in
+// document order — a sort that is merely "grouped" would make the first thing
+// they see depend on nothing they can predict.
+func TestGapRankingIsStableWithinAKind(t *testing.T) {
+	dir := writeTree(t, []gfile{
+		{"index.html", `<!doctype html>` +
+			`<script src="./first-gone.js"></script>` +
+			`<script src="./second-gone.js"></script>`},
+	})
+	g := ResolveEntryGraph(dir, EntryGraphOptions{})
+	first, second := -1, -1
+	for i, s := range g.Gaps {
+		if strings.Contains(s, "first-gone.js") {
+			first = i
+		}
+		if strings.Contains(s, "second-gone.js") {
+			second = i
+		}
+	}
+	if first < 0 || second < 0 {
+		t.Fatalf("fixture did not produce both gaps: %v", g.Gaps)
+	}
+	if first > second {
+		t.Errorf("two gaps of the same kind were reordered (%d > %d); the sort must be STABLE so the report "+
+			"follows the author's own file:\n%v", first, second, g.Gaps)
+	}
+}
+
+// TestGapsCarryNoAbsolutePaths is the general form of the leak that shipped.
+//
+// 🔴 ONE OF SEVEN GAP SITES INTERPOLATED A RAW ERROR instead of going through
+// relTo, so it emitted `stat /abs/.../index.html: no such file or directory`.
+// Now that gaps are printed to authors that is machine-specific noise AND a
+// single unbreakable token — measured at 120 runes on a deep fixture path,
+// producing a 136-rune line under a 79-rune budget, which no greedy wrap can
+// split. The check is over the ROOT rather than one message, so a new site
+// cannot reintroduce it.
+func TestGapsCarryNoAbsolutePaths(t *testing.T) {
+	trees := map[string][]gfile{
+		"no index.html": {{"package.json", `{}`}},
+		"dangling ref":  {{"index.html", `<!doctype html><script src="./gone.js"></script>`}},
+		"unreadable/oversize": {
+			{"index.html", `<!doctype html><script type="module" src="./e.js"></script>`},
+			{"e.js", "import './big.css';\n"},
+			{"big.css", strings.Repeat("/*pad*/\n", 300)},
+		},
+		"off-project": {{"index.html", `<!doctype html><script src="../../outside.js"></script>`}},
+	}
+	checked := 0
+	for name, files := range trees {
+		t.Run(name, func(t *testing.T) {
+			dir := writeTree(t, files)
+			opts := EntryGraphOptions{}
+			if name == "unreadable/oversize" {
+				opts.MaxFileBytes = 64 // force the read to fail on big.css
+			}
+			g := ResolveEntryGraph(dir, opts)
+			if g.Complete {
+				t.Fatalf("fixture is complete, so it records no gap to inspect")
+			}
+			for _, gap := range g.Gaps {
+				if strings.Contains(gap, dir) {
+					t.Errorf("gap leaks the absolute project root:\n%s", gap)
+				}
+				for _, tok := range strings.Fields(gap) {
+					if n := len([]rune(tok)); n > 60 {
+						t.Errorf("gap carries a %d-rune unbreakable token, which sets the printed line width "+
+							"on its own: %q", n, tok)
+					}
+				}
+			}
+			checked += len(g.Gaps)
+		})
+	}
+	// POSITIVE CONTROL: a zero here is indistinguishable from four fixtures that
+	// produced no gaps at all, in which case nothing above was inspected.
+	if checked < 4 {
+		t.Fatalf("only %d gap(s) were inspected across four fixtures — the corpus is not exercising the sites", checked)
+	}
 }

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -75,7 +75,13 @@ Defaults to the current directory.`,
 					errw := cmd.ErrOrStderr()
 					fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("validation failed (%d error(s)) — fix before submitting, or pass --skip-validate:", len(res.Errors))))
 					for _, e := range res.Errors {
-						fmt.Fprintf(errw, "  - %s\n", e.Message)
+						// printFinding, not a raw Fprintf: `printWarnings` below
+						// wraps, so a bare one here printed a 400-char unwrapped
+						// error and a wrapped warning in the SAME run — two
+						// layouts on the highest-traffic path. It was the fourth
+						// print site and the one that made "one place fixes
+						// every long message" false.
+						printFinding(errw, e.Message)
 					}
 					// Warnings are useful context on a failure too, and this is
 					// the last moment before the app would have gone to review.

--- a/internal/cmd/app_validate.go
+++ b/internal/cmd/app_validate.go
@@ -99,7 +99,7 @@ Defaults to the current directory.`,
 			if !res.OK() {
 				fmt.Fprintln(errw, ui.For(errw).ErrorMsg(fmt.Sprintf("%d validation error(s) in %s:", len(res.Errors), dir)))
 				for _, e := range res.Errors {
-					fmt.Fprintf(errw, "  - %s\n", e.Message)
+					printFinding(errw, e.Message)
 				}
 				// Surface warnings too — they're useful context even on a failure.
 				printWarnings(errw, res)
@@ -158,6 +158,6 @@ func printWarnings(w io.Writer, res validate.Result) {
 	}
 	fmt.Fprintln(w, ui.For(w).Warn(fmt.Sprintf("%d warning(s):", len(res.Warnings))))
 	for _, warn := range res.Warnings {
-		fmt.Fprintf(w, "  - %s\n", warn.Message)
+		printFinding(w, warn.Message)
 	}
 }

--- a/internal/cmd/app_validate_lockfile_test.go
+++ b/internal/cmd/app_validate_lockfile_test.go
@@ -45,7 +45,12 @@ func TestAppValidateFailsOnPnpmLockWithNpmBuildCommand(t *testing.T) {
 		`"outputDir"`,
 		"npm install",
 	} {
-		if !strings.Contains(stderr, want) {
+		// unwrapFinding because the printer WRAPS a finding to the terminal
+		// width (validate_print.go) — the message is one line on the wire and
+		// several on screen, so a raw substring test here is really asserting
+		// where the layout chose to break. `"buildCommand": "pnpm run build"`
+		// straddled a break the moment wrapping landed.
+		if !strings.Contains(unwrapFinding(stderr), want) {
 			t.Errorf("validate stderr missing %q:\n%s", want, stderr)
 		}
 	}

--- a/internal/cmd/app_validate_wrap_test.go
+++ b/internal/cmd/app_validate_wrap_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+// app_validate_wrap_test.go pins the OTHER half of issue #258: the ready-ack
+// advisory is a ~2 kB paragraph, and `app validate` printed it as ONE
+// 1938-character line.
+//
+// 🔴 THE TWO SURFACES HAVE OPPOSITE REQUIREMENTS, AND ONE FIX CANNOT SERVE BOTH
+// FROM THE PRODUCER. `--json` needs the message to stay a single line — it is a
+// string field a consumer reads — while the terminal needs it broken to a width
+// the producer cannot know. So the layout lives at the printer
+// (validate_print.go) and the message stays flat, which is the inverse of
+// AGENTS.md item 23's rule for a finding's `Field`. Both directions are asserted
+// here, because either alone is satisfied by a broken fix: wrap in the message
+// and the text test passes while `--json` is corrupted; wrap nowhere and the
+// `--json` test passes while the terminal is unreadable.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/blockproto"
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// prefixScaffold renders `static` and deletes the emitter — the canonical #206
+// project, and the one that produces the longest message this CLI emits.
+func prefixScaffold(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "block")
+	if _, err := scaffold.Render(scaffold.Static, dir, scaffold.Data{Slug: "wrap-block", Name: "Wrap Block"}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestValidateJSONMessagesAreOneLine is the wire contract.
+//
+// 🔴 IT DECODES. Per AGENTS.md item 23, a `strings.Contains(out, …)` over raw
+// `--json` stdout cannot tell a real newline inside a message from the `\n`
+// escape `encoding/json` writes for one — the escape is what a naive text test
+// sees, and it looks identical either way. So the payload is unmarshalled and
+// the decoded Go string is checked.
+func TestValidateJSONMessagesAreOneLine(t *testing.T) {
+	dir := prefixScaffold(t)
+	stdout, _, err := run(t, "app", "validate", dir, "--json")
+	if err != nil {
+		t.Fatalf("validate --json: %v\n%s", err, stdout)
+	}
+	var payload map[string]any
+	if jerr := json.Unmarshal([]byte(stdout), &payload); jerr != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", jerr, stdout)
+	}
+
+	checked := 0
+	for _, key := range []string{"errors", "warnings"} {
+		list, _ := payload[key].([]any)
+		for _, item := range list {
+			m, ok := item.(map[string]any)
+			if !ok {
+				t.Fatalf("%s[] element is not an object: %#v", key, item)
+			}
+			msg, ok := m["message"].(string)
+			if !ok {
+				t.Fatalf("%s[] element has no string message: %#v", m, m)
+			}
+			if strings.ContainsAny(msg, "\n\r") {
+				t.Errorf("a %s message carries a line break — wrapping belongs at the printer, not in the "+
+					"message, or every --json consumer gets a multi-line string field:\n%q", key, msg)
+			}
+			checked++
+		}
+	}
+	// POSITIVE CONTROL. A zero here is indistinguishable from a project that
+	// produced no findings at all, and this fixture must produce the ready-ack
+	// advisory — the longest message the CLI emits, and the one that provoked
+	// this test.
+	if checked == 0 {
+		t.Fatal("the fixture produced NO findings, so every assertion above is vacuous — a `static` scaffold " +
+			"with its emitter deleted must warn")
+	}
+	if !strings.Contains(stdout, "BLOCK_READY") {
+		t.Fatalf("the ready-ack advisory is absent from --json; this test is checking the wrong findings:\n%s", stdout)
+	}
+}
+
+// TestValidateTextOutputIsWrapped is the terminal half.
+func TestValidateTextOutputIsWrapped(t *testing.T) {
+	dir := prefixScaffold(t)
+	stdout, stderr, err := run(t, "app", "validate", dir)
+	if err != nil {
+		t.Fatalf("validate: %v\n%s\n%s", err, stdout, stderr)
+	}
+
+	longest, lines := 0, 0
+	advisoryLines := 0
+	inAdvisory := false
+	for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
+		lines++
+		if n := len([]rune(line)); n > longest {
+			longest = n
+		}
+		if strings.HasPrefix(line, findingBullet) {
+			inAdvisory = strings.Contains(line, "page")
+		}
+		if inAdvisory && strings.HasPrefix(line, "  ") {
+			advisoryLines++
+		}
+	}
+	if lines == 0 {
+		t.Fatal("validate printed nothing to stderr — the fixture is not warning and this test is vacuous")
+	}
+	if longest > findingWrapWidth {
+		t.Errorf("a stderr line is %d runes wide, over the %d-rune budget — the finding was not wrapped:\n%s",
+			longest, findingWrapWidth, stderr)
+	}
+	// 🔴 The WIDTH assertion alone is satisfied by a build that prints nothing
+	// long, so require the advisory to have actually been BROKEN UP. It is ~2 kB;
+	// at this width that is tens of lines, and any single-digit count means the
+	// message shrank rather than wrapped.
+	if advisoryLines < 10 {
+		t.Errorf("the ready-ack advisory occupies only %d line(s) — it is ~2 kB, so this is not a wrapped "+
+			"paragraph:\n%s", advisoryLines, stderr)
+	}
+
+	// The content survives the layout: unwrapping reproduces the logical message,
+	// including the issue-#258 gap report naming the reference that broke.
+	flat := unwrapFinding(stderr)
+	for _, want := range []string{
+		"did NOT check that the file is loaded",
+		`index.html <script src> "./civitai-host.js" points at civitai-host.js, which does not exist`,
+	} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("the wrapped output no longer carries %q — layout must not lose content:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestWrapRunesHangingIndent pins the shape at the function, where the input can
+// be controlled: the continuation indent must be the same width as the bullet,
+// or a wrapped finding stops reading as one list item.
+func TestWrapRunesHangingIndent(t *testing.T) {
+	if len(findingBullet) != len(findingIndent) {
+		t.Fatalf("bullet %q and indent %q differ in width; the text column will not line up",
+			findingBullet, findingIndent)
+	}
+	var b strings.Builder
+	printFinding(&b, strings.Repeat("word ", 200))
+	got := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+	if len(got) < 5 {
+		t.Fatalf("1000 characters wrapped to %d line(s) at width %d", len(got), findingWrapWidth)
+	}
+	if !strings.HasPrefix(got[0], findingBullet) {
+		t.Errorf("the first line does not carry the bullet: %q", got[0])
+	}
+	for i, line := range got[1:] {
+		if !strings.HasPrefix(line, findingIndent) || strings.HasPrefix(line, findingBullet) {
+			t.Errorf("continuation line %d is not hanging-indented: %q", i+1, line)
+		}
+		if len([]rune(line)) > findingWrapWidth {
+			t.Errorf("continuation line %d is %d runes: %q", i+1, len([]rune(line)), line)
+		}
+	}
+
+	// A short message stays on one line — wrapping must not shred every finding.
+	var short strings.Builder
+	printFinding(&short, "blockId: 'Bad_Id' does not match pattern")
+	if n := strings.Count(short.String(), "\n"); n != 1 {
+		t.Errorf("a short finding printed on %d lines, want 1:\n%s", n, short.String())
+	}
+}

--- a/internal/cmd/validate_print.go
+++ b/internal/cmd/validate_print.go
@@ -1,0 +1,58 @@
+package cmd
+
+// validate_print.go owns the LAYOUT of a validation finding in the terminal.
+//
+// 🔴 THE SPLIT IS THE INVERSE OF AGENTS.md ITEM 23, AND IT IS LOAD-BEARING IN
+// BOTH DIRECTIONS. Item 23 says a finding's `Field` must come from the PRODUCER
+// and never be re-derived at the printer. Its layout is the other half of the
+// same rule: `Finding.Message` is a `--json` string field, so it must stay ONE
+// LINE on the wire, and the line breaking has to happen here. Wrapping inside
+// the message would corrupt `--json` for exactly the consumers item 23 exists to
+// serve — and hard-wrapping a message at the producer also fixes a width the
+// producer cannot see.
+//
+// What drove it: the ready-ack advisory (internal/validate/readyack.go) is a
+// single ~2 kB paragraph. Printed with `fmt.Fprintf(w, "  - %s\n", …)` it was
+// ONE 1938-character line — unreadable in any terminal, and unreadable in a
+// scrollback. Wrapping HERE fixes that message and every other long one at the
+// same time, including any added later, which is why the fix is at the shared
+// print site rather than in the one message that provoked it.
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// findingWrapWidth is the total column width a finding is wrapped to. 79
+	// matches exitCodeHelpWidth: the CLI's two long-prose surfaces should not
+	// disagree about how wide a terminal is.
+	findingWrapWidth = 79
+	// findingBullet leads the first line; findingIndent is the hanging indent
+	// for continuations. They are the SAME WIDTH on purpose, so the text column
+	// is straight and a wrapped finding still reads as one list item.
+	findingBullet = "  - "
+	findingIndent = "    "
+)
+
+// printFinding writes one finding's message as a wrapped bulleted list item.
+//
+// It is deliberately whitespace-normalising (wrapRunes splits on
+// `strings.Fields`), so a message that acquired a stray newline still prints as
+// a clean block rather than breaking the indent.
+func printFinding(w io.Writer, msg string) {
+	for i, line := range wrapRunes(msg, findingWrapWidth-len(findingIndent)) {
+		lead := findingIndent
+		if i == 0 {
+			lead = findingBullet
+		}
+		fmt.Fprintf(w, "%s%s\n", lead, line)
+	}
+}
+
+// unwrapFinding is the inverse, for tests: collapse the printed block back to
+// the single logical line the producer emitted. It exists so an assertion about
+// a message's CONTENT does not have to know where the layout chose to break —
+// the failure mode a substring test hits the moment a width changes.
+func unwrapFinding(s string) string { return strings.Join(strings.Fields(s), " ") }

--- a/internal/cmd/validate_print.go
+++ b/internal/cmd/validate_print.go
@@ -38,17 +38,106 @@ const (
 
 // printFinding writes one finding's message as a wrapped bulleted list item.
 //
-// It is deliberately whitespace-normalising (wrapRunes splits on
-// `strings.Fields`), so a message that acquired a stray newline still prints as
-// a clean block rather than breaking the indent.
+// It is deliberately whitespace-normalising, so a message that acquired a stray
+// newline still prints as a clean block rather than breaking the indent.
 func printFinding(w io.Writer, msg string) {
-	for i, line := range wrapRunes(msg, findingWrapWidth-len(findingIndent)) {
+	width := findingWrapWidth - len(findingIndent)
+	for i, line := range wrapTokens(findingTokens(msg, width), width) {
 		lead := findingIndent
 		if i == 0 {
 			lead = findingBullet
 		}
 		fmt.Fprintf(w, "%s%s\n", lead, line)
 	}
+}
+
+// findingTokens splits msg into wrap units, keeping a DOUBLE-QUOTED span whole.
+//
+// 🔴 REMEDY TEXT IS MEANT TO BE PASTED, AND A GREEDY WRAP SPLIT IT. Measured on
+// the lockfile finding: `"buildCommand": "pnpm run build"` — which the message
+// tells the author to put in their manifest — came out as `"pnpm` / `run
+// build"` across a line break, where the unwrapped base printed it whole. That
+// is a user-visible regression introduced BY the wrapping fix.
+//
+// Two guards keep this from doing harm, and both are load-bearing:
+//   - A span that would not FIT in `width` is split back into its words. An
+//     atomic span wider than the budget would blow the width contract, which is
+//     the very thing wrapping is for.
+//   - An UNBALANCED quote (an odd `"` with no partner, e.g. a 6" measurement)
+//     never swallows the tail: the accumulator is flushed as ordinary words at
+//     end of input. Worst case is exactly today's greedy behaviour.
+//
+// Only `"` is grouped. An apostrophe cannot be: `project's` would open a span
+// that never closes, and these messages are full of them.
+func findingTokens(msg string, width int) []string {
+	var (
+		out  []string
+		span []string
+		open bool
+	)
+	flushUnbalanced := func() {
+		out = append(out, span...)
+		span, open = nil, false
+	}
+	for _, w := range strings.Fields(msg) {
+		odd := strings.Count(w, `"`)%2 == 1
+		if !open {
+			if !odd {
+				out = append(out, w)
+				continue
+			}
+			span, open = []string{w}, true
+			continue
+		}
+		span = append(span, w)
+		if !odd {
+			continue
+		}
+		// The span closed. Keep it whole only if it can fit on a line.
+		if joined := strings.Join(span, " "); len([]rune(joined)) <= width {
+			out = append(out, joined)
+		} else {
+			out = append(out, span...)
+		}
+		span, open = nil, false
+	}
+	if open {
+		flushUnbalanced()
+	}
+	return out
+}
+
+// wrapTokens greedily fills lines of at most width RUNES from pre-split tokens.
+//
+// 🔴 RECONCILE NOTE: `wrapRunes` in exitcodes_doc.go (another agent's file this
+// round) is exactly `wrapTokens(strings.Fields(s), width)`. The two are not
+// duplicated logic by accident — the assembly is identical and only the
+// TOKENIZER differs, which is the whole point of splitting them. If both land,
+// collapse `wrapRunes` into a one-line call to this.
+func wrapTokens(tokens []string, width int) []string {
+	if len(tokens) == 0 {
+		return []string{""}
+	}
+	var (
+		lines []string
+		cur   string
+		n     int
+	)
+	for _, t := range tokens {
+		lw := len([]rune(t))
+		if cur == "" {
+			cur, n = t, lw
+			continue
+		}
+		if n+1+lw > width {
+			lines = append(lines, cur)
+			cur, n = t, lw
+			continue
+		}
+		cur += " " + t
+		n += 1 + lw
+	}
+	return append(lines, cur)
 }
 
 // unwrapFinding is the inverse, for tests: collapse the printed block back to

--- a/internal/cmd/validate_print_test.go
+++ b/internal/cmd/validate_print_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+// validate_print_test.go covers the PRINTER: the fourth print site, and the
+// quoted-span rule that keeps remedy text pasteable.
+//
+// Split from app_validate_wrap_test.go because these are about
+// validate_print.go's own behaviour rather than about `app validate`'s output
+// contract, and because `app submit` is a different command.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// lockfileMismatch renders page-vite and swaps its lockfile, producing the
+// longest ERROR the CLI emits (~400 chars) — the one that reaches `app submit`.
+func lockfileMismatch(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "block")
+	if _, err := scaffold.Render(scaffold.PageVite, dir, scaffold.Data{Slug: "wrap-block", Name: "Wrap Block"}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	// A rendered page-vite ships NO lockfile, so writing a pnpm one alone
+	// produces the MISMATCH error (pnpm lockfile vs an npm buildCommand) rather
+	// than the missing-lockfile one. The mismatch is the message that carries
+	// the quoted remedy this file is about; the two-lockfile case would be a
+	// third message again.
+	if _, err := os.Stat(filepath.Join(dir, "package-lock.json")); err == nil {
+		t.Fatal("page-vite now ships a package-lock.json — this fixture would produce the " +
+			"two-lockfile error instead of the mismatch, and the assertions below are about the mismatch")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("lockfileVersion: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// findingLines returns the wrapped FINDING lines from a command's stderr — the
+// bulleted item plus its hanging-indent continuations.
+//
+// Header lines are excluded deliberately, and the reason is a real boundary
+// rather than convenience: a header interpolates THE DIRECTORY THE USER TYPED
+// (`✗ 1 validation error(s) in <dir>:`), so its width is the user's to control,
+// and wrapping it would break a path they may need to copy. Measured: that
+// header is the only >79-rune line either command emits at HEAD.
+func findingLines(stderr string) []string {
+	var out []string
+	inItem := false
+	for _, line := range strings.Split(stderr, "\n") {
+		switch {
+		case strings.HasPrefix(line, findingBullet):
+			inItem = true
+		case inItem && strings.HasPrefix(line, findingIndent):
+		default:
+			inItem = false
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// TestAppSubmitWrapsItsErrorsToo is the FOURTH print site.
+//
+// 🔴 `app validate` and `printWarnings` wrapped; `app submit`'s ERROR loop did
+// not, so a single run printed a 412-rune unwrapped error AND a wrapped warning
+// — two layouts in one run, on the highest-traffic path and the last point
+// before an app reaches review. Measured on the PR as first audited. It also
+// made this change's own stated rationale ("one place fixes every long message")
+// false, which is the part worth failing on.
+func TestAppSubmitWrapsItsErrorsToo(t *testing.T) {
+	dir := lockfileMismatch(t)
+	stdout, stderr, err := run(t, "app", "submit", dir)
+	if err == nil {
+		t.Fatalf("a mismatched lockfile must fail submit before any upload\nstdout:%s\nstderr:%s", stdout, stderr)
+	}
+	lines := findingLines(stderr)
+	// POSITIVE CONTROL: with no finding on screen every width assertion below is
+	// vacuous, and `app submit` refusing early for some unrelated reason looks
+	// identical from here.
+	if len(lines) < 2 {
+		t.Fatalf("app submit printed %d finding line(s); the lockfile error is ~400 chars and must wrap to "+
+			"several:\n%s", len(lines), stderr)
+	}
+	for _, line := range lines {
+		if n := len([]rune(line)); n > findingWrapWidth {
+			t.Errorf("app submit printed a %d-rune finding line, over the %d-rune budget — this is the "+
+				"unwrapped print site, and it puts two layouts in one run:\n%s", n, findingWrapWidth, line)
+		}
+	}
+	if !strings.Contains(unwrapFinding(stderr), "pnpm-lock.yaml is committed") {
+		t.Errorf("wrapping lost the lockfile error's content:\n%s", stderr)
+	}
+}
+
+// TestQuotedRemedySpansAreNotSplit pins the copy-pasteable unit.
+//
+// 🔴 THE WRAPPING FIX INTRODUCED A USER-VISIBLE REGRESSION OF ITS OWN.
+// `"pnpm run build"` — the value the message tells the author to put in their
+// manifest — came out as `"pnpm` / `run build"` across a line break, where the
+// unwrapped base printed it whole. Remedy text a message says to paste has to
+// survive the layout.
+func TestQuotedRemedySpansAreNotSplit(t *testing.T) {
+	dir := lockfileMismatch(t)
+	_, stderr, err := run(t, "app", "validate", dir)
+	if err == nil {
+		t.Fatalf("fixture must fail validate:\n%s", stderr)
+	}
+	for _, want := range []string{`"pnpm run build"`, `"npm run build"`} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("%s was split across a line break; it is a value the author has to paste:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestFindingTokensQuotedSpans drives the tokenizer directly, where inputs the
+// real messages do not happen to contain can still be exercised.
+//
+// 🔴 THE TWO FALLBACKS ARE THE POINT. Keeping a quoted span whole is only safe
+// because an OVERLONG span is split back into words (otherwise the atomic span
+// blows the width contract wrapping exists to hold) and because an UNBALANCED
+// quote cannot swallow the tail (worst case must be exactly today's greedy
+// behaviour, never worse).
+func TestFindingTokensQuotedSpans(t *testing.T) {
+	const width = 40
+	cases := []struct {
+		name string
+		in   string
+		want []string // nil = assert only the invariants below
+	}{
+		{"a quoted span is one token", `set "pnpm run build" now`,
+			[]string{"set", `"pnpm run build"`, "now"}},
+		{"balanced tokens are left alone", `the "page" surface`,
+			[]string{"the", `"page"`, "surface"}},
+		{"two spans on one line", `"a b" and "c d"`,
+			[]string{`"a b"`, "and", `"c d"`}},
+		{"an OVERLONG span is split back into words", `x "` + strings.Repeat("word ", 20) + `y" z`, nil},
+		{"an UNBALANCED quote does not swallow the tail", `a 6" pipe and more words`,
+			[]string{"a", `6"`, "pipe", "and", "more", "words"}},
+		{"apostrophes are not quotes", `this project's own terms`,
+			[]string{"this", "project's", "own", "terms"}},
+		{"empty", "", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := findingTokens(c.in, width)
+			if c.want != nil && strings.Join(got, "|") != strings.Join(c.want, "|") {
+				t.Errorf("findingTokens(%q) = %q, want %q", c.in, got, c.want)
+			}
+			// Invariant for EVERY case: no MULTI-WORD token may exceed the
+			// width, or an atomic span blows the wrap budget.
+			for _, tok := range got {
+				if len([]rune(tok)) > width && strings.Contains(tok, " ") {
+					t.Errorf("a %d-rune multi-word token survived at width %d, which blows the wrap budget: %q",
+						len([]rune(tok)), width, tok)
+				}
+			}
+			// And nothing may be lost or reordered.
+			flatIn := strings.Join(strings.Fields(c.in), " ")
+			flatOut := strings.Join(strings.Fields(strings.Join(got, " ")), " ")
+			if flatIn != flatOut {
+				t.Errorf("tokenizing changed the text:\n got: %q\nwant: %q", flatOut, flatIn)
+			}
+		})
+	}
+}
+
+// TestPrintFindingHoldsTheWidthWithQuotedSpans is the end-to-end pairing: the
+// quoted-span rule must not be able to push a printed line over the budget.
+func TestPrintFindingHoldsTheWidthWithQuotedSpans(t *testing.T) {
+	msgs := []string{
+		`set "` + strings.Repeat("a very long quoted phrase ", 8) + `" to fix it`,
+		`an unbalanced 6" quote ` + strings.Repeat("and more words ", 20),
+		strings.Repeat(`"a b" `, 40),
+	}
+	for i, msg := range msgs {
+		var b strings.Builder
+		printFinding(&b, msg)
+		lines := strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+		if len(lines) < 2 {
+			t.Errorf("msg %d did not wrap at all (%d line)", i, len(lines))
+		}
+		for _, line := range lines {
+			if n := len([]rune(line)); n > findingWrapWidth {
+				t.Errorf("msg %d printed a %d-rune line over the %d budget: %q", i, n, findingWrapWidth, line)
+			}
+		}
+	}
+}

--- a/internal/cmd/validate_print_test.go
+++ b/internal/cmd/validate_print_test.go
@@ -42,11 +42,31 @@ func lockfileMismatch(t *testing.T) string {
 // findingLines returns the wrapped FINDING lines from a command's stderr — the
 // bulleted item plus its hanging-indent continuations.
 //
-// Header lines are excluded deliberately, and the reason is a real boundary
-// rather than convenience: a header interpolates THE DIRECTORY THE USER TYPED
-// (`✗ 1 validation error(s) in <dir>:`), so its width is the user's to control,
-// and wrapping it would break a path they may need to copy. Measured: that
-// header is the only >79-rune line either command emits at HEAD.
+// 🔴 NON-FINDING LINES ARE OUT OF SCOPE, AND THE EARLIER JUSTIFICATION FOR THAT
+// WAS MISATTRIBUTED — corrected here from measurement rather than from memory.
+// THREE distinct lines can exceed the budget, and only ONE is about a path:
+//
+//	130 runes  `app validate`: ✗ N validation error(s) in <dir>:
+//	           DOES interpolate the directory the user typed, so its width is
+//	           theirs to control and wrapping would break a path they may need
+//	           to copy. Measured at a deep fixture path.
+//	 82 runes  `app submit`: ✗ validation failed (N error(s)) — fix before
+//	           submitting, or pass --skip-validate:
+//	           a CONSTANT with NO path in it — measured byte-identical at a
+//	           short and a deep path. It is over budget simply because it is a
+//	           long sentence.
+//	184 runes  `Error: refusing to submit without --yes …`
+//	           not a header at all: `cmd/civitai/main.go` prints `Error: %v` for
+//	           EVERY error returned by EVERY command.
+//
+// Wrapping that last one is a deliberate NON-change here. It is a CLI-wide error
+// path rather than a validation printer, so it would alter every command's
+// stderr at once, and AGENTS.md item 24 pins error-message preservation
+// byte-for-byte across it. If it is worth wrapping, it is worth doing as its own
+// change measured against that contract.
+//
+// So this helper scopes the width assertion to FINDINGS, which is what
+// validate_print.go actually owns.
 func findingLines(stderr string) []string {
 	var out []string
 	inItem := false

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -566,15 +566,40 @@ var readyAckAdvicePresenceOnly = readyAckAdvicePresenceOnlyHead + readyAckAdvice
 // A large project can produce many, and a wall of them buries the remedy that
 // follows.
 //
+// 🔴 THE VALUE IS PART OF THE CONTRACT, AND IT WAS UNPINNED. Every assertion in
+// TestGapReportUnitCap is written RELATIVE to this constant, so `= 99` reddened
+// **0** subtests — the wall of gaps the cap exists to prevent came straight back
+// under a green suite. `TestGapReportCapValue` now pins the literal.
+//
 // 🔴 THE OVERFLOW IS COUNTED OUT LOUD. A silently truncated list reads as "that
 // was all of them", which is the same class of lie as the guess this report
 // replaced: the author fixes three references, re-runs, and is told about three
 // more they were never shown. `readyAckGapReport` says how many it withheld.
 const readyAckGapCap = 3
 
-// readyAckGapLead introduces the resolver's own reasons.
+// readyAckGapLead introduces the resolver's own reasons when ALL of them are
+// shown. Only then can the message claim the cause is among them.
 const readyAckGapLead = " Here is what it could not follow, in this project's own terms — one of these is " +
 	"usually the actual bug: "
+
+// readyAckGapLeadTruncated is the lead when the cap withheld some.
+//
+// 🔴 THE UNCONDITIONAL LEAD WAS THIS PR'S OWN THESIS FAILING IN A NEW SHAPE.
+// Measured on an index.html carrying three CDN `<script src>` tags above a
+// dangling `./civitai-host.js`: at three shown of four, the report listed the
+// three off-project URLs and withheld the dangling reference — the actual bug —
+// under a lead-in asserting "one of these is usually the actual bug". Order is
+// deterministic, so that is a stable wrong emphasis, not a flake. This PR exists
+// because the message pointed away from the cause; a cap that recreates it is
+// the same defect with a different mechanism.
+//
+// TWO fixes, because either alone is insufficient. `blockproto.rankGaps` puts
+// the likely causes first, so the withheld ones are now the LEAST likely — that
+// is what makes any claim about this list defensible at all. And this lead stops
+// claiming the cause is present, because ranking is a heuristic and the cap can
+// still withhold the one that mattered.
+const readyAckGapLeadTruncated = " Here is what it could not follow, in this project's own terms, most-likely " +
+	"first — this list is TRUNCATED, so if none of these is your bug, fix them and re-run to see the rest: "
 
 // presenceOnlyAdvice is the presence-tier message for a graph that failed to
 // resolve for the reasons in gaps.
@@ -607,7 +632,11 @@ func readyAckGapReport(gaps []string) string {
 		shown = shown[:readyAckGapCap]
 	}
 	var b strings.Builder
-	b.WriteString(readyAckGapLead)
+	if extra > 0 {
+		b.WriteString(readyAckGapLeadTruncated)
+	} else {
+		b.WriteString(readyAckGapLead)
+	}
 	for i, g := range shown {
 		if i > 0 {
 			b.WriteString("; ")

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -52,6 +52,15 @@ package validate
 //	silently changes strength between project shapes is how the false pass above
 //	happened in the first place.
 //
+//	🔴 AND IT NAMES THE REASON RATHER THAN GUESSING AT IT (issue #258). The
+//	resolver records why it stopped, per reference, in `EntryGraph.Gaps`; this
+//	check used to discard that and offer a fixed list of plausible causes
+//	instead, so the canonical #206 project — a `static` scaffold whose
+//	`civitai-host.js` was deleted, where index.html plainly references a file
+//	that is not there — was told to go looking for a bundler alias. The reasons
+//	are now appended verbatim (capped, with the overflow counted). See
+//	presenceOnlyAdvice.
+//
 // 🔴 "CANNOT OBSERVE" MUST NOT SILENTLY BECOME "EVERYTHING PASSES" — but it also
 // must not manufacture advice. The split: an INCOMPLETE graph never produces a
 // wiring finding (that is the AGENTS.md item 10 doctrine), yet the presence
@@ -107,6 +116,7 @@ package validate
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -216,11 +226,12 @@ func readyAckChecks(dir string, generic any) []Finding {
 		return []Finding{newFinding(FieldProject, readyAckAdviceMissing)}
 	}
 
-	// Presence tier: wiring is undecidable for this project shape.
+	// Presence tier: wiring is undecidable for this project shape. The
+	// resolver's OWN reasons ride along — see presenceOnlyAdvice.
 	if tree == ackFound {
 		return nil
 	}
-	return []Finding{newFinding(FieldProject, readyAckAdvicePresenceOnly)}
+	return []Finding{newFinding(FieldProject, presenceOnlyAdvice(graph.Gaps))}
 }
 
 // resolveLoadedFiles walks the entry graph and reports whether any file the
@@ -508,22 +519,121 @@ var readyAckAdviceMissing = "the manifest declares a \"page\" surface but nothin
 	"posts " + readyAckType + ", and nothing index.html loads posts it either — " + readyAckWhy + ". Apps " +
 	"scaffolded before that fix ship no emitter: " + readyAckRemedy + ". Caveat: " + readyAckTail
 
-// readyAckAdvicePresenceOnly is the PRESENCE finding, and it discloses its own
-// weakness. It fires where the entry graph could not be resolved, so it is the
-// one message that must not let an author read "valid" as "wired".
-var readyAckAdvicePresenceOnly = "the manifest declares a \"page\" surface but nothing in this project's " +
-	"source posts " + readyAckType + " — " + readyAckWhy + ". Apps scaffolded before that fix ship no " +
-	"emitter: " + readyAckRemedy + ". 🔴 What this run did NOT check: it could not resolve the files your " +
-	"index.html loads (there is no index.html at the project root, or it holds a reference this CLI cannot " +
-	"follow — a bundler alias, a generated file, an off-project URL), so it checked only whether SOME file " +
-	"in the project mentions " + readyAckType + "; it did NOT check that the file is loaded. Adding the " +
-	"emitter without referencing it will silence this warning and leave the app just as broken — verify the " +
-	"reference yourself. It is also wrong about a project whose ack arrives from a bundled dependency or a " +
-	"file type it does not read. Caveat: " + readyAckTail
+// readyAckAdvicePresenceOnlyHead is the PRESENCE finding up to the point where
+// the resolver's own reasons are spliced in. It discloses its own weakness: it
+// fires where the entry graph could not be resolved, so it is the one message
+// that must not let an author read "valid" as "wired".
+//
+// 🔴 IT USED TO GUESS AT WHY IT HAD FALLEN BACK, AND THE GUESS WAS WRONG IN THE
+// COMMONEST CASE. This clause read "(there is no index.html at the project root,
+// or it holds a reference this CLI cannot follow — a bundler alias, a generated
+// file, an off-project URL)". In the canonical #206 shape — a `static` scaffold
+// whose `civitai-host.js` has been deleted — NONE of those is the reason: the
+// reason is that `<script src="./civitai-host.js">` points at a file that is not
+// there, and the resolver had already recorded exactly that in `EntryGraph.Gaps`
+// before this constant threw it away. So a five-file no-build app sent its
+// author hunting for a bundler alias that cannot exist in it. Issue #258. The
+// guess is gone; the real reasons are appended by presenceOnlyAdvice, and this
+// clause now only states what was NOT established.
+//
+// The DIAGNOSIS and the disclosure come first, then the gap report, then the
+// remedy — deliberately, and not the order this message grew in. The remedy is
+// the longest fragment by far (it is shared with both reachability tiers), so
+// splicing the reasons after it put the one project-specific sentence in the
+// message roughly two thirds of the way down a wall of generic advice. The
+// concrete cause now sits immediately after the sentence that admits the check
+// could not resolve the entry graph, which is the sentence it explains.
+var readyAckAdvicePresenceOnlyHead = "the manifest declares a \"page\" surface but nothing in this project's " +
+	"source posts " + readyAckType + " — " + readyAckWhy + ". 🔴 What this run did NOT check: it could not " +
+	"resolve the files your index.html loads, so it checked only whether SOME file in the project mentions " +
+	readyAckType + "; it did NOT check that the file is loaded."
 
-// readyAckAdvisories is every string this check can emit. Callers and tests
-// match against the SET rather than one variable, so a new tier cannot be
-// introduced without the tests that classify them noticing.
+// readyAckAdvicePresenceOnlyTail is the rest of the presence finding, after the
+// gap report.
+var readyAckAdvicePresenceOnlyTail = " Apps scaffolded before that fix ship no emitter: " + readyAckRemedy +
+	". Adding the emitter without referencing it will silence this warning " +
+	"and leave the app just as broken — verify the reference yourself. It is also wrong about a project " +
+	"whose ack arrives from a bundled dependency or a file type it does not read. Caveat: " + readyAckTail
+
+// readyAckAdvicePresenceOnly is the presence finding with NO gap report — the
+// shape emitted only if an incomplete graph somehow recorded no reason at all
+// (today it cannot: `EntryGraph.Complete` is cleared only by `gap()`, which
+// appends). It is also the LEDGER value below and the prose the message tests
+// assert against, so the wording every tier shares stays pinned in one place.
+var readyAckAdvicePresenceOnly = readyAckAdvicePresenceOnlyHead + readyAckAdvicePresenceOnlyTail
+
+// readyAckGapCap bounds how many resolver reasons the presence advisory renders.
+// A large project can produce many, and a wall of them buries the remedy that
+// follows.
+//
+// 🔴 THE OVERFLOW IS COUNTED OUT LOUD. A silently truncated list reads as "that
+// was all of them", which is the same class of lie as the guess this report
+// replaced: the author fixes three references, re-runs, and is told about three
+// more they were never shown. `readyAckGapReport` says how many it withheld.
+const readyAckGapCap = 3
+
+// readyAckGapLead introduces the resolver's own reasons.
+const readyAckGapLead = " Here is what it could not follow, in this project's own terms — one of these is " +
+	"usually the actual bug: "
+
+// presenceOnlyAdvice is the presence-tier message for a graph that failed to
+// resolve for the reasons in gaps.
+//
+// 🔴 THE REASONS COME FROM THE RESOLVER, NEVER FROM A GUESS AT THE PRINTER —
+// which is the same discipline AGENTS.md item 23 imposes on a finding's `Field`,
+// applied to its explanation. `EntryGraph.Gaps` already names the referencing
+// file, the specifier and the missing target for EVERY gap kind (a dangling
+// reference, a bare specifier, an off-project URL, an unreadable file, an
+// exhausted file budget, a truncated depth), so surfacing them generally fixes
+// all six at once rather than special-casing the one issue #258 reported.
+func presenceOnlyAdvice(gaps []string) string {
+	return readyAckAdvicePresenceOnlyHead + readyAckGapReport(gaps) + readyAckAdvicePresenceOnlyTail
+}
+
+// readyAckGapReport renders gaps as one sentence, or "" when there are none.
+//
+// 🔴 THE RESULT IS ONE LINE. A `Finding.Message` is a `--json` string field and
+// the human output wraps at the PRINTER (internal/cmd), per the inverse of
+// AGENTS.md item 23: the field comes from the producer, the layout does not. A
+// gap interpolates `%v` of an OS error, which is not guaranteed newline-free, so
+// each one is collapsed rather than trusted.
+func readyAckGapReport(gaps []string) string {
+	if len(gaps) == 0 {
+		return ""
+	}
+	shown, extra := gaps, 0
+	if len(shown) > readyAckGapCap {
+		extra = len(shown) - readyAckGapCap
+		shown = shown[:readyAckGapCap]
+	}
+	var b strings.Builder
+	b.WriteString(readyAckGapLead)
+	for i, g := range shown {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "(%d) %s", i+1, strings.Join(strings.Fields(g), " "))
+	}
+	if extra > 0 {
+		fmt.Fprintf(&b, "; and %d more this message does not list", extra)
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// readyAckAdvisories is every FIXED advisory string this check can emit.
+// Callers and tests match against the SET rather than one variable, so a new
+// tier cannot be introduced without the tests that classify them noticing.
+//
+// 🔴 IT IS A LEDGER OF BASES, NOT OF LITERAL OUTPUTS, AND SAYING SO IS THE POINT.
+// The presence tier's real message is `presenceOnlyAdvice(gaps)` — this base with
+// the resolver's reasons spliced between `…PresenceOnlyHead` and
+// `…PresenceOnlyTail` — so an equality test against this slice classifies the
+// two reachability tiers and MISSES every real presence-tier finding. Anything
+// that must recognise the emitted message has to bracket it with those two
+// halves instead (see readyAckKind in the tests). Describing this slice as
+// "every string this check can emit" would be false, and the falsity is silent:
+// a matcher built on it simply stops seeing one tier.
 var readyAckAdvisories = []string{
 	readyAckAdviceUnwired,
 	readyAckAdviceMissing,

--- a/internal/validate/readyack_gaps_test.go
+++ b/internal/validate/readyack_gaps_test.go
@@ -67,6 +67,17 @@ func assertNoLongTokens(t *testing.T, s string) {
 	}
 }
 
+// requireNonRoot skips a case that depends on a permission actually denying
+// something. Root bypasses mode bits, so such a fixture silently becomes a
+// different test rather than failing — the shape this file already got wrong
+// once with the size cap.
+func requireNonRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 does not deny, so this row cannot exercise a read failure")
+	}
+}
+
 // wantGapReport asserts the report names every literal in want, and fails
 // naming the ones it does not.
 func wantGapReport(t *testing.T, report string, want ...string) {
@@ -203,9 +214,38 @@ func TestEveryGapKindReachesTheAuthor(t *testing.T) {
 	})
 
 	t.Run("a file the resolver could not read", func(t *testing.T) {
-		// A stylesheet over the per-file size cap. It has to be a NON-source
-		// extension: the whole-tree scan would hit the same cap on a `.js` and
-		// report UNOBSERVABLE, which gates both tiers and emits nothing at all.
+		// 🔴 A CHMOD-000 FILE, NOT AN OVER-CAP ONE. This row used to force the
+		// per-file size cap, which is OUR limit rather than a problem with the
+		// file — so it never reached `readableErr`'s `*fs.PathError` branch and
+		// the row did not test what its name said. It is now genuinely
+		// unreadable. It has to be a NON-source extension: the whole-tree scan
+		// would fail on a `.js` too and report UNOBSERVABLE, which gates both
+		// tiers and emits nothing at all.
+		requireNonRoot(t)
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script type="module" src="./main.js"></script>`,
+			"main.js":    `import './locked.css';` + "\n",
+			"locked.css": ".a{color:red}\n",
+		})
+		locked := filepath.Join(dir, "locked.css")
+		if err := os.Chmod(locked, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(locked, 0o600) })
+		// Positive control on the FIXTURE, not the code: if the file is still
+		// readable the row proves nothing, and that is exactly how the previous
+		// version passed while exercising a different branch.
+		if _, err := os.ReadFile(locked); err == nil {
+			t.Skip("this filesystem ignores mode 0000; the row cannot exercise a real read failure")
+		}
+		wantGapReport(t, gapReportFor(t, dir), "could not read", "locked.css", "make it readable")
+	})
+
+	t.Run("a file the resolver DECLINED to read is a budget, not a defect", func(t *testing.T) {
+		// The mirror of the row above, and the reason they are separate: the
+		// per-file size cap is a limit this check imposes. Reporting it as an
+		// unreadable file gave false advice about a perfectly readable file AND
+		// outranked genuine gaps in the capped list.
 		dir := ackProject(t, ackManifest(false), map[string]string{
 			"index.html": `<!doctype html><script type="module" src="./main.js"></script>`,
 			"main.js":    `import './huge.css';` + "\n",
@@ -214,7 +254,11 @@ func TestEveryGapKindReachesTheAuthor(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(dir, "huge.css"), []byte(big), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		wantGapReport(t, gapReportFor(t, dir), "could not read", "huge.css")
+		report := gapReportFor(t, dir)
+		wantGapReport(t, report, "did not read", "huge.css", "not examined")
+		if strings.Contains(report, "make it readable") {
+			t.Errorf("the size-cap gap tells the author to fix a file that is perfectly readable:\n%s", report)
+		}
 	})
 
 	t.Run("no index.html at the project root", func(t *testing.T) {
@@ -454,7 +498,8 @@ func TestGapReportIsOneLine(t *testing.T) {
 // `readyAckGapReport(graph.Gaps)` to `readyAckAdviceUnwired` on purpose reddens
 // **0** subtests — the appended text is empty. It is kept because the invariant
 // it rests on is a property of `blockproto` that this package does not own (see
-// `TestIncompleteIsExactlyHavingGaps` there, which CAN fail), and because a
+// the `Complete == (len(Gaps) == 0)` assertion inside blockproto's
+// `TestEntryGraphCompleteness` corpus loop, which CAN fail), and because a
 // future tier that built its message from a non-empty source would trip it. Read
 // its green as "the invariant still holds", never as "the tiers were tested".
 func TestGapReportDoesNotLeakIntoTheStrongTiers(t *testing.T) {

--- a/internal/validate/readyack_gaps_test.go
+++ b/internal/validate/readyack_gaps_test.go
@@ -45,6 +45,28 @@ func gapReportFor(t *testing.T, dir string) string {
 	return ""
 }
 
+// maxGapToken is the widest single token a gap may contain.
+//
+// 🔴 A GREEDY WRAP CANNOT SPLIT A TOKEN, so one long token sets the line width
+// for the whole message however the printer is configured. The advisory is
+// printed at 79 columns less a 4-column hanging indent; this leaves margin
+// rather than sitting exactly on the boundary, because the point is "no gap
+// interpolates something unbounded", not "no gap is one rune over".
+const maxGapToken = 60
+
+// assertNoLongTokens fails if any whitespace-delimited token in s is wider than
+// maxGapToken. It is the general form of the absolute-path check: the hazard is
+// interpolating ANY unbounded value, and a path is only the one that shipped.
+func assertNoLongTokens(t *testing.T, s string) {
+	t.Helper()
+	for _, tok := range strings.Fields(s) {
+		if n := len([]rune(tok)); n > maxGapToken {
+			t.Errorf("a gap carries a %d-rune unbreakable token (max %d) — no wrap can split it, so it sets "+
+				"the printed line width on its own: %q", n, maxGapToken, tok)
+		}
+	}
+}
+
 // wantGapReport asserts the report names every literal in want, and fails
 // naming the ones it does not.
 func wantGapReport(t *testing.T, report string, want ...string) {
@@ -200,7 +222,21 @@ func TestEveryGapKindReachesTheAuthor(t *testing.T) {
 			"package.json": `{"dependencies": {"next": "^15.0.0"}}`,
 			"app/page.tsx": `export default function Page() { return null; }`,
 		})
-		wantGapReport(t, gapReportFor(t, dir), "index.html")
+		report := gapReportFor(t, dir)
+		wantGapReport(t, report, "index.html", "no such file")
+		// 🔴 AND IT CARRIES NO ABSOLUTE PATH. This was the ONE gap site of seven
+		// that interpolated a raw error instead of going through relTo, so it
+		// emitted `stat /abs/path/index.html: no such file or directory`. Two
+		// contracts broken at once: a machine-specific path in an author-facing
+		// message, and a single UNBREAKABLE token — measured at 120 runes on a
+		// deep fixture path, producing a 136-rune line under a 79-rune budget,
+		// because a greedy wrap cannot split a token. Every OTHER gap kind was
+		// already relative, which is why nothing caught it.
+		if strings.Contains(report, dir) {
+			t.Errorf("the gap report leaks the absolute project path — it is machine-specific noise AND an "+
+				"unbreakable token wider than the printer's line budget:\n%s", report)
+		}
+		assertNoLongTokens(t, report)
 	})
 
 	t.Run("an off-project URL in a script src", func(t *testing.T) {
@@ -245,6 +281,114 @@ func TestGapReportIsCappedAndSaysSo(t *testing.T) {
 	if !strings.Contains(report, want) {
 		t.Errorf("the gap report truncated silently — it must say %q, or an author reads three reasons "+
 			"as the complete list:\n%s", want, report)
+	}
+}
+
+// TestTheActualCauseSurvivesTheCap is this PR's own thesis, re-checked in the
+// shape the cap created.
+//
+// 🔴 MEASURED: three CDN `<script src>` tags above a dangling `./civitai-host.js`
+// produced a report listing the three off-project URLs and WITHHOLDING the
+// dangling reference — the real bug — beneath a lead-in asserting "one of these
+// is usually the actual bug". This PR exists because the message pointed away
+// from the cause; a cap that recreates that is the same defect with a different
+// mechanism. Order is document order and deterministic, so it was a stable wrong
+// emphasis rather than a flake.
+//
+// TWO fixes are asserted here because either alone is insufficient: the ranking
+// (the dangling reference must come FIRST, so the cap withholds the least likely
+// causes) and the lead (it must stop claiming the cause is present once anything
+// is withheld, because ranking is a heuristic).
+func TestTheActualCauseSurvivesTheCap(t *testing.T) {
+	dir := renderTemplate(t, scaffold.Static)
+	var cdn strings.Builder
+	for i := 0; i < readyAckGapCap; i++ {
+		fmt.Fprintf(&cdn, `<script src="https://cdn%d.example.com/lib%d.js"></script>`, i, i)
+	}
+	// The CDN tags go ABOVE the emitter reference, so document order puts the
+	// off-project URLs first — the losing order.
+	editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`,
+		cdn.String()+`<script src="./civitai-host.js"></script>`)
+	if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+		t.Fatal(err)
+	}
+	report := gapReportFor(t, dir)
+
+	// Positive control: the fixture really does overflow the cap, or "the cause
+	// is shown" is trivially true and this test proves nothing.
+	if !strings.Contains(report, "more this message does not list") {
+		t.Fatalf("the fixture did not exceed the cap, so nothing was withheld and this test is vacuous:\n%s", report)
+	}
+	dangling := `"./` + blockproto.ReadyAckFilename + `" points at`
+	if !strings.Contains(report, dangling) {
+		t.Fatalf("the ACTUAL cause was withheld by the cap while three off-project URLs were shown — the "+
+			"message points away from the bug, which is the defect this whole change exists to close:\n%s", report)
+	}
+	// FIRST, not merely present: at the cap the ordering is what decides whether
+	// it survives at all, and "present" would still pass with one CDN fewer.
+	if i, j := strings.Index(report, dangling), strings.Index(report, "cdn0.example.com"); j >= 0 && i > j {
+		t.Errorf("the dangling local reference is ranked BELOW an off-project URL; a CDN tag is routine in a "+
+			"working project and a missing local file is the #206 population:\n%s", report)
+	}
+	// And the lead must not claim the cause is in a truncated list.
+	if strings.Contains(report, readyAckGapLead) {
+		t.Errorf("a TRUNCATED report used the untruncated lead, which asserts the bug is among the items "+
+			"shown — it may be one of the withheld ones:\n%s", report)
+	}
+	if !strings.Contains(report, readyAckGapLeadTruncated) {
+		t.Errorf("a truncated report does not disclose that it is truncated:\n%s", report)
+	}
+}
+
+// TestGapLeadsAreDistinctAndNonEmpty disarms the assertions above.
+// `strings.Contains(x, "")` is always true, and two identical leads would make
+// "used the wrong lead" unobservable.
+func TestGapLeadsAreDistinctAndNonEmpty(t *testing.T) {
+	if readyAckGapLead == "" || readyAckGapLeadTruncated == "" {
+		t.Fatal("a gap lead is empty; every Contains assertion about the leads is vacuous")
+	}
+	if readyAckGapLead == readyAckGapLeadTruncated {
+		t.Fatal("the two gap leads are identical; a report cannot disclose whether it was truncated")
+	}
+	if strings.Contains(readyAckGapLeadTruncated, readyAckGapLead) ||
+		strings.Contains(readyAckGapLead, readyAckGapLeadTruncated) {
+		t.Fatal("one gap lead contains the other, so Contains cannot tell them apart")
+	}
+	// The untruncated lead claims the cause is present; only a complete list may.
+	if !strings.Contains(readyAckGapLead, "actual bug") {
+		t.Error("the untruncated lead no longer tells the author these ARE the candidate causes")
+	}
+	if !strings.Contains(readyAckGapLeadTruncated, "TRUNCATED") {
+		t.Error("the truncated lead no longer says it is truncated")
+	}
+}
+
+// TestGapReportCapValue pins the LITERAL.
+//
+// 🔴 EVERY ASSERTION IN TestGapReportUnitCap IS RELATIVE TO readyAckGapCap, so
+// setting it to 99 reddened **0** subtests — the wall of gaps the cap exists to
+// prevent came back under a fully green suite. A constant that only ever appears
+// on both sides of its own assertions is unpinned by construction.
+func TestGapReportCapValue(t *testing.T) {
+	if readyAckGapCap != 3 {
+		t.Fatalf("readyAckGapCap = %d, want 3 — this is a published product decision (the advisory shows at "+
+			"most three reasons and counts the rest), not a tuning knob a refactor may move silently. If the "+
+			"change is deliberate, edit this test and AGENTS.md item 20 together", readyAckGapCap)
+	}
+	// And the constant really does bound the OUTPUT, not just itself: 20 gaps in
+	// must render 3. Without this, pinning the literal is numerology.
+	gaps := make([]string, 20)
+	for i := range gaps {
+		gaps[i] = fmt.Sprintf("reason-%d", i)
+	}
+	got := readyAckGapReport(gaps)
+	for i := 0; i < 3; i++ {
+		if !strings.Contains(got, fmt.Sprintf("(%d)", i+1)) {
+			t.Errorf("reason %d missing: %s", i+1, got)
+		}
+	}
+	if strings.Contains(got, "(4)") {
+		t.Errorf("a fourth reason was rendered with readyAckGapCap = 3: %s", got)
 	}
 }
 
@@ -302,10 +446,17 @@ func TestGapReportIsOneLine(t *testing.T) {
 // a check that reports the presence tier at every project.
 // ---------------------------------------------------------------------------
 
-// TestGapReportDoesNotLeakIntoTheStrongTiers is the structural half of item 20's
-// disclosure rule, aimed at THIS change: the reachability tiers resolved the
-// graph completely, so they have no gaps to report and must not acquire the
-// weak tier's apparatus.
+// TestGapReportDoesNotLeakIntoTheStrongTiers is an INVARIANT GUARD, NOT
+// REGRESSION COVERAGE, and it is labelled so nobody counts it as coverage.
+//
+// 🔴 IT CANNOT FAIL TODAY, and an audit measured that: a strong tier implies
+// `graph.Complete`, which implies `len(graph.Gaps) == 0`, so even appending
+// `readyAckGapReport(graph.Gaps)` to `readyAckAdviceUnwired` on purpose reddens
+// **0** subtests — the appended text is empty. It is kept because the invariant
+// it rests on is a property of `blockproto` that this package does not own (see
+// `TestIncompleteIsExactlyHavingGaps` there, which CAN fail), and because a
+// future tier that built its message from a non-empty source would trip it. Read
+// its green as "the invariant still holds", never as "the tiers were tested".
 func TestGapReportDoesNotLeakIntoTheStrongTiers(t *testing.T) {
 	cases := []struct {
 		name, kind string
@@ -396,6 +547,15 @@ func TestPresenceAdviceHalvesBracketTheReport(t *testing.T) {
 // they would keep passing if the appended report happened to carry another
 // tier's own literal — the assertion never sees an emitted message. So the
 // literals are re-checked against a REAL rendered advisory here.
+//
+// 🔴 IT IS FIXTURE-SCOPED, AND THE PROPERTY IT CHECKS CANNOT HOLD IN GENERAL —
+// do not read it as structural. A gap interpolates author-chosen filenames, so a
+// project referencing `./orphan.js` produces a presence-tier report containing
+// the word `orphan`, which is the unwired tier's own literal. That is not a bug:
+// the tiers are told apart by their fixed halves (`isPresenceOnlyAdvice`), not
+// by keyword. What this pins is that the report we GENERATE — from the shipped
+// scaffold's own names — does not blur the tiers, which is the case that would
+// actually reach a user.
 func TestGapReportCannotSatisfyAnotherTiersStrengthAssertion(t *testing.T) {
 	dir := renderTemplate(t, scaffold.Static)
 	if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {

--- a/internal/validate/readyack_gaps_test.go
+++ b/internal/validate/readyack_gaps_test.go
@@ -83,14 +83,6 @@ func TestDanglingEmitterReferenceIsNamed(t *testing.T) {
 			"does not exist",                 // WHY the resolver stopped
 			"fix the reference",              // what to do about it
 		)
-		// 🔴 The guess must be GONE, not merely supplemented. This is a five-file
-		// no-build app: it has no bundler, so it cannot have a bundler alias, and
-		// being sent to look for one is the whole complaint in #258.
-		for _, gone := range []string{"bundler alias", "generated file", "off-project URL"} {
-			if strings.Contains(report, gone) {
-				t.Errorf("the gap report still speculates about %q at a project where it is impossible\ngot: %s", gone, report)
-			}
-		}
 	})
 
 	t.Run("page-vite: the entry module imports the deleted emitter", func(t *testing.T) {
@@ -108,6 +100,60 @@ func TestDanglingEmitterReferenceIsNamed(t *testing.T) {
 			"does not exist",
 		)
 	})
+}
+
+// TestPresenceAdviceNoLongerSpeculates is the OTHER half of issue #258, and it
+// has to read the WHOLE emitted message rather than the gap report.
+//
+// 🔴 A REPORT-SCOPED ABSENCE CHECK CANNOT SEE THE DEFECT, AND A MUTATION PROVED
+// IT. The first version of this assertion lived inside
+// TestDanglingEmitterReferenceIsNamed and asked only whether the GAP REPORT
+// speculates. Restoring the shipped guess to `readyAckAdvicePresenceOnlyHead` —
+// i.e. adding the true reasons and keeping the false ones, the most likely way
+// this regresses — reddened NOTHING: 0 failures across internal/validate and
+// internal/cmd. Naming the real cause is only half the fix; the speculation has
+// to be gone, and "gone" is a claim about the message a user reads.
+//
+// The fixture is chosen so every phrase below is PROVABLY false of it: a
+// rendered `static` scaffold is five files with no build step, so it has no
+// bundler and therefore no alias, nothing generates a file, every reference is
+// local, and index.html is right there at the root. A message that offers any of
+// them is manufacturing advice, which is the failure AGENTS.md item 10 spent
+// four measured corrections avoiding.
+func TestPresenceAdviceNoLongerSpeculates(t *testing.T) {
+	dir := renderTemplate(t, scaffold.Static)
+	if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+		t.Fatal(err)
+	}
+	res := wantAckKind(t, dir, "presence-only")
+
+	msg := ""
+	for _, w := range res.Warnings {
+		if isPresenceOnlyAdvice(w.Message) {
+			msg = w.Message
+		}
+	}
+	if msg == "" {
+		t.Fatal("no presence-tier message to inspect")
+	}
+	// The positive control: the message DOES name the real cause. Without it,
+	// "says none of the wrong things" is satisfied by a message that says nothing.
+	if !strings.Contains(msg, "which does not exist") {
+		t.Fatalf("the advisory does not name the real cause, so the absence assertions below are vacuous:\n%s", msg)
+	}
+	// Quoted from the wording that shipped, so a revert is caught verbatim.
+	for _, gone := range []string{
+		"a bundler alias",
+		"a generated file",
+		"an off-project URL",
+		"there is no index.html at the project root",
+	} {
+		if strings.Contains(msg, gone) {
+			t.Errorf("the advisory still offers %q at a five-file no-build scaffold where it is impossible — "+
+				"naming the real cause does not close #258 while the speculation is still printed alongside "+
+				"it:\n%s", gone, msg)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/validate/readyack_gaps_test.go
+++ b/internal/validate/readyack_gaps_test.go
@@ -1,0 +1,385 @@
+package validate
+
+// readyack_gaps_test.go covers issue #258: the presence tier used to GUESS at
+// why it had fallen back, and the guess was wrong in the commonest case.
+//
+// 🔴 THE DEFECT WAS THE MESSAGE, NOT THE TIERING. AGENTS.md item 20 records, as
+// a deliberate trade, that a reference to a file which is not there is a GAP
+// rather than a decided absence — so the canonical #206 shape (a `static`
+// scaffold whose `civitai-host.js` was deleted) is CORRECTLY checked on presence
+// only. What was wrong is that the advisory then offered "there is no index.html
+// at the project root, or it holds a reference this CLI cannot follow — a
+// bundler alias, a generated file, an off-project URL", none of which is true of
+// a five-file no-build app whose index.html plainly references a file that has
+// been deleted. The resolver had recorded exactly that in `EntryGraph.Gaps` and
+// the check threw it away.
+//
+// So every case here asserts on the GAP REPORT — the section spliced between the
+// two fixed halves of the presence message — never on the whole message. A
+// `strings.Contains(msg, "index.html")` is vacuous: the shared remedy names
+// index.html twice in every tier, and would pass for a message that still
+// guessed.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/blockproto"
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// gapReportFor drives the real pipeline and returns the presence tier's gap
+// report, failing if the project did not reach that tier.
+func gapReportFor(t *testing.T, dir string) string {
+	t.Helper()
+	res := wantAckKind(t, dir, "presence-only")
+	for _, w := range res.Warnings {
+		if isPresenceOnlyAdvice(w.Message) {
+			return presenceOnlyGapReport(t, w.Message)
+		}
+	}
+	t.Fatalf("no presence-tier advisory in %v", res.Warnings)
+	return ""
+}
+
+// wantGapReport asserts the report names every literal in want, and fails
+// naming the ones it does not.
+func wantGapReport(t *testing.T, report string, want ...string) {
+	t.Helper()
+	if report == "" {
+		t.Fatalf("the presence advisory carries NO gap report — the resolver's reasons were discarded, "+
+			"which is issue #258 exactly; wanted %q", want)
+	}
+	for _, w := range want {
+		if !strings.Contains(report, w) {
+			t.Errorf("the gap report does not name %q — an author cannot act on a reason that omits it\ngot: %s", w, report)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE DEFECT, REPRODUCED — both SDK-free templates.
+// ---------------------------------------------------------------------------
+
+// TestDanglingEmitterReferenceIsNamed is issue #258 as filed.
+//
+// 🔴 THE POSITIVE CONTROL AGAINST THE OLD TEXT IS THE ABSENCE ASSERTION, not the
+// presence one. A report that named the file AND still said "a bundler alias" is
+// the message that shipped; the fix is only real if the guess is gone.
+func TestDanglingEmitterReferenceIsNamed(t *testing.T) {
+	t.Run("static: index.html references the deleted emitter", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.Static)
+		wantAckKind(t, dir, "") // the untouched scaffold is silent
+		if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		report := gapReportFor(t, dir)
+		wantGapReport(t, report,
+			"index.html",                     // WHERE the reference lives
+			"./"+blockproto.ReadyAckFilename, // the specifier as the author wrote it
+			"does not exist",                 // WHY the resolver stopped
+			"fix the reference",              // what to do about it
+		)
+		// 🔴 The guess must be GONE, not merely supplemented. This is a five-file
+		// no-build app: it has no bundler, so it cannot have a bundler alias, and
+		// being sent to look for one is the whole complaint in #258.
+		for _, gone := range []string{"bundler alias", "generated file", "off-project URL"} {
+			if strings.Contains(report, gone) {
+				t.Errorf("the gap report still speculates about %q at a project where it is impossible\ngot: %s", gone, report)
+			}
+		}
+	})
+
+	t.Run("page-vite: the entry module imports the deleted emitter", func(t *testing.T) {
+		dir := renderTemplate(t, scaffold.PageVite)
+		wantAckKind(t, dir, "")
+		if err := os.Remove(filepath.Join(dir, "src", blockproto.ReadyAckFilename)); err != nil {
+			t.Fatal(err)
+		}
+		// The referencing file here is the entry MODULE, not index.html — which
+		// is the point of running this template too: the report has to name the
+		// file the author must edit, and for page-vite that is src/main.jsx.
+		wantGapReport(t, gapReportFor(t, dir),
+			"src/main.jsx",
+			"./"+blockproto.ReadyAckFilename,
+			"does not exist",
+		)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// THE GENERAL CASE. The fix surfaces `EntryGraph.Gaps` wholesale rather than
+// special-casing the dangling reference, so the other gap kinds must arrive too
+// — that is what distinguishes "issue #258 is closed" from "one message got a
+// better sentence".
+// ---------------------------------------------------------------------------
+
+func TestEveryGapKindReachesTheAuthor(t *testing.T) {
+	t.Run("a bare specifier that is not a declared dependency", func(t *testing.T) {
+		// `import '@/civitai-host.js'` is a real file behind a resolve.alias this
+		// CLI does not read. Here the guess the old message made was RIGHT — and
+		// it has to keep being said, from the resolver, naming the specifier.
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"package.json": `{"dependencies": {}}`,
+			"index.html":   `<!doctype html><script type="module" src="./main.js"></script>`,
+			"main.js":      `import '@/civitai-host.js';` + "\n",
+		})
+		wantGapReport(t, gapReportFor(t, dir),
+			"main.js",           // the file holding the reference
+			"@/civitai-host.js", // the specifier
+			"bundler alias",     // the reason, now earned rather than guessed
+		)
+	})
+
+	t.Run("a file the resolver could not read", func(t *testing.T) {
+		// A stylesheet over the per-file size cap. It has to be a NON-source
+		// extension: the whole-tree scan would hit the same cap on a `.js` and
+		// report UNOBSERVABLE, which gates both tiers and emits nothing at all.
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script type="module" src="./main.js"></script>`,
+			"main.js":    `import './huge.css';` + "\n",
+		})
+		big := strings.Repeat("/* pad */\n.a{color:red}\n", (maxAckFileBytes/22)+64)
+		if err := os.WriteFile(filepath.Join(dir, "huge.css"), []byte(big), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		wantGapReport(t, gapReportFor(t, dir), "could not read", "huge.css")
+	})
+
+	t.Run("no index.html at the project root", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(true), map[string]string{
+			"package.json": `{"dependencies": {"next": "^15.0.0"}}`,
+			"app/page.tsx": `export default function Page() { return null; }`,
+		})
+		wantGapReport(t, gapReportFor(t, dir), "index.html")
+	})
+
+	t.Run("an off-project URL in a script src", func(t *testing.T) {
+		dir := ackProject(t, ackManifest(false), map[string]string{
+			"index.html": `<!doctype html><script src="https://cdn.example.com/x.js"></script>` +
+				`<script src="./app.js"></script>`,
+			"app.js": `document.title = 'hi';` + "\n",
+		})
+		wantGapReport(t, gapReportFor(t, dir), "https://cdn.example.com/x.js", "could not resolve")
+	})
+}
+
+// TestGapReportIsCappedAndSaysSo pins the truncation disclosure.
+//
+// 🔴 A SILENTLY TRUNCATED LIST READS AS "THAT WAS ALL OF THEM" — the same class
+// of lie as the guess this report replaced. An author fixes the three references
+// they were shown, re-runs, and is told about three more that were there the
+// whole time.
+func TestGapReportIsCappedAndSaysSo(t *testing.T) {
+	const refs = readyAckGapCap + 4
+	var tags strings.Builder
+	for i := 0; i < refs; i++ {
+		fmt.Fprintf(&tags, `<script src="./missing%d.js"></script>`, i)
+	}
+	dir := ackProject(t, ackManifest(false), map[string]string{
+		"index.html": `<!doctype html>` + tags.String(),
+	})
+	report := gapReportFor(t, dir)
+
+	// Exactly readyAckGapCap reasons are numbered, and the numbering stops there.
+	for i := 1; i <= readyAckGapCap; i++ {
+		if !strings.Contains(report, fmt.Sprintf("(%d)", i)) {
+			t.Errorf("the gap report is missing reason (%d):\n%s", i, report)
+		}
+	}
+	if strings.Contains(report, fmt.Sprintf("(%d)", readyAckGapCap+1)) {
+		t.Errorf("the gap report rendered more than readyAckGapCap=%d reasons:\n%s", readyAckGapCap, report)
+	}
+	// And the overflow is COUNTED, not merely hinted at. `refs` references all
+	// gap, so the count is exact.
+	want := fmt.Sprintf("and %d more", refs-readyAckGapCap)
+	if !strings.Contains(report, want) {
+		t.Errorf("the gap report truncated silently — it must say %q, or an author reads three reasons "+
+			"as the complete list:\n%s", want, report)
+	}
+}
+
+// TestGapReportUnitCap is the same rule at the function, where the input can be
+// varied freely — the fixture above can only produce the counts a project shape
+// happens to yield.
+func TestGapReportUnitCap(t *testing.T) {
+	if got := readyAckGapReport(nil); got != "" {
+		t.Errorf("no gaps must render nothing, got %q", got)
+	}
+	for _, n := range []int{1, readyAckGapCap, readyAckGapCap + 1, 47} {
+		gaps := make([]string, n)
+		for i := range gaps {
+			gaps[i] = fmt.Sprintf("reason-%d", i)
+		}
+		got := readyAckGapReport(gaps)
+		shown := min(n, readyAckGapCap)
+		for i := 0; i < shown; i++ {
+			if !strings.Contains(got, fmt.Sprintf("reason-%d", i)) {
+				t.Errorf("n=%d: missing reason-%d in %q", n, i, got)
+			}
+		}
+		if shown < n {
+			if !strings.Contains(got, fmt.Sprintf("and %d more", n-shown)) {
+				t.Errorf("n=%d: overflow of %d not disclosed: %q", n, n-shown, got)
+			}
+			if strings.Contains(got, fmt.Sprintf("reason-%d", readyAckGapCap)) {
+				t.Errorf("n=%d: rendered past the cap: %q", n, got)
+			}
+		} else if strings.Contains(got, "more") {
+			t.Errorf("n=%d: claimed an overflow with nothing withheld: %q", n, got)
+		}
+	}
+}
+
+// TestGapReportIsOneLine pins the wire contract. `Finding.Message` is a `--json`
+// string field; the human layout happens at the printer (internal/cmd), and a
+// newline here would break a consumer without breaking any assertion about the
+// text. A gap interpolates `%v` of an OS error, which is not guaranteed
+// newline-free.
+func TestGapReportIsOneLine(t *testing.T) {
+	got := readyAckGapReport([]string{"a reason\nsplit over\r\ntwo lines", "and\ta tab"})
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("the gap report carries a line break: %q", got)
+	}
+	for _, want := range []string{"a reason split over two lines", "and a tab"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("collapsing whitespace lost content: want %q in %q", want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CONTROLS. Without these, "the presence tier names its reasons" is satisfied by
+// a check that reports the presence tier at every project.
+// ---------------------------------------------------------------------------
+
+// TestGapReportDoesNotLeakIntoTheStrongTiers is the structural half of item 20's
+// disclosure rule, aimed at THIS change: the reachability tiers resolved the
+// graph completely, so they have no gaps to report and must not acquire the
+// weak tier's apparatus.
+func TestGapReportDoesNotLeakIntoTheStrongTiers(t *testing.T) {
+	cases := []struct {
+		name, kind string
+		build      func(*testing.T) string
+	}{
+		{"unwired", "unwired", func(t *testing.T) string {
+			dir := renderTemplate(t, scaffold.Static)
+			editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+			return dir
+		}},
+		{"missing", "missing", func(t *testing.T) string {
+			dir := renderTemplate(t, scaffold.Static)
+			editFile(t, dir, "index.html", `<script src="./civitai-host.js"></script>`, "")
+			if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+				t.Fatal(err)
+			}
+			return dir
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := wantAckKind(t, c.build(t), c.kind)
+			for _, w := range res.Warnings {
+				if isPresenceOnlyAdvice(w.Message) {
+					t.Fatalf("the %s tier emitted a presence-tier message", c.name)
+				}
+				if strings.Contains(w.Message, readyAckGapLead) {
+					t.Fatalf("the %s tier carries the gap report's lead-in — it resolved the graph completely, "+
+						"so it has nothing it could not follow, and saying otherwise blurs the two tiers:\n%s",
+						c.name, w.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestGapReportNeverAppearsAtACorrectProject is the other control: the shipped
+// templates resolve completely and must stay silent, gap report or not.
+func TestGapReportNeverAppearsAtACorrectProject(t *testing.T) {
+	examined := 0
+	for _, tmpl := range scaffold.AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			wantAckKind(t, renderTemplate(t, tmpl), "")
+		})
+		examined++
+	}
+	if examined < 3 {
+		t.Fatalf("examined only %d template(s) — the enumeration stopped OBSERVING", examined)
+	}
+}
+
+// TestPresenceAdviceHalvesBracketTheReport pins the assumption every matcher in
+// this package now rests on: the head and the tail are non-empty and neither is
+// a prefix of the other tiers' messages, so bracketing really identifies the
+// presence tier.
+//
+// 🔴 An empty half silently disarms `isPresenceOnlyAdvice` —
+// `strings.HasPrefix(x, "")` is always true — which would classify BOTH
+// reachability tiers as presence-only and make every wantAckKind in this package
+// assert the wrong thing while staying green.
+func TestPresenceAdviceHalvesBracketTheReport(t *testing.T) {
+	if readyAckAdvicePresenceOnlyHead == "" || readyAckAdvicePresenceOnlyTail == "" {
+		t.Fatal("a half of the presence advisory is empty; isPresenceOnlyAdvice matches everything")
+	}
+	if got := readyAckAdvicePresenceOnlyHead + readyAckAdvicePresenceOnlyTail; got != readyAckAdvicePresenceOnly {
+		t.Fatal("readyAckAdvicePresenceOnly is not the concatenation of its two halves — the ledger entry " +
+			"and the emitted message have drifted apart")
+	}
+	if !isPresenceOnlyAdvice(readyAckAdvicePresenceOnly) {
+		t.Fatal("the no-gaps presence message is not recognised as one")
+	}
+	if !isPresenceOnlyAdvice(presenceOnlyAdvice([]string{"x"})) {
+		t.Fatal("a presence message WITH a gap report is not recognised as one")
+	}
+	for name, other := range map[string]string{"unwired": readyAckAdviceUnwired, "missing": readyAckAdviceMissing} {
+		if isPresenceOnlyAdvice(other) {
+			t.Errorf("the %s advisory is bracketed by the presence tier's halves — the tiers are no longer "+
+				"distinguishable, and readyAckKind reports the wrong one", name)
+		}
+	}
+}
+
+// TestGapReportCannotSatisfyAnotherTiersStrengthAssertion is the case
+// TestReadyAckAdvisoriesStateTheirOwnStrength cannot make, because that test
+// operates on the FIXED bases and this change adds text at runtime.
+//
+// 🔴 The inverse assertions there are what stop the tiers blurring together, and
+// they would keep passing if the appended report happened to carry another
+// tier's own literal — the assertion never sees an emitted message. So the
+// literals are re-checked against a REAL rendered advisory here.
+func TestGapReportCannotSatisfyAnotherTiersStrengthAssertion(t *testing.T) {
+	dir := renderTemplate(t, scaffold.Static)
+	if err := os.Remove(filepath.Join(dir, blockproto.ReadyAckFilename)); err != nil {
+		t.Fatal(err)
+	}
+	report := gapReportFor(t, dir)
+	// These are TestReadyAckAdvisoriesStateTheirOwnStrength's `own` literals for
+	// the two reachability tiers. None may appear in the presence tier's report.
+	for _, lit := range []string{
+		"DOES contain",
+		"nothing index.html loads reaches it",
+		"orphan",
+		"nothing index.html loads posts it either",
+	} {
+		if strings.Contains(report, lit) {
+			t.Errorf("the gap report carries %q, which is another tier's whole diagnosis — a reader can no "+
+				"longer tell which check ran:\n%s", lit, report)
+		}
+	}
+	// And the weak tier's own disclosure survives the splice, in the emitted
+	// message rather than only in the constant.
+	res := wantAckKind(t, dir, "presence-only")
+	for _, w := range res.Warnings {
+		if !isPresenceOnlyAdvice(w.Message) {
+			continue
+		}
+		for _, want := range []string{"did NOT check that the file is loaded", "will silence this warning"} {
+			if !strings.Contains(w.Message, want) {
+				t.Errorf("the emitted presence advisory lost %q — the disclosure is the fix, not a nicety", want)
+			}
+		}
+	}
+}

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -92,18 +92,44 @@ func ackProject(t *testing.T, manifestJSON string, files map[string]string) stri
 func hasReadyAckWarning(res Result) bool { return readyAckKind(res) != "" }
 
 // readyAckKind names the tier that fired, or "".
+//
+// 🔴 THE PRESENCE TIER IS NOT AN EQUALITY MATCH, AND MATCHING IT LIKE ONE MAKES
+// THIS HELPER BLIND TO THE ONE TIER IT MOST NEEDS TO SEE. Its real message is
+// `presenceOnlyAdvice(gaps)` — the base with the resolver's own reasons spliced
+// into the middle (issue #258) — so `w.Message == readyAckAdvicePresenceOnly` is
+// true only for a graph that recorded no reason at all, which no real project
+// produces. Every wantAckKind(…, "presence-only") in this package would then
+// report "" and read as "the check did not fire". It is bracketed instead.
 func readyAckKind(res Result) string {
 	for _, w := range res.Warnings {
-		switch w.Message {
-		case readyAckAdviceUnwired:
+		switch {
+		case w.Message == readyAckAdviceUnwired:
 			return "unwired"
-		case readyAckAdviceMissing:
+		case w.Message == readyAckAdviceMissing:
 			return "missing"
-		case readyAckAdvicePresenceOnly:
+		case isPresenceOnlyAdvice(w.Message):
 			return "presence-only"
 		}
 	}
 	return ""
+}
+
+// isPresenceOnlyAdvice reports whether msg is the presence tier's message, with
+// or without a gap report between its two fixed halves.
+func isPresenceOnlyAdvice(msg string) bool {
+	return strings.HasPrefix(msg, readyAckAdvicePresenceOnlyHead) &&
+		strings.HasSuffix(msg, readyAckAdvicePresenceOnlyTail)
+}
+
+// presenceOnlyGapReport returns the gap report spliced into msg, which must be a
+// presence-tier message. It is what lets a test assert on the REASONS without
+// re-stating the surrounding prose.
+func presenceOnlyGapReport(t *testing.T, msg string) string {
+	t.Helper()
+	if !isPresenceOnlyAdvice(msg) {
+		t.Fatalf("not a presence-tier advisory:\n%s", msg)
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(msg, readyAckAdvicePresenceOnlyHead), readyAckAdvicePresenceOnlyTail)
 }
 
 // wantAckKind asserts the exact tier. `want` of "" means no ready-ack warning.


### PR DESCRIPTION
Closes #258.

## The defect

In the canonical #206 shape — a `static` scaffold whose `civitai-host.js` has
been deleted — the presence-tier ready-ack advisory listed reasons it might have
fallen back, and **none of them was the actual reason**:

> there is no index.html at the project root, or it holds a reference this CLI
> cannot follow — a bundler alias, a generated file, an off-project URL

Not one is true of a five-file no-build app. The real reason is that
`<script src="./civitai-host.js">` points at a file that is not there — and
`EntryGraph.Gaps` had already recorded exactly that, per reference, before
`readyAckChecks` returned the constant `readyAckAdvicePresenceOnly` and
discarded the slice.

**The tiering is unchanged and correct.** AGENTS.md item 20 deliberately treats
a reference to a missing file as a *gap* rather than a decided absence, and
records this case as a known trade. The message was the defect.

## The fix

**Surface `Gaps` generally**, not the dangling reference specially — so all six
gap kinds (dangling reference, bare specifier, off-project URL, unreadable file,
file budget, depth truncation) reach the author from one change:

```
… it did NOT check that the file is loaded. Here is what it could not follow, in
this project's own terms — one of these is usually the actual bug: (1)
index.html <script src> "./civitai-host.js" points at civitai-host.js, which
does not exist — restore that file or fix the reference. …
```

- Capped at 3, **with the overflow counted out loud** (`; and 2 more this
  message does not list`). A silently truncated list reads as "that was all of
  them" — the same class of lie as the guess it replaced.
- The gap strings got a copy pass now that they are author-facing: one carried
  "this resolver's model of the project is incomplete", a fact about *us*.
  **What sets a gap is untouched** — only how it reads.
- The reasons are spliced between `…PresenceOnlyHead` and `…PresenceOnlyTail`,
  *before* the shared remedy rather than after it: the remedy is the longest
  fragment, so appending put the one project-specific sentence two thirds of the
  way down a wall of generic advice.

## Second half: the 1938-character line

The advisory is ~2 kB and `app validate` printed it as **one line**. Layout now
happens at the printer (`internal/cmd/validate_print.go`), wrapping **every**
finding to 79 columns with a hanging indent — one place fixes every long
message, including ones added later.

Wrapping inside `Finding.Message` would corrupt `--json`. This is the inverse of
AGENTS.md item 23: the *field* comes from the producer, the *layout* does not.
`wrapRunes` is reused as-is from `exitcodes_doc.go` (same package — no export,
no edit to that file).

## Mutation matrix

`--- FAIL` leaf lines counted from output (never an exit code); every mutation
checksum-gated, so an edit that silently failed to apply aborts instead of
reading as a survivor.

| mutation | FAIL |
| --- | --- |
| discard the gaps (pre-#258 behaviour) | 11 |
| restore the guess to the head | 1 |
| remove the cap | 2 |
| truncate silently (no "+K more") | 2 |
| drop the one-line collapse | 1 |
| newline inside the message | 2 (incl. the `--json` guard) |
| revert the printer to one unwrapped line | 1 |
| revert the gap wording to the maintainer form | 3 |
| splice the report after the tail | 24 |
| weak tier loses its disclosure | 2 |
| strong tier gains the disclosure (inverse) | 1 |
| report leaks another tier's own literal | 1 |
| **comment-only null mutant** | **0 (survives, as it must)** |

🔴 **One mutant survived the first round and is why an assertion moved.**
Restoring the guess to `…PresenceOnlyHead` *while keeping the real reasons* —
the most likely regression — reddened **0** subtests, because the absence check
was scoped to the gap report. `TestPresenceAdviceNoLongerSpeculates` now reads
the whole emitted message at a fixture where every quoted phrase is provably
impossible, with a positive control that the real cause is present so "says none
of the wrong things" is not satisfied by a message that says nothing.

`TestReadyAckAdvisoriesStateTheirOwnStrength` still passes and still *can* fail
in **both** directions (K: 2, L: 1 above). It reads the FIXED bases, so it
structurally cannot see text appended at runtime —
`TestGapReportCannotSatisfyAnotherTiersStrengthAssertion` covers that, and kills
the "report leaks `orphan`" mutant the strength test cannot.

## Coverage

- `static` **and** `page-vite` with the emitter deleted: the report names the
  referencing file (`index.html` / `src/main.jsx`), the specifier and the
  missing target — asserted on the **gap section**, not the whole message, since
  the shared remedy names `index.html` in every tier and a whole-message
  `Contains` would be vacuous.
- Three further gap kinds: bare specifier, unreadable (over-cap) file,
  no root `index.html`, plus an off-project URL.
- Controls: the orphan case keeps `readyAckAdviceUnwired`; all shipped templates
  stay silent; the strong tiers never acquire the gap apparatus.
- `--json` is asserted on the **decoded** `map[string]any` (a `Contains` over
  raw stdout cannot tell a real newline from the `\n` escape).
- The cap, at the fixture and at the function.

## `make ci`

`--- FAIL`: **0** · `build failed`: **0** · 18 packages `ok` · `gofmt -s -l .`
clean over 299 `.go` files (count quoted as the positive control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
