### PR TITLE
docs(#270): publish the real listing-media requirements, scaffold assets/, fix the broken quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,10 +166,12 @@ is model substitution, and 22 is the one gate on that path that guards CONTENT
 rather than money); items 18 and 20 cover the checks that tell an author their
 EXISTING app is missing the item-11 handshake (20 is the reachability repair to
 18's presence-only scan); item 23 covers the SHAPE of a validation finding — the
-`field` every `--json` consumer groups on; and item 24 covers the ONE
+`field` every `--json` consumer groups on; item 24 covers the ONE
 transport-vs-filesystem predicate now shared by the CLI-wide exit-code
 classifier (which every command's published exit code funnels through) and
-`pkg/civitai`'s read-GET retry loop.
+`pkg/civitai`'s read-GET retry loop; and item 25 is a third deliberate
+*non*-mirror — the store-listing image dimension/aspect bounds, which stay prose
+in the README rather than becoming a local check.
 The durable fix for the mirroring is a server-side
 `civitai app validate` endpoint that calls the real `BlockManifestValidator` —
 until that exists, vendoring is on purpose.
@@ -1864,6 +1866,42 @@ neither one's.
         dot-imported `net`) are listed in the file's own header; there is no
         full type resolution because `golang.org/x/tools/go/packages` would be a
         new dependency, which is an "ask first" below.
+25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,
+    and must NOT become a local check.** `civitai app listing set-icon` /
+    `set-cover` / `add-screenshot` validate the **format** and the **byte size**
+    of the source file (`maxIconBytes` / `maxCoverBytes` /
+    `maxScreenshotBytes`) and nothing else. The platform additionally enforces a
+    per-kind aspect range and a minimum dimension at ATTACH time
+    (`civitai/civitai → src/server/schema/blocks/app-listing.schema.ts`,
+    `validateListingImage`), returning a `BAD_REQUEST` that names the bound and
+    the measured value. Those numbers are documented in README →
+    *Listing media requirements* and in the scaffolded `assets/README.md`, and
+    that is deliberately as far as they go.
+    - **Why prose and not a check.** This is item 4's argument, applied to a
+      different constant set: stale *guidance* costs one round-trip carrying the
+      server's current bound, while a stale *gate* refuses valid images and the
+      author cannot override it. A local dimension check would also have to
+      re-derive the icon rescale below to avoid being wrong on day one. So do
+      not add a `LISTING_ICON_ASPECT_MIN` to `internal/cmd`, and do not "fix"
+      the docs by promoting the table into `internal/validate`. The CLI already
+      decodes width/height (`appapi.DecodeImageInfo`) — the omission is a
+      decision, not a missing feature.
+    - **The icon byte cap and the server's icon byte cap measure DIFFERENT
+      bytes, and the docs must not conflate them.** `maxIconBytes` (2 MiB) is
+      the SOURCE file, mirroring the server's `INLINE_ICON_MAX_DECODED_BYTES`
+      on the data-URI path the icon rides. The listing schema's
+      `MAX_LISTING_ICON_SIZE_BYTES` (1 MiB) is checked against
+      `Image.metadata.size`, which for that path is the byte length of the
+      **re-encoded** PNG the server produces after downscaling to ≤1024 px on
+      the longer side (`listing-meta.service.ts`) — not the file the author
+      passed. Cover and screenshot take the full-res path, where the CLI sends
+      `sizeBytes: len(data)`, so there the two caps DO describe the same bytes.
+    - **Never scaffold a placeholder icon or cover.** A placeholder passes every
+      format and byte check and uploads cleanly, so it can reach a public store
+      listing; a missing file fails loudly at the step that can still fix it.
+      `assets/` therefore ships with a README and no images, and
+      `internal/scaffold/assets_dir_test.go` fails if an image file appears
+      under it.
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/README.md
+++ b/README.md
@@ -1096,14 +1096,21 @@ Three behaviours that are not obvious from the numbers:
   most **1024 px** on its longer side and re-encoded to PNG — aspect preserved,
   and **never enlarged**. So an oversized icon is harmless, but an undersized one
   is not: the 128 px floor still bites, because nothing is ever scaled up.
+  One consequence to know about: the platform also caps the **re-encoded** icon
+  at 1 MiB, and that is a different measurement from the 2 MiB the CLI applies to
+  the file you pass. A detailed photographic icon can clear the local check and
+  still be refused for the size of the PNG the server made from it — the message
+  quotes bytes, not pixels. Flat, simple artwork re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   renders, so ship them at the size you want shown.
-- **A wrong image is rejected, not quietly accepted.** You find out at
-  `set-icon` / `set-cover` / `add-screenshot` time — before a moderator ever sees
-  it — and the message names the requirement. A source image above ~16
-  megapixels (say 5000 × 5000) is the one exception with an unhelpful message:
-  it fails the icon decoder with *"That icon couldn't be read"* rather than a
-  dimension error. Downscale it and retry.
+- **A wrong image is rejected, not quietly accepted, and it comes back fast.**
+  The CLI attaches *before* it waits on the content scan, so the platform's
+  verdict on shape arrives in a couple of seconds rather than after a scan that
+  can take two minutes — and always before a moderator sees it. The message names
+  the requirement. A source image above ~16 megapixels (say 5000 × 5000) is the
+  one exception with an unhelpful message: it fails the icon decoder with
+  *"That icon couldn't be read"* rather than a dimension error. Downscale it and
+  retry.
 
 > **Why the CLI does not enforce the second table.** These are platform
 > constants that can move. Stale *guidance* costs you one rejection that carries

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ contract, and **packages/submits** it for review.
   - [The `--json` result shape](#the---json-result-shape)
 - [Submit & auth](#submit--auth)
   - [After you submit: review → approve → deploy](#after-you-submit-review--approve--deploy)
+  - [Listing media requirements](#listing-media-requirements)
 - [Submission status](#submission-status)
   - [Deployed is not the same as listed in the store](#deployed-is-not-the-same-as-listed-in-the-store)
 - [Pull your app's repository (`app pull`)](#pull-your-apps-repository-app-pull)
@@ -220,10 +221,18 @@ civitai app status
 # 7. Attach the store-listing media. An icon AND a cover are REQUIRED before the
 #    listing can publish — do it now, while the app is in review; it carries
 #    forward on approval. `listing status` shows what's still missing.
+#    The scaffold creates `assets/` and a README of the requirements, but NO
+#    images — save your own icon.png and cover.png in there first.
 civitai app listing set-icon ./assets/icon.png
 civitai app listing set-cover ./assets/cover.png
 civitai app listing status
 ```
+
+> **Step 7 needs artwork you supply.** Every template scaffolds an `assets/`
+> directory with a README of the requirements, and deliberately **no placeholder
+> images** — a placeholder passes every check and uploads cleanly, which is how a
+> stub icon reaches a public listing. Sizes, formats and aspect ratios are in
+> [Listing media requirements](#listing-media-requirements).
 
 > Want to drive the **real** backend (real Buzz/compute) before submitting? Mint
 > a dev token with `civitai app dev-token` and run `npm run dev:live` — see
@@ -280,7 +289,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message` — **`field` is always present and never `null`**) for scriptable parsing — still exits non-zero on failure. See [Validate fidelity](#validate-fidelity) and [The `--json` result shape](#the---json-result-shape). |
 | `civitai app submit [dir] [--package-only] [--out f.zip] [--skip-validate]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). |
 | `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
-| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires. See [After you submit](#after-you-submit-review--approve--deploy). |
+| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires. The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
@@ -307,6 +316,11 @@ full details and examples.
   (never raw `postMessage`). Ships a `dev:harness` mock host, `.env.*` allowed
   parent-origin config, and a unit-test stub. Run `npm run dev:harness` (plain
   `npm run dev` renders blank without a host).
+
+Every template also scaffolds an **`assets/`** directory holding a README of the
+store-listing media requirements — and no images, so the `set-icon` / `set-cover`
+step fails loudly until you supply real artwork. See
+[Listing media requirements](#listing-media-requirements).
 
 ### The host handshake (`BLOCK_READY`)
 
@@ -997,21 +1011,28 @@ Screenshots:     0
   Add one:  civitai app listing set-icon <file>
   Add one:  civitai app listing set-cover <file>
 
-$ civitai app listing set-icon ./assets/icon.png    # square-ish, ≤2 MiB
-$ civitai app listing set-cover ./assets/cover.png  # landscape hero, ≤4 MiB
-$ civitai app listing add-screenshot ./shot.png --caption "Grid view"   # optional, up to 8
+$ civitai app listing set-icon ./assets/icon.png    # png/jpeg/webp, ≤2 MiB
+$ civitai app listing set-cover ./assets/cover.png  # png/jpeg/webp, ≤4 MiB
+$ civitai app listing add-screenshot ./assets/screenshot-1.png --caption "Grid view"   # optional, up to 8
 ```
+
+`assets/` is scaffolded by every template, with a README of the requirements and
+**no placeholder images** — the files above are ones you supply.
 
 Details worth knowing before you start:
 
 - **Source images** are png/jpeg/webp and are size-checked **locally before any
-  upload** — icon ≤2 MiB, cover ≤4 MiB, screenshot ≤2 MiB.
+  upload** — icon ≤2 MiB, cover ≤4 MiB, screenshot ≤2 MiB. That is the whole of
+  what the CLI **enforces**.
 - **Dimension and aspect rules are the platform's, and it states them.** The CLI
-  does not publish or enforce them (a copied number goes stale and starts
-  refusing valid images). It uploads, **attaches, and then waits for the content
-  scan** — in that order, because the platform validates dimensions, aspect and
-  format at the *attach* step. So a wrongly-shaped image comes back in a couple
-  of seconds with the platform's own message naming the bound and your value
+  does not enforce them locally — a copied number goes stale and starts refusing
+  valid images — but it does *document* the current bounds, as guidance rather
+  than as a gate: see
+  [Listing media requirements](#listing-media-requirements). It uploads,
+  **attaches, and then waits for the content scan** — in that order, because the
+  platform validates dimensions, aspect and format at the *attach* step. So a
+  wrongly-shaped image comes back in a couple of seconds with the platform's own
+  message naming the bound and your value
   (e.g. `icon must be square-ish (aspect 2.00 outside 0.9–1.1)`), instead of
   after the scan has finished.
 - **A blocked image never goes live.** The scan verdict is still waited on, so
@@ -1041,6 +1062,55 @@ $ civitai app submit                          # resubmit the new bundle
 pending publish request. It is **idempotent** (an already-withdrawn request still
 returns success) and only a **`pending`** request can be withdrawn — an already
 approved/rejected one cannot.
+
+### Listing media requirements
+
+Two different things check your listing images, and it is worth knowing which is
+which before you open an image editor.
+
+**What the CLI checks, locally, before anything is uploaded:** the file's
+**format** and its **byte size**. That is all.
+
+| kind | how many | format | byte cap (the file you pass) |
+| --- | --- | --- | --- |
+| **icon** | 1, required | png / jpeg / webp | ≤ 2 MiB |
+| **cover** | 1, required | png / jpeg / webp | ≤ 4 MiB |
+| **screenshot** | up to 8, optional | png / jpeg / webp | ≤ 2 MiB |
+
+**What the platform checks, server-side, when the image is attached:** the
+dimensions and the aspect ratio. The CLI does not reproduce these, so this table
+is *guidance* — the server is the authority and its rejection names the bound and
+your value (`icon must be square-ish (aspect 2.00 outside 0.9–1.1)`).
+
+| kind | aspect (width ÷ height) | minimum size |
+| --- | --- | --- |
+| **icon** | 0.9 – 1.1 — square-ish, not exactly square | 128 px on the shorter side |
+| **cover** | 1.3 – 2.4 — landscape, ~4:3 to ~21:9 | 640 px wide |
+| **screenshot** | 0.4 – 2.6 — either orientation | 320 px on the shorter side |
+
+Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
+
+Three behaviours that are not obvious from the numbers:
+
+- **Icons are re-encoded server-side.** Whatever you upload is downscaled to at
+  most **1024 px** on its longer side and re-encoded to PNG — aspect preserved,
+  and **never enlarged**. So an oversized icon is harmless, but an undersized one
+  is not: the 128 px floor still bites, because nothing is ever scaled up.
+- **Covers and screenshots are not rescaled.** What you upload is what the store
+  renders, so ship them at the size you want shown.
+- **A wrong image is rejected, not quietly accepted.** You find out at
+  `set-icon` / `set-cover` / `add-screenshot` time — before a moderator ever sees
+  it — and the message names the requirement. A source image above ~16
+  megapixels (say 5000 × 5000) is the one exception with an unhelpful message:
+  it fails the icon decoder with *"That icon couldn't be read"* rather than a
+  dimension error. Downscale it and retry.
+
+> **Why the CLI does not enforce the second table.** These are platform
+> constants that can move. Stale *guidance* costs you one rejection that carries
+> the current bound; a stale local *gate* refuses valid images and cannot be
+> argued with. The asymmetry is the reason the split exists — please don't
+> "helpfully" promote these numbers into a local check (see
+> [`AGENTS.md`](AGENTS.md) item 25).
 
 ## Submission status
 

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -292,15 +292,16 @@ func newAppListingSetIconCmd() *cobra.Command {
 	var assumeYes bool
 	cmd := &cobra.Command{
 		Use:   "set-icon <file>",
-		Short: "Set the listing icon (a square-ish image)",
-		Long: `Set your store listing's ICON — the small square-ish image shown beside your
-app's name. An icon is MANDATORY: a listing cannot publish without one.
+		Short: "Set the listing icon (" + listingSourceRule(kindIcon) + ")",
+		Long: `Set your store listing's ICON — the small image shown beside your app's name.
+An icon is MANDATORY: a listing cannot publish without one.
 
 The source file is validated locally first (` + listingSourceRule(kindIcon) + `),
 then ingested and attached, and the content scan is waited on afterwards.
 Nothing is uploaded if the local check fails. The platform validates the
 image's dimensions and aspect at the ATTACH step, so a wrongly-shaped image is
 refused in seconds rather than after the scan.
+See "Listing media requirements" in the README for the platform's bounds.
 
 On a listing that is already LIVE this opens a REVISION for moderator re-review
 instead of changing the live listing — pass --changelog to describe the change,
@@ -326,8 +327,8 @@ func newAppListingSetCoverCmd() *cobra.Command {
 	var assumeYes bool
 	cmd := &cobra.Command{
 		Use:   "set-cover <file>",
-		Short: "Set the listing cover (a landscape hero image)",
-		Long: `Set your store listing's COVER — the wide hero image at the top of the listing
+		Short: "Set the listing cover (" + listingSourceRule(kindCover) + ")",
+		Long: `Set your store listing's COVER — the wide image at the top of the listing
 page. A cover is MANDATORY: a listing cannot publish without one.
 
 The source file is validated locally first (` + listingSourceRule(kindCover) + `),
@@ -335,6 +336,7 @@ then ingested and attached, and the content scan is waited on afterwards.
 Nothing is uploaded if the local check fails. The platform validates the
 image's dimensions and aspect at the ATTACH step, so a wrongly-shaped image is
 refused in seconds rather than after the scan.
+See "Listing media requirements" in the README for the platform's bounds.
 
 On a listing that is already LIVE this opens a REVISION for moderator re-review
 instead of changing the live listing — pass --changelog to describe the change,
@@ -371,6 +373,7 @@ afterwards. Nothing is uploaded if the local check fails. The platform
 validates dimensions, aspect and format at the ATTACH step, so a bad image is
 refused in seconds rather than after the scan. --caption adds a one-line
 caption.
+See "Listing media requirements" in the README for the platform's bounds.
 
 Each run appends one screenshot; there is no bulk add. Use
 ` + "`civitai app listing reorder`" + ` to change the order afterwards and

--- a/internal/cmd/listing_media_docs_test.go
+++ b/internal/cmd/listing_media_docs_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// listingMediaCmdRe matches a documented `civitai app listing set-icon|set-cover|
+// add-screenshot <path>` invocation and captures the path argument.
+//
+// It is deliberately run over the RAW README, not the fenced-code-stripped copy
+// the anchor guards use: every one of these invocations lives inside a ```bash or
+// ```text block, so stripping fences would leave the guard matching nothing —
+// which is indistinguishable from "the README is correct".
+var listingMediaCmdRe = regexp.MustCompile(`civitai app listing (?:set-icon|set-cover|add-screenshot)\s+(\S+)`)
+
+// TestREADMEListingMediaPathsExistInEveryScaffoldedProject is the seam guard
+// between two surfaces that were each individually fine and broken together.
+//
+// The README's quickstart told authors to run
+// `civitai app listing set-icon ./assets/icon.png` as step 7. No template
+// created `assets/`. Measured on the binary built at 1eb4095, in a project
+// freshly scaffolded by the CLI itself:
+//
+//	$ civitai app listing set-icon ./assets/icon.png
+//	Error: no such file: ./assets/icon.png
+//	exit=2
+//
+// Nothing was wrong with the command, and nothing was wrong with the scaffold.
+// The defect lived in the relationship, so the guard has to pin the
+// RELATIONSHIP: every relative path the README hands an author must have its
+// parent directory present in a project the CLI actually scaffolds — for EVERY
+// template, since an author picks one and the quickstart does not say which.
+//
+// 🔴 It asserts the DIRECTORY, never the file. The images themselves must not be
+// scaffolded (a placeholder uploads cleanly to a public listing — see
+// internal/scaffold/assets_dir_test.go and AGENTS.md item 25), so a guard
+// demanding `assets/icon.png` would be a guard demanding the hazard.
+func TestREADMEListingMediaPathsExistInEveryScaffoldedProject(t *testing.T) {
+	matches := listingMediaCmdRe.FindAllStringSubmatch(readREADME(t), -1)
+
+	// Positive control. A zero-match run is what a regex typo, a renamed
+	// command or a wrong working directory all look like, and it would report a
+	// serene pass over nothing.
+	if len(matches) < 4 {
+		t.Fatalf("found only %d `civitai app listing set-*` invocations in README.md, want >= 4 — "+
+			"the extractor is reading the wrong text (pattern: %s)", len(matches), listingMediaCmdRe)
+	}
+
+	// Collect the distinct parent directories the README names. A path that is
+	// obviously a stand-in (`<file>`, `$ICON`) is not a promise to the reader.
+	dirs := map[string][]string{}
+	for _, m := range matches {
+		p := m[1]
+		if strings.ContainsAny(p, "<>$*") || filepath.IsAbs(p) {
+			continue
+		}
+		dir := filepath.Dir(filepath.Clean(p))
+		if dir == "." {
+			// The project root always exists; such a path makes no claim about
+			// the scaffold. Recorded rather than silently dropped so the count
+			// below stays honest.
+			continue
+		}
+		dirs[dir] = append(dirs[dir], p)
+	}
+	if len(dirs) == 0 {
+		t.Fatalf("every documented listing-media path resolved to the project root, so this guard checked nothing. "+
+			"Either the README stopped naming a directory (in which case the quickstart no longer shows authors where artwork lives), "+
+			"or the extractor is wrong. Paths seen: %v", matches)
+	}
+
+	var wantDirs []string
+	for d := range dirs {
+		wantDirs = append(wantDirs, d)
+	}
+	sort.Strings(wantDirs)
+
+	for _, tmpl := range scaffold.AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), "app")
+			if _, err := scaffold.Render(tmpl, dest, scaffold.Data{Slug: "app", Name: "App"}); err != nil {
+				t.Fatalf("scaffold %s: %v", tmpl, err)
+			}
+			for _, dir := range wantDirs {
+				info, err := os.Stat(filepath.Join(dest, filepath.FromSlash(dir)))
+				if err != nil || !info.IsDir() {
+					t.Errorf("README documents %v, but template %q scaffolds no %q directory — "+
+						"a reader who copies that command gets `Error: no such file` (exit 2). "+
+						"Either scaffold the directory or stop naming the path.",
+						dirs[dir], tmpl, dir)
+				}
+			}
+		})
+	}
+}
+
+// readmeSectionSlice returns the README text of the section anchored at slug,
+// raw (fences intact) so tables and sample output are visible to the caller.
+func readmeSectionSlice(t *testing.T, md, heading string) string {
+	t.Helper()
+	i := strings.Index(md, heading)
+	if i < 0 {
+		t.Fatalf("README.md has no %q heading — the listing-media requirements have nowhere to live", strings.TrimSpace(heading))
+	}
+	body := md[i+len(heading):]
+	// Bound at the next heading of the same or a higher level.
+	for _, next := range []string{"\n## ", "\n### "} {
+		if j := strings.Index(body, next); j >= 0 {
+			body = body[:j]
+		}
+	}
+	return body
+}
+
+// TestREADMEListingByteCapsMatchTheCLIConstants is a code↔prose drift guard.
+//
+// The dimension and aspect bounds in that section are PLATFORM constants the CLI
+// deliberately does not vendor (AGENTS.md item 25), so nothing here can check
+// them — they are guidance, and the server's rejection message is the authority.
+// The BYTE CAPS are different: those are this CLI's own local gate, so the
+// README quoting a number the binary does not enforce is a plain lie a test can
+// catch. That is the half that is checkable, so it is the half that is checked.
+func TestREADMEListingByteCapsMatchTheCLIConstants(t *testing.T) {
+	section := readmeSectionSlice(t, readREADME(t), "\n### Listing media requirements\n")
+
+	// Positive control on the extractor before reading anything out of it.
+	if len(section) < 500 {
+		t.Fatalf("the `Listing media requirements` section is only %d bytes — the section extractor is reading the wrong block:\n%s", len(section), section)
+	}
+
+	cases := []struct {
+		kind string
+		cap  int
+	}{
+		{"icon", maxIconBytes},
+		{"cover", maxCoverBytes},
+		{"screenshot", maxScreenshotBytes},
+	}
+	for _, tc := range cases {
+		row := ""
+		for _, line := range strings.Split(section, "\n") {
+			if strings.HasPrefix(line, "| **"+tc.kind+"**") && strings.Contains(line, "MiB") {
+				row = line
+				break
+			}
+		}
+		if row == "" {
+			t.Errorf("no `| **%s** | … MiB …` row in the Listing media requirements section — "+
+				"a reader cannot see the byte cap the CLI will reject their file with:\n%s", tc.kind, section)
+			continue
+		}
+		want := fmt.Sprintf("%d MiB", tc.cap/(1024*1024))
+		if !strings.Contains(row, want) {
+			t.Errorf("README says %q for %s, but the CLI enforces %s (%d bytes). "+
+				"The prose and the gate must agree — a reader sizing to the README should never be refused locally.",
+				strings.TrimSpace(row), tc.kind, want, tc.cap)
+		}
+	}
+
+	// The framing this section exists to establish: the dimension table is NOT a
+	// local check. Losing that sentence is how the next reader concludes the CLI
+	// is missing a validation and adds one.
+	for _, want := range []string{"server-side", "platform"} {
+		if !strings.Contains(section, want) {
+			t.Errorf("the Listing media requirements section never says %q — the dimension bounds then read as rules the CLI enforces", want)
+		}
+	}
+}

--- a/internal/cmd/listing_media_docs_test.go
+++ b/internal/cmd/listing_media_docs_test.go
@@ -102,6 +102,88 @@ func TestREADMEListingMediaPathsExistInEveryScaffoldedProject(t *testing.T) {
 	}
 }
 
+// TestListingMediaShortsQuoteTheirOwnCap covers the surface #274's cap guard
+// does not: `TestListingHelpQuotesTheEnforcedCaps` reads `c.Long` only, so a
+// Short could quote a cap the command does not enforce and stay green.
+//
+// The Shorts carry a cap because they replaced "a square-ish image" / "a
+// landscape hero image" (#270) — one-liners that stated a SHAPE the CLI does not
+// check while omitting the format and size it does. Both are built by
+// interpolating listingSourceRule(kind), so this asserts the interpolation picked
+// the right kind, which is exactly the copy-paste #274 caught in the Long bodies.
+//
+// Scoped to icon and cover on purpose: their caps DIFFER (2.0 MB vs 4.0 MB), so
+// "contains mine" and "does not contain the sibling's" are independent
+// assertions. add-screenshot's Short carries no cap, and its cap string is
+// byte-identical to the icon's today, so asserting on it would be #274's
+// declared equivalent mutant — a guard that cannot fail.
+func TestListingMediaShortsQuoteTheirOwnCap(t *testing.T) {
+	root := NewRootCmd()
+	listing, _, err := root.Find([]string{"app", "listing"})
+	if err != nil {
+		t.Fatalf("`app listing` is not in the command tree: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		kind    mediaKind
+		foreign mediaKind
+	}{
+		{"set-icon", kindIcon, kindCover},
+		{"set-cover", kindCover, kindIcon},
+	}
+	var checked int
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var short string
+			for _, c := range listing.Commands() {
+				if c.Name() == tc.name {
+					short = c.Short
+				}
+			}
+			if short == "" {
+				t.Fatalf("`app listing %s` is not registered (or has no Short) — a rename must "+
+					"update this test, not silently drop the row", tc.name)
+			}
+			checked++
+
+			mine := humanBytes(int64(kindByteCap(tc.kind)))
+			theirs := humanBytes(int64(kindByteCap(tc.foreign)))
+			if mine == theirs {
+				t.Fatalf("%s and %s render the same cap (%s), so this row cannot distinguish them — "+
+					"pick a differently-capped sibling", tc.kind, tc.foreign, mine)
+			}
+			if !strings.Contains(short, mine) {
+				t.Errorf("`app listing %s` Short (%q) does not quote the cap it enforces (%s) — "+
+					"the one-liner in `app listing --help` is the only thing many readers see",
+					tc.name, short, mine)
+			}
+			if strings.Contains(short, theirs) {
+				t.Errorf("`app listing %s` Short (%q) quotes %s, the %s cap — "+
+					"listingSourceRule was interpolated with the wrong kind",
+					tc.name, short, theirs, tc.foreign)
+			}
+			if !strings.Contains(short, listingImageFormats) {
+				t.Errorf("`app listing %s` Short (%q) does not state the accepted formats (%q)",
+					tc.name, short, listingImageFormats)
+			}
+			// The regression itself: a bare shape adjective, stated as though the
+			// CLI enforced it. Shape is the platform's and is attributed in Long.
+			for _, banned := range []string{"square-ish", "landscape hero"} {
+				if strings.Contains(short, banned) {
+					t.Errorf("`app listing %s` Short (%q) is back to describing a SHAPE the CLI does "+
+						"not check (%q). Shape is the platform's, validated at attach; the Short "+
+						"states what the CLI enforces locally. See AGENTS.md item 25.",
+						tc.name, short, banned)
+				}
+			}
+		})
+	}
+	if checked != 2 {
+		t.Fatalf("checked %d Shorts, want 2 — the command walk is wrong", checked)
+	}
+}
+
 // readmeSectionSlice returns the README text of the section anchored at slug,
 // raw (fences intact) so tables and sample output are visible to the caller.
 func readmeSectionSlice(t *testing.T, md, heading string) string {

--- a/internal/scaffold/assets_dir_test.go
+++ b/internal/scaffold/assets_dir_test.go
@@ -1,0 +1,109 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every template scaffolds an `assets/` directory for the store-listing media
+// (`civitai app listing set-icon|set-cover|add-screenshot`), holding a README of
+// the requirements and NOTHING ELSE.
+//
+// The directory exists because the README's quickstart names `./assets/icon.png`
+// and no template used to create the parent — the one copy-pasteable command in
+// that step exited 2 with `no such file` on a fresh scaffold (issue #270).
+//
+// 🔴 The EMPTINESS is the load-bearing half, and it is the half a future
+// "helpful" commit will undo. A placeholder icon.png passes the CLI's format +
+// byte check and the platform's aspect/dimension check and uploads cleanly — so
+// it can reach a PUBLIC store listing as a stub graphic. A missing file fails
+// loudly at `set-icon`, which is the moment the author can still fix it. See
+// AGENTS.md item 25.
+func TestEveryTemplateScaffoldsAssetsReadmeAndNoImages(t *testing.T) {
+	// imageExts is the "no placeholder" ledger: an image the platform would
+	// accept, plus the neighbours someone would reach for instead (svg/gif are
+	// rejected by the listing MIME allowlist, but scaffolding one is the same
+	// mistake). Extensions, not names, so `logo.png` is caught as well as
+	// `icon.png`.
+	imageExts := map[string]bool{
+		".png": true, ".jpg": true, ".jpeg": true, ".webp": true,
+		".gif": true, ".svg": true, ".avif": true, ".bmp": true, ".ico": true,
+	}
+
+	// Positive control: a template list that resolved to nothing would make
+	// every assertion below vacuous.
+	if len(AllTemplates()) < 3 {
+		t.Fatalf("AllTemplates() returned %d templates, want >= 3 — the walk below would prove almost nothing", len(AllTemplates()))
+	}
+
+	for _, tmpl := range AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), "app")
+			if _, err := Render(tmpl, dest, Data{Slug: "app", Name: "App"}); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+
+			assetsDir := filepath.Join(dest, "assets")
+			info, err := os.Stat(assetsDir)
+			if err != nil || !info.IsDir() {
+				t.Fatalf("template %q scaffolds no `assets/` directory (%v). "+
+					"The README quickstart tells authors to save an icon at ./assets/icon.png; without the directory, "+
+					"the documented `civitai app listing set-icon ./assets/icon.png` cannot work.", tmpl, err)
+			}
+
+			entries, err := os.ReadDir(assetsDir)
+			if err != nil {
+				t.Fatalf("read assets/: %v", err)
+			}
+			var names []string
+			for _, e := range entries {
+				names = append(names, e.Name())
+				if imageExts[strings.ToLower(filepath.Ext(e.Name()))] {
+					t.Errorf("template %q scaffolds an IMAGE at assets/%s. Never ship a placeholder icon or cover: "+
+						"it passes every format and byte check and uploads cleanly, so it can reach a public store listing as a stub. "+
+						"A missing file fails loudly at `civitai app listing set-icon`, which is the point. See AGENTS.md item 25.",
+						tmpl, e.Name())
+				}
+			}
+
+			readme := filepath.Join(assetsDir, "README.md")
+			b, err := os.ReadFile(readme)
+			if err != nil {
+				t.Fatalf("template %q has assets/ but no assets/README.md (entries: %v). "+
+					"An empty directory tells an author nothing about what belongs in it.", tmpl, names)
+			}
+			body := string(b)
+
+			// The requirement ledger. These are the platform's per-kind bounds
+			// (civitai/civitai src/server/schema/blocks/app-listing.schema.ts,
+			// validateListingImage) — an author who reads only this file must be
+			// able to size all three images from it. Asserted per template so the
+			// three copies cannot drift apart on the numbers while staying free to
+			// differ in prose.
+			for _, want := range []string{
+				"set-icon", "set-cover", "add-screenshot",
+				"0.9", "1.1", // icon aspect
+				"1.3", "2.4", // cover aspect
+				"0.4", "2.6", // screenshot aspect
+				"128", "640", "320", // per-kind minimum dimension
+				"2 MiB", "4 MiB", // the CLI's local byte caps
+			} {
+				if !strings.Contains(body, want) {
+					t.Errorf("template %q assets/README.md does not mention %q — an author sizing their artwork from this file would be missing a bound", tmpl, want)
+				}
+			}
+			// The framing, not just the numbers: these are checked server-side,
+			// and the file must say so rather than reading as a local rule.
+			if !strings.Contains(body, "platform") {
+				t.Errorf("template %q assets/README.md never attributes the dimension rules to the platform; "+
+					"unattributed numbers read as something the CLI enforces", tmpl)
+			}
+			if !strings.Contains(body, "no images") && !strings.Contains(body, "no placeholder") {
+				t.Errorf("template %q assets/README.md does not explain that the directory ships with no images on purpose; "+
+					"without that, the next contributor adds a placeholder", tmpl)
+			}
+		})
+	}
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -23,6 +23,9 @@ func TestRenderStatic(t *testing.T) {
 		".gitignore",
 		"README.md",
 		"app.js",
+		// The store-listing media directory: a README of the requirements and
+		// NO placeholder images (assets_dir_test.go pins both halves).
+		"assets/README.md",
 		"block.manifest.json",
 		// The vendored block -> host ready-ack emitter, copied verbatim from
 		// internal/blockproto (see ready_ack_contract_test.go).
@@ -53,6 +56,7 @@ func TestRenderPageVite(t *testing.T) {
 	for _, expect := range []string{
 		"block.manifest.json", "package.json", "vite.config.js", "index.html",
 		"src/main.jsx", "src/App.jsx", "src/index.css", "README.md", ".gitignore",
+		"assets/README.md",
 	} {
 		if !containsStr(got, expect) {
 			t.Errorf("page-vite missing expected file %q (got %v)", expect, got)
@@ -93,6 +97,7 @@ func TestRenderPageMoney(t *testing.T) {
 		"src/setup-dev-live.test.ts", "src/setup-plugin.test.ts",
 		"src/App.pollretry.test.tsx", "src/index.css",
 		"README.md", ".gitignore", ".env.development", ".env.production", ".env.example",
+		"assets/README.md",
 	} {
 		if !containsStr(got, expect) {
 			t.Errorf("page-money missing expected file %q (got %v)", expect, got)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -623,6 +623,19 @@ excludes build artifacts (`*.zip`) and dev-local / secret-bearing dotenv files
 `.env.production` (public `VITE_` origins only) ARE included — the production
 build reads `.env.production`.
 
+## Store-listing media (`assets/`)
+
+Your store listing **cannot publish without an icon and a cover**, and both are
+settable while the app is in review. `assets/` is scaffolded for them and ships
+with no images on purpose — see [`assets/README.md`](assets/README.md) for the
+size, format and aspect requirements, then:
+
+```bash
+civitai app listing set-icon  ./assets/icon.png
+civitai app listing set-cover ./assets/cover.png
+civitai app listing status
+```
+
 ## Submission lifecycle
 
 After `civitai app submit`, your publish request is `pending` review — a

--- a/internal/scaffold/templates/page-money/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/assets/README.md.tmpl
@@ -1,0 +1,54 @@
+# `assets/` — your store-listing media
+
+Nothing in here is served by your app. This directory holds the images your
+**store listing** needs, which you upload with `civitai app listing`:
+
+```bash
+civitai app listing set-icon       ./assets/icon.png
+civitai app listing set-cover      ./assets/cover.png
+civitai app listing add-screenshot ./assets/screenshot-1.png --caption "Grid view"
+civitai app listing status         # what is attached vs. what publishing still needs
+```
+
+An **icon and a cover are mandatory** before a listing can publish. Screenshots
+are optional (up to 8). You can attach all of it **while your app is in review**
+— it carries forward when a moderator approves the app.
+
+> **This directory ships with no images, on purpose.** A placeholder icon passes
+> every format and size check and uploads cleanly, which is how a stub graphic
+> ends up on a public store listing. A *missing* file fails loudly, at the one
+> moment you can still fix it.
+
+## What to put here
+
+| file | kind | aspect (w ÷ h) | minimum | source file |
+| --- | --- | --- | --- | --- |
+| `icon.png` | icon (1, required) | 0.9 – 1.1 (square-ish) | 128 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+| `cover.png` | cover (1, required) | 1.3 – 2.4 (~4:3 → ~21:9) | 640 px wide | png / jpeg / webp, ≤ 4 MiB |
+| `screenshot-1.png` … | screenshot (≤ 8, optional) | 0.4 – 2.6 (either orientation) | 320 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+
+Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
+
+## Who checks what
+
+The CLI checks the **format and the byte size** of the file you hand it, before
+anything is uploaded. It does **not** check dimensions or aspect ratio — those
+are validated by the platform when the image is attached, and the platform is
+the authority. A rejection names the bound and your value, e.g.:
+
+```text
+icon must be square-ish (aspect 2.00 outside 0.9–1.1)
+cover must be at least 640px wide (got 512px)
+```
+
+Two behaviours worth knowing:
+
+- **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
+  on the longer side (aspect preserved, never enlarged). So a large icon is
+  fine, but a **small** one stays small — the 128 px floor is real.
+- **Covers and screenshots are not rescaled.** What you upload is what the store
+  shows, so ship them at the size you want rendered.
+
+The numbers above are current platform guidance, not a contract this file can
+enforce. If one of them ever moves, the message you get back from an attach is
+the truth.

--- a/internal/scaffold/templates/page-money/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/assets/README.md.tmpl
@@ -51,7 +51,10 @@ Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
   on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real.
+  fine, but a **small** one stays small — the 128 px floor is real. The platform
+  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
+  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
+  and still be refused there. Flat artwork re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 

--- a/internal/scaffold/templates/page-money/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/assets/README.md.tmpl
@@ -14,6 +14,12 @@ An **icon and a cover are mandatory** before a listing can publish. Screenshots
 are optional (up to 8). You can attach all of it **while your app is in review**
 — it carries forward when a moderator approves the app.
 
+Listing media is uploaded by those commands, separately from your code. This
+directory is **not** excluded from `civitai app submit`, though, so whatever you
+leave here also rides along in the source bundle — measured at 37 files with an
+icon and a cover present. That is harmless at these sizes; just don't park a
+folder of rejects in here.
+
 > **This directory ships with no images, on purpose.** A placeholder icon passes
 > every format and size check and uploads cleanly, which is how a stub graphic
 > ends up on a public store listing. A *missing* file fails loudly, at the one

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -96,3 +96,16 @@ civitai app submit
 
 `submit` packages the SOURCE tree (manifest + src + build config), excluding
 `.git`, `node_modules`, and `dist` — the platform rebuilds from source.
+
+## Store-listing media (`assets/`)
+
+Your store listing **cannot publish without an icon and a cover**, and both are
+settable while the app is in review. `assets/` is scaffolded for them and ships
+with no images on purpose — see [`assets/README.md`](assets/README.md) for the
+size, format and aspect requirements, then:
+
+```bash
+civitai app listing set-icon  ./assets/icon.png
+civitai app listing set-cover ./assets/cover.png
+civitai app listing status
+```

--- a/internal/scaffold/templates/page-vite/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/assets/README.md.tmpl
@@ -1,0 +1,54 @@
+# `assets/` — your store-listing media
+
+Nothing in here is served by your app. This directory holds the images your
+**store listing** needs, which you upload with `civitai app listing`:
+
+```bash
+civitai app listing set-icon       ./assets/icon.png
+civitai app listing set-cover      ./assets/cover.png
+civitai app listing add-screenshot ./assets/screenshot-1.png --caption "Grid view"
+civitai app listing status         # what is attached vs. what publishing still needs
+```
+
+An **icon and a cover are mandatory** before a listing can publish. Screenshots
+are optional (up to 8). You can attach all of it **while your app is in review**
+— it carries forward when a moderator approves the app.
+
+> **This directory ships with no images, on purpose.** A placeholder icon passes
+> every format and size check and uploads cleanly, which is how a stub graphic
+> ends up on a public store listing. A *missing* file fails loudly, at the one
+> moment you can still fix it.
+
+## What to put here
+
+| file | kind | aspect (w ÷ h) | minimum | source file |
+| --- | --- | --- | --- | --- |
+| `icon.png` | icon (1, required) | 0.9 – 1.1 (square-ish) | 128 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+| `cover.png` | cover (1, required) | 1.3 – 2.4 (~4:3 → ~21:9) | 640 px wide | png / jpeg / webp, ≤ 4 MiB |
+| `screenshot-1.png` … | screenshot (≤ 8, optional) | 0.4 – 2.6 (either orientation) | 320 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+
+Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
+
+## Who checks what
+
+The CLI checks the **format and the byte size** of the file you hand it, before
+anything is uploaded. It does **not** check dimensions or aspect ratio — those
+are validated by the platform when the image is attached, and the platform is
+the authority. A rejection names the bound and your value, e.g.:
+
+```text
+icon must be square-ish (aspect 2.00 outside 0.9–1.1)
+cover must be at least 640px wide (got 512px)
+```
+
+Two behaviours worth knowing:
+
+- **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
+  on the longer side (aspect preserved, never enlarged). So a large icon is
+  fine, but a **small** one stays small — the 128 px floor is real.
+- **Covers and screenshots are not rescaled.** What you upload is what the store
+  shows, so ship them at the size you want rendered.
+
+The numbers above are current platform guidance, not a contract this file can
+enforce. If one of them ever moves, the message you get back from an attach is
+the truth.

--- a/internal/scaffold/templates/page-vite/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/assets/README.md.tmpl
@@ -51,7 +51,10 @@ Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
   on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real.
+  fine, but a **small** one stays small — the 128 px floor is real. The platform
+  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
+  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
+  and still be refused there. Flat artwork re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 

--- a/internal/scaffold/templates/page-vite/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/assets/README.md.tmpl
@@ -14,6 +14,12 @@ An **icon and a cover are mandatory** before a listing can publish. Screenshots
 are optional (up to 8). You can attach all of it **while your app is in review**
 — it carries forward when a moderator approves the app.
 
+Listing media is uploaded by those commands, separately from your code. This
+directory is **not** excluded from `civitai app submit`, though, so whatever you
+leave here also rides along in the source bundle — measured at 37 files with an
+icon and a cover present. That is harmless at these sizes; just don't park a
+folder of rejects in here.
+
 > **This directory ships with no images, on purpose.** A placeholder icon passes
 > every format and size check and uploads cleanly, which is how a stub graphic
 > ends up on a public store listing. A *missing* file fails loudly, at the one

--- a/internal/scaffold/templates/static/README.md.tmpl
+++ b/internal/scaffold/templates/static/README.md.tmpl
@@ -77,3 +77,16 @@ civitai app submit
 
 `submit` packages this directory (excluding `.git`, `node_modules`, `dist`) and
 submits it for moderator review.
+
+## Store-listing media (`assets/`)
+
+Your store listing **cannot publish without an icon and a cover**, and both are
+settable while the app is in review. `assets/` is scaffolded for them and ships
+with no images on purpose — see [`assets/README.md`](assets/README.md) for the
+size, format and aspect requirements, then:
+
+```bash
+civitai app listing set-icon  ./assets/icon.png
+civitai app listing set-cover ./assets/cover.png
+civitai app listing status
+```

--- a/internal/scaffold/templates/static/assets/README.md.tmpl
+++ b/internal/scaffold/templates/static/assets/README.md.tmpl
@@ -1,0 +1,54 @@
+# `assets/` — your store-listing media
+
+Nothing in here is served by your app. This directory holds the images your
+**store listing** needs, which you upload with `civitai app listing`:
+
+```bash
+civitai app listing set-icon       ./assets/icon.png
+civitai app listing set-cover      ./assets/cover.png
+civitai app listing add-screenshot ./assets/screenshot-1.png --caption "Grid view"
+civitai app listing status         # what is attached vs. what publishing still needs
+```
+
+An **icon and a cover are mandatory** before a listing can publish. Screenshots
+are optional (up to 8). You can attach all of it **while your app is in review**
+— it carries forward when a moderator approves the app.
+
+> **This directory ships with no images, on purpose.** A placeholder icon passes
+> every format and size check and uploads cleanly, which is how a stub graphic
+> ends up on a public store listing. A *missing* file fails loudly, at the one
+> moment you can still fix it.
+
+## What to put here
+
+| file | kind | aspect (w ÷ h) | minimum | source file |
+| --- | --- | --- | --- | --- |
+| `icon.png` | icon (1, required) | 0.9 – 1.1 (square-ish) | 128 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+| `cover.png` | cover (1, required) | 1.3 – 2.4 (~4:3 → ~21:9) | 640 px wide | png / jpeg / webp, ≤ 4 MiB |
+| `screenshot-1.png` … | screenshot (≤ 8, optional) | 0.4 – 2.6 (either orientation) | 320 px on the shorter side | png / jpeg / webp, ≤ 2 MiB |
+
+Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
+
+## Who checks what
+
+The CLI checks the **format and the byte size** of the file you hand it, before
+anything is uploaded. It does **not** check dimensions or aspect ratio — those
+are validated by the platform when the image is attached, and the platform is
+the authority. A rejection names the bound and your value, e.g.:
+
+```text
+icon must be square-ish (aspect 2.00 outside 0.9–1.1)
+cover must be at least 640px wide (got 512px)
+```
+
+Two behaviours worth knowing:
+
+- **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
+  on the longer side (aspect preserved, never enlarged). So a large icon is
+  fine, but a **small** one stays small — the 128 px floor is real.
+- **Covers and screenshots are not rescaled.** What you upload is what the store
+  shows, so ship them at the size you want rendered.
+
+The numbers above are current platform guidance, not a contract this file can
+enforce. If one of them ever moves, the message you get back from an attach is
+the truth.

--- a/internal/scaffold/templates/static/assets/README.md.tmpl
+++ b/internal/scaffold/templates/static/assets/README.md.tmpl
@@ -51,7 +51,10 @@ Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
   on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real.
+  fine, but a **small** one stays small — the 128 px floor is real. The platform
+  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
+  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
+  and still be refused there. Flat artwork re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 

--- a/internal/scaffold/templates/static/assets/README.md.tmpl
+++ b/internal/scaffold/templates/static/assets/README.md.tmpl
@@ -14,6 +14,12 @@ An **icon and a cover are mandatory** before a listing can publish. Screenshots
 are optional (up to 8). You can attach all of it **while your app is in review**
 — it carries forward when a moderator approves the app.
 
+Listing media is uploaded by those commands, separately from your code. This
+directory is **not** excluded from `civitai app submit`, though, so whatever you
+leave here also rides along in the source bundle — measured at 37 files with an
+icon and a cover present. That is harmless at these sizes; just don't park a
+folder of rejects in here.
+
 > **This directory ships with no images, on purpose.** A placeholder icon passes
 > every format and size check and uploads cleanly, which is how a stub graphic
 > ends up on a public store listing. A *missing* file fails loudly, at the one


### PR DESCRIPTION
Closes the CLI-side half of #270: the documentation and the `assets/` scaffold. The attach-order reorder is a separate lane and is not in here.

## The issue's premise was half wrong, and this PR follows the corrected version

The issue says the platform's dimension requirements "are not published". They are — they are named constants in `civitai/civitai` `src/server/schema/blocks/app-listing.schema.ts`, enforced server-side at **attach** by `validateListingImage`, with rejection messages that name the bound and the measured value. Re-read for this PR and **byte-identical on `main` and `release`**, so these are what an author hits today:

| kind | aspect (w ÷ h) | minimum | maximum | byte cap | formats |
|---|---|---|---|---|---|
| icon | 0.9 – 1.1 | 128px shorter side | 4096px longer side | 1 MiB | png / jpeg / webp |
| cover | 1.3 – 2.4 | 640px wide | — | 4 MiB | png / jpeg / webp |
| screenshot | 0.4 – 2.6 | 320px shorter side | — | 2 MiB, ≤8 per listing | png / jpeg / webp |

**One correction to those numbers, because they cannot go in the docs as written.** The icon's 1 MiB (`MAX_LISTING_ICON_SIZE_BYTES`) and the CLI's 2 MiB (`maxIconBytes`) measure *different bytes*, and conflating them would have documented a cap that does not apply to the author's file. The icon rides the inline data-URI path: the server decodes it, downscales to ≤1024px and **re-encodes to PNG**, then stores `metadata.size = png.byteLength` (`listing-meta.service.ts`) — and *that* is what `validateListingImage` compares against 1 MiB. The CLI's 2 MiB is the source file, mirroring `INLINE_ICON_MAX_DECODED_BYTES`. Cover and screenshot take the full-res path where the CLI sends `sizeBytes: len(data)`, so there the two caps do describe the same bytes. The README documents the CLI's caps for the file you pass, and the aspect/dimension table separately as server-side. AGENTS.md item 25 records why.

## What changed

- **`assets/` is scaffolded by all three templates**, with a README of the requirements and **no placeholder images**. A placeholder passes format + byte validation and uploads cleanly — that is how a stub icon reaches a public listing, whereas a missing file fails loudly at the one step that can still fix it.
- **README**: new TOC-linked **Listing media requirements** section, splitting what the CLI enforces locally (format + byte cap) from what the platform enforces at attach (aspect + minimum dimension), plus the icon rescale, the "covers/screenshots are not rescaled" fact, and the ~16 MP source that fails with the unhelpful *"That icon couldn't be read"*. "square-ish" / "landscape hero" are gone from every doc surface. The quickstart's step 7 now says the artwork is yours to supply, and `./shot.png` became `./assets/screenshot-1.png`.
- **AGENTS.md item 25** — these bounds stay prose. Stale *guidance* costs one round-trip carrying the server's current bound; a stale local *gate* refuses valid images and cannot be argued with. Please don't promote the table into `internal/cmd` or `internal/validate`.
- Template READMEs get a short **Store-listing media** section pointing at `assets/README.md`.

## Verification

**Executed the quickstart rather than reading it**, with the binary built from this branch:

```
$ civitai app create my-app          # → 36 files, page-money
$ ls my-app/assets/                  # → README.md  (and no images — the point)
$ civitai app listing set-icon ./assets/icon.png
Error: no such file: ./assets/icon.png      ← exit 2, the loud failure we want
```

Then, after saving a real 512×512 icon as `assets/README.md` instructs, the same command clears every local check and reaches the network (run against an offline base URL so nothing touched prod):

```
Error: Get "http://127.0.0.1:1/api/v1/blocks/submissions?blockId=my-app": dial tcp: connection refused
```

On `origin/main` (1eb4095) that same command exited **2** with `no such file` on a fresh scaffold of *all three* templates — that is the bug, reproduced and then removed. Positive controls on the local gate, which is what the README now claims it does: a non-image gets `unrecognized image (want png, jpeg, or webp)`, and a 2.9 MB icon gets `larger than the 2.0 MB max for a icon`.

**Red/green matrix** for the new guards — red at `origin/main` (1eb4095) with the test files copied into a clean worktree of that ref, green at HEAD:

| | origin/main | HEAD |
|---|---|---|
| new + touched tests | 12 RUN / **0 PASS / 12 FAIL** | 12 RUN / 12 PASS / 0 FAIL |
| full suite | — | 2719 RUN / **2715 PASS / 0 FAIL** / 4 SKIP |

The 4 skips are pre-existing environment-gated guards (`CIVITAI_ANTIPATTERN_SCAN_DIR`, `CIVITAI_CHECK_SUBMISSIONS_CAP`, `CIVITAI_CHECK_PUBLISHED_PINS`, `CIVITAI_CHECK_SCAFFOLD_RUNTIME`). No timeout panics.

**Mutation-verified**, each mutant killed by *its own* message, not a neighbour's:

| mutation | failure |
|---|---|
| plant `assets/icon.png` in a template | `template "page-vite" scaffolds an IMAGE at assets/icon.png` |
| README icon cap 2 MiB → 3 MiB | `README says "…≤ 3 MiB…" for icon, but the CLI enforces 2 MiB` |
| rename `assets/README.md.tmpl` away | `has assets/ but no assets/README.md (entries: [NOTES.txt])` |
| drop "server-side" from the README section | `the Listing media requirements section never says "server-side"` |
| drop "no images, on purpose" from a template README | `does not explain that the directory ships with no images on purpose` |

The one direction I did **not** mutate is changing `maxIconBytes` itself, because that lives in `internal/cmd/app_listing.go`, which another lane is editing. The guard derives its expectation from the constant, so both directions diverge by construction, but only the README side is empirically demonstrated.

Other gates: `gofmt -s -l .` clean, `go vet ./...` clean, **golangci-lint v2.12.2** (the exact CI pin, run from nixpkgs) → **0 issues**, and the offline half of `scaffold-currency` reproduced locally (`app init --template page-money` → `TestScanDirFromEnv` → *no anti-patterns found*). The npm halves of `scaffold-currency` / `template-page-vite` / `template-page-money` are untouched by adding one markdown file.

## One thing I found and did not fix

> **Update (rebase onto `4d22bda`):** item 1 below is **DONE** — #273 merged, so the `--help` wording landed in this PR as `4f7875b`. See the rebase comment for the before/after, the help-body headroom numbers, and the re-measured red/green matrix at the new base. Item 2 remains open.

### ~~1. The deferred `--help` wording~~ — done in `4f7875b`

1. **`internal/cmd/app_listing.go` still says "a square-ish image"** in `set-icon --help` (and "a landscape hero image" in `set-cover`). Deliberately left alone — another lane holds that file for the attach-order reorder. **Follow-up owed once it merges:** replace both `Short` strings with what the CLI actually enforces plus a pointer to the README section, so `--help` stops being the last surface repeating the phrase this PR removed everywhere else.
2. **`humanBytes` labels MiB values as MB** — the CLI prints `2.0 MB` for `2*1024*1024`. The README's "2 MiB" is the correct label. Cosmetic, and the fix belongs in `download.go`, which is shared with the download UI, so it is not smuggled in here.

Also worth knowing: `assets/` is **not** excluded from `civitai app submit`, so whatever an author leaves there ships in the source bundle (measured: 37 files with an icon and cover present). Left that way on purpose — a `static` app may legitimately serve images from `assets/` — and stated in `assets/README.md` rather than silently changing packaging.

Refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

