### PR TITLE
docs(cmd): give the public read-API commands real --help bodies

### DIFF
--- a/internal/cmd/articles.go
+++ b/internal/cmd/articles.go
@@ -52,20 +52,22 @@ func newArticlesSearchCmd() *cobra.Command {
 		Short: "Search articles (GET /api/v1/articles)",
 		Long: `Search articles via GET /api/v1/articles.
 
-Filters: --query (matches the TITLE, not the body), --tags, --username, --nsfw
-and --sort.
-` + serverOwnedEnumNote + `
---tags takes numeric tag IDS, comma-separated (e.g. --tags 5,12), not tag
-names — and ` + "`civitai tags search`" + ` renders names, not ids, so it cannot
+Filters: --query (matches the TITLE, not the body), --tags, --username and
+--nsfw. --tags takes numeric tag IDS, comma-separated (e.g. --tags 5,12), not
+tag names — and ` + "`civitai tags search`" + ` renders names, not ids, so it cannot
 supply this filter for you.
+
+--sort takes a server-owned value set.
+` + serverOwnedEnumNote + `
 
 Paging is cursor-only: the article feed is a keyset feed, so there is no --page
 here. ` + limitRule(articlesLimitMax) + `.
 The next cursor is printed under the results; pass it back via --cursor.
 
-The REACTIONS column is likes plus favourites. ` + "`articles get <id>`" + ` breaks
-those out and adds views and collected counts, and --content renders the guide
-itself.
+The REACTIONS column is likes plus favourites, from the list endpoint's own
+stats. ` + "`articles get <id>`" + ` reports all-time view / like / favourite /
+comment / collected counts instead — a different stats block, so the two need
+not agree — and --content renders the guide itself.
 
 ` + readAnonShort,
 		Example: `  civitai articles search --query "comfyui" --limit 5
@@ -109,7 +111,7 @@ itself.
 	cmd.Flags().StringVar(&username, "username", "", "filter by author username")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (Newest, \"Recently Updated\", \"Most Reactions\", \"Most Comments\", \"Most Bookmarks\", \"Most Collected\")")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(articlesLimitMax))
 	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
 	bindReadFlags(cmd)
 	return cmd

--- a/internal/cmd/articles.go
+++ b/internal/cmd/articles.go
@@ -18,11 +18,23 @@ func newArticlesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "articles",
 		Short: "Search and inspect articles on Civitai",
-		Long: `Read-only access to Civitai articles via the public REST API
-(GET /api/v1/articles). These endpoints are public and work anonymously; if you
-are logged in (civitai login) your token is sent automatically.`,
+		Long: `Read-only access to Civitai articles through the public REST API
+(GET /api/v1/articles, GET /api/v1/articles/{id}).
+
+` + readAnonNote + `
+
+Articles are the site's long-form guides. ` + "`articles search`" + ` finds them;
+` + "`articles get <id> --content`" + ` renders the BODY as readable text/markdown —
+headings, paragraphs, lists, links and code blocks, with the HTML stripped and
+entities decoded — so a guide is readable in the terminal without a browser.
+
+--json returns the raw API body, including the UNTOUCHED HTML content, and
+takes precedence over --content.
+
+` + readJSONNote,
 		Example: `  civitai articles search --query "workflow" --limit 5
-  civitai articles get 1234`,
+  civitai articles get 1234
+  civitai articles get 1234 --content`,
 	}
 	cmd.AddCommand(newArticlesSearchCmd())
 	cmd.AddCommand(newArticlesGetCmd())
@@ -40,11 +52,25 @@ func newArticlesSearchCmd() *cobra.Command {
 		Short: "Search articles (GET /api/v1/articles)",
 		Long: `Search articles via GET /api/v1/articles.
 
-Pagination is cursor-based (the article feed uses a keyset cursor — there is no
---page). The next cursor is printed after the results; pass it back via --cursor.`,
+Filters: --query (matches the TITLE, not the body), --tags, --username, --nsfw
+and --sort.
+` + serverOwnedEnumNote + `
+--tags takes numeric tag IDS, comma-separated (e.g. --tags 5,12), not tag
+names — and ` + "`civitai tags search`" + ` renders names, not ids, so it cannot
+supply this filter for you.
+
+Paging is cursor-only: the article feed is a keyset feed, so there is no --page
+here. ` + limitRule(articlesLimitMax) + `.
+The next cursor is printed under the results; pass it back via --cursor.
+
+The REACTIONS column is likes plus favourites. ` + "`articles get <id>`" + ` breaks
+those out and adds views and collected counts, and --content renders the guide
+itself.
+
+` + readAnonShort,
 		Example: `  civitai articles search --query "comfyui" --limit 5
   civitai articles search --sort "Most Reactions" --nsfw
-  civitai articles search --username some-creator --cursor <cursor>`,
+  civitai articles search --username some-creator --cursor '<cursor>'`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkLimit(limit, articlesLimitMax); err != nil {
@@ -100,7 +126,9 @@ By default it prints the article's metadata (title, author, stats, tags). Pass
 --content to also render the article BODY — the actual guide — as readable plain
 text / lightweight markdown (headings, paragraphs, lists, links, code blocks;
 HTML tags stripped and entities decoded). --json returns the raw API body
-(including the untouched HTML content) and takes precedence over --content.`,
+(including the untouched HTML content) and takes precedence over --content.
+
+` + readAnonShort,
 		Example: `  civitai articles get 1234
   civitai articles get 1234 --content
   civitai articles get 1234 --json`,

--- a/internal/cmd/collections.go
+++ b/internal/cmd/collections.go
@@ -118,7 +118,7 @@ next-page hint; deep paging requires --sort Newest.
 	cmd.Flags().StringVar(&query, "query", "", "text search query (matches the collection name)")
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (Newest, \"Most Followers\")")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(collectionsLimitMax))
 	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response (Newest sort only)")
 	bindReadFlags(cmd)
 	return cmd

--- a/internal/cmd/collections.go
+++ b/internal/cmd/collections.go
@@ -18,12 +18,26 @@ func newCollectionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collections",
 		Short: "Search and inspect collections on Civitai",
-		Long: `Read-only access to Civitai collections via the public REST API
-(GET /api/v1/collections). These endpoints are public and work anonymously; if
-you are logged in (civitai login) your token is sent automatically. Only public
-collections are discoverable.`,
+		Long: `Read-only access to Civitai collections through the public REST API
+(GET /api/v1/collections, GET /api/v1/collections/{id}).
+
+` + readAnonNote + `
+
+Only PUBLIC collections are discoverable. Logging in does not widen this
+surface to your own private collections, and there is no create, edit or
+add-to-collection path in the CLI — this group is read-only.
+
+` + "`collections search`" + ` finds collections by name; ` + "`collections get <id>`" + `
+shows one collection's owner, type, read permission, description and tags.
+
+Neither command pages through a collection's CONTENTS: the public route
+answers with collection metadata (` + "`search`" + ` adds an item COUNT), not with the
+models or images inside.
+
+` + readJSONNote,
 		Example: `  civitai collections search --query "favorites" --limit 5
-  civitai collections get 1234`,
+  civitai collections get 1234
+  civitai collections get 1234 --json`,
 	}
 	cmd.AddCommand(newCollectionsSearchCmd())
 	cmd.AddCommand(newCollectionsGetCmd())
@@ -41,14 +55,17 @@ func newCollectionsSearchCmd() *cobra.Command {
 		Short: "Search collections (GET /api/v1/collections)",
 		Long: `Search public collections via GET /api/v1/collections.
 
-Pagination is cursor-based (a keyset cursor on the collection id — there is no
---page). The next cursor is printed after the results; pass it back via --cursor.
+Paging is cursor-only: a keyset cursor on the collection id, so there is
+no --page here. ` + limitRule(collectionsLimitMax) + `.
+The next cursor is printed under the results; pass it back via --cursor.
 
 Cursor paging is only supported for the default (Newest) sort. This is a server
 constraint: for any other --sort (e.g. "Most Followers") the API returns a
 nextCursor that it then rejects — a dead cursor that yields no further pages. So
 for a non-Newest sort the CLI shows the first page only and does NOT print a
-next-page hint; deep paging requires --sort Newest.`,
+next-page hint; deep paging requires --sort Newest.
+
+` + readAnonShort,
 		Example: `  civitai collections search --query "anime" --limit 5
   civitai collections search --sort Newest --cursor <cursor>`,
 		Args: cobra.NoArgs,
@@ -111,6 +128,20 @@ func newCollectionsGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
 		Short: "Get a collection by id (GET /api/v1/collections/{id})",
+		Long: `Get one collection by id: GET /api/v1/collections/{id}.
+
+The id is the number in a civitai.com/collections/<id> URL. A non-integer or
+non-positive argument is refused locally, as a usage mistake, before any
+request is made.
+
+Prints the collection's name, owner, type, read permission, public flag,
+description (truncated) and tags. Only PUBLIC collections are readable here.
+
+Two differences from the ` + "`search`" + ` row for the same collection, both of them
+the API's shape rather than the CLI's: the detail body drops the item COUNT and
+adds the TAGS. Neither shape lists the collection's items.
+
+` + readAnonShort,
 		Example: `  civitai collections get 1234
   civitai collections get 1234 --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cmd/creators.go
+++ b/internal/cmd/creators.go
@@ -16,9 +16,22 @@ func newCreatorsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "creators",
 		Short: "Search creators on Civitai",
-		Long: `Read-only access to Civitai creators via the public REST API
-(GET /api/v1/creators). Works anonymously.`,
-		Example: `  civitai creators search --query artist --limit 10`,
+		Long: `Read-only access to Civitai creators through the public REST API
+(GET /api/v1/creators).
+
+` + readAnonNote + `
+
+A creator row is a USERNAME, a published-model COUNT and a LINK. The group is
+search-only: the public API has no per-creator profile route, so there is no
+` + "`creators get`" + ` to add.
+
+The follow-up is ` + "`civitai models search --username <name>`" + `, which is what
+actually lists a creator's models. Use ` + "`civitai users get <name>`" + ` if you want
+the user record (id, avatar) behind the name.
+
+` + readJSONNote,
+		Example: `  civitai creators search --query artist --limit 10
+  civitai creators search --query artist --json`,
 	}
 	cmd.AddCommand(newCreatorsSearchCmd())
 	return cmd
@@ -30,10 +43,25 @@ func newCreatorsSearchCmd() *cobra.Command {
 		limit, page int
 	)
 	cmd := &cobra.Command{
-		Use:     "search",
-		Short:   "Search creators (GET /api/v1/creators)",
-		Example: `  civitai creators search --query artist --limit 10`,
-		Args:    cobra.NoArgs,
+		Use:   "search",
+		Short: "Search creators (GET /api/v1/creators)",
+		Long: `Search creators via GET /api/v1/creators.
+
+--query matches the username; omit it to page the whole creator list.
+` + limitRule(creatorsLimitMax) + `.
+
+Paging is --page only. This endpoint answers with the classic page envelope
+(total items, current page, total pages) and no cursor, so there is no --cursor
+here; the footer prints the next --page for you.
+
+Each row is USERNAME, MODELS (that creator's published model count) and LINK
+(the equivalent models query on the website). To list the models themselves,
+run ` + "`civitai models search --username <name>`" + `.
+
+` + readAnonShort,
+		Example: `  civitai creators search --query artist --limit 10
+  civitai creators search --limit 50 --page 2`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkLimit(limit, creatorsLimitMax); err != nil {
 				return err

--- a/internal/cmd/creators.go
+++ b/internal/cmd/creators.go
@@ -52,7 +52,7 @@ func newCreatorsSearchCmd() *cobra.Command {
 
 Paging is --page only. This endpoint answers with the classic page envelope
 (total items, current page, total pages) and no cursor, so there is no --cursor
-here; the footer prints the next --page for you.
+here. The footer prints the next --page while the response says there is one.
 
 Each row is USERNAME, MODELS (that creator's published model count) and LINK
 (the equivalent models query on the website). To list the models themselves,
@@ -89,7 +89,7 @@ run ` + "`civitai models search --username <name>`" + `.
 		},
 	}
 	cmd.Flags().StringVar(&query, "query", "", "text search query")
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(creatorsLimitMax))
 	cmd.Flags().IntVar(&page, "page", 0, "page number")
 	bindReadFlags(cmd)
 	return cmd

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -62,11 +62,13 @@ func newImagesSearchCmd() *cobra.Command {
 		Short: "Search images (GET /api/v1/images)",
 		Long: `Search images via GET /api/v1/images.
 
-Filters: --model-id, --model-version-id, --post-id, --username, --base-model
-(repeatable — the API ORs the values), --type, --nsfw, --sort and --period.
+Filters: --model-id, --model-version-id, --post-id, --username, --nsfw and
+--base-model (repeatable — the API ORs the values). --base-model is matched
+LITERALLY, so a misspelling returns zero results rather than an error; the CLI
+says so on stderr.
+
+--type, --sort and --period take server-owned value sets.
 ` + serverOwnedEnumNote + `
---base-model is matched LITERALLY, so a misspelling returns zero results rather
-than an error; the CLI prints a stderr note when that happens.
 
 --sort is IGNORED when --model-id is set — the API returns that model's images
 in its own order whatever you ask, so the CLI notes it on stderr rather than
@@ -77,10 +79,7 @@ list, rendered as a per-image block instead of the table (a table cannot hold a
 prompt). With --json it adds the raw meta object to every item.
 
 Paging: ` + limitRule(imagesLimitMax) + `.
---page is shallow paging, --cursor is deep paging, and the next cursor is
-printed under the results. The API caps page × limit at 1000 and answers 429
-past it — the CLI reports that cap as a usage mistake, not a rate limit, so a
-retry loop does not spin on it.
+` + deepPagingNote + `
 
 ` + readAnonShort,
 		Example: `  civitai images search --limit 5
@@ -162,7 +161,7 @@ retry loop does not spin on it.
 			return nil
 		},
 	}
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-200)")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(imagesLimitMax))
 	cmd.Flags().IntVar(&page, "page", 0, "page number (shallow paging; prefer --cursor)")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
 	cmd.Flags().IntVar(&postID, "post-id", 0, "filter by post id")

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -20,8 +20,25 @@ func newImagesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "images",
 		Short: "Search images on Civitai",
-		Long: `Read-only access to Civitai images via the public REST API
-(GET /api/v1/images). Works anonymously.`,
+		Long: `Read-only access to Civitai images through the public REST API
+(GET /api/v1/images). Videos and audio posts ride the same route — pick one
+with --type image|video|audio.
+
+` + readAnonNote + `
+
+` + "`images search`" + ` is the feed; ` + "`images get <id>`" + ` is one image, by the id in
+a civitai.com/images/<id> URL.
+
+Both can render the GENERATION METADATA — prompt, negative prompt, sampler,
+cfg, steps, seed, and the resources "recipe" of checkpoint plus LoRAs — which
+is what makes this a reproduction tool rather than a gallery. ` + "`search`" + ` omits
+it unless you pass --meta, matching the API (which leaves meta out by default
+to keep pages small); ` + "`get`" + ` always asks for it.
+
+An uploader can hide their generation data. Those images print
+"meta: (hidden by uploader)" rather than failing.
+
+` + readJSONNote,
 		Example: `  civitai images search --limit 5
   civitai images search --model-id 4384 --period Month
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
@@ -45,8 +62,27 @@ func newImagesSearchCmd() *cobra.Command {
 		Short: "Search images (GET /api/v1/images)",
 		Long: `Search images via GET /api/v1/images.
 
-Pagination: use --page for shallow paging or --cursor for deep paging (the API
-caps page*limit at 1000). The next cursor is printed after the results.`,
+Filters: --model-id, --model-version-id, --post-id, --username, --base-model
+(repeatable — the API ORs the values), --type, --nsfw, --sort and --period.
+` + serverOwnedEnumNote + `
+--base-model is matched LITERALLY, so a misspelling returns zero results rather
+than an error; the CLI prints a stderr note when that happens.
+
+--sort is IGNORED when --model-id is set — the API returns that model's images
+in its own order whatever you ask, so the CLI notes it on stderr rather than
+let you believe the sort took. --model-version-id does honour --sort.
+
+--meta adds each image's prompt, sampler, cfg, steps, seed, model and resource
+list, rendered as a per-image block instead of the table (a table cannot hold a
+prompt). With --json it adds the raw meta object to every item.
+
+Paging: ` + limitRule(imagesLimitMax) + `.
+--page is shallow paging, --cursor is deep paging, and the next cursor is
+printed under the results. The API caps page × limit at 1000 and answers 429
+past it — the CLI reports that cap as a usage mistake, not a rate limit, so a
+retry loop does not spin on it.
+
+` + readAnonShort,
 		Example: `  civitai images search --limit 5
   civitai images search --model-version-id 128713 --sort Newest
   civitai images search --base-model "Krea 2" --sort "Most Reactions" --period Week
@@ -147,10 +183,24 @@ func newImagesGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
 		Short: "Get a single image by id (GET /api/v1/images?imageId=<id>)",
-		Long: `Fetch one image by its numeric id — the id in a civitai.com/images/<id>
-URL — and render its generation metadata (prompt, settings, resources), the same
-detail block as ` + "`images search --meta`" + `. Generation metadata is requested
-implicitly.`,
+		Long: `Fetch one image by its numeric id — the id in a civitai.com/images/<id> URL —
+and render its generation metadata: prompt, negative prompt, sampler, cfg,
+steps, seed, and the resources recipe (checkpoint plus LoRAs, with weights and
+hashes). Metadata is requested implicitly, so this is the same detail block
+` + "`images search --meta`" + ` prints.
+
+There is no per-id REST route. This is GET /api/v1/images?imageId=<id> — the
+search endpoint keyed to a single id — which is why ` + "`--json`" + ` hands back a
+one-item search envelope rather than a bare image object.
+
+The id is validated locally: a non-integer, non-positive, or beyond-32-bit
+value is refused as a usage mistake before any request, so an oversized id
+comes back as a clear refusal instead of a server error.
+
+A resource line falls back to meta.hashes when the generator inlined no hash;
+those hashes are exactly what ` + "`model-versions by-hash`" + ` resolves.
+
+` + readAnonShort,
 		Example: `  civitai images get 136456589
   civitai images get 136456589 --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -59,10 +59,11 @@ The output carries the base model, the trigger words, the AIR identifier and
 every file with its size and type. A version whose primary file is not model
 weights is tagged with that type ([Archive], [Training Data], [Other]).
 
-What a version does NOT carry is model-level data: .model is only
-{name, type, nsfw, poi} — no creator, no model download count. If you started
-from a version and need those, read them from ` + "`models get`" + ` /
-` + "`models search`" + ` and join on the version's .modelId.
+What a version does NOT carry is model-level data. Its .model is a stub — the
+CLI reads a name, a type and an nsfw flag out of it — and there is no creator
+and no model-level download count on this response at all. If you started from
+a version and need those, read them from ` + "`models get`" + ` / ` + "`models search`" + `
+and join on the version's .modelId.
 
 ` + readAnonShort,
 		Example: `  civitai model-versions get 128713

--- a/internal/cmd/model_versions.go
+++ b/internal/cmd/model_versions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/civitai/cli/pkg/civitai"
@@ -16,11 +17,29 @@ func newModelVersionsCmd() *cobra.Command {
 		Use:     "model-versions",
 		Short:   "Inspect model versions on Civitai",
 		Aliases: []string{"model-version", "mv"},
-		Long: `Read-only access to Civitai model versions via the public REST API. Look up a
-version by its id or by a file hash (AutoV2, SHA256, …). Works anonymously.`,
 		Example: `  civitai model-versions get 128713
+  civitai mv get 128713 --json
   civitai model-versions by-hash 5D8D26E2A6`,
 	}
+	// The alias list is rendered FROM cmd.Aliases rather than retyped, so a
+	// dropped or added alias cannot leave the help advertising a spelling the
+	// tree no longer answers to. TestReadAPIHelpNamesItsAliases pins it.
+	cmd.Long = `Read-only access to Civitai model versions through the public REST API
+(GET /api/v1/model-versions/{id} and .../by-hash/{hash}).
+Aliases: ` + strings.Join(cmd.Aliases, ", ") + `.
+
+` + readAnonNote + `
+
+A model VERSION is the downloadable unit, and it is what most of the rest of
+this CLI wants: ` + "`civitai download --version <id>`" + `,
+` + "`civitai generate --checkpoint <id>`" + ` and ` + "`--lora <id>`" + ` all take a version
+id, never a model id. ` + "`civitai models get <id>`" + ` is where you read those
+version ids off a model.
+
+` + "`by-hash`" + ` runs that lookup backwards: it identifies a file you already have
+on disk, which is how you put a name to an unlabelled .safetensors.
+
+` + readJSONNote
 	cmd.AddCommand(newModelVersionsGetCmd())
 	cmd.AddCommand(newModelVersionsByHashCmd())
 	return cmd
@@ -28,10 +47,27 @@ version by its id or by a file hash (AutoV2, SHA256, …). Works anonymously.`,
 
 func newModelVersionsGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "get <id>",
-		Short:   "Get a model version by id (GET /api/v1/model-versions/{id})",
-		Example: `  civitai model-versions get 128713`,
-		Args:    cobra.ExactArgs(1),
+		Use:   "get <id>",
+		Short: "Get a model version by id (GET /api/v1/model-versions/{id})",
+		Long: `Get one model version by its version id: GET /api/v1/model-versions/{id}.
+
+This is the id ` + "`civitai download --version`" + ` and
+` + "`civitai generate --checkpoint / --lora`" + ` take. A non-integer argument is
+refused locally, as a usage mistake, before any request is made.
+
+The output carries the base model, the trigger words, the AIR identifier and
+every file with its size and type. A version whose primary file is not model
+weights is tagged with that type ([Archive], [Training Data], [Other]).
+
+What a version does NOT carry is model-level data: .model is only
+{name, type, nsfw, poi} — no creator, no model download count. If you started
+from a version and need those, read them from ` + "`models get`" + ` /
+` + "`models search`" + ` and join on the version's .modelId.
+
+` + readAnonShort,
+		Example: `  civitai model-versions get 128713
+  civitai mv get 128713 --json`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := readFlags(cmd)
 			if _, err := strconv.Atoi(args[0]); err != nil {
@@ -61,11 +97,28 @@ func newModelVersionsGetCmd() *cobra.Command {
 
 func newModelVersionsByHashCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "by-hash <hash>",
-		Short:   "Get a model version by file hash (GET /api/v1/model-versions/by-hash/{hash})",
-		Long:    `Look up a model version by any of its file hashes (AutoV1, AutoV2, SHA256, CRC32, BLAKE3). The hash is matched case-insensitively.`,
-		Example: `  civitai model-versions by-hash 5D8D26E2A6`,
-		Args:    cobra.ExactArgs(1),
+		Use:   "by-hash <hash>",
+		Short: "Get a model version by file hash (GET /api/v1/model-versions/by-hash/{hash})",
+		Long: `Look up a model version by any of its file hashes:
+GET /api/v1/model-versions/by-hash/{hash}.
+
+AutoV1, AutoV2, SHA256, CRC32 and BLAKE3 hashes all work — the server
+upper-cases the value, so case does not matter here. This is the "what IS this
+file?" lookup for a .safetensors you already have on disk.
+
+Note the API reports SHA256 in UPPER case while sha256sum prints lower case, so
+case-fold before comparing if you hash a file yourself. (` + "`civitai download`" + `'s
+own verification is already case-insensitive.)
+
+On a hit the CLI prints a ready-to-run download line for the resolved version.
+It uses --version rather than a bare positional id deliberately: a bare id is
+ambiguous between a model id and a version id, and the printed command must
+never be the one that trips that stop.
+
+` + readAnonShort,
+		Example: `  civitai model-versions by-hash 5D8D26E2A6
+  civitai mv by-hash 5D8D26E2A6 --json`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o := readFlags(cmd)
 			client, _, err := newReader(o)

--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -28,10 +28,6 @@ func newModelsCmd() *cobra.Command {
 --limit / --page / --cursor. ` + "`models get <id>`" + ` returns one model with its
 full version list.
 
-A search hit already embeds .modelVersions[] — every version's files, hashes
-and trained words — so iterating search results rarely needs a follow-up
-` + "`model-versions get`" + ` per version.
-
 What lives one level down: a model is the PAGE, a model VERSION is the
 downloadable unit. ` + "`civitai download`" + ` and ` + "`civitai generate --checkpoint`" + `
 both take a version id, which ` + "`models get`" + ` lists.
@@ -59,17 +55,16 @@ func newModelsSearchCmd() *cobra.Command {
 		Short: "Search models (GET /api/v1/models)",
 		Long: `Search models via GET /api/v1/models.
 
-Filters: --query (free text), --tag, --username, --type, --base-model
-(repeatable — the API ORs the given values) and --nsfw.
+Filters: --query (free text), --tag, --username, --base-model (repeatable — the
+API ORs the given values) and --nsfw. --base-model is matched LITERALLY, so a
+misspelling returns zero results rather than an error; the CLI says so on
+stderr.
+
+--type, --sort and --period take server-owned value sets.
 ` + serverOwnedEnumNote + `
---base-model in particular is matched LITERALLY, so a misspelling returns zero
-results rather than an error; the CLI prints a stderr note when that happens.
 
 Paging: ` + limitRule(modelsLimitMax) + `.
---page is shallow paging, --cursor is deep paging, and the next cursor is
-printed under the results. The API caps page × limit at 1000 and answers 429
-past it — the CLI recognises that deep-paging cap and reports it as a usage
-mistake rather than as a rate limit, so a retry loop does not spin on it.
+` + deepPagingNote + `
 
 --period changes the SORT, not the DOWNLOADS column: the API returns only the
 all-time download count, so a later row can legitimately show more downloads
@@ -148,7 +143,7 @@ than an earlier one. The column is labelled DL(all-time) for that reason.
 	cmd.Flags().StringVar(&sort, "sort", "", "sort order (e.g. \"Highest Rated\", \"Most Downloaded\", Newest)")
 	cmd.Flags().StringVar(&period, "period", "", "time period (AllTime, Year, Month, Week, Day)")
 	cmd.Flags().BoolVar(&nsfw, "nsfw", false, "include NSFW results")
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page (1-100)")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(modelsLimitMax))
 	cmd.Flags().IntVar(&page, "page", 0, "page number (shallow paging; prefer --cursor for deep paging)")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
 	bindReadFlags(cmd)

--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -18,11 +18,29 @@ func newModelsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "models",
 		Short: "Search and inspect models on Civitai",
-		Long: `Read-only access to Civitai models via the public REST API
-(GET /api/v1/models). These commands work anonymously; if you are logged in
-(civitai login) your token is sent automatically.`,
+		Long: `Read-only access to Civitai models through the public REST API
+(GET /api/v1/models, GET /api/v1/models/{id}).
+
+` + readAnonNote + `
+
+` + "`models search`" + ` is the discovery surface — filter by --query / --tag /
+--username / --type / --base-model, order with --sort / --period, and page with
+--limit / --page / --cursor. ` + "`models get <id>`" + ` returns one model with its
+full version list.
+
+A search hit already embeds .modelVersions[] — every version's files, hashes
+and trained words — so iterating search results rarely needs a follow-up
+` + "`model-versions get`" + ` per version.
+
+What lives one level down: a model is the PAGE, a model VERSION is the
+downloadable unit. ` + "`civitai download`" + ` and ` + "`civitai generate --checkpoint`" + `
+both take a version id, which ` + "`models get`" + ` lists.
+
+` + readJSONNote,
 		Example: `  civitai models search --query "pony" --limit 5
-  civitai models get 4384`,
+  civitai models search --type LORA --base-model Illustrious --limit 20
+  civitai models get 4384
+  civitai models get 4384 --json`,
 	}
 	cmd.AddCommand(newModelsSearchCmd())
 	cmd.AddCommand(newModelsGetCmd())
@@ -41,12 +59,27 @@ func newModelsSearchCmd() *cobra.Command {
 		Short: "Search models (GET /api/v1/models)",
 		Long: `Search models via GET /api/v1/models.
 
-Pagination: use --page for shallow paging, or --cursor for deep paging (the API
-caps page*limit at 1000 and otherwise returns 429 — prefer --cursor). The next
-cursor is printed after the results.`,
+Filters: --query (free text), --tag, --username, --type, --base-model
+(repeatable — the API ORs the given values) and --nsfw.
+` + serverOwnedEnumNote + `
+--base-model in particular is matched LITERALLY, so a misspelling returns zero
+results rather than an error; the CLI prints a stderr note when that happens.
+
+Paging: ` + limitRule(modelsLimitMax) + `.
+--page is shallow paging, --cursor is deep paging, and the next cursor is
+printed under the results. The API caps page × limit at 1000 and answers 429
+past it — the CLI recognises that deep-paging cap and reports it as a usage
+mistake rather than as a rate limit, so a retry loop does not spin on it.
+
+--period changes the SORT, not the DOWNLOADS column: the API returns only the
+all-time download count, so a later row can legitimately show more downloads
+than an earlier one. The column is labelled DL(all-time) for that reason.
+
+` + readAnonShort,
 		Example: `  civitai models search --query "pony" --limit 5
   civitai models search --type LORA --sort "Most Downloaded" --period Month
-  civitai models search --username some-creator --cursor <cursor>`,
+  civitai models search --base-model Pony --base-model Illustrious --limit 20
+  civitai models search --username some-creator --cursor '<cursor>'`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkLimit(limit, modelsLimitMax); err != nil {
@@ -126,6 +159,21 @@ func newModelsGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <id>",
 		Short: "Get a model by id (GET /api/v1/models/{id})",
+		Long: `Get one model by id: GET /api/v1/models/{id}.
+
+The id is the number in a civitai.com/models/<id> URL. A non-integer argument
+is refused locally, as a usage mistake, before any request is made.
+
+The human output lists every published VERSION (id, name, base model) — that
+version id is what ` + "`civitai download --version`" + ` and
+` + "`civitai generate --checkpoint`" + ` take. A version whose primary file is not
+model weights is tagged with its actual file type ([Archive], [Training Data],
+[Other]); it still downloads, the tag just says it is not a .safetensors.
+
+--json carries much more than the human view — the description HTML, per-file
+hashes and download URLs, and the full stats block.
+
+` + readAnonShort,
 		Example: `  civitai models get 4384
   civitai models get 4384 --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cmd/read_help.go
+++ b/internal/cmd/read_help.go
@@ -38,9 +38,32 @@ const readAnonShort = `Works anonymously (no login needed); --anon forces an ano
 when you are logged in.`
 
 // readJSONNote states the --json contract once. It is a claim about stdout
-// purity that the whole "Scripting with --json" README section rests on.
-const readJSONNote = `--json prints the raw /api/v1 response on stdout, unchanged — notes and errors
-go to stderr, so ` + "`… --json | jq -e .`" + ` always parses.`
+// PURITY — the property the whole "Scripting with --json" README section rests
+// on — and deliberately not a claim about BYTES.
+//
+// 🔴 IT MUST NOT SAY "UNCHANGED", AND AN EARLIER REVISION OF THIS CONSTANT DID.
+// emitJSON (read.go) re-indents the body through json.Indent. Measured against a
+// recording server, `models search --json` over a 113-byte compact body: 194
+// bytes on stdout, not byte-identical. So the DOCUMENT is the API's and the
+// BYTES are not — and a scripter who took "unchanged" literally would diff or
+// hash CLI output against the API body and get a mismatch with nothing wrong.
+// The README's "Scripting with --json" section is careful about exactly this: it
+// promises "pure JSON — nothing else is written to stdout", never byte-identity.
+//
+// It also does NOT mention emitJSON's raw-control-byte repair
+// (escapeJSONStringControlChars), and that omission is measured rather than an
+// oversight: every read command reaches emitJSON only AFTER getInto has
+// unmarshalled the same bytes into a typed struct, and encoding/json rejects a
+// raw C0 byte inside a string literal there first. Measured: a body carrying a
+// literal CR inside a description exits 1 with "unexpected response from
+// /api/v1/models (status 200)" and an EMPTY stdout — emitJSON is never entered.
+// The repair is real defence-in-depth for any future caller that passes raw
+// bytes through without a typed decode; it is not a behaviour of this group, so
+// it is not described as one.
+const readJSONNote = `--json writes the API response to stdout and nothing else — notes and errors go
+to stderr, so ` + "`… --json | jq -e .`" + ` always parses. The document is the API's,
+the bytes are not: it is re-indented on the way out, so do not diff or hash it
+against the wire.`
 
 // limitRule renders one endpoint's --limit bounds.
 //
@@ -57,8 +80,40 @@ func limitRule(max int) string {
 	return fmt.Sprintf("--limit takes 1–%d; omit it for the server's default page size", max)
 }
 
-// serverOwnedEnumNote is the honest statement about --sort / --period / --type /
-// --base-model: the CLI does not model those value sets AT ALL.
+// limitFlagUsage renders the --limit FLAG DESCRIPTION from the same ceiling.
+//
+// 🔴 THE FLAG BLOCK IS A SECOND PUBLISHED SURFACE, AND IT WAS THE ONE LEFT
+// HAND-TYPED. Six read commands bind --limit; four described their ceiling as a
+// literal ("(1-100)", "(1-200)") and two stated no bound at all while their Long
+// now derives one — so moving a ceiling produced a `--help` page that
+// contradicted ITSELF, flag block versus body, with the suite green. The idiom
+// already existed thirty lines away in apps.go, which renders this string from
+// appsLimitMax; this is that idiom, shared.
+// TestReadAPILimitFlagUsageIsDerived pins it.
+func limitFlagUsage(max int) string {
+	return fmt.Sprintf("results per page (1-%d)", max)
+}
+
+// deepPagingNote is the ONE statement of the API's page-offset cap, for the two
+// commands that offer both paging modes.
+//
+// 🔴 STATE WHAT IS PINNED AND WHAT IS NOT. The two halves of this sentence have
+// very different standing. That --page is the shallow mode and --cursor the deep
+// one is a CLI-side fact and is asserted (TestReadAPIHelpDescribesItsOwnPagingShape
+// requires each mode to be named with its role, which is what makes an inversion
+// observable). The "1000" and the "429" are SERVER facts with no local
+// counterpart anywhere in this repo — pkg/civitai's isDeepPagingCap matches the
+// server's PHRASING, not the number — so nothing here can catch them going
+// stale. Single-sourcing them at least means they cannot disagree between the
+// two commands that quote them, and that is the whole of the guarantee.
+// Measured against civitai.com in the README's terms as of 2026-08.
+const deepPagingNote = `--page is shallow paging, --cursor is deep paging, and the next cursor is
+printed under the results. The API caps page × limit at 1000 and answers 429
+past it — the CLI reports that cap as a usage mistake, not a rate limit, so a
+retry loop does not spin on it.`
+
+// serverOwnedEnumNote is the honest statement about the ENUM-VALUED filters —
+// --type, --sort, --period: the CLI does not model those value sets AT ALL.
 //
 // It is worded as a claim about the CLI, not about the server, because that is
 // the only half this repo can verify: addIfSet copies the flag value into the
@@ -67,5 +122,13 @@ func limitRule(max int) string {
 // Z" here would be a vendored enum — the thing AGENTS.md item 13 forbids on the
 // generate path for the same reason: it buys no correctness, goes stale, and
 // starts refusing values the server has since added.
-const serverOwnedEnumNote = `The CLI does not check these value sets — it passes them through and the server
-rejects an unknown one with HTTP 400, which the CLI reports as a usage mistake.`
+//
+// 🔴 ITS ANTECEDENT MUST BE THE ENUM FLAGS ONLY, AND AN EARLIER REVISION PUT IT
+// UNDER A LIST THAT ALSO NAMED --nsfw AND --query. That made it FALSE for two
+// reasons: --nsfw is a bool cobra parses itself (measured:
+// `articles search --nsfw=maybe` is refused client-side, exit 2, with ZERO
+// requests made — the opposite of "passed through for the server to reject"),
+// and --query/--username have no value set to be wrong about. Each caller now
+// names the enum flags immediately above it.
+const serverOwnedEnumNote = `The CLI does not check those value sets — it passes the value through and the
+server rejects an unknown one with HTTP 400, reported as a usage mistake.`

--- a/internal/cmd/read_help.go
+++ b/internal/cmd/read_help.go
@@ -1,0 +1,71 @@
+package cmd
+
+import "fmt"
+
+// Shared help text for the PUBLIC READ API command group (models,
+// model-versions, images, articles, collections, tags, creators, users).
+//
+// It is stated ONCE here and interpolated into the eight family bodies rather
+// than retyped, for the same reason the `app listing` bodies compute their byte
+// caps: a fact typed out eight times is a fact that will be wrong in seven
+// places the first time it moves. What is derivable from the code is derived —
+// notably every `--limit` bound, which is rendered from the SAME constant
+// checkLimit refuses on.
+
+// readAnonNote is the ONE statement of what credentials this group needs, for
+// the eight GROUP bodies.
+//
+// 🔴 IT MUST STAY SCOPED TO THE PUBLIC READ ROUTES. The blanket claim "reads are
+// anonymous — no login needed" used to sit in the README over a table that also
+// listed `civitai app list` / `app view`, and it was FALSE for those two: the
+// store endpoint keys the visible catalog off your identity, so an anonymous
+// call is refused outright (see newAppListCmd's Long). PR #268 corrected the
+// README by scoping the claim; this constant is that scoped claim, and the
+// contrast is kept IN the sentence so the next person to copy it somewhere else
+// carries the exception with it.
+//
+// What the CLI side of this claim rests on is checkable and is checked:
+// TestReadAPICommandsRunAnonymously drives every leaf in this group with no
+// token configured and asserts it succeeds and sends no Authorization header.
+const readAnonNote = `No login is needed — these are public read routes (unlike ` + "`civitai app list`" + `
+and ` + "`app view`" + `, which are refused without a token). The CLI still sends your
+stored token when you have one; --anon forces an anonymous request.`
+
+// readAnonShort is the leaf-level form. A leaf gets its own docs page, so it
+// cannot rely on the group body being read first, but it also cannot afford
+// three lines of the same paragraph.
+const readAnonShort = `Works anonymously (no login needed); --anon forces an anonymous request even
+when you are logged in.`
+
+// readJSONNote states the --json contract once. It is a claim about stdout
+// purity that the whole "Scripting with --json" README section rests on.
+const readJSONNote = `--json prints the raw /api/v1 response on stdout, unchanged — notes and errors
+go to stderr, so ` + "`… --json | jq -e .`" + ` always parses.`
+
+// limitRule renders one endpoint's --limit bounds.
+//
+// 🔴 IT IS COMPUTED FROM THE ENDPOINT'S OWN CEILING CONSTANT AND MUST STAY THAT
+// WAY. The number in the help has to be the number checkLimit refuses above,
+// and the six ceilings are not the same (100 for models/articles/collections,
+// 200 for images/tags/creators) — so a hand-typed bound here is a second copy of
+// a constant that reads fine, survives any test that only greps for "a limit
+// being mentioned", and goes stale the day a ceiling moves.
+// TestReadAPIHelpQuotesTheEnforcedLimit pins the coupling in both directions,
+// and pins each ledgered ceiling against what the command ACTUALLY accepts and
+// refuses, so the ledger cannot drift into agreeing with a stale help body.
+func limitRule(max int) string {
+	return fmt.Sprintf("--limit takes 1–%d; omit it for the server's default page size", max)
+}
+
+// serverOwnedEnumNote is the honest statement about --sort / --period / --type /
+// --base-model: the CLI does not model those value sets AT ALL.
+//
+// It is worded as a claim about the CLI, not about the server, because that is
+// the only half this repo can verify: addIfSet copies the flag value into the
+// query string unexamined, and the rejection arrives as the API's HTTP 400,
+// which readError reports as a usage mistake. Saying "the valid values are X, Y,
+// Z" here would be a vendored enum — the thing AGENTS.md item 13 forbids on the
+// generate path for the same reason: it buys no correctness, goes stale, and
+// starts refusing values the server has since added.
+const serverOwnedEnumNote = `The CLI does not check these value sets — it passes them through and the server
+rejects an unknown one with HTTP 400, which the CLI reports as a usage mistake.`

--- a/internal/cmd/read_help_test.go
+++ b/internal/cmd/read_help_test.go
@@ -1,0 +1,627 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/civitai/cli/pkg/civitai"
+	"github.com/spf13/cobra"
+)
+
+// ----------------------------------------------------------------------------
+// Node discovery
+// ----------------------------------------------------------------------------
+
+// readAPINode is one node of the public-read-API command group: either a LEAF
+// (a command that actually calls the read API) or the GROUP it hangs under.
+type readAPINode struct {
+	path string // e.g. "models search"
+	cmd  *cobra.Command
+	leaf bool
+}
+
+// readAPINodes returns every node of the public read API group, discovered by
+// WALKING the real command tree.
+//
+// 🔴 THE MEMBERSHIP TEST IS STRUCTURAL, NOT A LIST OF NAMES. A leaf is a command
+// carrying BOTH the --json and --anon flags, which is exactly what bindReadFlags
+// attaches and nothing else in this CLI has: `civitai download` has --anon but
+// no --json, and every other --json (app status, buzz, generate, workflows …)
+// comes without --anon. So a new read command is picked up here the moment it is
+// wired, and fails the completeness guard below until it is documented — which a
+// hardcoded list cannot do, because a command missing from the list is
+// indistinguishable from a command that passed.
+//
+// The groups are then the leaves' PARENTS, again derived rather than named. The
+// root is asserted not to be one: a read leaf hanging directly off the root
+// would mean this group's shape changed, and the guards below assume a group
+// page exists to carry the shared prose.
+func readAPINodes(t *testing.T) []readAPINode {
+	t.Helper()
+	var (
+		out    []readAPINode
+		groups = map[*cobra.Command]bool{}
+		root   = NewRootCmd()
+	)
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Flags().Lookup("json") != nil && c.Flags().Lookup("anon") != nil {
+			out = append(out, readAPINode{path: cmdPath(c), cmd: c, leaf: true})
+			if p := c.Parent(); p != nil {
+				if p == root {
+					t.Fatalf("read leaf %q hangs off the root — this group is expected to be "+
+						"grouped, and the shared help lives on the group page", c.Name())
+				}
+				groups[p] = true
+			} else {
+				t.Fatalf("read leaf %q has no parent", c.Name())
+			}
+		}
+		for _, s := range c.Commands() {
+			walk(s)
+		}
+	}
+	walk(root)
+	for g := range groups {
+		out = append(out, readAPINode{path: cmdPath(g), cmd: g})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out
+}
+
+// cmdPath renders a command's path without the "civitai " root prefix.
+func cmdPath(c *cobra.Command) string {
+	return strings.TrimPrefix(c.CommandPath(), c.Root().Name()+" ")
+}
+
+// The floors. They are asserted, not assumed: a walk that matched nothing would
+// otherwise report a serene pass over an empty set, and every guard below
+// iterates the same slice.
+const (
+	wantReadAPILeaves = 13
+	wantReadAPIGroups = 8
+	wantReadAPINodes  = wantReadAPILeaves + wantReadAPIGroups
+)
+
+func TestReadAPINodeWalkFindsTheWholeGroup(t *testing.T) {
+	nodes := readAPINodes(t)
+	var leaves, groups int
+	for _, n := range nodes {
+		if n.leaf {
+			leaves++
+		} else {
+			groups++
+		}
+	}
+	if leaves != wantReadAPILeaves || groups != wantReadAPIGroups {
+		var got []string
+		for _, n := range nodes {
+			kind := "group"
+			if n.leaf {
+				kind = "leaf"
+			}
+			got = append(got, kind+" "+n.path)
+		}
+		t.Fatalf("walked %d leaves / %d groups, want %d / %d — adding a read command means "+
+			"documenting it, so move these floors deliberately.\nfound:\n  %s",
+			leaves, groups, wantReadAPILeaves, wantReadAPIGroups, strings.Join(got, "\n  "))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Completeness + budget (the pilot's contract, applied to this group)
+// ----------------------------------------------------------------------------
+
+// TestReadAPIHelpBodiesAreComplete: every node carries an authored Long, Short
+// and Example.
+//
+// Five of these commands (collections get, creators search, model-versions get,
+// models get, tags search) shipped with NO Long at all — cobra falls back to
+// Short, so `--help` printed one line, and the docs generator, which parses that
+// same help text, published one line too.
+func TestReadAPIHelpBodiesAreComplete(t *testing.T) {
+	nodes := readAPINodes(t)
+	if len(nodes) != wantReadAPINodes {
+		t.Fatalf("walked %d nodes, want %d", len(nodes), wantReadAPINodes)
+	}
+	for _, n := range nodes {
+		t.Run(n.path, func(t *testing.T) {
+			if strings.TrimSpace(n.cmd.Long) == "" {
+				t.Errorf("`%s` has no Long — `--help` will print only its Short (%q), and the "+
+					"docs generator publishes exactly what `--help` prints", n.path, n.cmd.Short)
+			}
+			if strings.TrimSpace(n.cmd.Short) == "" {
+				t.Errorf("`%s` has no Short", n.path)
+			}
+			if strings.TrimSpace(n.cmd.Example) == "" {
+				t.Errorf("`%s` has no Example", n.path)
+			}
+		})
+	}
+}
+
+// TestReadAPIHelpStaysWithinTheBudget applies the pilot's ceiling: 1400 runes
+// per body, 80 columns per line.
+//
+// 🔴 RUNES, NOT BYTES, in both measurements. These bodies are full of em-dashes
+// and en-dashes (3 bytes, one column each), so a byte count reports a 79-column
+// line as 81 and reddens prose that renders fine.
+func TestReadAPIHelpStaysWithinTheBudget(t *testing.T) {
+	nodes := readAPINodes(t)
+	var checked int
+	for _, n := range nodes {
+		body := strings.TrimSpace(n.cmd.Long)
+		if body == "" {
+			continue // TestReadAPIHelpBodiesAreComplete owns that failure
+		}
+		checked++
+		if got := utf8.RuneCountInString(body); got > helpBodyBudget {
+			t.Errorf("`%s` Long is %d chars, over the %d budget — prose that does not fit a "+
+				"screen belongs in the guide, not in `--help`", n.path, got, helpBodyBudget)
+		}
+		for _, line := range strings.Split(body, "\n") {
+			if got := utf8.RuneCountInString(line); got > 80 {
+				t.Errorf("`%s` Long has an %d-column line (>80) — cobra does not wrap Long, so "+
+					"it will hard-wrap in a standard terminal:\n%s", n.path, got, line)
+			}
+		}
+	}
+	if checked != wantReadAPINodes {
+		t.Fatalf("only %d bodies were measured, want %d — a body that is empty is not a body "+
+			"that is within budget", checked, wantReadAPINodes)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// The derived facts
+// ----------------------------------------------------------------------------
+
+// readAPILimitLedger maps each list command to the ceiling its RunE enforces.
+//
+// The ledger is not trusted. TestReadAPIHelpQuotesTheEnforcedLimit checks it in
+// BOTH directions: its key set must equal the set of read leaves that actually
+// bind a --limit flag (so a new list command cannot slip past, and a removed one
+// cannot leave a stale row looking like coverage), and every row's ceiling is
+// exercised against the real command — accepted at the ceiling, refused one
+// above it. Only then is the help required to quote it.
+var readAPILimitLedger = map[string]int{
+	"models search":      modelsLimitMax,
+	"images search":      imagesLimitMax,
+	"articles search":    articlesLimitMax,
+	"collections search": collectionsLimitMax,
+	"tags search":        tagsLimitMax,
+	"creators search":    creatorsLimitMax,
+}
+
+// TestReadAPIHelpQuotesTheEnforcedLimit pins the coupling between what `--help`
+// PROMISES about --limit and what the command actually ENFORCES.
+//
+// 🔴 THE POINT IS THE DIRECTION OF DERIVATION. The expected string is computed
+// from the endpoint's own ceiling constant through the SAME limitRule the body
+// interpolates, and that constant is independently proven to be the enforced
+// boundary by driving the real command at max and max+1. So moving a ceiling
+// without moving the help reddens this test whether the body computes its number
+// or has a stale literal typed into it, and mis-wiring one command's help to
+// another's constant reddens it too — the cross-endpoint assertion below is what
+// catches that, and it is not redundant with the per-command one.
+func TestReadAPIHelpQuotesTheEnforcedLimit(t *testing.T) {
+	nodes := readAPINodes(t)
+
+	// (1) The ledger's key set must be exactly the leaves that bind --limit.
+	haveLimit := map[string]bool{}
+	for _, n := range nodes {
+		if n.leaf && n.cmd.Flags().Lookup("limit") != nil {
+			haveLimit[n.path] = true
+		}
+	}
+	for path := range haveLimit {
+		if _, ok := readAPILimitLedger[path]; !ok {
+			t.Errorf("`%s` binds --limit but has no ledger row — a list command whose ceiling "+
+				"is unledgered is a ceiling nothing checks", path)
+		}
+	}
+	for path := range readAPILimitLedger {
+		if !haveLimit[path] {
+			t.Errorf("ledger row %q no longer binds --limit — a stale row is a false map, not "+
+				"harmless", path)
+		}
+	}
+	if len(haveLimit) != len(readAPILimitLedger) || len(haveLimit) == 0 {
+		t.Fatalf("ledger/tree disagree: %d commands bind --limit, %d rows ledgered",
+			len(haveLimit), len(readAPILimitLedger))
+	}
+
+	byPath := map[string]*cobra.Command{}
+	for _, n := range nodes {
+		byPath[n.path] = n.cmd
+	}
+
+	// (2) Per command: the ledgered ceiling is the ENFORCED one, and the help
+	// quotes it.
+	for path, max := range readAPILimitLedger {
+		t.Run(path, func(t *testing.T) {
+			args := strings.Fields(path)
+
+			// Refused one above the ceiling, and the request never goes out.
+			hits := setupReadAPIServer(t)
+			_, _, err := run(t, append(append([]string{}, args...), "--limit", strconv.Itoa(max+1))...)
+			// 🔴 Classification by errors.Is, never by message text (AGENTS item
+			// 7): a test asserting on the wording says nothing about the exit code
+			// the README promises for a bad flag value.
+			if !errors.Is(err, ErrUsage) && !errors.Is(err, civitai.ErrBadRequest) {
+				t.Fatalf("`%s --limit %d` should be refused as a usage mistake, got %v",
+					path, max+1, err)
+			}
+			if n := hits.count(); n != 0 {
+				t.Errorf("`%s --limit %d` was refused but still made %d request(s) — the ceiling "+
+					"must be enforced before the network", path, max+1, n)
+			}
+
+			// Accepted AT the ceiling, and the value reaches the wire.
+			hits = setupReadAPIServer(t)
+			if _, _, err := run(t, append(append([]string{}, args...), "--limit", strconv.Itoa(max))...); err != nil {
+				t.Fatalf("`%s --limit %d` should be accepted, got %v", path, max, err)
+			}
+			if got := hits.lastQuery().Get("limit"); got != strconv.Itoa(max) {
+				t.Errorf("`%s --limit %d` sent limit=%q — the ledgered ceiling is not the value "+
+					"the command actually passes", path, max, got)
+			}
+
+			// Only now is the help held to it.
+			want := limitRule(max)
+			if !strings.Contains(byPath[path].Long, want) {
+				t.Errorf("`%s` Long does not state the limit it enforces.\nwant: %q\nLong:\n%s",
+					path, want, byPath[path].Long)
+			}
+		})
+	}
+
+	// (3) 🔴 CROSS-ENDPOINT: a body must not quote a DIFFERENT ceiling.
+	//
+	// Three of these endpoints cap at 100 and three at 200, so `limitRule(100)`
+	// and `limitRule(200)` are each shared by three commands — which means a
+	// same-ceiling swap (models <-> articles) is INVISIBLE here and is declared
+	// an equivalent mutant in the file header. What this catches is the swap that
+	// MATTERS: a 100-capped body quoting 200 (or the reverse), which is what a
+	// copy-paste between two families produces.
+	for path, max := range readAPILimitLedger {
+		for otherPath, otherMax := range readAPILimitLedger {
+			if otherMax == max {
+				continue
+			}
+			if strings.Contains(byPath[path].Long, limitRule(otherMax)) {
+				t.Errorf("`%s` (ceiling %d) quotes `%s`'s ceiling %d — this is what a copy-paste "+
+					"between two families looks like", path, max, otherPath, otherMax)
+			}
+		}
+	}
+}
+
+// TestReadAPIHelpDescribesItsOwnPagingShape pins the other fact a reader acts
+// on, and it is the one a copy-paste gets wrong silently: these six list
+// commands do NOT page the same way. models/images take both --page and
+// --cursor; articles/collections are cursor-only (a keyset feed, no --page);
+// tags/creators are page-only (a classic page envelope, no cursor).
+//
+// The expectation is read off the command's OWN FLAGS, never a table, so the
+// guard cannot drift from the tree. Absence is required to be DOCUMENTED rather
+// than merely unmentioned ("there is no --page here"), because a body that is
+// silent about --page is indistinguishable from a body that forgot it — and the
+// two phrasings are kept distinguishable so the present case cannot satisfy the
+// absent one.
+func TestReadAPIHelpDescribesItsOwnPagingShape(t *testing.T) {
+	var checked int
+	for _, n := range readAPINodes(t) {
+		if !n.leaf || n.cmd.Flags().Lookup("limit") == nil {
+			continue
+		}
+		checked++
+		t.Run(n.path, func(t *testing.T) {
+			for _, flag := range []string{"page", "cursor"} {
+				var (
+					has     = n.cmd.Flags().Lookup(flag) != nil
+					long    = n.cmd.Long
+					mention = "--" + flag
+					absent  = "no --" + flag
+				)
+				switch {
+				case has && !strings.Contains(long, mention):
+					t.Errorf("`%s` accepts %s but its Long never names it", n.path, mention)
+				case has && strings.Contains(long, absent):
+					t.Errorf("`%s` accepts %s but its Long says %q", n.path, mention, absent)
+				case !has && !strings.Contains(long, absent):
+					t.Errorf("`%s` has no %s flag and its Long does not say so — %q must be "+
+						"stated, or a reader cannot tell a missing paging mode from a missing "+
+						"sentence", n.path, mention, absent)
+				case !has && strings.Count(long, mention) != strings.Count(long, absent):
+					// 🔴 STATING THE ABSENCE IS NOT ENOUGH — the body must not ALSO
+					// advertise the flag somewhere else. Measured: appending "Use
+					// --cursor for deep paging." to `tags search` (which has no
+					// cursor) SURVIVED the three cases above, because the
+					// documented-absence sentence was still sitting there. Every
+					// occurrence of the flag must therefore be an occurrence of the
+					// "no --x" phrase.
+					t.Errorf("`%s` has no %s flag but its Long mentions %s outside the %q "+
+						"sentence (%d mentions, %d of them the documented absence) — a body "+
+						"that documents the absence AND advertises the flag is worse than "+
+						"either alone", n.path, mention, mention, absent,
+						strings.Count(long, mention), strings.Count(long, absent))
+				}
+			}
+		})
+	}
+	if checked != len(readAPILimitLedger) {
+		t.Fatalf("checked %d list commands, want %d", checked, len(readAPILimitLedger))
+	}
+}
+
+// TestReadAPIHelpNamesItsAliases: a node with aliases must name every one of
+// them, and the text is rendered FROM cmd.Aliases (see newModelVersionsCmd) so a
+// dropped alias cannot leave the help advertising a spelling the tree no longer
+// answers to.
+//
+// The count floor matters: exactly one node in this group has aliases today, and
+// a guard that iterated an empty set would pass silently if that changed.
+func TestReadAPIHelpNamesItsAliases(t *testing.T) {
+	var withAliases int
+	for _, n := range readAPINodes(t) {
+		if len(n.cmd.Aliases) == 0 {
+			continue
+		}
+		withAliases++
+		for _, a := range n.cmd.Aliases {
+			if !strings.Contains(n.cmd.Long, a) {
+				t.Errorf("`%s` answers to the alias %q but its Long never mentions it", n.path, a)
+			}
+		}
+	}
+	if withAliases != 1 {
+		t.Fatalf("%d read-API nodes carry aliases, want 1 — if that changed, this guard's "+
+			"positive control did too", withAliases)
+	}
+}
+
+// TestReadAPIHelpStatesItsAuthRequirement is the guard for the claim this group
+// is most likely to get WRONG, because the CLI's other list commands got it
+// wrong: PR #268 corrected a blanket "reads are anonymous — no login needed"
+// that was FALSE for `app list` / `app view`.
+//
+// Two halves, and neither substitutes for the other:
+//
+//   - every node states the requirement, from the ONE shared constant (so eight
+//     families cannot end up with eight differently-worded auth claims); and
+//   - TestReadAPICommandsRunAnonymously proves the claim behaviourally.
+//
+// A body that merely contains the word "anonymous" would satisfy neither.
+func TestReadAPIHelpStatesItsAuthRequirement(t *testing.T) {
+	var groups, leaves int
+	for _, n := range readAPINodes(t) {
+		want, label := readAnonNote, "readAnonNote"
+		if n.leaf {
+			want, label = readAnonShort, "readAnonShort"
+		}
+		if !strings.Contains(n.cmd.Long, want) {
+			t.Errorf("`%s` Long does not carry %s — the auth requirement is stated once, in "+
+				"read_help.go, precisely so it cannot be re-worded per family", n.path, label)
+			continue
+		}
+		if n.leaf {
+			leaves++
+		} else {
+			groups++
+		}
+	}
+	if groups != wantReadAPIGroups || leaves != wantReadAPILeaves {
+		t.Fatalf("auth note found on %d groups / %d leaves, want %d / %d",
+			groups, leaves, wantReadAPIGroups, wantReadAPILeaves)
+	}
+	// The two forms must stay distinguishable, or the group/leaf split above is
+	// satisfiable by one string appearing everywhere.
+	if strings.Contains(readAnonNote, readAnonShort) || strings.Contains(readAnonShort, readAnonNote) {
+		t.Fatal("readAnonNote and readAnonShort must not contain one another — the per-form " +
+			"assertions above would stop distinguishing them")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// The behavioural half of the auth claim
+// ----------------------------------------------------------------------------
+
+// readAPIInvocations is the argv for every read leaf, used to exercise the whole
+// group against a fake server. Its key set is asserted equal to the walked leaf
+// set, so a new leaf cannot be silently left unexercised.
+var readAPIInvocations = map[string][]string{
+	"models search":          {"models", "search"},
+	"models get":             {"models", "get", "4384"},
+	"model-versions get":     {"model-versions", "get", "128713"},
+	"model-versions by-hash": {"model-versions", "by-hash", "5D8D26E2A6"},
+	"images search":          {"images", "search"},
+	"images get":             {"images", "get", "136456589"},
+	"articles search":        {"articles", "search"},
+	"articles get":           {"articles", "get", "1234"},
+	"collections search":     {"collections", "search"},
+	"collections get":        {"collections", "get", "1234"},
+	"tags search":            {"tags", "search"},
+	"creators search":        {"creators", "search"},
+	"users get":              {"users", "get", "alice"},
+}
+
+// TestReadAPICommandsRunAnonymously is what makes "no login is needed" evidence
+// rather than a sentence.
+//
+// With NO token configured, every leaf in the group must complete successfully
+// and send NO Authorization header. The request COUNT is asserted too: a leaf
+// that made zero requests would satisfy "sent no Authorization header" while
+// proving nothing at all — the reassuring-zero shape.
+//
+// It is deliberately not a claim about the SERVER (this repo cannot make one).
+// It is the claim the help actually makes: the CLI does not require a credential
+// on these routes and does not invent one.
+func TestReadAPICommandsRunAnonymously(t *testing.T) {
+	leaves := map[string]bool{}
+	for _, n := range readAPINodes(t) {
+		if n.leaf {
+			leaves[n.path] = true
+		}
+	}
+	for path := range leaves {
+		if _, ok := readAPIInvocations[path]; !ok {
+			t.Fatalf("read leaf %q has no invocation row — it would go unexercised", path)
+		}
+	}
+	for path := range readAPIInvocations {
+		if !leaves[path] {
+			t.Fatalf("invocation row %q is not a read leaf any more", path)
+		}
+	}
+	if len(leaves) != wantReadAPILeaves {
+		t.Fatalf("walked %d leaves, want %d", len(leaves), wantReadAPILeaves)
+	}
+
+	for path, args := range readAPIInvocations {
+		t.Run(path, func(t *testing.T) {
+			hits := setupReadAPIServer(t)
+			if _, _, err := run(t, args...); err != nil {
+				t.Fatalf("`%s` failed with no token configured: %v", path, err)
+			}
+			if n := hits.count(); n < 1 {
+				t.Fatalf("`%s` made no request — the header assertion below would be vacuous", path)
+			}
+			for _, auth := range hits.authHeaders() {
+				if auth != "" {
+					t.Errorf("`%s` sent Authorization %q with no token configured", path, auth)
+				}
+			}
+		})
+	}
+
+	// Positive control for the header assertion itself: with a token configured
+	// the SAME harness must observe a non-empty Authorization, or the loop above
+	// is a probe wired to nothing.
+	t.Run("control/token is observable", func(t *testing.T) {
+		hits := setupReadAPIServer(t)
+		t.Setenv("CIVITAI_TOKEN", "test-token")
+		if _, _, err := run(t, "models", "search"); err != nil {
+			t.Fatalf("models search with a token: %v", err)
+		}
+		got := hits.authHeaders()
+		if len(got) == 0 || got[0] == "" {
+			t.Fatalf("harness never observed an Authorization header even WITH a token — the "+
+				"anonymous assertions above prove nothing (headers seen: %v)", got)
+		}
+	})
+
+	// Negative control for --anon: a configured token must be dropped.
+	t.Run("control/--anon drops a configured token", func(t *testing.T) {
+		hits := setupReadAPIServer(t)
+		t.Setenv("CIVITAI_TOKEN", "test-token")
+		if _, _, err := run(t, "models", "search", "--anon"); err != nil {
+			t.Fatalf("models search --anon: %v", err)
+		}
+		for _, auth := range hits.authHeaders() {
+			if auth != "" {
+				t.Errorf("--anon still sent Authorization %q", auth)
+			}
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// Harness
+// ----------------------------------------------------------------------------
+
+// readAPIRecorder records what the CLI actually sent.
+type readAPIRecorder struct {
+	mu      sync.Mutex
+	queries []url.Values
+	auths   []string
+}
+
+func (r *readAPIRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.queries = append(r.queries, req.URL.Query())
+	r.auths = append(r.auths, req.Header.Get("Authorization"))
+}
+
+func (r *readAPIRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.queries)
+}
+
+func (r *readAPIRecorder) authHeaders() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.auths...)
+}
+
+func (r *readAPIRecorder) lastQuery() url.Values {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.queries) == 0 {
+		return url.Values{}
+	}
+	return r.queries[len(r.queries)-1]
+}
+
+// setupReadAPIServer points the CLI at a fake /api/v1 that answers every read
+// route this group uses, with no token configured and the update check off.
+//
+// The bodies are the minimum each renderer needs to reach a clean exit — a
+// single item where an empty page would be reported as not-found (`images get`,
+// `users get`), an empty page otherwise.
+func setupReadAPIServer(t *testing.T) *readAPIRecorder {
+	t.Helper()
+	rec := &readAPIRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(readAPIBodyFor(r.URL.Path, r.URL.Query())))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+	return rec
+}
+
+func readAPIBodyFor(path string, q url.Values) string {
+	switch {
+	case path == "/api/v1/users":
+		// `users get alice` requires an EXACT username match, so the fixture has
+		// to answer with the name that was asked for.
+		name := "alice"
+		if v := q.Get("query"); v != "" {
+			name = v
+		}
+		b, _ := json.Marshal(map[string]any{
+			"items": []map[string]any{{"id": 5, "username": name, "image": "https://img/u"}},
+		})
+		return string(b)
+	case path == "/api/v1/images":
+		// `images get` reports an empty page as not-found, so this must be a hit.
+		return `{"items":[{"id":136456589,"url":"https://img/1","width":8,"height":8,
+			"nsfwLevel":"None","username":"alice","meta":null,"stats":{}}],"metadata":{}}`
+	case strings.HasPrefix(path, "/api/v1/model-versions/"):
+		return `{"id":128713,"modelId":4384,"name":"v1","baseModel":"SD 1.5","files":[]}`
+	case strings.HasPrefix(path, "/api/v1/models/"):
+		return `{"id":4384,"name":"m","type":"Checkpoint","modelVersions":[]}`
+	case strings.HasPrefix(path, "/api/v1/articles/"):
+		return `{"id":1234,"title":"a","content":"<p>hi</p>"}`
+	case strings.HasPrefix(path, "/api/v1/collections/"):
+		return `{"id":1234,"name":"c","type":"Model","read":"Public","isPublic":true}`
+	default:
+		return `{"items":[],"metadata":{}}`
+	}
+}

--- a/internal/cmd/read_help_test.go
+++ b/internal/cmd/read_help_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -55,7 +56,7 @@ func readAPINodes(t *testing.T) []readAPINode {
 	var walk func(c *cobra.Command)
 	walk = func(c *cobra.Command) {
 		if c.Flags().Lookup("json") != nil && c.Flags().Lookup("anon") != nil {
-			out = append(out, readAPINode{path: cmdPath(c), cmd: c, leaf: true})
+			out = append(out, readAPINode{path: readAPICmdPath(c), cmd: c, leaf: true})
 			if p := c.Parent(); p != nil {
 				if p == root {
 					t.Fatalf("read leaf %q hangs off the root — this group is expected to be "+
@@ -72,14 +73,18 @@ func readAPINodes(t *testing.T) []readAPINode {
 	}
 	walk(root)
 	for g := range groups {
-		out = append(out, readAPINode{path: cmdPath(g), cmd: g})
+		out = append(out, readAPINode{path: readAPICmdPath(g), cmd: g})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
 	return out
 }
 
-// cmdPath renders a command's path without the "civitai " root prefix.
-func cmdPath(c *cobra.Command) string {
+// readAPICmdPath renders a command's path without the "civitai " root prefix.
+//
+// Named for this file rather than `cmdPath`: a package-level `cmdPath` shadows
+// the `cmdPath string` PARAMETER of printPageFooter (read.go) in test builds,
+// which compiles but makes that function harder to read than it needs to be.
+func readAPICmdPath(c *cobra.Command) string {
 	return strings.TrimPrefix(c.CommandPath(), c.Root().Name()+" ")
 }
 
@@ -155,6 +160,16 @@ func TestReadAPIHelpBodiesAreComplete(t *testing.T) {
 // 🔴 RUNES, NOT BYTES, in both measurements. These bodies are full of em-dashes
 // and en-dashes (3 bytes, one column each), so a byte count reports a 79-column
 // line as 81 and reddens prose that renders fine.
+//
+// 🔴 KNOWN SHIPPED RESIDUAL — READ THIS BEFORE ACTING ON A FAILURE HERE.
+// `images search` sits at 1386 of the 1400 runes: about FOURTEEN of headroom.
+// Five of these bodies interpolate shared constants (readAnonNote,
+// readAnonShort, readJSONNote, serverOwnedEnumNote, deepPagingNote), so growing
+// ONE of those by a sentence reddens this test naming `images search` — the
+// longest consumer — rather than naming the constant that actually grew. If that
+// is why you are here, edit the constant or trim `images search`, and do not
+// raise the budget to make a shared sentence fit; the budget is what stops a
+// migration turning into a `--help` nobody reads.
 func TestReadAPIHelpStaysWithinTheBudget(t *testing.T) {
 	nodes := readAPINodes(t)
 	var checked int
@@ -166,7 +181,11 @@ func TestReadAPIHelpStaysWithinTheBudget(t *testing.T) {
 		checked++
 		if got := utf8.RuneCountInString(body); got > helpBodyBudget {
 			t.Errorf("`%s` Long is %d chars, over the %d budget — prose that does not fit a "+
-				"screen belongs in the guide, not in `--help`", n.path, got, helpBodyBudget)
+				"screen belongs in the guide, not in `--help`. If you did not edit this body, "+
+				"check whether a SHARED constant grew (readAnonNote / readAnonShort / "+
+				"readJSONNote / serverOwnedEnumNote / deepPagingNote): this is the longest "+
+				"consumer, so it is named first whichever one moved",
+				n.path, got, helpBodyBudget)
 		}
 		for _, line := range strings.Split(body, "\n") {
 			if got := utf8.RuneCountInString(line); got > 80 {
@@ -276,11 +295,33 @@ func TestReadAPIHelpQuotesTheEnforcedLimit(t *testing.T) {
 					"the command actually passes", path, max, got)
 			}
 
-			// Only now is the help held to it.
-			want := limitRule(max)
-			if !strings.Contains(byPath[path].Long, want) {
+			// Only now is the help held to it — in TWO independent ways.
+			long := byPath[path].Long
+
+			// 🔴 (a) THE NUMBER ITSELF, NOT THE RENDERED SENTENCE. Asserting only
+			// `Contains(long, limitRule(max))` computes the expectation with the
+			// SAME function the body interpolates, so a bug INSIDE limitRule moves
+			// both sides together and this guard cannot see it. Measured: `max` ->
+			// `max+1` inside limitRule rendered "--limit takes 1–101" while
+			// `models search --limit 101` still errored "must be between 1 and 100"
+			// — and `go test ./...` was 18/18 ok, 0 FAIL. That is AGENTS' "never
+			// derive a test's expectation from the implementation it tests", and
+			// this line is the fix: strconv.Itoa is not limitRule.
+			if !strings.Contains(long, strconv.Itoa(max)) {
+				t.Errorf("`%s` Long never states the number it enforces (%d).\nLong:\n%s",
+					path, max, long)
+			}
+			// (b) …and inside the shared sentence, so the number cannot merely be
+			// present somewhere unrelated (an example id, the 1000 offset cap).
+			if want := limitRule(max); !strings.Contains(long, want) {
 				t.Errorf("`%s` Long does not state the limit it enforces.\nwant: %q\nLong:\n%s",
-					path, want, byPath[path].Long)
+					path, want, long)
+			}
+
+			// (c) The FLAG BLOCK is a second published surface and must agree.
+			if usage := byPath[path].Flags().Lookup("limit").Usage; !strings.Contains(usage, strconv.Itoa(max)) {
+				t.Errorf("`%s --limit`'s flag description (%q) does not state the ceiling %d — "+
+					"`--help` would contradict itself, flag block versus body", path, usage, max)
 			}
 		})
 	}
@@ -306,6 +347,172 @@ func TestReadAPIHelpQuotesTheEnforcedLimit(t *testing.T) {
 	}
 }
 
+// byteIdentityClaims is the control corpus for the --json wording check: ways of
+// promising something emitJSON does not deliver. The checker is required to fire
+// on each, so it cannot rot into a filter that matches nothing.
+var byteIdentityClaims = []string{
+	"--json prints the raw /api/v1 response on stdout, unchanged.",
+	"The response is passed through verbatim.",
+	"stdout is byte-identical to the API body.",
+	"The bytes are reproduced byte for byte.",
+}
+
+var byteIdentityWords = []string{"unchanged", "verbatim", "byte-identical", "byte for byte"}
+
+func claimsByteIdentity(s string) bool {
+	l := strings.ToLower(s)
+	for _, w := range byteIdentityWords {
+		if strings.Contains(l, w) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReadJSONNoteDoesNotClaimByteIdentity measures the property and then holds
+// the prose to it.
+//
+// 🔴 THE FIRST VERSION OF readJSONNote SHIPPED "unchanged" ONTO ALL EIGHT GROUP
+// PAGES AND IT WAS FALSE. emitJSON re-indents through json.Indent, so a scripter
+// who diffed or hashed CLI output against the API body would find a mismatch
+// with nothing wrong. The README prose this was migrated FROM never said it — it
+// promises stdout PURITY ("nothing else is written to stdout"), which is a
+// different guarantee — so the falsehood was introduced by the migration, not
+// inherited by it.
+//
+// Both halves are needed: the measurement alone does not stop the word coming
+// back, and the wording check alone is a spelled guard over a property nobody
+// re-measured.
+func TestReadJSONNoteDoesNotClaimByteIdentity(t *testing.T) {
+	const compact = `{"items":[{"id":1,"name":"Pony","type":"Checkpoint"}],"metadata":{}}`
+
+	var sent []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sent = []byte(compact)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(sent)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_BASE_URL", srv.URL)
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+
+	out, _, err := run(t, "models", "search", "--json")
+	if err != nil {
+		t.Fatalf("models search --json: %v", err)
+	}
+	if len(sent) == 0 {
+		t.Fatal("the server was never hit — the comparison below would be vacuous")
+	}
+
+	// (a) The document survives: this is the promise that IS true, and asserting
+	// it stops the test degrading into "the output is mangled, fine".
+	var fromWire, fromCLI any
+	if err := json.Unmarshal(sent, &fromWire); err != nil {
+		t.Fatalf("fixture is not valid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(out), &fromCLI); err != nil {
+		t.Fatalf("--json stdout does not parse — the pure-JSON promise is broken: %v\n%s", err, out)
+	}
+	if !reflect.DeepEqual(fromWire, fromCLI) {
+		t.Fatalf("--json changed the DOCUMENT, not just the bytes:\nwire: %s\nCLI:  %s", sent, out)
+	}
+
+	// (b) …and the bytes do NOT survive, which is why the note must not say so.
+	if strings.TrimRight(out, "\n") == string(sent) {
+		t.Fatalf("stdout is byte-identical to the wire — this test's premise is stale; "+
+			"re-check emitJSON before relaxing the wording rule.\n%s", out)
+	}
+
+	// (c) The wording.
+	if claimsByteIdentity(readJSONNote) {
+		t.Errorf("readJSONNote claims byte identity, which (b) just measured to be false:\n%s",
+			readJSONNote)
+	}
+	// (d) Positive control: the checker fires on the phrasings that matter.
+	for _, claim := range byteIdentityClaims {
+		if !claimsByteIdentity(claim) {
+			t.Errorf("the byte-identity checker does not fire on %q", claim)
+		}
+	}
+	if len(byteIdentityClaims) < 4 {
+		t.Fatalf("only %d control phrasings", len(byteIdentityClaims))
+	}
+}
+
+// TestLimitRenderersMatchLiteralExpectations is the ANCHOR that stops every
+// other limit assertion from being a tautology.
+//
+// 🔴 EVERY OTHER GUARD IN THIS FILE COMPARES A BODY AGAINST limitRule /
+// limitFlagUsage OUTPUT, AND A BODY THAT INTERPOLATES THE SAME FUNCTION MOVES
+// WITH IT. Measured on the first version: changing `max` to `max+1` inside
+// limitRule made `models search --help` promise "--limit takes 1–101" while the
+// command still refused 101, and the ENTIRE suite stayed green (18/18 ok).
+//
+// So these expectations are LITERAL — typed out, derived from nothing — and they
+// are the one place in this file where that is correct. Both ceilings in use are
+// covered, because a renderer could be wrong for one and right for the other.
+func TestLimitRenderersMatchLiteralExpectations(t *testing.T) {
+	for _, tc := range []struct {
+		max       int
+		rule      string
+		flagUsage string
+	}{
+		{100, "--limit takes 1–100; omit it for the server's default page size", "results per page (1-100)"},
+		{200, "--limit takes 1–200; omit it for the server's default page size", "results per page (1-200)"},
+	} {
+		if got := limitRule(tc.max); got != tc.rule {
+			t.Errorf("limitRule(%d) = %q, want %q", tc.max, got, tc.rule)
+		}
+		if got := limitFlagUsage(tc.max); got != tc.flagUsage {
+			t.Errorf("limitFlagUsage(%d) = %q, want %q", tc.max, got, tc.flagUsage)
+		}
+	}
+	// Both ceilings actually in use must be covered by the rows above, or this
+	// anchor drifts into pinning numbers nothing ships.
+	inUse := map[int]bool{}
+	for _, max := range readAPILimitLedger {
+		inUse[max] = true
+	}
+	for max := range inUse {
+		if max != 100 && max != 200 {
+			t.Errorf("ceiling %d is shipped but has no literal row here", max)
+		}
+	}
+	if len(inUse) != 2 {
+		t.Fatalf("%d distinct ceilings in use, want 2 — add a literal row", len(inUse))
+	}
+}
+
+// TestReadAPILimitFlagUsageIsDerived closes the second published surface.
+//
+// Four of the six list commands described their ceiling as a hand-typed literal
+// in the FLAG BLOCK ("(1-100)", "(1-200)") and two stated no bound at all while
+// their Long derived one — so moving a ceiling produced a `--help` page that
+// contradicted itself, and nothing failed. The idiom already existed in apps.go.
+func TestReadAPILimitFlagUsageIsDerived(t *testing.T) {
+	byPath := map[string]*cobra.Command{}
+	for _, n := range readAPINodes(t) {
+		byPath[n.path] = n.cmd
+	}
+	var checked int
+	for path, max := range readAPILimitLedger {
+		f := byPath[path].Flags().Lookup("limit")
+		if f == nil {
+			t.Fatalf("`%s` has no --limit flag", path)
+		}
+		checked++
+		if want := limitFlagUsage(max); f.Usage != want {
+			t.Errorf("`%s --limit` usage is %q, want %q — render it from the ceiling constant, "+
+				"the way apps.go already does", path, f.Usage, want)
+		}
+	}
+	if checked != len(readAPILimitLedger) || checked == 0 {
+		t.Fatalf("checked %d flag descriptions, want %d", checked, len(readAPILimitLedger))
+	}
+}
+
 // TestReadAPIHelpDescribesItsOwnPagingShape pins the other fact a reader acts
 // on, and it is the one a copy-paste gets wrong silently: these six list
 // commands do NOT page the same way. models/images take both --page and
@@ -318,13 +525,36 @@ func TestReadAPIHelpQuotesTheEnforcedLimit(t *testing.T) {
 // silent about --page is indistinguishable from a body that forgot it — and the
 // two phrasings are kept distinguishable so the present case cannot satisfy the
 // absent one.
+//
+// 🔴 IT PINS WHICH MODES ARE NAMED, AND WHICH ROLE EACH IS GIVEN — NOT THE REST
+// OF THE PARAGRAPH. State that plainly, because an earlier PR body claimed this
+// guard pinned "the paging shape" full stop and it did not: an audit inverted
+// `models search` to "--cursor is shallow paging, --page is deep paging" and
+// every assertion here stayed green. The role check below closes exactly that
+// inversion. What remains UNPINNED is the server-side arithmetic in the same
+// sentence — "1000", "429" — which has no local counterpart anywhere in this
+// repo to check against (pkg/civitai's isDeepPagingCap matches the server's
+// PHRASING, not the number). Single-sourcing it in deepPagingNote means the two
+// commands quoting it cannot disagree with each other; nothing here can tell you
+// it is still true of the server.
 func TestReadAPIHelpDescribesItsOwnPagingShape(t *testing.T) {
-	var checked int
+	var checked, bothModes int
 	for _, n := range readAPINodes(t) {
 		if !n.leaf || n.cmd.Flags().Lookup("limit") == nil {
 			continue
 		}
 		checked++
+		if n.cmd.Flags().Lookup("page") != nil && n.cmd.Flags().Lookup("cursor") != nil {
+			bothModes++
+			// A command offering BOTH modes must say which is which, from the one
+			// shared sentence — so an inversion has to be made in deepPagingNote,
+			// where it is one edit away from both call sites rather than hiding in
+			// one of them.
+			if !strings.Contains(n.cmd.Long, deepPagingNote) {
+				t.Errorf("`%s` offers both --page and --cursor but does not carry deepPagingNote, "+
+					"which is where the shallow/deep roles are stated", n.path)
+			}
+		}
 		t.Run(n.path, func(t *testing.T) {
 			for _, flag := range []string{"page", "cursor"} {
 				var (
@@ -361,6 +591,23 @@ func TestReadAPIHelpDescribesItsOwnPagingShape(t *testing.T) {
 	}
 	if checked != len(readAPILimitLedger) {
 		t.Fatalf("checked %d list commands, want %d", checked, len(readAPILimitLedger))
+	}
+	if bothModes != 2 {
+		t.Fatalf("%d commands offer both paging modes, want 2 — the role assertion above had "+
+			"no subjects", bothModes)
+	}
+	// 🔴 THE ROLES THEMSELVES, PINNED AGAINST LITERALS. deepPagingNote is
+	// interpolated into the bodies, so "the body contains deepPagingNote" cannot
+	// see an inversion made INSIDE deepPagingNote — the same tautology
+	// TestLimitRenderersMatchLiteralExpectations exists to break for limitRule.
+	for _, want := range []string{
+		"--page is shallow paging",
+		"--cursor is deep paging",
+	} {
+		if !strings.Contains(deepPagingNote, want) {
+			t.Errorf("deepPagingNote no longer says %q — swapping the two roles tells a reader "+
+				"to page deep with the mode the API caps at 1000:\n%s", want, deepPagingNote)
+		}
 	}
 }
 
@@ -402,6 +649,17 @@ func TestReadAPIHelpNamesItsAliases(t *testing.T) {
 //   - TestReadAPICommandsRunAnonymously proves the claim behaviourally.
 //
 // A body that merely contains the word "anonymous" would satisfy neither.
+//
+// 🔴 NEITHER HALF CONSTRAINS WHAT THE SENTENCE CLAIMS, WHICH IS THE WHOLE POINT
+// OF #268 — so TestReadAnonNoteKeepsItsException below is the third half. This
+// one is checking DISTRIBUTION (does every page carry the note); that one checks
+// CONTENT (does the note still say the true thing). Measured: replacing
+// readAnonNote's exception clause with the blanket claim #268 removed, and a
+// LENGTH-NEUTRAL blanket rewrite of readAnonShort, both survived a fully green
+// `go test ./...` before it existed. Note the near miss that made a longer
+// rewrite look guarded: it was killed by the BUDGET guard, for pushing
+// `images search` past 1400 runes — green for the wrong reason, and invisible to
+// any rewrite that keeps the length.
 func TestReadAPIHelpStatesItsAuthRequirement(t *testing.T) {
 	var groups, leaves int
 	for _, n := range readAPINodes(t) {
@@ -429,6 +687,99 @@ func TestReadAPIHelpStatesItsAuthRequirement(t *testing.T) {
 	if strings.Contains(readAnonNote, readAnonShort) || strings.Contains(readAnonShort, readAnonNote) {
 		t.Fatal("readAnonNote and readAnonShort must not contain one another — the per-form " +
 			"assertions above would stop distinguishing them")
+	}
+}
+
+// authRequiringCommands is the ledger of commands that DO need a credential —
+// the exception that makes the blanket claim #268 removed a false one.
+//
+// It is not taken on trust: each row is RUN with no token configured and must be
+// refused with civitai.ErrUnauthorized. Only then is readAnonNote required to
+// name it. So the exception clause is backed by measurement, and deleting the
+// clause fails while deleting the exception ITSELF (were `app list` ever to go
+// anonymous) fails differently and by name.
+var authRequiringCommands = map[string][]string{
+	"app list": {"app", "list"},
+	"app view": {"app", "view", "some-slug"},
+}
+
+// blanketAuthClaims is the CONTROL CORPUS for the universal-quantifier check:
+// phrasings of the claim #268 had to remove. It is asserted below that the
+// checker FIRES on each of them, so the denylist cannot rot into a filter that
+// matches nothing.
+var blanketAuthClaims = []string{
+	"Reads are anonymous — no login needed, and every command in this CLI works without a token.",
+	"No login is needed for any command in this CLI.",
+	"Reads are anonymous; all commands work without a token.",
+	"Nothing in this CLI requires a login.",
+}
+
+// universalAuthQuantifiers is the denylist. It is a SPELLED guard and is
+// declared as one: a blanket claim phrased around every entry here would slip
+// through. It is paired with the exception-naming rule below, which is
+// structural, precisely because neither is sufficient alone.
+var universalAuthQuantifiers = []string{
+	"every command", "any command", "all commands", "nothing in this cli",
+	"anywhere in this cli", "the whole cli", "no command ",
+}
+
+func claimsBlanketAnonymity(s string) bool {
+	l := strings.ToLower(s)
+	for _, q := range universalAuthQuantifiers {
+		if strings.Contains(l, q) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestReadAnonNoteKeepsItsException is the CONTENT half of the auth guard.
+func TestReadAnonNoteKeepsItsException(t *testing.T) {
+	// (1) The exception is real — measured, not assumed.
+	for name, args := range authRequiringCommands {
+		t.Run("exception is real/"+name, func(t *testing.T) {
+			setupReadAPIServer(t) // no token configured
+			_, _, err := run(t, args...)
+			if !errors.Is(err, civitai.ErrUnauthorized) {
+				t.Fatalf("`civitai %s` was expected to be refused without a token (that is what "+
+					"makes the blanket claim false); got %v", name, err)
+			}
+		})
+	}
+	if len(authRequiringCommands) == 0 {
+		t.Fatal("no auth-requiring commands ledgered — the exception clause would have no basis")
+	}
+
+	// (2) readAnonNote must NAME every one of them. This is what a blanket
+	// rewrite deletes, and it is structural: the names come from the ledger the
+	// measurement above just validated.
+	for name := range authRequiringCommands {
+		if !strings.Contains(readAnonNote, name) {
+			t.Errorf("readAnonNote does not name `%s`, which IS refused without a token — "+
+				"dropping the exception restores exactly the false blanket claim #268 removed:\n%s",
+				name, readAnonNote)
+		}
+	}
+
+	// (3) Neither form may make a universal claim about the CLI.
+	for label, s := range map[string]string{"readAnonNote": readAnonNote, "readAnonShort": readAnonShort} {
+		if claimsBlanketAnonymity(s) {
+			t.Errorf("%s makes a blanket claim about every command in the CLI, which is false "+
+				"(see the ledger above):\n%s", label, s)
+		}
+	}
+
+	// (4) 🔴 POSITIVE CONTROL for (3). A denylist that matches nothing is
+	// indistinguishable from a denylist that is doing its job, so the checker is
+	// required to FIRE on each known phrasing of the removed claim.
+	for _, claim := range blanketAuthClaims {
+		if !claimsBlanketAnonymity(claim) {
+			t.Errorf("the blanket-claim checker does not fire on %q — it cannot be relied on to "+
+				"catch the regression it exists for", claim)
+		}
+	}
+	if len(blanketAuthClaims) < 4 {
+		t.Fatalf("only %d control phrasings — too few to show the checker fires", len(blanketAuthClaims))
 	}
 }
 

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -54,7 +54,7 @@ func newTagsSearchCmd() *cobra.Command {
 
 Paging is --page only. This endpoint answers with the classic page envelope
 (total items, current page, total pages) and no cursor, so there is no --cursor
-here; the footer prints the next --page for you.
+here. The footer prints the next --page while the response says there is one.
 
 Each row is a tag NAME and a LINK. The name is what
 ` + "`civitai models search --tag <name>`" + ` takes — that is the follow-up this
@@ -92,7 +92,7 @@ website.
 		},
 	}
 	cmd.Flags().StringVar(&query, "query", "", "text search query")
-	cmd.Flags().IntVar(&limit, "limit", 0, "results per page")
+	cmd.Flags().IntVar(&limit, "limit", 0, limitFlagUsage(tagsLimitMax))
 	cmd.Flags().IntVar(&page, "page", 0, "page number")
 	bindReadFlags(cmd)
 	return cmd

--- a/internal/cmd/tags.go
+++ b/internal/cmd/tags.go
@@ -16,9 +16,24 @@ func newTagsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tags",
 		Short: "Search model tags on Civitai",
-		Long: `Read-only access to Civitai model tags via the public REST API
-(GET /api/v1/tags). Works anonymously.`,
-		Example: `  civitai tags search --query anime --limit 10`,
+		Long: `Read-only access to Civitai MODEL tags through the public REST API
+(GET /api/v1/tags).
+
+` + readAnonNote + `
+
+These are the model taxonomy — the same names ` + "`civitai models search --tag`" + `
+filters on, which is what this group is for: find the tag, then search with it.
+
+The group is search-only, and deliberately so: the public route answers with a
+tag NAME and a LINK per tag and nothing else, so there is nothing for a
+` + "`tags get`" + ` to fetch.
+
+Not to be confused with ` + "`civitai articles search --tags`" + `, which takes numeric
+tag IDS rather than these names — a different filter on a different endpoint.
+
+` + readJSONNote,
+		Example: `  civitai tags search --query anime --limit 10
+  civitai tags search --query anime --json`,
 	}
 	cmd.AddCommand(newTagsSearchCmd())
 	return cmd
@@ -30,10 +45,26 @@ func newTagsSearchCmd() *cobra.Command {
 		limit, page int
 	)
 	cmd := &cobra.Command{
-		Use:     "search",
-		Short:   "Search tags (GET /api/v1/tags)",
-		Example: `  civitai tags search --query anime --limit 10`,
-		Args:    cobra.NoArgs,
+		Use:   "search",
+		Short: "Search tags (GET /api/v1/tags)",
+		Long: `Search model tags via GET /api/v1/tags.
+
+--query matches the tag name; omit it to page the whole tag list.
+` + limitRule(tagsLimitMax) + `.
+
+Paging is --page only. This endpoint answers with the classic page envelope
+(total items, current page, total pages) and no cursor, so there is no --cursor
+here; the footer prints the next --page for you.
+
+Each row is a tag NAME and a LINK. The name is what
+` + "`civitai models search --tag <name>`" + ` takes — that is the follow-up this
+command exists to set up. The link is the equivalent models query on the
+website.
+
+` + readAnonShort,
+		Example: `  civitai tags search --query anime --limit 10
+  civitai tags search --limit 50 --page 2`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkLimit(limit, tagsLimitMax); err != nil {
 				return err

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -16,14 +16,27 @@ func newUsersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "users",
 		Short: "Look up users on Civitai",
-		Long: `Read-only access to Civitai users via the public REST API.
+		Long: `Read-only access to Civitai users through the public REST API.
 
-NOTE: the public users route is the search endpoint GET /api/v1/users (keyed by
-?query= or ?ids=). The per-id route /api/v1/users/{userId} is an INTERNAL
-webhook (POST + system token) and is NOT usable by the CLI, so "users get"
-resolves a user through the public search. Works anonymously.`,
+` + readAnonNote + `
+
+NOTE: the only public users route is the SEARCH endpoint GET /api/v1/users,
+keyed by ?query= or ?ids=. The per-id route /api/v1/users/{userId} is an
+INTERNAL webhook (POST plus a system token) and is not usable from the CLI, so
+` + "`users get`" + ` resolves a user through that public search.
+
+That is also why there is no ` + "`users search`" + `: the search endpoint is already
+what ` + "`users get`" + ` calls, and it answers with a handful of fuzzy neighbours
+rather than a browsable, pageable list — it has no pagination envelope at all.
+
+What comes back is identity only: id, username and avatar URL. For a user's
+models use ` + "`civitai models search --username <name>`" + `; for their published
+model COUNT use ` + "`civitai creators search --query <name>`" + `.
+
+` + readJSONNote,
 		Example: `  civitai users get some-username
-  civitai users get 5`,
+  civitai users get 5
+  civitai users get 5 --json`,
 	}
 	cmd.AddCommand(newUsersGetCmd())
 	return cmd
@@ -33,10 +46,25 @@ func newUsersGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <username-or-id>",
 		Short: "Look up a user by username or id (public search: GET /api/v1/users)",
-		Long: `Look up a user by username or numeric id via the public user search
-(GET /api/v1/users). A numeric argument is matched via ?ids=; anything else via
-?query= (returning the best-matching users, from which an exact username match
-is selected when present).`,
+		Long: `Look up a user by username or numeric id through the public user search
+(GET /api/v1/users). A numeric argument is sent as ?ids= and returns exactly
+that user; anything else is sent as ?query=.
+
+A NAME lookup is FUZZY on the server side — the endpoint answers with the
+closest-matching users, not with your user. So the CLI requires an exact
+(case-insensitive) username match before it prints anybody: a typo lists the
+near misses and fails as not-found rather than confidently printing the wrong
+person. When several users match, the exact one is printed and the rest are
+listed under "other matches". Pass the numeric id when you need certainty.
+
+An unknown user comes back from this endpoint as an empty HTTP 200 rather than
+a 404. The CLI still reports it as NOT FOUND, so a script gets the same signal
+it would from a real 404.
+
+The result is identity only — id, username, avatar URL. There are no stats and
+no model list on this route.
+
+` + readAnonShort,
 		Example: `  civitai users get some-username
   civitai users get 5 --json`,
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
Continues the README-prose → `Long` migration that #274 piloted on `app listing`, over the **public read API** group — the one part of the tree where the README is genuinely the richer surface, and the only section with no command-reference table row of its own.

As of docs#49 the generator publishes each command's full `Long`, so everything here reaches developer.civitai.com on the next snapshot refresh. This is `Long`-only: `Annotations` is set on 0 of the 53 nodes and cobra renders it in neither `--help` nor `__complete`, so it cannot reach the docs site.

Merged with `origin/main` (`fbb36df`), so the measurements below are against what this will land on.

> **Revised after an adversarial audit.** The audit reproduced every measurement in the original body exactly — and found **three guards that were green while the thing they claimed to pin was broken**, plus **four prose claims this migration itself introduced that the code contradicts**. All seven are fixed in `731a55e` / `194e232`; the "what the guards do NOT pin" section below is new and deliberate.

## What changed

**21 nodes** — the whole read-API group, discovered structurally (a leaf is a command with both `--json` and `--anon`, which is exactly what `bindReadFlags` attaches and nothing else in this CLI has):

| family | nodes |
| --- | --- |
| `models` | group, `search`, `get` |
| `model-versions` | group, `get`, `by-hash` |
| `images` | group, `search`, `get` |
| `articles` | group, `search`, `get` |
| `collections` | group, `search`, `get` |
| `tags` | group, `search` |
| `creators` | group, `search` |
| `users` | group, `get` |

Five of them (`collections get`, `creators search`, `model-versions get`, `models get`, `tags search`) had **no `Long` at all** — cobra falls back to `Short`, so `--help` printed one line and the generator published one line with it.

Two of the 21 were not in the original scope and are pulled in by the group-wide guards rather than rewritten: **`articles get`** (+102 bytes — the shared anonymous-access line only) and **`collections search`** (+168 — that line plus the derived `--limit` ceiling and a rewrap). Exempting them would have meant a group where the auth requirement and the page ceiling are stated on 19 of 21 pages.

## Facts are derived, not retyped

- **Every `--limit` bound** — in the body *and* now in the flag description — renders through `limitRule` / `limitFlagUsage` from the endpoint's own ceiling constant, the same one `checkLimit` refuses above. The six ceilings are **not** equal (100 for models/articles/collections, 200 for images/tags/creators). Four commands previously described the ceiling as a hand-typed literal in the flag block and two stated no bound at all, so moving a ceiling produced a `--help` page that contradicted *itself* — flag block versus body — with the suite green. The idiom already existed in `apps.go`; it is now shared.
- **The `model-versions` alias list** renders from `cmd.Aliases`.
- **The paging shape** is described per command and asserted against that command's own flags; the shallow/deep roles are single-sourced in `deepPagingNote`.
- **What is server-side is labelled server-side.** `--type` / `--sort` / `--period` value sets are *not* modelled by the CLI — `addIfSet` copies them into the query unexamined and the API rejects an unknown one with a 400. The help says exactly that instead of vendoring an enum (AGENTS item 13's reasoning on a read path).
- **No exit-code numbers appear in the new prose.** The contract is already generated from `exitCodeDocs`; restating "exit 2" in 21 bodies would be a new drift surface for no gain.

## Auth accuracy

#268 corrected a blanket "reads are anonymous — no login needed" that was **false** for `app list` / `app view`. The claim here is stated once, keeps that exception *inside the sentence*, and is scoped to what this repo can verify — a claim about the CLI, not the server. It is now guarded on **both** axes:

- **behaviour** — `TestReadAPICommandsRunAnonymously` runs all 13 leaves with no token, requiring a clean exit and **no** `Authorization` header, with a token-configured positive control and an `--anon` control;
- **content** — `TestReadAnonNoteKeepsItsException` *runs* `app list` and `app view` with no token, requires each to be refused with `ErrUnauthorized`, and only then requires the note to name them. Before it existed, replacing the exception clause with the blanket claim survived a fully green suite.

## What the guards do NOT pin

Stated because the first version of this body overstated two of them.

- **The paging guard pins which modes are named and which role each is given — not the rest of the paragraph.** The audit inverted `models search` to "`--cursor` is shallow paging, `--page` is deep paging" and every assertion stayed green; the role check closes that. The server-side arithmetic in the same sentence (`1000`, `429`) has **no local counterpart** anywhere in this repo — `pkg/civitai`'s `isDeepPagingCap` matches the server's *phrasing*, not the number — so nothing catches it going stale. Single-sourcing it means the two commands quoting it cannot disagree with each other; that is the whole of the guarantee. Confirmed as a **declared known survivor** in the matrix below.
- **The auth content guard is half structural, half spelled.** Naming the measured exceptions is structural. The universal-quantifier check is a denylist with a control corpus; a blanket claim phrased around every entry would slip through.
- **`serverOwnedEnumNote`'s placement is prose, and unguarded.** Moving it back under a filter list that also names `--nsfw` would make it false again with nothing failing.

## Prose claims the audit falsified (all introduced here, none inherited)

1. **`--json` said "unchanged"** on all 8 group pages. `emitJSON` re-indents through `json.Indent` — measured, 113 bytes in → **194** out — so a scripter who diffed or hashed CLI output against the API body would find a mismatch with nothing wrong. The README prose this came from promises stdout *purity*, never byte-identity. Reworded, and `TestReadJSONNoteDoesNotClaimByteIdentity` now measures the property and holds the prose to it. Independently measured while fixing it: `emitJSON`'s raw-control-byte repair is **unreachable** from this group — a body with a literal CR fails `getInto`'s typed unmarshal first (exit 1, empty stdout) — so the help deliberately does not mention it.
2. **`models` claimed a search hit embeds `.modelVersions[]`** with "every version's files, hashes and trained words". `ModelListItem` models no such field and `TrainedWords` lives only on `ModelVersionDetail`. **Dropped, not reworded** — see the README note below.
3. **`model-versions get` said `.model` is `{name, type, nsfw, poi}`.** `ModelVersionModel` is `{Name, Type, NSFW}`; `poi` appears nowhere in this repo outside one README line.
4. **`serverOwnedEnumNote` sat under lists naming `--nsfw` and `--query`.** Measured: `articles search --nsfw=maybe` is refused *client-side* with **zero** requests — the opposite of "passed through for the server to reject". Each caller now names only the enum flags above it.

Two smaller ones: `tags`/`creators` said the footer prints the next `--page` unconditionally (`printPageFooter` prints it only while the response says another page exists), and `articles search` implied `articles get` breaks out the same numbers (it reports a different, all-time stats block that need not agree). Both qualified.

**README follow-up, deliberately not done here.** Claims 2 and 3 were inherited from `README.md` (lines ~741–749). I removed them from `--help` because *this repo cannot substantiate them* — but the CLI's parsed structs are declared subsets of the payload, so their absence is **not** evidence the API omits the fields. Correcting the README on that inference would be replacing one unverified claim with another. It needs one live `--json` measurement against `civitai.com`; flagged here rather than guessed.

## Measured `--help` delta (whole tree, 53 nodes)

Binaries built from `origin/main@fbb36df` and from this branch; `--help` captured at every node by walking each binary's own `Available Commands` (never a hardcoded list) and compared with `cmp`.

```
node set identical: 53 nodes on both sides
byte-identical: 32/53  (60.4%)
changed:        21/53  (39.6%)

whole tree: 104375 -> 121564 bytes (+17189, +16.5%)
whole tree:   1993 ->   2340 lines (+347,  +17.4%)
```

Per node (bytes / lines):

```
  articles                        940 ->   1790 (+850)    24 ->  41 (+17)
  articles get                   1216 ->   1318 (+102)    25 ->  28 (+3)
  articles search                1469 ->   2369 (+900)    28 ->  46 (+18)
  collections                    1018 ->   1944 (+926)    25 ->  44 (+19)
  collections get                 674 ->   1313 (+639)    17 ->  31 (+14)
  collections search             1596 ->   1764 (+168)    31 ->  35 (+4)
  creators                        745 ->   1640 (+895)    21 ->  39 (+18)
  creators search                 780 ->   1514 (+734)    19 ->  34 (+15)
  images                         1031 ->   2169 (+1138)   26 ->  48 (+22)
  images get                      857 ->   1626 (+769)    20 ->  35 (+15)
  images search                  2118 ->   3326 (+1208)   37 ->  60 (+23)
  model-versions                 1007 ->   1968 (+961)    26 ->  46 (+20)
  model-versions by-hash          739 ->   1533 (+794)    16 ->  34 (+18)
  model-versions get              650 ->   1559 (+909)    16 ->  34 (+18)
  models                          895 ->   1852 (+957)    24 ->  43 (+19)
  models get                      649 ->   1392 (+743)    17 ->  32 (+15)
  models search                  1899 ->   2908 (+1009)   33 ->  52 (+19)
  tags                            714 ->   1717 (+1003)   21 ->  41 (+20)
  tags search                     763 ->   1502 (+739)    19 ->  35 (+16)
  users                          1013 ->   1964 (+951)    26 ->  44 (+18)
  users get                       874 ->   1668 (+794)    20 ->  36 (+16)
```

**Attribution.** Against the *original* PR base `2387762` the delta is **25/53 changed**. The extra four — `app listing`, `app listing set-icon`, `app listing set-cover`, `app listing add-screenshot` — are byte-identical between this branch and current `origin/main`, i.e. they come from #275, not from this PR. Verified per node with `cmp` against both baselines.

## Mutation matrix — 27 mutants, 0 unexpected outcomes

Checksum-gated: every mutant's file hash is verified to have MOVED, so an edit that silently failed to apply is reported `NOT-APPLIED` and can never read as a survivor. A null mutant and a deliberately-unmatchable probe are the controls.

| mutant | expect | verdict | killed by |
| --- | --- | --- | --- |
| null (comment-only) | survive | SURVIVED | — |
| probe: pattern that cannot match (gate control) | not-applied | NOT-APPLIED | — |
| `models` help quotes the **images** ceiling | kill | KILLED | `…QuotesTheEnforcedLimit` |
| `models` help hardcodes `1–50` | kill | KILLED | `…QuotesTheEnforcedLimit` |
| `models search` **enforces** the images ceiling, help unchanged | kill | KILLED | `…QuotesTheEnforcedLimit` |
| limit ledger: row deleted / stale row added | kill | KILLED (both) | `…QuotesTheEnforcedLimit`, `…PagingShape`, `…LimitFlagUsageIsDerived` |
| auth note dropped from `tags search` | kill | KILLED | `…StatesItsAuthRequirement` |
| auth note downgraded: `models` group carries the leaf form | kill | KILLED | `…StatesItsAuthRequirement` |
| `creators search` stops documenting the missing `--cursor` | kill | KILLED | `…PagingShape` |
| `tags search` **advertises** a `--cursor` it does not have | kill | KILLED | `…PagingShape` |
| alias list truncated to the first alias | kill | KILLED | `…NamesItsAliases` |
| `--anon` stops forcing an anonymous client | kill | KILLED | `…CommandsRunAnonymously` |
| reads start requiring a token | kill | KILLED | `…CommandsRunAnonymously` (22 leaf failures) |
| `models get` loses its `Long` / its `Example` | kill | KILLED (both) | `…BodiesAreComplete` |
| a `Long` grows a 90-column line | kill | KILLED | `…StaysWithinTheBudget` |
| a read leaf loses `bindReadFlags` | kill | KILLED | 5 guards + `…NodeWalkFindsTheWholeGroup` |
| **R2** `limitRule` renders `max+1` | kill | KILLED | `TestLimitRenderersMatchLiteralExpectations` (+`…QuotesTheEnforcedLimit`) |
| **R2** `limitFlagUsage` renders `max+1` | kill | KILLED | `TestLimitRenderersMatchLiteralExpectations` |
| **R2** `readAnonNote` drops the exception for the blanket claim | kill | KILLED | `TestReadAnonNoteKeepsItsException` |
| **R2** `readAnonShort` blanket rewrite, **length-neutral** | kill | KILLED | `TestReadAnonNoteKeepsItsException` |
| **R2** `deepPagingNote` inverts the shallow/deep roles | kill | KILLED | `…PagingShape` |
| **R2** `models search` swaps the shared note for an inline inverted one | kill | KILLED | `…PagingShape` |
| **R2** `models search --limit` usage reverts to a stale literal | kill | KILLED | `…LimitFlagUsageIsDerived` |
| **R2** `readJSONNote` reintroduces the byte-identity claim | kill | KILLED | `TestReadJSONNoteDoesNotClaimByteIdentity` |
| **R2** `deepPagingNote`'s server numbers (1000→100, 429→503) | **survive (declared)** | SURVIVED | — |

Every R2 mutant is one the audit ran against the previous revision and found **surviving a fully green suite**; each now dies by the intended guard with its own message.

**One declared KNOWN SURVIVOR**, not an equivalent mutant: changing `1000`/`429` in `deepPagingNote` is a real semantic change that nothing catches, because those are server facts with no local counterpart. See "What the guards do NOT pin".

**One declared EQUIVALENT mutant.** `limitRule(articlesLimitMax)` → `limitRule(collectionsLimitMax)` renders **byte-identical** help (both ceilings are 100). Proven the pilot's way: the two binaries differ, and `cmp` on the rendered `articles search --help` is identical. A 100-capped body quoting 200 — the swap that matters — *is* caught.

**Guard-hole found by the battery and fixed, not reported around:** appending `Use --cursor for deep paging.` to `tags search` survived the first paging guard (the documented-absence sentence still satisfied it). The guard now requires every occurrence of the flag to *be* an occurrence of the `no --x` phrase.

## `make ci`

Green, read from the output rather than the exit code: **18/18 packages `ok`**, zero `FAIL`, no `panic: test timed out`, `gofmt -s -l .` prints nothing, `go vet ./...` clean.

## Residuals shipped knowingly

- **The `1000` / `429` deep-paging numbers are unpinned** (above) — the single most likely thing here to go stale silently.
- **Same-ceiling `--limit` swaps are invisible** — only two distinct strings exist across six endpoints; declared equivalent above.
- **The anonymous-access proof is about the CLI, not the server.** That the *server* serves these routes anonymously is not testable from this repo, and the help is worded so it does not claim to be.
- **`--sort` / `--period` / `--type` values are not enumerated in `--help`.** The flag usage strings still carry hand-typed example values; enumerating them in the bodies would be a vendored enum with no local counterpart.
- **`images search` has ~14 runes of budget headroom.** Five bodies interpolate shared constants, so growing one of those reddens the budget guard naming `images search` rather than the constant that grew. The guard's failure message and comment now say so.
- **`readAnonShort` appears on all 13 leaf pages** — deliberate: each leaf gets its own docs page and cannot rely on the group's having been read.
- **Two README claims (`.modelVersions[]` embedding, `poi`) are left in place** pending one live measurement — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
