### PR TITLE
fix(#270): stop pinning a server sentence in the README, and label MiB as MiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,7 @@ your value (`icon must be square-ish (aspect 2.00 outside 0.9–1.1)`).
 
 Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
 
-Three behaviours that are not obvious from the numbers:
+Four behaviours that are not obvious from the numbers:
 
 - **Icons are re-encoded server-side.** Whatever you upload is downscaled to at
   most **1024 px** on its longer side and re-encoded to PNG — aspect preserved,
@@ -1177,16 +1177,21 @@ Three behaviours that are not obvious from the numbers:
   the file you pass. A detailed photographic icon can clear the local check and
   still be refused for the size of the PNG the server made from it — the message
   quotes bytes, not pixels. Flat, simple artwork re-encodes far smaller.
+- **An icon's upper bound is a PIXEL count, not a file size.** The decoder that
+  re-encodes it refuses a source above roughly **16 megapixels** — about
+  4096 × 4096 — and it refuses it *regardless of how small the file is*. A flat
+  5000 × 5000 PNG compresses to a few hundred KB, so it clears every byte cap in
+  the first table and is still rejected. Downscale before you upload:
+  **1024 × 1024** is plenty, because that is what the server re-encodes to
+  anyway.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   renders, so ship them at the size you want shown.
 - **A wrong image is rejected, not quietly accepted, and it comes back fast.**
   The CLI attaches *before* it waits on the content scan, so the platform's
   verdict on shape arrives in a couple of seconds rather than after a scan that
   can take two minutes — and always before a moderator sees it. The message names
-  the requirement. A source image above ~16 megapixels (say 5000 × 5000) is the
-  one exception with an unhelpful message: it fails the icon decoder with
-  *"That icon couldn't be read"* rather than a dimension error. Downscale it and
-  retry.
+  the bound it applied and the value it measured — read it rather than guessing
+  which limit you crossed.
 
 > **Why the CLI does not enforce the second table.** These are platform
 > constants that can move. Stale *guidance* costs you one rejection that carries

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -47,7 +47,7 @@ const listingImageFormats = "png, jpeg or webp"
 // 🔴 IT IS COMPUTED FROM THE CAP CONSTANTS AND MUST STAY THAT WAY — the number
 // in the help has to be the number loadAndValidateImage enforces, and it is
 // rendered through the SAME humanBytes the refusal message uses, so `--help`
-// predicts the error text byte-for-byte ("larger than the 2.0 MB max") instead
+// predicts the error text byte-for-byte ("larger than the 2.0 MiB max") instead
 // of quoting a differently-rounded prose figure. A hand-typed "2 MiB" here is a
 // second copy of a constant: it reads fine, it survives every test that only
 // greps for a cap being mentioned, and it goes stale the day a cap moves.

--- a/internal/cmd/app_listing_help_test.go
+++ b/internal/cmd/app_listing_help_test.go
@@ -57,7 +57,7 @@ func listingHelpNodes(t *testing.T) map[string]*cobra.Command {
 //
 // The cross-kind assertions are separate and are not redundant with the
 // per-kind ones: icon and screenshot share a cap (2 MiB), so "set-cover quotes
-// 4.0 MB" is satisfied by a body that ALSO quotes the icon's — the shape a
+// 4.0 MiB" is satisfied by a body that ALSO quotes the icon's — the shape a
 // copy-paste between the two bodies produces.
 func TestListingHelpQuotesTheEnforcedCaps(t *testing.T) {
 	nodes := listingHelpNodes(t)
@@ -106,7 +106,7 @@ func TestListingHelpQuotesTheEnforcedCaps(t *testing.T) {
 	// 🔴 THE GROUP ASSERTION MUST BE CAP-IN-CONTEXT, NOT CAP-ALONE.
 	//
 	// `humanBytes(maxIconBytes)` and `humanBytes(maxScreenshotBytes)` are the SAME
-	// STRING today ("2.0 MB"), so three bare Contains checks over three strings —
+	// STRING today ("2.0 MiB"), so three bare Contains checks over three strings —
 	// two of them byte-identical — enforce only TWO of the three caps. Measured:
 	// deleting the icon cap from the group body, and deleting the screenshot cap
 	// from it, BOTH survived a green suite, because the other one's identical
@@ -130,7 +130,7 @@ func TestListingHelpQuotesTheEnforcedCaps(t *testing.T) {
 }
 
 // TestListingHelpNamesTheKindItDescribes closes the other half of the shared-cap
-// hole: a per-kind body asserted only to contain "2.0 MB" is satisfied by the
+// hole: a per-kind body asserted only to contain "2.0 MiB" is satisfied by the
 // OTHER 2 MiB kind's sentence.
 //
 // Measured: swapping `set-cover`'s `listingSourceRule(kindCover)` to `kindIcon`
@@ -141,7 +141,7 @@ func TestListingHelpQuotesTheEnforcedCaps(t *testing.T) {
 // 🔴 THE ICON <-> SCREENSHOT SWAP IS A DECLARED **EQUIVALENT MUTANT**, NOT A
 // SURVIVING HOLE, AND THE DIFFERENCE MATTERS TO WHOEVER EDITS THIS NEXT.
 // `humanBytes(maxIconBytes)` and `humanBytes(maxScreenshotBytes)` are both
-// "2.0 MB" today, so swapping `kindScreenshot` -> `kindIcon` produces a DIFFERENT
+// "2.0 MiB" today, so swapping `kindScreenshot` -> `kindIcon` produces a DIFFERENT
 // BINARY and BYTE-IDENTICAL rendered help — measured, `cmp` on the two `--help`
 // outputs, with the differing binaries as the negative control. There is nothing
 // for any assertion to observe, which is why `foreign` deliberately names COVER
@@ -150,7 +150,7 @@ func TestListingHelpQuotesTheEnforcedCaps(t *testing.T) {
 // The protection against the swap MATTERING is elsewhere and was measured too —
 // set maxScreenshotBytes to 3 MiB under that mutation and
 // TestListingHelpQuotesTheEnforcedCaps reddens with "does not quote the cap it
-// enforces (3.0 MB)". So the swap is invisible exactly while it is harmless.
+// enforces (3.0 MiB)". So the swap is invisible exactly while it is harmless.
 func TestListingHelpNamesTheKindItDescribes(t *testing.T) {
 	nodes := listingHelpNodes(t)
 	cases := []struct {

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -1033,8 +1033,25 @@ func (p *progressWriter) line() string {
 	return fmt.Sprintf("  %s  %s", p.name, humanBytes(p.written))
 }
 
-// humanBytes renders a byte count in binary units (KiB/MiB/GiB…), abbreviated
-// as KB/MB/GB for brevity.
+// humanBytes renders a byte count in IEC binary units (KiB/MiB/GiB…).
+//
+// 🔴 THE LABEL AND THE DIVISOR HAVE TO AGREE. This divided by 1024 and printed
+// the SI suffixes (KB/MB/GB) "for brevity", which is not an abbreviation — it is
+// a different quantity. 2,097,152 bytes rendered as "2.0 MB", 4.9% below the
+// value it described. That was cosmetic while the string only reached download
+// progress; #275 put it in `--help`, where `set-icon` / `set-cover` interpolate
+// listingSourceRule(kind) and so advertised "at most 2.0 MB" / "at most 4.0 MB"
+// for caps the README documents — correctly — as 2 MiB and 4 MiB.
+//
+// It is fixed by RELABELLING, not by re-basing the arithmetic: every caller is
+// already a binary quantity. maxIconBytes and its siblings are literal
+// 1024-multiples mirroring server constants that are themselves 1024-multiples;
+// download progress counts raw bytes against a Content-Length; and the catalog's
+// SizeKB is multiplied by 1024 at the call site. A 1000 divisor would restate all
+// of them in a unit none of them is measured in and make `--help` quote "2.1 MB"
+// for the 2 MiB cap the README and AGENTS.md item 25 both name. The numbers this
+// returns are therefore unchanged from every release before this one; only the
+// suffix moved. TestHumanBytesLabelsItsOwnArithmetic pins both halves.
 func humanBytes(n int64) string {
 	const unit = 1024
 	if n < unit {
@@ -1045,5 +1062,5 @@ func humanBytes(n int64) string {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/cmd/humanbytes_test.go
+++ b/internal/cmd/humanbytes_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHumanBytesLabelsItsOwnArithmetic pins the unit SUFFIX to the divisor the
+// function actually uses.
+//
+// The regression it exists for: humanBytes divided by 1024 and labelled the
+// result with the SI suffixes (KB/MB/GB), so 2 MiB rendered as "2.0 MB" — a
+// figure 4.9% below the bytes it described. That was invisible while the string
+// only ever reached download progress, and #275 put it in `--help`: the
+// set-icon / set-cover one-liners interpolate listingSourceRule(kind), which
+// renders the cap through this function, so two commands advertised "at most
+// 2.0 MB" / "at most 4.0 MB" for caps the README documents as 2 MiB / 4 MiB.
+//
+// 🔴 The table has to pin the DIVISOR as well as the LABEL, because "relabel"
+// and "re-base the arithmetic" are two different fixes and only one of them was
+// wanted. Both mutants were run against this table rather than reasoned about:
+//
+//	SI labels over a 1024 divisor (the bug)  -> every prefixed row reddens.
+//	IEC labels over a 1000 divisor           -> 1023, 1,000,000, all three cap
+//	                                            rows, 1.5 MiB and every rung
+//	                                            from GiB up redden; only the
+//	                                            1024 row survives, because
+//	                                            %.1f rounds 1.024 back to "1.0".
+//
+// The 1,000,000 row is the loudest of those and is here on purpose: it is the
+// value where the two systems disagree about which RUNG to use at all
+// ("976.6 KiB" vs "1.0 MiB"), so it fails legibly rather than by a last digit.
+func TestHumanBytesLabelsItsOwnArithmetic(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"zero", 0, "0 B"},
+		{"one", 1, "1 B"},
+		{"just under a KiB", 1023, "1023 B"},
+		{"exactly a KiB", 1024, "1.0 KiB"},
+		// A decimal megabyte. Binary-labelled it is NOT "1.0 M<anything>".
+		{"one decimal MB", 1_000_000, "976.6 KiB"},
+		{"icon cap", maxIconBytes, "2.0 MiB"},
+		{"cover cap", maxCoverBytes, "4.0 MiB"},
+		{"screenshot cap", maxScreenshotBytes, "2.0 MiB"},
+		{"a MiB and a half", 1536 * 1024, "1.5 MiB"},
+		{"GiB", 1 << 30, "1.0 GiB"},
+		{"TiB", 1 << 40, "1.0 TiB"},
+		{"PiB", 1 << 50, "1.0 PiB"},
+		{"EiB", 1 << 60, "1.0 EiB"},
+	}
+	if len(cases) < 13 {
+		t.Fatalf("the table lost rows (%d) — a shrunken table is how this guard stops "+
+			"covering the unit ladder without anything going red", len(cases))
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := humanBytes(tc.in); got != tc.want {
+				t.Errorf("humanBytes(%d) = %q, want %q — the divisor is 1024, so the label "+
+					"must be the IEC one (KiB/MiB/GiB); an SI label over binary math "+
+					"understates the value it is describing", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHumanBytesNeverPrintsAnSILabel is the shape half of the assertion above.
+//
+// The table pins thirteen points; this pins the property, so a new unit added to
+// the ladder cannot arrive SI-labelled just because nobody added a row for it.
+// It sweeps the whole ladder (including the sub-KiB "N B" case, which is
+// correctly unprefixed in both systems) and requires every prefixed answer to
+// carry the "i".
+func TestHumanBytesNeverPrintsAnSILabel(t *testing.T) {
+	var checked int
+	for exp := 0; exp <= 6; exp++ {
+		n := int64(1)
+		for i := 0; i < exp; i++ {
+			n *= 1024
+		}
+		// A value comfortably inside the band, so rounding cannot push it up a rung.
+		for _, mult := range []int64{1, 3} {
+			got := humanBytes(n * mult)
+			checked++
+			unit := got[strings.LastIndex(got, " ")+1:]
+			if unit == "B" {
+				continue // bare bytes carry no prefix in either system
+			}
+			if !strings.HasSuffix(unit, "iB") {
+				t.Errorf("humanBytes(%d) = %q — unit %q is an SI label on a 1024-based "+
+					"divisor. Either label it IEC (%siB) or change the divisor to 1000, "+
+					"but the two must agree.", n*mult, got, unit, strings.TrimSuffix(unit, "B"))
+			}
+		}
+	}
+	// Positive control: a sweep that walked nothing would report the same serene
+	// pass as a correct one.
+	if checked != 14 {
+		t.Fatalf("swept %d values, want 14 — the ladder walk is wrong, so its clean "+
+			"verdict is a fact about the loop, not about humanBytes", checked)
+	}
+}

--- a/internal/cmd/listing_media_docs_test.go
+++ b/internal/cmd/listing_media_docs_test.go
@@ -112,7 +112,7 @@ func TestREADMEListingMediaPathsExistInEveryScaffoldedProject(t *testing.T) {
 // interpolating listingSourceRule(kind), so this asserts the interpolation picked
 // the right kind, which is exactly the copy-paste #274 caught in the Long bodies.
 //
-// Scoped to icon and cover on purpose: their caps DIFFER (2.0 MB vs 4.0 MB), so
+// Scoped to icon and cover on purpose: their caps DIFFER (2.0 MiB vs 4.0 MiB), so
 // "contains mine" and "does not contain the sibling's" are independent
 // assertions. add-screenshot's Short carries no cap, and its cap string is
 // byte-identical to the icon's today, so asserting on it would be #274's
@@ -254,5 +254,128 @@ func TestREADMEListingByteCapsMatchTheCLIConstants(t *testing.T) {
 		if !strings.Contains(section, want) {
 			t.Errorf("the Listing media requirements section never says %q — the dimension bounds then read as rules the CLI enforces", want)
 		}
+	}
+}
+
+// emphasisedQuotedSentenceRe matches a markdown-emphasised verbatim quotation —
+// *"…"* — which in this section is only ever used for one thing: reproducing the
+// exact sentence the platform is expected to print back.
+//
+// It is a SHAPE, not a spelling. Banning the one message that rotted would be a
+// guard against re-typing four particular words; banning the shape catches the
+// next author who pins a different sentence the same way.
+var emphasisedQuotedSentenceRe = regexp.MustCompile(`\*"[^"]+"\*`)
+
+// TestREADMEDoesNotPinAServerSentenceForTheOversizedSource is the doc-rot guard
+// for the half of this section that nothing else can check.
+//
+// The byte caps are the CLI's own constants, so the sibling test above can
+// compare prose against code. The platform's REJECTION TEXT is not in this repo
+// at all, so the only defence is not to quote it. That is not hypothetical: the
+// README documented the oversized-source case by quoting the decoder's
+// catch-all, *"That icon couldn't be read"*, and civitai/civitai#3737 replaced
+// that message with one that names the pixel limit and the measured value. The
+// paragraph was accurate when written and became false on a merge in another
+// repo, with nothing here to notice.
+//
+// So the rule this pins: state what the platform DOES (it names the bound), not
+// what it SAYS. A sentence is exactly the thing that moves.
+//
+// 🔴 The two halves are different kinds of guard and are labelled as such.
+// The quotation ban is a REGRESSION guard — it is red on the tree that shipped
+// the stale paragraph. The "advice survived" assertions are INVARIANT guards:
+// they were already true before this fix, and they are here because deleting the
+// paragraph is the other way to satisfy the ban.
+func TestREADMEDoesNotPinAServerSentenceForTheOversizedSource(t *testing.T) {
+	// Validate the instrument before reading its verdict. A regex that cannot
+	// match the shape it exists to find reports "clean" over anything.
+	const probe = `it fails the icon decoder with *"That icon couldn't be read"* rather than`
+	if !emphasisedQuotedSentenceRe.MatchString(probe) {
+		t.Fatalf("the extractor does not match the shape it exists to find (%s) — "+
+			"a clean verdict below would be a fact about the regex, not about the README",
+			emphasisedQuotedSentenceRe)
+	}
+
+	section := readmeSectionSlice(t, readREADME(t), "\n### Listing media requirements\n")
+	if len(section) < 500 {
+		t.Fatalf("the `Listing media requirements` section is only %d bytes — the section extractor is reading the wrong block:\n%s", len(section), section)
+	}
+
+	if hits := emphasisedQuotedSentenceRe.FindAllString(section, -1); len(hits) > 0 {
+		t.Errorf("the Listing media requirements section pins %d verbatim server sentence(s): %q.\n"+
+			"A quoted message is a claim about another repo's source that this one cannot check, and it "+
+			"goes stale silently — civitai/civitai#3737 rewrote exactly such a message. Say what the "+
+			"platform names in its rejection; do not reproduce the sentence.", len(hits), hits)
+	}
+
+	// Invariant half: the de-pinning must not take the advice with it. An author
+	// whose 5000x5000 icon is refused while every byte cap says they are fine has
+	// no way to reach the answer from the tables alone.
+	for _, want := range []string{"megapixel", "ownscale"} {
+		if !strings.Contains(section, want) {
+			t.Errorf("the Listing media requirements section no longer mentions %q — the "+
+				"pixel-ceiling advice is the reason this paragraph exists; de-pinning the "+
+				"server's wording must not delete the guidance", want)
+		}
+	}
+}
+
+// TestListingCapRenderingAgreesWithTheREADMEUnitSystem is the seam between the
+// two surfaces that quote a byte cap at an author: `--help`, which renders it
+// through humanBytes, and the README table, which spells it out in prose.
+//
+// Each was internally consistent and they disagreed with each other: the table
+// said "2 MiB" while `civitai app listing set-icon --help` said "at most 2.0 MiB"
+// for the same 2,097,152 bytes. Neither TestREADMEListingByteCapsMatchTheCLIConstants
+// (prose vs constant) nor TestListingHelpQuotesTheEnforcedCaps (help vs constant)
+// can see it, because both compare against the constant and never against each
+// other — the defect lives in the relationship, so the guard has to pin the
+// relationship.
+func TestListingCapRenderingAgreesWithTheREADMEUnitSystem(t *testing.T) {
+	section := readmeSectionSlice(t, readREADME(t), "\n### Listing media requirements\n")
+	if len(section) < 500 {
+		t.Fatalf("the `Listing media requirements` section is only %d bytes — the section extractor is reading the wrong block:\n%s", len(section), section)
+	}
+
+	cases := []struct {
+		kind string
+		cap  int
+	}{
+		{"icon", maxIconBytes},
+		{"cover", maxCoverBytes},
+		{"screenshot", maxScreenshotBytes},
+	}
+	var checked int
+	for _, tc := range cases {
+		rendered := humanBytes(int64(tc.cap))
+		unit := rendered[strings.LastIndex(rendered, " ")+1:]
+		if unit == "" || unit == rendered {
+			t.Fatalf("could not split a unit out of humanBytes(%d) = %q — the rest of this "+
+				"test would compare against an empty string and pass", tc.cap, rendered)
+		}
+		row := ""
+		for _, line := range strings.Split(section, "\n") {
+			if strings.HasPrefix(line, "| **"+tc.kind+"**") && strings.Contains(line, "iB") {
+				row = line
+				break
+			}
+		}
+		if row == "" {
+			// The sibling test owns "the row is missing"; here it means the
+			// comparison could not be made, which must not read as agreement.
+			t.Errorf("no byte-cap row for %s in the Listing media requirements section — "+
+				"the unit check could not run", tc.kind)
+			continue
+		}
+		checked++
+		if !strings.Contains(row, unit) {
+			t.Errorf("`civitai app listing` renders the %s cap as %q, but the README row never says %q — "+
+				"the help and the docs quote the same constant in different unit systems, so an "+
+				"author who sizes to one is surprised by the other.\nrow: %s",
+				tc.kind, rendered, unit, strings.TrimSpace(row))
+		}
+	}
+	if checked != len(cases) {
+		t.Fatalf("compared %d of %d caps — a guard that skipped rows is not a guard that passed", checked, len(cases))
 	}
 }


### PR DESCRIPTION
Two follow-ups to #270. Both are about a string that says one thing and means another; neither changes what the CLI accepts or refuses.

## 1. The README pinned a server message that has already been rewritten

The *Listing media requirements* section documented the oversized-source case by reproducing the decoder's catch-all verbatim — *"That icon couldn't be read"*. That was accurate when written and stopped being accurate when **civitai/civitai#3737** merged, replacing it with a message that names the pixel limit and the measured value (`That icon is 5000×5000 (25,000,000 pixels), over the 16,777,216 pixel limit. …`). It is not live yet — dp-prod serves `release` and the fix is on `main` — so this lands before the rot is visible rather than after.

The paragraph now asserts **intent** rather than **text**, which is the discipline the rest of that section already follows and the same doc-rot class the whole issue is about:

- a new bullet says the icon ceiling is a **pixel count, not a file size** — roughly 16 megapixels, refused no matter how small the file is, because a flat 5000 × 5000 PNG compresses to a few hundred KB and clears every byte cap in the first table — and tells you to downscale to 1024 × 1024, which is what the server re-encodes to anyway;
- the "one exception with an unhelpful message" carve-out is gone, so the section's general claim (*the message names the bound it applied and the value it measured*) now covers this case too, without quoting a sentence.

Checked and deliberately **not** changed: the scaffolded `internal/scaffold/templates/*/assets/README.md.tmpl` (identical across all three templates) never carried this paragraph, so there is nothing to fix in both places. It does quote two aspect/dimension rejections as *format* examples, and the README quotes one — those bounds have not moved and the quotes are attributed as illustrations, so they are out of scope here.

## 2. `humanBytes` divided by 1024 and printed the SI suffixes

`2.0 MB` for 2,097,152 bytes is not an abbreviation of 2 MiB; it is a figure 4.9% below the value it describes. That was cosmetic while the string only reached download progress. #275 put it in `--help`: `set-icon` / `set-cover` build their `Short` from `listingSourceRule(kind)`, so two commands advertised "at most 2.0 MB" / "at most 4.0 MB" for caps this README documents — correctly — as 2 MiB and 4 MiB.

**Fixed by relabelling, not by re-basing the arithmetic.** Every call site is already a binary quantity:

| call site | quantity |
| --- | --- |
| `internal/cmd/app_listing.go:56` (`listingSourceRule`) | `maxIconBytes` & co. — literal `N * 1024 * 1024`, mirroring server constants that are also 1024-multiples |
| `internal/cmd/app_listing.go:86` (group `Long`) | same three constants |
| `internal/cmd/app_listing.go:458` (`Uploading …`) | `len(data)` |
| `internal/cmd/app_listing.go:779` (the refusal) | `len(data)` vs `kindByteCap(kind)` |
| `internal/cmd/download.go:553` (`size:`) | `f.SizeKB * 1024` |
| `internal/cmd/download.go:658`, `:702` (file lists) | `f.SizeKB * 1024` |
| `internal/cmd/download.go:811` (`Saved …`) | bytes written |
| `internal/cmd/download.go:1031`, `:1033` (progress) | bytes written / Content-Length |
| `internal/cmd/generate_output.go:161` (`Saved …`) | bytes written |

A 1000 divisor would restate all of them in a unit none of them is measured in, change every number users have seen in download output since the CLI shipped, and make `--help` quote "2.1 MB" for the cap AGENTS.md item 25 calls 2 MiB. So: the numbers are unchanged, only the suffix moved. No test asserted an `"MB"` literal — every expectation is derived through `humanBytes` — and no doc quotes a sample of its output; the five stale `2.0 MB` / `4.0 MB` mentions were all in comments and are updated.

The one user-visible knock-on is `--help` width. Measured, not inferred: the `at most N.N MiB` line in `set-icon`, `set-cover` and `add-screenshot` goes 79 → **80** columns, which is the max `app_listing_help_test.go` enforces and a value two bodies on `main` already sit at. Rune budgets: `add-screenshot` 1304 → **1305/1400** (95 spare), the `app listing` group body 1305 → **1308/1400** (92 spare).

## Test discipline

Each guard was watched fail on `origin/main` (`e34f598`) with only the test files copied in, and again under a targeted mutation.

| test | red at `origin/main` | green at HEAD | mutation |
| --- | --- | --- | --- |
| `TestHumanBytesLabelsItsOwnArithmetic` | ✅ every prefixed row (`"1.0 KB"` want `"1.0 KiB"`, …) | ✅ | IEC labels over a **1000** divisor → reddens 1023, 1,000,000, all three cap rows, 1.5 MiB and every rung from GiB up; only the `1024` row survives it (`%.1f` rounds 1.024 back to `"1.0"`) |
| `TestHumanBytesNeverPrintsAnSILabel` | ✅ 12 findings across the ladder | ✅ | it is the *property* behind the table, so a new rung cannot arrive SI-labelled because nobody added a row; asserts a swept count of 14 so a broken walk cannot read as clean |
| `TestREADMEDoesNotPinAServerSentenceForTheOversizedSource` | ✅ `pins 1 verbatim server sentence(s)` | ✅ | bans the **shape** (`*"…"*`), not the four words that rotted: planting a *different* invented message (`*"Upload failed, try again later"*`) reddens it. Deleting the pixel bullet instead reddens the other half, with its own message. Both halves killed independently. |
| `TestListingCapRenderingAgreesWithTheREADMEUnitSystem` | ✅ all three caps | ✅ | drifting the README row to `≤ 2 MB` while the help stays IEC reddens it, and the `compared 2 of 3 caps` fatal stops a skipped row reading as a pass |

The last one is the seam neither existing guard could see: `TestREADMEListingByteCapsMatchTheCLIConstants` compares prose against the constant, `TestListingHelpQuotesTheEnforcedCaps` compares help against the constant, and nothing compared the two renderings with each other — which is exactly how one said `MiB` and the other said `MB` for the same 2,097,152 bytes.

`TestREADMEDoesNotPinAServerSentence…`'s second half ("the advice survived") is an **invariant** guard, not a regression guard — it was already true before this change, and it is there so that deleting the paragraph is not a way to satisfy the ban. Labelled as such in the source.

## Verification

- Full suite, counted from `-v` output rather than an exit code:
  - `origin/main` `e34f598`: `RUN=3034 PASS=3030 FAIL=0 SKIP=4`, 18/18 packages `ok`
  - this branch: `RUN=3051 PASS=3047 FAIL=0 SKIP=4`, 18/18 packages `ok` (+17 = 2 new parents in `listing_media_docs_test.go`, 1 parent + 13 subtests + 1 parent in `humanbytes_test.go`)
  - no `panic: test timed out` in either log
- `gofmt -s -l .` → 0 files · `go vet ./...` → clean · `go build ./...` → ok
- `golangci-lint` **v2.12.2** (the version pinned in `.github/workflows/ci.yml`): `0 issues`, rc=0. Instrument validated first — a probe file with an ST1005 error string and an unused func made the same invocation report `2 issues`, rc=1, so the clean verdict is about the code and not about the config.

Follow-up to #270.
