### PR TITLE
docs(handoff): r4 — end-of-session state, live diagnosis blocks, pruned

### DIFF
--- a/claudedocs/handoff-cli-docs-consolidation.md
+++ b/claudedocs/handoff-cli-docs-consolidation.md
@@ -1,4 +1,4 @@
-# Handoff: cli-docs-consolidation — 2026-08-09 (r3, SHIPPED)
+# Handoff: cli-docs-consolidation — 2026-08-09 (r4, SHIPPED + VERIFIED)
 
 ## Goal
 Decide whether `civitai/cli`'s in-repo docs should be dropped in favour of the hosted
@@ -12,229 +12,42 @@ generator can produce. But the README's *command-reference* prose can migrate in
 Deleting it and generating from `Short` would destroy ~80% of its content: reference
 table cells measure 60–2,263 chars (median ~400) against `Short` strings of 24–79.
 
-## State now (2026-08-09)
+## State now (2026-08-09, end of session)
 
-- **The pipeline is closed end-to-end.** See "SHIPPED" below for the six PRs.
-  `civitai/cli` @ `01c486e`+, `civitai-developer-docs` @ `3153eab`+ — both moved
-  repeatedly during the work; pin a SHA before measuring anything.
-- **Open from this session:** docs **#52** (the snapshot re-capture — the last
-  mile; nothing above is on the site without it).
-- Other sessions have unrelated PRs open in the docs repo (**#45**, **#5**) and
-  several in `cli`.
-- 🔴 **Both repos are SHARED checkouts.** `cli`'s tree shows
-  ` M claudedocs/handoff-app-blocks-hardening.md` — **another session's edit.**
-  Other sessions landed #244–#251 and #254 in `cli` during this work. Always
-  `git branch --show-current` before any write; work in a worktree.
+- **Both repos clean; nothing of this work is in flight.** `civitai/cli` @
+  `c5c3817`, `civitai-developer-docs` @ `2426938`. Both moved MANY times during
+  the session — **pin a SHA before measuring anything.**
+- **8 PRs merged** (table below). `build-site` is now a **required** context on
+  the docs repo.
+- **Open, neither mine to close:** `cli#271` (DIRTY — see the investigation
+  block) and `docs#5` (CLEAN, unblocked, another session's content).
 
-### DONE — earlier rounds (12 PRs + 1 issue)
+### 🔴 THREE PARALLEL SESSIONS ARE EDITING `internal/cmd/app_listing.go`
 
-| PR | Repo | What |
+Live worktrees, all touching the file `cli#274` rewrote:
+
+| worktree | branch | also touches |
 |---|---|---|
-| #243 | cli | 8 wrong `AGENTS.md` `item N` cross-refs + `agents_xrefs_test.go` |
-| #247 | cli | `agents_index_test.go` — catches an item the file's own index never names |
-| #252 | cli | this handoff |
-| #37 | docs | CLI snapshot 30 commits stale; `metrics` missing; reverse assertion; `__complete` enumeration |
-| #38 | docs | `hostHandlerParity` drift was **semantic**, not cosmetic; `replyNote` split |
-| #39 | docs | 69 example lines rendered; anchor slugs; heading depth |
-| #40 | docs | 7 stale SDK stamps, a wrong `ModelSlotContext` cast, Nix install + 3 guards |
-| #41 | docs | least-privilege `contents: read` on all 6 workflows |
-| #43 | docs | removed `paths:` from the 4 required workflows (they deadlocked the gate) |
-| #44 | docs | took the npm pin-freshness fetch out of the required `test-bridge` gate |
-| #42 | docs | **CLI reference 19 → 52 commands + global flags** |
-| #46 | docs | retired the hand-maintained flag tables from `site/guide/cli.md` |
-| **issue #253** | cli | the `login --help` NUL byte — filed here, **FIXED by #264** (`9cfe468`) |
+| `cli-270-listing-docs` | `zach/270-listing-media-docs` | `app_listing.go`, `listing_media_docs_test.go` |
+| `cli-270-attach-order` | `zach/270-attach-before-scan` | `app_listing.go`, `appapi/listing.go` |
+| `cli-270-docrot-humanbytes` | `zach/270-readme-generalise-and-humanbytes` | **merged as #282** |
 
-### Verified live
-- Published reference documents `generate`, `workflows`, `download`, `models`,
-  `app metrics`, and `--spend`/`--budget` (the site previously told authors
-  `dev:live` could not spend Buzz).
-- `civitai-developer-docs` branch protection **created this session** — it had
-  **none** before. Requires `test-cli`, `test-messages`, `test-bridge`,
-  `typecheck-snippets` (`strict=false`, `enforce_admins=false`, no reviews).
-  `cli` protection unchanged (5 contexts).
-- `appblocks-drift.yml` scheduled cron **green at 2026-08-07T07:52:57Z** — first
-  green schedule since 07-27; #38 fixed the 10-day red streak.
-- Forgejo downgrade (`civitai/civitai#3713`) **rolled out** — prod on `5.0.2249`,
-  6/6 pods. Released by another session.
+**Do not edit `app_listing.go` without checking those first**, and never in the
+base clone. `cli#271`'s branch is checked out in `/tmp/wt-handoff3`, which is why
+its conflict was left to its owner rather than resolved.
 
-## The Long/Annotations split — SCOPED AND PILOTED (2026-08-07, session 2)
+### The derived-not-typed rule PAID OFF, measured
 
-The premise of next-step 1 below was **half wrong, and the half that was wrong is
-the half that mattered.** Measured on the whole tree at `aeceb6b`, 53 command
-nodes, via a scratch test that dumps the real cobra tree (`Short`/`Long`/
-`Example`/`Annotations`) as JSON — not by parsing help text:
-
-| Fact | Measured |
-|---|---|
-| Nodes carrying an `Annotations` map | **0 of 53** |
-| Nodes with NO `Long` at all | 8 |
-| Nodes with a `Long` under 400 chars | 16 more |
-| README table cells, 16 matched rows | 6,255 chars total |
-| `Long` on those same 16 nodes | **19,017 chars** total |
-
-**`Long` is already 3× RICHER than the README table for the App-authoring
-commands.** For 14 of the 16 matched rows the ratio is >1 (`app submit` 11×,
-`app init` 9×). Only `whoami` is genuinely README-richer (590 vs 431). So
-"migrate the README's prose into `Long`" is mostly ALREADY DONE where the handoff
-assumed it was pending — and the real gap is the **public read-API group**
-(`models`/`images`/`collections`/`creators`/`tags`/`users`/`model-versions`/
-`articles`), which owns 19 of the 24 empty-or-thin nodes and has **no table row
-at all**.
-
-### 🔴 `Annotations` CANNOT reach the docs site. Measured, not inferred.
-
-The generator captures exactly two channels per node — `civitai <path> --help`
-and `civitai __complete <path> ""` — and parses the text
-(`gen-appblocks-cli.mjs:13-15`). Cobra's default help template does not render
-`Annotations`. Probe: set `Annotations{"probe:visible-in-help": "ZZPROBEZZ"}` on
-`workflows get` and rebuild —
-
-- `strings <binary> | grep -c ZZPROBEZZ` → **1** (the probe really applied)
-- in `--help` → **0**; in `__complete` → **0**
-- positive control, a word that IS in that help (`PRESIGNED`) → **1**
-- `workflows get --help` is byte-identical with and without it (1512 both)
-
-So an `Annotations` half is a no-op for docs unless (a) a custom help template
-renders them — at which point they are `Long` with extra steps and cost the same
-terminal space, or (b) a `cli.json` export seam, which the gotchas below
-**disprove**. **Recommendation: drop the `Annotations` half.** The split that
-survives is `Long` (prose, budgeted) vs the *guide* (everything that does not fit).
-
-### 🔴 THE BLOCKER: the generator PARSES `Long` and then THROWS IT AWAY.
-
-`gen-appblocks-cli.mjs:781` —
-`description: short || parseLongDescription(help).split('\n')[0] || ''`
-
-`parseLongDescription` captures the whole `Long` body, but it is only a
-**fallback**, and even then only its **first line**. A subcommand always has a
-`Short` from the parent's "Available Commands" block, so `short` always wins.
-Measured end-to-end through the real generator with `CIVITAI_CLI_LIVE=1
-CIVITAI_CLI_BIN=<pilot binary>`: the pilot added ~4,000 chars of `Long` and the
-published `cli.json` gained **+926 chars, all of it `examples`**. The `Long`
-reached `--help` and nothing else.
-
-**Nothing about this migration reaches developer.civitai.com until that line
-changes** (emit `longDescription: parseLongDescription(help)` alongside
-`description`, and render it in `<CliReference />`). That is a `civitai-developer-docs`
-PR and it is the **prerequisite**, not a follow-up — do it before migrating any
-further group.
-
-🔴 **AND THE FIX IS WORTH MORE THAN THE WHOLE MIGRATION.** Measured by adding that
-one line to a scratch copy of the generator and running it against the pilot
-binary: **52 of 52** commands gain a `longDescription`, publishing **43,460 chars
-of prose that ALREADY EXISTS in the CLI today** — `cli.json` goes 42,784 →
-88,747 chars (**+107%**). The largest are `generate` (5,726), `download` (3,742),
-`app dev-token` (3,245), `app create` (2,385), `app validate` (2,293). None of
-that required writing a word. Do this BEFORE authoring any more `Long`, or the
-authoring is measured against a surface that discards it.
-
-### Pilot — `civitai app listing`, 7 nodes, on branch `zach/help-long-pilot`
-
-Chosen because it holds 3 of the 8 no-`Long` nodes, maps to the README's densest
-single table row, and its missing facts (formats + per-kind byte caps) are **Go
-constants**, so the help can be derived from the validator rather than duplicated.
-
-- set-icon / set-cover / add-screenshot gained a `Long` + `Example` (had neither).
-- status / rm-screenshot / reorder gained an `Example`.
-- Formats + caps now stated, **computed** from `maxIconBytes`/`maxCoverBytes`/
-  `maxScreenshotBytes` through the same `humanBytes` the refusal message uses, so
-  `--help` predicts the error text.
-- Four pre-existing lines over 80 columns rewrapped.
-
-**`--help` cost, base vs the committed pilot, all 54 captured nodes:** 47 nodes
-byte-identical, 7 changed; tree 100,451 → 104,190 bytes (**+3.7%**) and
-1,987 → 2,065 lines (**+3.9%**). Per node the group runs 16→32 lines (set-icon),
-17→40 (add-screenshot, the largest).
-
-Three guards, none subsuming the others — caps-vs-constants (incl. cross-kind,
-since icon and screenshot share a 2 MiB cap), completeness (Long+Short+Example on
-every node, tree-walked with a count floor), budget (1400 chars / 80 columns).
-**9/9 mutants killed by the intended guard, checksum-gated; a comment-only null
-mutant survived.** `make ci` green, 18/18 packages.
-
-🔴 **Count RUNES, not bytes, in a column guard.** The first version used `len()`
-and failed four PRE-EXISTING bodies that render inside 80 columns — em-dashes are
-3 bytes, one column.
-
-### Where the remaining ~46 nodes stand
-
-| Bucket | Count | Nodes |
-|---|---|---|
-| No `Long` | 5 left | `collections get`, `creators search`, `model-versions get`, `models get`, `tags search` |
-| Thin (<400) | 14 left | the rest of the read-API group |
-| Mid (400–1200) | 17 left | mostly fine |
-| Rich (>1200) | 11 | `generate` (5,726), `download` (3,742), root (4,203) — these need a BUDGET, not more prose |
-
-## Open investigations — live diagnosis state
-
-### ~~`civitai login --help` emits a raw NUL byte — #253~~ — FIXED
-Closed by `9cfe468` (#264). Re-verified on a clean build at `aeceb6b`:
-`civitai login --help | tr -dc '\000' | wc -c` → **0** (positive control:
-`printf 'a\000b' | tr -dc '\000' | wc -c` → 1, so the pipe is wired).
-The original diagnosis is kept below for the mechanism.
-
-### `civitai login --help` NUL byte — the original diagnosis (mechanism only)
-- **Symptom + exact repro:** `civitai login --help > out.txt` yields a file git,
-  grep and `file(1)` classify as binary.
-- **Observed (with values), on a CLEAN build from `origin/main`** (not a dirty tree):
-  - `internal/cmd/login.go:42` — `const tokenFlagNoValue = "\x00civitai-token-no-value"`
-  - `civitai login --help | tr -dc '\000' | wc -c` → **1**
-  - `file -b` → **`data`**; `grep -c token` → `binary file matches`
-  - `od -c` at the break: `e n - n o - v a l u e " ]  \0   s   t`
-  - Mechanism: pflag's `FlagUsagesWrapped` builds rows as `<flag>\x00<usage>` and
-    **splits on the first `\x00`**. `NoOptDefVal` is interpolated as `[="%s"]`, so
-    the row holds two NULs, pflag aligns on ours, and its own separator reaches
-    stdout. A parser reading the row sees the flag as `--token string[="`.
-- **Ruled out:** terminal/TTY artifact (reproduces piped to a file); a dirty-tree
-  artifact (clean build from `origin/main` reproduces it).
-- **Status:** repaired **downstream only**, at the docs capture seam (#42). CLI-side
-  unfixed. Suggested fix in #253: any non-NUL sentinel — the only requirement is
-  that `NoOptDefVal` be non-empty and not collide with a real token — plus a
-  regression test asserting `login --help` contains no `\x00`, since the failure is
-  invisible in a terminal.
-
-### `scripts/check-appblocks-pins.mjs:35-38` states a trigger that no longer exists
-- **Observed, still present on `origin/main`:** *"It ALSO runs on a PR that touches
-  package.json so a pin bump is verified against `latest` at review time."*
-- **Why false:** #43 removed the `paths:` filter (so it ran on *every* PR, not only
-  package.json ones), then #44 removed the PR invocation entirely. `check:pins` is
-  now **schedule-only** via `appblocks-drift.yml:72-77`.
-- **Ruled out:** not the comment #44 *did* fix — that was the sibling file
-  `check-design-system-pins.mjs:172-181`.
-- **Next probe:** one comment edit pointing at `appblocks-drift.yml`. LOW.
-
-### `check-appblocks-pins.mjs` exits 2 on a SemVer build-metadata `latest`
-- **Observed (measured, mechanism corrected):** `parseSemver` **returns `null`**,
-  it does not throw — `parseSemver("0.31.0+build.7")` → `null`,
-  `parseSemver("0.31.0")` → `{major:0,minor:31,patch:0,pre:null}`. The throw is an
-  explicit guard in `compareSemver`: `if (!pa || !pb) throw new Error(...)`, whose
-  doc comment says "Unparseable -> throws" — intentional, not an oversight. That
-  propagates to the catch at ~`:190` → **exit 2**.
-- **Why it matters:** exit 2 is triggerable purely by *someone else's* publish, and
-  the in-file comment lists the red paths as "lagging / 404-410 / unexpected error"
-  without saying an upstream publish can cause the third. `X.Y.Z+meta` is valid
-  SemVer 2.0.0.
-- **Next probe:** accept build metadata in `parseSemver` (strip `+…` before compare)
-  or document it. Argues **for** #44 having removed this from the required gate. LOW.
-
-### IA wart: a public-API reader is now sent into the Apps section
-- **Symptom:** `site/guide/cli.md` (public-API guide — searching/downloading models)
-  now links flag reference to `apps/reference/cli.md`, under `/apps/` (App
-  *authoring*). That page's intro greets the reader with "the canonical tool for
-  authoring Civitai Apps" before mentioning downloads.
-- **Why it exists:** #46 deleted the guide's hand-maintained flag tables; the
-  generated reference is the only remaining copy, and it lives under `/apps/`.
-- **Options written up, none chosen:** (a) alias or render `<CliReference />` under
-  `/site/` too; (b) move the generated reference somewhere audience-neutral;
-  (c) minimum — reword the reference page's intro so it does not presume authoring.
-- **Note:** docs PR **#45** (another session, open) touches the `.md`/LLM channel and
-  may interact — the generated reference does **not** reach `llms-full.txt` because
-  `apps/reference/cli.md` is a bare `<CliReference />` tag (INFERRED from how
-  `vitepress-plugin-llms` operates; confirm by building and reading the artifact).
+`#282` (another session) relabelled `humanBytes` from `MB` to `MiB`. Because
+`listingSourceRule` computes its cap from `maxIconBytes` through that same
+function, `civitai app listing set-icon --help` **followed automatically** —
+it now reads `at most 2.0 MiB` with no edit to any help body. Verified on
+`c5c3817`: all five listing guards still exist and **86 subtests pass**. A
+hand-typed "2 MiB" would have silently disagreed with the code instead.
 
 ## SHIPPED — the pipeline is end-to-end (2026-08-09)
 
-Five PRs merged; the loop that this whole workstream was about is closed.
+Eight PRs merged; the loop this workstream was about is closed AND guarded.
 
 | PR | Repo | What |
 |---|---|---|
@@ -244,6 +57,11 @@ Five PRs merged; the loop that this whole workstream was about is closed.
 | #276 | cli | public read-API group, 21 nodes |
 | #50 | docs | `build-site` job asserting the built CLI-reference HTML |
 | #52 | docs | re-capture the snapshot — **without this none of the above is on the site** |
+| #277 | cli | handoff r3 |
+| #53 | docs | commits-behind drift signal (below) |
+
+Also: `build-site` **promoted to a required context**; `docs#5` was collaterally
+blocked by that and unblocked again (see the investigation block).
 
 Every merge verified **by content on `origin/main`**, never by ancestry — a
 squash merge makes `git merge-base --is-ancestor` false forever, so the ancestry
@@ -258,39 +76,94 @@ Capture from a **clean build pinned by SHA, with real version ldflags** — a ba
 `go build` off a `git archive` stamps `version=dev`, the base clone is dirty, and
 `~/.local/bin/civitai` has silently produced **47 commands instead of 52**.
 
+🔴 **AND UNTIL #53 NOTHING TOLD YOU.** `check-appblocks-cli-snapshot.mjs` parses
+`ahead` and `sha` out of the header and then classifies on the **tag alone**;
+`main` moves daily and tags are rare, so a snapshot 30 commits stale at the
+current tag verdicts `ok`. It said `ok` throughout the failure above. #53 adds
+`commitsSinceSnapshot`, printed on BOTH passing verdicts — **reported, never
+failed**, because failing on every upstream commit is a permanently-red daily
+gate. Measured live: the stale sha reports **12**, the current one 3, a bogus sha
+`null`. Watch that line in the scheduled `appblocks-drift` run.
+
+## Open investigations — live diagnosis state
+
+### `cli#271` conflicts with `#277`; its branch is checked out in a LIVE worktree
+- **Symptom + repro:** `gh pr view 271 --repo civitai/cli --json mergeStateStatus`
+  → `DIRTY`. `git merge-tree --write-tree pr271 origin/main` → **rc=1** (branch on
+  the EXIT CODE, never a marker grep — `merge-tree` prints only a tree OID on
+  success and emits no `<<<<<<<`).
+- **Observed:** #271 was cut from `aeceb6b`, the same base #277 started from, and
+  rewrites 144/131 lines of `claudedocs/handoff-cli-docs-consolidation.md`.
+  Its branch `docs/handoff-consolidation-r3` is checked out at **`/tmp/wt-handoff3`**
+  — `git worktree add` refuses it, and writing there would clobber a live session.
+- **Content of #271 that this file does NOT have** (must survive the merge):
+  (1) the snapshot-freshness gap — **already extracted and shipped as docs#53**;
+  (2) `llms-full.txt` carries the CLI reference now, **0 → 15** `civitai generate`
+  mentions after docs#45, so the llms concern is CLOSED, not open/INFERRED;
+  (3) the IA finding is narrower than recorded here — #42 fixed the frontmatter,
+  only `apps/reference/cli.md:23-24` and `:36` still presume App authoring.
+- **Ruled out:** resolving it here. Not a technical block — a concurrency one.
+- **Next probe:** once `/tmp/wt-handoff3` is free,
+  `git -C /tmp/wt-handoff3 merge origin/main`, take `main`'s version as the base
+  and splice in (2) and (3). Do NOT take #271's "State now"/"DONE" tables — they
+  predate all eight merges. Analysis is posted as a comment on the PR.
+
+### `check:built-site` cannot see a defect in the predicate it shares
+- **Symptom:** the guard added by docs#50 passes while the rendered page is wrong.
+- **Observed:** mutate `cliLongBody` itself to `return String(command?.description ?? '')`,
+  rebuild → the page renders **52** `.ab-long` blocks each containing the one-line
+  summary, and `check:built-site` reports **all 9 checks ok, rc=0**. Structural, not
+  a bug: `want` is recomputed through the same function the component calls, so
+  the two agree by construction.
+- **Ruled out:** "the gate set is broken" — the already-required `test-cli` kills
+  that mutant with 3 failures (`cliLongBody SUPPRESSES only…`, `synthetic controls
+  for each branch`, `STRUCTURAL — the committed fences equal cliLongBody…`).
+- **Also measured:** `grep -rn "vitepress build|npm run build" .github/workflows/`
+  returned nothing before #50 — no job built the site at all. Two mutants #50 does
+  kill that nothing else did: `{{ longText(c) }}` → `{{ c.description }}` (still 44
+  blocks, so a count assertion misses it) and `v-html` (15 of 44 emit raw `<slug>`).
+- **Leading hypothesis:** acceptable as-is; the risk is a reader believing
+  `check:built-site` covers the predicate.
+- **Next probe:** none needed to decide — the choice is whether to add a Vue test
+  runner. If not, add one sentence at the check saying what it structurally cannot
+  see.
+
+### `README.md`'s `.modelVersions[]` and `poi` claims are wrong and UNVERIFIED
+- **Symptom:** `README.md` ~741 says a `models search` hit "already embeds
+  `.modelVersions[]` — every version's files, hashes and trained words"; ~747 says
+  `.model` is "only {name, type, nsfw, poi}".
+- **Observed:** `ModelListItem` (`pkg/civitai/models.go:23-30`) has **no**
+  `modelVersions` field; `ModelVersionSummary` (:36-41) carries only
+  `ID/Name/BaseModel/Files`; `TrainedWords` exists only on `ModelVersionDetail`
+  (`model_versions.go:85`). `ModelVersionModel` is `{Name, Type, NSFW}` — `poi`
+  appears **nowhere in the repo except that README line**.
+- **Ruled out — do not "fix" by inference.** The CLI's structs are declared
+  SUBSETS of the API payload, so a field's absence in Go is NOT evidence the API
+  omits it. `cli#276` removed the claims from `--help` (where they had been
+  retyped) and deliberately left the README alone.
+- **Next probe, verbatim:**
+  `civitai models search --limit 1 --json | jq '.items[0] | {hasVersions: has("modelVersions")}'`
+  and `civitai model-versions get <id> --json | jq '.model | keys'`.
+
 ## Next steps (ranked)
 
-1. **Promote `build-site` to a required context** in `civitai-developer-docs`.
-   Unblocked by #51 (the build no longer fetches a third-party host). Until then
-   the renderer guard reports and gates nothing. Current required set:
-   `test-cli, test-messages, test-bridge, typecheck-snippets`.
-2. 🔴 **The `.vue` SFC is still unguarded by CI, and #50 only half-closes it.**
-   Nothing runs a Vue test runner; #50 builds the site and asserts the built HTML,
-   which kills the delete/wrong-variable/`v-html` mutants — but a defect inside
-   the SHARED `cliLongBody` predicate is invisible to it by construction (`want`
-   is recomputed through the same function the component calls). Measured: that
-   mutant renders 52 wrong blocks with all 9 built-site checks green. The
-   already-required `test-cli` catches it, so the gate SET holds — do not read
-   `check:built-site` alone as covering the predicate.
-3. **Settle the README's `.modelVersions[]` and `poi` claims** — both are wrong in
-   `README.md` (~741 and ~747) and were retyped from there into `--help` before
-   the audit caught them. Deliberately NOT "fixed" by inference: the CLI's structs
-   are declared SUBSETS, so a field's absence there is not evidence the API omits
-   it. Needs one live `--json` call against civitai.com.
-4. **`build-site.yml`'s inline comment is now stale** — it still calls the
-   `copy:spec` fetch "the one thing to fix first if this job is ever made a
-   required check". #51 fixed it. A comment is a claim.
-5. **The next migration bucket needs a BUDGET, not more prose.** After the pilot
-   (7) and the read-API group (21), what remains is ~17 MID nodes and 11 RICH ones
-   — and the RICH ones are the problem: `generate` is 5,726 chars, root 4,203,
+1. 🔴 **Resolve `cli#271`** — see the investigation block. It carries two measured
+   findings this file lacks, and it is the only thing left that can lose work.
+2. **Decide the `.vue` question** — add a Vue test runner, or document what
+   `check:built-site` structurally cannot see. One sentence either way.
+3. **Settle the two README claims** with the one live `--json` call above.
+4. **The next migration bucket needs a BUDGET, not more prose.** After the pilot
+   (7 nodes) and the read-API group (21), what remains is ~17 MID and 11 RICH —
+   and the RICH ones are the problem: `generate` 5,726 chars, root 4,203,
    `download` 3,742. Now that `Long` is published these land on BOTH surfaces, so
-   the question changed: it is no longer "migrate prose in" but "what belongs in
+   the question changed: no longer "migrate prose in" but "what belongs in
    `--help` versus the guide". Answer that before writing more.
-6. **Do NOT add an `Annotations` half.** Measured disproof above.
-7. **Decide the IA wart** (below) — cheapest is option (c).
-8. The two LOW items below (pins header comment; `parseSemver` build metadata).
-9. **Prune `claudedocs/`** — dated handoffs that belong in neither the repo nor the
-   site. Coordinate: other sessions actively write here.
+5. **Do NOT add an `Annotations` half.** Measured disproof above.
+6. **Decide the IA wart** (below) — cheapest is option (c), and #271 narrows it to
+   two sentences in the page BODY (the frontmatter was fixed by #42).
+7. The two LOW items below (pins header comment; `parseSemver` build metadata).
+8. **Prune `claudedocs/`** — this file is 400+ lines and other sessions write here
+   too. Coordinate before pruning.
 
 ## Gotchas / decisions / dead-ends
 
@@ -440,9 +313,29 @@ git -C ${D} show origin/main:appblocks-snapshots/civitai-cli-help.txt | command 
 #   <bin> <cmd> --help | grep -c ZZPROBEZZ -> 0   (it never reaches the channel)
 #   <bin> <cmd> --help | grep -c <a word actually in that help> -> 1  (control)
 
-# 🔴 The generator drops Long. This is the blocker, not a nicety.
-command grep -n 'description: short ||' ${D}/scripts/gen-appblocks-cli.mjs
-# End-to-end proof: generate from a binary with a fattened Long and diff cli.json —
-# only `examples` moves.
-CIVITAI_CLI_LIVE=1 CIVITAI_CLI_BIN=<your build> node ${D}/scripts/gen-appblocks-cli.mjs
+# 🔴 RETRACTED — "the generator drops Long" was true and is FIXED by docs#49.
+# It now emits `longDescription` alongside an untouched `description`:
+git -C ${D} show origin/main:scripts/gen-appblocks-cli.mjs | command grep -c longDescription  # expect >=1
+
+# the site actually carries this session's prose (0 here = stale snapshot)
+git -C ${D} show origin/main:appblocks-snapshots/civitai-cli-help.txt | command grep -c 'Set your store listing'  # expect 2  (#274)
+git -C ${D} show origin/main:appblocks-snapshots/civitai-cli-help.txt | command grep -c 'No login is needed'      # expect 8  (#276)
+
+# the drift signal #53 added — the tag check alone CANNOT see staleness
+cd ${D} && npm ci --ignore-scripts >/dev/null && node scripts/check-appblocks-cli-snapshot.mjs
+#   expect rc=0 and a line reading "N civitai/cli commit(s) have landed since…"
+#   positive control that the number is real, not a constant:
+cd ${D} && node -e "import('./scripts/check-appblocks-cli-snapshot.mjs').then(async m => {
+  console.log('stale sha 9cfe468 ->', await m.commitsSinceSnapshot('9cfe468'));  // a LARGE number
+  console.log('bogus sha         ->', await m.commitsSinceSnapshot('0000000'));  // must be null
+})"
+
+# build-site IS required now (re-measure; never infer gating from a job existing)
+gh api repos/civitai/civitai-developer-docs/branches/main/protection \
+  --jq '.required_status_checks.contexts'   # expect […, "build-site"]
+
+# 🔴 LOCAL-RUN TRAP: the shared base clones' node_modules have drifted ahead of
+# package-lock.json. Three docs tests fail identically on PRISTINE origin/main
+# until you `npm ci` in your own worktree. Run the discriminating control before
+# believing a local red.
 ```

--- a/claudedocs/handoff-cli-docs-consolidation.md
+++ b/claudedocs/handoff-cli-docs-consolidation.md
@@ -45,6 +45,39 @@ it now reads `at most 2.0 MiB` with no edit to any help body. Verified on
 `c5c3817`: all five listing guards still exist and **86 subtests pass**. A
 hand-typed "2 MiB" would have silently disagreed with the code instead.
 
+## The scoping answer (kept — next steps still depend on it)
+
+Measured across all 53 command nodes by dumping the real cobra tree as JSON, not
+by parsing help text:
+
+| Fact | Measured |
+|---|---|
+| Nodes carrying an `Annotations` map | **0 of 53** |
+| Nodes with NO `Long` at all | 8 → **now 0** (#274, #276) |
+| Nodes with a `Long` under 400 chars | 16 → mostly closed |
+| README table cells, 16 matched rows | 6,255 chars |
+| `Long` on those same 16 nodes | **19,017 chars** |
+
+`Long` was already ~3× richer than the README table for the App-authoring
+commands, so that half of the "migration" was mostly already done. The real gap
+was the public read-API group — no table row at all — which #276 closed.
+
+### 🔴 `Annotations` CANNOT reach the docs site — measured, not inferred
+
+The generator captures exactly two channels per node (`civitai <path> --help` and
+`civitai __complete <path> ""`) and parses the text. Cobra's default help template
+renders `Annotations` in neither. Probe on `workflows get` with
+`Annotations{"probe:visible-in-help": "ZZPROBEZZ"}`:
+
+- `strings <binary> | grep -c ZZPROBEZZ` → **1** (the probe really applied)
+- in `--help` → **0**; in `__complete` → **0**
+- positive control, a word that IS in that help (`PRESIGNED`) → **1**
+- `workflows get --help` byte-identical with and without it (1512 both)
+
+So an `Annotations` half is a no-op for docs unless a custom help template renders
+them — at which point they are `Long` with extra steps and cost the same terminal
+space. **The surviving split is `Long` (prose, budgeted) vs the guide.**
+
 ## SHIPPED — the pipeline is end-to-end (2026-08-09)
 
 Eight PRs merged; the loop this workstream was about is closed AND guarded.


### PR DESCRIPTION
Session handoff. Eight PRs merged, `build-site` promoted to a required context, and the snapshot now carries this session's prose — so the doc's next-steps list was mostly done and its "how to verify" block was checking the wrong things.

Net **−107 lines**: 248 removed (shipped status, done next-steps, a retracted blocker), 141 added (what a fresh session cannot re-derive).

## Three live-diagnosis blocks, with observed values

- **`cli#271` conflicts and its branch is checked out in a live worktree** (`/tmp/wt-handoff3`), so it was left to its owner rather than clobbered. Records the two measured findings it carries that this file lacked — `llms-full.txt` went 0 → 15 `civitai generate` mentions after docs#45, and the IA wart is narrower than recorded because #42 already fixed the frontmatter — plus the fact that its third finding is already shipped as docs#53.
- **`check:built-site` cannot see a defect inside the `cliLongBody` predicate it shares** with the component. Measured: 52 wrong blocks render with all 9 checks green. Not a broken gate — the required `test-cli` kills it — but a reader could believe otherwise.
- **The README's `.modelVersions[]` / `poi` claims** are wrong against the CLI's types and deliberately *not* fixed by inference, since those structs are declared subsets. Carries the exact `--json | jq` probe that settles it.

## Two things measured this session that change how to work here

🔴 **Three parallel sessions are editing `internal/cmd/app_listing.go` right now.** Their worktrees are listed. Check before touching that file.

**The derive-don't-type rule paid off, and it's measured:** #282 (another session) relabelled `humanBytes` from MB to MiB, and `app listing set-icon --help` followed automatically, because `listingSourceRule` computes its cap from the constant through that same function. All five listing guards still pass at `c5c3817` (86 subtests). A hand-typed "2 MiB" would have silently disagreed with the code.

## Verify block rewritten

It now **retracts** "the generator drops Long" (fixed by docs#49), checks that the *site* carries the prose rather than that the CLI does, drives the new drift signal with its positive control (stale sha → 12, bogus sha → `null`), and warns that the shared base clones' `node_modules` drift makes three docs tests fail identically on pristine `main`.

## One self-caught defect

The first prune deleted the Annotations disproof section, leaving next-step 5's "Measured disproof above" pointing at nothing. Caught by a post-write sanity grep, restored in the second commit, and the reference verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
