### PR TITLE
docs(agents): the map named a deleted package and missed five live ones — ledger it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ contributor checklist see [`CONTRIBUTING.md`](CONTRIBUTING.md).
   `gh` / `kubectl` / `stripe` mold.
 - JSON Schema validation via **santhosh-tekuri/jsonschema/v6**; self-update via
   **minio/selfupdate**. Release tooling: **goreleaser v2**.
+- **Interactive layer** (there IS one — this CLI is not print-only):
+  **huh v1.0.0** (`app init`'s form), **bubbletea v1.3.10** + **bubbles v1.0.0**
+  (`app dev-tunnel`'s spinner), **lipgloss v1.1.0** + **termenv v0.16.0** (every
+  styled string). It all funnels through `internal/ui`; read its `CONVENTION.md`
+  before adding color anywhere else.
+- One job each: `x/term` (TTY detection, gating prompts + spinner),
+  `x/crypto/ssh` (dev-tunnel), `x/net/html` (`internal/cmd/htmlrender.go`),
+  `x/text/message` (required by jsonschema/v6's `LocalizedString`),
+  `gopkg.in/yaml.v3` (config).
 - Module path `github.com/civitai/cli`; the executable is `./cmd/civitai`.
 
 ## What this is
@@ -61,10 +70,10 @@ Run the binary you built with `./bin/civitai <cmd>`; per-package coverage is
 ## Shell & CI gotchas
 
 These produce **clean exits and reassuring output while doing nothing** — the
-expensive class. Read the tool's *output*, not just its exit code.
+expensive class. Read the tool's *output*, not just its exit code. Host-generic
+shell traps were removed from here (they belong in your global rules); what
+follows is specific to this repo's toolchain.
 
-- **`cmd | head; echo rc=$?`** reports `head`'s status, not `cmd`'s. Capture
-  before piping, or use `set -o pipefail`.
 - **`gofmt -s -l .` checking zero files** prints nothing and exits 0 — same as
   "all clean". If a path is misquoted or the working tree is wrong, the clean
   verdict says nothing about the code. Verify you're in the right directory and
@@ -77,10 +86,10 @@ expensive class. Read the tool's *output*, not just its exit code.
 - **`go test ./...` with a broken import in `_test.go`** can compile to 0 tests
   and pass. If a package you expect tests for is silent, check explicitly:
   `go test -v -count=1 ./path/to/pkg | head`.
-- **`date -u -d "3 days ago 16:30"` vs `date -u -d "today -3 day"`** — the
-  latter silently returns the wrong day on some boxes. Build windows from epoch
-  math (`END=$(date -u +%s); START=$((END - 3*86400))`) for reliability.
-- **`gh pr checks` / `gh pr view --json statusCheckRollup` pitfalls:**
+- **`gh pr checks` / `gh pr view --json statusCheckRollup` pitfalls.** Kept: with
+  eight jobs of which only some gate, "have the checks settled?" is a live
+  question here, and each trap below answers it wrongly in the REASSURING
+  direction:
   - `.conclusion` is `null` for commit statuses (only check-runs populate it) —
     poll `.state` instead.
   - Checks go through `QUEUED` → `IN_PROGRESS` → conclusion. A poll matching
@@ -112,8 +121,24 @@ These go beyond the global defaults because this repo's release pipeline
 - `cmd/civitai/main.go` — binary entrypoint; injects build version/commit/date.
 - `internal/cmd/` — the Cobra tree, **one file per command**, wired in
   `root.go`.
-- `internal/{scaffold,validate,pkgzip,manifest,api,config,auth}` — the building
-  blocks behind those commands.
+- `internal/{scaffold,validate,pkgzip,manifest,config,auth}` — the building
+  blocks behind those commands. No `api` — #172 promoted it to `pkg/civitai` on
+  2026-07-20 and it sat here stale until found by hand, so this section is now a
+  BIDIRECTIONAL LEDGER: `layout_ledger_test.go` fails both when a package under
+  `internal/` is unnamed and when a named one does not exist.
+- `internal/appapi` — the App-Blocks REST/tRPC client (submissions, listing
+  media, `app metrics`); holds the `Submitter` / `Verifier` seams tests fake.
+- `internal/ui` — the ONE presentation layer; color is configured once, from the
+  root command. `internal/ui/CONVENTION.md` is the rule set, including why
+  `--json` must never pass through it.
+- `internal/devtunnel` + `internal/dnsprobe` — `app dev-tunnel`: the reverse SSH
+  tunnel (ephemeral in-memory key, never on disk) and the DoH resolver that keeps
+  the unpublished `dev-*.civit.ai` host out of the OS negative cache.
+  `devtunnel/embedcheck.go` is item 10.
+- `internal/blockproto` — the vendored block→host ready-ack (item 11) plus the
+  entry-graph resolver it and `internal/validate` share (item 20).
+- `internal/antipattern` — the scaffold-currency denylist: fails a template
+  shipping code against a dead platform endpoint or message (item 18).
 - `internal/genapi` — the orchestrator **generation** client behind
   `civitai generate` and `civitai workflows …`: tRPC transport, the two envelope
   shapes, the graph payload, model-version resolution. Deliberately not in
@@ -122,6 +147,11 @@ These go beyond the global defaults because this repo's release pipeline
   items 12–17, 19, 21 and 22 before touching it.
 - **Module root** (`package cli`, `main.go` + `schema.go`) exists *only* to
   `go:embed` the vendored `schema/` and `examples/`. It is not the executable.
+- `npm/` — the `@civitai/cli` wrapper (postinstall downloads the matching raw
+  binary from the GitHub Release). Not built by `make`; see the release section.
+- `flake.nix` / `flake.lock` — the Nix package. `vendorHash` pins the module set,
+  so a dependency change breaks the flake build until `bump-flake-vendorhash.yml`
+  updates it; `flake.yml` is what catches that.
 
 ## House conventions (with one real snippet)
 
@@ -160,7 +190,7 @@ func newWhoAmICmd() *cobra.Command {
 - **Output:** write to `cmd.OutOrStdout()` / `cmd.ErrOrStderr()`, never bare
   `fmt.Println`, so commands stay testable.
 - **Testability:** network/disk seams sit behind small interfaces
-  (`api.Submitter`, `api.Verifier`) or take a dir argument, so tests use
+  (`appapi.Submitter`, `appapi.Verifier`) or take a dir argument, so tests use
   `httptest` + `t.TempDir()` with no live server. New behaviour needs tests that
   cover the **error paths**, not just the happy path.
 - **Config:** `~/.config/civitai/config.yaml` (0600, atomic write). Overridable
@@ -938,7 +968,8 @@ the generation path mirrors nothing.**
 - Adding a new third-party dependency (this is a small, focused project).
 
 🚫 **Never**
-- Tag a release or push a `v*` tag without the maintainer (that triggers goreleaser → GitHub Release + tap push).
+- Tag a release or push a `v*` tag without the maintainer (that triggers goreleaser → **draft** GitHub Release + tap push).
+- **Publish a draft GitHub Release, or dispatch `release-npm.yml`, without the maintainer.** A separate consent from tagging: publishing the draft pushes `@civitai/cli` to npm. "Never" not "Ask first" because npm unpublish is restricted — a mistake is fixed only by publishing again, unlike everything under "Ask first", which is one revert away. See the release section.
 - Use bare `fmt.Println` for command output, or commit with `gofmt` diffs.
 - Treat local `civitai app validate` as authoritative — the server is.
 
@@ -947,13 +978,26 @@ the generation path mirrors nothing.**
 Releases are built by **goreleaser** from a GitHub Actions workflow on a `v*`
 tag push. With `main` green: `git tag v0.1.0 && git push origin v0.1.0`.
 `.github/workflows/release.yml` cross-compiles linux/darwin/windows ×
-amd64/arm64 (no windows/arm64), stamps version/commit/date ldflags, produces
-archives + `checksums.txt`, creates the GitHub Release (**`draft: true`** —
+amd64/arm64 — the **full cross product, windows/arm64 included** (no `ignore:`
+rule exists; confirm on a release, not the config:
+`gh release view v0.1.90 --json assets`). It stamps version/commit/date ldflags,
+produces archives + the bare `civitai-raw` binaries + `checksums.txt`, creates
+the GitHub Release (**`draft: true`** —
 publish manually after sanity-checking artifacts), and updates the **Homebrew
 cask** in `civitai/homebrew-tap` (goreleaser v2 uses `homebrew_casks:`, not the
 old `brews:`; needs the `HOMEBREW_TAP_GITHUB_TOKEN` secret with write to the
 tap). Validate config without releasing: `goreleaser check` and
 `goreleaser release --snapshot --clean` (dry-run into `./dist`).
+
+🔴 **TWO CHANNELS: PUBLISHING THE DRAFT IS WHAT FIRES THE SECOND.**
+`release-npm.yml` triggers on `release: types: [published]` and publishes the
+`npm/` wrapper **`@civitai/cli`**. So clicking "Publish release" is not the last
+step of the GitHub release — it is also, in the same click, an npm publish, and
+npm unpublish is restricted, so a bad version is fixed by publishing another, not
+by taking it back. Auth is **OIDC trusted publishing**: no `NPM_TOKEN`, and the
+trust is bound to repo + *that workflow file path*, so moving or renaming it
+breaks publishing and no secret rotation fixes it. Its own comments carry the
+rest (the `npm@11.18.0` pin, the raw-asset precondition) — read them there.
 
 ## License
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,12 @@
 
 ## Claude-specific
 
-- This is a single-binary Go project. Use the `make` targets (`make ci` mirrors
-  CI) — never reach for a non-Go package manager.
+- This is a single-binary Go project. Use the `make` targets — never reach for a
+  non-Go package manager. `make ci` does **not** mirror CI (it omits lint); run
+  `make lint` too. #287 removed that same false claim from `AGENTS.md`.
 - `AGENTS.md` is the single source of truth for this repo; keep curated guidance
   there, not here.
+- The split: `AGENTS.md` holds **decisions and rationale**; `README.md` is the
+  **published user contract** (exit codes, `--json` shapes, the command
+  reference) that items 24 and 26 must move in lockstep with — a behaviour change
+  touching either is incomplete until both are updated.

--- a/internal/validate/lockfile.go
+++ b/internal/validate/lockfile.go
@@ -335,11 +335,23 @@ const maxLockfileBytes = 64 << 20
 //     and a hand-made file is what issue #255 is about — not a mirror of a
 //     behaviour npm actually has.
 //   - pnpm / yarn: non-empty after a whitespace trim, and nothing more.
-//     `pnpm-lock.yaml` would need a YAML parser (a new third-party dependency,
-//     which is an "ask first" in AGENTS.md) and a yarn v1 `yarn.lock` carries no
-//     version key at all — it is a comment header and a flat list. "Not empty"
-//     is the whole of what can be said here without inventing authority, and it
-//     is exactly the reported defect from issue #255.
+//     `pnpm-lock.yaml` would need a YAML parser, and a yarn v1 `yarn.lock`
+//     carries no version key at all — it is a comment header and a flat list.
+//     "Not empty" is the whole of what can be said here without inventing
+//     authority, and it is exactly the reported defect from issue #255.
+//     🔴 "A NEW THIRD-PARTY DEPENDENCY, WHICH IS AN 'ASK FIRST'" IS RETRACTED
+//     FROM THIS BULLET — THE REASON WAS FALSE, THE DECISION IS NOT. Measured:
+//     `gopkg.in/yaml.v3 v3.0.1` is already a DIRECT requirement (`go list -m`
+//     reports `indirect=false`) and `internal/config/config.go` imports it in
+//     PRODUCTION code to read and write `~/.config/civitai/config.yaml`. So the
+//     parser was never the cost, and a false reason is worse than no reason: it
+//     invites someone to "fix" the rule the moment they notice the dependency is
+//     already there. The RULE and the BEHAVIOUR are unchanged, because the real
+//     argument stands on its own — a `pnpm-lock.yaml` carries no
+//     `lockfileVersion`-style invariant this check could assert, so parsing it
+//     buys nothing over the whitespace trim while adding a second parse surface
+//     to a FATAL check, and asserting more than that is the invented authority
+//     this bullet exists to refuse. See claudedocs/decisions/03-lockfile-check.md.
 //
 // 🔴 TWO RESIDUALS, STATED RATHER THAN HIDDEN — both are cases where this check
 // is STRICTER than `npm ci`, which is the direction that can block a working

--- a/layout_ledger_test.go
+++ b/layout_ledger_test.go
@@ -1,0 +1,236 @@
+package cli_test
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// AGENTS.md's "Layout (the non-obvious parts only)" section is the map a reader
+// follows to find out what a package is FOR before touching it. Nothing checked
+// that the map matched the territory, and it did not: the list named
+// `internal/api` — a package DELETED on 2026-07-20 when #172 promoted it to the
+// importable `pkg/civitai` SDK — while five packages that DO exist
+// (`antipattern`, `blockproto`, `devtunnel`, `dnsprobe`, `ui`) were absent, three
+// of them the subject of numbered items 10, 11 and 18. A reader who went looking
+// for `internal/api` found nothing; a reader who wondered what `internal/ui` was
+// got no answer from the file that exists to answer it.
+//
+// Both directions are silences, which is why neither was caught by review, and
+// why this guard is BIDIRECTIONAL. A guard that only rejected a missing package
+// would have left `api` sitting there; a guard that only rejected a stale entry
+// would have left `ui` unmentioned.
+//
+// # What this guard checks, and what it deliberately does not
+//
+// It checks PRESENCE — that the set of package names the Layout section spells
+// equals the set of directories under `internal/`. It says NOTHING about whether
+// the description beside a name is true, or still true. That is not a hole this
+// guard can close (no test can read English), and it is stated here so a green
+// run is not read as "the Layout section is accurate".
+//
+// # Design decisions
+//
+// 1. THE SCOPE IS THE LAYOUT SECTION, NOT THE FILE. AGENTS.md is ~2600 lines and
+// names most of these packages somewhere in the numbered items. If the guard
+// scanned the whole file, a package would count as "documented" because item 20
+// mentions it in passing — which is precisely the reader-hostile state this
+// exists to prevent, since the Layout section is where a reader looks. The region
+// is delimited structurally, heading to next heading, so ordinary edits inside it
+// do not move the bounds.
+//
+// 2. IT READS CODE SPANS, NOT PROSE. A name only counts when it appears inside
+// backticks, which is how every entry in that section is written. This keeps a
+// sentence that happens to say "internal/foo" in running text from satisfying the
+// ledger, and it is why the section's own note about the departed `api` package
+// deliberately does not spell it as a path.
+//
+// 3. IT WALKS ONLY THE IMMEDIATE CHILDREN OF `internal/`. `go list ./internal/...`
+// also reports `internal/scaffold/cmd/bump-pins`, a build-time tool nested inside
+// a package that IS ledgered. The Layout section is about the top-level building
+// blocks; requiring an entry for every nested tool would make it the exhaustive
+// tree its own heading says it is not.
+//
+// 4. IT HAS A COUNT FLOOR IN BOTH DIRECTIONS. A locator that silently matched
+// nothing — a renamed heading, a moved section — would report an empty ledger
+// against an empty filesystem read and pass serenely. So both sets must be
+// non-trivially populated before the comparison is believed. This is the
+// "reassuring zero" the repo's rules warn about: without the floor, the most
+// likely way for this guard to break is the way that looks like success.
+const layoutSectionHeading = "## Layout (the non-obvious parts only)"
+
+// layoutMinPackages is the floor for BOTH sets — the filesystem read and the
+// parse. It is well under the real count (15 at the time of writing) so ordinary
+// churn never trips it; it exists only to catch a read or a parse that returned
+// nothing at all.
+const layoutMinPackages = 8
+
+// internalPkgRe pulls the first path segment after `internal/` out of a code
+// span. It matches `internal/ui`, `internal/ui/CONVENTION.md` and each member of
+// a brace expansion `internal/{a,b,c}` alike, because the section legitimately
+// uses all three spellings.
+var internalPkgRe = regexp.MustCompile(`internal/(\{[^}]*\}|[a-z][a-z0-9_]*)`)
+
+// codeSpanRe matches a single-backtick code span. AGENTS.md uses no triple-backtick
+// fences inside the Layout section, so the simple form is sufficient there.
+var codeSpanRe = regexp.MustCompile("`([^`\n]+)`")
+
+func layoutSection(t *testing.T) string {
+	t.Helper()
+
+	b, err := os.ReadFile("AGENTS.md")
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	doc := string(b)
+
+	start := strings.Index(doc, layoutSectionHeading)
+	if start < 0 {
+		t.Fatalf("AGENTS.md no longer contains the heading %q — this guard's locator is broken, "+
+			"which is NOT the same as the ledger being clean. Fix the locator or the heading.",
+			layoutSectionHeading)
+	}
+	rest := doc[start+len(layoutSectionHeading):]
+
+	end := strings.Index(rest, "\n## ")
+	if end < 0 {
+		t.Fatalf("no heading follows %q — the section is unbounded, so the region would swallow "+
+			"the rest of the file and this guard would stop being scoped", layoutSectionHeading)
+	}
+	return rest[:end]
+}
+
+// parseInternalRefs pulls the internal/ package names out of one code span. It
+// is the ONE parser: both the ledger below and the spelling corpus call it, so a
+// narrowing of it fails the corpus by name rather than silently shrinking the
+// ledger and blaming the filesystem.
+func parseInternalRefs(span string, into map[string]bool) {
+	for _, m := range internalPkgRe.FindAllStringSubmatch(span, -1) {
+		name := m[1]
+		if !strings.HasPrefix(name, "{") {
+			into[name] = true
+			continue
+		}
+		// Brace expansion: `internal/{scaffold,validate,…}`.
+		for _, part := range strings.Split(strings.Trim(name, "{}"), ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				into[p] = true
+			}
+		}
+	}
+}
+
+// ledgeredPackages parses the package names the Layout section spells.
+func ledgeredPackages(t *testing.T) map[string]bool {
+	t.Helper()
+
+	got := map[string]bool{}
+	for _, span := range codeSpanRe.FindAllStringSubmatch(layoutSection(t), -1) {
+		parseInternalRefs(span[1], got)
+	}
+	return got
+}
+
+// realPackages reads the immediate children of internal/ that hold Go code.
+func realPackages(t *testing.T) map[string]bool {
+	t.Helper()
+
+	entries, err := os.ReadDir("internal")
+	if err != nil {
+		t.Fatalf("read internal/: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir("internal/" + e.Name())
+		if err != nil {
+			t.Fatalf("read internal/%s: %v", e.Name(), err)
+		}
+		for _, f := range files {
+			if !f.IsDir() && strings.HasSuffix(f.Name(), ".go") {
+				got[e.Name()] = true
+				break
+			}
+		}
+	}
+	return got
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestLayoutSectionLedgersEveryInternalPackage(t *testing.T) {
+	real := realPackages(t)
+	ledgered := ledgeredPackages(t)
+
+	// Positive controls. Either set coming back empty (or near-empty) means the
+	// instrument is broken, and a broken instrument reports a clean ledger.
+	if len(real) < layoutMinPackages {
+		t.Fatalf("only %d package(s) found under internal/ (%v) — expected at least %d. "+
+			"The filesystem read is broken; a comparison against it would pass for the wrong reason.",
+			len(real), sortedKeys(real), layoutMinPackages)
+	}
+	if len(ledgered) < layoutMinPackages {
+		t.Fatalf("only %d package name(s) parsed out of the Layout section (%v) — expected at least %d. "+
+			"The parse is broken; every 'missing' report below would be noise and every 'stale' "+
+			"report would be silence.", len(ledgered), sortedKeys(ledgered), layoutMinPackages)
+	}
+
+	for _, name := range sortedKeys(real) {
+		if !ledgered[name] {
+			t.Errorf("internal/%s exists but the Layout section of AGENTS.md never names it. "+
+				"Add a bullet saying what it is FOR — that section is where a reader looks "+
+				"before touching a package.", name)
+		}
+	}
+
+	for _, name := range sortedKeys(ledgered) {
+		if !real[name] {
+			t.Errorf("the Layout section of AGENTS.md names internal/%s, which does not exist. "+
+				"A map pointing at a deleted package is worse than no map: a reader greps for it, "+
+				"finds nothing, and cannot tell a rename from their own mistake.", name)
+		}
+	}
+}
+
+// TestLayoutLedgerParserHandlesEverySpelling drives the parser against a control
+// corpus rather than against AGENTS.md, so a future narrowing of the regex fails
+// here by name instead of silently shrinking the ledger. Without it the parser
+// could quietly stop understanding brace expansion — dropping six real packages
+// from the ledgered set — and the guard above would then report six spurious
+// "exists but is never named" errors that a maintainer would most cheaply
+// "fix" by deleting this file.
+func TestLayoutLedgerParserHandlesEverySpelling(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		span string
+		want []string
+	}{
+		{"plain", "internal/ui", []string{"ui"}},
+		{"with a file suffix", "internal/ui/CONVENTION.md", []string{"ui"}},
+		{"with an underscore", "internal/foo_bar", []string{"foo_bar"}},
+		{"brace expansion", "internal/{a,b,c}", []string{"a", "b", "c"}},
+		{"brace expansion with spaces", "internal/{a, b}", []string{"a", "b"}},
+		{"two in one span", "internal/a + internal/b", []string{"a", "b"}},
+		{"none", "pkg/civitai", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := map[string]bool{}
+			parseInternalRefs(tc.span, got)
+			if strings.Join(sortedKeys(got), ",") != strings.Join(tc.want, ",") {
+				t.Errorf("parsing %q: got %v, want %v", tc.span, sortedKeys(got), tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Accuracy fixes to the **non-item** prose of `AGENTS.md`, plus `CLAUDE.md` and one code comment.

**Rebased onto `77bd422`.** Main moved three times during this work (#287, #290, #293). Everything below is re-measured on the rebased tree — no number here is inherited from the pre-rebase version of this PR.

🔴 The numbered-item list is **untouched**. #290 split its nine largest items into `claudedocs/decisions/`; all six of its guards pass unchanged.

---

## 🔴 Retraction — a false claim I shipped in the first revision of this PR

The first revision said, in three places, that `make lint` **"falls back to `go vet`"** when golangci-lint is absent. **That is false.** The Makefile hard-fails:

```
lint:
	@command -v golangci-lint >/dev/null 2>&1 || { \
		echo "golangci-lint not found. Install it: ..."; exit 1; }
	golangci-lint run
```

Worse than a stale fact: `git show c5c3817:Makefile` confirms the hard-fail was already there **at this branch's own base**, so the claim was false at the moment I wrote it. I took it from the `AGENTS.md` line I was editing instead of reading the Makefile sitting in the same worktree — the exact failure this PR exists to fix, committed while fixing it. All three sites are gone (the table that carried two of them is dropped entirely, below).

#287 measured and fixed the `AGENTS.md` copy independently. `CLAUDE.md` carried the sibling claim — "`make ci` mirrors CI" — and is corrected here; `grep` confirms neither phrasing survives in `AGENTS.md`, `CLAUDE.md` or `README.md`.

## Dropped — #287 owns this content now

Removed from this PR rather than re-applied, because re-adding it recreates exactly the duplication I flagged in the first review round:

- ~~the eight-row CI job table~~
- ~~the `gh api …/protection` block and the measured required-contexts list~~ — item 11 owns it; #287 deliberately points there instead of restating it
- ~~the ✅ **Always** bullet~~ — verified I never edited it; #287's version stands untouched

Only one line of mine still references the job count, in the `gh pr checks` justification, and it now says "eight jobs of which only some gate" without restating which.

## Kept — none of it overlaps #287

### 1. `internal/api` has not existed since #172
```
$ ls internal/     # 14 dirs, no `api`
$ git log --oneline -1 4405553
4405553 refactor: promote internal/api to importable pkg/civitai SDK (#172)
$ grep -n "Submitter\|Verifier" internal/appapi/appblocks.go
34:type Submitter interface {     39:type Verifier interface {
```
Fixed in Layout and in House conventions (`appapi.Submitter` / `appapi.Verifier`), and now guarded.

### 2. "(no windows/arm64)" was false
No `ignore:` rule in `.goreleaser.yaml`. Confirmed against a real release, not the config:
```
$ gh release view v0.1.90 --json assets --jq '.assets[].name' | grep windows_arm64
civitai_0.1.90_windows_arm64.exe
civitai_0.1.90_windows_arm64.zip
```

### 3. The npm channel, and what publishing the draft actually does
`release-npm.yml` fires on `release: types: [published]`; `.goreleaser.yaml:101` sets `draft: true`. So **clicking "Publish release" is also an npm publish** of `@civitai/cli`. Auth is OIDC trusted publishing — no `NPM_TOKEN`, trust bound to repo + *that workflow file path*, so moving the file breaks publishing and no secret rotation fixes it.

Filed under 🚫 **Never**, not ⚠️ Ask first: npm unpublish is restricted, so a mistake is corrected only by publishing again — a different reversibility class from everything under "Ask first", which is one revert away. The operational details (the `npm@11.18.0` pin, the raw-asset precondition) are left in the workflow's own comments and pointed at rather than copied.

### 4. Stack omitted the entire interactive layer
Each dep mapped to its call site: `huh`→`app_init.go`; `bubbletea`+`bubbles`→`internal/ui/spinner.go` + `app_dev_tunnel.go` (`ui.Spinner()` has exactly one caller); `lipgloss`+`termenv`→`internal/ui/ui.go`; `x/term`→TTY detection in 4 files; `x/crypto/ssh`→`internal/devtunnel`; `x/net/html`→`htmlrender.go`; `x/text/message`→`validate.go:33` (required by jsonschema/v6's `LocalizedString`, not a choice); `yaml.v3`→`config.go`.

### 5. Layout omitted 5 of 14 packages
`antipattern`, `blockproto`, `devtunnel`, `dnsprobe`, `ui` — three of them the subject of items 10, 11 and 18, in a file whose own map never mentioned them. Plus `npm/` and `flake.nix`/`flake.lock`.

### 6/7. CI section → **dropped**, #287 owns it. Gotchas trim → kept
Removed `cmd | head; echo rc=$?` and the `date -u -d` bullet (host-generic; covered by global rules). **Kept the `gh pr checks` block** — it is *not* duplicated globally (the global rules cover `mergeable`/`mergeStateStatus` for conflicts, not check-run polling), this repo fans out across eight jobs and gates on a subset, and all four traps err in the reassuring direction. The lead-in now records why, so a future trimmer has the reasoning.

### 8. Added at your request: the false YAML claim in `lockfile.go`
`internal/validate/lockfile.go` justified not parsing `pnpm-lock.yaml` as needing "a new third-party dependency, an 'ask first'". Re-verified myself rather than inheriting #290's measurement:
```
$ go list -m -f '{{.Path}} indirect={{.Indirect}}' gopkg.in/yaml.v3
gopkg.in/yaml.v3 indirect=false
$ grep -n "yaml" internal/config/config.go
13: "gopkg.in/yaml.v3"      189: out, err := yaml.Marshal(...)   # production
```
Reason retracted in place; **rule and behaviour unchanged** — the real argument (a `pnpm-lock.yaml` carries no invariant this check could assert) stands on its own.

---

## `layout_ledger_test.go` — re-measured on the rebased tree

Makes the Layout section a bidirectional ledger against `internal/`: fails when a real package is unnamed **and** when a named one does not exist. Scoped to the Layout section (not the whole file, or an item mentioning a package in passing would count as documenting it); reads code spans, not prose; walks only immediate children of `internal/` (so `internal/scaffold/cmd/bump-pins` needs no bullet); one shared parser for both the ledger and its control corpus; count floors in both directions so a broken locator cannot compare an empty parse to an empty read and pass.

**Mutation counts re-run against the split AGENTS.md.** `md5sum` confirmed both files restored byte-identical after each:

| mutation | leaf/parent FAILs | evidence |
|---|---|---|
| delete `internal/dnsprobe` from Layout | **1** | names `dnsprobe` |
| **the original defect** — `api` back in the brace list | **1** | "names internal/api, which does not exist" |
| rename the section heading (break the locator) | **1, FATAL** | "this guard's locator is broken, which is NOT the same as the ledger being clean" |
| narrow the regex to drop brace expansion | **4** = 2 parents + 2 named leaves | corpus fails as `brace_expansion` / `brace_expansion_with_spaces`, so the diagnosis is "the parser broke", not five spurious "package missing" reports |

Identical to the pre-rebase counts — the guard is unaffected by the tier split, and its locator still finds the section.

**What it does not do,** stated in the file: presence only. It cannot tell whether a description is *true*.

**No guard for defects 2/3/6** — each would pin a fact the platform may legitimately change.

## Verification (rebased tree)

- `make ci` — **18 `ok` packages, 0 FAIL, 0 "no test files", 0 timeout panics**; `go mod tidy` left `go.mod`/`go.sum` clean.
- **`golangci-lint run ./...` at the CI-pinned v2.12.2** (`nix-shell -p golangci-lint`) — **0 issues**. Run explicitly because `make ci` does not, per #287.
- `gofmt -s -l .` — clean, positive control **322** `.go` files found.
- **#290's six guards all PASS**: `TestSplitItemBodiesArePreservedVerbatim`, `TestSplitTableCoversEveryEvidenceFile`, `TestSplitDigestsAreTheBaseCommitsText`, `TestEveryBaseBodyLineSurvivedTheMove`, `TestEvidencePointersAndFilesAreTheSameSet`, `TestEvidenceStubsCarryAThesisAndAPointer`.
- **Size ceiling: `AGENTS.md` is 67,799 bytes — 201 under the 68,000 limit.** My first rebased draft came in at 69,796 (1,796 over). I did **not** raise `agentsMaxBytes`, which the guard explicitly forbids; I cut my own additions instead — compressed every bullet, moved the npm operational details to a pointer at the workflow's own comments, and dropped the module-root test-file note (a bonus, not one of the assigned defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
