### PR TITLE
docs(handoff): fold cli#271's surviving findings into r5, re-measured

### DIFF
--- a/claudedocs/handoff-cli-docs-consolidation.md
+++ b/claudedocs/handoff-cli-docs-consolidation.md
@@ -1,4 +1,4 @@
-# Handoff: cli-docs-consolidation — 2026-08-09 (r4, SHIPPED + VERIFIED)
+# Handoff: cli-docs-consolidation — 2026-08-09 (r5, SHIPPED + VERIFIED; `cli#271` folded in)
 
 ## Goal
 Decide whether `civitai/cli`'s in-repo docs should be dropped in favour of the hosted
@@ -19,8 +19,11 @@ table cells measure 60–2,263 chars (median ~400) against `Short` strings of 24
   the session — **pin a SHA before measuring anything.**
 - **8 PRs merged** (table below). `build-site` is now a **required** context on
   the docs repo.
-- **Open, neither mine to close:** `cli#271` (DIRTY — see the investigation
-  block) and `docs#5` (CLEAN, unblocked, another session's content).
+- **`cli#271` is CLOSED** — its surviving content is in this file (see the
+  investigation block for what was taken, what was not, and why it was resolved by
+  extraction rather than by merging into a checkout this session does not own).
+- **Open, not mine to close:** `docs#5` (CLEAN, unblocked, another session's
+  content).
 
 ### 🔴 THREE PARALLEL SESSIONS ARE EDITING `internal/cmd/app_listing.go`
 
@@ -120,26 +123,36 @@ gate. Measured live: the stale sha reports **12**, the current one 3, a bogus sh
 
 ## Open investigations — live diagnosis state
 
-### `cli#271` conflicts with `#277`; its branch is checked out in a LIVE worktree
-- **Symptom + repro:** `gh pr view 271 --repo civitai/cli --json mergeStateStatus`
-  → `DIRTY`. `git merge-tree --write-tree pr271 origin/main` → **rc=1** (branch on
-  the EXIT CODE, never a marker grep — `merge-tree` prints only a tree OID on
-  success and emits no `<<<<<<<`).
-- **Observed:** #271 was cut from `aeceb6b`, the same base #277 started from, and
-  rewrites 144/131 lines of `claudedocs/handoff-cli-docs-consolidation.md`.
-  Its branch `docs/handoff-consolidation-r3` is checked out at **`/tmp/wt-handoff3`**
-  — `git worktree add` refuses it, and writing there would clobber a live session.
-- **Content of #271 that this file does NOT have** (must survive the merge):
-  (1) the snapshot-freshness gap — **already extracted and shipped as docs#53**;
-  (2) `llms-full.txt` carries the CLI reference now, **0 → 15** `civitai generate`
-  mentions after docs#45, so the llms concern is CLOSED, not open/INFERRED;
-  (3) the IA finding is narrower than recorded here — #42 fixed the frontmatter,
-  only `apps/reference/cli.md:23-24` and `:36` still presume App authoring.
-- **Ruled out:** resolving it here. Not a technical block — a concurrency one.
-- **Next probe:** once `/tmp/wt-handoff3` is free,
-  `git -C /tmp/wt-handoff3 merge origin/main`, take `main`'s version as the base
-  and splice in (2) and (3). Do NOT take #271's "State now"/"DONE" tables — they
-  predate all eight merges. Analysis is posted as a comment on the PR.
+### `cli#271` — RESOLVED BY EXTRACTION, not by merge (2026-08-09)
+- **What it was:** the r3 handoff, cut from `aeceb6b`. `main` moved under it (#277,
+  then #288 rewrote the same file), so it went `CONFLICTING` / `DIRTY` —
+  `git merge-tree --write-tree pr271 origin/main` → **rc=1**. Branch on the EXIT
+  CODE, never a marker grep: `merge-tree` prints only a tree OID on success and
+  emits no `<<<<<<<`, so a grep finds nothing whether or not a conflict exists.
+- 🔴 **Why it was not merged in place.** Its branch `docs/handoff-consolidation-r3`
+  is checked out at **`/tmp/wt-handoff3`**, so resolving it there meant writing into
+  a checkout this session does not own. Measured before deciding rather than
+  assumed: that worktree's tree is **clean** and its index has not been touched
+  since **2026-08-07 16:12** — idle, not busy. Idle is still not mine. Taking
+  `main` as the base and folding r3's surviving content in from a fresh branch
+  reaches the same file contents with no shared-checkout write, so that is what
+  happened, and #271 was closed pointing here.
+- **Everything of #271's that this file lacked has been folded in:**
+  (1) the snapshot-freshness gap — **already shipped as docs#53**, so nothing to
+  carry; (2) the llms-channel closure (**0 → 15** `civitai generate` mentions in
+  `llms-full.txt` after docs#45, plus 11 `--layout`) — recorded in the IA block
+  below, where it belongs, since it was the concern that used to ride along with
+  it; (3) the IA block itself; (4) the two `check-appblocks-pins.mjs` LOW items;
+  (5) the docs-side NUL-repair decision and the "a re-capture is never just the one
+  row" gotcha, both under *Gotchas*.
+- 🔴 **Every line number in #271 was RE-MEASURED before being copied, and three had
+  drifted** (`apps/reference/cli.md:23-24`→`:24`, `:36`→`:37`; `parseSemver`
+  `:59`→`:58`). A handoff's line numbers are a claim about a tree that has moved
+  since — re-measure, don't transcribe.
+- **Deliberately NOT taken:** r3's "State now" and its 14-PR DONE table. Both
+  predate all eight merges recorded above, and shipped-PR provenance is in git.
+- **Residual:** the `docs/handoff-consolidation-r3` branch and `/tmp/wt-handoff3`
+  still exist. Deleting either is its owner's call, not a leftover to tidy.
 
 ### `check:built-site` cannot see a defect in the predicate it shares
 - **Symptom:** the guard added by docs#50 passes while the rendered page is wrong.
@@ -178,10 +191,72 @@ gate. Measured live: the stale sha reports **12**, the current one 3, a bogus sh
   `civitai models search --limit 1 --json | jq '.items[0] | {hasVersions: has("modelVersions")}'`
   and `civitai model-versions get <id> --json | jq '.model | keys'`.
 
+### IA: the reference page's BODY still presumes App authoring — the frontmatter does not
+- **Symptom:** `site/guide/cli.md` — the *public-API* guide, about searching and
+  downloading models — sends readers to `apps/reference/cli.md` for flag reference,
+  a page that lives under `/apps/`, i.e. App **authoring**.
+- **Observed — NARROWER than this file recorded before #271 was folded in.** #42
+  already fixed the frontmatter, and it is audience-neutral today: *"The whole
+  civitai CLI command tree — commands, flags, examples and the global flags —
+  generated from the canonical Go CLI (civitai/cli)."* Only the **body** still
+  presumes the App author, and re-measured on docs `origin/main` @ `2426938` it is
+  exactly **two lines**: `apps/reference/cli.md:24` — *"is the canonical tool for
+  **authoring Civitai Apps**"* — and `:37` — *"(App authors usually do)"*.
+- **Ruled out:** the llms-channel concern that used to ride along with this one.
+  docs#45 closed it — `llms-full.txt` carries the CLI reference now, **0 → 15**
+  `civitai generate` mentions and 11 `--layout`, where it was **0/0** before. That
+  is measured, not inferred; do not re-open it as an open question.
+- **Options, none chosen:** **(a) reword those two body sentences — the cheapest,
+  and now the only thing wrong with the framing**; (b) alias/render
+  `<CliReference />` under `/site/` too; (c) move the reference somewhere
+  audience-neutral.
+  🔴 An earlier revision of the *Next steps* list said "cheapest is option (c)".
+  That was a mis-transcription of #271 and is wrong in the expensive direction:
+  (c) moves a page and every link into it, (a) is two sentences.
+- **Next probe:**
+  `git -C <docs> show origin/main:apps/reference/cli.md | sed -n '21,40p'`
+
+### Two LOW items in docs `scripts/check-appblocks-pins.mjs` — both still live
+Re-measured on docs `origin/main` @ `2426938`. Both were carried by #271; its line
+numbers are corrected here rather than copied.
+
+- **`:36-38` states a trigger that no longer exists.** The header reads *"It ALSO
+  runs on a PR that touches package.json so a pin bump is verified against `latest`
+  at review time."* False: #43 removed the `paths:` filter (so it ran on *every*
+  PR, not only package.json ones) and #44 then removed the PR invocation entirely.
+  `check:pins` is **schedule-only**, from `appblocks-drift.yml:86`.
+  🔴 **The obvious check gives the wrong answer here.**
+  `grep -c 'check:pins' .github/workflows/appblocks-bridge.yml` returns **1**, which
+  reads as "still wired to a PR" — it is a **comment** at `:16`. Count `run:` lines
+  instead (`grep -cE '^\s*run:.*check:pins'` → **0**), which is what this file's
+  *How to verify* block already does. Fix is one comment edit pointing at
+  `appblocks-drift.yml`. LOW.
+- **`:58` `parseSemver` makes a SemVer build-metadata `latest` exit 2.** Mechanism
+  measured, not inferred — and **it is not the one an earlier write-up gave**:
+  `parseSemver` **returns `null`**, it does not throw. Regex unchanged at `:59`:
+  `/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/`. Measured:
+  `parseSemver("0.31.0+build.7")` → `null`; `parseSemver("0.31.0")` →
+  `{major:0,minor:31,patch:0,pre:null}`. The throw is the explicit guard inside
+  `compareSemver` (`if (!pa || !pb) throw`, whose doc comment says
+  "Unparseable -> throws" — intentional, not an oversight): measured,
+  `compareSemver("0.31.0+build.7","0.31.0")` threw `unparseable semver:
+  0.31.0+build.7`, while the positive control `compareSemver("0.31.0","0.32.0")`
+  returned `-1`. `compareSemver` is called at `:87`, **outside** `fetchLatest`'s
+  try/catch at `:111-123`, so it escapes to the only top-level handler —
+  `main().catch` at `:190` → `process.exit(2)` at `:192`.
+- **Why the second one matters:** exit 2 is triggerable purely by *someone else's*
+  publish — `X.Y.Z+meta` is valid SemVer 2.0.0 — and the in-file comment lists the
+  red paths without naming that one. The **pin** side cannot reach it:
+  `readPinnedVersion` (`:100`) rejects a non-exact pin with a friendly reason, so
+  only the registry's `latest` can. Fix: strip `+…` before compare, or document it.
+  LOW.
+
 ## Next steps (ranked)
 
-1. 🔴 **Resolve `cli#271`** — see the investigation block. It carries two measured
-   findings this file lacks, and it is the only thing left that can lose work.
+1. ~~**Resolve `cli#271`**~~ — **DONE.** Its surviving content is folded in above
+   (IA block, the two `check-appblocks-pins.mjs` LOW items, two gotchas); the PR is
+   closed. Nothing of it can be lost now. See the investigation block for what was
+   deliberately left behind and why the merge was not done in place.
 2. **Decide the `.vue` question** — add a Vue test runner, or document what
    `check:built-site` structurally cannot see. One sentence either way.
 3. **Settle the two README claims** with the one live `--json` call above.
@@ -192,9 +267,11 @@ gate. Measured live: the stale sha reports **12**, the current one 3, a bogus sh
    the question changed: no longer "migrate prose in" but "what belongs in
    `--help` versus the guide". Answer that before writing more.
 5. **Do NOT add an `Annotations` half.** Measured disproof above.
-6. **Decide the IA wart** (below) — cheapest is option (c), and #271 narrows it to
-   two sentences in the page BODY (the frontmatter was fixed by #42).
-7. The two LOW items below (pins header comment; `parseSemver` build metadata).
+6. **Decide the IA wart** — see the *IA* investigation block above. Cheapest is
+   option **(a)**: two sentences in the page BODY (`apps/reference/cli.md:24` and
+   `:37`). The frontmatter was already fixed by #42, so that is all that is left.
+7. The two LOW items in docs `check-appblocks-pins.mjs` — stale header comment at
+   `:36-38`, `parseSemver` build metadata at `:58`. Investigation block above.
 8. **Prune `claudedocs/`** — this file is 400+ lines and other sessions write here
    too. Coordinate before pruning.
 
@@ -273,6 +350,17 @@ gate. Measured live: the stale sha reports **12**, the current one 3, a bogus sh
   `CIVITAI_CLI_LIVE=1` opt-in **plus** a live-vs-snapshot diff. Also:
   `cli/bin/civitai` is rebuilt by other sessions and is often `-dirty` — a binary
   built from a dirty tree is evidence about that working copy and about no commit.
+- 🔴 **The docs-side NUL repair at the capture seam MUST STAY**, even though cli#264
+  fixed it at source. The generator can capture from *any* binary, and `v0.1.90`-era
+  builds still emit the NUL. Its test now covers a **historical fixture**, not
+  current output — the header in `gen-appblocks-cli.mjs` says so. Do not "clean it
+  up" on the strength of the source fix.
+- **A re-capture is never "just the one row".** docs#48's diff carried **7 hunks**
+  across three CLI PRs (#242, #251, #264). Attribute every hunk to a commit, and
+  cross-check the other direction
+  (`git diff <old>..<new> -- internal/cmd/ ':!*_test.go'`) so a *missing* change is
+  caught too — a re-capture that silently drops a change looks identical to one that
+  had nothing to carry.
 - **#46's deletion was better-justified than it looked.** The `### Download flags`
   table listed **12** flags; `download` has **14**. The two missing were `--version`
   and `--yes` — *both* about the ambiguous-id safety stop — so the rotted rows were
@@ -366,6 +454,25 @@ cd ${D} && node -e "import('./scripts/check-appblocks-cli-snapshot.mjs').then(as
 # build-site IS required now (re-measure; never infer gating from a job existing)
 gh api repos/civitai/civitai-developer-docs/branches/main/protection \
   --jq '.required_status_checks.contexts'   # expect […, "build-site"]
+
+# the two LOW items in check-appblocks-pins.mjs (folded in from cli#271)
+# (a) the stale header comment — and the grep that LIES about it:
+git -C ${D} show origin/main:scripts/check-appblocks-pins.mjs | command grep -n 'ALSO runs on a PR'   # expect a hit at :36
+git -C ${D} show origin/main:.github/workflows/appblocks-bridge.yml | command grep -c 'check:pins'                 # 1 — but it is a COMMENT at :16
+git -C ${D} show origin/main:.github/workflows/appblocks-bridge.yml | command grep -cE '^\s*run:.*check:pins'       # 0 — this is the real answer
+git -C ${D} show origin/main:.github/workflows/appblocks-drift.yml  | command grep -cE '^\s*run:.*check:pins'       # 1 (schedule-only)
+# NB the #44 check higher up greps drift.yml unscoped and expects 2 — that counts
+# the run: step at :86 AND a comment at :101. Both numbers are right; they measure
+# different things. Scope to run: whenever the question is "is it actually wired".
+# (b) parseSemver vs SemVer build metadata. The control is the point: a harness
+#     that reports null for everything looks identical to a real finding.
+cd ${D} && node -e "import('./scripts/check-appblocks-pins.mjs').then(m => {
+  console.log('+meta ->', m.parseSemver('0.31.0+build.7'));   // null   (the finding)
+  console.log('plain ->', m.parseSemver('0.31.0'));           // parsed (control)
+  try { m.compareSemver('0.31.0+build.7','0.31.0'); console.log('NO throw — finding is GONE'); }
+  catch (e) { console.log('threw:', e.message); }             // 'unparseable semver: 0.31.0+build.7'
+  console.log('control compare ->', m.compareSemver('0.31.0','0.32.0'));  // -1, must NOT throw
+})"
 
 # 🔴 LOCAL-RUN TRAP: the shared base clones' node_modules have drifted ahead of
 # package-lock.json. Three docs tests fail identically on PRISTINE origin/main


### PR DESCRIPTION
Resolves #271 by **extraction**, not by merge.

## Why not just merge #271

`main` moved under it — #277, then #288 rewrote the same file — so it sat at
`CONFLICTING` / `DIRTY`. `git merge-tree --write-tree pr271 origin/main` → **rc=1**
(branching on the exit code, not a marker grep: `merge-tree` prints only a tree OID
on success and emits no `<<<<<<<`, so a grep finds nothing either way).

Its branch `docs/handoff-consolidation-r3` is checked out at `/tmp/wt-handoff3`.
Measured before deciding rather than assumed: that worktree's tree is **clean** and
its index has not been touched since **2026-08-07 16:12** — idle, not busy. Idle is
still not this session's to write to. Taking `main` as the base and folding r3's
surviving content in from a fresh branch reaches the same file contents with **no
shared-checkout write and no push to another session's branch**.

## What was carried over

Each item **re-measured against docs `origin/main` @ `2426938`**, not transcribed —
**three of r3's line numbers had drifted**:

| Finding | #271 said | Measured today |
|---|---|---|
| IA body presumption | `apps/reference/cli.md:23-24`, `:36` | `:24`, `:37` |
| `parseSemver` | `:59` | `:58` (its regex is on `:59`) |

- **The IA finding.** #42 already fixed the frontmatter (it is audience-neutral
  today), so only **two body lines** still presume App authoring. This also corrects
  r4's *"cheapest is option (c)"* — a mis-transcription, and wrong in the expensive
  direction: (a) is two sentences, (c) moves a page and every link into it.
- **The llms-channel closure** — `llms-full.txt` carries the CLI reference now,
  **0 → 15** `civitai generate` mentions after docs#45. Filed inside the IA block,
  since it was the concern that used to ride along with it.
- **The two `check-appblocks-pins.mjs` LOW items.** The stale header comment at
  `:36-38`, and `parseSemver` at `:58` turning a SemVer build-metadata `latest` into
  exit 2. Mechanism **measured, not inferred** — and it is not the one an earlier
  write-up gave: `parseSemver` *returns `null`*; `compareSemver` is what throws
  (`unparseable semver: 0.31.0+build.7`), and it is called at `:87` **outside**
  `fetchLatest`'s try/catch, so it escapes to `main().catch` at `:190` →
  `process.exit(2)`.
- **Two gotchas r4 dropped** — the docs-side NUL repair must stay (its test covers a
  *historical fixture*, not current output), and a re-capture is never "just the one
  row" (docs#48 carried 7 hunks across three CLI PRs).

## Also fixed

- **Two dangling `(below)` pointers** in *Next steps* — r4 pruned the sections they
  referred to, so items 6 and 7 pointed at nothing.
- **A verify snippet for both LOW items, with positive controls.** A harness that
  reports `null` for everything looks identical to a real finding, so the block pairs
  each finding with a case that must *not* trip it. Both halves were run as written:
  `bridge.yml` `grep -c 'check:pins'` → **1** (a *comment* at `:16`), `run:`-scoped →
  **0**; `parseSemver('0.31.0')` parses and `compareSemver('0.31.0','0.32.0')` → `-1`
  without throwing.

## Deliberately not taken

r3's *State now* and its 14-PR DONE table — both predate the eight merges r4 records,
and shipped-PR provenance is in git.

## Verification

Docs-only change to `claudedocs/`; no Go guard reads that directory (checked). The
claims in it were each measured live against docs `origin/main` @ `2426938`, and the
verify snippet added by this PR was run as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
