### PR TITLE
chore(dogfood): a sandbox for the CREDENTIALED run — metered spend, kernel-enforced blindness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,10 @@ These go beyond the global defaults because this repo's release pipeline
   entry-graph resolver it and `internal/validate` share (item 20).
 - `internal/antipattern` — the scaffold-currency denylist: fails a template
   shipping code against a dead platform endpoint or message (item 18).
+- `internal/dogfoodguard` — DEV-ONLY `package main`: resolves an argv to a
+  command path + real flag values via cobra's own `Find`/`ParseFlags`, for the
+  dogfood sandbox gate (`claudedocs/dogfood-3-sandbox.md`). Never executes;
+  never shipped.
 - `internal/genapi` — the orchestrator **generation** client behind
   `civitai generate` and `civitai workflows …`: tRPC transport, the two envelope
   shapes, the graph payload, model-version resolution. Deliberately not in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,7 @@ These go beyond the global defaults because this repo's release pipeline
   entry-graph resolver it and `internal/validate` share (item 20).
 - `internal/antipattern` — the scaffold-currency denylist: fails a template
   shipping code against a dead platform endpoint or message (item 18).
-- `internal/dogfoodguard` — DEV-ONLY `package main`: resolves an argv to a
-  command path + real flag values via cobra's own `Find`/`ParseFlags`, for the
-  dogfood sandbox gate (`claudedocs/dogfood-3-sandbox.md`). Never executes;
-  never shipped.
+- `internal/dogfoodguard` — DEV-ONLY argv classifier for the dogfood sandbox.
 - `internal/genapi` — the orchestrator **generation** client behind
   `civitai generate` and `civitai workflows …`: tRPC transport, the two envelope
   shapes, the graph payload, model-version resolution. Deliberately not in

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-.PHONY: all build install test vet lint fmt clean tidy ci ci-shallow mutate
+.PHONY: all build install test vet lint fmt clean tidy ci ci-shallow mutate dogfood-check
 
 all: build
 
@@ -63,6 +63,19 @@ ci-shallow:
 # Measurements: claudedocs/mutation-testing-experiment.md
 mutate:
 	./scripts/mutate.sh $(PKG)
+
+# The dogfood sandbox (scripts/dogfood-sandbox.sh) is a shell file that gates a
+# money-spending CLI, so it gets its own shellcheck + a selftest. `--offline`
+# needs no credential and no network: it drives the real gate against a stub
+# binary, so the meter, the ledger lock and every refusal are regression-tested
+# here rather than only during a run. See claudedocs/dogfood-3-sandbox.md.
+dogfood-check:
+	@command -v shellcheck >/dev/null 2>&1 || { \
+		echo "shellcheck not found. Install it: https://www.shellcheck.net/ (Nix: nix-shell -p shellcheck)"; \
+		exit 1; \
+	}
+	shellcheck -x --exclude=SC2153 scripts/dogfood-sandbox.sh
+	bash scripts/dogfood-sandbox.sh selftest --offline
 
 clean:
 	rm -rf bin dist

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -61,8 +61,9 @@ only when the agent is launched through `dogfood-sandbox.sh enter`:
 
 | control | enforced by | strength |
 |---|---|---|
-| the repo checkout, `AGENTS.md` and both handoffs are not visible | Linux mount namespace (`bwrap`) | **kernel — only under `enter`, and see §5** |
-| the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel — only under `enter`** |
+| the repo checkout, `AGENTS.md` and both handoffs are not visible | Linux mount namespace (`bwrap`) | **kernel — under `enter`** |
+| the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel — under `enter`** |
+| the host `~/.claude/projects` transcripts are not reachable | Linux mount namespace (`bwrap`) | **kernel — under `enter --with-claude`** |
 | an argv means the same thing to the gate as to the CLI | cobra's own parser (`internal/dogfoodguard`) | **structural** |
 | `upgrade` cannot replace the binary under evaluation | mode bits + the guard | convention |
 | credential isolation without the jail | `HOME` / `XDG_CONFIG_HOME` on the child | convention |
@@ -343,7 +344,7 @@ three real `--dry-run` estimates moved the balance by **0**
 ### `selftest`
 
 `make dogfood-check` runs `shellcheck -x` plus
-`dogfood-sandbox.sh selftest --offline` — **88 assertions, 88 pass**, no
+`dogfood-sandbox.sh selftest --offline` — **225 assertions, 225 pass**, no
 credential and no network required, so this is regression-testable in CI. The
 credentialed `selftest` (against a live sandbox) runs **79**, the same set minus
 the 13 stub-driven end-to-end rows plus 4 live lockdown/balance rows. It covers
@@ -522,7 +523,7 @@ again. Five 🔴 plus a 🟡 list. All reproduced here before fixing.
 | 2 | `--ro-bind /nix /nix` re-exposed the repo — `nix build` copies the tree to a world-readable `/nix/store/<hash>-source` | **4** readable copies of this repo's `AGENTS.md` inside the jail | the jail binds only the tool CLOSURE; measured inside: **0** `AGENTS.md`, **0** `claudedocs`, **0** `-source` dirs, **0** handoffs, and it refuses to start rather than fall back to binding `/nix` |
 | 3 | `enter` cannot host a Claude Code process | `claude` not on PATH inside; `HOME` rewritten so no `~/.claude` | measured: `claude --version` **does** run inside a jail carrying its 31-path closure — but a real session needs credentials, and the obvious way to supply them re-imports `~/.claude/projects`, i.e. this repo's transcripts. **Not shipped.** The checklist now states the run will be outside the jail and that neither kernel row applies then |
 | 4 | the meter assumed `buzz` reflects the charge by return; a stale-but-successful read was a silent zero | 3 submits, meter **0**, balance really moved 111, nothing latched | a zero or negative delta now latches `meter_broken` and charges the worst case. Re-measured: stale → **1** allowed then latched; credit-masked → latched. `--no-wait` refused by default; `calibrate` (one deliberate, operator-watched generation) is required before any spend |
-| 5 | the caps were pinned by roughly one assertion between them | 6 checksum-gated mutants surviving 88/0 — total cap, remaining budget, generate cap, app cap, empty `SLUG_PREFIX`, negative-delta clamp | each has an isolated, reason-pinned row; all six now killed |
+| 5 | the caps were pinned by roughly one assertion between them | 6 checksum-gated mutants surviving 88/0 — total cap, remaining budget, generate cap, app cap, empty `SLUG_PREFIX`, negative-delta clamp | isolated rows added — 🔴 **but the claim made here was itself falsified next round: the rows asserted only the REASON, so a `deny`→`allow` flip with an identical message still survived. See round 3 below.** |
 
 🟡 also fixed: `workflows` closed like `app` (`cancel` of a workflow this run did
 not create is refused — it **does not refund**); listing revisions counted and
@@ -573,6 +574,75 @@ shape that would reach the readback is a write that succeeds and does not
 persist — `/dev/null` is the obvious one, and `read_scalar` rejects that as
 malformed one step earlier. It is kept as cheap defence-in-depth and recorded
 here as knowingly unpinned rather than deleted or pretended-about.
+
+## The third hardening round (blind re-audit #2)
+
+A second blind auditor built a recording origin server that observes the real
+`generateFromGraph`, positive- and negative-controlled it, and ran a 40-row
+differential. **Zero rows where the gate said plain ALLOW and the binary spent.**
+Its verdict was still no — *"not because the sandbox is unsafe, but because two
+defects make the run fail at its purpose and one makes the evidence unreliable"*.
+All reproduced here first.
+
+| # | what | measured before | after |
+|---|---|---|---|
+| 1 | a non-spending FAILURE latched the meter and killed the run | `--max-cost 5` against an estimate of 8 → rc 2, delta 0, **latched**, 5 Buzz credited that never moved, every later generate rc 126 | the latch is rc-aware; re-measured: failed generate rc 2, no latch, 0 credited, 0 submits burned, next generate works |
+| 2 | no node/npm, and app submits burned by LOCAL failures | `app validate` rc 1 (`npm ci` hard-fails) with no lockfile — the agent could never produce a submittable app; 3 rejected submits consumed all 3 slots | node+npm in the closure; re-measured **inside the jail**: `npm install` rc 0, lockfile written, `validate` rc 0, `package-only` rc 0. Counters bump on SUCCESS |
+| 3 | `st_reason` asserted the reason but never the VERDICT | 5 of 5 `deny`→`allow` flips with byte-identical messages survived 177/177 | `st_reason` asserts both; the flip class now kills 25 mutants |
+| 4 | both id-recording paths broken, in opposite directions | `app status` human table has no id column → `pubreq.allow` never populated, `withdraw` ALWAYS denied; workflow ids filtered by SHAPE over the account-wide list | `app status <slug> --json`, scoped to the submitted app; workflow ids by before/after PROVENANCE |
+
+🟡 also fixed: `--timeout` gated beside `--no-wait` (it stops the waiting, not
+the charge); unknown subcommands asked of cobra (`hassubcommands` + argc)
+instead of a hand-written parent list — the old table missed `models`, `images`,
+`users`, `tags`, all of which the binary rejects with exit 2; the manifest
+parsed by `encoding/json` in the classifier, because a grep took the FIRST
+`blockId` and Go takes the LAST (measured: gate ALLOW, CLI would submit
+`someones-real-app`); provenance hashes VERIFIED at guard time, not merely
+recorded; a deleted counter is malformed; an interrupted spend is reconciled
+from an `inflight` record on the next invocation; `sandbox_env` and an empty
+`for` loop deleted.
+
+**Three defects found here, not by the auditor.** `command -v printf` returns
+the shell BUILTIN, so the jail's closure computation fed `readlink -f` a bogus
+path and `nix-store` failed on the whole list. Adding node/npm to the closure
+was necessary but NOT sufficient — `readlink -f` collapses npm's launcher
+symlink, so node looked for `npm-prefix.js` beside the *node* binary and
+`npm install` still exited 1; explicit shims fixed it. And the `assert_writable`
+pre-flight had to be added, because moving the counter bump to after-success
+would otherwise have let an unwritable ledger stop blocking.
+
+### Mutation matrix — 52 mutants, all checksum-gated
+
+```
+BASELINE                                          225 passed, 0 failed
+25 deny->allow flips (byte-identical reason)      ALL KILLED
+rc-aware latch / counters-on-success              KILLED
+provenance verify / provenance compares nothing   KILLED
+assert_writable / reconcile_inflight / inflight   KILLED
+hassubcommands / argserr / resolve_block_id       KILLED
+GUARD_BIN reset / record_pubreq / workflow prov.  KILLED
+read_scalar EMPTY / MISSING, latches, parser, …   KILLED
+ledger lock removed                               KILLED (see below)
+write_scalar readback removed                     SURVIVED — declared
+NULL comment-only                                 SURVIVED — as required
+TOTALS: killed=50 survived=2 invalid=0
+```
+
+🔴 **The concurrency row was flaky and is now replaced.** With `flock` deleted,
+the 8-concurrent test reported **1, 2 and 5** allowed submits on three
+consecutive runs — it passed a third of the time, because process startup
+staggers the racers by more than the critical section takes. A guard that is
+right two times in three is worse than none, so mutual exclusion is now pinned
+as a PRIMITIVE (`__locktest`: one process holds, a second must be blocked, then
+acquires once released) and the end-to-end row is kept only as a
+ledger-consistency smoke test.
+
+🔴 **Two process errors of mine, recorded because both produced green that meant
+nothing.** I ran the mutation matrix in the BACKGROUND while editing the same
+file — its restore trap silently reverted an edit I had just made. And
+overwriting the classifier binary to test substitution hits **ETXTBSY**, so the
+write failed silently and the row passed against the *real* classifier; `rm`
+first, and assert the substitution actually happened.
 
 ## What this does not protect against
 
@@ -661,6 +731,35 @@ are the ones being shipped knowingly.
     meter is verified" — nothing here has yet observed a real charge.**
 12. **Nothing here bounds rate limits, account flags, or platform-side
     consequences** of a real submission (moderation attention, reputation).
+13. 🔴 **`npm install` IS ARBITRARY CODE EXECUTION INSIDE THE JAIL, AND IT IS
+    NEW.** node/npm are in the closure because without them the run cannot reach
+    its own purpose — measured, `app validate` fails on a missing lockfile and
+    no app is ever submittable. The cost: `npm install` reaches
+    `registry.npmjs.org` and **runs package lifecycle scripts**. Closure size
+    went from 69 to **168** store paths (181 with `--with-claude`). The jail
+    still has no repo, no operator `$HOME` and no real credential store, so the
+    blast radius is the sandbox plus the network — which is not nothing.
+14. 🔴 **A SECOND CREDENTIAL IS NOW AT REST IN THE SANDBOX, AND IT IS NOT THE
+    CIVITAI KEY.** `enter --with-claude` copies `~/.claude/.credentials.json`
+    into the run root. It is an OAuth token pair whose scopes are
+    `user:inference`, `user:mcp_servers`, `user:file_upload`, `user:profile`,
+    `user:sessions:claude_code` on a `max` subscription — so reading it lets
+    someone spend the owner's Claude quota and reach their account connectors.
+    Whatever can read the Civitai key can read this one.
+    - **ACCEPTED BY THE OWNER:** the claude.ai MCP connectors ride the
+      CREDENTIAL, not the filesystem. Measured — a jailed session with a
+      completely fresh `$HOME` still initialised `claude.ai proxy transport for
+      server mcpsrv_012…` against `mcp-proxy.anthropic.com`, a **Gmail**
+      connector. A fresh HOME does not remove it; only a differently-scoped
+      token would.
+    - **ACCEPTED BY THE OWNER:** the run uses the live session credential rather
+      than a dedicated minted token, so it must be kept SHORT and inside the
+      token's validity window. `expiresAt` was ~5.5 h out when measured; a run
+      crossing it triggers a refresh *inside the sandbox*, and whether that
+      rotates the refresh token and logs the operator out is **unmeasured** —
+      deliberately, because the test is the damage. `claude setup-token` would
+      mint an independent, revocable token; it is one owner action and was not
+      taken.
 
 ## Go / no-go checklist
 
@@ -700,23 +799,24 @@ Read time ~2 minutes. Everything below is verifiable in one command each.
 
 **Where the run actually happens — read this, the earlier version was wrong**
 
-- [ ] 🔴 **Decide, and know what you are choosing.** `enter` gives a jail in
-      which the repo genuinely does not exist (measured: 0 `AGENTS.md`, 0
-      handoffs, 0 `-source` copies) and the operator's config is unreachable.
-      **But it cannot host a Claude Code process today.** `claude --version`
-      runs inside it, so hosting is not impossible — a real session needs
-      credentials, and the natural way to supply them mounts `~/.claude`, whose
-      `projects/` holds transcripts of this very repo. That would hand the
-      agent the source it is supposed to be blind to, so it is **not shipped**.
-- [ ] **Therefore, unless you build that plumbing yourself, the agent runs
-      OUTSIDE the jail and NEITHER kernel row applies.** Blindness is then
-      procedural: the agent is launched with its cwd in `$ROOT/workspace`, given
-      only `AGENT-BRIEF.md`, the `civitai` on PATH and `README.md`, and told not
-      to go looking. That is exactly how dogfood runs 1 and 2 were kept blind,
-      and it worked — but it is an instruction, not a boundary.
-- [ ] Use `enter` at minimum to *verify* the sandbox (it is what the blindness
-      and isolation measurements above were taken in), and prefer it for any
-      shell-driven agent that does not need Claude Code.
+- [ ] 🔴 **RUN IT IN THE JAIL — `dogfood-sandbox.sh enter --with-claude`.** An
+      earlier version of this checklist said the run would happen outside and
+      that neither kernel row applied. That is **superseded**: the jail now
+      hosts a real Claude Code session with a FRESH `$HOME` seeded with only
+      `.claude/.credentials.json`. The host `~/.claude` is never bound, so its
+      `projects/` — 34 project directories including this repo's own
+      transcripts and both prior dogfood runs — stays unreachable, and the
+      session creates its own `projects/` inside the sandbox.
+- [ ] **Blindness, measured inside that jail with a real session running:**
+      `AGENTS.md` 0 · `claudedocs` files 0 · `*-source` trees 0 ·
+      `handoff-dogfood-*.md` 0 · host `~/.claude/projects` 0 · civitai `.go`
+      sources 0. **Positive-controlled**: the same rig with deliberately wrong
+      mounts reports 120 / 1320 / 324 / 3 / 1, with `find` and `wc` present in
+      both runs — so the zeros are a measurement, not a rig wired to nothing.
+- [ ] Accept the two credential residuals (13 and 14 above): `npm install`
+      executes package lifecycle scripts inside the jail, and a second
+      credential — your Claude OAuth token, carrying Gmail connector access —
+      is at rest in the run root for the duration.
 
 **Calibrate the meter before the agent starts**
 
@@ -741,7 +841,7 @@ shred -u ~/.dogfood-token
 
 # 3. confirm the harness is honest before trusting it
 scripts/dogfood-sandbox.sh selftest        # against the live sandbox
-make dogfood-check                         # shellcheck -x + 177/177, no credential needed
+make dogfood-check                         # shellcheck -x + 225/225, no credential needed
 
 # 4b. calibrate the meter — ONE deliberate generation, spends real Buzz
 scripts/dogfood-sandbox.sh calibrate --yes

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -61,8 +61,9 @@ only when the agent is launched through `dogfood-sandbox.sh enter`:
 
 | control | enforced by | strength |
 |---|---|---|
-| the repo checkout, `AGENTS.md` and both handoffs are not visible | Linux mount namespace (`bwrap`) | **kernel — only under `enter`** |
+| the repo checkout, `AGENTS.md` and both handoffs are not visible | Linux mount namespace (`bwrap`) | **kernel — only under `enter`, and see §5** |
 | the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel — only under `enter`** |
+| an argv means the same thing to the gate as to the CLI | cobra's own parser (`internal/dogfoodguard`) | **structural** |
 | `upgrade` cannot replace the binary under evaluation | mode bits + the guard | convention |
 | credential isolation without the jail | `HOME` / `XDG_CONFIG_HOME` on the child | convention |
 | the per-invocation `--max-cost` ceiling | the guard script | convention |
@@ -351,6 +352,73 @@ branch (including `--max-cost=N` form parsing, `app submit -o <path>` not being
 mistaken for the project dir, and listing identity via `--slug` vs `--dir`),
 the balance parser's positive and negative controls, and the lockdown modes.
 
+## The classifier: the shim no longer parses argv
+
+🔴 **Three separate bypasses had one root cause, and patching spellings twice
+did not stop the third.** The shim kept its own model of how the CLI reads a
+command line:
+
+| bypass | what the shim believed | what pflag does |
+|---|---|---|
+| `--no-color generate … --yes` | `$1` is the command | root persistent bools are stripped before the command is resolved |
+| `--negative-prompt --help` | `--help` is present ⇒ help | the token after a value-taking flag is its VALUE |
+| `--print-input=false` | the flag is present ⇒ preview | a bool set to false is present **and false** |
+
+Each was fixed as an instance. The class survived, and each instance was a real
+charge with the meter reading zero. So the classification moved into Go.
+
+**`internal/dogfoodguard`** builds the real tree with `cmd.NewRootCmd()`,
+resolves the command with cobra's own `Find`, parses with `ParseFlags`, and
+reads values through `Flags().GetBool` / `GetInt` / `GetString`. It emits
+TAB-separated `key<TAB>value` lines and **never executes anything** — no
+`Execute`, no `RunE`. The shim keeps the meter, ledger, caps, `flock`, `enter`
+and the forbidden list; only the question "what is this invocation?" moved.
+
+- **Where it lives, and why.** `internal/dogfoodguard`, `package main`. It has
+  to be inside this module to import `internal/cmd` at all. It is under
+  `internal/` rather than `cmd/` so that a future release-tooling glob over
+  `./cmd/*` cannot pick it up.
+- **goreleaser: no change needed, and none made.** `.goreleaser.yaml` has
+  exactly one `builds:` entry with an explicit `main: ./cmd/civitai` (no glob),
+  and `archives` reference `ids: [civitai]`. A new main package publishes
+  nothing. Verified by reading the config, not assumed.
+- **No new dependency**; cobra and pflag were already here. `go.mod` unchanged.
+- **It is not a user-facing command** and cannot appear in `civitai --help`,
+  because it is a separate binary rather than a subcommand.
+- 🔴 **Build it from the SAME tree as the binary under test.** It embeds the
+  command tree, so a classifier from another commit could disagree with the
+  binary — the exact defect class it exists to remove. `init` builds it from
+  the repo alongside the binary and records both hashes in `policy.env`.
+- 🔴 **Fail closed.** A non-zero exit, empty output, a missing `ok`, a
+  non-numeric `argc`, or **any field the shim does not recognise** is a DENY.
+  The last one is not hypothetical politeness: an unrecognised field means the
+  shim and the classifier have drifted, which is the thing this design exists
+  to prevent.
+
+### Exactness — is the new path right, or just differently wrong?
+
+A classifier that is wrong in a NEW way is not progress, so its verdict is
+compared against what the real binary actually does over a 30-invocation corpus
+(run with an empty isolated config and no token, so every credentialed path
+stops at exit 3 having spent nothing). The rules asserted:
+
+| classifier says | binary must |
+|---|---|
+| flag-parse-error / unknown-command | exit **2** |
+| help = true | exit **0** and print `Usage:` |
+| generate, print-input = true | exit **0** and emit a JSON graph |
+| generate, otherwise | exit **3** (needs a credential) |
+| a group command with a leftover positional | exit **2** |
+
+**Result: 45 agreements, 0 mismatches.** The corpus includes all three historic
+bypasses, all twelve pflag boolean spellings, `--max-cost 08`, `--` separators
+and unknown commands at three depths.
+
+Two mismatches in the first run were the *probe's* fault, not the classifier's —
+it pattern-matched the first line of help output and `app listing`/`workflows`
+open with a description rather than `Usage:`. Asserting on `Usage:` anywhere
+fixed the probe; the exit codes had agreed all along.
+
 ## The hardening round (adversarial audit of #296)
 
 An independent audit attacked the first version. The bwrap jail held (uid 1000,
@@ -443,6 +511,69 @@ That is the whole failure mode of the original `verdict=$(policy_verdict …)`
 subshell, reproduced deliberately: an internal error left the verdict empty and
 `"" != "DENY"` ran the command.
 
+## The second hardening round (blind re-audit)
+
+A fresh auditor, deliberately not shown the first round's findings, broke it
+again. Five 🔴 plus a 🟡 list. All reproduced here before fixing.
+
+| # | what | measured before | after |
+|---|---|---|---|
+| 1 | a pflag bool `=false` is present-but-false; the shim read "present" | `--print-input=false`, `--dry-run=false`, `--help=false` each ALLOW + **charged**, meter 0; `app submit <foreign> --yes --package-only=false` skipped the prefix gate | all DENY; classification moved to cobra (above) |
+| 2 | `--ro-bind /nix /nix` re-exposed the repo — `nix build` copies the tree to a world-readable `/nix/store/<hash>-source` | **4** readable copies of this repo's `AGENTS.md` inside the jail | the jail binds only the tool CLOSURE; measured inside: **0** `AGENTS.md`, **0** `claudedocs`, **0** `-source` dirs, **0** handoffs, and it refuses to start rather than fall back to binding `/nix` |
+| 3 | `enter` cannot host a Claude Code process | `claude` not on PATH inside; `HOME` rewritten so no `~/.claude` | measured: `claude --version` **does** run inside a jail carrying its 31-path closure — but a real session needs credentials, and the obvious way to supply them re-imports `~/.claude/projects`, i.e. this repo's transcripts. **Not shipped.** The checklist now states the run will be outside the jail and that neither kernel row applies then |
+| 4 | the meter assumed `buzz` reflects the charge by return; a stale-but-successful read was a silent zero | 3 submits, meter **0**, balance really moved 111, nothing latched | a zero or negative delta now latches `meter_broken` and charges the worst case. Re-measured: stale → **1** allowed then latched; credit-masked → latched. `--no-wait` refused by default; `calibrate` (one deliberate, operator-watched generation) is required before any spend |
+| 5 | the caps were pinned by roughly one assertion between them | 6 checksum-gated mutants surviving 88/0 — total cap, remaining budget, generate cap, app cap, empty `SLUG_PREFIX`, negative-delta clamp | each has an isolated, reason-pinned row; all six now killed |
+
+🟡 also fixed: `workflows` closed like `app` (`cancel` of a workflow this run did
+not create is refused — it **does not refund**); listing revisions counted and
+capped, since a live-listing change goes back to review; an empty or missing
+counter file is malformed rather than zero, and a failed write is fatal;
+`--max-cost 08` is a clean refusal instead of a bash-octal crash with no ledger
+row; `pubreq`/`workflow` ids this run creates are recorded automatically so the
+agent can withdraw and cancel its OWN work; `log_invocation` moved inside the
+lock; ALLOW rows now carry their reason, so a bypass and a genuine `--dry-run`
+are no longer byte-identical in the ledger.
+
+**Two defects found here, not by the auditor.** `command -v printf` returns the
+shell BUILTIN, not a path — feeding that to `readlink -f` produced a
+non-existent path, `nix-store` failed on the whole list, and the jail reported
+"nix-store missing" and refused (fail-closed, but for the wrong reason). And
+overwriting the classifier binary in place to test drift handling hits
+**ETXTBSY**, so the write silently failed and four "drift is refused" rows were
+passing against the *real* classifier — a reassuring green from a substitution
+that never happened. The classifier path is now injectable (and reset at
+startup, so an exported `GUARD_BIN` cannot reach the gate — pinned by its own
+row, in a fresh process).
+
+### Mutation matrix (26 mutants, all checksum-gated)
+
+```
+BASELINE                                        177 passed, 0 failed
+presence-not-value on print-input/dry-run  KILLED 14   package-only KILLED 6   help KILLED 9
+classifier failure fails OPEN              KILLED 103
+unknown subcommand allowed                 KILLED 5
+TOTAL_SPEND_CAP deleted                    KILLED 2    remaining-budget deleted   KILLED 2
+MAX_GENERATE_SUBMITS deleted               KILLED 1    MAX_APP_SUBMITS deleted    KILLED 1
+SLUG_PREFIX empty-check removed            KILLED 1    negative-delta latch       KILLED 2
+MAX_LISTING_MUTATIONS deleted              KILLED 1    zero-delta latch           KILLED 3
+failed-read latch removed                  KILLED 2    meter_broken gate          KILLED 2
+calibration gate removed                   KILLED 2    --no-wait gate             KILLED 1
+read_scalar EMPTY as zero                  KILLED 13   read_scalar MISSING as zero KILLED 18
+ledger lock removed                        KILLED 2    tsv_escape drops newlines  KILLED 3
+withdraw allowlist bypassed                KILLED 3    cancel allowlist bypassed  KILLED 2
+listing prefix gate bypassed               KILLED 1    unrecognised guard field   KILLED (after adding rows)
+write_scalar readback removed              SURVIVED — declared below
+NULL comment-only                          SURVIVED — as required
+```
+
+🔴 **The one declared survivor.** Removing `write_scalar`'s readback leaves the
+suite green, because `printf > file || return 1` already catches every
+*constructible* failure: an unwritable file, a directory, `/dev/full`. The only
+shape that would reach the readback is a write that succeeds and does not
+persist — `/dev/null` is the obvious one, and `read_scalar` rejects that as
+malformed one step earlier. It is kept as cheap defence-in-depth and recorded
+here as knowingly unpinned rather than deleted or pretended-about.
+
 ## What this does not protect against
 
 An unrecorded residual is indistinguishable from a bug nobody noticed. These
@@ -472,30 +603,35 @@ are the ones being shipped knowingly.
    other Buzz activity on the account during the run — the website, another
    session, a subscription tick — is attributed to the run. Do not run this
    while using the account for anything else.
-5. **A charge that settles after the post-call sample is missed by that call's
-   delta.** `finish`'s start-minus-end figure catches it; that is why both
-   numbers are reported and why a disagreement between them is meaningful.
+5. **A charge that settles after the post-call sample is now LATCHED, not
+   missed — but latching is a stop, not a measurement.** A zero or negative
+   delta charges the worst case the estimate allowed and refuses every later
+   spend. That bounds the damage to one job; it does not tell you what that job
+   really cost. `finish`'s start-minus-end figure is still the authority, and a
+   disagreement between the two numbers is the interesting signal.
+   🔴 **`calibrate` is what makes any of this more than a guess, and it has
+   never been run** — see residual 11.
 6. **`app submit` enters a human review queue on a real account.** Withdraw
    works only while `pending`. See the non-reversible list in §4 — an approved
    app is live, a rejected one is terminal, and the blockId is consumed
    permanently either way.
-7. **The gate re-implements argv parsing; it is not Cobra — and that is where
-   every one of the audit's two worst findings came from.** It now resolves
-   commands against a CLOSED VOCABULARY and tokenizes flags with per-command
-   knowledge of which ones consume the next token, but it is still a
-   re-implementation. Known costs, deliberately taken:
-   - **An unknown command or subcommand is REFUSED, not passed through.** A new
-     `civitai` verb, or a typo, produces a `SANDBOX POLICY` line rather than the
-     CLI's own error. That is the fail-closed direction, and it means the gate's
-     vocabulary has to be updated when the CLI grows a command.
-   - **On `generate`, an unrecognised flag is assumed to consume the next
-     token.** That biases toward refusal: `--mystery --dry-run` is treated as a
-     submit, not a preview. A false refusal, never a false allow.
-   - **`civitai generate "prompt" --help` is refused**, because `--help` after a
-     bare positional cannot be distinguished from `--help` as a flag value under
-     an allowlist rule. Use `civitai generate --help`.
+7. **The gate no longer parses argv — but it now depends on a classifier
+   binary.** Cobra answers "what is this invocation?", which removes the class
+   that produced three bypasses. What replaces it:
+   - **The classifier must be built from the same tree as the binary.** `init`
+     does that and records both hashes, but nothing *enforces* it if someone
+     passes `--guard` a stale build. A stale classifier could disagree with the
+     binary exactly as the shell parser did.
+   - **An unknown command or subcommand is REFUSED**, so a typo produces a
+     `SANDBOX POLICY` line rather than the CLI's own error. Fail-closed, and a
+     small fidelity cost.
    - A TOCTOU window remains between reading the manifest and exec'ing the CLI;
      irrelevant for a cooperative agent, real in principle.
+   - **`GUARD_BIN` is injectable** so the selftest can substitute fake
+     classifiers (overwriting the real one in place hits ETXTBSY). It is reset
+     to empty at startup so an exported value cannot reach the gate — pinned by
+     a row that runs in a fresh process, but it is one assignment away from
+     being a bypass if that line is ever deleted.
 8. **Concurrency is bounded, not eliminated.** The cap check, the counter bump
    and the reservation are one `flock`-held section, and a submit reserves its
    `--max-cost` for the duration — measured, 8 concurrent submits against 10
@@ -514,10 +650,15 @@ are the ones being shipped knowingly.
    read as harness noise, not a finding.**
 10. **The login and update-notice surfaces are not exercised at all** — a
     coverage gap accepted because runs 1 and 2 covered login un-credentialed.
-11. **The spend path has never been exercised end to end.** The meter was proved
-    against a stub. Proving it against real money requires spending real money,
-    which is precisely what the go/no-go below is for. **This is the gap the
-    owner is approving, and it should not be read as "the meter is verified".**
+11. 🔴 **THE SPEND PATH HAS STILL NEVER BEEN EXERCISED, AND `calibrate` IS
+    ITSELF UNTESTED.** The meter is proved against stubs — including, now, the
+    stale-read and credit-masked cases. Proving it against real money requires
+    spending real money, which is what `calibrate` is for and why it is required
+    before the agent may spend. But `calibrate` has never been run: it is code
+    written to make an untested assumption testable, and it is untested. Its
+    failure mode is the safe one (it hard-fails and writes `meter_broken` if the
+    balance does not move), but **do not read "the meter fails closed" as "the
+    meter is verified" — nothing here has yet observed a real charge.**
 12. **Nothing here bounds rate limits, account flags, or platform-side
     consequences** of a real submission (moderation attention, reputation).
 
@@ -557,12 +698,34 @@ Read time ~2 minutes. Everything below is verifiable in one command each.
 - [ ] `login`, `upgrade`, `app dev-tunnel`, `app dev-token` refused. Accepted
       coverage gap on login and the update notice.
 
-**Run it in the jail (this is the one that matters)**
+**Where the run actually happens — read this, the earlier version was wrong**
 
-- [ ] Launch the agent via `dogfood-sandbox.sh enter`. Without it, credential
-      isolation and blindness are convention rather than kernel-enforced, and
-      the agent can read the repo, `AGENTS.md` and both prior handoffs — which
-      invalidates the method.
+- [ ] 🔴 **Decide, and know what you are choosing.** `enter` gives a jail in
+      which the repo genuinely does not exist (measured: 0 `AGENTS.md`, 0
+      handoffs, 0 `-source` copies) and the operator's config is unreachable.
+      **But it cannot host a Claude Code process today.** `claude --version`
+      runs inside it, so hosting is not impossible — a real session needs
+      credentials, and the natural way to supply them mounts `~/.claude`, whose
+      `projects/` holds transcripts of this very repo. That would hand the
+      agent the source it is supposed to be blind to, so it is **not shipped**.
+- [ ] **Therefore, unless you build that plumbing yourself, the agent runs
+      OUTSIDE the jail and NEITHER kernel row applies.** Blindness is then
+      procedural: the agent is launched with its cwd in `$ROOT/workspace`, given
+      only `AGENT-BRIEF.md`, the `civitai` on PATH and `README.md`, and told not
+      to go looking. That is exactly how dogfood runs 1 and 2 were kept blind,
+      and it worked — but it is an instruction, not a boundary.
+- [ ] Use `enter` at minimum to *verify* the sandbox (it is what the blindness
+      and isolation measurements above were taken in), and prefer it for any
+      shell-driven agent that does not need Claude Code.
+
+**Calibrate the meter before the agent starts**
+
+- [ ] 🔴 `dogfood-sandbox.sh calibrate --yes` submits **one** real generation,
+      deliberately, while you watch, and records whether the balance moved by
+      the time the command returned. Every spend cap depends on that being
+      true, and until this round it was assumed rather than measured. The gate
+      refuses to spend until it has run (or `init --skip-calibration` was
+      recorded). **This is the one place the harness spends money on purpose.**
 
 **Commands**
 
@@ -577,8 +740,11 @@ scripts/dogfood-sandbox.sh init --binary ./bin/civitai --token-file ~/.dogfood-t
 shred -u ~/.dogfood-token
 
 # 3. confirm the harness is honest before trusting it
-scripts/dogfood-sandbox.sh selftest        # expect 79/79 against the live sandbox
-make dogfood-check                         # shellcheck + 88/88, no credential needed
+scripts/dogfood-sandbox.sh selftest        # against the live sandbox
+make dogfood-check                         # shellcheck -x + 177/177, no credential needed
+
+# 4b. calibrate the meter — ONE deliberate generation, spends real Buzz
+scripts/dogfood-sandbox.sh calibrate --yes
 
 # 4. run the agent blind, inside the jail, cwd $ROOT/workspace,
 #    given only: the `civitai` on PATH, README.md, --help, and AGENT-BRIEF.md

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -65,7 +65,9 @@ only when the agent is launched through `dogfood-sandbox.sh enter`:
 | the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel — under `enter`** |
 | the host `~/.claude/projects` transcripts are not reachable | Linux mount namespace (`bwrap`) | **kernel — under `enter --with-claude`** |
 | an argv means the same thing to the gate as to the CLI | cobra's own parser (`internal/dogfoodguard`) | **structural** |
-| `upgrade` cannot replace the binary under evaluation | mode bits + the guard | convention |
+| `upgrade` cannot replace the binary under evaluation | mode bits + the guard | convention **outside** the jail; **kernel** inside it (`--ro-bind real/`) |
+| the harness script cannot be edited by the agent | `--ro-bind harness/` | **kernel — under `enter`** |
+| the operator's environment does not enter the jail | `bwrap --clearenv` | **kernel — under `enter`** |
 | credential isolation without the jail | `HOME` / `XDG_CONFIG_HOME` on the child | convention |
 | the per-invocation `--max-cost` ceiling | the guard script | convention |
 | the total spend cap and the meter | the guard script | convention |
@@ -74,8 +76,14 @@ only when the agent is launched through `dogfood-sandbox.sh enter`:
 | `login`, `dev-tunnel`, `dev-token`, unknown commands refused | the guard script | convention |
 | the audit ledger | the guard script | convention |
 
-🔴 **The `upgrade` row moved from "kernel" to "convention", and the earlier
-version of this table was wrong about it.** The mode bits genuinely defeat the
+🔴 **The `upgrade` row is now split, and the earlier table was wrong in BOTH
+directions in turn.** It first claimed kernel enforcement it did not have; the
+correction then said "convention" full stop, which undersold what `enter` can
+do. Inside the jail `real/`, `harness/` and `bin/` are re-bound READ-ONLY after
+the parent bind, so the mode-bit argument becomes a mount argument — measured,
+`chmod u+w $ROOT/real` and `touch $ROOT/real/.civitai.new` now both return 1 and
+overwriting the harness reports "Read-only file system". Outside the jail the
+original caveat stands verbatim: The mode bits genuinely defeat the
 *command* — `selfupdate` `O_CREATE`s `.civitai.new` in a `0500` directory and
 gets `EACCES` — but they do not bind the *agent*, because a process owning an
 inode may always chmod it. Measured, **inside the jail, as uid 1000**:
@@ -344,7 +352,7 @@ three real `--dry-run` estimates moved the balance by **0**
 ### `selftest`
 
 `make dogfood-check` runs `shellcheck -x` plus
-`dogfood-sandbox.sh selftest --offline` — **225 assertions, 225 pass**, no
+`dogfood-sandbox.sh selftest --offline` — **241 assertions, 241 pass**, no
 credential and no network required, so this is regression-testable in CI. The
 credentialed `selftest` (against a live sandbox) runs **79**, the same set minus
 the 13 stub-driven end-to-end rows plus 4 live lockdown/balance rows. It covers
@@ -644,6 +652,58 @@ overwriting the classifier binary to test substitution hits **ETXTBSY**, so the
 write failed silently and the row passed against the *real* classifier; `rm`
 first, and assert the substitution actually happened.
 
+## The fourth hardening round (blind re-audit #3)
+
+A third blind auditor built a ground-truth probe that runs the **real
+`Execute()`** with recorders replacing every `RunE` — so dispatch, `ParseFlags`,
+`Args`, `ValidateRequiredFlags` and `PersistentPreRunE` all run exactly as in the
+shipped binary — and diffed it field-by-field against `dogfoodguard` over 70
+rows: **zero disagreements**. Two 🔴 remained, both in the ledger rather than the
+classifier.
+
+| # | what | measured before | after |
+|---|---|---|---|
+| 1 | `reconcile_inflight` could not tell a CRASHED spend from a RUNNING one | one `whoami` at t=1s of a 3-second generate consumed the record **3/3**: false `RECONCILED` row, reservation released mid-flight. With 8 racers the meter read **2064 where 37 had moved** — one charge counted twice | the record carries the writer's PID and a live one is skipped; a second concurrent `generate` is refused outright. Re-measured 5/5: `RECONCILED=0`, meter **2027** = exactly 1990+37 |
+| 2 | the rc-aware fix suppressed too much — a generate can charge and THEN fail | rc≠0 + failed post-read → 37 really moved, **meter 0, no latch**; rc≠0 + credit masking → same | the suppression now applies to ONE case: the read worked and the delta really is 0. Re-measured: both now latch and charge the worst case; the benign control (rc≠0, healthy read, nothing moved) is still suppressed |
+
+🟡 also fixed, each measured: the writability pre-flight proved the wrong file —
+with only `observed_spend` at 0444, **111 Buzz moved, meter 0, no latch**, while
+every row logged `delta=37`; `observed_spend` and `reserved` are now asserted
+before a spend and a failed meter write latches, because it cannot be refused
+after the money has moved. `enter` now passes **`--clearenv`** (measured without
+it: **118** inherited variables including a real `CIVITAI_TOKEN`, an unrelated
+`sk-ant-…` key, and a `CDPATH` naming the repo the jail exists to hide) and
+**read-only re-binds** `real/`, `harness/` and `bin/` after the parent bind
+(measured before: `chmod u+w $ROOT/real` and `touch .civitai.new` both
+succeeded). `teardown` now shreds both credential files and cleans
+`*.superseded-*` roots, which `init --force` used to leave holding the Civitai
+key and the Anthropic token. `civitai help generate` works — cobra registers
+`help` in `Execute()`, which the classifier deliberately never calls, so
+`InitDefaultHelpCmd()` is called explicitly; that removes the fifth fidelity
+distortion rather than documenting it.
+
+🔴 **A comment of mine was wrong and is corrected:** it claimed cobra's
+`ValidateArgs` never fires for this tree. It does — `workflows cancel` with no
+id gives *"accepts 1 arg(s), received 0"* and `generate a b` gives *"accepts at
+most 1 arg(s), received 2"*. Both are now real selftest rows instead of a faked
+one.
+
+🔴 **The audit's headline concurrency number did not reproduce for me, and the
+defect did.** It reported 8 ALLOW_SPEND / 0 DENY; I measured **1 / 7 on 5
+consecutive runs**, so the cap itself held. What reproduced every time was the
+bystander consuming the crash record — a false `RECONCILED` row and a
+double-counted meter. Same root cause, opposite direction of error (mine
+over-counted, theirs under-counted); both are fixed by the liveness check, and I
+am reporting the numbers I measured rather than the ones I was handed.
+
+### The matrix is now a committed artifact
+
+`scripts/dogfood-mutate.sh` — 59 checksum-gated mutants, runnable on demand.
+Three rounds reported mutation results that the next round had to take on trust
+and could not re-derive, and one of those tables was later falsified.
+`scripts/mutate.sh` covers Go packages only, so the shell gate — where the money
+decisions live — had no re-runnable evidence until now.
+
 ## What this does not protect against
 
 An unrecorded residual is indistinguishable from a bug nobody noticed. These
@@ -704,8 +764,12 @@ are the ones being shipped knowingly.
      being a bypass if that line is ever deleted.
 8. **Concurrency is bounded, not eliminated.** The cap check, the counter bump
    and the reservation are one `flock`-held section, and a submit reserves its
-   `--max-cost` for the duration — measured, 8 concurrent submits against 10
-   Buzz of headroom now yield exactly 1. But the reservation is the ESTIMATE
+   `--max-cost` for the duration. 🔴 **The claim that stood here — "8 concurrent
+   submits against 10 Buzz of headroom now yield exactly 1" — was true of the
+   ALLOW count and false about the LEDGER**: every such run also had a bystander
+   consume the in-flight crash record, writing a false `RECONCILED` row and
+   counting one charge twice (meter 2064 where 37 moved). A second concurrent
+   `generate` is now refused outright, which is the honest bound. But the reservation is the ESTIMATE
    ceiling, not the realized charge, so N concurrent jobs can still overshoot by
    the same "realized exceeds estimate" margin as residual 2. **If `flock` is
    absent the lock silently degrades to a no-op** — `selftest` asserts it is
@@ -760,6 +824,20 @@ are the ones being shipped knowingly.
       deliberately, because the test is the damage. `claude setup-token` would
       mint an independent, revocable token; it is one owner action and was not
       taken.
+
+15. 🔴 **The unknown-verdict backstop in `cmd_guard` survives deletion, and
+    that is now DECLARED rather than merely true.** No valid input can reach it —
+    `policy_verdict` always sets a verdict — so only an internal bug can, which
+    is what it is for. Its value was shown by a two-stage mutant (make a branch
+    return without setting `VERDICT`, then delete the backstop: rc 126 → rc 0,
+    binary ran) and it is listed here alongside `write_scalar`'s readback as a
+    knowingly-unpinned guard, because the previous round left it undeclared.
+16. **`make dogfood-check` is still not in CI, and `internal/dogfoodguard` shows
+    `[no test files]` under `make ci`.** The classifier — the component three
+    audits have now agreed is the load-bearing one — is pinned only by a suite CI
+    never runs. Workflow files are ask-first, so this is flagged rather than
+    fixed; it is the single cheapest remaining improvement and it needs a
+    maintainer's hand.
 
 ## Go / no-go checklist
 
@@ -841,7 +919,7 @@ shred -u ~/.dogfood-token
 
 # 3. confirm the harness is honest before trusting it
 scripts/dogfood-sandbox.sh selftest        # against the live sandbox
-make dogfood-check                         # shellcheck -x + 225/225, no credential needed
+make dogfood-check                         # shellcheck -x + 241/241, no credential needed
 
 # 4b. calibrate the meter — ONE deliberate generation, spends real Buzz
 scripts/dogfood-sandbox.sh calibrate --yes

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -352,7 +352,7 @@ three real `--dry-run` estimates moved the balance by **0**
 ### `selftest`
 
 `make dogfood-check` runs `shellcheck -x` plus
-`dogfood-sandbox.sh selftest --offline` — **241 assertions, 241 pass**, no
+`dogfood-sandbox.sh selftest --offline` — **266 assertions, 266 pass**, no
 credential and no network required, so this is regression-testable in CI. The
 credentialed `selftest` (against a live sandbox) runs **79**, the same set minus
 the 13 stub-driven end-to-end rows plus 4 live lockdown/balance rows. It covers
@@ -698,11 +698,39 @@ am reporting the numbers I measured rather than the ones I was handed.
 
 ### The matrix is now a committed artifact
 
-`scripts/dogfood-mutate.sh` — 59 checksum-gated mutants, runnable on demand.
+`scripts/dogfood-mutate.sh` — 64 checksum-gated mutants, runnable on demand.
 Three rounds reported mutation results that the next round had to take on trust
 and could not re-derive, and one of those tables was later falsified.
 `scripts/mutate.sh` covers Go packages only, so the shell gate — where the money
 decisions live — had no re-runnable evidence until now.
+
+## The fifth hardening round (blind re-audit #4)
+
+This one **settled the concurrency adjudication**: both earlier measurements were
+of pre-fix code, the variable was generate *duration*, and at HEAD it measured 24
+runs across four fixtures with **zero variance — 1 allowed / 7 denied, meter
+exactly 2027**. It then mutated out the two fixes and reproduced both earlier
+results byte-for-byte. Three 🔴 remained.
+
+| # | what | measured before | after |
+|---|---|---|---|
+| 1 | **the README hands the agent an ungated second CLI holding the same credential** | `README.md:115` says `npm install -g @civitai/cli`, and node/npm are in the closure. `npx -y @civitai/cli whoami` returned **401** — positive proof it read the `config.yaml` in the sandbox `$HOME` and authenticated with it. With the real key it would spend with no cap, no counter, no ledger row and no latch. **No defeat-intent: it is the documented install command** | the credential is no longer written to `$HOME` at all. It lives in `ledger/credential` (0600) and is injected as `CIVITAI_TOKEN` into the gated child only. Re-measured: ungated CLI **rc 3 (unauthenticated)**, gated **rc 0**, positive control (same call with a token in env) **rc 0** |
+| 2 | `reconcile_inflight` regenerated the three defects removed from `settle_spend` | delta 0 → recorded 0, no latch; NEGATIVE delta → clamped to 0, twelve lines from the comment saying clamping "is what made that silent"; unwritable meter → ignored; and the ledger asserted *"0 Buzz reconciled"* | both paths now call one `apply_settlement`. Re-measured: real delta **37/no latch**, zero **50/LATCH**, negative **50/LATCH**, unwritable meter **LATCH** |
+| 2b | the liveness check used a PID, and `enter` runs `--unshare-pid` | a stale record carrying pid **1 or 2** was never reconciled: charge escaped, reservation leaked, and every later generate refused with *"another generation is still running (pid 1)"* — **one interrupted generate bricked the spend path** | liveness is an `flock` held for the child's lifetime. Re-measured: stale pid 1 and pid 2 both reconcile (meter 37, record cleared, reserved 0) |
+| 3 | mandatory `calibrate` spent **outside** the meter | 37 moved, `observed_spend` 0, submits 0, ledger rows 0; `finish` then reported *observed 37 / MEASURED 74*. The doc lists that disagreement as an ABORT CONDITION, so the prescribed procedure guaranteed the alarm fired every run — **a permanently-red gate** | `calibrate` runs through the shim. Re-measured: meter **37**, submits **1**, rows **1**, and `finish` reports **observed 37 / MEASURED 37** |
+
+🟡 also: `app pull` is now gated by `SLUG_PREFIX` — it reaches an owner-only
+endpoint, lazily provisions a Forgejo identity and git writes an access token
+into `.git/config` (a **third** credential, now in `shred_secrets`); the audit
+files themselves (`invocations.tsv`, `spend.tsv`) are asserted appendable before
+a spend, because with `invocations.tsv` at 0444 a generate charged and wrote
+**zero** rows; `finish` reconciles before reporting; the concurrency **outcome**
+(exactly 1 of 8) is now asserted in CI rather than only ledger consistency;
+`unescape` undoes `escape` in the reverse order.
+
+🔴 **`AGENT-BRIEF.md` now names the `civitai` on PATH as the only one in scope**
+and tells the agent not to install a second copy. Nothing said so before, and
+the README actively suggests otherwise.
 
 ## What this does not protect against
 
@@ -803,8 +831,17 @@ are the ones being shipped knowingly.
     went from 69 to **168** store paths (181 with `--with-claude`). The jail
     still has no repo, no operator `$HOME` and no real credential store, so the
     blast radius is the sandbox plus the network — which is not nothing.
-14. 🔴 **A SECOND CREDENTIAL IS NOW AT REST IN THE SANDBOX, AND IT IS NOT THE
-    CIVITAI KEY.** `enter --with-claude` copies `~/.claude/.credentials.json`
+14. 🔴 **CREDENTIAL INVENTORY — THERE ARE THREE, NOT TWO.** (a) the Civitai
+    token, now in `ledger/credential` (0600) and injected rather than written
+    into `$HOME`; (b) under `--with-claude`, the Anthropic OAuth token in
+    `home/.claude/.credentials.json`; (c) any git access token `app pull` writes
+    into a workspace `.git/config`. All three are shredded by `teardown`.
+    🔴 **The residual that remains after the injection fix:** `ledger/credential`
+    is readable by the same UID, so an agent that goes looking can still find it
+    and hand it to an ungated binary. What changed is that this now requires
+    INTENT — before, the README's own `npm install -g @civitai/cli` was enough,
+    with the second CLI authenticating straight off the config file.
+15. 🔴 **THE ANTHROPIC TOKEN, AND WHAT IT GRANTS.** `enter --with-claude` copies `~/.claude/.credentials.json`
     into the run root. It is an OAuth token pair whose scopes are
     `user:inference`, `user:mcp_servers`, `user:file_upload`, `user:profile`,
     `user:sessions:claude_code` on a `max` subscription — so reading it lets
@@ -825,14 +862,14 @@ are the ones being shipped knowingly.
       mint an independent, revocable token; it is one owner action and was not
       taken.
 
-15. 🔴 **The unknown-verdict backstop in `cmd_guard` survives deletion, and
+16. 🔴 **The unknown-verdict backstop in `cmd_guard` survives deletion, and
     that is now DECLARED rather than merely true.** No valid input can reach it —
     `policy_verdict` always sets a verdict — so only an internal bug can, which
     is what it is for. Its value was shown by a two-stage mutant (make a branch
     return without setting `VERDICT`, then delete the backstop: rc 126 → rc 0,
     binary ran) and it is listed here alongside `write_scalar`'s readback as a
     knowingly-unpinned guard, because the previous round left it undeclared.
-16. **`make dogfood-check` is still not in CI, and `internal/dogfoodguard` shows
+17. **`make dogfood-check` is still not in CI, and `internal/dogfoodguard` shows
     `[no test files]` under `make ci`.** The classifier — the component three
     audits have now agreed is the load-bearing one — is pinned only by a suite CI
     never runs. Workflow files are ask-first, so this is flagged rather than
@@ -919,7 +956,7 @@ shred -u ~/.dogfood-token
 
 # 3. confirm the harness is honest before trusting it
 scripts/dogfood-sandbox.sh selftest        # against the live sandbox
-make dogfood-check                         # shellcheck -x + 241/241, no credential needed
+make dogfood-check                         # shellcheck -x + 266/266, no credential needed
 
 # 4b. calibrate the meter — ONE deliberate generation, spends real Buzz
 scripts/dogfood-sandbox.sh calibrate --yes

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -55,26 +55,42 @@ with the sandbox environment, and appends to the audit log.
 
 ## The controls, and how strong each one actually is
 
-The distinction that matters is **who enforces it**. Three tiers:
+The distinction that matters is **who enforces it**. There are exactly **two**
+kernel-enforced controls, and they are both mount-namespace controls that exist
+only when the agent is launched through `dogfood-sandbox.sh enter`:
 
 | control | enforced by | strength |
 |---|---|---|
-| the repo checkout is not visible to the agent | Linux mount namespace (`bwrap`) | **kernel** |
-| the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel** |
-| `upgrade` cannot replace the binary under evaluation | filesystem mode bits | **kernel** |
+| the repo checkout, `AGENTS.md` and both handoffs are not visible | Linux mount namespace (`bwrap`) | **kernel — only under `enter`** |
+| the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel — only under `enter`** |
+| `upgrade` cannot replace the binary under evaluation | mode bits + the guard | convention |
 | credential isolation without the jail | `HOME` / `XDG_CONFIG_HOME` on the child | convention |
 | the per-invocation `--max-cost` ceiling | the guard script | convention |
-| the total spend cap | the guard script | convention |
+| the total spend cap and the meter | the guard script | convention |
 | `app submit` / listing media restricted to a throwaway app | the guard script | convention |
 | `withdraw` restricted to submissions this run created | the guard script | convention |
-| `login`, `dev-tunnel`, `dev-token` refused | the guard script | convention |
+| `login`, `dev-tunnel`, `dev-token`, unknown commands refused | the guard script | convention |
+| the audit ledger | the guard script | convention |
 
-"Convention" means: the agent runs as the same Unix user, so it *can* invoke
-`$ROOT/real/civitai` directly and bypass the guard entirely. It has no reason
-to, and the brief does not suggest it — but nothing stops it. **Run in the jail
-(`dogfood-sandbox.sh enter`) and the top two rows become kernel-enforced;
-without it they are convention too.** That is the single most important
-operational choice in this document.
+🔴 **The `upgrade` row moved from "kernel" to "convention", and the earlier
+version of this table was wrong about it.** The mode bits genuinely defeat the
+*command* — `selfupdate` `O_CREATE`s `.civitai.new` in a `0500` directory and
+gets `EACCES` — but they do not bind the *agent*, because a process owning an
+inode may always chmod it. Measured, **inside the jail, as uid 1000**:
+`chmod u+w $ROOT/real` → rc 0, then `touch $ROOT/real/.civitai.new` → rc 0, and
+overwriting the binary succeeds. The same is true of the harness script itself.
+So: the lockdown stops `civitai upgrade` from doing what it does; it does not
+stop an agent that decides to take the permission back.
+
+🔴 **Say the consequence plainly, because it is what the owner is actually
+approving: the agent holds your full-scope personal API key and an unrestricted
+network.** Everything in the "convention" rows is a property of a shell script
+running as you, next to a credential you can read and a binary you can execute
+directly. Measured inside the jail: the config file is readable, the harness is
+readable, `$ROOT/real/civitai` is directly invocable bypassing the guard, and
+DNS resolves. Nothing here bounds what the account can be made to do — it bounds
+what the *CLI under test* does when driven through the shim, which is a much
+smaller claim and the only one this harness can support.
 
 ### 1. Credential isolation
 
@@ -125,7 +141,7 @@ Calibration, measured against the live estimator during validation: a bare
 So the per-call ceiling of 100 is generous for realistic jobs and the total cap
 of 2000 is roughly 0.05% of the account's 4,187,454 Buzz.
 
-### 3. `upgrade` is blocked structurally, not by instruction
+### 3. `upgrade` is blocked at the command, not at the agent
 
 `minio/selfupdate`'s `Apply` writes `.civitai.new` into
 `filepath.Dir(targetPath)` with `os.OpenFile(O_CREATE|…)` (`apply.go:67–72`)
@@ -140,6 +156,11 @@ would have left a hole.
 The guard also refuses `upgrade` outright, so the agent gets a clear message
 rather than a confusing `EACCES` from inside the CLI. Both are present; neither
 is redundant.
+
+🔴 **But neither is kernel-enforced against the agent** — see the table above.
+`chmod u+w` undoes the mode bits from inside the jail, and calling
+`$ROOT/real/civitai` directly bypasses the guard. This blocks the command; it
+does not bind the agent.
 
 ### 4. A dedicated throwaway app
 
@@ -311,30 +332,134 @@ warns about, hit while validating a harness. The audit log was the tiebreaker.
 An ad-hoc `grep -o '"total":[0-9]*'` therefore matches **nothing**, and
 `$(( B0 - B1 ))` turns two empty strings into a confident `0`. That is exactly
 what the first dry-run delta measurement reported, and it was meaningless. The
-harness's parser strips whitespace first, refuses to return a non-integer, and
+harness's parser strips whitespace first, is ANCHORED AT BOTH ENDS so it cannot
+return a truncated prefix (the audit's finding 5 — `{"total":1e9}` used to parse
+as `1`), rejects a negative, absurd or duplicated total, and
 is negative-controlled against a payload with no `total`. Re-measured properly:
 three real `--dry-run` estimates moved the balance by **0**
 (4187454 → 4187454).
 
 ### `selftest`
 
-`dogfood-sandbox.sh selftest` — 28 assertions, 28 pass. It covers every policy
+`make dogfood-check` runs `shellcheck -x` plus
+`dogfood-sandbox.sh selftest --offline` — **88 assertions, 88 pass**, no
+credential and no network required, so this is regression-testable in CI. The
+credentialed `selftest` (against a live sandbox) runs **79**, the same set minus
+the 13 stub-driven end-to-end rows plus 4 live lockdown/balance rows. It covers
+every policy
 branch (including `--max-cost=N` form parsing, `app submit -o <path>` not being
 mistaken for the project dir, and listing identity via `--slug` vs `--dir`),
 the balance parser's positive and negative controls, and the lockdown modes.
+
+## The hardening round (adversarial audit of #296)
+
+An independent audit attacked the first version. The bwrap jail held (uid 1000,
+host userns; a nested `unshare -Ur` confers nothing because `/home` is not
+mounted in it; `/` shows only `dev etc nix proc run tmp usr`). The gate did not.
+**Ten findings, all reproduced independently here before fixing, all fixed, each
+with a selftest row that goes red when the fix is reverted.**
+
+The two that matter most were not attacks — they were the stated threat model
+("read `--help`, try things, mis-type flags") landing on the gate:
+
+| # | what | measured before | after |
+|---|---|---|---|
+| 1 | a root persistent flag before the subcommand — `--no-color generate … --yes` — hid the command from a positional classifier | **ALLOW**, stub charged 37, meter 0; `--no-update-check upgrade` also ALLOW | DENY, and for the *right reason* |
+| 2 | pflag takes the token after a value-taking flag as its VALUE, so `--negative-prompt --help` satisfied a "is `--help` present?" test | **ALLOW**, charged 37, meter 0 | DENY |
+| 3 | the gate failed OPEN on its own internal errors — one key deleted from the file the header tells the operator to edit | `--max-cost 99999` **submitted and charged** | DENY, policy validated on read |
+| 4 | the POST-call balance sample failed open silently | 5 submits, 185 truly spent, **meter 0** | worst case charged, `meter_broken` latched, all later spends refused |
+| 5 | the balance parser accepted a truncated prefix | `{"total":1e9}` → **1**, so every delta is 0 — a meter reading a constant forever | anchored at both ends; 8 reject cases |
+| 6 | the cap was race-defeatable by an ordinary background job | 8 concurrent → **8 ALLOW_SPEND**, counter lost 3 | `flock` + a reservation; 8 concurrent → **1** |
+| 7 | the audit record was forgeable by a multi-line prompt (a newline is legitimate in a prompt) | one invocation wrote **2** ledger rows | escaped; 1 row |
+| 8 | `upgrade` was documented as kernel-enforced | `chmod u+w` → rc 0 **inside the jail** | table and residual #1 corrected |
+| 9 | `app withdraw <non-pubreq id>` allowed on a false reason (`app_withdraw.go` does no format validation) | ALLOW | any id must be allowlisted |
+| 10 | the strength table and residual #1 overstated what is enforced | — | rewritten; see above |
+
+Plus the 🟡 set: `--max-cost` now reads the **last** occurrence (pflag does —
+verified on a free read, `--limit 1 --limit 3` returns three results, so
+`--max-cost 5 --max-cost 99999` used to show the gate a 5 while the CLI enforced
+99999); `CIVITAI_BASE_URL`/`CIVITAI_TOKEN` are pinned and cleared, because the
+meter's oracle was an environment variable the agent controls; the balance read
+is bounded by `timeout 60`; a malformed ledger scalar is a refusal rather than a
+disabled cap; and `init --force` now **supersedes** the previous run root
+instead of deleting the ledger before the new credential has been validated.
+
+**Two additional defects found here, not in the audit.** The same
+value-eats-the-next-token bug aimed at the *dangerous* direction:
+`--negative-prompt --dry-run` made the gate see a free preview while the CLI
+submitted and charged. And an unknown subcommand (`app frobnicate`,
+`app listing frobnicate`) resolved to the empty string, which was
+indistinguishable from a bare `civitai app` and therefore ALLOWED. Both are now
+denied, and the gate fails closed on any command outside its closed vocabulary.
+
+### Mutation matrix
+
+Every fix was reverted to its pre-hardening spelling, checksum-gated (target
+must occur; file hash must change; mutant must parse) and re-run:
+
+```
+BASELINE                                          88 passed, 0 failed
+F1  command resolved positionally             KILLED  4 failures
+F2  blanket --help short-circuit              KILLED  5
+F5  unanchored balance parser                 KILLED  2
+F7  tsv_escape is identity                    KILLED  3
+F6  ledger lock removed                       KILLED  2
+F4  lost post-sample silently ignored         KILLED  1
+F4b meter_broken latch removed                KILLED  2
+F3  policy numeric validation removed         KILLED  3
+F3b unset-before-source removed               KILLED  1
+MC  flag_value returns FIRST not LAST         KILLED  2
+F9  withdraw only gates pubreq_-shaped ids    KILLED  2
+SUB unknown app subcommand allowed            KILLED  1
+SUB2 unknown listing verb allowed             KILLED  1
+NULL comment-only                             SURVIVED (as required)
+```
+
+🔴 **F1 initially killed only ONE row, and that was the interesting result.**
+With the command resolved positionally again, `--no-color generate … --yes`
+still DENIED — as an unrecognised command *called* `--no-color` — so every
+verdict-only assertion for that bypass stayed green while the gate was blind.
+A bystander branch was carrying the control. The finding-1 rows now assert the
+**reason**, and the mutant kills four.
+
+Two further guards were added because the classifier being right says nothing
+about whether the guard acts on it: `selftest --offline` now drives the **real
+guard** end-to-end against a stub binary that charges a known amount (13 rows,
+including the concurrency race, the newline-forgery row, the `meter_broken`
+latch, an unrecognised command, and a malformed policy refusing even a read).
+It needs no credential and no network, which is what makes it runnable in CI.
+
+**The empty-verdict backstop needed a two-stage mutant**, because no valid input
+can reach it — only an internal bug can. Measured, with the real binary
+instrumented to log whether it ran at all:
+
+```
+stage 0  unmutated                                        rc=126  binary ran: 0
+stage A  branch returns without setting VERDICT           rc=126  binary ran: 0   <- backstop caught it
+stage B  stage A + the backstop deleted                   rc=0    binary ran: 1   <- executed
+```
+
+That is the whole failure mode of the original `verdict=$(policy_verdict …)`
+subshell, reproduced deliberately: an internal error left the verdict empty and
+`"" != "DENY"` ran the command.
 
 ## What this does not protect against
 
 An unrecorded residual is indistinguishable from a bug nobody noticed. These
 are the ones being shipped knowingly.
 
-1. **Same Unix user. The guard is a shell script, not a sandbox.** The agent can
-   read `$ROOT/harness/dogfood-sandbox.sh`, see every rule, invoke
-   `$ROOT/real/civitai` directly and bypass all of it — and it can rewrite
-   `$ROOT/ledger/*`, corrupting both the spend meter and the audit trail. Only
-   the mount-namespace and mode-bit controls are outside its reach. Real
-   isolation needs a second UID or a container; neither is available here
-   without root.
+1. 🔴 **THE AGENT HAS YOUR FULL-SCOPE PERSONAL API KEY AND AN UNRESTRICTED
+   NETWORK, AND NOTHING HERE CHANGES THAT.** Everything except the two
+   mount-namespace rows is convention: the agent runs as the same Unix user, so
+   it can read the seeded credential, read `$ROOT/harness/dogfood-sandbox.sh`
+   and see every rule, invoke `$ROOT/real/civitai` directly to bypass the gate
+   entirely, `chmod u+w` the "read-only" binary, and rewrite `$ROOT/ledger/*` to
+   corrupt both the spend meter and the audit trail. All of that was measured
+   inside the jail as uid 1000. **The caps bound what the CLI under test does
+   when driven through the shim. They do not bound what the account can be made
+   to do.** Real isolation needs a second UID or a container; neither is
+   available here without root. If that residual is unacceptable, the answer is
+   a scoped or low-balance credential, not a better shell script.
 2. **`--max-cost` does not cap spend, so neither does the total cap, exactly.**
    The cap is evaluated *before* each submit, so a submit can always start while
    the cumulative figure is one Buzz under the limit, and the realized charge
@@ -354,15 +479,31 @@ are the ones being shipped knowingly.
    works only while `pending`. See the non-reversible list in §4 — an approved
    app is live, a rejected one is terminal, and the blockId is consumed
    permanently either way.
-7. **The gate re-implements argv parsing; it is not Cobra.** It understands
-   `--flag V` and `--flag=V` and the value-taking flags of the commands it
-   gates. A spelling Cobra accepts that the gate parses differently could
-   mis-resolve a project directory and, in the worst case, let a foreign app
-   through. It fails closed on `generate` (an unrecognised `--max-cost` is a
-   refusal) but the identity checks fail closed only when they can tell they are
-   confused. There is also a TOCTOU window between reading the manifest and
-   exec'ing the CLI; irrelevant for a cooperative agent, real in principle.
-8. **The ledger is not concurrency-safe.** One agent at a time.
+7. **The gate re-implements argv parsing; it is not Cobra — and that is where
+   every one of the audit's two worst findings came from.** It now resolves
+   commands against a CLOSED VOCABULARY and tokenizes flags with per-command
+   knowledge of which ones consume the next token, but it is still a
+   re-implementation. Known costs, deliberately taken:
+   - **An unknown command or subcommand is REFUSED, not passed through.** A new
+     `civitai` verb, or a typo, produces a `SANDBOX POLICY` line rather than the
+     CLI's own error. That is the fail-closed direction, and it means the gate's
+     vocabulary has to be updated when the CLI grows a command.
+   - **On `generate`, an unrecognised flag is assumed to consume the next
+     token.** That biases toward refusal: `--mystery --dry-run` is treated as a
+     submit, not a preview. A false refusal, never a false allow.
+   - **`civitai generate "prompt" --help` is refused**, because `--help` after a
+     bare positional cannot be distinguished from `--help` as a flag value under
+     an allowlist rule. Use `civitai generate --help`.
+   - A TOCTOU window remains between reading the manifest and exec'ing the CLI;
+     irrelevant for a cooperative agent, real in principle.
+8. **Concurrency is bounded, not eliminated.** The cap check, the counter bump
+   and the reservation are one `flock`-held section, and a submit reserves its
+   `--max-cost` for the duration — measured, 8 concurrent submits against 10
+   Buzz of headroom now yield exactly 1. But the reservation is the ESTIMATE
+   ceiling, not the realized charge, so N concurrent jobs can still overshoot by
+   the same "realized exceeds estimate" margin as residual 2. **If `flock` is
+   absent the lock silently degrades to a no-op** — `selftest` asserts it is
+   present precisely so that degradation is visible rather than assumed.
 9. **Four deliberate fidelity distortions the agent will see, none of which the
    real CLI does:** refusals prefixed `SANDBOX POLICY` with exit code 126; a
    mandatory `--max-cost` on any real generation; `login` refused entirely; and
@@ -383,6 +524,16 @@ are the ones being shipped knowingly.
 ## Go / no-go checklist
 
 Read time ~2 minutes. Everything below is verifiable in one command each.
+
+**The one sentence to read first**
+
+> 🔴 **The agent will hold your full-scope personal API key and an unrestricted
+> network connection, running as your Unix user.** Every spend cap, submit cap
+> and forbidden-command rule in this harness is a shell script it can read and
+> step around; only the repo-invisibility and config-unreachability are enforced
+> by the kernel, and only under `enter`. What the caps bound is what the CLI
+> under test does when driven through the shim — not what the account can be
+> made to do. Approve on that basis or not at all.
 
 **Facts to confirm before approving**
 
@@ -426,7 +577,8 @@ scripts/dogfood-sandbox.sh init --binary ./bin/civitai --token-file ~/.dogfood-t
 shred -u ~/.dogfood-token
 
 # 3. confirm the harness is honest before trusting it
-scripts/dogfood-sandbox.sh selftest        # expect 28/28
+scripts/dogfood-sandbox.sh selftest        # expect 79/79 against the live sandbox
+make dogfood-check                         # shellcheck + 88/88, no credential needed
 
 # 4. run the agent blind, inside the jail, cwd $ROOT/workspace,
 #    given only: the `civitai` on PATH, README.md, --help, and AGENT-BRIEF.md

--- a/claudedocs/dogfood-3-sandbox.md
+++ b/claudedocs/dogfood-3-sandbox.md
@@ -1,0 +1,458 @@
+# Dogfood run 3 — the credentialed sandbox
+
+Design + validation record for `scripts/dogfood-sandbox.sh`, the harness that
+makes a **credentialed** blind dogfood run of the `civitai` CLI survivable and
+auditable.
+
+Status: **built and validated on the free surface. Not yet run. Awaiting the
+go/no-go at the end of this document.**
+
+## Why this exists
+
+Runs 1 (`claudedocs/handoff-dogfood-154.md`, issues #223–#227 → 9 merged PRs)
+and 2 (`claudedocs/handoff-dogfood-2.md`, issues #255–#260 → 6 merged PRs) were
+both deliberately **un-credentialed**. That was the right call then — an
+isolated `XDG_CONFIG_HOME` with no token removes every dangerous capability at
+once — but it has a structural consequence that run 2's own handoff states:
+
+> Both runs were deliberately un-credentialed, so `civitai generate` — the CLI's
+> only irreversibly money-spending surface, and the subject of AGENTS items
+> 12–22 — is *structurally unreachable* by this harness.
+
+Two clean runs therefore say **nothing** about the spend path, which is the
+single largest untested surface in the product and the one carrying eleven of
+the twenty-seven AGENTS items. Run 3 targets it. This harness is the
+precondition.
+
+## The threat model, stated plainly
+
+The agent is **exploring, not attacking**. It will do what a competent
+first-time user does: read `--help`, try things, mis-type flags, and reach for
+the obvious next command — including `civitai login --token`, `civitai upgrade`,
+and `civitai generate --yes`. The harness must survive *that*, and must make the
+run auditable afterwards. It is explicitly **not** a defence against an agent
+that decides to defeat it; see [What this does not protect
+against](#what-this-does-not-protect-against).
+
+## Layout
+
+```
+$ROOT/                                 default /tmp/claude-1000/dogfood3-scratch/run
+  bin/civitai        0555, dir 0500    the shim the agent gets on PATH
+  real/civitai       0555, dir 0500    the binary under evaluation
+  harness/…          0555, dir 0500    a COPY of this script (self-contained run)
+  home/                                HOME inside the sandbox
+    .config/civitai/config.yaml 0600   the seeded credential
+    .config/civitai/pending/           generate's idempotency records
+  workspace/                           the agent's working directory
+  ledger/            0700              audit trail + spend meter + policy
+  AGENT-BRIEF.md                       what the blind agent is told
+```
+
+`bin/civitai` is a two-line shim into `dogfood-sandbox.sh guard`, which decides
+ALLOW / DENY, brackets a real spend with balance samples, execs the real binary
+with the sandbox environment, and appends to the audit log.
+
+## The controls, and how strong each one actually is
+
+The distinction that matters is **who enforces it**. Three tiers:
+
+| control | enforced by | strength |
+|---|---|---|
+| the repo checkout is not visible to the agent | Linux mount namespace (`bwrap`) | **kernel** |
+| the operator's real `~/.config/civitai` is not reachable | Linux mount namespace (`bwrap`) | **kernel** |
+| `upgrade` cannot replace the binary under evaluation | filesystem mode bits | **kernel** |
+| credential isolation without the jail | `HOME` / `XDG_CONFIG_HOME` on the child | convention |
+| the per-invocation `--max-cost` ceiling | the guard script | convention |
+| the total spend cap | the guard script | convention |
+| `app submit` / listing media restricted to a throwaway app | the guard script | convention |
+| `withdraw` restricted to submissions this run created | the guard script | convention |
+| `login`, `dev-tunnel`, `dev-token` refused | the guard script | convention |
+
+"Convention" means: the agent runs as the same Unix user, so it *can* invoke
+`$ROOT/real/civitai` directly and bypass the guard entirely. It has no reason
+to, and the brief does not suggest it — but nothing stops it. **Run in the jail
+(`dogfood-sandbox.sh enter`) and the top two rows become kernel-enforced;
+without it they are convention too.** That is the single most important
+operational choice in this document.
+
+### 1. Credential isolation
+
+The sandbox gets its own `HOME` and `XDG_CONFIG_HOME`. `config.Dir()` resolves
+through `os.UserConfigDir()`, which honours `XDG_CONFIG_HOME` on Linux, so the
+CLI's config, its OAuth refresh writes, its update-check cache and
+`generate`'s pending-idempotency records all land inside `$ROOT/home`.
+
+**How the token reaches the sandbox.** Never as a harness argument (shell
+history), never into the repo, never into a world-readable file. `init` takes
+either `--token-file <path>` or the `CIVITAI_DOGFOOD_TOKEN` environment
+variable, and seeds it **through the CLI itself** (`login --token`) so the
+config format stays the CLI's business rather than a vendored copy. The
+resulting `config.yaml` is `0600`. The audit log redacts any `--token` value.
+
+Residual on the seeding step: `login --token <key>` puts the key in that
+process's argv, readable from `/proc` **by the same user only** for the
+duration of one call. Accepted rather than hidden.
+
+### 2. The spend ceiling
+
+🔴 **`--max-cost` is not a spending cap, and the CLI says so itself:**
+
+> `--max-cost` IS AN ESTIMATE CHECK, NOT A SPENDING CAP. … The realized charge
+> can exceed the estimate, and it is not refunded. … Do not run an unattended
+> loop believing it caps spend.
+
+So the harness does not rely on it. It does three separate things:
+
+1. **Refuses any `generate` that would actually submit unless it carries
+   `--max-cost N` with `N ≤ PER_CALL_MAX_COST`** (default 100 Buzz).
+   `--dry-run` and `--print-input` are unrestricted — they spend nothing.
+2. **Meters actual spend.** It samples `buzz --json` immediately before and
+   after every allowed submit, accumulates the deltas, and refuses further
+   submits once the cumulative figure reaches `TOTAL_SPEND_CAP` (default 2000
+   Buzz) — or when the remaining budget is smaller than the requested
+   `--max-cost`.
+3. **Caps the number of mutating invocations** independently of cost:
+   `MAX_GENERATE_SUBMITS` (20) and `MAX_APP_SUBMITS` (3).
+
+🔴 **The meter fails CLOSED.** If the balance read fails or does not parse, the
+submit is **refused** rather than treated as "spent 0". This is the difference
+between a meter and a decoration, and it is the one behaviour most likely to be
+"simplified" away.
+
+Calibration, measured against the live estimator during validation: a bare
+`txt2img` prices **8** Buzz; the same prompt at `--quantity 4` prices **30**.
+So the per-call ceiling of 100 is generous for realistic jobs and the total cap
+of 2000 is roughly 0.05% of the account's 4,187,454 Buzz.
+
+### 3. `upgrade` is blocked structurally, not by instruction
+
+`minio/selfupdate`'s `Apply` writes `.civitai.new` into
+`filepath.Dir(targetPath)` with `os.OpenFile(O_CREATE|…)` (`apply.go:67–72`)
+before renaming it over the target. `$ROOT/real` is mode `0500`, so that
+`O_CREATE` is `EACCES` and the rename/unlink cannot happen either.
+
+Measured on this host — a `0500` directory refuses create, rename **and**
+unlink, but **does not** refuse an in-place write to an existing file (`rc=0`).
+That is why the binary itself is additionally `0555`: the directory mode alone
+would have left a hole.
+
+The guard also refuses `upgrade` outright, so the agent gets a clear message
+rather than a confusing `EACCES` from inside the CLI. Both are present; neither
+is redundant.
+
+### 4. A dedicated throwaway app
+
+Anything that submits an app or mutates listing media is restricted to a
+**blockId prefix** (default `dogfood3-<YYYYMMDD>-`). The guard resolves the
+identity the same way the CLI does — `--slug` if given, otherwise the `blockId`
+in `<--dir|positional dir|.>/block.manifest.json` — and refuses anything
+outside the prefix. It fails closed: if it cannot read a blockId, it denies.
+
+**The cleanup path, and what it cannot undo.** Per `app withdraw --help`:
+withdraw calls the self-scoped `POST /api/v1/blocks/withdraw`, works only on a
+submission still in the **`pending`** review state, and is idempotent.
+
+Not reversible, and the owner should read this list before approving:
+
+- **An approved app is live.** If a moderator approves before the run withdraws,
+  `withdraw` cannot un-publish it. Removal is a platform-side action.
+- **The blockId is permanent.** AGENTS item 27: the blockId "can NEVER be
+  renamed". A throwaway app permanently consumes that slug on the account.
+- **A rejected submission cannot be withdrawn** either — it is already terminal.
+- **Listing media on a live listing creates a revision that goes back to
+  review** (that is what `--changelog` is for). `rm-screenshot` removes a
+  screenshot; there is no un-set for icon/cover, only replace.
+- **Buzz spent is gone.** No cancel-for-refund; `--timeout` and Ctrl-C stop the
+  waiting, not the charge.
+
+`withdraw` is additionally restricted to publish-request ids **this sandbox
+recorded**, so the agent cannot withdraw one of the account's real pending
+submissions. `dogfood-sandbox.sh allow-pubreq <id>` is the operator's escape
+hatch.
+
+### 5. Blindness
+
+The method depends on the agent having only the built binary, `README.md` and
+`--help`. `dogfood-sandbox.sh enter` spawns a `bubblewrap` jail that binds only
+the Nix store, the system profile, `/usr`, DNS and TLS trust, and the run root.
+**Nothing under `/home` is bound**, so the repo checkout, `AGENTS.md`, the
+handoffs and the operator's real config do not exist inside the namespace.
+
+Verified (transcript below): inside the jail `/home` does not exist, the repo
+path does not exist, `civitai whoami` still authenticates as `zachlowdenzx`, an
+anonymous public read still works, and the guard still refuses `upgrade` and an
+uncapped `generate`.
+
+🔴 **Order is load-bearing in the `bwrap` invocation.** The default run root
+lives under `/tmp`, so `--tmpfs /tmp` must be applied *before* the run-root
+bind or the tmpfs shadows it. That was a real bug found in validation —
+`bwrap: Can't chdir to <root>/workspace: No such file or directory` — and it is
+now commented at the call site.
+
+### 6. The audit trail
+
+`ledger/invocations.tsv` — one line per invocation: UTC timestamp, verdict
+(`ALLOW` / `ALLOW_SPEND` / `ALLOW_APP_SUBMIT` / `DENY`), exit code, duration in
+ms, the scrubbed argv, and either the observed Buzz delta or the refusal reason.
+`ledger/buzz.tsv` holds every balance sample with its raw payload;
+`ledger/spend.tsv` holds before/after/delta per submit. `finish` prints the
+report and the authoritative **start-minus-end** balance delta.
+
+Two spend figures are reported on purpose: the per-call sum (attributable to
+individual invocations) and the start-to-end delta (catches anything the
+per-call sampling missed). They should agree; if they do not, the difference is
+the interesting number.
+
+## Validation
+
+Everything below was run against the real account on the **free surface only**.
+Total Buzz moved: **0**. Account `zachlowdenzx` (id 8753561), opening and
+closing balance both **4,187,454** Buzz.
+
+The harness is binary-agnostic — `init --binary <path>` takes whatever build
+you point it at — but for provenance: these numbers were measured against the
+binary built at `8ec3cb0`, and the free-surface exit-code table was re-confirmed
+against `9862c1e` (the tip when this branched, which changed `app validate`
+message text).
+
+### Instrument validation — the meter, proved with a stub
+
+The meter cannot be proved on real money without spending real money, so it was
+proved against a stub binary that "charges" a known 37 per generation. This is
+the harness's own negative/positive control pair.
+
+| # | check | result |
+|---|---|---|
+| 1 | `--dry-run` does not move the meter | `observed_spend=0` |
+| 2 | submit without `--max-cost` refused | `rc=126`, meter still 0 |
+| 3 | `--max-cost` above the per-call ceiling refused | `rc=126` |
+| 4 | **POSITIVE CONTROL** — an allowed submit moves the meter | `observed_spend=37` |
+| 5 | the meter accumulates | `37 → 74` |
+| 6 | remaining-budget refusal, then the total-cap refusal, then the invocation-cap refusal — each isolated so neither masks the other | `126` / `126`, with the distinct reason printed for each |
+| 7 | `upgrade`, `login`, `dev-tunnel` refused; `upgrade --help` allowed | `126,126,126` / `0` |
+| 8 | the token never reaches the audit log | no literal; `<redacted>` present |
+| 9 | **NEGATIVE CONTROL** — an unparseable balance read must refuse, not assume zero | `rc=126`, reason `balance read failed (fail closed)` |
+
+Check 9 failed on the first attempt for an instructive reason: the probe could
+not overwrite the stub because `$ROOT/real` was already `0500` — the lockdown
+blocking the test *is itself* evidence the lockdown works — so the "negative
+control" silently ran against the healthy stub and reported a pass-looking
+`rc=0`. Re-run with the mode relaxed first, it fails closed as designed.
+
+Check 6 also had to be rebuilt: the invocation cap was tripping first and
+masking the total-spend branch, so a green there was not evidence the spend cap
+worked. Each branch is now isolated and prints its own reason.
+
+### Isolation — the positive control, in both directions
+
+A one-directional test ("the real config is unchanged") is satisfied by a write
+that never happened. So both directions are asserted:
+
+```
+operator config sha256 BEFORE anything: ce75626af69be0c4dd1bc0fd84f489ead61fcf45e8b2f9d1306b2575388968a3
+
+  the guard refuses `login` outright:                       rc=126
+  bypassing the guard, the CLI runs `login --token BOGUS…` with the sandbox env:
+    operator config: ce75626a… -> ce75626a…   PASS  UNCHANGED
+    sandbox  config: ce75626a… -> 0fcef8c7…   PASS  DID change (so the above is not vacuous)
+    sandbox whoami with the bogus key:        rc=3   (the bogus key really is in force)
+  re-seeded with the real credential:         whoami rc=0
+
+operator pending-generation records: 8 files, untouched
+sandbox  pending-generation records: 0 files
+
+FINAL operator config sha256:          ce75626af69be0c4dd1bc0fd84f489ead61fcf45e8b2f9d1306b2575388968a3
+```
+
+Byte-identical at the start and the end of the entire session.
+
+### `upgrade` is structurally blocked
+
+```
+binary dir mode: dr-x------
+binary    mode: -r-xr-xr-x
+simulate selfupdate's O_CREATE of .civitai.new:
+  touch: cannot touch '…/real/.civitai.new': Permission denied   rc=1
+guard refusal:                                                    rc=126
+```
+
+### The jail
+
+```
+outside: repo visible: yes      /home/zach visible: yes
+inside:  /home exists?          NO (repo checkout unreachable)
+         repo path exists?      NO
+         civitai on PATH?       …/run/bin/civitai
+         civitai whoami         Logged in as zachlowdenzx (id 8753561)   rc=0
+         models search          rc=0
+         upgrade                rc=126
+         generate w/o --max-cost rc=126
+```
+
+### Exit codes, read without a pipe in between
+
+All nine gate refusals return **126**; every allowed command passes the CLI's
+own code straight through (`whoami` 0, `app validate` on a lockfile-less
+scaffold 1, `app listing set-icon /dev/null` 2).
+
+The first version of that probe read `$?` after `… | head -2` and reported
+`rc=0` for refusals that had in fact returned 126 — the pipe trap `AGENTS.md`
+warns about, hit while validating a harness. The audit log was the tiebreaker.
+
+### The balance parser, positive-controlled against the real payload
+
+`buzz --json` pretty-prints with a space after the colon:
+
+```json
+{ "blue": 1338425, "green": 999980, "total": 4187454, "yellow": 1849049 }
+```
+
+An ad-hoc `grep -o '"total":[0-9]*'` therefore matches **nothing**, and
+`$(( B0 - B1 ))` turns two empty strings into a confident `0`. That is exactly
+what the first dry-run delta measurement reported, and it was meaningless. The
+harness's parser strips whitespace first, refuses to return a non-integer, and
+is negative-controlled against a payload with no `total`. Re-measured properly:
+three real `--dry-run` estimates moved the balance by **0**
+(4187454 → 4187454).
+
+### `selftest`
+
+`dogfood-sandbox.sh selftest` — 28 assertions, 28 pass. It covers every policy
+branch (including `--max-cost=N` form parsing, `app submit -o <path>` not being
+mistaken for the project dir, and listing identity via `--slug` vs `--dir`),
+the balance parser's positive and negative controls, and the lockdown modes.
+
+## What this does not protect against
+
+An unrecorded residual is indistinguishable from a bug nobody noticed. These
+are the ones being shipped knowingly.
+
+1. **Same Unix user. The guard is a shell script, not a sandbox.** The agent can
+   read `$ROOT/harness/dogfood-sandbox.sh`, see every rule, invoke
+   `$ROOT/real/civitai` directly and bypass all of it — and it can rewrite
+   `$ROOT/ledger/*`, corrupting both the spend meter and the audit trail. Only
+   the mount-namespace and mode-bit controls are outside its reach. Real
+   isolation needs a second UID or a container; neither is available here
+   without root.
+2. **`--max-cost` does not cap spend, so neither does the total cap, exactly.**
+   The cap is evaluated *before* each submit, so a submit can always start while
+   the cumulative figure is one Buzz under the limit, and the realized charge
+   for that job can exceed its estimate with no refund. **The honest ceiling is
+   `TOTAL_SPEND_CAP` plus the realized cost of one job whose estimate was at
+   most `PER_CALL_MAX_COST` — not `TOTAL_SPEND_CAP`.**
+3. **A submitted generation cannot be un-charged.** `--timeout`, Ctrl-C and
+   cancel all stop the waiting, not the billing.
+4. **The meter samples a balance; it does not read a transaction log.** Any
+   other Buzz activity on the account during the run — the website, another
+   session, a subscription tick — is attributed to the run. Do not run this
+   while using the account for anything else.
+5. **A charge that settles after the post-call sample is missed by that call's
+   delta.** `finish`'s start-minus-end figure catches it; that is why both
+   numbers are reported and why a disagreement between them is meaningful.
+6. **`app submit` enters a human review queue on a real account.** Withdraw
+   works only while `pending`. See the non-reversible list in §4 — an approved
+   app is live, a rejected one is terminal, and the blockId is consumed
+   permanently either way.
+7. **The gate re-implements argv parsing; it is not Cobra.** It understands
+   `--flag V` and `--flag=V` and the value-taking flags of the commands it
+   gates. A spelling Cobra accepts that the gate parses differently could
+   mis-resolve a project directory and, in the worst case, let a foreign app
+   through. It fails closed on `generate` (an unrecognised `--max-cost` is a
+   refusal) but the identity checks fail closed only when they can tell they are
+   confused. There is also a TOCTOU window between reading the manifest and
+   exec'ing the CLI; irrelevant for a cooperative agent, real in principle.
+8. **The ledger is not concurrency-safe.** One agent at a time.
+9. **Four deliberate fidelity distortions the agent will see, none of which the
+   real CLI does:** refusals prefixed `SANDBOX POLICY` with exit code 126; a
+   mandatory `--max-cost` on any real generation; `login` refused entirely; and
+   the update check suppressed (`CIVITAI_NO_UPDATE_CHECK=1`, so the CLI never
+   advises an upgrade the gate would forbid). The brief tells the agent to
+   discount these — **but a blind agent may still file one as a CLI bug, and any
+   issue mentioning `SANDBOX POLICY` or "generate requires --max-cost" should be
+   read as harness noise, not a finding.**
+10. **The login and update-notice surfaces are not exercised at all** — a
+    coverage gap accepted because runs 1 and 2 covered login un-credentialed.
+11. **The spend path has never been exercised end to end.** The meter was proved
+    against a stub. Proving it against real money requires spending real money,
+    which is precisely what the go/no-go below is for. **This is the gap the
+    owner is approving, and it should not be read as "the meter is verified".**
+12. **Nothing here bounds rate limits, account flags, or platform-side
+    consequences** of a real submission (moderation attention, reputation).
+
+## Go / no-go checklist
+
+Read time ~2 minutes. Everything below is verifiable in one command each.
+
+**Facts to confirm before approving**
+
+- [ ] The account is yours and you accept **real** spend: cap is
+      `TOTAL_SPEND_CAP` (default **2000 Buzz**) *plus one job's overshoot* —
+      not a hard 2000. Current balance 4,187,454.
+- [ ] You accept that a **throwaway app may reach a human moderator**, that its
+      blockId is consumed **permanently**, and that if it is approved before
+      withdrawal it is **live** and this harness cannot un-publish it.
+- [ ] You accept that **any other Buzz use on this account during the run will
+      be attributed to the run**, so the account should be otherwise idle.
+
+**Decisions to confirm**
+
+- [ ] Per-invocation ceiling **100 Buzz** (a default job prices 8; quantity 4
+      prices 30). Change with `--per-call-max`.
+- [ ] Total cap **2000 Buzz**, **20** generate submits, **3** app submits.
+      Change with `--total-cap` / `--max-generates` / `--max-app-submits`.
+- [ ] Sanctioned blockId prefix `dogfood3-<YYYYMMDD>-`. Change with
+      `--slug-prefix`.
+- [ ] `login`, `upgrade`, `app dev-tunnel`, `app dev-token` refused. Accepted
+      coverage gap on login and the update notice.
+
+**Run it in the jail (this is the one that matters)**
+
+- [ ] Launch the agent via `dogfood-sandbox.sh enter`. Without it, credential
+      isolation and blindness are convention rather than kernel-enforced, and
+      the agent can read the repo, `AGENTS.md` and both prior handoffs — which
+      invalidates the method.
+
+**Commands**
+
+```bash
+# 1. seed the credential without putting it in shell history
+umask 077; printf '%s' '<personal API key>' > ~/.dogfood-token
+
+# 2. build the sandbox (records the opening balance; refuses to start if the
+#    balance cannot be read, because a run whose meter does not work is not a
+#    run you can audit)
+scripts/dogfood-sandbox.sh init --binary ./bin/civitai --token-file ~/.dogfood-token
+shred -u ~/.dogfood-token
+
+# 3. confirm the harness is honest before trusting it
+scripts/dogfood-sandbox.sh selftest        # expect 28/28
+
+# 4. run the agent blind, inside the jail, cwd $ROOT/workspace,
+#    given only: the `civitai` on PATH, README.md, --help, and AGENT-BRIEF.md
+scripts/dogfood-sandbox.sh enter
+
+# 5. at any point
+scripts/dogfood-sandbox.sh status
+
+# 6. afterwards — the authoritative spend figure
+scripts/dogfood-sandbox.sh finish
+scripts/dogfood-sandbox.sh teardown --delete    # keep the ledger first if you want it
+```
+
+**Abort conditions during the run**
+
+- [ ] `status` shows observed spend climbing faster than the estimates in the
+      log — stop and reconcile before continuing.
+- [ ] The two spend figures at `finish` disagree — investigate before believing
+      either.
+- [ ] Any `SANDBOX POLICY` refusal you did not expect — the gate mis-classifying
+      is more likely than the agent being clever.
+
+## After the run
+
+Triage the agent's report the way runs 1 and 2 were triaged: an issue per
+finding, discarding anything that names `SANDBOX POLICY` or the mandatory
+`--max-cost`. Attach `ledger/invocations.tsv` to the handoff — it is the record
+of what the agent actually did, which is a different thing from what it says it
+did.

--- a/internal/dogfoodguard/main.go
+++ b/internal/dogfoodguard/main.go
@@ -146,6 +146,13 @@ func main() {
 	root.SetOut(os.Stderr)
 	root.SetErr(os.Stderr)
 
+	// 🔴 `help` IS ADDED BY Execute(), WHICH WE NEVER CALL. Without this,
+	// `root.Find` never sees a `help` command, so `civitai help generate` — the
+	// first thing a blind agent reaches for — resolved to the root with a
+	// leftover positional and was REFUSED. Fail-closed, but a pointless
+	// distortion. InitDefaultHelpCmd registers it exactly as Execute would.
+	root.InitDefaultHelpCmd()
+
 	target, remaining, err := root.Find(args)
 	if err != nil {
 		// An unknown command is a real answer, not an internal failure: report

--- a/internal/dogfoodguard/main.go
+++ b/internal/dogfoodguard/main.go
@@ -51,8 +51,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -72,6 +74,9 @@ var reportedInts = []string{"max-cost", "quantity"}
 // Strings the sandbox policy branches on (identity of the thing being mutated).
 var reportedStrings = []string{"slug", "dir", "id", "out", "external-id", "input"}
 
+// Flags reported as their raw string value, whatever their type.
+var reportedRaw = []string{"timeout"}
+
 // escape keeps one record on one line and one field in one column.
 func escape(s string) string {
 	r := strings.NewReplacer("\\", "\\\\", "\n", "\\n", "\r", "\\r", "\t", "\\t")
@@ -88,8 +93,48 @@ func fail(msg string) {
 	os.Exit(1)
 }
 
+// blockIDOf answers "which app would the CLI act on?" using encoding/json —
+// the same decoder the CLI uses.
+//
+// 🔴 THE SHELL VERSION GREPPED THE FIRST `"blockId"`, AND encoding/json TAKES
+// THE LAST. Measured on a manifest carrying the key twice: the gate resolved
+// `sanctioned-ok` and allowed the submit, while the CLI would have submitted
+// `someones-real-app`. That is the same gate-vs-binary disagreement class the
+// classifier exists to remove, so the answer comes from the same library the
+// binary uses rather than from a regex.
+func blockIDOf(dir string) {
+	var m struct {
+		BlockID string `json:"blockId"`
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "block.manifest.json"))
+	if err != nil {
+		emit(os.Stdout, "ok", "0")
+		emit(os.Stdout, "err", err.Error())
+		os.Exit(1)
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		emit(os.Stdout, "ok", "0")
+		emit(os.Stdout, "err", "manifest is not valid JSON: "+err.Error())
+		os.Exit(1)
+	}
+	if m.BlockID == "" {
+		emit(os.Stdout, "ok", "0")
+		emit(os.Stdout, "err", "manifest declares no blockId")
+		os.Exit(1)
+	}
+	emit(os.Stdout, "ok", "1")
+	emit(os.Stdout, "blockid", m.BlockID)
+}
+
 func main() {
 	args := os.Args[1:]
+
+	// `blockid <dir>` resolves the app a project directory would submit.
+	if len(args) >= 2 && args[0] == "blockid" {
+		blockIDOf(args[1])
+		return
+	}
+
 	// A leading `--` separates the guard's own (absent) flags from the argv
 	// under test, so an invocation starting with a flag is unambiguous.
 	if len(args) > 0 && args[0] == "--" {
@@ -139,7 +184,35 @@ func main() {
 	emit(out, "ok", "1")
 	emit(out, "path", commandPath(root, target))
 
+	// 🔴 ASK COBRA WHETHER THE CLI WOULD ACCEPT THESE ARGUMENTS. The shell gate
+	// carried a hand-written list of "group" commands to spot an unknown
+	// subcommand — the kind of table this classifier exists to delete — and it
+	// was wrong: an unknown subcommand under `models`, `images`, `users` or
+	// `tags` was ALLOWED because those parents were not in the list. Measured,
+	// the binary exits 2 for all of them.
+	//
+	// `Runnable()` is NOT the discriminator: every one of those parents is
+	// runnable (they print their own help). The two that are:
+	//   * HasSubCommands + a leftover positional  => that positional is a
+	//     subcommand that does not exist;
+	//   * ValidateArgs   => the command's own Args validator, i.e. exactly what
+	//     the binary would enforce.
+	emit(out, "runnable", boolStr(target.Runnable()))
+	emit(out, "hassubcommands", boolStr(target.HasSubCommands()))
+
 	flags := target.Flags()
+
+	// Raw values for flags whose type the shell does not need to understand —
+	// it only needs to know they were set. `--timeout` is here because it is an
+	// unblocked `--no-wait`: it stops the CLI waiting, not the charge.
+	for _, name := range reportedRaw {
+		f := flags.Lookup(name)
+		if f == nil {
+			continue
+		}
+		emit(out, "raw."+name, f.Value.String())
+		emit(out, "changed."+name, boolStr(flags.Changed(name)))
+	}
 	for _, name := range reportedBools {
 		if flags.Lookup(name) == nil {
 			continue
@@ -183,6 +256,11 @@ func main() {
 	emit(out, "argc", fmt.Sprintf("%d", len(positional)))
 	for i, a := range positional {
 		emit(out, fmt.Sprintf("arg.%d", i), a)
+	}
+	if err := target.ValidateArgs(positional); err != nil {
+		emit(out, "argserr", err.Error())
+	} else {
+		emit(out, "argserr", "")
 	}
 }
 

--- a/internal/dogfoodguard/main.go
+++ b/internal/dogfoodguard/main.go
@@ -72,7 +72,7 @@ var reportedBools = []string{
 var reportedInts = []string{"max-cost", "quantity"}
 
 // Strings the sandbox policy branches on (identity of the thing being mutated).
-var reportedStrings = []string{"slug", "dir", "id", "out", "external-id", "input"}
+var reportedStrings = []string{"slug", "dir", "id", "out", "external-id", "input", "app"}
 
 // Flags reported as their raw string value, whatever their type.
 var reportedRaw = []string{"timeout"}

--- a/internal/dogfoodguard/main.go
+++ b/internal/dogfoodguard/main.go
@@ -1,0 +1,206 @@
+// Command dogfoodguard classifies a `civitai` invocation for the dogfood
+// sandbox (scripts/dogfood-sandbox.sh) by asking the REAL command tree what the
+// argv means, and prints a machine-readable verdict.
+//
+// 🔴 WHY THIS EXISTS. The sandbox shim used to maintain its own model of how
+// the CLI parses argv, and that model disagreed with pflag three times, each
+// time letting a real spend or a real mutation past the gate:
+//
+//   - `--no-color generate … --yes` — Cobra strips the root persistent bools
+//     before resolving the command, so a positional `$1` classifier saw
+//     `--no-color` as the command and skipped every branch.
+//   - `--negative-prompt --help` — pflag takes the token after a value-taking
+//     flag as its VALUE even when it starts with `--`, so an "is --help
+//     present?" scan reported a help request for a real submit.
+//   - `--print-input=false` — a boolean set to FALSE is still "present", so a
+//     presence test read a spending run as a free preview.
+//
+// Patching spellings fixed instances, not the class. This program removes the
+// second parser: it builds the actual tree with cmd.NewRootCmd(), resolves the
+// command with Cobra's own Find (which handles root persistent flags, `--`,
+// aliases and abbreviation exactly as the binary does, because it IS what the
+// binary does), parses with ParseFlags, and reads values through
+// Flags().GetBool / GetInt / GetString. `--print-input=false` therefore reads
+// as false, which is the entire point.
+//
+// 🔴 IT NEVER EXECUTES ANYTHING. Find + ParseFlags only — no Execute, no RunE,
+// no PersistentPreRun. It performs no I/O beyond writing its verdict, and it
+// holds no credential.
+//
+// This is a DEV/TEST tool. It is deliberately a separate main package rather
+// than a subcommand, so it cannot appear in `civitai --help`, and it lives
+// under internal/ rather than cmd/ so release tooling globbing ./cmd/* can
+// never ship it. .goreleaser.yaml builds exactly one binary
+// (main: ./cmd/civitai) and needs no change.
+//
+// Output is TAB-separated key/value lines on stdout, values escaped so a
+// prompt containing a newline or a tab cannot forge a record:
+//
+//	ok       1
+//	path     app listing set-icon
+//	bool.dry-run     false
+//	int.max-cost     5
+//	changed.max-cost true
+//	str.slug         my-app
+//	argc     1
+//	arg.0    ./icon.png
+//
+// On any failure it prints `ok\t0` plus `err\t<message>` and exits non-zero.
+// The shim treats a non-zero exit, empty output, or an unrecognised field as
+// DENY.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	clicmd "github.com/civitai/cli/internal/cmd"
+)
+
+// Booleans the sandbox policy branches on.
+var reportedBools = []string{
+	"dry-run", "print-input", "package-only", "help", "no-wait", "yes",
+	"json", "force", "skip-validate", "strict",
+}
+
+// Ints the sandbox policy branches on.
+var reportedInts = []string{"max-cost", "quantity"}
+
+// Strings the sandbox policy branches on (identity of the thing being mutated).
+var reportedStrings = []string{"slug", "dir", "id", "out", "external-id", "input"}
+
+// escape keeps one record on one line and one field in one column.
+func escape(s string) string {
+	r := strings.NewReplacer("\\", "\\\\", "\n", "\\n", "\r", "\\r", "\t", "\\t")
+	return r.Replace(s)
+}
+
+func emit(w *os.File, k, v string) {
+	fmt.Fprintf(w, "%s\t%s\n", k, escape(v))
+}
+
+func fail(msg string) {
+	emit(os.Stdout, "ok", "0")
+	emit(os.Stdout, "err", msg)
+	os.Exit(1)
+}
+
+func main() {
+	args := os.Args[1:]
+	// A leading `--` separates the guard's own (absent) flags from the argv
+	// under test, so an invocation starting with a flag is unambiguous.
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+
+	root := clicmd.NewRootCmd()
+	// Silence anything Cobra might want to print; we only ever inspect.
+	root.SetOut(os.Stderr)
+	root.SetErr(os.Stderr)
+
+	target, remaining, err := root.Find(args)
+	if err != nil {
+		// An unknown command is a real answer, not an internal failure: report
+		// it so the shim can refuse by name.
+		emit(os.Stdout, "ok", "0")
+		emit(os.Stdout, "err", err.Error())
+		emit(os.Stdout, "kind", "unknown-command")
+		os.Exit(2)
+	}
+	if target == nil {
+		fail("cobra resolved no command")
+	}
+
+	// Cobra adds these during Execute, which we never call.
+	target.InitDefaultHelpFlag()
+	target.InitDefaultVersionFlag()
+
+	parseErr := ""
+	if err := target.ParseFlags(remaining); err != nil {
+		parseErr = err.Error()
+	}
+
+	out := os.Stdout
+	if parseErr != "" {
+		// A flag the CLI itself would reject. The shim denies rather than
+		// guessing what the user meant — this is how `--max-cost 08` and
+		// `--dry-run=maybe` become refusals instead of shell arithmetic
+		// crashes or silent misreads.
+		emit(out, "ok", "0")
+		emit(out, "err", parseErr)
+		emit(out, "kind", "flag-parse-error")
+		emit(out, "path", commandPath(root, target))
+		os.Exit(3)
+	}
+
+	emit(out, "ok", "1")
+	emit(out, "path", commandPath(root, target))
+
+	flags := target.Flags()
+	for _, name := range reportedBools {
+		if flags.Lookup(name) == nil {
+			continue
+		}
+		v, err := flags.GetBool(name)
+		if err != nil {
+			// Declared but not a bool on this command: report it as unknown
+			// rather than assuming either way.
+			emit(out, "bool."+name, "unreadable")
+			continue
+		}
+		emit(out, "bool."+name, boolStr(v))
+		emit(out, "changed."+name, boolStr(flags.Changed(name)))
+	}
+	for _, name := range reportedInts {
+		if flags.Lookup(name) == nil {
+			continue
+		}
+		v, err := flags.GetInt(name)
+		if err != nil {
+			emit(out, "int."+name, "unreadable")
+			continue
+		}
+		emit(out, "int."+name, fmt.Sprintf("%d", v))
+		emit(out, "changed."+name, boolStr(flags.Changed(name)))
+	}
+	for _, name := range reportedStrings {
+		if flags.Lookup(name) == nil {
+			continue
+		}
+		v, err := flags.GetString(name)
+		if err != nil {
+			emit(out, "str."+name, "unreadable")
+			continue
+		}
+		emit(out, "str."+name, v)
+		emit(out, "changed."+name, boolStr(flags.Changed(name)))
+	}
+
+	positional := flags.Args()
+	emit(out, "argc", fmt.Sprintf("%d", len(positional)))
+	for i, a := range positional {
+		emit(out, fmt.Sprintf("arg.%d", i), a)
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// commandPath returns the resolved command path WITHOUT the root's name, so
+// the shim compares against "app listing set-icon" rather than
+// "civitai app listing set-icon" (the binary is renamed in the sandbox).
+func commandPath(root, target *cobra.Command) string {
+	full := target.CommandPath()
+	rootName := root.Name()
+	if full == rootName {
+		return ""
+	}
+	return strings.TrimPrefix(full, rootName+" ")
+}

--- a/scripts/dogfood-mutate.sh
+++ b/scripts/dogfood-mutate.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# dogfood-mutate.sh — the mutation battery for scripts/dogfood-sandbox.sh.
+#
+# 🔴 WHY THIS IS A COMMITTED SCRIPT AND NOT A TRANSCRIPT. Three review rounds
+# reported mutation results the next round had to take on trust and could not
+# re-derive; one of those published tables was later falsified (rows that
+# asserted a REASON and never the VERDICT, so 8 deny->allow flips survived).
+# `scripts/mutate.sh` covers Go packages only, so the shell gate — where the
+# money decisions live — had no re-runnable evidence. This is that artifact:
+# every mutant is CHECKSUM-GATED (the target must occur, the file hash must
+# change, the mutant must still parse), so a pattern that stops matching is
+# reported INVALID rather than silently scored as a survivor.
+#
+#   ./scripts/dogfood-mutate.sh          # full battery
+#
+# Expected on a clean tree: killed=53 survived=2 invalid=0, the two survivors
+# being the NULL control and write_scalar's readback (declared redundant in
+# claudedocs/dogfood-3-sandbox.md).
+# Every mutation is a perl program in SINGLE quotes: the `$`-expressions inside
+# are perl/sed syntax and must NOT be expanded by this shell. The directive must
+# precede the first COMMAND to be file-wide.
+# shellcheck disable=SC2016
+set -u
+HERE=$(cd "$(dirname "$(readlink -f "$0")")" && pwd)
+S="${HERE}/dogfood-sandbox.sh"
+B=$(mktemp -t dogfood-mutate-orig.XXXXXX)
+cp "${S}" "${B}"
+trap 'cp "${B}" "${S}"; rm -f "${B}"' EXIT INT TERM
+
+echo "BASELINE: $(bash "${S}" selftest --offline 2>&1 | tail -1)"
+echo
+
+KILLED=0; SURVIVED=0; INVALID=0
+run() {
+  local name="$1"; shift
+  local h0 h1 out fails
+  h0=$(sha256sum "${S}" | cut -d' ' -f1)
+  "$@" >/dev/null 2>&1
+  h1=$(sha256sum "${S}" | cut -d' ' -f1)
+  if [ "${h0}" = "${h1}" ]; then printf '  INVALID  %-52s (unchanged)\n' "${name}"; INVALID=$((INVALID+1)); cp "${B}" "${S}"; return; fi
+  if ! bash -n "${S}" 2>/dev/null; then printf '  INVALID  %-52s (parse)\n' "${name}"; INVALID=$((INVALID+1)); cp "${B}" "${S}"; return; fi
+  out=$(bash "${S}" selftest --offline 2>&1)
+  fails=$(printf '%s' "${out}" | grep -c '^  FAIL')
+  if [ "${fails}" = 0 ]; then printf '  SURVIVED %-52s\n' "${name}"; SURVIVED=$((SURVIVED+1))
+  else printf '  KILLED   %-52s %-3s | %s\n' "${name}" "${fails}" \
+    "$(printf '%s' "${out}" | grep -m1 '^  FAIL' | sed 's/^  FAIL  //; s/  */ /g' | cut -c1-46)"; KILLED=$((KILLED+1)); fi
+  cp "${B}" "${S}"
+}
+P() { perl -0pi -e "$1" "${S}"; }
+
+echo "--- 🔴 deny->allow with a BYTE-IDENTICAL reason (8 survived last round) ---"
+flip() { run "deny->allow: $1" P "s/deny (\"[^\"]*$2)/allow \$1/"; }
+flip "upgrade"                "would replace the binary under evaluation"
+flip "login"                  "this sandbox is already authenticated"
+flip "dev-tunnel/dev-token"   "is out of scope for this run"
+flip "unknown subcommand"     "is not a subcommand of"
+flip "args the CLI rejects"   "the CLI would reject these arguments"
+flip "TOTAL_SPEND_CAP"        "the run's total spend cap"
+flip "MAX_GENERATE_SUBMITS"   "the generation cap for this run"
+flip "MAX_APP_SUBMITS"        "the app-submission cap"
+flip "MAX_LISTING_MUTATIONS"  "the listing-mutation cap"
+flip "remaining budget"       "--max-cost \\\$\{mc\} exceeds the"
+flip "per-call ceiling"       "--max-cost \\\$\{mc\} exceeds this run's"
+flip "no --max-cost"          "a generation that actually submits"
+flip "--no-wait"              "--no-wait returns before the charge"
+flip "--timeout"              "--timeout stops the CLI waiting"
+flip "meter_broken"           "the spend meter stopped agreeing"
+flip "calibration"            "the spend meter has not been calibrated"
+flip "submit prefix"          "this run may only submit its own throwaway app"
+flip "listing prefix"         "this run may not touch the account"
+flip "submit unreadable id"   "cannot read a blockId"
+flip "listing unidentifiable" "cannot identify which app"
+flip "withdraw allowlist"     "so it may be one of the account"
+flip "cancel allowlist"       "cancelling DOES NOT REFUND"
+flip "classifier drift"       "the invocation could not be classified"
+flip "flag parse error"       "the CLI would reject these flags"
+flip "unknown command"        "the CLI does not recognise this command"
+
+echo
+echo "--- structural: this round's fixes ---"
+run "rc-aware latch removed (latch on any zero delta)" \
+  P 's/\tif \[ "\$\{rc\}" != 0 \]; then/\tif false; then/'
+run "app counter bumps regardless of rc" \
+  P 's/\t\t\tif \[ "\$\{rc\}" = 0 \]; then\n\t\t\t\tlocal a/\t\t\tif true; then\n\t\t\t\tlocal a/' 
+run "provenance verification removed" \
+  P 's/\tPROVENANCE_ERROR=""\n\tlocal want got/\tPROVENANCE_ERROR=""; return 0\n\tlocal want got/'
+run "provenance compares nothing" \
+  P 's/\t\tif \[ "\$\{got\}" != "\$\{want\}" \]; then/\t\tif false; then/'
+run "assert_writable removed" \
+  P 's/\t\tALLOW_SPEND\)      assert_writable generate_submits "\$\{scrubbed\}"/\t\tALLOW_SPEND)      :/'
+run "reconcile_inflight removed" \
+  P 's/\treconcile_inflight\n//'
+run "inflight record never written" \
+  P 's/\t\t\t> "\$\{ROOT\}\/ledger\/inflight"/\t\t\t> \/dev\/null/'
+run "hassubcommands check removed" \
+  P 's/\tif \[ "\$\{GHASSUB\}" = "true" \] \&\& \[ "\$\{GARGC\}" -gt 0 \]; then/\tif false; then/'
+run "argserr ignored" \
+  P 's/\tif \[ -n "\$\{GARGSERR\}" \]; then/\tif false; then/'
+run "resolve_block_id ignores a failed lookup" \
+  P 's/\t\t\*\) return 1 ;;\n\tesac\n\tprintf/\t\t*) : ;;\n\tesac\n\tprintf/'
+run "GUARD_BIN reset deleted" \
+  P 's/^GUARD_BIN=""$//m'
+run "record_pubreq_ids is a no-op" \
+  P 's/\tout=\$\(real_cli app status "\$\{slug\}" --json 2>\/dev\/null\) \|\| return 0/\treturn 0/'
+run "workflow provenance ignored (shape filter)" \
+  P 's/\t\tcomm -13 "\$\{ROOT\}\/ledger\/workflow.before" "\$\{after\}" \\\n\t\t\t>> "\$\{ROOT\}\/ledger\/workflow.allow" 2>\/dev\/null \|\| true/\t\tcat "${after}" >> "${ROOT}\/ledger\/workflow.allow" 2>\/dev\/null || true/'
+
+echo
+echo "--- structural: previous rounds, re-verified ---"
+run "read_scalar EMPTY as zero" \
+  P 's/(\tv=\$\(tr -d . \\n\\r\\t. < "\$\{f\}" 2>\/dev\/null\) \|\| return 1\n)/$1\t[ -n "\${v}" ] || { printf 0; return 0; }\n/' 
+run "read_scalar MISSING as zero" \
+  P 's/\t\[ -f "\$\{f\}" \] \|\| return 1/\t[ -f "${f}" ] || { printf 0; return 0; }/'
+run "write_scalar readback removed" \
+  P 's/\t\[ "\$\{back\}" = "\$\{v\}" \] \|\| return 1\n//'
+run "ledger lock removed" \
+  P 's/\tflock -x -w "\$\{LOCK_WAIT\}" 9 \|\| return 1\n//'
+run "tsv_escape drops newlines" \
+  P 's/\ts="\$\{s\/\/\$.\\n.\/\\\\n\}"\n//'
+run "unanchored balance parser" \
+  P "s/'\"total\":-\\\\\?\[0-9\]\[0-9\]\*\[,\}\]'/'\"total\":-\\\\?[0-9][0-9]*'/g"
+run "zero-delta latch removed" \
+  P 's/\t\telif \[ "\$\{delta\}" = 0 \]; then/\t\telif false; then/'
+run "negative-delta latch removed" \
+  P 's/\t\tif \[ "\$\{delta\}" -lt 0 \]; then/\t\tif false; then/'
+run "failed-read latch removed" \
+  P 's/\tif \[ -z "\$\{after\}" \]; then/\tif false; then/'
+run "SLUG_PREFIX empty-check removed" \
+  P 's/\tif \[ -z "\$\{SLUG_PREFIX:-\}" \]; then\n\t\tPOLICY_ERROR="policy key SLUG_PREFIX is missing or empty"; return 1\n\tfi\n//'
+run "classifier failure fails OPEN" \
+  P 's/\tif ! classify "\$@"; then/\tif false; then/'
+run "help keyed on presence not value" \
+  P 's/\tif \[ "\$\(gbool help\)" = "true" \]; then allow "help"; return 0; fi/\tif [ "$(gchanged help)" = "true" ]; then allow "help"; return 0; fi/'
+run "free-preview keyed on presence not value" \
+  P 's/if \[ "\$\(gbool print-input\)" = "true" \] \|\| \[ "\$\(gbool dry-run\)" = "true" \]; then/if [ "$(gchanged print-input)" = "true" ] || [ "$(gchanged dry-run)" = "true" ]; then/'
+
+echo
+echo "--- structural: round 5 ---"
+run "rc-aware suppression swallows a FAILED post-read" \
+  P 's/\tif \[ -z "\$\{after\}" \]; then/\tif [ -z "${after}" ] \&\& [ "${rc}" = 0 ]; then/'
+run "rc-aware suppression swallows a NEGATIVE delta" \
+  P 's/\t\tif \[ "\$\{delta\}" -lt 0 \]; then/\t\tif [ "${delta}" -lt 0 ] \&\& [ "${rc}" = 0 ]; then/'
+run "inflight liveness check removed" \
+  P 's/\tif \[ -n "\$\{pid\}" \] \&\& kill -0 "\$\{pid\}" 2>\/dev\/null; then\n\t\treturn 0\n\tfi\n//'
+run "concurrent-generate refusal removed" \
+  P 's/\t\t\t\tif \[ -n "\$\{inflight_pid\}" \] \&\& kill -0 "\$\{inflight_pid\}" 2>\/dev\/null; then/\t\t\t\tif false; then/'
+run "inflight record omits the pid" \
+  P 's/"\$\(now_iso\)" "\$\{mc\}" "\$\{before\}" "\$\$" "\$\{scrubbed\}"/"$(now_iso)" "${mc}" "${before}" "" "${scrubbed}"/'
+run "meter file writability not asserted" \
+  P 's/\t\t                  assert_writable observed_spend "\$\{scrubbed\}"\n//'
+run "meter_write_failed does not latch" \
+  P 's/meter_write_failed\(\) \{\n\tbreak_meter/meter_write_failed() {\n\treturn 0\n\tbreak_meter/'
+
+echo
+echo "--- null control (MUST survive) ---"
+run "NULL comment-only" \
+  P 's/^# Every path is absolute.*$/# Every path is absolute; every cd gated; every var braced./m'
+
+echo
+echo "TOTALS: killed=${KILLED} survived=${SURVIVED} invalid=${INVALID}"

--- a/scripts/dogfood-mutate.sh
+++ b/scripts/dogfood-mutate.sh
@@ -12,9 +12,16 @@
 # change, the mutant must still parse), so a pattern that stops matching is
 # reported INVALID rather than silently scored as a survivor.
 #
+# 🔴 KNOWN LIMITATION: the gate cannot see a mutation whose REPLACEMENT text is
+# malformed. Measured once — perl interpolated `${ROOT}` and `$(...)` in a
+# replacement, so the mutant wrote to `/home/.config/...` instead of the run
+# root, changed the file, parsed cleanly, and read as a SURVIVOR. Escape every
+# `$` on the replacement side, and when a mutant survives, read the mutated
+# region before believing it.
+#
 #   ./scripts/dogfood-mutate.sh          # full battery
 #
-# Expected on a clean tree: killed=53 survived=2 invalid=0, the two survivors
+# Expected on a clean tree: killed=62 survived=2 invalid=0, the two survivors
 # being the NULL control and write_scalar's readback (declared redundant in
 # claudedocs/dogfood-3-sandbox.md).
 # Every mutation is a perl program in SINGLE quotes: the `$`-expressions inside
@@ -79,8 +86,8 @@ flip "unknown command"        "the CLI does not recognise this command"
 
 echo
 echo "--- structural: this round's fixes ---"
-run "rc-aware latch removed (latch on any zero delta)" \
-  P 's/\tif \[ "\$\{rc\}" != 0 \]; then/\tif false; then/'
+run "rc-aware suppression removed entirely" \
+  P 's/\tif \[ -n "\$\{after\}" \] \&\& \[ "\$\{before\}" = "\$\{after\}" \] \&\& \[ "\$\{rc\}" != 0 \]; then/\tif false; then/'
 run "app counter bumps regardless of rc" \
   P 's/\t\t\tif \[ "\$\{rc\}" = 0 \]; then\n\t\t\t\tlocal a/\t\t\tif true; then\n\t\t\t\tlocal a/' 
 run "provenance verification removed" \
@@ -121,11 +128,11 @@ run "tsv_escape drops newlines" \
 run "unanchored balance parser" \
   P "s/'\"total\":-\\\\\?\[0-9\]\[0-9\]\*\[,\}\]'/'\"total\":-\\\\?[0-9][0-9]*'/g"
 run "zero-delta latch removed" \
-  P 's/\t\telif \[ "\$\{delta\}" = 0 \]; then/\t\telif false; then/'
+  P 's/\tif \[ "\$\{delta\}" = 0 \]; then/\tif false; then/'
 run "negative-delta latch removed" \
-  P 's/\t\tif \[ "\$\{delta\}" -lt 0 \]; then/\t\tif false; then/'
+  P 's/\tif \[ "\$\{delta\}" -lt 0 \]; then/\tif false; then/'
 run "failed-read latch removed" \
-  P 's/\tif \[ -z "\$\{after\}" \]; then/\tif false; then/'
+  P 's/\tif \[ -z "\$\{before\}" \] \|\| \[ -z "\$\{after\}" \]; then/\tif false; then/'
 run "SLUG_PREFIX empty-check removed" \
   P 's/\tif \[ -z "\$\{SLUG_PREFIX:-\}" \]; then\n\t\tPOLICY_ERROR="policy key SLUG_PREFIX is missing or empty"; return 1\n\tfi\n//'
 run "classifier failure fails OPEN" \
@@ -137,12 +144,12 @@ run "free-preview keyed on presence not value" \
 
 echo
 echo "--- structural: round 5 ---"
-run "rc-aware suppression swallows a FAILED post-read" \
-  P 's/\tif \[ -z "\$\{after\}" \]; then/\tif [ -z "${after}" ] \&\& [ "${rc}" = 0 ]; then/'
-run "rc-aware suppression swallows a NEGATIVE delta" \
-  P 's/\t\tif \[ "\$\{delta\}" -lt 0 \]; then/\t\tif [ "${delta}" -lt 0 ] \&\& [ "${rc}" = 0 ]; then/'
+run "rc suppression widened to any non-zero exit" \
+  P 's/\tif \[ -n "\$\{after\}" \] \&\& \[ "\$\{before\}" = "\$\{after\}" \] \&\& \[ "\$\{rc\}" != 0 \]; then/\tif [ "${rc}" != 0 ]; then/'
+run "rc suppression drops the readable-balance guard" \
+  P 's/\tif \[ -n "\$\{after\}" \] \&\& \[ "\$\{before\}" = "\$\{after\}" \] \&\& \[ "\$\{rc\}" != 0 \]; then/\tif [ "${before}" = "${after}" ] \&\& [ "${rc}" != 0 ]; then/'
 run "inflight liveness check removed" \
-  P 's/\tif \[ -n "\$\{pid\}" \] \&\& kill -0 "\$\{pid\}" 2>\/dev\/null; then\n\t\treturn 0\n\tfi\n//'
+  P 's/\t\tif ! flock -x -n 7; then/\t\tif false; then/'
 run "concurrent-generate refusal removed" \
   P 's/\t\t\t\tif \[ -n "\$\{inflight_pid\}" \] \&\& kill -0 "\$\{inflight_pid\}" 2>\/dev\/null; then/\t\t\t\tif false; then/'
 run "inflight record omits the pid" \
@@ -151,6 +158,16 @@ run "meter file writability not asserted" \
   P 's/\t\t                  assert_writable observed_spend "\$\{scrubbed\}"\n//'
 run "meter_write_failed does not latch" \
   P 's/meter_write_failed\(\) \{\n\tbreak_meter/meter_write_failed() {\n\treturn 0\n\tbreak_meter/'
+run "reconcile does not share apply_settlement" \
+  P 's/\tdelta=\$\(apply_settlement "\$\{before\}" "\$\{now\}" "\$\{mc\}" "reconcile"\)/\tdelta=0/'
+run "credential written into HOME again" \
+  P 's/\trm -f "\$\{ROOT\}\/home\/.config\/civitai\/config.yaml"/\tmkdir -p "\$\{ROOT\}\/home\/.config\/civitai" \&\& cp "\$\{ROOT\}\/ledger\/credential" "\$\{ROOT\}\/home\/.config\/civitai\/config.yaml"/'
+run "app pull prefix gate removed" \
+  P 's/\t\t\t\t\*\) deny "\\`\$\{pull_app\}\\` is outside/\t\t\t\t*) allow "${pull_app} is outside/'
+run "audit-log appendability not asserted" \
+  P 's/\t\t                  assert_appendable invocations.tsv "\$\{scrubbed\}"\n//'
+run "calibrate bypasses the gate again" \
+  P 's/\t"\$\{ROOT\}\/bin\/civitai" generate "a plain grey square, calibration" --yes/\treal_cli generate "a plain grey square, calibration" --yes/'
 
 echo
 echo "--- null control (MUST survive) ---"

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -52,32 +52,29 @@ DEFAULT_PER_CALL_MAX_COST=100
 DEFAULT_TOTAL_SPEND_CAP=2000
 DEFAULT_MAX_GENERATE_SUBMITS=20
 DEFAULT_MAX_APP_SUBMITS=3
+# A listing change on a LIVE listing goes back to moderator review, so it costs
+# human attention exactly as a submit does and is capped for the same reason.
+DEFAULT_MAX_LISTING_MUTATIONS=10
+# Seconds to wait before re-sampling when a submit reports a zero delta.
+DEFAULT_METER_SETTLE_SECONDS=5
+# Require `calibrate` (one deliberate, operator-watched generation) before the
+# agent may spend, so the meter's core assumption is measured, not assumed.
+DEFAULT_REQUIRE_CALIBRATION=1
+# --no-wait returns before the charge settles; off unless calibration showed the
+# balance moves by the time the command returns.
+DEFAULT_ALLOW_NO_WAIT=0
 DEFAULT_SLUG_PREFIX=""
 DEFAULT_BASE_URL="https://civitai.com"
 
-# ---------------------------------------------------------------------------
-# Closed vocabularies. An unrecognised command is DENIED, not passed through:
-# a new subcommand may spend or mutate, and the gate cannot know that it does
-# not.
-# ---------------------------------------------------------------------------
-TOPLEVEL_CMDS="app articles buzz collections completion creators download generate help images login model-versions models tags upgrade users version whoami workflows"
-APP_SUBCMDS="create init validate submit withdraw status list view pull metrics listing dev-token dev-tunnel"
-LISTING_SUBCMDS="status set-icon set-cover add-screenshot rm-screenshot reorder"
-WORKFLOWS_SUBCMDS="list get cancel"
-
-# Root persistent flags. All BOOLEAN — Cobra strips them anywhere they appear
-# and they never consume the following token.
-ROOT_BOOL_FLAGS="--color --no-color --no-update-check --help -h --version -v"
-
-# Boolean flags of the gated commands. Used to decide whether a `--help` is a
-# real help request or the VALUE of a preceding value-taking flag.
-CMD_BOOL_FLAGS="--yes -y --dry-run --print-input --json --force --no-wait --no-download --fail-on-substitution --package-only --skip-validate --strict --no-browser --package-only"
-
-# Flags that CONSUME the next token, per command path.
-VALUE_FLAGS_GENERATE="--checkpoint --lora --image --input --negative-prompt --aspect-ratio --quantity --out-dir --timeout --max-cost --external-id --ecosystem"
-VALUE_FLAGS_APP_SUBMIT="-o --out"
-VALUE_FLAGS_APP_LISTING="--slug --dir --caption --changelog"
-VALUE_FLAGS_APP_WITHDRAW="--id"
+# 🔴 THE COMMAND AND FLAG VOCABULARIES THAT USED TO LIVE HERE ARE GONE ON
+# PURPOSE. This file previously carried its own tables of top-level commands,
+# app/listing/workflows subcommands, root persistent bools, per-command
+# boolean flags and per-command value-taking flags — i.e. a second, hand-written
+# model of pflag. That model disagreed with the real parser three times, each
+# disagreement letting a real spend or mutation through. internal/dogfoodguard
+# now answers every one of those questions from the actual cobra tree. Do not
+# reintroduce a table here: if the gate needs to know something about an argv,
+# teach the classifier to report it.
 
 err()  { printf 'dogfood-sandbox: %s\n' "$*" >&2; }
 die()  { err "$*"; exit 1; }
@@ -85,12 +82,6 @@ note() { printf '%s\n' "$*"; }
 
 SANDBOX_TAG="SANDBOX POLICY"
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
-
-in_list() {
-	local needle="$1" hay="$2" x
-	for x in ${hay}; do [ "${x}" = "${needle}" ] && return 0; done
-	return 1
-}
 
 # ---------------------------------------------------------------------------
 # Balance parsing
@@ -164,10 +155,13 @@ load_policy() {
 	# 🔴 UNSET FIRST. Sourcing does not clear a key the file no longer defines,
 	# so a value left over from an earlier load masked a deleted key and the
 	# validation below passed on a policy that was missing one.
-	unset PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS SLUG_PREFIX BASE_URL
+	unset PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS \
+	      MAX_LISTING_MUTATIONS METER_SETTLE_SECONDS REQUIRE_CALIBRATION ALLOW_NO_WAIT \
+	      SLUG_PREFIX BASE_URL
 	# shellcheck disable=SC1090
 	. "${f}" || { POLICY_ERROR="policy file ${f} could not be read"; return 1; }
-	for k in PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS; do
+	for k in PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS \
+	         MAX_LISTING_MUTATIONS METER_SETTLE_SECONDS REQUIRE_CALIBRATION ALLOW_NO_WAIT; do
 		eval "v=\${${k}:-}"
 		case "${v}" in
 			''|*[!0-9]*)
@@ -181,19 +175,33 @@ load_policy() {
 	return 0
 }
 
-# A ledger counter. A missing file is 0; a MALFORMED one is an error, never 0.
+# A ledger counter.
+#
+# 🔴 MISSING AND EMPTY ARE BOTH MALFORMED, NEVER ZERO. `init` creates every
+# counter, so an absent or emptied file means the ledger has been truncated —
+# and reading that as 0 silently restarts every cap. Measured on the previous
+# version: with the counters emptied, a submit was allowed with the meter and
+# the submit count both back at 0.
 read_scalar() {
 	local f="${ROOT}/ledger/$1" v
-	[ -f "${f}" ] || { printf '0'; return 0; }
-	v=$(tr -d ' \n\r\t' < "${f}")
-	[ -n "${v}" ] || { printf '0'; return 0; }
+	[ -f "${f}" ] || return 1
+	v=$(tr -d ' \n\r\t' < "${f}" 2>/dev/null) || return 1
 	case "${v}" in
 		''|*[!0-9]*) return 1 ;;
 	esac
 	printf '%s' "${v}"
 }
 
-write_scalar() { printf '%s\n' "$2" > "${ROOT}/ledger/$1"; }
+# 🔴 A WRITE THAT FAILS MUST NOT LOOK LIKE A WRITE THAT WORKED. With the
+# counter files unwritable the old version bumped nothing and allowed submit
+# after submit. Every caller treats a non-zero return as fatal.
+write_scalar() {
+	local f="${ROOT}/ledger/$1" v="$2" back
+	printf '%s\n' "${v}" > "${f}" 2>/dev/null || return 1
+	back=$(tr -d ' \n\r\t' < "${f}" 2>/dev/null) || return 1
+	[ "${back}" = "${v}" ] || return 1
+	return 0
+}
 
 # ---------------------------------------------------------------------------
 # Running the real binary
@@ -235,6 +243,24 @@ sample_balance() {
 	printf '%s\t%s\t%s\n' "$(now_iso)" "${phase}" "$(tsv_escape "${json}")" \
 		>> "${ROOT}/ledger/buzz.tsv"
 	printf '%s' "${total}"
+}
+
+# Internal: print the verdict for an argv WITHOUT executing anything. Used by
+# the selftest to prove that a GUARD_BIN inherited from the environment cannot
+# reach the gate, which needs a fresh process to be a real test.
+cmd_verdict() {
+	local root=""
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--)     shift; break ;;
+			*)      break ;;
+		esac
+	done
+	ROOT="${root:-${DEFAULT_ROOT}}"
+	load_policy || { printf 'DENY'; return 0; }
+	policy_verdict "$@"
+	printf '%s' "${VERDICT:-DENY}"
 }
 
 # Internal: a `buzz --json` that `timeout` can kill as its own process.
@@ -282,19 +308,29 @@ cmd_init() {
 	local max_app="${DEFAULT_MAX_APP_SUBMITS}"
 	local slug_prefix="${DEFAULT_SLUG_PREFIX}"
 	local base_url="${DEFAULT_BASE_URL}"
+	local max_listing="${DEFAULT_MAX_LISTING_MUTATIONS}"
+	local settle="${DEFAULT_METER_SETTLE_SECONDS}"
+	local require_cal="${DEFAULT_REQUIRE_CALIBRATION}"
+	local allow_no_wait="${DEFAULT_ALLOW_NO_WAIT}"
+	local guard=""
 
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			--root)            root="$2"; shift 2 ;;
-			--binary)          binary="$2"; shift 2 ;;
-			--token-file)      token_file="$2"; shift 2 ;;
-			--per-call-max)    per_call="$2"; shift 2 ;;
-			--total-cap)       total_cap="$2"; shift 2 ;;
-			--max-generates)   max_gen="$2"; shift 2 ;;
-			--max-app-submits) max_app="$2"; shift 2 ;;
-			--slug-prefix)     slug_prefix="$2"; shift 2 ;;
-			--base-url)        base_url="$2"; shift 2 ;;
-			--force)           force=1; shift ;;
+			--root)                root="$2"; shift 2 ;;
+			--binary)              binary="$2"; shift 2 ;;
+			--guard)               guard="$2"; shift 2 ;;
+			--token-file)          token_file="$2"; shift 2 ;;
+			--per-call-max)        per_call="$2"; shift 2 ;;
+			--total-cap)           total_cap="$2"; shift 2 ;;
+			--max-generates)       max_gen="$2"; shift 2 ;;
+			--max-app-submits)     max_app="$2"; shift 2 ;;
+			--max-listing-changes) max_listing="$2"; shift 2 ;;
+			--settle-seconds)      settle="$2"; shift 2 ;;
+			--skip-calibration)    require_cal=0; shift ;;
+			--allow-no-wait)       allow_no_wait=1; shift ;;
+			--slug-prefix)         slug_prefix="$2"; shift 2 ;;
+			--base-url)            base_url="$2"; shift 2 ;;
+			--force)               force=1; shift ;;
 			*) die "init: unknown flag $1" ;;
 		esac
 	done
@@ -337,6 +373,24 @@ cmd_init() {
 
 	cp "${binary}" "${ROOT}/real/civitai" || die "init: could not copy the binary"
 
+	# 🔴 THE CLASSIFIER MUST COME FROM THE SAME TREE AS THE BINARY UNDER TEST.
+	# It embeds the command tree, so a classifier built from a different commit
+	# can disagree with the binary about what an argv means — which is the exact
+	# class of defect it exists to remove. Build both from one checkout.
+	if [ -z "${guard}" ]; then
+		local repo
+		repo=$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd) || die "init: cannot locate the repo"
+		command -v go >/dev/null 2>&1 \
+			|| die "init: go is not on PATH; build internal/dogfoodguard yourself and pass --guard <path>"
+		guard="${ROOT}/real/dogfoodguard"
+		( cd "${repo}" && go build -o "${guard}" ./internal/dogfoodguard ) \
+			|| die "init: could not build the classifier from ${repo}"
+	else
+		[ -x "${guard}" ] || die "init: --guard ${guard} is not executable"
+		cp "${guard}" "${ROOT}/real/dogfoodguard" || die "init: could not copy the classifier"
+	fi
+	[ -x "${ROOT}/real/dogfoodguard" ] || die "init: no classifier at ${ROOT}/real/dogfoodguard"
+
 	local self
 	self=$(readlink -f "$0")
 	cp "${self}" "${ROOT}/harness/dogfood-sandbox.sh" || die "init: could not copy the harness"
@@ -352,11 +406,13 @@ SHIM
 	: > "${ROOT}/ledger/buzz.tsv"
 	: > "${ROOT}/ledger/spend.tsv"
 	: > "${ROOT}/ledger/pubreq.allow"
-	write_scalar generate_submits 0
-	write_scalar app_submits 0
-	write_scalar observed_spend 0
-	write_scalar reserved 0
-	rm -f "${ROOT}/ledger/meter_broken"
+	: > "${ROOT}/ledger/workflow.allow"
+	write_scalar generate_submits 0   || die "init: ledger not writable"
+	write_scalar app_submits 0        || die "init: ledger not writable"
+	write_scalar listing_mutations 0  || die "init: ledger not writable"
+	write_scalar observed_spend 0     || die "init: ledger not writable"
+	write_scalar reserved 0           || die "init: ledger not writable"
+	rm -f "${ROOT}/ledger/meter_broken" "${ROOT}/ledger/calibration.ok"
 
 	cat > "${ROOT}/ledger/policy.env" <<POLICY
 # Written by dogfood-sandbox.sh init on $(now_iso). Read and VALIDATED by every
@@ -366,10 +422,15 @@ PER_CALL_MAX_COST=${per_call}
 TOTAL_SPEND_CAP=${total_cap}
 MAX_GENERATE_SUBMITS=${max_gen}
 MAX_APP_SUBMITS=${max_app}
+MAX_LISTING_MUTATIONS=${max_listing}
+METER_SETTLE_SECONDS=${settle}
+REQUIRE_CALIBRATION=${require_cal}
+ALLOW_NO_WAIT=${allow_no_wait}
 SLUG_PREFIX="${slug_prefix}"
 BASE_URL="${base_url}"
 BINARY_SOURCE="${binary}"
 BINARY_SHA256="$(sha256sum "${binary}" | cut -d' ' -f1)"
+GUARD_SHA256="$(sha256sum "${ROOT}/real/dogfoodguard" | cut -d' ' -f1)"
 HARNESS_SHA256="$(sha256sum "${self}" | cut -d' ' -f1)"
 POLICY
 	chmod 0600 "${ROOT}/ledger/policy.env"
@@ -388,7 +449,7 @@ POLICY
 	start=$(sample_balance "start") || die "init: could not read the opening Buzz balance — refusing to start a run whose meter does not work"
 	write_scalar start_balance "${start}"
 
-	chmod 0555 "${ROOT}/real/civitai"
+	chmod 0555 "${ROOT}/real/civitai" "${ROOT}/real/dogfoodguard"
 	chmod 0500 "${ROOT}/real" "${ROOT}/bin" "${ROOT}/harness"
 
 	cmd_write_brief
@@ -445,207 +506,82 @@ BRIEF
 }
 
 # ---------------------------------------------------------------------------
-# ARGV TOKENIZER
+# CLASSIFICATION — delegated to the REAL Cobra command tree.
 #
-# Fills TOK_KIND[i] for each argv token: "flag", "value", or "positional".
-# Value-taking flags are resolved per command path. An UNRECOGNISED flag on a
-# spending command is treated as value-taking, which biases the classification
-# toward DENY rather than toward an unmetered submit.
+# 🔴 THE SHIM NO LONGER PARSES ARGV. It used to keep its own model of how the
+# CLI reads a command line, and that model disagreed with pflag three times,
+# each disagreement letting a real spend or a real mutation through:
+#   * `--no-color generate … --yes`      (root persistent flags precede the command)
+#   * `--negative-prompt --help`         (a flag VALUE that looks like a flag)
+#   * `--print-input=false`              (present, but FALSE)
+# Each was fixed as a spelling; the class survived. internal/dogfoodguard now
+# answers "what is this invocation?" using cobra's own Find + ParseFlags, so
+# the gate and the binary cannot disagree by construction. It never executes
+# anything.
+#
+# 🔴 FAIL CLOSED: a non-zero exit, empty output, a missing `ok`, or an
+# unrecognised field is a DENY.
 # ---------------------------------------------------------------------------
-declare -a TOK TOK_KIND
-CMD1=""; CMD2=""; CMD3=""
-# The token that SHOULD have been a subcommand but is not in the vocabulary.
-# Without this an unknown verb resolved to the empty string and was
-# indistinguishable from a bare `civitai app`, which the gate allows as a usage
-# request — so `app frobnicate` and `app listing frobnicate` were ALLOWED.
-CMD2_UNKNOWN=""; CMD3_UNKNOWN=""
-IDX1=-1; IDX2=-1; IDX3=-1
+declare -A GBOOL GINT GSTR GCHANGED
+declare -a GARG
+GPATH=""; GARGC=0; GERR=""; GKIND=""
 
-value_flags_for_path() {
-	case "${CMD1}:${CMD2}" in
-		generate:*)     printf '%s' "${VALUE_FLAGS_GENERATE}" ;;
-		app:submit)     printf '%s' "${VALUE_FLAGS_APP_SUBMIT}" ;;
-		app:listing)    printf '%s' "${VALUE_FLAGS_APP_LISTING}" ;;
-		app:withdraw)   printf '%s' "${VALUE_FLAGS_APP_WITHDRAW}" ;;
-		*)              printf '%s' "" ;;
-	esac
+# 🔴 ASSIGNED UNCONDITIONALLY AT STARTUP, WHICH IS THE POINT. The selftest
+# swaps in fake classifiers to prove the shim refuses drifted output, and it
+# cannot do that by overwriting the real binary — a running executable gives
+# ETXTBSY and the write SILENTLY fails, which made four "drift is refused" rows
+# pass against the real classifier instead. So the path is injectable. Setting
+# it here to the empty string discards any value inherited from the
+# environment, so an agent exporting GUARD_BIN cannot point the gate at a
+# classifier of its own.
+GUARD_BIN=""
+
+unescape() {
+	local s="$1"
+	s="${s//\\t/$'\t'}"
+	s="${s//\\r/$'\r'}"
+	s="${s//\\n/$'\n'}"
+	s="${s//\\\\/\\}"
+	printf '%s' "${s}"
 }
 
-# Resolve the command path against the closed vocabulary. The FIRST token that
-# is not a flag is the command; root persistent bools never consume a value, so
-# skipping every leading `-*` is correct here and is what fixes the
-# `--no-color generate` bypass.
-# The first token after index `from` that does not start with '-'. Between a
-# parent command and its subcommand Cobra permits only the parent's own flags,
-# and none of `civitai`'s parent commands has a value-taking flag — so "first
-# token not starting with -" is the correct rule here and needs no knowledge of
-# which flags consume a value.
-next_word_after() {
-	local from="$1" i n
-	n=${#TOK[@]}
-	for (( i=from+1; i<n; i++ )); do
-		case "${TOK[i]}" in -*) continue ;; esac
-		printf '%s\t%s' "${TOK[i]}" "${i}"; return 0
-	done
-	return 1
-}
-
-resolve_command() {
-	CMD1=""; CMD2=""; CMD3=""; CMD2_UNKNOWN=""; CMD3_UNKNOWN=""
-	IDX1=-1; IDX2=-1; IDX3=-1
-	local i n t pair word idx
-	n=${#TOK[@]}
-	for (( i=0; i<n; i++ )); do
-		t="${TOK[i]}"
-		case "${t}" in -*) continue ;; esac
-		CMD1="${t}"; IDX1=${i}; break
-	done
-	[ -n "${CMD1}" ] || return 0
-
-	if [ "${CMD1}" = "app" ]; then
-		if pair=$(next_word_after "${IDX1}"); then
-			word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
-			if in_list "${word}" "${APP_SUBCMDS}"; then
-				CMD2="${word}"; IDX2="${idx}"
-			else
-				CMD2_UNKNOWN="${word}"; return 0
-			fi
-		fi
-		if [ "${CMD2}" = "listing" ]; then
-			if pair=$(next_word_after "${IDX2}"); then
-				word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
-				if in_list "${word}" "${LISTING_SUBCMDS}"; then
-					CMD3="${word}"; IDX3="${idx}"
-				else
-					CMD3_UNKNOWN="${word}"
-				fi
-			fi
-		fi
-	elif [ "${CMD1}" = "workflows" ]; then
-		if pair=$(next_word_after "${IDX1}"); then
-			word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
-			if in_list "${word}" "${WORKFLOWS_SUBCMDS}"; then
-				CMD2="${word}"; IDX2="${idx}"
-			else
-				CMD2_UNKNOWN="${word}"
-			fi
-		fi
+classify() {
+	GBOOL=(); GINT=(); GSTR=(); GCHANGED=(); GARG=()
+	GPATH=""; GARGC=0; GERR=""; GKIND=""
+	local bin="${GUARD_BIN:-${ROOT}/real/dogfoodguard}" out rc ok="" k v
+	if [ ! -x "${bin}" ]; then
+		GERR="the classifier ${bin} is missing or not executable"; return 1
 	fi
+	out=$("${bin}" -- "$@" 2>/dev/null); rc=$?
+	if [ -z "${out}" ]; then
+		GERR="the classifier produced no output (exit ${rc})"; return 1
+	fi
+	while IFS=$'\t' read -r k v; do
+		[ -n "${k}" ] || continue
+		case "${k}" in
+			ok)          ok="${v}" ;;
+			err)         GERR=$(unescape "${v}") ;;
+			kind)        GKIND="${v}" ;;
+			path)        GPATH=$(unescape "${v}") ;;
+			argc)        GARGC="${v}" ;;
+			arg.*)       GARG[${k#arg.}]=$(unescape "${v}") ;;
+			bool.*)      GBOOL[${k#bool.}]="${v}" ;;
+			int.*)       GINT[${k#int.}]="${v}" ;;
+			str.*)       GSTR[${k#str.}]=$(unescape "${v}") ;;
+			changed.*)   GCHANGED[${k#changed.}]="${v}" ;;
+			*)           GERR="the classifier emitted an unrecognised field \`${k}\`"; return 1 ;;
+		esac
+	done <<< "${out}"
+	case "${GARGC}" in
+		''|*[!0-9]*) GERR="the classifier reported a non-numeric argument count"; return 1 ;;
+	esac
+	[ "${ok}" = "1" ] || return 1
 	return 0
 }
 
-tokenize() {
-	TOK=("$@")
-	TOK_KIND=()
-	resolve_command
-	local vflags spending=0
-	vflags=$(value_flags_for_path)
-	[ "${CMD1}" = "generate" ] && spending=1
-	local i n t expect_value=0
-	n=${#TOK[@]}
-	for (( i=0; i<n; i++ )); do
-		t="${TOK[i]}"
-		if [ "${expect_value}" = 1 ]; then
-			TOK_KIND[i]="value"; expect_value=0; continue
-		fi
-		case "${t}" in
-			--*=*)  TOK_KIND[i]="flag" ;;
-			-*)
-				TOK_KIND[i]="flag"
-				if in_list "${t}" "${vflags}"; then
-					expect_value=1
-				elif in_list "${t}" "${ROOT_BOOL_FLAGS}" || in_list "${t}" "${CMD_BOOL_FLAGS}"; then
-					: # boolean, consumes nothing
-				elif [ "${spending}" = 1 ]; then
-					# Unknown flag on the money path: assume it eats the next
-					# token, so a following --dry-run/--help is NOT mistaken for
-					# a free preview or a help request.
-					expect_value=1
-				fi
-				;;
-			*)      TOK_KIND[i]="positional" ;;
-		esac
-	done
-}
-
-# Is FLAG present as a FLAG (never as another flag's value)?
-tok_has_flag() {
-	local want="$1" i n
-	n=${#TOK[@]}
-	for (( i=0; i<n; i++ )); do
-		[ "${TOK_KIND[i]}" = "flag" ] || continue
-		case "${TOK[i]}" in
-			"${want}"|"${want}"=*) return 0 ;;
-		esac
-	done
-	return 1
-}
-
-# Value of FLAG. Returns the LAST occurrence, because pflag does — measured on
-# a free read, `--limit 1 --limit 3` returns three results. Reading the first
-# let `--max-cost 5 --max-cost 99999` show the gate a 5 while the CLI enforced
-# 99999.
-tok_flag_value() {
-	local want="$1" i n found=1 out=""
-	n=${#TOK[@]}
-	for (( i=0; i<n; i++ )); do
-		[ "${TOK_KIND[i]}" = "flag" ] || continue
-		case "${TOK[i]}" in
-			"${want}"=*) out="${TOK[i]#*=}"; found=0 ;;
-			"${want}")
-				if [ $(( i + 1 )) -lt "${n}" ] && [ "${TOK_KIND[i+1]}" = "value" ]; then
-					out="${TOK[i+1]}"; found=0
-				fi ;;
-		esac
-	done
-	[ "${found}" = 0 ] || return 1
-	printf '%s' "${out}"
-}
-
-# Positional arguments AFTER the resolved command path — i.e. every positional
-# token whose index is past the last command word. Indices come from
-# resolve_command, so this needs no re-matching by string value (which used to
-# mis-skip an argument that happened to equal its own command's name).
-tok_positionals_after_command() {
-	local i n last
-	n=${#TOK[@]}
-	last="${IDX1}"
-	[ "${IDX2}" -gt "${last}" ] 2>/dev/null && last="${IDX2}"
-	[ "${IDX3}" -gt "${last}" ] 2>/dev/null && last="${IDX3}"
-	for (( i=last+1; i<n; i++ )); do
-		[ "${TOK_KIND[i]}" = "positional" ] || continue
-		printf '%s\n' "${TOK[i]}"
-	done
-}
-
-# Is there a genuine --help / -h?
-#
-# 🔴 ALLOWLIST, NOT DENYLIST. A `--help` counts only when the token before it
-# is nothing, a command word, or a KNOWN boolean flag. `--negative-prompt
-# --help` is pflag taking `--help` as the prompt VALUE, and the old blanket
-# "is --help anywhere in argv" test turned that into a full bypass of every
-# DENY branch — measured: a real submit, charged, meter untouched.
-tok_is_help_request() {
-	local i n prev
-	n=${#TOK[@]}
-	for (( i=0; i<n; i++ )); do
-		case "${TOK[i]}" in
-			--help|-h|--help=*) ;;
-			*) continue ;;
-		esac
-		[ "${TOK_KIND[i]}" = "flag" ] || continue
-		if [ "${i}" = 0 ]; then return 0; fi
-		prev="${TOK[i-1]}"
-		if in_list "${prev}" "${ROOT_BOOL_FLAGS}" \
-			|| in_list "${prev}" "${CMD_BOOL_FLAGS}" \
-			|| in_list "${prev}" "${TOPLEVEL_CMDS}" \
-			|| in_list "${prev}" "${APP_SUBCMDS}" \
-			|| in_list "${prev}" "${LISTING_SUBCMDS}"; then
-			return 0
-		fi
-	done
-	return 1
-}
+gbool()    { printf '%s' "${GBOOL[$1]:-false}"; }
+gstr()     { printf '%s' "${GSTR[$1]:-}"; }
+gchanged() { printf '%s' "${GCHANGED[$1]:-false}"; }
 
 resolve_block_id() {
 	local dir="$1" slug="$2" manifest id
@@ -659,6 +595,17 @@ resolve_block_id() {
 	printf '%s' "${id}"
 }
 
+# Commands that are pure groups: they run nothing themselves, so a leftover
+# positional means the user named a subcommand that does not exist. Cobra
+# resolves `app frobnicate` to `app` with one argument, which is how an unknown
+# subcommand is detected without a vocabulary of our own.
+is_group_path() {
+	case "$1" in
+		""|app|"app listing"|workflows|"app listing"*) return 0 ;;
+	esac
+	return 1
+}
+
 # ---------------------------------------------------------------------------
 # policy_verdict — sets VERDICT / VERDICT_REASON / VERDICT_MC.
 #
@@ -668,141 +615,165 @@ resolve_block_id() {
 # ---------------------------------------------------------------------------
 VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
 
-deny() { VERDICT="DENY"; VERDICT_REASON="$1"; return 0; }
+deny()  { VERDICT="DENY"; VERDICT_REASON="$1"; return 0; }
 allow() { VERDICT="ALLOW"; VERDICT_REASON="${1:-}"; return 0; }
 
 policy_verdict() {
 	VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
-	tokenize "$@"
 
-	if tok_is_help_request; then allow "help"; return 0; fi
-
-	if [ -z "${CMD1}" ]; then allow "root usage"; return 0; fi
-
-	if ! in_list "${CMD1}" "${TOPLEVEL_CMDS}"; then
-		deny "\`${CMD1}\` is not a command this gate recognises; it fails closed rather than guess whether a new command spends or mutates"
-		return 0
-	fi
-
-	case "${CMD1}" in
-		upgrade) deny "\`upgrade\` would replace the binary under evaluation mid-run"; return 0 ;;
-		login)   deny "this sandbox is already authenticated; run \`civitai whoami\` to see as whom"; return 0 ;;
-	esac
-
-	if [ "${CMD1}" = "app" ]; then
-		if [ -n "${CMD2_UNKNOWN}" ]; then
-			deny "unrecognised \`app ${CMD2_UNKNOWN}\`; the gate fails closed rather than guess whether it mutates"
-			return 0
-		fi
-		if [ -z "${CMD2}" ]; then allow "app usage"; return 0; fi
-		case "${CMD2}" in
-			dev-tunnel|dev-token)
-				deny "\`app ${CMD2}\` is out of scope for this run"; return 0 ;;
-			withdraw)
-				local id=""
-				id=$(tok_flag_value "--id") || id=""
-				if [ -z "${id}" ]; then
-					id=$(tok_positionals_after_command | head -1)
-				fi
-				if [ -z "${id}" ]; then
-					allow "withdraw with no id (a usage error the CLI reports)"; return 0
-				fi
-				# 🔴 ANY id, not just a pubreq_-shaped one. app_withdraw.go takes
-				# args[0] with no format validation, so the old "the CLI will
-				# refuse it" fallback was a false statement about a branch that
-				# reaches the network.
-				if grep -qxF "${id}" "${ROOT}/ledger/pubreq.allow" 2>/dev/null; then
-					allow "withdraw of a submission this sandbox created"; return 0
-				fi
-				deny "\`${id}\` was not created by this sandbox, so it may be one of the account's real pending submissions"
-				return 0 ;;
-			submit)
-				if tok_has_flag "--package-only"; then
-					allow "--package-only never submits"; return 0
-				fi
-				local dir id n
-				dir=$(tok_positionals_after_command | head -1)
-				[ -n "${dir}" ] || dir="."
-				if ! id=$(resolve_block_id "${dir}" ""); then
-					deny "cannot read a blockId from ${dir}/block.manifest.json, so the app being submitted cannot be identified"
-					return 0
-				fi
-				case "${id}" in
-					"${SLUG_PREFIX}"*) ;;
-					*) deny "blockId \`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may only submit its own throwaway app"; return 0 ;;
-				esac
-				n=$(read_scalar app_submits) || { deny "the app-submission counter is unreadable"; return 0; }
-				if [ "${n}" -ge "${MAX_APP_SUBMITS}" ]; then
-					deny "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"; return 0
-				fi
-				VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; return 0 ;;
-			listing)
-				if [ -n "${CMD3_UNKNOWN}" ]; then
-					deny "unrecognised \`app listing ${CMD3_UNKNOWN}\`; the gate fails closed on anything that might mutate a listing"
-					return 0
-				fi
-				case "${CMD3}" in
-					"") allow "listing usage"; return 0 ;;
-					status) allow "listing read"; return 0 ;;
-					set-icon|set-cover|add-screenshot|rm-screenshot|reorder)
-						local slug dir id
-						slug=$(tok_flag_value "--slug") || slug=""
-						dir=$(tok_flag_value "--dir") || dir=""
-						[ -n "${dir}" ] || dir="."
-						if ! id=$(resolve_block_id "${dir}" "${slug}"); then
-							deny "cannot identify which app \`app listing ${CMD3}\` would mutate (no --slug, and no readable blockId in ${dir}/block.manifest.json)"
-							return 0
-						fi
-						case "${id}" in
-							"${SLUG_PREFIX}"*) allow "listing mutation on ${id}"; return 0 ;;
-							*) deny "\`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may not touch the account's real listings"; return 0 ;;
-						esac ;;
-					*) deny "unrecognised \`app listing ${CMD3}\`; the gate fails closed on anything that might mutate a listing"; return 0 ;;
-				esac ;;
-			create|init|validate|status|list|view|pull|metrics)
-				allow "app read/local"; return 0 ;;
+	if ! classify "$@"; then
+		case "${GKIND}" in
+			unknown-command)
+				deny "the CLI does not recognise this command (${GERR})" ;;
+			flag-parse-error)
+				deny "the CLI would reject these flags (${GERR}); the gate refuses rather than guess what was meant" ;;
 			*)
-				deny "unrecognised \`app ${CMD2}\`; the gate fails closed"; return 0 ;;
+				deny "the invocation could not be classified (${GERR:-no detail}) — refusing" ;;
+		esac
+		return 0
+	fi
+
+	# Help is free on every command, including the forbidden ones. This is the
+	# REAL value of the help flag, so `--help=false` is not a help request.
+	if [ "$(gbool help)" = "true" ]; then allow "help"; return 0; fi
+
+	local path="${GPATH}"
+
+	if is_group_path "${path}"; then
+		case "${path}" in
+			"app listing set-icon"|"app listing set-cover"|"app listing add-screenshot"|"app listing rm-screenshot"|"app listing reorder"|"app listing status") ;;
+			*)
+				if [ "${GARGC}" -gt 0 ]; then
+					deny "\`${GARG[0]:-?}\` is not a subcommand of \`${path:-civitai}\`; the gate fails closed rather than guess whether it spends or mutates"
+					return 0
+				fi
+				allow "usage"; return 0 ;;
 		esac
 	fi
 
-	if [ "${CMD1}" = "generate" ]; then
-		if tok_has_flag "--print-input" || tok_has_flag "--dry-run"; then
-			allow "generate preview (spends nothing)"; return 0
-		fi
-		if [ -f "${ROOT}/ledger/meter_broken" ]; then
-			deny "the spend meter could not read a balance earlier in this run, so spend is no longer being counted — refusing to submit (see ledger/meter_broken)"
-			return 0
-		fi
-		local cum res committed remaining mc n
-		cum=$(read_scalar observed_spend) || { deny "the spend ledger is unreadable or malformed — refusing to submit"; return 0; }
-		res=$(read_scalar reserved)       || { deny "the reservation ledger is unreadable or malformed — refusing to submit"; return 0; }
-		committed=$(( cum + res ))
-		if [ "${committed}" -ge "${TOTAL_SPEND_CAP}" ]; then
-			deny "the run's total spend cap (${TOTAL_SPEND_CAP} Buzz) is reached — ${cum} observed, ${res} committed in flight"
-			return 0
-		fi
-		n=$(read_scalar generate_submits) || { deny "the submission counter is unreadable"; return 0; }
-		if [ "${n}" -ge "${MAX_GENERATE_SUBMITS}" ]; then
-			deny "the generation cap for this run (${MAX_GENERATE_SUBMITS} submits) is already used"; return 0
-		fi
-		if ! mc=$(tok_flag_value "--max-cost"); then
-			deny "a generation that actually submits must carry --max-cost (at most ${PER_CALL_MAX_COST}); use --dry-run to price it first"
-			return 0
-		fi
-		case "${mc}" in
-			''|*[!0-9]*) deny "--max-cost must be a whole number of Buzz, got \`${mc}\`"; return 0 ;;
-		esac
-		if [ "${mc}" -gt "${PER_CALL_MAX_COST}" ]; then
-			deny "--max-cost ${mc} exceeds this run's per-invocation ceiling of ${PER_CALL_MAX_COST} Buzz"; return 0
-		fi
-		remaining=$(( TOTAL_SPEND_CAP - committed ))
-		if [ "${mc}" -gt "${remaining}" ]; then
-			deny "--max-cost ${mc} exceeds the ${remaining} Buzz left under this run's total cap"; return 0
-		fi
-		VERDICT="ALLOW_SPEND"; VERDICT_REASON="submit with --max-cost ${mc}"; VERDICT_MC="${mc}"
-		return 0
-	fi
+	case "${path}" in
+		upgrade)
+			deny "\`upgrade\` would replace the binary under evaluation mid-run"; return 0 ;;
+		login)
+			deny "this sandbox is already authenticated; run \`civitai whoami\` to see as whom"; return 0 ;;
+		"app dev-tunnel"|"app dev-token")
+			deny "\`${path}\` is out of scope for this run"; return 0 ;;
+
+		"app withdraw")
+			local id
+			id=$(gstr id)
+			[ -n "${id}" ] || id="${GARG[0]:-}"
+			if [ -z "${id}" ]; then
+				allow "withdraw with no id (a usage error the CLI reports)"; return 0
+			fi
+			if grep -qxF "${id}" "${ROOT}/ledger/pubreq.allow" 2>/dev/null; then
+				allow "withdraw of a submission this sandbox created"; return 0
+			fi
+			deny "\`${id}\` was not created by this sandbox, so it may be one of the account's real pending submissions"
+			return 0 ;;
+
+		"app submit")
+			if [ "$(gbool package-only)" = "true" ]; then
+				allow "--package-only never submits"; return 0
+			fi
+			local dir id n
+			dir="${GARG[0]:-}"
+			[ -n "${dir}" ] || dir="."
+			if ! id=$(resolve_block_id "${dir}" ""); then
+				deny "cannot read a blockId from ${dir}/block.manifest.json, so the app being submitted cannot be identified"
+				return 0
+			fi
+			case "${id}" in
+				"${SLUG_PREFIX}"*) ;;
+				*) deny "blockId \`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may only submit its own throwaway app"; return 0 ;;
+			esac
+			n=$(read_scalar app_submits) || { deny "the app-submission counter is unreadable or malformed"; return 0; }
+			if [ "${n}" -ge "${MAX_APP_SUBMITS}" ]; then
+				deny "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"; return 0
+			fi
+			VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; return 0 ;;
+
+		"app listing status")
+			allow "listing read"; return 0 ;;
+
+		"app listing set-icon"|"app listing set-cover"|"app listing add-screenshot"|"app listing rm-screenshot"|"app listing reorder")
+			local slug dir id m
+			slug=$(gstr slug); dir=$(gstr dir)
+			[ -n "${dir}" ] || dir="."
+			if ! id=$(resolve_block_id "${dir}" "${slug}"); then
+				deny "cannot identify which app \`${path}\` would mutate (no --slug, and no readable blockId in ${dir}/block.manifest.json)"
+				return 0
+			fi
+			case "${id}" in
+				"${SLUG_PREFIX}"*) ;;
+				*) deny "\`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may not touch the account's real listings"; return 0 ;;
+			esac
+			# A listing change on a LIVE listing goes back to moderator review,
+			# so it carries the same human cost as a submit and is capped too.
+			m=$(read_scalar listing_mutations) || { deny "the listing-mutation counter is unreadable or malformed"; return 0; }
+			if [ "${m}" -ge "${MAX_LISTING_MUTATIONS}" ]; then
+				deny "the listing-mutation cap for this run (${MAX_LISTING_MUTATIONS}) is already used"; return 0
+			fi
+			VERDICT="ALLOW_LISTING"; VERDICT_REASON="listing mutation on ${id}"; return 0 ;;
+
+		"workflows cancel")
+			local wid
+			wid="${GARG[0]:-}"
+			if [ -z "${wid}" ]; then
+				allow "cancel with no id (a usage error the CLI reports)"; return 0
+			fi
+			if grep -qxF "${wid}" "${ROOT}/ledger/workflow.allow" 2>/dev/null; then
+				allow "cancel of a workflow this sandbox created"; return 0
+			fi
+			deny "workflow \`${wid}\` was not created by this sandbox — cancelling DOES NOT REFUND, so the gate will not cancel a job it did not start"
+			return 0 ;;
+
+		generate)
+			if [ "$(gbool print-input)" = "true" ] || [ "$(gbool dry-run)" = "true" ]; then
+				allow "generate preview (spends nothing)"; return 0
+			fi
+			if [ -f "${ROOT}/ledger/meter_broken" ]; then
+				deny "the spend meter stopped agreeing with the account earlier in this run, so spend is no longer being counted — refusing to submit (see ledger/meter_broken)"
+				return 0
+			fi
+			if [ "${REQUIRE_CALIBRATION}" = "1" ] && [ ! -f "${ROOT}/ledger/calibration.ok" ]; then
+				deny "the spend meter has not been calibrated against a real generation; run \`dogfood-sandbox.sh calibrate\` (it spends once, deliberately, while you watch) or re-init with --skip-calibration"
+				return 0
+			fi
+			if [ "$(gbool no-wait)" = "true" ] && [ "${ALLOW_NO_WAIT}" != "1" ]; then
+				deny "--no-wait returns before the charge has settled, and the meter reads the balance when the command returns — refused so the ledger cannot silently under-count"
+				return 0
+			fi
+			local cum res committed remaining mc n
+			cum=$(read_scalar observed_spend) || { deny "the spend ledger is unreadable or malformed — refusing to submit"; return 0; }
+			res=$(read_scalar reserved)       || { deny "the reservation ledger is unreadable or malformed — refusing to submit"; return 0; }
+			committed=$(( cum + res ))
+			if [ "${committed}" -ge "${TOTAL_SPEND_CAP}" ]; then
+				deny "the run's total spend cap (${TOTAL_SPEND_CAP} Buzz) is reached — ${cum} observed, ${res} committed in flight"
+				return 0
+			fi
+			n=$(read_scalar generate_submits) || { deny "the submission counter is unreadable or malformed"; return 0; }
+			if [ "${n}" -ge "${MAX_GENERATE_SUBMITS}" ]; then
+				deny "the generation cap for this run (${MAX_GENERATE_SUBMITS} submits) is already used"; return 0
+			fi
+			if [ "$(gchanged max-cost)" != "true" ]; then
+				deny "a generation that actually submits must carry --max-cost (at most ${PER_CALL_MAX_COST}); use --dry-run to price it first"
+				return 0
+			fi
+			mc="${GINT[max-cost]:-}"
+			case "${mc}" in
+				''|*[!0-9]*) deny "--max-cost must be a non-negative whole number of Buzz, got \`${mc}\`"; return 0 ;;
+			esac
+			if [ "${mc}" -gt "${PER_CALL_MAX_COST}" ]; then
+				deny "--max-cost ${mc} exceeds this run's per-invocation ceiling of ${PER_CALL_MAX_COST} Buzz"; return 0
+			fi
+			remaining=$(( TOTAL_SPEND_CAP - committed ))
+			if [ "${mc}" -gt "${remaining}" ]; then
+				deny "--max-cost ${mc} exceeds the ${remaining} Buzz left under this run's total cap"; return 0
+			fi
+			VERDICT="ALLOW_SPEND"; VERDICT_REASON="submit with --max-cost ${mc}"; VERDICT_MC="${mc}"
+			return 0 ;;
+	esac
 
 	allow "read-only or local"
 	return 0
@@ -845,9 +816,11 @@ cmd_guard() {
 	policy_verdict "${argv[@]+"${argv[@]}"}"
 
 	# 🔴 An empty or unrecognised verdict is a DENY. This is the backstop for
-	# any internal failure that leaves VERDICT unset.
+	# any internal failure that leaves VERDICT unset — measured as load-bearing:
+	# with a branch returning without setting VERDICT, deleting this case lets
+	# the real binary run.
 	case "${VERDICT}" in
-		ALLOW|ALLOW_SPEND|ALLOW_APP_SUBMIT|DENY) ;;
+		ALLOW|ALLOW_SPEND|ALLOW_APP_SUBMIT|ALLOW_LISTING|DENY) ;;
 		*) refuse "the gate could not classify this invocation (internal error) — refusing" "${scrubbed}" ;;
 	esac
 
@@ -855,20 +828,31 @@ cmd_guard() {
 		refuse "${VERDICT_REASON}" "${scrubbed}"
 	fi
 
+	# 🔴 EVERY counter bump is fatal if the write fails. With the ledger
+	# unwritable the previous version bumped nothing and allowed submit after
+	# submit, meter and counter both reading 0 forever.
 	local before="" mc="${VERDICT_MC}"
-	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
-		before=$(sample_balance "pre-generate") || \
-			refuse "could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" "${scrubbed}"
-		local res n
-		res=$(read_scalar reserved) || refuse "the reservation ledger is unreadable" "${scrubbed}"
-		n=$(read_scalar generate_submits) || refuse "the submission counter is unreadable" "${scrubbed}"
-		write_scalar reserved "$(( res + mc ))"
-		write_scalar generate_submits "$(( n + 1 ))"
-	elif [ "${VERDICT}" = "ALLOW_APP_SUBMIT" ]; then
-		local a
-		a=$(read_scalar app_submits) || refuse "the app-submission counter is unreadable" "${scrubbed}"
-		write_scalar app_submits "$(( a + 1 ))"
-	fi
+	case "${VERDICT}" in
+		ALLOW_SPEND)
+			before=$(sample_balance "pre-generate") || \
+				refuse "could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" "${scrubbed}"
+			local res n
+			res=$(read_scalar reserved)       || refuse "the reservation ledger is unreadable or malformed" "${scrubbed}"
+			n=$(read_scalar generate_submits) || refuse "the submission counter is unreadable or malformed" "${scrubbed}"
+			write_scalar reserved "$(( res + mc ))"       || refuse "could not record the spend reservation — refusing to submit" "${scrubbed}"
+			write_scalar generate_submits "$(( n + 1 ))"  || refuse "could not record the submission — refusing to submit" "${scrubbed}"
+			;;
+		ALLOW_APP_SUBMIT)
+			local a
+			a=$(read_scalar app_submits) || refuse "the app-submission counter is unreadable or malformed" "${scrubbed}"
+			write_scalar app_submits "$(( a + 1 ))" || refuse "could not record the app submission — refusing" "${scrubbed}"
+			;;
+		ALLOW_LISTING)
+			local m
+			m=$(read_scalar listing_mutations) || refuse "the listing-mutation counter is unreadable or malformed" "${scrubbed}"
+			write_scalar listing_mutations "$(( m + 1 ))" || refuse "could not record the listing mutation — refusing" "${scrubbed}"
+			;;
+	esac
 
 	unlock_ledger
 
@@ -886,37 +870,106 @@ cmd_guard() {
 	t1=$(date +%s%N)
 
 	local delta=""
+	# 🔴 The ledger append happens INSIDE the lock, along with the settlement
+	# accounting: it used to run after unlock_ledger, so concurrent invocations
+	# appended unserialised.
+	lock_ledger || err "could not re-take the ledger lock; the ledger may be inconsistent"
+
 	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
-		local after res cum
-		lock_ledger || err "could not re-take the ledger lock; the spend ledger may be short one entry"
-		after=$(sample_balance "post-generate") || after=""
-		res=$(read_scalar reserved) || res="${mc}"
-		cum=$(read_scalar observed_spend) || cum=0
-		if [ -n "${after}" ]; then
-			delta=$(( before - after ))
-			[ "${delta}" -ge 0 ] || delta=0
-			write_scalar observed_spend "$(( cum + delta ))"
-			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
-				>> "${ROOT}/ledger/spend.tsv"
-		else
-			# 🔴 FAIL CLOSED ON A LOST SAMPLE. Dropping the delta silently let a
-			# flaky balance read under-count forever — measured: 5 submits,
-			# 185 truly spent, meter 0. Charge the worst case the estimate
-			# allowed and stop the money path for the rest of the run.
-			delta="unknown"
-			write_scalar observed_spend "$(( cum + mc ))"
-			printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s\n' "$(now_iso)" "${before}" "${mc}" \
-				>> "${ROOT}/ledger/spend.tsv"
-			: > "${ROOT}/ledger/meter_broken"
-			printf '%s: %s\n' "${SANDBOX_TAG}" \
-				"the post-submit balance read failed; ${mc} Buzz has been charged to the ledger as a worst case and no further generation will be allowed this run" >&2
-		fi
-		write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))"
-		unlock_ledger
+		delta=$(settle_spend "${before}" "${mc}")
 	fi
 
-	log_invocation "${VERDICT}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" "${delta:-}"
+	# Record the ids this run created, so the agent can withdraw its OWN
+	# submission and cancel its OWN workflow without the operator doing it by
+	# hand. Reads only; costs one extra API call after a mutation.
+	case "${VERDICT}" in
+		ALLOW_APP_SUBMIT) record_pubreq_ids ;;
+		ALLOW_SPEND)      record_workflow_ids ;;
+	esac
+
+	log_invocation "${VERDICT}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" \
+		"${VERDICT_REASON}${delta:+ | delta=${delta}}"
+	unlock_ledger
 	return "${rc}"
+}
+
+# Reconcile the balance after a submit. Echoes the delta (or `unknown`).
+#
+# 🔴 THREE WAYS THIS CAN LIE, AND ALL THREE NOW LATCH `meter_broken`:
+#   * the read FAILS            — charge the worst case the estimate allowed;
+#   * the read SUCCEEDS but is STALE — a job that certainly cost something
+#     reports a delta of 0. Measured against a stub settling 2s later (the
+#     shape of --no-wait): 3 submits, meter 0, balance really moved 111, and
+#     nothing latched. A zero delta after a submit is now re-sampled once after
+#     a settle delay and, if still zero, treated as a broken meter;
+#   * the delta is NEGATIVE — a Buzz credit landing in the same window HIDES a
+#     real charge. Measured: a +100 grant alongside a 37 charge recorded 0.
+#     Clamping to zero is what made that silent, so it no longer clamps.
+settle_spend() {
+	local before="$1" mc="$2" after res cum delta
+	res=$(read_scalar reserved)      || res="${mc}"
+	cum=$(read_scalar observed_spend) || cum=0
+
+	after=$(sample_balance "post-generate") || after=""
+
+	if [ -n "${after}" ] && [ "${after}" = "${before}" ] && [ "${METER_SETTLE_SECONDS}" -gt 0 ]; then
+		sleep "${METER_SETTLE_SECONDS}"
+		after=$(sample_balance "post-generate-resample") || after=""
+	fi
+
+	if [ -z "${after}" ]; then
+		write_scalar observed_spend "$(( cum + mc ))" || true
+		printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s\n' "$(now_iso)" "${before}" "${mc}" \
+			>> "${ROOT}/ledger/spend.tsv"
+		break_meter "the post-submit balance read failed; ${mc} Buzz charged to the ledger as a worst case"
+		printf '%s' "unknown"
+	else
+		delta=$(( before - after ))
+		if [ "${delta}" -lt 0 ]; then
+			write_scalar observed_spend "$(( cum + mc ))" || true
+			printf '%s\tgenerate\t%s\t%s\tNEGATIVE(%s)-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${mc}" \
+				>> "${ROOT}/ledger/spend.tsv"
+			break_meter "the balance went UP across a submit (delta ${delta}); a credit can hide a real charge, so ${mc} Buzz was charged as a worst case"
+			printf '%s' "negative:${delta}"
+		elif [ "${delta}" = 0 ]; then
+			write_scalar observed_spend "$(( cum + mc ))" || true
+			printf '%s\tgenerate\t%s\t%s\tZERO-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${mc}" \
+				>> "${ROOT}/ledger/spend.tsv"
+			break_meter "a submitted generation moved the balance by 0, so the meter is not seeing charges; ${mc} Buzz charged as a worst case"
+			printf '%s' "zero"
+		else
+			write_scalar observed_spend "$(( cum + delta ))" || true
+			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
+				>> "${ROOT}/ledger/spend.tsv"
+			printf '%s' "${delta}"
+		fi
+	fi
+	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
+}
+
+break_meter() {
+	printf '%s\n' "$1" > "${ROOT}/ledger/meter_broken"
+	printf '%s: %s — no further generation will be allowed this run\n' "${SANDBOX_TAG}" "$1" >&2
+}
+
+# After an app submit, record the publish-request ids this account now has
+# pending, so the agent can withdraw its own. Read-only.
+record_pubreq_ids() {
+	local out
+	out=$(real_cli app status 2>/dev/null) || return 0
+	printf '%s' "${out}" | grep -o 'pubreq_[A-Za-z0-9_-]*' | sort -u \
+		>> "${ROOT}/ledger/pubreq.allow" 2>/dev/null || true
+	sort -u -o "${ROOT}/ledger/pubreq.allow" "${ROOT}/ledger/pubreq.allow" 2>/dev/null || true
+}
+
+# After a generation, record the workflow ids this run owns, so the agent can
+# cancel its own job (cancelling DOES NOT REFUND, so it may not cancel others').
+record_workflow_ids() {
+	local out
+	out=$(real_cli workflows list 2>/dev/null) || return 0
+	printf '%s' "${out}" | grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | sort -u \
+		>> "${ROOT}/ledger/workflow.allow" 2>/dev/null || true
+	sort -u -o "${ROOT}/ledger/workflow.allow" "${ROOT}/ledger/workflow.allow" 2>/dev/null || true
 }
 
 log_invocation() {
@@ -940,6 +993,67 @@ cmd_allow_pubreq() {
 	[ -n "${id}" ] || die "allow-pubreq: pass the publish-request id"
 	printf '%s\n' "${id}" >> "${ROOT}/ledger/pubreq.allow"
 	note "recorded ${id} as withdrawable"
+}
+
+# ---------------------------------------------------------------------------
+# calibrate — the ONE deliberate, operator-watched generation that measures the
+# meter's core assumption: does `buzz` reflect the charge by the time `generate`
+# returns?
+#
+# 🔴 THIS SPENDS REAL BUZZ, ONCE, ON PURPOSE. Everything else in this harness
+# assumes the balance moves before the command returns, and that assumption was
+# never tested — measured against a stub settling 2 s later, three submits left
+# the meter reading 0 while the balance really moved, with nothing latched. A
+# harness whose meter is assumed rather than measured is not auditable, so the
+# gate refuses to spend until this has been run (or --skip-calibration was
+# recorded at init).
+# ---------------------------------------------------------------------------
+cmd_calibrate() {
+	local root="${DEFAULT_ROOT}" yes=0
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--yes)  yes=1; shift ;;
+			*) die "calibrate: unknown flag $1" ;;
+		esac
+	done
+	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
+
+	if [ "${yes}" != 1 ]; then
+		note "calibrate will submit ONE real generation and SPEND REAL BUZZ."
+		note "It exists so the spend meter is measured rather than assumed."
+		note "Re-run with --yes to proceed."
+		return 2
+	fi
+
+	local before after delta
+	before=$(sample_balance "calibrate-before") || die "calibrate: could not read the opening balance"
+	note "balance before: ${before}"
+
+	note "submitting one generation (--max-cost ${PER_CALL_MAX_COST}) …"
+	real_cli generate "a plain grey square, calibration" --yes --max-cost "${PER_CALL_MAX_COST}" \
+		--no-download >/dev/null 2>&1
+	local rc=$?
+
+	after=$(sample_balance "calibrate-after") || die "calibrate: could not read the closing balance"
+	delta=$(( before - after ))
+	note "balance after:  ${after}   delta=${delta}   (generate rc=${rc})"
+
+	if [ "${rc}" != 0 ]; then
+		die "calibrate: the generation itself failed (rc=${rc}); fix that before calibrating"
+	fi
+	if [ "${delta}" -le 0 ]; then
+		printf '%s\n' "calibration FAILED: the balance did not move by the time generate returned (delta ${delta})" \
+			> "${ROOT}/ledger/meter_broken"
+		die "calibrate: the balance did NOT move by the time the command returned (delta ${delta}). The meter cannot count spend on this account/endpoint — do not run the dogfood until that is understood."
+	fi
+
+	printf 'calibrated %s delta=%s before=%s after=%s\n' "$(now_iso)" "${delta}" "${before}" "${after}" \
+		> "${ROOT}/ledger/calibration.ok"
+	note ""
+	note "CALIBRATED — one generation moved the balance by ${delta} Buzz before the"
+	note "command returned, so the meter observes charges synchronously."
+	note "Recorded in ${ROOT}/ledger/calibration.ok"
 }
 
 cmd_status() {
@@ -1000,22 +1114,84 @@ cmd_enter() {
 	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
 	command -v bwrap >/dev/null 2>&1 || die "enter: bwrap (bubblewrap) is not on PATH"
 
-	local shell_bin="${SHELL:-/bin/sh}"
+	local shell_bin
+	shell_bin=$(command -v bash) || die "enter: no bash on PATH"
 	[ $# -gt 0 ] || set -- "${shell_bin}" -i
+
+	# 🔴 DO NOT BIND /nix WHOLESALE. `nix build` copies the WHOLE working tree
+	# to a world-readable /nix/store/<hash>-source (flake.nix: `src =
+	# lib.cleanSource ./.`), so `--ro-bind /nix /nix` put this repo — AGENTS.md,
+	# the handoffs, the decisions — back inside a jail whose entire purpose is
+	# that the agent cannot read them. Measured: 4 readable copies of this
+	# repo's AGENTS.md under /nix/store, and one `grep -rl` ends the blindness.
+	# The earlier §5 transcript checked /home and the repo path and never
+	# checked /nix, which is exactly how the claim survived.
+	#
+	# So: bind only the CLOSURE of the handful of tools the jail needs. Anything
+	# not reachable from those roots — including every -source copy — is absent.
+	local -a roots=() binds=()
+	local b p
+	# 🔴 `command -v` returns the NAME for a shell builtin, not a path —
+	# `command -v printf` is literally `printf`. Feeding that to readlink -f
+	# yields a cwd-relative path that does not exist, and nix-store then fails
+	# on the whole list, which read as "nix-store is missing". Only absolute
+	# paths are roots.
+	for b in bash env cat cp rm mkdir chmod chown date grep sed tr head cut wc \
+	         sha256sum flock timeout mv ls readlink stat sort tail touch find id \
+	         dirname basename mktemp sleep awk diff coreutils; do
+		p=$(command -v "${b}" 2>/dev/null) || continue
+		case "${p}" in /*) ;; *) continue ;; esac
+		p=$(readlink -f "${p}") || continue
+		[ -e "${p}" ] || continue
+		roots+=("${p}")
+	done
+	[ "${#roots[@]}" -gt 0 ] || die "enter: could not resolve any tool paths"
+
+	local ca=""
+	for p in /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-bundle.crt; do
+		[ -e "${p}" ] && { ca=$(readlink -f "${p}"); break; }
+	done
+	[ -n "${ca}" ] && roots+=("${ca}")
+
+	# nix-store is not always on PATH even where it exists (a restricted shell,
+	# a non-login environment), so look in the usual places rather than
+	# concluding it is absent and refusing.
+	local nixstore=""
+	for p in "$(command -v nix-store 2>/dev/null)" \
+	         /run/current-system/sw/bin/nix-store \
+	         /nix/var/nix/profiles/default/bin/nix-store; do
+		[ -n "${p}" ] && [ -x "${p}" ] && { nixstore="${p}"; break; }
+	done
+
+	local closure=""
+	[ -n "${nixstore}" ] && closure=$("${nixstore}" -qR "${roots[@]}" 2>/dev/null | sort -u)
+	if [ -z "${closure}" ]; then
+		die "enter: could not compute the store closure (nix-store missing or failed). Refusing to fall back to binding /nix wholesale, which would put the repo back inside the jail."
+	fi
+	while IFS= read -r p; do
+		[ -n "${p}" ] || continue
+		binds+=(--ro-bind "${p}" "${p}")
+	done <<< "${closure}"
+
+	local envbin path_dirs
+	envbin=$(readlink -f "$(command -v env)")
+	path_dirs="${ROOT}/bin"
+	for b in bash coreutils grep sed findutils util-linux gawk diffutils; do :; done
+	for p in "${roots[@]}"; do
+		case "${path_dirs}:" in *":$(dirname "${p}"):"*) continue ;; esac
+		path_dirs="${path_dirs}:$(dirname "${p}")"
+	done
 
 	# 🔴 ORDER IS LOAD-BEARING. bwrap applies these in sequence, so `--tmpfs
 	# /tmp` must come BEFORE the run-root bind: the default run root lives under
 	# /tmp, and a tmpfs mounted afterwards SHADOWS it. Measured — with the bind
 	# first, bwrap died with "Can't chdir to <root>/workspace: No such file or
-	# directory". PATH is set explicitly rather than inherited because the
-	# operator's ~/.nix-profile/bin does not exist inside the jail.
+	# directory".
 	exec bwrap \
-		--ro-bind /nix /nix \
-		--ro-bind /run/current-system /run/current-system \
+		"${binds[@]}" \
+		--ro-bind "${envbin}" /usr/bin/env \
 		--ro-bind /etc/resolv.conf /etc/resolv.conf \
-		--ro-bind /etc/ssl /etc/ssl \
-		--ro-bind /etc/static /etc/static \
-		--ro-bind /usr /usr \
+		${ca:+--ro-bind "${ca}" /etc/ssl/certs/ca-certificates.crt} \
 		--proc /proc --dev /dev --tmpfs /tmp \
 		--bind "${ROOT}" "${ROOT}" \
 		--unshare-pid --die-with-parent \
@@ -1023,7 +1199,8 @@ cmd_enter() {
 		--setenv XDG_CONFIG_HOME "${ROOT}/home/.config" \
 		--setenv XDG_CACHE_HOME "${ROOT}/home/.cache" \
 		--setenv CIVITAI_NO_UPDATE_CHECK 1 \
-		--setenv PATH "${ROOT}/bin:/run/current-system/sw/bin:/usr/bin:/bin" \
+		${ca:+--setenv SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt} \
+		--setenv PATH "${path_dirs}" \
 		--chdir "${ROOT}/workspace" \
 		"$@"
 }
@@ -1057,19 +1234,19 @@ SELFTEST_FAIL=0
 st_check() {
 	local label="$1" want="$2" got="$3"
 	if [ "${want}" = "${got}" ]; then
-		printf '  PASS  %-58s (%s)\n' "${label}" "${got}"; SELFTEST_PASS=$(( SELFTEST_PASS + 1 ))
+		printf '  PASS  %-62s (%s)\n' "${label}" "${got}"; SELFTEST_PASS=$(( SELFTEST_PASS + 1 ))
 	else
-		printf '  FAIL  %-58s want=%s got=%s\n' "${label}" "${want}" "${got}"; SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+		printf '  FAIL  %-62s want=%s got=%s\n' "${label}" "${want}" "${got}"; SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
 	fi
 }
 
 vd() { policy_verdict "$@"; printf '%s' "${VERDICT}"; }
 
-# 🔴 A DENY is not evidence that the branch you meant was reached. Measured:
-# with the command resolved positionally again, `--no-color generate … --yes`
-# still DENIED — as an unrecognised command called `--no-color` — so every
-# verdict-only assertion for that bypass stayed green while the gate was blind.
-# These rows pin the REASON, so a refusal from a bystander branch fails.
+# 🔴 A DENY is not evidence that the branch you meant was reached. Measured
+# twice now: with the command resolved positionally, `--no-color generate …
+# --yes` still DENIED — as an unrecognised command called `--no-color` — and a
+# blind auditor found a dev-tunnel row carried by a bystander the same way.
+# These rows pin the REASON.
 st_reason() {
 	local label="$1" needle="$2"; shift 2
 	policy_verdict "$@"
@@ -1077,6 +1254,14 @@ st_reason() {
 		*"${needle}"*) st_check "${label}" "match" "match" ;;
 		*)             st_check "${label}" "match" "no-match: ${VERDICT_REASON}" ;;
 	esac
+}
+
+st_reset_ledger() {
+	write_scalar observed_spend "${1:-0}"
+	write_scalar reserved "${2:-0}"
+	write_scalar generate_submits "${3:-0}"
+	write_scalar app_submits "${4:-0}"
+	write_scalar listing_mutations "${5:-0}"
 }
 
 cmd_selftest() {
@@ -1091,137 +1276,217 @@ cmd_selftest() {
 
 	if [ "${offline}" = 1 ]; then
 		root="${TMPDIR:-/tmp}/dogfood-selftest-$$"
-		rm -rf "${root}"; mkdir -p "${root}/ledger" "${root}/workspace"
+		rm -rf "${root}"; mkdir -p "${root}/ledger" "${root}/workspace" "${root}/real"
 		cat > "${root}/ledger/policy.env" <<OFFLINE
 ROOT="${root}"
 PER_CALL_MAX_COST=100
 TOTAL_SPEND_CAP=2000
 MAX_GENERATE_SUBMITS=20
 MAX_APP_SUBMITS=3
+MAX_LISTING_MUTATIONS=10
+METER_SETTLE_SECONDS=0
+REQUIRE_CALIBRATION=0
+ALLOW_NO_WAIT=0
 SLUG_PREFIX="sanctioned-"
 BASE_URL="https://civitai.com"
 OFFLINE
 		: > "${root}/ledger/pubreq.allow"
-		printf '0\n' > "${root}/ledger/observed_spend"
-		printf '0\n' > "${root}/ledger/reserved"
-		printf '0\n' > "${root}/ledger/generate_submits"
-		printf '0\n' > "${root}/ledger/app_submits"
+		: > "${root}/ledger/workflow.allow"
+		local repo
+		repo=$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd) || die "selftest: cannot locate the repo"
+		command -v go >/dev/null 2>&1 || die "selftest --offline needs go to build internal/dogfoodguard"
+		( cd "${repo}" && go build -o "${root}/real/dogfoodguard" ./internal/dogfoodguard ) \
+			|| die "selftest: could not build the classifier"
 	fi
 
 	ROOT="${root}"
 	load_policy || die "selftest: ${POLICY_ERROR}"
+	st_reset_ledger
 
 	local td="${ROOT}/ledger/_selftest"
 	rm -rf "${td}"; mkdir -p "${td}/good" "${td}/bad"
 	printf '{"blockId":"%sdemo","name":"d","version":"1.0.0","kind":"page"}\n' "${SLUG_PREFIX}" > "${td}/good/block.manifest.json"
 	printf '{"blockId":"someones-real-app","name":"d","version":"1.0.0","kind":"page"}\n'        > "${td}/bad/block.manifest.json"
 
-	note "--- forbidden commands ---"
-	st_check "upgrade denied"                      "DENY"  "$(vd upgrade)"
-	st_check "login denied"                        "DENY"  "$(vd login --token x)"
-	st_check "app dev-tunnel denied"               "DENY"  "$(vd app dev-tunnel)"
-	st_check "app dev-token denied"                "DENY"  "$(vd app dev-token)"
-	st_check "unknown top-level command denied"    "DENY"  "$(vd frobnicate --yes)"
-	st_check "unknown app subcommand denied"       "DENY"  "$(vd app frobnicate)"
-	st_check "unknown listing verb denied"         "DENY"  "$(vd app listing frobnicate)"
+	note "--- the classifier is the REAL cobra tree ---"
+	st_check "classifier present" "yes" "$([ -x "${ROOT}/real/dogfoodguard" ] && printf yes || printf no)"
+	st_check "an unclassifiable invocation denies" "DENY" "$(vd --definitely-not-a-flag)"
 
-	note "--- FINDING 1: root persistent flags must not hide the command ---"
-	st_check "--no-color generate is still a spend"    "DENY" "$(vd --no-color generate cat --yes)"
-	st_check "--no-color upgrade still denied"         "DENY" "$(vd --no-color upgrade)"
-	st_check "--no-update-check upgrade still denied"  "DENY" "$(vd --no-update-check upgrade)"
-	st_check "--color login still denied"              "DENY" "$(vd --color login --token x)"
-	st_check "app --no-color submit foreign denied"    "DENY" "$(vd app --no-color submit "${td}/bad" --yes)"
-	st_check "--no-color app withdraw denied"          "DENY" "$(vd --no-color app withdraw pubreq_OTHER)"
-	st_check "--no-color generate --max-cost is spend" "ALLOW_SPEND" "$(vd --no-color generate cat --yes --max-cost 5)"
-	note "    the REASON must be the real branch, not the unknown-command fallback"
-	st_reason "--no-color generate refused for the MONEY reason" "--max-cost" \
-		--no-color generate cat --yes
-	st_reason "--no-color upgrade refused AS upgrade" "replace the binary" \
-		--no-color upgrade
-	st_reason "app --no-color submit foreign refused on the PREFIX" "sanctioned prefix" \
-		app --no-color submit "${td}/bad" --yes
-	st_reason "--no-color app withdraw refused on the ALLOWLIST" "not created by this sandbox" \
-		--no-color app withdraw pubreq_OTHER
+	# 🔴 The shim and the classifier are versioned together. Output the shim
+	# does not fully understand means they have DRIFTED, and drift is exactly
+	# the failure this whole design removes — so it denies rather than acting on
+	# the fields it did recognise. Only runnable where the classifier is
+	# writable (the offline root); the credentialed sandbox locks it 0500.
+	local fake="${ROOT}/ledger/_fakeguard"
+	mkfake() { printf '#!/usr/bin/env bash\n%s\n' "$1" > "${fake}"; chmod 0755 "${fake}"; GUARD_BIN="${fake}"; }
+	mkfake 'printf "ok\t1\npath\tgenerate\nbogus\tx\n"'
+	st_reason "an UNRECOGNISED classifier field denies" "could not be classified" generate cat --yes --max-cost 5
+	mkfake 'printf "path\tgenerate\n"'
+	st_reason "classifier output with no ok field denies" "could not be classified" generate cat --yes --max-cost 5
+	mkfake 'exit 9'
+	st_reason "a silent non-zero classifier denies" "could not be classified" generate cat --dry-run
+	mkfake 'printf "ok\t1\npath\tgenerate\nargc\tnotanumber\n"'
+	st_reason "a non-numeric argument count denies" "could not be classified" generate cat --dry-run
+	# A classifier that claims everything is a harmless read must still not be
+	# able to say so from OUTSIDE the sandbox: GUARD_BIN is reset at startup, so
+	# an exported value cannot reach the gate.
+	mkfake 'printf "ok\t1\npath\twhoami\nargc\t0\n"'
+	st_check "an injected classifier IS honoured inside the selftest" "ALLOW" "$(vd generate cat --yes)"
+	GUARD_BIN=""; rm -f "${fake}"
+	st_check "the real classifier is back" "DENY" "$(vd generate cat --yes)"
+	st_check "an INHERITED GUARD_BIN is ignored" "DENY" \
+		"$(GUARD_BIN=/bin/true bash "$0" __verdict --root "${ROOT}" -- generate cat --yes 2>/dev/null)"
 
-	note "--- FINDING 2: --help as a flag VALUE is not a help request ---"
-	st_check "genuine generate --help"                 "ALLOW" "$(vd generate --help)"
-	st_check "genuine upgrade --help"                  "ALLOW" "$(vd upgrade --help)"
-	st_check "genuine app listing set-icon --help"     "ALLOW" "$(vd app listing set-icon --help)"
-	st_check "bare --help"                             "ALLOW" "$(vd --help)"
-	st_check "--negative-prompt --help is NOT help"    "DENY"  "$(vd generate cat --yes --negative-prompt --help)"
-	st_check "--ecosystem --help is NOT help"          "DENY"  "$(vd generate cat --yes --ecosystem --help)"
-	st_check "submit -o --help is NOT help"            "DENY"  "$(vd app submit "${td}/bad" --yes -o --help)"
-	st_check "--negative-prompt -h is NOT help"        "DENY"  "$(vd generate cat --yes --negative-prompt -h)"
-	note "    (and the same trick aimed at --dry-run, which the audit did not list)"
-	st_check "--negative-prompt --dry-run is NOT free" "DENY"  "$(vd generate cat --yes --negative-prompt --dry-run)"
-	st_check "--input --print-input is NOT free"       "DENY"  "$(vd generate --yes --input --print-input)"
-	st_check "an unknown flag before --dry-run is not free" "DENY" "$(vd generate cat --yes --mystery --dry-run)"
+	note "--- forbidden commands (reason-pinned, so no bystander can carry them) ---"
+	st_reason "upgrade denied AS upgrade"        "replace the binary"        upgrade
+	st_reason "login denied AS login"            "already authenticated"     login --token x
+	st_reason "dev-tunnel denied AS dev-tunnel"  "out of scope"              app dev-tunnel
+	st_reason "dev-token denied AS dev-token"    "out of scope"              app dev-token
+	st_reason "unknown top-level denied"         "not a subcommand"          frobnicate
+	st_reason "unknown app subcommand denied"    "not a subcommand"          app frobnicate
+	st_reason "unknown listing verb denied"      "not a subcommand"          app listing frobnicate
+	st_reason "unknown workflows verb denied"    "not a subcommand"          workflows frobnicate
+
+	note "--- root persistent flags before the subcommand ---"
+	st_reason "--no-color generate hits the MONEY branch" "--max-cost" --no-color generate cat --yes
+	st_reason "--no-color upgrade denied AS upgrade"      "replace the binary" --no-color upgrade
+	st_reason "--no-update-check upgrade denied"          "replace the binary" --no-update-check upgrade
+	st_reason "--color login denied AS login"             "already authenticated" --color login --token x
+	st_reason "app --no-color submit foreign on PREFIX"   "sanctioned prefix" app --no-color submit "${td}/bad" --yes
+	st_check  "--no-color generate --max-cost is a spend" "ALLOW_SPEND" "$(vd --no-color generate cat --yes --max-cost 5)"
+
+	note "--- a flag VALUE that looks like a flag ---"
+	st_check "--negative-prompt --help is NOT help"     "DENY" "$(vd generate cat --yes --negative-prompt --help)"
+	st_check "--negative-prompt --dry-run is NOT free"  "DENY" "$(vd generate cat --yes --negative-prompt --dry-run)"
+	st_check "--ecosystem --print-input is NOT free"    "DENY" "$(vd generate cat --yes --ecosystem --print-input)"
+	st_check "submit -o --help is NOT help"             "DENY" "$(vd app submit "${td}/bad" --yes -o --help)"
+	st_check "genuine generate --help"                  "ALLOW" "$(vd generate --help)"
+	st_check "genuine upgrade --help"                   "ALLOW" "$(vd upgrade --help)"
+	st_check "genuine listing set-icon --help"          "ALLOW" "$(vd app listing set-icon --help)"
+	st_check "bare --help"                              "ALLOW" "$(vd --help)"
+
+	note "--- 🔴 ALL TWELVE pflag boolean spellings, on every gated bool ---"
+	local v
+	for v in 1 t T TRUE true True; do
+		st_check "--dry-run=${v} is a free preview"      "ALLOW" "$(vd generate cat --yes --dry-run="${v}")"
+		st_check "--print-input=${v} is a free preview"  "ALLOW" "$(vd generate cat --yes --print-input="${v}")"
+	done
+	for v in 0 f F FALSE false False; do
+		st_check "--dry-run=${v} still SPENDS"           "DENY"  "$(vd generate cat --yes --dry-run="${v}")"
+		st_check "--print-input=${v} still SPENDS"       "DENY"  "$(vd generate cat --yes --print-input="${v}")"
+		st_check "--help=${v} is NOT a help request"     "DENY"  "$(vd generate cat --yes --help="${v}")"
+		st_reason "--package-only=${v} still gated"      "sanctioned prefix" app submit "${td}/bad" --yes --package-only="${v}"
+	done
+	for v in 1 t T TRUE true True; do
+		st_check "--help=${v} IS a help request"         "ALLOW" "$(vd generate cat --yes --help="${v}")"
+		st_check "--package-only=${v} never submits"     "ALLOW" "$(vd app submit "${td}/bad" --yes --package-only="${v}")"
+	done
+	st_reason "an unparseable bool value denies"  "would reject these flags" generate cat --yes --dry-run=maybe
+	st_reason "an unparseable int value denies"   "would reject these flags" generate cat --yes --max-cost abc
+	st_reason "--max-cost 08 denies (not a crash)" "would reject these flags" generate cat --yes --max-cost 08
 
 	note "--- generate money path ---"
-	st_check "real dry-run is free"                "ALLOW"       "$(vd generate cat --dry-run)"
-	st_check "real print-input is free"            "ALLOW"       "$(vd generate cat --print-input)"
-	st_check "no --max-cost denied"                "DENY"        "$(vd generate cat --yes)"
-	st_check "--max-cost over ceiling denied"      "DENY"        "$(vd generate cat --yes --max-cost 101)"
-	st_check "--max-cost at ceiling allowed"       "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 100)"
-	st_check "--max-cost=N form"                   "ALLOW_SPEND" "$(vd generate cat --yes --max-cost=1)"
-	st_check "non-numeric --max-cost denied"       "DENY"        "$(vd generate cat --yes --max-cost abc)"
-	note "    LAST --max-cost wins, as pflag does"
-	st_check "--max-cost 5 then 99999 denied"      "DENY"        "$(vd generate cat --yes --max-cost 5 --max-cost 99999)"
-	st_check "--max-cost 99999 then 5 allowed"     "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 99999 --max-cost 5)"
+	st_check "real dry-run is free"            "ALLOW"       "$(vd generate cat --dry-run)"
+	st_check "no --max-cost denied"            "DENY"        "$(vd generate cat --yes)"
+	st_check "--max-cost at ceiling allowed"   "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 100)"
+	st_check "--max-cost=N form"               "ALLOW_SPEND" "$(vd generate cat --yes --max-cost=1)"
+	st_reason "--max-cost over ceiling denied" "per-invocation ceiling" generate cat --yes --max-cost 101
+	st_check "LAST --max-cost wins (5 then 99999)"  "DENY"        "$(vd generate cat --yes --max-cost 5 --max-cost 99999)"
+	st_check "LAST --max-cost wins (99999 then 5)"  "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 99999 --max-cost 5)"
+	st_reason "--no-wait refused by default"   "settled" generate cat --yes --max-cost 5 --no-wait
+
+	note "--- 🔴 EACH CAP, ISOLATED, REASON-PINNED ---"
+	st_reset_ledger 2000 0 0 0 0
+	st_reason "TOTAL_SPEND_CAP branch"        "total spend cap" generate cat --yes --max-cost 1
+	st_reset_ledger 1995 0 0 0 0
+	st_reason "remaining-budget branch"       "left under this run's total cap" generate cat --yes --max-cost 50
+	st_reset_ledger 0 0 20 0 0
+	st_reason "MAX_GENERATE_SUBMITS branch"   "generation cap" generate cat --yes --max-cost 1
+	# A reservation alone must reach the cap: 0 observed + 2000 in flight is a
+	# full budget even though nothing has settled yet.
+	st_reset_ledger 0 2000 0 0 0
+	st_reason "the RESERVATION alone reaches the cap" "committed in flight" generate cat --yes --max-cost 1
+	st_reset_ledger 0 1999 0 0 0
+	st_reason "a reservation shrinks the remaining budget" "left under this run's total cap" generate cat --yes --max-cost 5
+	st_reset_ledger 0 0 0 3 0
+	st_reason "MAX_APP_SUBMITS branch"        "app-submission cap" app submit "${td}/good" --yes
+	st_reset_ledger 0 0 0 0 10
+	st_reason "MAX_LISTING_MUTATIONS branch"  "listing-mutation cap" app listing set-icon i.png --dir "${td}/good"
+	st_reset_ledger
+
+	note "--- 🔴 a malformed or EMPTY ledger scalar is not zero ---"
+	local f
+	for f in observed_spend reserved generate_submits; do
+		printf 'garbage\n' > "${ROOT}/ledger/${f}"
+		st_reason "malformed ${f} refuses a spend" "unreadable or malformed" generate cat --yes --max-cost 5
+		: > "${ROOT}/ledger/${f}"
+		st_reason "EMPTY ${f} refuses a spend"     "unreadable or malformed" generate cat --yes --max-cost 5
+		write_scalar "${f}" 0
+	done
+	printf 'garbage\n' > "${ROOT}/ledger/app_submits"
+	st_reason "malformed app_submits refuses a submit" "unreadable or malformed" app submit "${td}/good" --yes
+	write_scalar app_submits 0
+	printf 'garbage\n' > "${ROOT}/ledger/listing_mutations"
+	st_reason "malformed listing_mutations refuses" "unreadable or malformed" app listing set-icon i.png --dir "${td}/good"
+	write_scalar listing_mutations 0
 
 	note "--- app identity gating ---"
-	st_check "submit sanctioned"                   "ALLOW_APP_SUBMIT" "$(vd app submit "${td}/good" --yes)"
-	st_check "submit foreign denied"               "DENY"             "$(vd app submit "${td}/bad" --yes)"
-	st_check "submit -o value not read as dir"     "ALLOW_APP_SUBMIT" "$(vd app submit -o "${td}/bad" "${td}/good")"
-	st_check "package-only allowed"                "ALLOW"            "$(vd app submit "${td}/bad" --package-only)"
-	st_check "listing foreign --slug denied"       "DENY"             "$(vd app listing set-icon i.png --slug someones-real-app)"
-	st_check "listing sanctioned --dir"            "ALLOW"            "$(vd app listing set-icon i.png --dir "${td}/good")"
-	st_check "listing unidentifiable denied"       "DENY"             "$(vd app listing set-icon i.png --dir "${ROOT}/ledger")"
-	st_check "listing status is a read"            "ALLOW"            "$(vd app listing status)"
+	st_check "submit sanctioned"               "ALLOW_APP_SUBMIT" "$(vd app submit "${td}/good" --yes)"
+	st_reason "submit foreign denied"          "sanctioned prefix" app submit "${td}/bad" --yes
+	st_check "submit -o value not read as dir" "ALLOW_APP_SUBMIT" "$(vd app submit -o "${td}/bad" "${td}/good")"
+	st_check "listing sanctioned --dir"        "ALLOW_LISTING"    "$(vd app listing set-icon i.png --dir "${td}/good")"
+	st_reason "listing foreign --slug denied"  "may not touch the account's real listings" app listing set-icon i.png --slug someones-real-app
+	st_reason "listing unidentifiable denied"  "cannot identify" app listing set-icon i.png --dir "${ROOT}/ledger"
+	st_check "listing status is a read"        "ALLOW" "$(vd app listing status)"
 
-	note "--- FINDING 9: withdraw ---"
-	st_check "unknown pubreq id denied"            "DENY"  "$(vd app withdraw pubreq_UNKNOWN)"
-	st_check "non-pubreq-shaped id denied"         "DENY"  "$(vd app withdraw NOT-A-PUBREQ-ID)"
-	st_check "--id form denied"                    "DENY"  "$(vd app withdraw --id NOT-A-PUBREQ-ID)"
-	st_check "no id at all is a CLI usage error"   "ALLOW" "$(vd app withdraw)"
+	note "--- withdraw + workflows cancel allowlists ---"
+	st_reason "unknown pubreq denied"          "not created by this sandbox" app withdraw pubreq_UNKNOWN
+	st_reason "non-pubreq-shaped id denied"    "not created by this sandbox" app withdraw NOT-A-PUBREQ-ID
+	st_reason "--id form denied"               "not created by this sandbox" app withdraw --id NOT-A-PUBREQ
+	st_check  "no id is a CLI usage error"     "ALLOW" "$(vd app withdraw)"
 	printf 'pubreq_MINE\n' >> "${ROOT}/ledger/pubreq.allow"
-	st_check "allowlisted id permitted"            "ALLOW" "$(vd app withdraw pubreq_MINE)"
+	st_check  "allowlisted pubreq permitted"   "ALLOW" "$(vd app withdraw pubreq_MINE)"
+	st_reason "cancel of a foreign workflow denied" "DOES NOT REFUND" workflows cancel someone-elses
+	printf 'wf-mine\n' >> "${ROOT}/ledger/workflow.allow"
+	st_check  "cancel of our own workflow allowed" "ALLOW" "$(vd workflows cancel wf-mine)"
+	st_check  "workflows list is a read"       "ALLOW" "$(vd workflows list)"
 
-	note "--- FINDING 3: malformed policy / ledger fails CLOSED ---"
-	printf 'garbage\n' > "${ROOT}/ledger/observed_spend"
-	st_check "malformed observed_spend denies spend" "DENY" "$(vd generate cat --yes --max-cost 5)"
-	printf '0\n' > "${ROOT}/ledger/observed_spend"
-	printf '\n' > "${ROOT}/ledger/reserved"
-	st_check "empty reserved reads as 0"             "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
-	printf 'x\n' > "${ROOT}/ledger/reserved"
-	st_check "malformed reserved denies spend"       "DENY" "$(vd generate cat --yes --max-cost 5)"
-	printf '0\n' > "${ROOT}/ledger/reserved"
-	local saved_pc="${PER_CALL_MAX_COST}"
+	note "--- calibration + meter_broken gates ---"
+	printf 'REQUIRE_CALIBRATION=1\n' >> "${ROOT}/ledger/policy.env"
+	load_policy || die "selftest: policy reload failed"
+	st_reason "uncalibrated meter refuses to spend" "calibrated" generate cat --yes --max-cost 5
+	printf 'calibrated\n' > "${ROOT}/ledger/calibration.ok"
+	st_check  "calibrated meter may spend" "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
+	: > "${ROOT}/ledger/meter_broken"
+	st_reason "a broken meter refuses to spend" "no longer being counted" generate cat --yes --max-cost 5
+	st_check  "dry-run still allowed with a broken meter" "ALLOW" "$(vd generate cat --dry-run)"
+	rm -f "${ROOT}/ledger/meter_broken" "${ROOT}/ledger/calibration.ok"
+	grep -v '^REQUIRE_CALIBRATION=1$' "${ROOT}/ledger/policy.env" > "${ROOT}/ledger/p.tmp"
+	mv "${ROOT}/ledger/p.tmp" "${ROOT}/ledger/policy.env"
+	load_policy || die "selftest: policy restore failed"
+
+	note "--- policy validation ---"
 	local pol="${ROOT}/ledger/policy.env" bak="${ROOT}/ledger/policy.bak"
 	cp "${pol}" "${bak}"
-	grep -v '^PER_CALL_MAX_COST=' "${bak}" > "${pol}"
-	if load_policy; then
-		st_check "policy missing a key is rejected" "rejected" "accepted"
-	else
-		st_check "policy missing a key is rejected" "rejected" "rejected"
-	fi
+	local key
+	for key in PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS \
+	           MAX_LISTING_MUTATIONS REQUIRE_CALIBRATION ALLOW_NO_WAIT METER_SETTLE_SECONDS; do
+		grep -v "^${key}=" "${bak}" > "${pol}"
+		if load_policy; then st_check "policy without ${key} rejected" "rejected" "accepted"
+		else st_check "policy without ${key} rejected" "rejected" "rejected"; fi
+	done
+	# 🔴 An EMPTY SLUG_PREFIX matches every blockId, so it is not merely a
+	# missing key — it is a gate that silently passes the account's real apps.
+	sed 's/^SLUG_PREFIX=.*/SLUG_PREFIX=""/' "${bak}" > "${pol}"
+	if load_policy; then st_check "policy with an EMPTY SLUG_PREFIX rejected" "rejected" "accepted"
+	else st_check "policy with an EMPTY SLUG_PREFIX rejected" "rejected" "rejected"; fi
 	printf 'PER_CALL_MAX_COST=notanumber\n' >> "${pol}"
-	if load_policy; then
-		st_check "policy with a non-numeric key is rejected" "rejected" "accepted"
-	else
-		st_check "policy with a non-numeric key is rejected" "rejected" "rejected"
-	fi
+	if load_policy; then st_check "non-numeric policy key rejected" "rejected" "accepted"
+	else st_check "non-numeric policy key rejected" "rejected" "rejected"; fi
 	cp "${bak}" "${pol}"; rm -f "${bak}"
 	load_policy || die "selftest: could not restore the policy"
-	st_check "policy restored" "${saved_pc}" "${PER_CALL_MAX_COST}"
 
-	note "--- FINDING 4: the meter_broken latch stops the money path ---"
-	: > "${ROOT}/ledger/meter_broken"
-	st_check "spend refused once the meter is broken" "DENY"  "$(vd generate cat --yes --max-cost 5)"
-	st_check "dry-run still allowed"                  "ALLOW" "$(vd generate cat --dry-run)"
-	rm -f "${ROOT}/ledger/meter_broken"
-
-	note "--- FINDING 5: the balance parser ---"
+	note "--- the balance parser ---"
 	local j
 	for j in '{"total":3.5}' '{"total":1e9}' '{"total":-500}' '{"total":99999999999999999999}' \
 	         '{"blue":1}' '' '{"total":}' '{"total":1,"total":2}'; do
@@ -1231,32 +1496,24 @@ OFFLINE
 			st_check "parser rejects ${j:-<empty>}" "reject" "reject"
 		fi
 	done
-	st_check "parser accepts compact"        "4187454" "$(parse_buzz_total '{"total":4187454}' || printf FAILED)"
-	st_check "parser accepts spaced/pretty"  "4187454" "$(parse_buzz_total '{
+	st_check "parser accepts compact"       "4187454" "$(parse_buzz_total '{"total":4187454}' || printf FAILED)"
+	st_check "parser accepts pretty"        "4187454" "$(parse_buzz_total '{
   "blue": 1338425,
-  "green": 999980,
-  "total": 4187454,
-  "yellow": 1849049
+  "total": 4187454
 }' || printf FAILED)"
-	st_check "parser accepts a real zero"    "0"       "$(parse_buzz_total '{"total":0}' || printf FAILED)"
+	st_check "parser accepts a real zero"   "0" "$(parse_buzz_total '{"total":0}' || printf FAILED)"
 
-	note "--- FINDING 6: the ledger lock exists ---"
-	if command -v flock >/dev/null 2>&1; then
-		st_check "flock is available" "yes" "yes"
-	else
-		st_check "flock is available" "yes" "no"
-	fi
-
-	note "--- FINDING 7: TSV escaping ---"
-	st_check "newline escaped"  'a\nb'  "$(tsv_escape "$(printf 'a\nb')")"
-	st_check "tab escaped"      'a\tb'  "$(tsv_escape "$(printf 'a\tb')")"
+	note "--- TSV escaping + lock ---"
+	st_check "newline escaped" 'a\nb' "$(tsv_escape "$(printf 'a\nb')")"
+	st_check "tab escaped"     'a\tb' "$(tsv_escape "$(printf 'a\tb')")"
 	st_check "argv scrub escapes a newline" 'gen a\nDENY\tx' "$(scrub_argv gen "$(printf 'a\nDENY\tx')")"
-	st_check "token redacted"   'login --token <redacted>' "$(scrub_argv login --token SECRETVALUE)"
+	st_check "token redacted"  'login --token <redacted>' "$(scrub_argv login --token SECRETVALUE)"
+	st_check "flock available" "yes" "$(command -v flock >/dev/null 2>&1 && printf yes || printf no)"
 
 	rm -rf "${td}"
 
 	if [ "${offline}" = 1 ]; then
-		selftest_e2e
+		selftest_e2e "${ROOT}/real/dogfoodguard"
 		note ""
 		note "--- offline mode: the credentialed checks below were skipped ---"
 		rm -rf "${ROOT}"
@@ -1274,7 +1531,9 @@ OFFLINE
 		note "--- lockdown ---"
 		st_check "binary dir not writable"  "no" "$([ -w "${ROOT}/real" ] && printf yes || printf no)"
 		st_check "binary file not writable" "no" "$([ -w "${ROOT}/real/civitai" ] && printf yes || printf no)"
+		st_check "classifier present"       "yes" "$([ -x "${ROOT}/real/dogfoodguard" ] && printf yes || printf no)"
 		st_check "sandbox config exists"    "yes" "$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+		st_reset_ledger
 	fi
 
 	note ""
@@ -1284,15 +1543,17 @@ OFFLINE
 
 # ---------------------------------------------------------------------------
 # End-to-end exercise of the GUARD (not just the classifier), driven by a stub
-# binary that charges a known amount. This is what makes the meter, the lock
-# and the ledger regression-testable without a credential or a network — the
-# classifier being right says nothing about whether the guard acts on it.
+# binary that charges a known amount. The classifier being right says nothing
+# about whether the guard acts on it.
 # ---------------------------------------------------------------------------
 selftest_e2e() {
 	local base="${TMPDIR:-/tmp}/dogfood-e2e-$$"
+	local guard_src="$1"
 	rm -rf "${base}"
 	mkdir -p "${base}/real" "${base}/bin" "${base}/ledger" \
 	         "${base}/home/.config" "${base}/home/.cache" "${base}/workspace"
+	cp "${guard_src}" "${base}/real/dogfoodguard" || { st_check "e2e classifier copied" yes no; return; }
+	chmod 0755 "${base}/real/dogfoodguard"
 
 	cat > "${base}/real/civitai" <<'STUB'
 #!/usr/bin/env bash
@@ -1300,17 +1561,18 @@ set -u
 BAL="${XDG_CACHE_HOME}/bal"; NB="${XDG_CACHE_HOME}/nbuzz"
 [ -f "${BAL}" ] || echo 10000 > "${BAL}"
 [ -f "${NB}" ]  || echo 0 > "${NB}"
-args=()
-for a in "$@"; do
-  case "${a}" in --no-color|--color|--no-update-check) ;; *) args+=("${a}") ;; esac
-done
+args=(); for a in "$@"; do case "${a}" in --no-color|--color|--no-update-check) ;; *) args+=("${a}") ;; esac; done
 set -- "${args[@]+"${args[@]}"}"
 case "${1:-}" in
   buzz)
     n=$(cat "${NB}"); echo $(( n + 1 )) > "${NB}"
     if [ -n "${STUB_FLAKY_BUZZ:-}" ] && [ $(( n % 2 )) = 1 ]; then echo boom >&2; exit 5; fi
     printf '{\n  "total": %s\n}\n' "$(cat "${BAL}")" ;;
-  generate) echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; echo generated ;;
+  generate)
+    if [ -n "${STUB_LAGGY:-}" ]; then :                       # charge never lands
+    elif [ -n "${STUB_CREDIT:-}" ]; then echo $(( $(cat "${BAL}") - 37 + 100 )) > "${BAL}"
+    else echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; fi
+    echo generated ;;
   *) : ;;
 esac
 exit 0
@@ -1323,81 +1585,124 @@ exec "$(readlink -f "$0")" guard --root "${base}" -- "\$@"
 SHIM
 	chmod 0755 "${base}/bin/civitai"
 
-	cat > "${base}/ledger/policy.env" <<POL
+	e2e_policy() {
+		cat > "${base}/ledger/policy.env" <<POL
 ROOT="${base}"
 PER_CALL_MAX_COST=100
 TOTAL_SPEND_CAP=2000
 MAX_GENERATE_SUBMITS=50
 MAX_APP_SUBMITS=3
+MAX_LISTING_MUTATIONS=10
+METER_SETTLE_SECONDS=0
+REQUIRE_CALIBRATION=${1:-0}
+ALLOW_NO_WAIT=0
 SLUG_PREFIX="sanctioned-"
 BASE_URL="https://example.invalid"
 POL
-	: > "${base}/ledger/invocations.tsv"; : > "${base}/ledger/buzz.tsv"
-	: > "${base}/ledger/spend.tsv";       : > "${base}/ledger/pubreq.allow"
-	printf '0\n' > "${base}/ledger/observed_spend"
-	printf '0\n' > "${base}/ledger/reserved"
-	printf '0\n' > "${base}/ledger/generate_submits"
-	printf '0\n' > "${base}/ledger/app_submits"
+	}
+	e2e_reset() {
+		: > "${base}/ledger/invocations.tsv"; : > "${base}/ledger/buzz.tsv"
+		: > "${base}/ledger/spend.tsv";       : > "${base}/ledger/pubreq.allow"
+		: > "${base}/ledger/workflow.allow"
+		local f
+		for f in observed_spend reserved generate_submits app_submits listing_mutations; do
+			printf '0\n' > "${base}/ledger/${f}"
+		done
+		printf '10000\n' > "${base}/home/.cache/bal"
+		printf '0\n' > "${base}/home/.cache/nbuzz"
+		rm -f "${base}/ledger/meter_broken" "${base}/ledger/calibration.ok"
+	}
+	e2e_policy 0; e2e_reset
 
-	local C="${base}/bin/civitai"
-	local rc meter lines allow
+	local C="${base}/bin/civitai" rc allow lines i
 
 	note "--- end-to-end through the real guard (stub charges 37) ---"
 
 	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1; rc=$?
-	meter=$(cat "${base}/ledger/observed_spend")
-	st_check "e2e allowed spend returns the CLI's rc" "0" "${rc}"
-	st_check "e2e meter moved by the real charge"     "37" "${meter}"
+	st_check "e2e allowed spend returns the CLI's rc" "0"  "${rc}"
+	st_check "e2e meter moved by the real charge"     "37" "$(cat "${base}/ledger/observed_spend")"
 
-	"${C}" --no-color generate cat --yes >/dev/null 2>&1; rc=$?
-	st_check "e2e --no-color generate refused"        "126" "${rc}"
-
-	"${C}" generate cat --yes --negative-prompt --help >/dev/null 2>&1; rc=$?
-	st_check "e2e --negative-prompt --help refused"   "126" "${rc}"
-
-	"${C}" --no-update-check upgrade >/dev/null 2>&1; rc=$?
-	st_check "e2e --no-update-check upgrade refused"  "126" "${rc}"
-
-	"${C}" frobnicate --yes >/dev/null 2>&1; rc=$?
-	st_check "e2e an unrecognised command refused"    "126" "${rc}"
-
-	# The guard must refuse everything when its own policy will not validate.
-	cp "${base}/ledger/policy.env" "${base}/ledger/policy.keep"
-	grep -v '^TOTAL_SPEND_CAP=' "${base}/ledger/policy.keep" > "${base}/ledger/policy.env"
-	"${C}" whoami >/dev/null 2>&1; rc=$?
-	st_check "e2e a malformed policy refuses even a read" "126" "${rc}"
-	cp "${base}/ledger/policy.keep" "${base}/ledger/policy.env"
-	rm -f "${base}/ledger/policy.keep"
+	"${C}" --no-color generate cat --yes >/dev/null 2>&1
+	st_check "e2e --no-color generate refused"        "126" "$?"
+	"${C}" generate cat --yes --print-input=false >/dev/null 2>&1
+	st_check "e2e --print-input=false refused"        "126" "$?"
+	"${C}" generate cat --yes --dry-run=false >/dev/null 2>&1
+	st_check "e2e --dry-run=false refused"            "126" "$?"
+	"${C}" generate cat --yes --negative-prompt --help >/dev/null 2>&1
+	st_check "e2e --negative-prompt --help refused"   "126" "$?"
+	"${C}" --no-update-check upgrade >/dev/null 2>&1
+	st_check "e2e --no-update-check upgrade refused"  "126" "$?"
+	"${C}" frobnicate >/dev/null 2>&1
+	st_check "e2e an unrecognised command refused"    "126" "$?"
+	"${C}" workflows cancel someone-elses >/dev/null 2>&1
+	st_check "e2e cancel of a foreign workflow refused" "126" "$?"
+	"${C}" generate cat --yes --max-cost 08 >/dev/null 2>&1; rc=$?
+	st_check "e2e --max-cost 08 refuses cleanly"      "126" "${rc}"
 
 	lines=$(wc -l < "${base}/ledger/invocations.tsv")
 	"${C}" generate "$(printf 'a\nDENY\tinjected')" --yes --max-cost 5 >/dev/null 2>&1
 	st_check "e2e a newline prompt adds ONE ledger row" "1" \
 		"$(( $(wc -l < "${base}/ledger/invocations.tsv") - lines ))"
+	st_check "e2e ALLOW rows carry a reason" "yes" \
+		"$(awk -F'\t' '$2 ~ /^ALLOW/ && $6 != "" {n++} END{print (n>0)?"yes":"no"}' "${base}/ledger/invocations.tsv")"
+
+	# The guard must refuse everything when its own policy will not validate.
+	cp "${base}/ledger/policy.env" "${base}/ledger/policy.keep"
+	grep -v '^TOTAL_SPEND_CAP=' "${base}/ledger/policy.keep" > "${base}/ledger/policy.env"
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e a malformed policy refuses even a read" "126" "$?"
+	cp "${base}/ledger/policy.keep" "${base}/ledger/policy.env"
+	rm -f "${base}/ledger/policy.keep"
 
 	# Concurrency: leave exactly 10 Buzz of headroom and fire 8 at once.
-	printf '1990\n' > "${base}/ledger/observed_spend"
-	printf '0\n' > "${base}/ledger/reserved"
-	printf '0\n' > "${base}/ledger/generate_submits"
-	: > "${base}/ledger/invocations.tsv"
-	local i
+	e2e_reset; printf '1990\n' > "${base}/ledger/observed_spend"
 	for i in 1 2 3 4 5 6 7 8; do "${C}" generate "p${i}" --yes --max-cost 10 >/dev/null 2>&1 & done
 	wait
 	allow=$(grep -c 'ALLOW_SPEND' "${base}/ledger/invocations.tsv" 2>/dev/null || printf 0)
 	st_check "e2e 8 concurrent submits, 10 Buzz headroom" "1" "${allow}"
 	st_check "e2e submit counter matches the allowed rows" "${allow}" "$(cat "${base}/ledger/generate_submits")"
 
-	# A post-call balance read that fails must charge the worst case and latch.
-	printf '0\n' > "${base}/ledger/observed_spend"
-	printf '0\n' > "${base}/ledger/reserved"
-	printf '0\n' > "${base}/ledger/generate_submits"
-	printf '0\n' > "${base}/home/.cache/nbuzz"
-	rm -f "${base}/ledger/meter_broken"
+	note "--- 🔴 the three ways the meter can lie, each must LATCH ---"
+
+	e2e_reset
 	STUB_FLAKY_BUZZ=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
-	st_check "e2e a lost post-sample charges the worst case" "60" "$(cat "${base}/ledger/observed_spend")"
-	st_check "e2e a lost post-sample latches meter_broken"   "yes" \
+	st_check "e2e a FAILED post-read charges the worst case" "60" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e a FAILED post-read latches"                "yes" \
 		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	e2e_reset
+	STUB_LAGGY=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e a ZERO delta charges the worst case"       "60" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e a ZERO delta latches"                      "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1
+	st_check "e2e spend refused after the latch"             "126" "$?"
+
+	e2e_reset
+	STUB_CREDIT=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e a NEGATIVE delta charges the worst case"   "60" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e a NEGATIVE delta latches"                  "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	note "--- 🔴 a truncated or unwritable ledger must not restart the caps ---"
+	e2e_reset
+	: > "${base}/ledger/generate_submits"
+	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1
+	st_check "e2e an EMPTIED counter refuses a spend" "126" "$?"
+	e2e_reset
+	chmod 0444 "${base}/ledger/generate_submits"
 	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1; rc=$?
-	st_check "e2e spend refused after the latch"            "126" "${rc}"
+	chmod 0644 "${base}/ledger/generate_submits"
+	st_check "e2e an UNWRITABLE counter refuses a spend" "126" "${rc}"
+	st_check "e2e nothing was charged in that attempt"   "10000" "$(cat "${base}/home/.cache/bal")"
+
+	note "--- calibration gate, end to end ---"
+	e2e_policy 1; e2e_reset
+	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1
+	st_check "e2e uncalibrated refuses to spend" "126" "$?"
+	printf 'calibrated\n' > "${base}/ledger/calibration.ok"
+	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1
+	st_check "e2e calibrated may spend"          "0" "$?"
 
 	rm -rf "${base}"
 }
@@ -1412,6 +1717,7 @@ main() {
 	[ $# -gt 0 ] && shift
 	case "${sub}" in
 		init)          cmd_init "$@" ;;
+		calibrate)     cmd_calibrate "$@" ;;
 		guard)         cmd_guard "$@" ;;
 		status)        cmd_status "$@" ;;
 		finish)        cmd_finish "$@" ;;
@@ -1420,6 +1726,7 @@ main() {
 		allow-pubreq)  cmd_allow_pubreq "$@" ;;
 		teardown)      cmd_teardown "$@" ;;
 		__buzz)        cmd_buzz_probe "$@" ;;
+		__verdict)     cmd_verdict "$@" ;;
 		*)             usage ;;
 	esac
 }

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -211,14 +211,6 @@ write_scalar() {
 # read the spend meter uses as its oracle. CIVITAI_TOKEN is cleared so the
 # seeded config file is the only credential.
 # ---------------------------------------------------------------------------
-sandbox_env() {
-	printf '%s\0' \
-		"HOME=${ROOT}/home" \
-		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
-		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
-		"CIVITAI_NO_UPDATE_CHECK=1" \
-		"CIVITAI_BASE_URL=${BASE_URL:-${DEFAULT_BASE_URL}}"
-}
 
 real_cli() {
 	env -u CIVITAI_TOKEN -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
@@ -283,12 +275,46 @@ cmd_buzz_probe() {
 # nothing.
 # ---------------------------------------------------------------------------
 LOCK_HELD=0
+LOCK_WAIT="${LOCK_WAIT:-60}"
 lock_ledger() {
 	command -v flock >/dev/null 2>&1 || return 0   # degraded; reported by selftest
 	exec 9>"${ROOT}/ledger/.lock" || return 1
-	flock -x -w 60 9 || return 1
+	flock -x -w "${LOCK_WAIT}" 9 || return 1
 	LOCK_HELD=1
 	return 0
+}
+
+# Internal: exercise the lock PRIMITIVE directly.
+#
+# 🔴 THE END-TO-END RACE IS NOT A RELIABLE GUARD. Measured with `flock` deleted,
+# the 8-concurrent row reported 1, 2 and 5 allowed submits on three consecutive
+# runs — it passed a third of the time, because process startup (bash, policy
+# load, a sha256 over a 21 MB binary) staggers the racers by more than the
+# critical section takes. A guard that is right two times in three is worse than
+# no guard, so the mutual exclusion is pinned here instead: hold the lock in one
+# process and prove a second cannot take it.
+cmd_locktest() {
+	local root="" mode="" secs="2"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			hold|try) mode="$1"; shift ;;
+			*) secs="$1"; shift ;;
+		esac
+	done
+	ROOT="${root:-${DEFAULT_ROOT}}"
+	case "${mode}" in
+		hold)
+			lock_ledger || { printf 'no-lock'; return 1; }
+			: > "${ROOT}/ledger/.locktest-held"
+			sleep "${secs}"
+			unlock_ledger ;;
+		try)
+			LOCK_WAIT=1
+			if lock_ledger; then printf 'acquired'; unlock_ledger
+			else printf 'blocked'; fi ;;
+		*) printf 'usage'; return 2 ;;
+	esac
 }
 unlock_ledger() {
 	[ "${LOCK_HELD}" = 1 ] || return 0
@@ -401,6 +427,29 @@ cmd_init() {
 exec "${ROOT}/harness/dogfood-sandbox.sh" guard --root "${ROOT}" -- "\$@"
 SHIM
 	chmod 0555 "${ROOT}/bin/civitai"
+
+	# 🔴 npm's LAUNCHER IS A SYMLINK AND `readlink -f` COLLAPSES IT. Resolving
+	# `npm` to its store target puts `lib/node_modules/npm/bin/npm` on PATH, and
+	# node then looks for `npm-prefix.js` beside the NODE binary — measured
+	# inside the jail: `Cannot find module
+	# '…/nodejs-slim/bin/node_modules/npm/bin/npm-prefix.js'`, `npm install`
+	# exited 1, and the agent still could not produce a lockfile. So node/npm in
+	# the closure was necessary but NOT sufficient. These shims invoke npm the
+	# way its own launcher does. Written here because ${ROOT}/bin is locked 0500
+	# at the end of init.
+	local npm_bin npm_dir
+	npm_bin=$(command -v npm 2>/dev/null || true)
+	if [ -n "${npm_bin}" ]; then
+		npm_dir=$(dirname "$(readlink -f "${npm_bin}")")
+		if [ -f "${npm_dir}/npm-cli.js" ]; then
+			printf '#!/usr/bin/env bash\nexec node %q "$@"\n' "${npm_dir}/npm-cli.js" > "${ROOT}/bin/npm"
+			chmod 0555 "${ROOT}/bin/npm"
+		fi
+		if [ -f "${npm_dir}/npx-cli.js" ]; then
+			printf '#!/usr/bin/env bash\nexec node %q "$@"\n' "${npm_dir}/npx-cli.js" > "${ROOT}/bin/npx"
+			chmod 0555 "${ROOT}/bin/npx"
+		fi
+	fi
 
 	: > "${ROOT}/ledger/invocations.tsv"
 	: > "${ROOT}/ledger/buzz.tsv"
@@ -525,6 +574,7 @@ BRIEF
 declare -A GBOOL GINT GSTR GCHANGED
 declare -a GARG
 GPATH=""; GARGC=0; GERR=""; GKIND=""
+GRUNNABLE=""; GHASSUB=""; GARGSERR=""; GBLOCKID=""
 
 # 🔴 ASSIGNED UNCONDITIONALLY AT STARTUP, WHICH IS THE POINT. The selftest
 # swaps in fake classifiers to prove the shim refuses drifted output, and it
@@ -548,6 +598,7 @@ unescape() {
 classify() {
 	GBOOL=(); GINT=(); GSTR=(); GCHANGED=(); GARG=()
 	GPATH=""; GARGC=0; GERR=""; GKIND=""
+	GRUNNABLE=""; GHASSUB=""; GARGSERR=""; GBLOCKID=""
 	local bin="${GUARD_BIN:-${ROOT}/real/dogfoodguard}" out rc ok="" k v
 	if [ ! -x "${bin}" ]; then
 		GERR="the classifier ${bin} is missing or not executable"; return 1
@@ -568,7 +619,12 @@ classify() {
 			bool.*)      GBOOL[${k#bool.}]="${v}" ;;
 			int.*)       GINT[${k#int.}]="${v}" ;;
 			str.*)       GSTR[${k#str.}]=$(unescape "${v}") ;;
+			raw.*)       GSTR[${k#raw.}]=$(unescape "${v}") ;;
 			changed.*)   GCHANGED[${k#changed.}]="${v}" ;;
+			runnable)    GRUNNABLE="${v}" ;;
+			hassubcommands) GHASSUB="${v}" ;;
+			argserr)     GARGSERR=$(unescape "${v}") ;;
+			blockid)     GBLOCKID=$(unescape "${v}") ;;
 			*)           GERR="the classifier emitted an unrecognised field \`${k}\`"; return 1 ;;
 		esac
 	done <<< "${out}"
@@ -583,27 +639,24 @@ gbool()    { printf '%s' "${GBOOL[$1]:-false}"; }
 gstr()     { printf '%s' "${GSTR[$1]:-}"; }
 gchanged() { printf '%s' "${GCHANGED[$1]:-false}"; }
 
+# Which app would the CLI act on? Answered by encoding/json in the classifier.
+#
+# 🔴 THIS USED TO BE A GREP FOR THE FIRST `"blockId"`, AND Go TAKES THE LAST.
+# Measured on a manifest carrying the key twice — `sanctioned-ok` first,
+# `someones-real-app` second — the gate resolved the sanctioned one and returned
+# ALLOW_APP_SUBMIT while the CLI would have submitted the foreign app. Same
+# gate-vs-binary disagreement class the classifier exists to remove.
 resolve_block_id() {
-	local dir="$1" slug="$2" manifest id
+	local dir="$1" slug="$2" bin out
 	if [ -n "${slug}" ]; then printf '%s' "${slug}"; return 0; fi
-	manifest="${dir%/}/block.manifest.json"
-	[ -r "${manifest}" ] || return 1
-	id=$(tr -d '\n' < "${manifest}" \
-		| grep -o '"blockId"[[:space:]]*:[[:space:]]*"[^"]*"' \
-		| head -1 | sed 's/.*"blockId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
-	[ -n "${id}" ] || return 1
-	printf '%s' "${id}"
-}
-
-# Commands that are pure groups: they run nothing themselves, so a leftover
-# positional means the user named a subcommand that does not exist. Cobra
-# resolves `app frobnicate` to `app` with one argument, which is how an unknown
-# subcommand is detected without a vocabulary of our own.
-is_group_path() {
-	case "$1" in
-		""|app|"app listing"|workflows|"app listing"*) return 0 ;;
+	bin="${GUARD_BIN:-${ROOT}/real/dogfoodguard}"
+	[ -x "${bin}" ] || return 1
+	out=$("${bin}" blockid "${dir}" 2>/dev/null) || return 1
+	case "${out}" in
+		*"ok"$'\t'"1"*) ;;
+		*) return 1 ;;
 	esac
-	return 1
+	printf '%s' "$(printf '%s' "${out}" | grep -m1 '^blockid' | cut -f2)"
 }
 
 # ---------------------------------------------------------------------------
@@ -613,13 +666,13 @@ is_group_path() {
 # must kill the whole gate (so nothing runs) rather than return an empty string
 # the caller reads as "not DENY".
 # ---------------------------------------------------------------------------
-VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
+VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0; VERDICT_SLUG=""
 
 deny()  { VERDICT="DENY"; VERDICT_REASON="$1"; return 0; }
 allow() { VERDICT="ALLOW"; VERDICT_REASON="${1:-}"; return 0; }
 
 policy_verdict() {
-	VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
+	VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0; VERDICT_SLUG=""
 
 	if ! classify "$@"; then
 		case "${GKIND}" in
@@ -639,17 +692,22 @@ policy_verdict() {
 
 	local path="${GPATH}"
 
-	if is_group_path "${path}"; then
-		case "${path}" in
-			"app listing set-icon"|"app listing set-cover"|"app listing add-screenshot"|"app listing rm-screenshot"|"app listing reorder"|"app listing status") ;;
-			*)
-				if [ "${GARGC}" -gt 0 ]; then
-					deny "\`${GARG[0]:-?}\` is not a subcommand of \`${path:-civitai}\`; the gate fails closed rather than guess whether it spends or mutates"
-					return 0
-				fi
-				allow "usage"; return 0 ;;
-		esac
+	# 🔴 UNKNOWN SUBCOMMANDS, ASKED OF COBRA RATHER THAN OF A TABLE. The old
+	# `is_group_path` listed the parents by hand and missed `models`, `images`,
+	# `users` and `tags` — measured, the binary exits 2 for an unknown
+	# subcommand under every one of them while the gate said ALLOW. A command
+	# that HAS subcommands and was handed a positional was handed a subcommand
+	# that does not exist, whatever its parent. (`Runnable()` does NOT
+	# discriminate: all of those parents are runnable, they print their help.)
+	if [ -n "${GARGSERR}" ]; then
+		deny "the CLI would reject these arguments (${GARGSERR})"
+		return 0
 	fi
+	if [ "${GHASSUB}" = "true" ] && [ "${GARGC}" -gt 0 ]; then
+		deny "\`${GARG[0]:-?}\` is not a subcommand of \`${path:-civitai}\`; the gate fails closed rather than guess whether it spends or mutates"
+		return 0
+	fi
+	if [ "${GHASSUB}" = "true" ]; then allow "usage"; return 0; fi
 
 	case "${path}" in
 		upgrade)
@@ -691,7 +749,7 @@ policy_verdict() {
 			if [ "${n}" -ge "${MAX_APP_SUBMITS}" ]; then
 				deny "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"; return 0
 			fi
-			VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; return 0 ;;
+			VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; VERDICT_SLUG="${id}"; return 0 ;;
 
 		"app listing status")
 			allow "listing read"; return 0 ;;
@@ -742,6 +800,15 @@ policy_verdict() {
 			fi
 			if [ "$(gbool no-wait)" = "true" ] && [ "${ALLOW_NO_WAIT}" != "1" ]; then
 				deny "--no-wait returns before the charge has settled, and the meter reads the balance when the command returns — refused so the ledger cannot silently under-count"
+				return 0
+			fi
+			# 🔴 `--timeout` IS AN UNBLOCKED `--no-wait`. The CLI's own help says
+			# it "stops the CLI waiting; it does NOT stop the generation and does
+			# NOT stop the charge". A short timeout therefore returns before the
+			# charge settles, which is the same silent under-count `--no-wait` is
+			# refused for — measured, `--timeout 1s` was ALLOW_SPEND.
+			if [ "$(gchanged timeout)" = "true" ] && [ "${ALLOW_NO_WAIT}" != "1" ]; then
+				deny "--timeout stops the CLI waiting but not the charge, so a short timeout returns before the balance settles — refused for the same reason as --no-wait"
 				return 0
 			fi
 			local cum res committed remaining mc n
@@ -811,7 +878,22 @@ cmd_guard() {
 		exit 126
 	fi
 
+	# 🔴 VERIFY THE PROVENANCE HASHES, DO NOT MERELY RECORD THEM. `init` writes
+	# BINARY_SHA256 and GUARD_SHA256 into policy.env and nothing ever read them
+	# back. Measured: replacing real/dogfoodguard with a two-line "everything is
+	# a read" script made the gate run an UNMETERED `generate --yes` and log it
+	# as read-only. The classifier is the gate's only source of truth about what
+	# an argv means, so an unverified classifier is no gate at all.
+	verify_provenance || {
+		printf '%s: %s\n' "${SANDBOX_TAG}" "${PROVENANCE_ERROR}" >&2
+		printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$(now_iso)" "DENY" "126" "0" "${scrubbed}" \
+			"provenance: $(tsv_escape "${PROVENANCE_ERROR}")" >> "${ROOT}/ledger/invocations.tsv" 2>/dev/null
+		exit 126
+	}
+
 	lock_ledger || refuse "could not take the ledger lock within 60s" "${scrubbed}"
+
+	reconcile_inflight
 
 	policy_verdict "${argv[@]+"${argv[@]}"}"
 
@@ -832,27 +914,35 @@ cmd_guard() {
 	# unwritable the previous version bumped nothing and allowed submit after
 	# submit, meter and counter both reading 0 forever.
 	local before="" mc="${VERDICT_MC}"
+	# 🔴 COUNTERS FOR THE MODERATOR-FACING ACTIONS ARE BUMPED AFTER THE CALL, ON
+	# SUCCESS. Bumping before exec and ignoring rc meant three LOCAL validation
+	# failures — the CLI refusing to package a project — burned all three app
+	# submissions and the fourth was refused. Measured: rc=1,1,1 with the counter
+	# at 1,2,3, then rc=126. Only the SPEND reservation stays pre-exec, because
+	# that is money at risk rather than a count of things that happened.
+	# 🔴 PROVE THE COUNTER IS WRITABLE BEFORE THE CALL, EVEN THOUGH IT IS BUMPED
+	# AFTER IT. Moving the bump to after-success (so a local validation failure
+	# no longer burns a submission) would otherwise mean an unwritable ledger
+	# stops blocking: the spend happens, the write fails, the count is lost and
+	# the cap is evadable. This is a no-op rewrite of the current value purely
+	# to establish writability while refusing still costs nothing.
 	case "${VERDICT}" in
-		ALLOW_SPEND)
-			before=$(sample_balance "pre-generate") || \
-				refuse "could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" "${scrubbed}"
-			local res n
-			res=$(read_scalar reserved)       || refuse "the reservation ledger is unreadable or malformed" "${scrubbed}"
-			n=$(read_scalar generate_submits) || refuse "the submission counter is unreadable or malformed" "${scrubbed}"
-			write_scalar reserved "$(( res + mc ))"       || refuse "could not record the spend reservation — refusing to submit" "${scrubbed}"
-			write_scalar generate_submits "$(( n + 1 ))"  || refuse "could not record the submission — refusing to submit" "${scrubbed}"
-			;;
-		ALLOW_APP_SUBMIT)
-			local a
-			a=$(read_scalar app_submits) || refuse "the app-submission counter is unreadable or malformed" "${scrubbed}"
-			write_scalar app_submits "$(( a + 1 ))" || refuse "could not record the app submission — refusing" "${scrubbed}"
-			;;
-		ALLOW_LISTING)
-			local m
-			m=$(read_scalar listing_mutations) || refuse "the listing-mutation counter is unreadable or malformed" "${scrubbed}"
-			write_scalar listing_mutations "$(( m + 1 ))" || refuse "could not record the listing mutation — refusing" "${scrubbed}"
-			;;
+		ALLOW_SPEND)      assert_writable generate_submits "${scrubbed}" ;;
+		ALLOW_APP_SUBMIT) assert_writable app_submits "${scrubbed}" ;;
+		ALLOW_LISTING)    assert_writable listing_mutations "${scrubbed}" ;;
 	esac
+
+	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
+		before=$(sample_balance "pre-generate") || \
+			refuse "could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" "${scrubbed}"
+		local res
+		res=$(read_scalar reserved) || refuse "the reservation ledger is unreadable or malformed" "${scrubbed}"
+		write_scalar reserved "$(( res + mc ))" || refuse "could not record the spend reservation — refusing to submit" "${scrubbed}"
+		# A crash between here and the reconciliation must not lose the charge.
+		printf '%s\t%s\t%s\t%s\n' "$(now_iso)" "${mc}" "${before}" "${scrubbed}" \
+			> "${ROOT}/ledger/inflight"
+		workflow_snapshot
+	fi
 
 	unlock_ledger
 
@@ -876,15 +966,31 @@ cmd_guard() {
 	lock_ledger || err "could not re-take the ledger lock; the ledger may be inconsistent"
 
 	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
-		delta=$(settle_spend "${before}" "${mc}")
+		delta=$(settle_spend "${before}" "${mc}" "${rc}")
+		rm -f "${ROOT}/ledger/inflight"
+		# A submission counts when it happened: rc 0, or any observed charge.
+		local n
+		if [ "${rc}" = 0 ] || { [ "${delta}" != "0" ] && [ "${delta}" != "" ]; }; then
+			n=$(read_scalar generate_submits) && write_scalar generate_submits "$(( n + 1 ))"
+		fi
 	fi
 
 	# Record the ids this run created, so the agent can withdraw its OWN
 	# submission and cancel its OWN workflow without the operator doing it by
-	# hand. Reads only; costs one extra API call after a mutation.
+	# hand. Reads only; costs one extra API call after a successful mutation.
 	case "${VERDICT}" in
-		ALLOW_APP_SUBMIT) record_pubreq_ids ;;
-		ALLOW_SPEND)      record_workflow_ids ;;
+		ALLOW_APP_SUBMIT)
+			if [ "${rc}" = 0 ]; then
+				local a
+				a=$(read_scalar app_submits) && write_scalar app_submits "$(( a + 1 ))"
+				record_pubreq_ids "${VERDICT_SLUG}"
+			fi ;;
+		ALLOW_LISTING)
+			if [ "${rc}" = 0 ]; then
+				local m
+				m=$(read_scalar listing_mutations) && write_scalar listing_mutations "$(( m + 1 ))"
+			fi ;;
+		ALLOW_SPEND) record_workflow_ids ;;
 	esac
 
 	log_invocation "${VERDICT}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" \
@@ -906,9 +1012,34 @@ cmd_guard() {
 #     real charge. Measured: a +100 grant alongside a 37 charge recorded 0.
 #     Clamping to zero is what made that silent, so it no longer clamps.
 settle_spend() {
-	local before="$1" mc="$2" after res cum delta
+	local before="$1" mc="$2" rc="${3:-0}" after res cum delta
 	res=$(read_scalar reserved)      || res="${mc}"
 	cum=$(read_scalar observed_spend) || cum=0
+
+	# 🔴 A ZERO DELTA ON A NON-ZERO EXIT IS EXPECTED, NOT A BROKEN METER. The
+	# command failed before spending: the CLI's own `--max-cost` refusal, a
+	# balance-too-low refusal, a 4xx/5xx, a bad `--input`, an `--ecosystem`
+	# typo. Latching on those killed the run at the agent's first likely
+	# mistake — and the brief MANDATES `--max-cost`, which the agent cannot
+	# size without a `--dry-run` first. Measured: `--max-cost 5` against an
+	# estimate of 8 gave rc=2, delta 0, meter_broken latched, and every
+	# subsequent generate refused. It also credited 5 Buzz that never moved.
+	if [ "${rc}" != 0 ]; then
+		after=$(sample_balance "post-generate-failed") || after=""
+		if [ -n "${after}" ] && [ "${after}" != "${before}" ]; then
+			delta=$(( before - after ))
+			if [ "${delta}" -gt 0 ]; then
+				write_scalar observed_spend "$(( cum + delta ))" || true
+				printf '%s\tgenerate\t%s\t%s\t%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${rc}" \
+					>> "${ROOT}/ledger/spend.tsv"
+			fi
+		else
+			delta=0
+		fi
+		write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
+		printf '%s' "${delta:-0}"
+		return 0
+	fi
 
 	after=$(sample_balance "post-generate") || after=""
 
@@ -947,29 +1078,115 @@ settle_spend() {
 	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
 }
 
+# Read a counter and write the same value back, so an unreadable or unwritable
+# ledger is a refusal BEFORE anything is spent rather than a lost count after.
+assert_writable() {
+	local name="$1" scrubbed="$2" v
+	v=$(read_scalar "${name}") || refuse "the ${name} counter is unreadable or malformed" "${scrubbed}"
+	write_scalar "${name}" "${v}" || refuse "the ${name} counter is not writable, so this run could not be counted — refusing" "${scrubbed}"
+}
+
+PROVENANCE_ERROR=""
+verify_provenance() {
+	PROVENANCE_ERROR=""
+	local want got
+	for pair in "civitai:${BINARY_SHA256:-}" "dogfoodguard:${GUARD_SHA256:-}"; do
+		local name="${pair%%:*}" want="${pair#*:}"
+		if [ -z "${want}" ]; then
+			PROVENANCE_ERROR="policy.env records no hash for ${name} — refusing to run against an unverifiable binary"
+			return 1
+		fi
+		got=$(sha256sum "${ROOT}/real/${name}" 2>/dev/null | cut -d' ' -f1)
+		if [ -z "${got}" ]; then
+			PROVENANCE_ERROR="${ROOT}/real/${name} is missing — refusing"
+			return 1
+		fi
+		if [ "${got}" != "${want}" ]; then
+			PROVENANCE_ERROR="${name} does not match the hash recorded at init (recorded ${want:0:12}…, found ${got:0:12}…) — refusing to run a substituted binary"
+			return 1
+		fi
+	done
+	return 0
+}
+
+# 🔴 A SPEND KILLED MID-FLIGHT MUST NOT VANISH FROM THE LEDGER. SIGKILL cannot
+# be trapped, so the guard writes an `inflight` record BEFORE the call and
+# clears it after; the next invocation reconciles whatever it finds. Measured
+# before this existed: SIGKILL during a submit moved 37 Buzz, left
+# observed_spend at 0, wrote zero ledger rows, and leaked the reservation.
+reconcile_inflight() {
+	local f="${ROOT}/ledger/inflight"
+	[ -f "${f}" ] || return 0
+	local ts mc before now cum res delta
+	IFS=$'\t' read -r ts mc before _ < "${f}"
+	rm -f "${f}"
+	case "${mc}" in ''|*[!0-9]*) mc=0 ;; esac
+	case "${before}" in ''|*[!0-9]*) before="" ;; esac
+	cum=$(read_scalar observed_spend) || cum=0
+	res=$(read_scalar reserved) || res=0
+	now=$(sample_balance "reconcile") || now=""
+	if [ -n "${before}" ] && [ -n "${now}" ]; then
+		delta=$(( before - now ))
+		[ "${delta}" -lt 0 ] && delta=0
+	else
+		delta="${mc}"
+	fi
+	write_scalar observed_spend "$(( cum + delta ))" || true
+	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
+	printf '%s\tRECONCILED\t0\t0\t%s\t%s\n' "$(now_iso)" \
+		"$(tsv_escape "an earlier generation did not finish cleanly (started ${ts})")" \
+		"$(tsv_escape "delta=${delta}")" >> "${ROOT}/ledger/invocations.tsv"
+	printf '%s: %s\n' "${SANDBOX_TAG}" \
+		"an earlier generation was interrupted; ${delta} Buzz reconciled into the ledger" >&2
+}
+
 break_meter() {
 	printf '%s\n' "$1" > "${ROOT}/ledger/meter_broken"
 	printf '%s: %s — no further generation will be allowed this run\n' "${SANDBOX_TAG}" "$1" >&2
 }
 
-# After an app submit, record the publish-request ids this account now has
-# pending, so the agent can withdraw its own. Read-only.
+# After a SUCCESSFUL app submit, record the publish-request ids for the app this
+# run submitted, so the agent can withdraw its own before a moderator sees it.
+#
+# 🔴 THIS GREPPED THE HUMAN TABLE, WHICH HAS NO ID COLUMN. `app status` prints
+# BLOCK_ID/VERSION/STATUS/DEPLOY/SUBMITTED/URL (app_status.go:128) — measured
+# with a positive control, 0 `pubreq_` matches in the human output and 2 in
+# `--json`. So pubreq.allow was never populated and `app withdraw` was ALWAYS
+# denied: the documented cleanup path did not exist. Scoped to the submitted
+# blockId, so it records only what this run created.
 record_pubreq_ids() {
-	local out
-	out=$(real_cli app status 2>/dev/null) || return 0
+	local slug="${1:-}" out
+	[ -n "${slug}" ] || return 0
+	out=$(real_cli app status "${slug}" --json 2>/dev/null) || return 0
 	printf '%s' "${out}" | grep -o 'pubreq_[A-Za-z0-9_-]*' | sort -u \
 		>> "${ROOT}/ledger/pubreq.allow" 2>/dev/null || true
 	sort -u -o "${ROOT}/ledger/pubreq.allow" "${ROOT}/ledger/pubreq.allow" 2>/dev/null || true
 }
 
-# After a generation, record the workflow ids this run owns, so the agent can
-# cancel its own job (cancelling DOES NOT REFUND, so it may not cancel others').
+# Workflow ids are recorded by PROVENANCE, not by shape.
+#
+# 🔴 THE OLD VERSION FILTERED THE ACCOUNT-WIDE `workflows list` BY UUID SHAPE.
+# Measured, that captured a workflow this run did not create and missed a
+# ULID-shaped one — and `workflows cancel` DOES NOT REFUND, so allowlisting
+# someone else's job is exactly the wrong direction. This snapshots the ids
+# that existed BEFORE the submit and records only what appeared after.
+workflow_snapshot() {
+	real_cli workflows list --json 2>/dev/null \
+		| grep -oE '"id"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*"\([^"]*\)"$/\1/' \
+		| sort -u > "${ROOT}/ledger/workflow.before" 2>/dev/null || : > "${ROOT}/ledger/workflow.before"
+}
+
 record_workflow_ids() {
-	local out
-	out=$(real_cli workflows list 2>/dev/null) || return 0
-	printf '%s' "${out}" | grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | sort -u \
-		>> "${ROOT}/ledger/workflow.allow" 2>/dev/null || true
+	local after="${ROOT}/ledger/workflow.after"
+	real_cli workflows list --json 2>/dev/null \
+		| grep -oE '"id"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*"\([^"]*\)"$/\1/' \
+		| sort -u > "${after}" 2>/dev/null || return 0
+	if [ -f "${ROOT}/ledger/workflow.before" ]; then
+		comm -13 "${ROOT}/ledger/workflow.before" "${after}" \
+			>> "${ROOT}/ledger/workflow.allow" 2>/dev/null || true
+	fi
 	sort -u -o "${ROOT}/ledger/workflow.allow" "${ROOT}/ledger/workflow.allow" 2>/dev/null || true
+	rm -f "${after}" "${ROOT}/ledger/workflow.before"
 }
 
 log_invocation() {
@@ -1107,12 +1324,35 @@ cmd_finish() {
 }
 
 cmd_enter() {
-	local root="${DEFAULT_ROOT}"
+	local root="${DEFAULT_ROOT}" with_claude=0
 	while [ $# -gt 0 ]; do
-		case "$1" in --root) root="$2"; shift 2 ;; *) break ;; esac
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--with-claude) with_claude=1; shift ;;
+			*) break ;;
+		esac
 	done
 	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
 	command -v bwrap >/dev/null 2>&1 || die "enter: bwrap (bubblewrap) is not on PATH"
+
+	# --with-claude seeds a FRESH $HOME with ONLY the credential file.
+	#
+	# 🔴 THE HOST ~/.claude IS NEVER BOUND, AND THAT IS THE WHOLE POINT. It
+	# holds `projects/` — 34 project directories on this host, including this
+	# repo's own transcripts and both prior dogfood runs — so binding it would
+	# hand the agent exactly what the method exists to hide. Measured: a fresh
+	# HOME containing only `.claude/.credentials.json` runs a real session
+	# (`claude -p` → rc 0), the session CREATES `projects/` itself, and every
+	# blindness probe reads 0 inside the jail while the same rig reads
+	# 120/1507/331/3 with the mounts deliberately wrong.
+	if [ "${with_claude}" = 1 ]; then
+		local hostcred="${HOME}/.claude/.credentials.json"
+		[ -r "${hostcred}" ] || die "enter --with-claude: no credential at ${hostcred}"
+		mkdir -p "${ROOT}/home/.claude"
+		(umask 077; cp "${hostcred}" "${ROOT}/home/.claude/.credentials.json") \
+			|| die "enter --with-claude: could not seed the credential"
+		chmod 0600 "${ROOT}/home/.claude/.credentials.json"
+	fi
 
 	local shell_bin
 	shell_bin=$(command -v bash) || die "enter: no bash on PATH"
@@ -1136,15 +1376,31 @@ cmd_enter() {
 	# yields a cwd-relative path that does not exist, and nix-store then fails
 	# on the whole list, which read as "nix-store is missing". Only absolute
 	# paths are roots.
-	for b in bash env cat cp rm mkdir chmod chown date grep sed tr head cut wc \
-	         sha256sum flock timeout mv ls readlink stat sort tail touch find id \
-	         dirname basename mktemp sleep awk diff coreutils; do
+	# 🔴 node/npm ARE IN THE CLOSURE, AND THAT IS A DELIBERATE WIDENING OF THE
+	# EXECUTION SURFACE. Without them the run cannot reach its own purpose:
+	# measured, `app create <prefix>myapp` succeeds but writes no lockfile, and
+	# `app validate` then exits 1 (`npm ci … hard-fails`), so the agent can never
+	# produce a submittable app. With them, `npm install` reaches
+	# registry.npmjs.org AND RUNS PACKAGE LIFECYCLE SCRIPTS — arbitrary code
+	# execution inside the jail that did not exist before. The jail still has no
+	# access to the repo, the operator's HOME or the real credential store, so
+	# the blast radius is the sandbox plus the network; it is not nothing, and
+	# the doc says so.
+	local tools="bash env cat cp rm mkdir chmod chown date grep sed tr head cut wc
+	             sha256sum flock timeout mv ls readlink stat sort tail touch find id
+	             dirname basename mktemp sleep awk diff comm coreutils
+	             node npm npx git tar gzip xz which uname getent"
+	for b in ${tools}; do
 		p=$(command -v "${b}" 2>/dev/null) || continue
 		case "${p}" in /*) ;; *) continue ;; esac
 		p=$(readlink -f "${p}") || continue
 		[ -e "${p}" ] || continue
 		roots+=("${p}")
 	done
+	if [ "${with_claude}" = 1 ]; then
+		p=$(command -v claude 2>/dev/null) || p=""
+		[ -n "${p}" ] && roots+=("$(readlink -f "${p}")")
+	fi
 	[ "${#roots[@]}" -gt 0 ] || die "enter: could not resolve any tool paths"
 
 	local ca=""
@@ -1176,7 +1432,6 @@ cmd_enter() {
 	local envbin path_dirs
 	envbin=$(readlink -f "$(command -v env)")
 	path_dirs="${ROOT}/bin"
-	for b in bash coreutils grep sed findutils util-linux gawk diffutils; do :; done
 	for p in "${roots[@]}"; do
 		case "${path_dirs}:" in *":$(dirname "${p}"):"*) continue ;; esac
 		path_dirs="${path_dirs}:$(dirname "${p}")"
@@ -1247,13 +1502,22 @@ vd() { policy_verdict "$@"; printf '%s' "${VERDICT}"; }
 # --yes` still DENIED — as an unrecognised command called `--no-color` — and a
 # blind auditor found a dev-tunnel row carried by a bystander the same way.
 # These rows pin the REASON.
+# 🔴 A REASON IS NOT EVIDENCE OF A DENY — the exact inverse of the note above,
+# and it was missed for two rounds. `allow "…"` and `deny "…"` set the same
+# VERDICT_REASON, so a `deny`→`allow` flip with a byte-identical message was
+# INVISIBLE: measured, 5 of 5 such flips (login, TOTAL_SPEND_CAP,
+# MAX_GENERATE_SUBMITS, the withdraw allowlist, the --no-wait gate) survived a
+# 177/177 suite. This asserts BOTH, so the verdict cannot be carried by the
+# message and the message cannot be carried by the verdict.
 st_reason() {
-	local label="$1" needle="$2"; shift 2
+	local label="$1" want_verdict="$2" needle="$3"; shift 3
 	policy_verdict "$@"
+	local got="${VERDICT}"
 	case "${VERDICT_REASON}" in
-		*"${needle}"*) st_check "${label}" "match" "match" ;;
-		*)             st_check "${label}" "match" "no-match: ${VERDICT_REASON}" ;;
+		*"${needle}"*) ;;
+		*) got="${VERDICT}/reason:${VERDICT_REASON}" ;;
 	esac
+	st_check "${label}" "${want_verdict}/reason" "${got}/reason"
 }
 
 st_reset_ledger() {
@@ -1320,39 +1584,63 @@ OFFLINE
 	local fake="${ROOT}/ledger/_fakeguard"
 	mkfake() { printf '#!/usr/bin/env bash\n%s\n' "$1" > "${fake}"; chmod 0755 "${fake}"; GUARD_BIN="${fake}"; }
 	mkfake 'printf "ok\t1\npath\tgenerate\nbogus\tx\n"'
-	st_reason "an UNRECOGNISED classifier field denies" "could not be classified" generate cat --yes --max-cost 5
+	st_reason "an UNRECOGNISED classifier field denies" "DENY" "could not be classified" generate cat --yes --max-cost 5
 	mkfake 'printf "path\tgenerate\n"'
-	st_reason "classifier output with no ok field denies" "could not be classified" generate cat --yes --max-cost 5
+	st_reason "classifier output with no ok field denies" "DENY" "could not be classified" generate cat --yes --max-cost 5
 	mkfake 'exit 9'
-	st_reason "a silent non-zero classifier denies" "could not be classified" generate cat --dry-run
+	st_reason "a silent non-zero classifier denies" "DENY" "could not be classified" generate cat --dry-run
 	mkfake 'printf "ok\t1\npath\tgenerate\nargc\tnotanumber\n"'
-	st_reason "a non-numeric argument count denies" "could not be classified" generate cat --dry-run
+	st_reason "a non-numeric argument count denies" "DENY" "could not be classified" generate cat --dry-run
+	# These two branches are unreachable through today's command tree — cobra's
+	# ValidateArgs never errors for these commands, and `unknown-command` is
+	# reported as a flag-parse error for the spellings the corpus uses. They are
+	# still gate branches, so they are exercised through an injected classifier
+	# rather than left as unpinned code.
+	mkfake 'printf "ok\t1\npath\tmodels\nargc\t0\nhassubcommands\tfalse\nargserr\taccepts at most 1 arg\n"'
+	st_reason "an argserr from cobra denies" "DENY" "would reject these arguments" models search x
+	mkfake 'printf "ok\t0\nkind\tunknown-command\nerr\tunknown command \"zzz\"\n"; exit 2'
+	st_reason "an unknown-command kind denies" "DENY" "does not recognise this command" zzz
 	# A classifier that claims everything is a harmless read must still not be
 	# able to say so from OUTSIDE the sandbox: GUARD_BIN is reset at startup, so
 	# an exported value cannot reach the gate.
-	mkfake 'printf "ok\t1\npath\twhoami\nargc\t0\n"'
+	# 🔴 THE FIXTURE MUST BE ALLOW-SHAPED, OR THE ROW IS A BYSTANDER. With
+	# `GUARD_BIN=/bin/true` the injected classifier produces NO output, so the
+	# gate denies for that reason whether or not the reset exists — the row
+	# passed with the protection deleted. An allow-shaped fake distinguishes
+	# them: honoured it says ALLOW, ignored it says DENY.
+	mkfake 'printf "ok\t1\npath\twhoami\nargc\t0\nhassubcommands\tfalse\nargserr\t\n"'
 	st_check "an injected classifier IS honoured inside the selftest" "ALLOW" "$(vd generate cat --yes)"
+	cp "${fake}" "${ROOT}/ledger/_allowfake"
 	GUARD_BIN=""; rm -f "${fake}"
 	st_check "the real classifier is back" "DENY" "$(vd generate cat --yes)"
 	st_check "an INHERITED GUARD_BIN is ignored" "DENY" \
-		"$(GUARD_BIN=/bin/true bash "$0" __verdict --root "${ROOT}" -- generate cat --yes 2>/dev/null)"
+		"$(GUARD_BIN="${ROOT}/ledger/_allowfake" bash "$0" __verdict --root "${ROOT}" -- generate cat --yes 2>/dev/null)"
+	rm -f "${ROOT}/ledger/_allowfake"
+
+	note "--- a DELETED counter is malformed, not zero ---"
+	local cf
+	for cf in observed_spend generate_submits; do
+		mv "${ROOT}/ledger/${cf}" "${ROOT}/ledger/${cf}.away"
+		st_reason "a DELETED ${cf} refuses a spend" "DENY" "unreadable or malformed" generate cat --yes --max-cost 5
+		mv "${ROOT}/ledger/${cf}.away" "${ROOT}/ledger/${cf}"
+	done
 
 	note "--- forbidden commands (reason-pinned, so no bystander can carry them) ---"
-	st_reason "upgrade denied AS upgrade"        "replace the binary"        upgrade
-	st_reason "login denied AS login"            "already authenticated"     login --token x
-	st_reason "dev-tunnel denied AS dev-tunnel"  "out of scope"              app dev-tunnel
-	st_reason "dev-token denied AS dev-token"    "out of scope"              app dev-token
-	st_reason "unknown top-level denied"         "not a subcommand"          frobnicate
-	st_reason "unknown app subcommand denied"    "not a subcommand"          app frobnicate
-	st_reason "unknown listing verb denied"      "not a subcommand"          app listing frobnicate
-	st_reason "unknown workflows verb denied"    "not a subcommand"          workflows frobnicate
+	st_reason "upgrade denied AS upgrade"        "DENY" "replace the binary"        upgrade
+	st_reason "login denied AS login"            "DENY" "already authenticated"     login --token x
+	st_reason "dev-tunnel denied AS dev-tunnel"  "DENY" "out of scope"              app dev-tunnel
+	st_reason "dev-token denied AS dev-token"    "DENY" "out of scope"              app dev-token
+	st_reason "unknown top-level denied"         "DENY" "not a subcommand"          frobnicate
+	st_reason "unknown app subcommand denied"    "DENY" "not a subcommand"          app frobnicate
+	st_reason "unknown listing verb denied"      "DENY" "not a subcommand"          app listing frobnicate
+	st_reason "unknown workflows verb denied"    "DENY" "not a subcommand"          workflows frobnicate
 
 	note "--- root persistent flags before the subcommand ---"
-	st_reason "--no-color generate hits the MONEY branch" "--max-cost" --no-color generate cat --yes
-	st_reason "--no-color upgrade denied AS upgrade"      "replace the binary" --no-color upgrade
-	st_reason "--no-update-check upgrade denied"          "replace the binary" --no-update-check upgrade
-	st_reason "--color login denied AS login"             "already authenticated" --color login --token x
-	st_reason "app --no-color submit foreign on PREFIX"   "sanctioned prefix" app --no-color submit "${td}/bad" --yes
+	st_reason "--no-color generate hits the MONEY branch" "DENY" "--max-cost" --no-color generate cat --yes
+	st_reason "--no-color upgrade denied AS upgrade"      "DENY" "replace the binary" --no-color upgrade
+	st_reason "--no-update-check upgrade denied"          "DENY" "replace the binary" --no-update-check upgrade
+	st_reason "--color login denied AS login"             "DENY" "already authenticated" --color login --token x
+	st_reason "app --no-color submit foreign on PREFIX"   "DENY" "sanctioned prefix" app --no-color submit "${td}/bad" --yes
 	st_check  "--no-color generate --max-cost is a spend" "ALLOW_SPEND" "$(vd --no-color generate cat --yes --max-cost 5)"
 
 	note "--- a flag VALUE that looks like a flag ---"
@@ -1375,78 +1663,113 @@ OFFLINE
 		st_check "--dry-run=${v} still SPENDS"           "DENY"  "$(vd generate cat --yes --dry-run="${v}")"
 		st_check "--print-input=${v} still SPENDS"       "DENY"  "$(vd generate cat --yes --print-input="${v}")"
 		st_check "--help=${v} is NOT a help request"     "DENY"  "$(vd generate cat --yes --help="${v}")"
-		st_reason "--package-only=${v} still gated"      "sanctioned prefix" app submit "${td}/bad" --yes --package-only="${v}"
+		st_reason "--package-only=${v} still gated"      "DENY" "sanctioned prefix" app submit "${td}/bad" --yes --package-only="${v}"
 	done
 	for v in 1 t T TRUE true True; do
 		st_check "--help=${v} IS a help request"         "ALLOW" "$(vd generate cat --yes --help="${v}")"
 		st_check "--package-only=${v} never submits"     "ALLOW" "$(vd app submit "${td}/bad" --yes --package-only="${v}")"
 	done
-	st_reason "an unparseable bool value denies"  "would reject these flags" generate cat --yes --dry-run=maybe
-	st_reason "an unparseable int value denies"   "would reject these flags" generate cat --yes --max-cost abc
-	st_reason "--max-cost 08 denies (not a crash)" "would reject these flags" generate cat --yes --max-cost 08
+	st_reason "an unparseable bool value denies"  "DENY" "would reject these flags" generate cat --yes --dry-run=maybe
+	st_reason "an unparseable int value denies"   "DENY" "would reject these flags" generate cat --yes --max-cost abc
+	st_reason "--max-cost 08 denies (not a crash)" "DENY" "would reject these flags" generate cat --yes --max-cost 08
 
 	note "--- generate money path ---"
 	st_check "real dry-run is free"            "ALLOW"       "$(vd generate cat --dry-run)"
 	st_check "no --max-cost denied"            "DENY"        "$(vd generate cat --yes)"
 	st_check "--max-cost at ceiling allowed"   "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 100)"
 	st_check "--max-cost=N form"               "ALLOW_SPEND" "$(vd generate cat --yes --max-cost=1)"
-	st_reason "--max-cost over ceiling denied" "per-invocation ceiling" generate cat --yes --max-cost 101
+	st_reason "--max-cost over ceiling denied" "DENY" "per-invocation ceiling" generate cat --yes --max-cost 101
 	st_check "LAST --max-cost wins (5 then 99999)"  "DENY"        "$(vd generate cat --yes --max-cost 5 --max-cost 99999)"
 	st_check "LAST --max-cost wins (99999 then 5)"  "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 99999 --max-cost 5)"
-	st_reason "--no-wait refused by default"   "settled" generate cat --yes --max-cost 5 --no-wait
+	st_reason "--no-wait refused by default"   "DENY" "settled" generate cat --yes --max-cost 5 --no-wait
 
 	note "--- 🔴 EACH CAP, ISOLATED, REASON-PINNED ---"
 	st_reset_ledger 2000 0 0 0 0
-	st_reason "TOTAL_SPEND_CAP branch"        "total spend cap" generate cat --yes --max-cost 1
+	st_reason "TOTAL_SPEND_CAP branch"        "DENY" "total spend cap" generate cat --yes --max-cost 1
 	st_reset_ledger 1995 0 0 0 0
-	st_reason "remaining-budget branch"       "left under this run's total cap" generate cat --yes --max-cost 50
+	st_reason "remaining-budget branch"       "DENY" "left under this run's total cap" generate cat --yes --max-cost 50
 	st_reset_ledger 0 0 20 0 0
-	st_reason "MAX_GENERATE_SUBMITS branch"   "generation cap" generate cat --yes --max-cost 1
+	st_reason "MAX_GENERATE_SUBMITS branch"   "DENY" "generation cap" generate cat --yes --max-cost 1
 	# A reservation alone must reach the cap: 0 observed + 2000 in flight is a
 	# full budget even though nothing has settled yet.
 	st_reset_ledger 0 2000 0 0 0
-	st_reason "the RESERVATION alone reaches the cap" "committed in flight" generate cat --yes --max-cost 1
+	st_reason "the RESERVATION alone reaches the cap" "DENY" "committed in flight" generate cat --yes --max-cost 1
 	st_reset_ledger 0 1999 0 0 0
-	st_reason "a reservation shrinks the remaining budget" "left under this run's total cap" generate cat --yes --max-cost 5
+	st_reason "a reservation shrinks the remaining budget" "DENY" "left under this run's total cap" generate cat --yes --max-cost 5
 	st_reset_ledger 0 0 0 3 0
-	st_reason "MAX_APP_SUBMITS branch"        "app-submission cap" app submit "${td}/good" --yes
+	st_reason "MAX_APP_SUBMITS branch"        "DENY" "app-submission cap" app submit "${td}/good" --yes
 	st_reset_ledger 0 0 0 0 10
-	st_reason "MAX_LISTING_MUTATIONS branch"  "listing-mutation cap" app listing set-icon i.png --dir "${td}/good"
+	st_reason "MAX_LISTING_MUTATIONS branch"  "DENY" "listing-mutation cap" app listing set-icon i.png --dir "${td}/good"
 	st_reset_ledger
 
 	note "--- 🔴 a malformed or EMPTY ledger scalar is not zero ---"
 	local f
 	for f in observed_spend reserved generate_submits; do
 		printf 'garbage\n' > "${ROOT}/ledger/${f}"
-		st_reason "malformed ${f} refuses a spend" "unreadable or malformed" generate cat --yes --max-cost 5
+		st_reason "malformed ${f} refuses a spend" "DENY" "unreadable or malformed" generate cat --yes --max-cost 5
 		: > "${ROOT}/ledger/${f}"
-		st_reason "EMPTY ${f} refuses a spend"     "unreadable or malformed" generate cat --yes --max-cost 5
+		st_reason "EMPTY ${f} refuses a spend"     "DENY" "unreadable or malformed" generate cat --yes --max-cost 5
 		write_scalar "${f}" 0
 	done
 	printf 'garbage\n' > "${ROOT}/ledger/app_submits"
-	st_reason "malformed app_submits refuses a submit" "unreadable or malformed" app submit "${td}/good" --yes
+	st_reason "malformed app_submits refuses a submit" "DENY" "unreadable or malformed" app submit "${td}/good" --yes
 	write_scalar app_submits 0
 	printf 'garbage\n' > "${ROOT}/ledger/listing_mutations"
-	st_reason "malformed listing_mutations refuses" "unreadable or malformed" app listing set-icon i.png --dir "${td}/good"
+	st_reason "malformed listing_mutations refuses" "DENY" "unreadable or malformed" app listing set-icon i.png --dir "${td}/good"
 	write_scalar listing_mutations 0
 
 	note "--- app identity gating ---"
 	st_check "submit sanctioned"               "ALLOW_APP_SUBMIT" "$(vd app submit "${td}/good" --yes)"
-	st_reason "submit foreign denied"          "sanctioned prefix" app submit "${td}/bad" --yes
+	st_reason "submit foreign denied"          "DENY" "sanctioned prefix" app submit "${td}/bad" --yes
 	st_check "submit -o value not read as dir" "ALLOW_APP_SUBMIT" "$(vd app submit -o "${td}/bad" "${td}/good")"
 	st_check "listing sanctioned --dir"        "ALLOW_LISTING"    "$(vd app listing set-icon i.png --dir "${td}/good")"
-	st_reason "listing foreign --slug denied"  "may not touch the account's real listings" app listing set-icon i.png --slug someones-real-app
-	st_reason "listing unidentifiable denied"  "cannot identify" app listing set-icon i.png --dir "${ROOT}/ledger"
+	st_reason "listing foreign --slug denied"  "DENY" "may not touch the account's real listings" app listing set-icon i.png --slug someones-real-app
+	st_reason "listing unidentifiable denied"  "DENY" "cannot identify" app listing set-icon i.png --dir "${ROOT}/ledger"
 	st_check "listing status is a read"        "ALLOW" "$(vd app listing status)"
 
+	note "--- unknown subcommands, asked of cobra rather than a table ---"
+	local parent
+	for parent in models images users tags articles collections creators model-versions app workflows; do
+		st_reason "unknown subcommand under \`${parent}\` denied" "DENY" "is not a subcommand" ${parent} frobnicate
+	done
+	st_check "a known subcommand still runs"      "ALLOW" "$(vd models search --query x)"
+	st_check "a parent with no args is usage"     "ALLOW" "$(vd models)"
+	st_check "a positional the CLI accepts"       "ALLOW" "$(vd app view someslug)"
+	st_check "download takes a positional"        "ALLOW" "$(vd download 12345)"
+
+	note "--- 🔴 the manifest is parsed by encoding/json, not by grep ---"
+	printf '{"blockId":"%sok","name":"n","version":"1.0.0","kind":"page","blockId":"someones-real-app"}\n' "${SLUG_PREFIX}" \
+		> "${td}/good/dup.json"
+	mkdir -p "${td}/dup"; cp "${td}/good/dup.json" "${td}/dup/block.manifest.json"
+	st_reason "a DUPLICATE blockId resolves to the LAST value, as Go does" "DENY" \
+		"sanctioned prefix" app submit "${td}/dup" --yes
+	printf 'not json at all\n' > "${td}/dup/block.manifest.json"
+	st_reason "an unparseable manifest denies" "DENY" "cannot read a blockId" app submit "${td}/dup" --yes
+	printf '{"name":"n"}\n' > "${td}/dup/block.manifest.json"
+	st_reason "a manifest with no blockId denies" "DENY" "cannot read a blockId" app submit "${td}/dup" --yes
+	# A classifier that reports failure while EXITING ZERO. Today's classifier
+	# never does this — `|| return 1` already catches its non-zero exit — so
+	# without this row the ok-check is an unpinned redundancy.
+	# The fake must SUCCEED for the argv classification and FAIL only for the
+	# blockid lookup, or the run is denied earlier and the row proves nothing.
+	mkfake 'if [ "$1" = "blockid" ]; then printf "ok\t0\nerr\tno manifest\n"; exit 0; fi
+printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-only\tfalse\nargc\t1\narg.0\t%s\n" "$4"'
+	st_reason "a lookup that fails while exiting 0 denies" "DENY" "cannot read a blockId" app submit "${td}/dup" --yes
+	GUARD_BIN=""; rm -f "${fake}"
+	rm -rf "${td}/dup" "${td}/good/dup.json"
+
+	note "--- --timeout is an unblocked --no-wait ---"
+	st_reason "--timeout refused by default" "DENY" "stops the CLI waiting" generate cat --yes --max-cost 5 --timeout 1s
+	st_check  "no --timeout is fine"         "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
+
 	note "--- withdraw + workflows cancel allowlists ---"
-	st_reason "unknown pubreq denied"          "not created by this sandbox" app withdraw pubreq_UNKNOWN
-	st_reason "non-pubreq-shaped id denied"    "not created by this sandbox" app withdraw NOT-A-PUBREQ-ID
-	st_reason "--id form denied"               "not created by this sandbox" app withdraw --id NOT-A-PUBREQ
+	st_reason "unknown pubreq denied"          "DENY" "not created by this sandbox" app withdraw pubreq_UNKNOWN
+	st_reason "non-pubreq-shaped id denied"    "DENY" "not created by this sandbox" app withdraw NOT-A-PUBREQ-ID
+	st_reason "--id form denied"               "DENY" "not created by this sandbox" app withdraw --id NOT-A-PUBREQ
 	st_check  "no id is a CLI usage error"     "ALLOW" "$(vd app withdraw)"
 	printf 'pubreq_MINE\n' >> "${ROOT}/ledger/pubreq.allow"
 	st_check  "allowlisted pubreq permitted"   "ALLOW" "$(vd app withdraw pubreq_MINE)"
-	st_reason "cancel of a foreign workflow denied" "DOES NOT REFUND" workflows cancel someone-elses
+	st_reason "cancel of a foreign workflow denied" "DENY" "DOES NOT REFUND" workflows cancel someone-elses
 	printf 'wf-mine\n' >> "${ROOT}/ledger/workflow.allow"
 	st_check  "cancel of our own workflow allowed" "ALLOW" "$(vd workflows cancel wf-mine)"
 	st_check  "workflows list is a read"       "ALLOW" "$(vd workflows list)"
@@ -1454,11 +1777,11 @@ OFFLINE
 	note "--- calibration + meter_broken gates ---"
 	printf 'REQUIRE_CALIBRATION=1\n' >> "${ROOT}/ledger/policy.env"
 	load_policy || die "selftest: policy reload failed"
-	st_reason "uncalibrated meter refuses to spend" "calibrated" generate cat --yes --max-cost 5
+	st_reason "uncalibrated meter refuses to spend" "DENY" "calibrated" generate cat --yes --max-cost 5
 	printf 'calibrated\n' > "${ROOT}/ledger/calibration.ok"
 	st_check  "calibrated meter may spend" "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
 	: > "${ROOT}/ledger/meter_broken"
-	st_reason "a broken meter refuses to spend" "no longer being counted" generate cat --yes --max-cost 5
+	st_reason "a broken meter refuses to spend" "DENY" "no longer being counted" generate cat --yes --max-cost 5
 	st_check  "dry-run still allowed with a broken meter" "ALLOW" "$(vd generate cat --dry-run)"
 	rm -f "${ROOT}/ledger/meter_broken" "${ROOT}/ledger/calibration.ok"
 	grep -v '^REQUIRE_CALIBRATION=1$' "${ROOT}/ledger/policy.env" > "${ROOT}/ledger/p.tmp"
@@ -1565,14 +1888,37 @@ args=(); for a in "$@"; do case "${a}" in --no-color|--color|--no-update-check) 
 set -- "${args[@]+"${args[@]}"}"
 case "${1:-}" in
   buzz)
+    [ -n "${STUB_BUZZ_ALWAYS_FAILS:-}" ] && { echo boom >&2; exit 5; }
+    # Widen the locked section so the concurrency row is deterministic: the
+    # pre-spend balance read happens INSIDE the lock, so without flock the
+    # eight racers overlap reliably rather than by luck.
+    [ -n "${STUB_SLOW_BUZZ:-}" ] && sleep 0.3
     n=$(cat "${NB}"); echo $(( n + 1 )) > "${NB}"
     if [ -n "${STUB_FLAKY_BUZZ:-}" ] && [ $(( n % 2 )) = 1 ]; then echo boom >&2; exit 5; fi
     printf '{\n  "total": %s\n}\n' "$(cat "${BAL}")" ;;
+  workflows)
+    if [ -n "${STUB_WORKFLOWS:-}" ]; then
+      if [ -f "${XDG_CACHE_HOME}/wf-submitted" ]; then
+        printf '[{"id":"wf-old"},{"id":"wf-new"}]\n'
+      else printf '[{"id":"wf-old"}]\n'; fi
+    fi ;;
   generate)
+    # A failure that spends NOTHING — the CLI's own --max-cost refusal shape.
+    [ -n "${STUB_FAIL_RC:-}" ] && { echo "estimate exceeds --max-cost" >&2; exit "${STUB_FAIL_RC}"; }
+    if [ -n "${STUB_REPORT_INFLIGHT:-}" ]; then
+      [ -f "${XDG_CACHE_HOME}/../../ledger/inflight" ] && echo yes > "${XDG_CACHE_HOME}/saw-inflight" || echo no > "${XDG_CACHE_HOME}/saw-inflight"
+    fi
+    [ -n "${STUB_WORKFLOWS:-}" ] && : > "${XDG_CACHE_HOME}/wf-submitted"
     if [ -n "${STUB_LAGGY:-}" ]; then :                       # charge never lands
     elif [ -n "${STUB_CREDIT:-}" ]; then echo $(( $(cat "${BAL}") - 37 + 100 )) > "${BAL}"
     else echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; fi
     echo generated ;;
+  app)
+    [ -n "${STUB_APP_RC:-}" ] && { echo "validation failed" >&2; exit "${STUB_APP_RC}"; }
+    if [ "${2:-}" = "status" ] && [ -n "${STUB_PUBREQ:-}" ]; then
+      printf '{"submissions":[{"publishRequestId":"pubreq_MINE"}]}\n'
+    fi
+    : ;;
   *) : ;;
 esac
 exit 0
@@ -1586,6 +1932,9 @@ SHIM
 	chmod 0755 "${base}/bin/civitai"
 
 	e2e_policy() {
+		# The hashes are real: the guard verifies them before every invocation,
+		# so a fixture without them refuses everything (which is how this block
+		# first went red — correctly).
 		cat > "${base}/ledger/policy.env" <<POL
 ROOT="${base}"
 PER_CALL_MAX_COST=100
@@ -1598,6 +1947,8 @@ REQUIRE_CALIBRATION=${1:-0}
 ALLOW_NO_WAIT=0
 SLUG_PREFIX="sanctioned-"
 BASE_URL="https://example.invalid"
+BINARY_SHA256="$(sha256sum "${base}/real/civitai" | cut -d' ' -f1)"
+GUARD_SHA256="$(sha256sum "${base}/real/dogfoodguard" | cut -d' ' -f1)"
 POL
 	}
 	e2e_reset() {
@@ -1656,11 +2007,32 @@ POL
 
 	# Concurrency: leave exactly 10 Buzz of headroom and fire 8 at once.
 	e2e_reset; printf '1990\n' > "${base}/ledger/observed_spend"
-	for i in 1 2 3 4 5 6 7 8; do "${C}" generate "p${i}" --yes --max-cost 10 >/dev/null 2>&1 & done
+	for i in 1 2 3 4 5 6 7 8; do STUB_SLOW_BUZZ=1 "${C}" generate "p${i}" --yes --max-cost 10 >/dev/null 2>&1 & done
 	wait
 	allow=$(grep -c 'ALLOW_SPEND' "${base}/ledger/invocations.tsv" 2>/dev/null || printf 0)
-	st_check "e2e 8 concurrent submits, 10 Buzz headroom" "1" "${allow}"
-	st_check "e2e submit counter matches the allowed rows" "${allow}" "$(cat "${base}/ledger/generate_submits")"
+	# NOT a strict count: see cmd_locktest — with the lock deleted this row
+	# still passed on a third of runs, so it is kept only as a smoke test that
+	# concurrent invocations do not corrupt the ledger. The mutual exclusion
+	# itself is pinned deterministically below.
+	st_check "e2e concurrent submits keep the counter consistent" \
+		"${allow}" "$(cat "${base}/ledger/generate_submits")"
+
+	note "--- 🔴 the ledger lock, pinned as a PRIMITIVE (deterministic) ---"
+	rm -f "${base}/ledger/.locktest-held"
+	bash "$(readlink -f "$0")" __locktest --root "${base}" hold 3 >/dev/null 2>&1 &
+	local holder=$!
+	local waited=0
+	while [ ! -f "${base}/ledger/.locktest-held" ] && [ "${waited}" -lt 30 ]; do
+		sleep 0.1; waited=$(( waited + 1 ))
+	done
+	st_check "e2e the holder took the lock" "yes" \
+		"$([ -f "${base}/ledger/.locktest-held" ] && printf yes || printf no)"
+	st_check "e2e a second process is BLOCKED while it is held" "blocked" \
+		"$(bash "$(readlink -f "$0")" __locktest --root "${base}" try 2>/dev/null)"
+	wait "${holder}" 2>/dev/null
+	st_check "e2e the lock is free once released" "acquired" \
+		"$(bash "$(readlink -f "$0")" __locktest --root "${base}" try 2>/dev/null)"
+	rm -f "${base}/ledger/.locktest-held"
 
 	note "--- 🔴 the three ways the meter can lie, each must LATCH ---"
 
@@ -1696,6 +2068,91 @@ POL
 	st_check "e2e an UNWRITABLE counter refuses a spend" "126" "${rc}"
 	st_check "e2e nothing was charged in that attempt"   "10000" "$(cat "${base}/home/.cache/bal")"
 
+	note "--- 🔴 the PRE-read fail-closed path, which had no coverage at all ---"
+	e2e_reset
+	# A balance read that fails BEFORE the submit must refuse and spend nothing.
+	STUB_BUZZ_ALWAYS_FAILS=1 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e a failed PRE-read refuses"          "126"   "$?"
+	st_check "e2e a failed PRE-read spent nothing"    "10000" "$(cat "${base}/home/.cache/bal")"
+	st_check "e2e a failed PRE-read left the meter 0" "0"     "$(cat "${base}/ledger/observed_spend")"
+
+	note "--- 🔴 a non-spending FAILURE must not latch or credit ---"
+	e2e_reset
+	STUB_FAIL_RC=2 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e a failed generate returns the CLI rc" "2" "$?"
+	st_check "e2e a failed generate did not latch"      "no" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	st_check "e2e a failed generate credited nothing"   "0" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e a failed generate burned no submit"   "0" "$(cat "${base}/ledger/generate_submits")"
+	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e the NEXT generate still works"        "0" "$?"
+
+	note "--- 🔴 an interrupted spend is reconciled on the next invocation ---"
+	e2e_reset
+	printf '%s\t50\t10000\tgenerate interrupted\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${base}/ledger/inflight"
+	printf '50\n' > "${base}/ledger/reserved"
+	printf '9963\n' > "${base}/home/.cache/bal"
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e the interrupted charge was reconciled" "37" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e the leaked reservation was released"   "0"  "$(cat "${base}/ledger/reserved")"
+	st_check "e2e a RECONCILED row was written"          "1" \
+		"$(grep -c 'RECONCILED' "${base}/ledger/invocations.tsv")"
+
+	note "--- app/listing counters bump on SUCCESS only ---"
+	e2e_reset
+	mkdir -p "${base}/workspace/app"
+	printf '{"blockId":"sanctioned-x","name":"n","version":"1.0.0","kind":"page"}\n' \
+		> "${base}/workspace/app/block.manifest.json"
+	STUB_APP_RC=1 "${C}" app submit "${base}/workspace/app" --yes >/dev/null 2>&1
+	st_check "e2e a REJECTED submit burns no slot" "0" "$(cat "${base}/ledger/app_submits")"
+	"${C}" app submit "${base}/workspace/app" --yes >/dev/null 2>&1
+	st_check "e2e an ACCEPTED submit counts"       "1" "$(cat "${base}/ledger/app_submits")"
+
+	note "--- 🔴 provenance is VERIFIED, not merely recorded ---"
+	e2e_reset
+	# 🔴 UNLINK BEFORE WRITING. Overwriting a binary that has just been executed
+	# gives ETXTBSY and the write SILENTLY FAILS — measured, the substitution
+	# never happened and this row passed against the REAL classifier, which is
+	# the second time that trap has produced a green row about a swap that did
+	# not occur. `rm` then create makes a new inode.
+	rm -f "${base}/real/dogfoodguard"
+	printf '#!/usr/bin/env bash\nprintf "ok\\t1\\npath\\twhoami\\nargc\\t0\\nhassubcommands\\tfalse\\nargserr\\t\\n"\n' \
+		> "${base}/real/dogfoodguard"
+	chmod 0755 "${base}/real/dogfoodguard"
+	st_check "e2e the classifier really WAS substituted" "yes" \
+		"$([ "$(head -c 2 "${base}/real/dogfoodguard")" = "#!" ] && printf yes || printf no)"
+	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e a SUBSTITUTED classifier is refused" "126" "$?"
+	st_check "e2e the substitution spent nothing"      "10000" "$(cat "${base}/home/.cache/bal")"
+	rm -f "${base}/real/dogfoodguard"
+	cp "${guard_src}" "${base}/real/dogfoodguard"; chmod 0755 "${base}/real/dogfoodguard"
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e the restored classifier works again" "0" "$?"
+
+	note "--- 🔴 the in-flight record exists DURING the call ---"
+	e2e_reset
+	STUB_REPORT_INFLIGHT=1 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e the stub saw an inflight record mid-call" "yes" \
+		"$(cat "${base}/home/.cache/saw-inflight" 2>/dev/null || printf no)"
+
+	note "--- id recording: pubreq and workflow provenance ---"
+	e2e_reset
+	mkdir -p "${base}/workspace/app2"
+	printf '{"blockId":"sanctioned-y","name":"n","version":"1.0.0","kind":"page"}\n' \
+		> "${base}/workspace/app2/block.manifest.json"
+	STUB_PUBREQ=1 "${C}" app submit "${base}/workspace/app2" --yes >/dev/null 2>&1
+	st_check "e2e a submit records its OWN pubreq id" "1" \
+		"$(grep -c 'pubreq_MINE' "${base}/ledger/pubreq.allow" 2>/dev/null || printf 0)"
+	"${C}" app withdraw pubreq_MINE >/dev/null 2>&1
+	st_check "e2e withdraw of the recorded id is allowed" "0" "$?"
+	"${C}" app withdraw pubreq_SOMEONEELSE >/dev/null 2>&1
+	st_check "e2e withdraw of a foreign id is refused"   "126" "$?"
+
+	e2e_reset
+	STUB_WORKFLOWS=1 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	st_check "e2e only the NEW workflow id is allowlisted" "wf-new" \
+		"$(tr -d ' \n' < "${base}/ledger/workflow.allow" 2>/dev/null)"
+
 	note "--- calibration gate, end to end ---"
 	e2e_policy 1; e2e_reset
 	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1
@@ -1727,6 +2184,7 @@ main() {
 		teardown)      cmd_teardown "$@" ;;
 		__buzz)        cmd_buzz_probe "$@" ;;
 		__verdict)     cmd_verdict "$@" ;;
+		__locktest)    cmd_locktest "$@" ;;
 		*)             usage ;;
 	esac
 }

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -57,6 +57,9 @@ DEFAULT_MAX_APP_SUBMITS=3
 DEFAULT_MAX_LISTING_MUTATIONS=10
 # Seconds to wait before re-sampling when a submit reports a zero delta.
 DEFAULT_METER_SETTLE_SECONDS=5
+# Calibration prices a MINIMAL job, not the per-call ceiling: it exists to prove
+# the meter observes a charge, not to spend the maximum allowed.
+CALIBRATE_MAX_COST="${CALIBRATE_MAX_COST:-25}"
 # Require `calibrate` (one deliberate, operator-watched generation) before the
 # agent may spend, so the meter's core assumption is measured, not assumed.
 DEFAULT_REQUIRE_CALIBRATION=1
@@ -212,14 +215,36 @@ write_scalar() {
 # seeded config file is the only credential.
 # ---------------------------------------------------------------------------
 
+# 🔴 THE CREDENTIAL IS INJECTED, NEVER LEFT ON DISK IN $HOME. `README.md` — one
+# of the three things the blind agent is given — says `npm install -g
+# @civitai/cli`, and node/npm are in the closure, so a SECOND, UNGATED CLI is
+# one documented command away. While a `config.yaml` sat in the sandbox $HOME
+# that second binary authenticated with it: measured, `npx -y @civitai/cli
+# whoami` returned 401 against a deliberately fake seeded value, which is
+# positive proof it read and sent the file. It would then have spent with no
+# --max-cost, no cap, no counter, no bracketing, no ledger row and no latch —
+# and no defeat-intent is required, it is the documented install command.
+#
+# So the token lives in ledger/credential (0600) and reaches only the child this
+# gate execs. A second binary starts unauthenticated and every ungated path is
+# inert. Residual, stated in the doc: the file is readable by the same UID, so
+# an agent that goes looking can still find it — but that is intent, not the
+# README.
+sandbox_credential() {
+	local f="${ROOT}/ledger/credential"
+	[ -r "${f}" ] || return 0
+	head -c 4096 "${f}" | tr -d '\r\n'
+}
+
 real_cli() {
-	env -u CIVITAI_TOKEN -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
+	env -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
 		-u CIVITAI_CHECK_SUBMISSIONS_CAP -u CIVITAI_CHECK_PUBLISHED_PINS \
 		"HOME=${ROOT}/home" \
 		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
 		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
 		"CIVITAI_NO_UPDATE_CHECK=1" \
 		"CIVITAI_BASE_URL=${BASE_URL:-${DEFAULT_BASE_URL}}" \
+		"CIVITAI_TOKEN=$(sandbox_credential)" \
 		"${ROOT}/real/civitai" "$@"
 }
 
@@ -488,12 +513,12 @@ POLICY
 	chmod 0600 "${ROOT}/ledger/policy.env"
 	load_policy || die "init: the policy just written does not validate: ${POLICY_ERROR}"
 
-	real_cli login --token "${token}" >/dev/null 2>&1 \
-		|| die "init: seeding the credential failed — check the token"
+	(umask 077; printf '%s' "${token}" > "${ROOT}/ledger/credential") \
+		|| die "init: could not store the credential"
+	chmod 0600 "${ROOT}/ledger/credential"
 	token=""
-	[ -f "${ROOT}/home/.config/civitai/config.yaml" ] \
-		|| die "init: no config written at ${ROOT}/home/.config/civitai/config.yaml"
-	chmod 0600 "${ROOT}/home/.config/civitai/config.yaml"
+	# Nothing may write a config into the sandbox HOME — see sandbox_credential.
+	rm -f "${ROOT}/home/.config/civitai/config.yaml"
 
 	real_cli whoami >/dev/null 2>&1 || die "init: whoami failed with the seeded credential"
 
@@ -526,6 +551,11 @@ cmd_write_brief() {
 
 You have a \`civitai\` binary on your PATH, its \`README.md\`, and \`--help\`.
 Work only inside \`${ROOT}/workspace\`.
+
+🔴 **The \`civitai\` on your PATH is the only one in scope.** The README suggests
+\`npm install -g @civitai/cli\`; do NOT install or run a second copy. It would not
+be the build under evaluation, it is not covered by the safety gate, and any
+finding from it tells the authors nothing about this binary.
 
 This is a real, credentialed account. \`civitai generate\` **spends real money**.
 A sandbox policy gate sits in front of the CLI and refuses some invocations; a
@@ -589,6 +619,10 @@ GHASSUB=""; GARGSERR=""
 # classifier of its own.
 GUARD_BIN=""
 
+# escape() writes \\ first, then \n/\r/\t; undoing it must therefore take the
+# single-character escapes FIRST and the backslash LAST, or a literal "\\n" in
+# a prompt round-trips to a newline. Every current consumer fails closed on the
+# difference, but the asymmetry was real.
 unescape() {
 	local s="$1"
 	s="${s//\\t/$'\t'}"
@@ -765,6 +799,24 @@ policy_verdict() {
 				deny "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"; return 0
 			fi
 			VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; VERDICT_SLUG="${id}"; return 0 ;;
+
+		"app pull")
+			# 🔴 `app pull` REACHES THE ACCOUNT'S REAL APPS AND PROVISIONS A
+			# THIRD CREDENTIAL. It hits an owner-only endpoint, lazily creates a
+			# Forgejo identity, and git writes an access token into
+			# `.git/config` — and `git` is in the closure. SLUG_PREFIX exists to
+			# stop this run touching real apps; it covered submit and listing
+			# and not this.
+			local pull_app
+			pull_app=$(gstr app)
+			if [ -z "${pull_app}" ]; then
+				allow "pull with no --app (a usage error the CLI reports)"; return 0
+			fi
+			case "${pull_app}" in
+				"${SLUG_PREFIX}"*) allow "pull of this run's own app"; return 0 ;;
+				*) deny "\`${pull_app}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — \`app pull\` reaches a real app and writes a git credential into .git/config"
+				   return 0 ;;
+			esac ;;
 
 		"app listing status")
 			allow "listing read"; return 0 ;;
@@ -963,7 +1015,13 @@ cmd_guard() {
 		# computed from, so they are what must be writable before a spend.
 		ALLOW_SPEND)      assert_writable generate_submits "${scrubbed}"
 		                  assert_writable observed_spend "${scrubbed}"
-		                  assert_writable reserved "${scrubbed}" ;;
+		                  assert_writable reserved "${scrubbed}"
+		                  # The audit trail is the deliverable: with
+		                  # invocations.tsv at 0444 a generate charged 37 and
+		                  # wrote ZERO rows. Disk-full is the realistic trigger,
+		                  # and ${ROOT} also holds the npm cache.
+		                  assert_appendable invocations.tsv "${scrubbed}"
+		                  assert_appendable spend.tsv "${scrubbed}" ;;
 		ALLOW_APP_SUBMIT) assert_writable app_submits "${scrubbed}" ;;
 		ALLOW_LISTING)    assert_writable listing_mutations "${scrubbed}" ;;
 	esac
@@ -977,6 +1035,11 @@ cmd_guard() {
 		# A crash between here and the reconciliation must not lose the charge.
 		printf '%s\t%s\t%s\t%s\t%s\n' "$(now_iso)" "${mc}" "${before}" "$$" "${scrubbed}" \
 			> "${ROOT}/ledger/inflight"
+		# Held for the lifetime of THIS process, so a later invocation can tell
+		# a running spend from a crashed one without consulting a pid.
+		if command -v flock >/dev/null 2>&1; then
+			exec 8>"${ROOT}/ledger/inflight.lock" && flock -x -n 8
+		fi
 		workflow_snapshot
 	fi
 
@@ -984,13 +1047,14 @@ cmd_guard() {
 
 	local t0 t1 rc
 	t0=$(date +%s%N)
-	env -u CIVITAI_TOKEN -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
+	env -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
 		-u CIVITAI_CHECK_SUBMISSIONS_CAP -u CIVITAI_CHECK_PUBLISHED_PINS \
 		"HOME=${ROOT}/home" \
 		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
 		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
 		"CIVITAI_NO_UPDATE_CHECK=1" \
 		"CIVITAI_BASE_URL=${BASE_URL}" \
+		"CIVITAI_TOKEN=$(sandbox_credential)" \
 		"${ROOT}/real/civitai" "${argv[@]+"${argv[@]}"}"
 	rc=$?
 	t1=$(date +%s%N)
@@ -1048,9 +1112,8 @@ cmd_guard() {
 #     real charge. Measured: a +100 grant alongside a 37 charge recorded 0.
 #     Clamping to zero is what made that silent, so it no longer clamps.
 settle_spend() {
-	local before="$1" mc="$2" rc="${3:-0}" after res cum delta
-	res=$(read_scalar reserved)      || res="${mc}"
-	cum=$(read_scalar observed_spend) || cum=0
+	local before="$1" mc="$2" rc="${3:-0}" after res delta
+	res=$(read_scalar reserved) || res="${mc}"
 
 	after=$(sample_balance "post-generate") || after=""
 
@@ -1060,53 +1123,23 @@ settle_spend() {
 	fi
 
 	# 🔴 THE rc-AWARE SUPPRESSION APPLIES TO EXACTLY ONE CASE: THE READ WORKED
-	# AND THE DELTA REALLY IS 0.
-	#
-	# Suppressing on rc alone was too strong in both directions, and both were
-	# measured. A zero delta on a non-zero exit IS expected — the CLI's own
-	# `--max-cost` refusal, a bad `--input`, an `--ecosystem` typo — and
-	# latching on it killed the run at the agent's first likely mistake. But a
-	# generate can charge and THEN fail: AGENTS item 28(b) refuses to assert
-	# what becomes of a charge, and #279 records submits that quoted `ready` and
-	# produced no outputs. Measured control pair, rc=1 throughout:
-	#   read fails  -> 37 really moved, meter 0, no latch   <- the hole
-	#   credit hides -> 37 really moved, meter 0, no latch   <- the hole
-	#   read healthy -> 37 metered                           <- correct
-	# So an UNREADABLE balance and a NEGATIVE delta latch whatever the exit code
-	# was; only the observable zero is trusted, and only then.
-	if [ -z "${after}" ]; then
-		write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
-		printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s (rc=%s)\n' "$(now_iso)" "${before}" "${mc}" "${rc}" \
+	# AND THE DELTA REALLY IS 0. Suppressing on rc alone was wrong in both
+	# directions and both were measured. A zero delta on a non-zero exit IS
+	# expected — the CLI's own `--max-cost` refusal, a bad `--input`, an
+	# `--ecosystem` typo — and latching on it killed the run at the agent's
+	# first likely mistake. But a generate can charge and THEN fail (AGENTS item
+	# 28(b); #279), and with rc≠0 a failed read or a credit-masked charge left
+	# 37 Buzz unmetered and unlatched. So this is the ONLY case rc suppresses;
+	# everything else goes through apply_settlement, which both this path and
+	# the crash path share.
+	if [ -n "${after}" ] && [ "${before}" = "${after}" ] && [ "${rc}" != 0 ]; then
+		printf '%s\tgenerate\t%s\t%s\t0 (rc=%s, no charge)\n' "$(now_iso)" "${before}" "${after}" "${rc}" \
 			>> "${ROOT}/ledger/spend.tsv"
-		break_meter "the post-submit balance read failed (rc=${rc}); ${mc} Buzz charged to the ledger as a worst case"
-		delta="unknown"
+		delta=0
 	else
-		delta=$(( before - after ))
-		if [ "${delta}" -lt 0 ]; then
-			write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
-			printf '%s\tgenerate\t%s\t%s\tNEGATIVE(%s)-assumed-%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${mc}" "${rc}" \
-				>> "${ROOT}/ledger/spend.tsv"
-			break_meter "the balance went UP across a submit (delta ${delta}, rc=${rc}); a credit can hide a real charge, so ${mc} Buzz was charged as a worst case"
-			delta="negative:${delta}"
-		elif [ "${delta}" = 0 ]; then
-			if [ "${rc}" != 0 ]; then
-				# Observably nothing moved and the command failed: benign.
-				printf '%s\tgenerate\t%s\t%s\t0 (rc=%s, no charge)\n' "$(now_iso)" "${before}" "${after}" "${rc}" \
-					>> "${ROOT}/ledger/spend.tsv"
-				delta=0
-			else
-				write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
-				printf '%s\tgenerate\t%s\t%s\tZERO-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${mc}" \
-					>> "${ROOT}/ledger/spend.tsv"
-				break_meter "a submitted generation moved the balance by 0, so the meter is not seeing charges; ${mc} Buzz charged as a worst case"
-				delta="zero"
-			fi
-		else
-			write_scalar observed_spend "$(( cum + delta ))" || meter_write_failed
-			printf '%s\tgenerate\t%s\t%s\t%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${rc}" \
-				>> "${ROOT}/ledger/spend.tsv"
-		fi
+		delta=$(apply_settlement "${before}" "${after}" "${mc}" "generate")
 	fi
+
 	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
 	printf '%s' "${delta}"
 }
@@ -1127,6 +1160,13 @@ assert_writable() {
 	local name="$1" scrubbed="$2" v
 	v=$(read_scalar "${name}") || refuse "the ${name} counter is unreadable or malformed" "${scrubbed}"
 	write_scalar "${name}" "${v}" || refuse "the ${name} counter is not writable, so this run could not be counted — refusing" "${scrubbed}"
+}
+
+# Prove an append-only ledger file can actually be appended to.
+assert_appendable() {
+	local name="$1" scrubbed="$2"
+	printf '' >> "${ROOT}/ledger/${name}" 2>/dev/null \
+		|| refuse "the ${name} audit log is not writable, so this run could not be recorded — refusing" "${scrubbed}"
 }
 
 PROVENANCE_ERROR=""
@@ -1160,40 +1200,95 @@ verify_provenance() {
 reconcile_inflight() {
 	local f="${ROOT}/ledger/inflight"
 	[ -f "${f}" ] || return 0
-	local ts mc before pid now cum res delta
-	IFS=$'\t' read -r ts mc before pid _ < "${f}"
 
-	# 🔴 A RUNNING GENERATE IS NOT A CRASHED ONE, AND THIS COULD NOT TELL THEM
-	# APART. The record was one file with no liveness check, so ANY invocation
-	# arriving mid-generate consumed it — deleted the record, released the
-	# reservation and wrote a false RECONCILED row. It takes one read command
-	# inside the window, and a real generate waits up to the 10-minute
-	# `--timeout` default. Measured 3/3 with a `whoami` at t=1s of a 3-second
-	# generate: a RECONCILED row every time. With 8 racers the meter reported
-	# 2064 where 37 had actually moved — one charge counted twice, once by the
-	# bystander and once by the real settlement.
-	if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
-		return 0
+	# 🔴 LIVENESS BY LOCK, NOT BY PID. The pid check was namespace-unsafe:
+	# `enter` runs `--unshare-pid`, so the first command in the jail has $$ = 1
+	# or 2, and a stale record carrying either was NEVER reconciled — measured,
+	# pid 1 and pid 2 both left the record in place, leaked the reservation, and
+	# then made every later generate refuse with "another generation is still
+	# running". One interrupted generate bricked the spend path for the whole
+	# run, and `--die-with-parent` makes that routine. The writer instead holds
+	# an exclusive flock for the duration of its child; if we can take it, the
+	# writer is gone.
+	if command -v flock >/dev/null 2>&1; then
+		exec 7>"${ROOT}/ledger/inflight.lock" || return 0
+		if ! flock -x -n 7; then
+			exec 7>&- 2>/dev/null
+			return 0
+		fi
+		flock -u 7 2>/dev/null; exec 7>&- 2>/dev/null
 	fi
+
+	local ts mc before _pid
+	IFS=$'\t' read -r ts mc before _pid _ < "${f}"
 	rm -f "${f}"
 	case "${mc}" in ''|*[!0-9]*) mc=0 ;; esac
 	case "${before}" in ''|*[!0-9]*) before="" ;; esac
-	cum=$(read_scalar observed_spend) || cum=0
-	res=$(read_scalar reserved) || res=0
+
+	local now delta
 	now=$(sample_balance "reconcile") || now=""
-	if [ -n "${before}" ] && [ -n "${now}" ]; then
-		delta=$(( before - now ))
-		[ "${delta}" -lt 0 ] && delta=0
-	else
-		delta="${mc}"
-	fi
-	write_scalar observed_spend "$(( cum + delta ))" || true
-	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
+
+	# 🔴 ONE RULE, ONE PLACE. This used to carry its own arithmetic and
+	# regenerated all three defects settle_spend had just had removed:
+	# measured, a reconcile with delta 0 recorded 0 and did not latch, a
+	# NEGATIVE delta was clamped to 0 (with settle_spend's own comment saying
+	# clamping "is what made that silent" twelve lines away), and an unwritable
+	# meter was ignored — after which the run simply continued. Ctrl-C on a slow
+	# generate is the likeliest trigger and lands on the delta-0 row. Both paths
+	# now call apply_settlement.
+	delta=$(apply_settlement "${before}" "${now}" "${mc}" "reconcile")
+
+	write_scalar reserved "$(( $(read_scalar reserved || printf 0) - mc < 0 ? 0 : $(read_scalar reserved || printf 0) - mc ))" || true
 	printf '%s\tRECONCILED\t0\t0\t%s\t%s\n' "$(now_iso)" \
 		"$(tsv_escape "an earlier generation did not finish cleanly (started ${ts})")" \
 		"$(tsv_escape "delta=${delta}")" >> "${ROOT}/ledger/invocations.tsv"
 	printf '%s: %s\n' "${SANDBOX_TAG}" \
-		"an earlier generation was interrupted; ${delta} Buzz reconciled into the ledger" >&2
+		"an earlier generation was interrupted; ${delta} reconciled into the ledger" >&2
+}
+
+# The settlement arithmetic, shared by the live path and the crash path.
+#
+# before/after are balances ("" when unreadable), mc is the worst case the
+# estimate allowed, phase names the caller for the spend log. Echoes the delta
+# it recorded. Latches meter_broken on every shape it cannot trust: an
+# unreadable balance, a negative delta, or a zero delta the caller says should
+# have moved money.
+apply_settlement() {
+	local before="$1" after="$2" mc="$3" phase="$4" cum delta
+	cum=$(read_scalar observed_spend) || cum=0
+
+	if [ -z "${before}" ] || [ -z "${after}" ]; then
+		write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+		printf '%s\t%s\t%s\tUNREADABLE\tassumed-%s\n' "$(now_iso)" "${phase}" "${before:-UNKNOWN}" "${mc}" \
+			>> "${ROOT}/ledger/spend.tsv"
+		break_meter "a balance read failed during ${phase}; ${mc} Buzz charged to the ledger as a worst case"
+		printf '%s' "unknown"
+		return 0
+	fi
+
+	delta=$(( before - after ))
+	if [ "${delta}" -lt 0 ]; then
+		write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+		printf '%s\t%s\t%s\t%s\tNEGATIVE(%s)-assumed-%s\n' "$(now_iso)" "${phase}" "${before}" "${after}" "${delta}" "${mc}" \
+			>> "${ROOT}/ledger/spend.tsv"
+		break_meter "the balance went UP across ${phase} (delta ${delta}); a credit can hide a real charge, so ${mc} Buzz was charged as a worst case"
+		printf '%s' "negative:${delta}"
+		return 0
+	fi
+
+	if [ "${delta}" = 0 ]; then
+		write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+		printf '%s\t%s\t%s\t%s\tZERO-assumed-%s\n' "$(now_iso)" "${phase}" "${before}" "${after}" "${mc}" \
+			>> "${ROOT}/ledger/spend.tsv"
+		break_meter "${phase} saw the balance move by 0 for a generation that was submitted, so the meter is not seeing charges; ${mc} Buzz charged as a worst case"
+		printf '%s' "zero"
+		return 0
+	fi
+
+	write_scalar observed_spend "$(( cum + delta ))" || meter_write_failed
+	printf '%s\t%s\t%s\t%s\t%s\n' "$(now_iso)" "${phase}" "${before}" "${after}" "${delta}" \
+		>> "${ROOT}/ledger/spend.tsv"
+	printf '%s' "${delta}"
 }
 
 break_meter() {
@@ -1303,9 +1398,22 @@ cmd_calibrate() {
 	before=$(sample_balance "calibrate-before") || die "calibrate: could not read the opening balance"
 	note "balance before: ${before}"
 
-	note "submitting one generation (--max-cost ${PER_CALL_MAX_COST}) …"
-	real_cli generate "a plain grey square, calibration" --yes --max-cost "${PER_CALL_MAX_COST}" \
-		--no-download >/dev/null 2>&1
+	# 🔴 CALIBRATE GOES THROUGH THE GATE. It used to call real_cli directly, so
+	# the one spend the go/no-go MAKES MANDATORY bypassed the lock, the caps,
+	# the meter, the counter and the ledger entirely — measured: 37 Buzz moved,
+	# observed_spend 0, submits 0, ledger rows 0, and `finish` then reported
+	# "observed 37 / MEASURED TOTAL SPEND 74". The doc lists a disagreement
+	# between those two figures as an ABORT CONDITION, so the prescribed
+	# procedure guaranteed the alarm fired every run — a permanently-red gate
+	# that trains the operator to explain away the only signal that catches an
+	# escaped charge.
+	#
+	# The gate refuses to spend until calibration.ok exists, so it is written
+	# provisionally and removed again if the run does not prove the meter.
+	printf 'provisional %s\n' "$(now_iso)" > "${ROOT}/ledger/calibration.ok"
+	note "submitting one generation through the gate (--max-cost ${CALIBRATE_MAX_COST}) …"
+	"${ROOT}/bin/civitai" generate "a plain grey square, calibration" --yes \
+		--max-cost "${CALIBRATE_MAX_COST}" --no-download >/dev/null 2>&1
 	local rc=$?
 
 	after=$(sample_balance "calibrate-after") || die "calibrate: could not read the closing balance"
@@ -1313,9 +1421,11 @@ cmd_calibrate() {
 	note "balance after:  ${after}   delta=${delta}   (generate rc=${rc})"
 
 	if [ "${rc}" != 0 ]; then
+		rm -f "${ROOT}/ledger/calibration.ok"
 		die "calibrate: the generation itself failed (rc=${rc}); fix that before calibrating"
 	fi
 	if [ "${delta}" -le 0 ]; then
+		rm -f "${ROOT}/ledger/calibration.ok"
 		printf '%s\n' "calibration FAILED: the balance did not move by the time generate returned (delta ${delta})" \
 			> "${ROOT}/ledger/meter_broken"
 		die "calibrate: the balance did NOT move by the time the command returned (delta ${delta}). The meter cannot count spend on this account/endpoint — do not run the dogfood until that is understood."
@@ -1361,6 +1471,9 @@ cmd_finish() {
 		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
 	done
 	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
+	# An outstanding crash record would otherwise leave the two figures
+	# disagreeing for a reason the report never explains.
+	lock_ledger && { reconcile_inflight; unlock_ledger; }
 	local start end
 	start=$(read_scalar start_balance) || die "finish: no usable opening balance recorded"
 	if ! end=$(sample_balance "end"); then
@@ -1584,7 +1697,15 @@ cmd_teardown() {
 # difference between "deleted" and "deleted and overwritten once".
 shred_secrets() {
 	local root="$1" f
-	for f in "${root}/home/.config/civitai/config.yaml" \
+	# Three credentials can exist in a run root: the Civitai token, the Anthropic
+	# OAuth token under --with-claude, and any git access token `app pull` wrote
+	# into a workspace .git/config.
+	local gitcfg
+	while IFS= read -r gitcfg; do
+		[ -n "${gitcfg}" ] && rm -f "${gitcfg}" 2>/dev/null
+	done < <(find "${root}/workspace" -name config -path '*/.git/*' 2>/dev/null)
+	for f in "${root}/ledger/credential" \
+	         "${root}/home/.config/civitai/config.yaml" \
 	         "${root}/home/.claude/.credentials.json"; do
 		[ -f "${f}" ] || continue
 		if command -v shred >/dev/null 2>&1; then
@@ -1884,6 +2005,14 @@ printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-
 	st_reason "--timeout refused by default" "DENY" "stops the CLI waiting" generate cat --yes --max-cost 5 --timeout 1s
 	st_check  "no --timeout is fine"         "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
 
+	note "--- 🔴 app pull reaches REAL apps and provisions a git credential ---"
+	st_reason "pull of a foreign app denied" "DENY" "outside the sanctioned prefix" \
+		app pull --app someones-real-app
+	st_check  "pull of our own app allowed" "ALLOW" "$(vd app pull --app "${SLUG_PREFIX}mine")"
+	# --app is a REQUIRED flag, so the classifier reports it and the gate denies
+	# — which is what the binary does too (exit 2). Not a distortion.
+	st_reason "pull with no --app denied as the CLI would" "DENY" "would reject these arguments" app pull
+
 	note "--- withdraw + workflows cancel allowlists ---"
 	st_reason "unknown pubreq denied"          "DENY" "not created by this sandbox" app withdraw pubreq_UNKNOWN
 	st_reason "non-pubreq-shaped id denied"    "DENY" "not created by this sandbox" app withdraw NOT-A-PUBREQ-ID
@@ -1959,6 +2088,7 @@ printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-
 
 	if [ "${offline}" = 1 ]; then
 		selftest_e2e "${ROOT}/real/dogfoodguard"
+		selftest_init_contract "${ROOT}/real/dogfoodguard"
 		note ""
 		note "--- offline mode: the credentialed checks below were skipped ---"
 		rm -rf "${ROOT}"
@@ -1977,13 +2107,77 @@ printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-
 		st_check "binary dir not writable"  "no" "$([ -w "${ROOT}/real" ] && printf yes || printf no)"
 		st_check "binary file not writable" "no" "$([ -w "${ROOT}/real/civitai" ] && printf yes || printf no)"
 		st_check "classifier present"       "yes" "$([ -x "${ROOT}/real/dogfoodguard" ] && printf yes || printf no)"
-		st_check "sandbox config exists"    "yes" "$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+		st_check "credential is NOT on disk in HOME" "no" \
+			"$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+		st_check "credential is held for injection"  "yes" \
+			"$([ -s "${ROOT}/ledger/credential" ] && printf yes || printf no)"
 		st_reset_ledger
 	fi
 
 	note ""
 	note "selftest: ${SELFTEST_PASS} passed, ${SELFTEST_FAIL} failed"
 	[ "${SELFTEST_FAIL}" = 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# init + calibrate, driven by a stub binary. No credential, no network.
+# ---------------------------------------------------------------------------
+selftest_init_contract() {
+	local base="${TMPDIR:-/tmp}/dogfood-init-$$"
+	local guard_src="$1"
+	rm -rf "${base}"; mkdir -p "${base}"
+	local stub="${base}/civitai-stub"
+	cat > "${stub}" <<'STUB'
+#!/usr/bin/env bash
+set -u
+: "${XDG_CACHE_HOME:=${HOME}/.cache}"
+mkdir -p "${XDG_CACHE_HOME}"
+BAL="${XDG_CACHE_HOME}/bal"; [ -f "${BAL}" ] || echo 10000 > "${BAL}"
+a=(); for x in "$@"; do case "${x}" in --no-color|--color|--no-update-check) ;; *) a+=("${x}") ;; esac; done
+set -- "${a[@]+"${a[@]}"}"
+case "${1:-}" in
+  buzz)   [ -n "${CIVITAI_TOKEN:-}" ] || { echo "unauthorized (401)" >&2; exit 3; }
+          printf '{\n  "total": %s\n}\n' "$(cat "${BAL}")" ;;
+  whoami) [ -n "${CIVITAI_TOKEN:-}" ] || { echo "unauthorized (401)" >&2; exit 3; }
+          echo authed ;;
+  generate) [ -n "${CIVITAI_TOKEN:-}" ] || { echo "unauthorized (401)" >&2; exit 3; }
+          echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; echo generated ;;
+  *) : ;;
+esac
+exit 0
+STUB
+	chmod 0755 "${stub}"
+
+	local run="${base}/run"
+	CIVITAI_DOGFOOD_TOKEN=stub-token bash "$(readlink -f "$0")" init \
+		--root "${run}" --binary "${stub}" --guard "${guard_src}" \
+		--slug-prefix "sanctioned-" --settle-seconds 0 >/dev/null 2>&1
+
+	note "--- 🔴 init leaves NO credential in the sandbox HOME ---"
+	st_check "init wrote no civitai config" "no" \
+		"$([ -f "${run}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+	st_check "init stored the credential for injection" "yes" \
+		"$([ -s "${run}/ledger/credential" ] && printf yes || printf no)"
+	st_check "the credential file is owner-only" "600" \
+		"$(stat -c '%a' "${run}/ledger/credential" 2>/dev/null)"
+	# POSITIVE CONTROL: an UNGATED binary in the same HOME is unauthenticated,
+	# while the gated one works — otherwise "no config" proves nothing.
+	HOME="${run}/home" XDG_CONFIG_HOME="${run}/home/.config" \
+		XDG_CACHE_HOME="${run}/home/.cache" "${stub}" whoami >/dev/null 2>&1
+	st_check "an UNGATED binary is unauthenticated" "3" "$?"
+	"${run}/bin/civitai" whoami >/dev/null 2>&1
+	st_check "the GATED binary is authenticated"    "0" "$?"
+
+	note "--- 🔴 calibrate spends THROUGH the gate ---"
+	bash "$(readlink -f "$0")" calibrate --root "${run}" --yes >/dev/null 2>&1
+	st_check "calibrate moved the meter"          "37" "$(cat "${run}/ledger/observed_spend" 2>/dev/null)"
+	st_check "calibrate counted a submission"     "1"  "$(cat "${run}/ledger/generate_submits" 2>/dev/null)"
+	st_check "calibrate wrote a ledger row"       "1"  "$(grep -c ALLOW_SPEND "${run}/ledger/invocations.tsv" 2>/dev/null || true)"
+	st_check "calibrate recorded its verdict"     "yes" \
+		"$([ -f "${run}/ledger/calibration.ok" ] && printf yes || printf no)"
+
+	chmod -R u+w "${base}" 2>/dev/null
+	rm -rf "${base}"
 }
 
 # ---------------------------------------------------------------------------
@@ -2342,6 +2536,63 @@ POL
 	STUB_WORKFLOWS=1 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
 	st_check "e2e only the NEW workflow id is allowlisted" "wf-new" \
 		"$(tr -d ' \n' < "${base}/ledger/workflow.allow" 2>/dev/null)"
+
+	note "--- 🔴 the crash path settles by the SAME rule as the live path ---"
+	# Each row drives reconcile_inflight through the shim by leaving a record
+	# whose writer is gone, then asserts the meter AND the latch.
+	stale_record() {  # $1 = mc, $2 = before-balance
+		printf '%s\t%s\t%s\t999999\t stale\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" \
+			> "${base}/ledger/inflight"
+		rm -f "${base}/ledger/inflight.lock"
+	}
+	e2e_reset; printf '9963\n' > "${base}/home/.cache/bal"
+	stale_record 50 10000
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e reconcile: a real delta is metered"   "37" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e reconcile: a real delta does not latch" "no" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	e2e_reset
+	stale_record 50 10000   # balance unchanged => delta 0
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e reconcile: a ZERO delta charges the worst case" "50" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e reconcile: a ZERO delta LATCHES"                "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	e2e_reset; printf '10100\n' > "${base}/home/.cache/bal"
+	stale_record 50 10000   # balance went UP
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e reconcile: a NEGATIVE delta charges the worst case" "50" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e reconcile: a NEGATIVE delta LATCHES"                "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	e2e_reset; printf '9963\n' > "${base}/home/.cache/bal"
+	stale_record 50 10000
+	chmod 0444 "${base}/ledger/observed_spend"
+	"${C}" whoami >/dev/null 2>&1
+	chmod 0644 "${base}/ledger/observed_spend"
+	st_check "e2e reconcile: an unwritable meter LATCHES" "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	note "--- 🔴 the audit trail must be writable before a spend ---"
+	e2e_reset
+	chmod 0444 "${base}/ledger/invocations.tsv"
+	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1; rc=$?
+	chmod 0644 "${base}/ledger/invocations.tsv"
+	st_check "e2e an unwritable audit log refuses a spend" "126"   "${rc}"
+	st_check "e2e that refusal spent nothing"              "10000" "$(cat "${base}/home/.cache/bal")"
+
+	note "--- 🔴 the sandbox HOME holds NO credential ---"
+	st_check "e2e no civitai config on disk" "no" \
+		"$([ -f "${base}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+
+	note "--- 🔴 concurrency OUTCOME, not just ledger consistency ---"
+	e2e_reset; printf '1990\n' > "${base}/ledger/observed_spend"
+	for i in 1 2 3 4 5 6 7 8; do STUB_SLOW_BUZZ=1 "${C}" generate "c${i}" --yes --max-cost 10 >/dev/null 2>&1 & done
+	wait
+	st_check "e2e 8 racers, 10 Buzz headroom => exactly 1 allowed" "1" \
+		"$(grep -c ALLOW_SPEND "${base}/ledger/invocations.tsv" 2>/dev/null || true)"
+	st_check "e2e 8 racers write no reconcile rows" "0" "$(reconciled_rows "${base}")"
 
 	note "--- calibration gate, end to end ---"
 	e2e_policy 1; e2e_reset

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -1,0 +1,773 @@
+#!/usr/bin/env bash
+#
+# dogfood-sandbox.sh — build and operate the sandbox for a CREDENTIALED blind
+# dogfood run of the civitai CLI.
+#
+# Runs 1 and 2 (issues #223-#227, #255-#260) were deliberately un-credentialed,
+# which made `civitai generate` — the only irreversibly money-spending surface —
+# structurally unreachable. This harness is what makes a credentialed run
+# survivable and auditable.
+#
+# Design doc, including WHAT THIS DOES NOT PROTECT AGAINST:
+#   claudedocs/dogfood-3-sandbox.md
+#
+# Subcommands:
+#   init         build the sandbox, seed the credential, lock it down, sample balance
+#   guard        policy gate — invoked by the generated `civitai` shim, not by hand
+#   status       spend so far, invocation counts, remaining budget
+#   finish       sample the closing balance and print the audit report
+#   selftest     positive controls on the FREE surface (spends nothing)
+#   enter        spawn a bubblewrap jail in which the repo does not exist
+#   allow-pubreq record a publish-request id as withdrawable
+#   teardown     unlock the read-only dirs and (optionally) delete the run root
+#
+# Every path is absolute; every `cd` is gated; every variable is braced.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults. Override on `init` via flags, or afterwards by editing
+# ${ROOT}/ledger/policy.env (which `init` writes and every later call reads).
+# ---------------------------------------------------------------------------
+DEFAULT_ROOT="/tmp/claude-1000/dogfood3-scratch/run"
+
+# Buzz an ESTIMATE may reach for a single `generate` submit. Enforced by
+# REFUSING a submit that does not carry `--max-cost <= this`. The CLI's own
+# help is explicit that --max-cost is not a spending cap; see the design doc.
+DEFAULT_PER_CALL_MAX_COST=100
+
+# Cumulative OBSERVED spend (start balance minus current) at which further
+# `generate` submits are refused. Checked BEFORE each submit.
+DEFAULT_TOTAL_SPEND_CAP=2000
+
+# Hard ceilings on the number of mutating invocations, independent of cost.
+DEFAULT_MAX_GENERATE_SUBMITS=20
+DEFAULT_MAX_APP_SUBMITS=3
+
+# Only apps whose blockId starts with this may be submitted or have their
+# listing media mutated. `init` derives a dated default.
+DEFAULT_SLUG_PREFIX=""
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+err()  { printf 'dogfood-sandbox: %s\n' "$*" >&2; }
+die()  { err "$*"; exit 1; }
+note() { printf '%s\n' "$*"; }
+
+# Machine-readable marker so a refusal from THIS harness can never be mistaken
+# for a civitai CLI error and filed as a dogfood issue against the CLI.
+SANDBOX_TAG="SANDBOX POLICY"
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Extract "total" from `civitai buzz --json`. Fails LOUDLY on no match: a
+# balance read that silently yields empty must never be read as "spent 0".
+parse_buzz_total() {
+	local json="$1" v
+	v=$(printf '%s' "${json}" | tr -d ' \n\t' | grep -o '"total":-\?[0-9]\+' | head -1 | cut -d: -f2)
+	case "${v}" in
+		''|*[!0-9-]*) return 1 ;;
+	esac
+	printf '%s' "${v}"
+}
+
+# Scrub credentials out of an argv before it reaches the audit log.
+scrub_argv() {
+	local out="" a skip=0
+	for a in "$@"; do
+		if [ "${skip}" = 1 ]; then out="${out} <redacted>"; skip=0; continue; fi
+		case "${a}" in
+			--token=*)  a='--token=<redacted>' ;;
+			--token)    skip=1 ;;
+		esac
+		out="${out} ${a}"
+	done
+	printf '%s' "${out# }"
+}
+
+load_policy() {
+	[ -f "${ROOT}/ledger/policy.env" ] || die "no policy at ${ROOT}/ledger/policy.env — run \`init\` first"
+	# shellcheck disable=SC1091
+	. "${ROOT}/ledger/policy.env"
+}
+
+# Run the REAL binary with the sandbox environment, bypassing the guard.
+# Used by init/finish/selftest and by the guard's own balance sampling.
+real_cli() {
+	HOME="${ROOT}/home" \
+	XDG_CONFIG_HOME="${ROOT}/home/.config" \
+	XDG_CACHE_HOME="${ROOT}/home/.cache" \
+	CIVITAI_NO_UPDATE_CHECK=1 \
+	"${ROOT}/real/civitai" "$@"
+}
+
+# Sample the balance. Echoes the total on stdout; non-zero on any failure.
+sample_balance() {
+	local phase="$1" json total
+	json=$(real_cli buzz --json 2>/dev/null)
+	total=$(parse_buzz_total "${json}") || return 1
+	printf '%s\t%s\t%s\n' "$(now_iso)" "${phase}" "${json}" >> "${ROOT}/ledger/buzz.tsv"
+	printf '%s' "${total}"
+}
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+cmd_init() {
+	local binary="" token_file="" root="${DEFAULT_ROOT}" force=0
+	local per_call="${DEFAULT_PER_CALL_MAX_COST}"
+	local total_cap="${DEFAULT_TOTAL_SPEND_CAP}"
+	local max_gen="${DEFAULT_MAX_GENERATE_SUBMITS}"
+	local max_app="${DEFAULT_MAX_APP_SUBMITS}"
+	local slug_prefix="${DEFAULT_SLUG_PREFIX}"
+
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root)          root="$2"; shift 2 ;;
+			--binary)        binary="$2"; shift 2 ;;
+			--token-file)    token_file="$2"; shift 2 ;;
+			--per-call-max)  per_call="$2"; shift 2 ;;
+			--total-cap)     total_cap="$2"; shift 2 ;;
+			--max-generates) max_gen="$2"; shift 2 ;;
+			--max-app-submits) max_app="$2"; shift 2 ;;
+			--slug-prefix)   slug_prefix="$2"; shift 2 ;;
+			--force)         force=1; shift ;;
+			*) die "init: unknown flag $1" ;;
+		esac
+	done
+
+	ROOT="${root}"
+	[ -n "${binary}" ] || die "init: --binary <path to built civitai> is required"
+	[ -x "${binary}" ] || die "init: ${binary} is not an executable file"
+
+	if [ -e "${ROOT}" ] && [ "${force}" != 1 ]; then
+		die "init: ${ROOT} already exists (use --force to rebuild, or \`teardown\` first)"
+	fi
+	if [ -e "${ROOT}" ]; then
+		cmd_teardown --root "${ROOT}" --delete --quiet
+	fi
+
+	# The token must never arrive as a harness argument (shell history) and must
+	# never be written into the repo.
+	local token=""
+	if [ -n "${token_file}" ]; then
+		[ -r "${token_file}" ] || die "init: cannot read --token-file ${token_file}"
+		token=$(head -c 4096 "${token_file}" | tr -d '\r\n')
+	elif [ -n "${CIVITAI_DOGFOOD_TOKEN:-}" ]; then
+		token="${CIVITAI_DOGFOOD_TOKEN}"
+	else
+		die "init: supply the credential via --token-file <path> or the CIVITAI_DOGFOOD_TOKEN environment variable"
+	fi
+	[ -n "${token}" ] || die "init: the supplied credential is empty"
+
+	if [ -z "${slug_prefix}" ]; then
+		slug_prefix="dogfood3-$(date -u +%Y%m%d)-"
+	fi
+
+	mkdir -p "${ROOT}/real" "${ROOT}/bin" "${ROOT}/harness" \
+	         "${ROOT}/home/.config" "${ROOT}/home/.cache" \
+	         "${ROOT}/workspace" "${ROOT}/ledger" || die "init: mkdir failed"
+	chmod 0700 "${ROOT}" "${ROOT}/home" "${ROOT}/ledger"
+
+	cp "${binary}" "${ROOT}/real/civitai" || die "init: could not copy the binary"
+
+	# The harness runs from a COPY so the run is self-contained and so a jail
+	# that does not mount the repo still works.
+	local self
+	self=$(readlink -f "$0")
+	cp "${self}" "${ROOT}/harness/dogfood-sandbox.sh" || die "init: could not copy the harness"
+	chmod 0555 "${ROOT}/harness/dogfood-sandbox.sh"
+
+	# The `civitai` the agent gets is a shim into the policy gate.
+	cat > "${ROOT}/bin/civitai" <<SHIM
+#!/usr/bin/env bash
+exec "${ROOT}/harness/dogfood-sandbox.sh" guard --root "${ROOT}" -- "\$@"
+SHIM
+	chmod 0555 "${ROOT}/bin/civitai"
+
+	: > "${ROOT}/ledger/invocations.tsv"
+	: > "${ROOT}/ledger/buzz.tsv"
+	: > "${ROOT}/ledger/pubreq.allow"
+	printf '0\n' > "${ROOT}/ledger/generate_submits"
+	printf '0\n' > "${ROOT}/ledger/app_submits"
+
+	cat > "${ROOT}/ledger/policy.env" <<POLICY
+# Written by dogfood-sandbox.sh init on $(now_iso). Read by every later call.
+ROOT="${ROOT}"
+PER_CALL_MAX_COST=${per_call}
+TOTAL_SPEND_CAP=${total_cap}
+MAX_GENERATE_SUBMITS=${max_gen}
+MAX_APP_SUBMITS=${max_app}
+SLUG_PREFIX="${slug_prefix}"
+BINARY_SOURCE="${binary}"
+BINARY_SHA256="$(sha256sum "${binary}" | cut -d' ' -f1)"
+HARNESS_SHA256="$(sha256sum "${self}" | cut -d' ' -f1)"
+POLICY
+	chmod 0600 "${ROOT}/ledger/policy.env"
+
+	# Seed the credential THROUGH the CLI (it is the authority on the config
+	# format) into the sandbox config only.
+	real_cli login --token "${token}" >/dev/null 2>&1 \
+		|| die "init: seeding the credential failed — check the token"
+	token=""
+	[ -f "${ROOT}/home/.config/civitai/config.yaml" ] \
+		|| die "init: no config written at ${ROOT}/home/.config/civitai/config.yaml"
+	chmod 0600 "${ROOT}/home/.config/civitai/config.yaml"
+
+	# Prove the credential works before locking anything down.
+	real_cli whoami >/dev/null 2>&1 || die "init: whoami failed with the seeded credential"
+
+	local start
+	start=$(sample_balance "start") || die "init: could not read the opening Buzz balance — refusing to start a run whose meter does not work"
+	printf '%s\n' "${start}" > "${ROOT}/ledger/start_balance"
+
+	# Structural: `upgrade` writes .civitai.new into the binary's directory via
+	# O_CREATE (minio/selfupdate apply.go). A 0500 directory makes that EACCES.
+	# The 0555 on the file itself closes the in-place-write variant.
+	chmod 0555 "${ROOT}/real/civitai"
+	chmod 0500 "${ROOT}/real" "${ROOT}/bin" "${ROOT}/harness"
+
+	cmd_write_brief
+
+	note "sandbox ready at ${ROOT}"
+	note "  PATH entry ............ ${ROOT}/bin        (the agent's \`civitai\`)"
+	note "  agent working dir ..... ${ROOT}/workspace"
+	note "  opening balance ....... ${start} Buzz"
+	note "  per-call estimate cap . ${per_call} Buzz (--max-cost required at or below this)"
+	note "  total spend cap ....... ${total_cap} Buzz"
+	note "  generate submits ...... ${max_gen} max"
+	note "  app submits ........... ${max_app} max"
+	note "  sanctioned blockId .... ${slug_prefix}*"
+	note ""
+	note "Brief for the blind agent: ${ROOT}/AGENT-BRIEF.md"
+}
+
+cmd_write_brief() {
+	# The caps live in policy.env, not in init's locals, so source them —
+	# without this the brief renders literal placeholder text and a blind agent
+	# is told the prefix is "the sanctioned prefix".
+	load_policy
+	cat > "${ROOT}/AGENT-BRIEF.md" <<BRIEF
+# civitai CLI — evaluation sandbox
+
+You have a \`civitai\` binary on your PATH, its \`README.md\`, and \`--help\`.
+Work only inside \`${ROOT}/workspace\`.
+
+This is a real, credentialed account. \`civitai generate\` **spends real money**.
+A sandbox policy gate sits in front of the CLI and refuses some invocations; a
+refusal from the gate is prefixed \`${SANDBOX_TAG}\` and is **not** a CLI bug —
+do not file it as one. Everything else you see IS the CLI.
+
+The gate:
+
+- \`civitai generate\` that actually submits must carry \`--max-cost N\` with
+  N at most **${PER_CALL_MAX_COST}**. \`--dry-run\` and \`--print-input\` are
+  unrestricted; they spend nothing. (This requirement is the sandbox's, not the
+  CLI's — do not report it as a CLI bug.)
+- The run may spend at most **${TOTAL_SPEND_CAP} Buzz** in total, across at
+  most **${MAX_GENERATE_SUBMITS}** generations.
+- \`app submit\` and \`app listing set-*\`/\`add-screenshot\`/\`rm-screenshot\`/
+  \`reorder\` only work on an app whose \`blockId\` starts with
+  \`${SLUG_PREFIX}\`, and at most **${MAX_APP_SUBMITS}** submissions are
+  allowed. Scaffold your app with a name under that prefix, e.g.
+  \`civitai app create ${SLUG_PREFIX}myapp\`.
+- \`upgrade\`, \`login\`, \`app dev-tunnel\` and \`app dev-token\` are refused.
+
+Submitting an app puts it in front of a real human moderator. That is expected
+and approved for this run — but do it deliberately, not to see what happens.
+
+Report what you find as you would to the tool's authors: what worked, what was
+confusing, what was wrong, and what you could not do.
+BRIEF
+}
+
+# ---------------------------------------------------------------------------
+# guard — the policy gate. Invoked as: guard --root <ROOT> -- <civitai argv...>
+# ---------------------------------------------------------------------------
+cmd_guard() {
+	local root=""
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--)     shift; break ;;
+			*)      break ;;
+		esac
+	done
+	ROOT="${root:-${DEFAULT_ROOT}}"
+	load_policy
+
+	local argv=("$@")
+	local scrubbed
+	scrubbed=$(scrub_argv "${argv[@]+"${argv[@]}"}")
+
+	local verdict reason
+	verdict=$(policy_verdict "${argv[@]+"${argv[@]}"}")
+	reason="${verdict#*:}"
+	verdict="${verdict%%:*}"
+
+	if [ "${verdict}" = "DENY" ]; then
+		printf '%s: %s\n' "${SANDBOX_TAG}" "${reason}" >&2
+		log_invocation "DENY" "126" "0" "${scrubbed}" "${reason}"
+		return 126
+	fi
+
+	# A real spend: bracket the call with balance samples.
+	local before="" after="" delta=""
+	if [ "${verdict}" = "ALLOW_SPEND" ]; then
+		before=$(sample_balance "pre-generate") || {
+			printf '%s: %s\n' "${SANDBOX_TAG}" \
+				"could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" >&2
+			log_invocation "DENY" "126" "0" "${scrubbed}" "balance read failed (fail closed)"
+			return 126
+		}
+		bump_counter "generate_submits"
+	fi
+	if [ "${verdict}" = "ALLOW_APP_SUBMIT" ]; then
+		bump_counter "app_submits"
+	fi
+
+	local t0 t1 rc
+	t0=$(date +%s%N)
+	HOME="${ROOT}/home" \
+	XDG_CONFIG_HOME="${ROOT}/home/.config" \
+	XDG_CACHE_HOME="${ROOT}/home/.cache" \
+	CIVITAI_NO_UPDATE_CHECK=1 \
+	"${ROOT}/real/civitai" "${argv[@]+"${argv[@]}"}"
+	rc=$?
+	t1=$(date +%s%N)
+
+	if [ "${verdict}" = "ALLOW_SPEND" ] && [ -n "${before}" ]; then
+		after=$(sample_balance "post-generate") || after=""
+		if [ -n "${after}" ]; then
+			delta=$(( before - after ))
+			local cum
+			cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
+			printf '%s\n' "$(( cum + delta ))" > "${ROOT}/ledger/observed_spend"
+			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
+				>> "${ROOT}/ledger/spend.tsv"
+		fi
+	fi
+
+	log_invocation "${verdict}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" "${delta:-}"
+	return "${rc}"
+}
+
+log_invocation() {
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$(now_iso)" "$1" "$2" "$3" "$4" "${5:-}" >> "${ROOT}/ledger/invocations.tsv"
+}
+
+bump_counter() {
+	local f="${ROOT}/ledger/$1" n
+	n=$(cat "${f}" 2>/dev/null || printf '0')
+	printf '%s\n' "$(( n + 1 ))" > "${f}"
+}
+
+read_counter() {
+	cat "${ROOT}/ledger/$1" 2>/dev/null || printf '0'
+}
+
+# Does argv contain this exact token?
+has_flag() {
+	local want="$1"; shift
+	local a
+	for a in "$@"; do
+		[ "${a}" = "${want}" ] && return 0
+	done
+	return 1
+}
+
+# Value of --flag V or --flag=V; empty if absent.
+flag_value() {
+	local want="$1"; shift
+	local a next=0
+	for a in "$@"; do
+		if [ "${next}" = 1 ]; then printf '%s' "${a}"; return 0; fi
+		case "${a}" in
+			"${want}")   next=1 ;;
+			"${want}"=*) printf '%s' "${a#*=}"; return 0 ;;
+		esac
+	done
+	return 1
+}
+
+# The blockId a mutating app command would act on: --slug wins, else the
+# manifest in --dir (listing) or the positional dir (submit), default ".".
+resolve_block_id() {
+	local dir="$1" slug="$2" manifest id
+	if [ -n "${slug}" ]; then printf '%s' "${slug}"; return 0; fi
+	manifest="${dir%/}/block.manifest.json"
+	[ -r "${manifest}" ] || return 1
+	id=$(tr -d '\n' < "${manifest}" \
+		| grep -o '"blockId"[[:space:]]*:[[:space:]]*"[^"]*"' \
+		| head -1 | sed 's/.*"blockId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+	[ -n "${id}" ] || return 1
+	printf '%s' "${id}"
+}
+
+# Echoes "<VERDICT>:<reason>". VERDICT is ALLOW, ALLOW_SPEND, ALLOW_APP_SUBMIT
+# or DENY. Deliberately fails CLOSED: anything it cannot classify but that can
+# mutate or spend is denied.
+policy_verdict() {
+	local c1="${1:-}" c2="${2:-}" c3="${3:-}"
+
+	# Help is always free, on every command, including the forbidden ones —
+	# reading --help must never be blocked, or the agent cannot learn the tool.
+	if has_flag "--help" "$@" || has_flag "-h" "$@"; then
+		printf 'ALLOW:help'; return 0
+	fi
+
+	case "${c1}" in
+		upgrade)
+			printf 'DENY:%s' "\`upgrade\` would replace the binary under evaluation mid-run"
+			return 0 ;;
+		login)
+			printf 'DENY:%s' "this sandbox is already authenticated; run \`civitai whoami\` to see as whom"
+			return 0 ;;
+	esac
+
+	if [ "${c1}" = "app" ]; then
+		case "${c2}" in
+			dev-tunnel|dev-token)
+				printf 'DENY:%s' "\`app ${c2}\` is out of scope for this run"
+				return 0 ;;
+			withdraw)
+				local id
+				id=$(printf '%s\n' "$@" | grep -m1 '^pubreq_' || true)
+				[ -n "${id}" ] || id=$(flag_value "--id" "$@" || true)
+				if [ -z "${id}" ]; then
+					printf 'ALLOW:withdraw with no id (the CLI will refuse it)'; return 0
+				fi
+				if grep -qxF "${id}" "${ROOT}/ledger/pubreq.allow" 2>/dev/null; then
+					printf 'ALLOW:withdraw of a submission this sandbox created'; return 0
+				fi
+				printf 'DENY:%s' "${id} was not created by this sandbox, so it may be one of the account's real pending submissions"
+				return 0 ;;
+			submit)
+				if has_flag "--package-only" "$@"; then
+					printf 'ALLOW:--package-only never submits'; return 0
+				fi
+				local n dir="" a skipnext=0
+				# positional dir: first non-flag arg after `submit`, skipping -o/--out values
+				for a in "${@:3}"; do
+					if [ "${skipnext}" = 1 ]; then skipnext=0; continue; fi
+					case "${a}" in
+						-o|--out) skipnext=1 ;;
+						-*)       ;;
+						*)        dir="${a}"; break ;;
+					esac
+				done
+				[ -n "${dir}" ] || dir="."
+				local id
+				if ! id=$(resolve_block_id "${dir}" ""); then
+					printf 'DENY:%s' "cannot read a blockId from ${dir}/block.manifest.json, so the app being submitted cannot be identified"
+					return 0
+				fi
+				case "${id}" in
+					"${SLUG_PREFIX}"*) ;;
+					*) printf 'DENY:%s' "blockId \`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may only submit its own throwaway app"
+					   return 0 ;;
+				esac
+				n=$(read_counter "app_submits")
+				if [ "${n}" -ge "${MAX_APP_SUBMITS}" ]; then
+					printf 'DENY:%s' "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"
+					return 0
+				fi
+				printf 'ALLOW_APP_SUBMIT:submitting %s' "${id}"
+				return 0 ;;
+			listing)
+				case "${c3}" in
+					status|"")
+						printf 'ALLOW:listing read'; return 0 ;;
+					set-icon|set-cover|add-screenshot|rm-screenshot|reorder)
+						local slug dir id
+						slug=$(flag_value "--slug" "$@" || true)
+						dir=$(flag_value "--dir" "$@" || true)
+						[ -n "${dir}" ] || dir="."
+						if ! id=$(resolve_block_id "${dir}" "${slug}"); then
+							printf 'DENY:%s' "cannot identify which app \`app listing ${c3}\` would mutate (no --slug, and no readable blockId in ${dir}/block.manifest.json)"
+							return 0
+						fi
+						case "${id}" in
+							"${SLUG_PREFIX}"*)
+								printf 'ALLOW:listing mutation on %s' "${id}"; return 0 ;;
+							*)
+								printf 'DENY:%s' "\`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may not touch the account's real listings"
+								return 0 ;;
+						esac ;;
+					*)
+						printf 'DENY:%s' "unrecognised \`app listing ${c3}\`; the gate fails closed on anything that might mutate a listing"
+						return 0 ;;
+				esac ;;
+		esac
+		printf 'ALLOW:app read/local'; return 0
+	fi
+
+	if [ "${c1}" = "generate" ]; then
+		if has_flag "--print-input" "$@" || has_flag "--dry-run" "$@"; then
+			printf 'ALLOW:generate preview (spends nothing)'; return 0
+		fi
+		local n cum remaining mc
+		# The MONEY cap is checked before the invocation cap: when both are
+		# tripped the spend figure is the more actionable reason to print.
+		cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
+		if [ "${cum}" -ge "${TOTAL_SPEND_CAP}" ]; then
+			printf 'DENY:%s' "the run's total spend cap (${TOTAL_SPEND_CAP} Buzz) is reached — ${cum} observed"
+			return 0
+		fi
+		n=$(read_counter "generate_submits")
+		if [ "${n}" -ge "${MAX_GENERATE_SUBMITS}" ]; then
+			printf 'DENY:%s' "the generation cap for this run (${MAX_GENERATE_SUBMITS} submits) is already used"
+			return 0
+		fi
+		if ! mc=$(flag_value "--max-cost" "$@"); then
+			printf 'DENY:%s' "a generation that actually submits must carry --max-cost (at most ${PER_CALL_MAX_COST}); use --dry-run to price it first"
+			return 0
+		fi
+		case "${mc}" in
+			''|*[!0-9]*)
+				printf 'DENY:%s' "--max-cost must be a whole number of Buzz, got \`${mc}\`"
+				return 0 ;;
+		esac
+		if [ "${mc}" -gt "${PER_CALL_MAX_COST}" ]; then
+			printf 'DENY:%s' "--max-cost ${mc} exceeds this run's per-invocation ceiling of ${PER_CALL_MAX_COST} Buzz"
+			return 0
+		fi
+		remaining=$(( TOTAL_SPEND_CAP - cum ))
+		if [ "${mc}" -gt "${remaining}" ]; then
+			printf 'DENY:%s' "--max-cost ${mc} exceeds the ${remaining} Buzz left under this run's total cap"
+			return 0
+		fi
+		printf 'ALLOW_SPEND:submit with --max-cost %s' "${mc}"
+		return 0
+	fi
+
+	printf 'ALLOW:read-only or local'
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# allow-pubreq / status / finish / selftest / enter / teardown
+# ---------------------------------------------------------------------------
+cmd_allow_pubreq() {
+	local root="${DEFAULT_ROOT}" id=""
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			*) id="$1"; shift ;;
+		esac
+	done
+	ROOT="${root}"; load_policy
+	[ -n "${id}" ] || die "allow-pubreq: pass the publish-request id"
+	printf '%s\n' "${id}" >> "${ROOT}/ledger/pubreq.allow"
+	note "recorded ${id} as withdrawable"
+}
+
+cmd_status() {
+	local root="${DEFAULT_ROOT}"
+	while [ $# -gt 0 ]; do
+		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
+	done
+	ROOT="${root}"; load_policy
+	local start cum
+	start=$(cat "${ROOT}/ledger/start_balance" 2>/dev/null || printf '?')
+	cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
+	note "run root .............. ${ROOT}"
+	note "opening balance ....... ${start} Buzz"
+	note "observed spend ........ ${cum} / ${TOTAL_SPEND_CAP} Buzz"
+	note "generate submits ...... $(read_counter generate_submits) / ${MAX_GENERATE_SUBMITS}"
+	note "app submits ........... $(read_counter app_submits) / ${MAX_APP_SUBMITS}"
+	note "invocations logged .... $(wc -l < "${ROOT}/ledger/invocations.tsv" 2>/dev/null || printf 0)"
+	note "refusals .............. $(grep -c '	DENY	' "${ROOT}/ledger/invocations.tsv" 2>/dev/null || printf 0)"
+}
+
+cmd_finish() {
+	local root="${DEFAULT_ROOT}"
+	while [ $# -gt 0 ]; do
+		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
+	done
+	ROOT="${root}"; load_policy
+	local start end
+	start=$(cat "${ROOT}/ledger/start_balance" 2>/dev/null) || die "finish: no opening balance recorded"
+	if ! end=$(sample_balance "end"); then
+		err "finish: could not read the closing balance — the spend total below is the per-call ledger only"
+		end=""
+	fi
+	printf '%s\n' "${end}" > "${ROOT}/ledger/end_balance"
+	note "=== dogfood run audit ==="
+	cmd_status --root "${ROOT}"
+	if [ -n "${end}" ]; then
+		note "closing balance ....... ${end} Buzz"
+		note "MEASURED TOTAL SPEND .. $(( start - end )) Buzz"
+	fi
+	note ""
+	note "full invocation log ... ${ROOT}/ledger/invocations.tsv"
+	note "balance samples ....... ${ROOT}/ledger/buzz.tsv"
+}
+
+cmd_selftest() {
+	local root="${DEFAULT_ROOT}"
+	while [ $# -gt 0 ]; do
+		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
+	done
+	ROOT="${root}"; load_policy
+
+	local pass=0 fail=0
+	check() {
+		local label="$1" want="$2" got="$3"
+		if [ "${want}" = "${got}" ]; then
+			printf '  PASS  %-56s (%s)\n' "${label}" "${got}"; pass=$(( pass + 1 ))
+		else
+			printf '  FAIL  %-56s want=%s got=%s\n' "${label}" "${want}" "${got}"; fail=$(( fail + 1 ))
+		fi
+	}
+
+	note "--- policy verdicts (no CLI is executed) ---"
+	check "upgrade is denied"                 "DENY"             "$(policy_verdict upgrade | cut -d: -f1)"
+	check "upgrade --help is allowed"         "ALLOW"            "$(policy_verdict upgrade --help | cut -d: -f1)"
+	check "login is denied"                   "DENY"             "$(policy_verdict login --token x | cut -d: -f1)"
+	check "dev-tunnel is denied"              "DENY"             "$(policy_verdict app dev-tunnel | cut -d: -f1)"
+	check "dev-token is denied"               "DENY"             "$(policy_verdict app dev-token | cut -d: -f1)"
+	check "generate --dry-run is free"        "ALLOW"            "$(policy_verdict generate x --dry-run | cut -d: -f1)"
+	check "generate --print-input is free"    "ALLOW"            "$(policy_verdict generate x --print-input | cut -d: -f1)"
+	check "generate without --max-cost denied" "DENY"            "$(policy_verdict generate x --yes | cut -d: -f1)"
+	check "generate over per-call cap denied"  "DENY"            "$(policy_verdict generate x --yes --max-cost $(( PER_CALL_MAX_COST + 1 )) | cut -d: -f1)"
+	check "generate at the cap is a spend"     "ALLOW_SPEND"     "$(policy_verdict generate x --yes --max-cost "${PER_CALL_MAX_COST}" | cut -d: -f1)"
+	check "generate --max-cost=N form parsed"  "ALLOW_SPEND"     "$(policy_verdict generate x --yes --max-cost=1 | cut -d: -f1)"
+	check "non-numeric --max-cost denied"      "DENY"            "$(policy_verdict generate x --yes --max-cost abc | cut -d: -f1)"
+	check "withdraw of an unknown id denied"   "DENY"            "$(policy_verdict app withdraw pubreq_UNKNOWN | cut -d: -f1)"
+	check "app list is allowed"                "ALLOW"           "$(policy_verdict app list | cut -d: -f1)"
+	check "models search is allowed"           "ALLOW"           "$(policy_verdict models search --query x | cut -d: -f1)"
+	check "listing status is allowed"          "ALLOW"           "$(policy_verdict app listing status | cut -d: -f1)"
+	check "unknown listing verb denied"        "DENY"            "$(policy_verdict app listing frobnicate | cut -d: -f1)"
+
+	# Identity gating needs real manifests on disk.
+	local td="${ROOT}/ledger/_selftest"
+	rm -rf "${td}"; mkdir -p "${td}/good" "${td}/bad"
+	printf '{"blockId":"%sdemo","name":"d","version":"1.0.0","kind":"page"}\n' "${SLUG_PREFIX}" > "${td}/good/block.manifest.json"
+	printf '{"blockId":"someones-real-app","name":"d","version":"1.0.0","kind":"page"}\n'        > "${td}/bad/block.manifest.json"
+	check "submit of a sanctioned blockId"     "ALLOW_APP_SUBMIT" "$(policy_verdict app submit "${td}/good" --yes | cut -d: -f1)"
+	check "submit of a foreign blockId denied" "DENY"             "$(policy_verdict app submit "${td}/bad" --yes | cut -d: -f1)"
+	check "submit -o value not read as dir"    "ALLOW_APP_SUBMIT" "$(policy_verdict app submit -o "${td}/bad" "${td}/good" | cut -d: -f1)"
+	check "listing on a foreign --slug denied" "DENY"             "$(policy_verdict app listing set-icon i.png --slug someones-real-app | cut -d: -f1)"
+	check "listing on sanctioned --dir"        "ALLOW"            "$(policy_verdict app listing set-icon i.png --dir "${td}/good" | cut -d: -f1)"
+	check "listing with no identity denied"    "DENY"             "$(policy_verdict app listing set-icon i.png --dir "${ROOT}/ledger" | cut -d: -f1)"
+	rm -rf "${td}"
+
+	note ""
+	note "--- balance meter (a real read; spends nothing) ---"
+	local b
+	if b=$(sample_balance "selftest"); then
+		check "buzz --json parses to an integer total" "yes" "$(case "${b}" in ''|*[!0-9]*) printf no ;; *) printf yes ;; esac)"
+		note "  observed balance: ${b} Buzz"
+	else
+		check "buzz --json parses to an integer total" "yes" "no"
+	fi
+	# Negative control: the parser must FAIL on rubbish, not return 0.
+	if parse_buzz_total '{"blue":1}' >/dev/null 2>&1; then
+		check "balance parser rejects a payload with no total" "reject" "accept"
+	else
+		check "balance parser rejects a payload with no total" "reject" "reject"
+	fi
+
+	note ""
+	note "--- isolation ---"
+	local real_cfg="${HOME}/.config/civitai/config.yaml"
+	if [ -f "${real_cfg}" ]; then
+		note "  operator config present at ${real_cfg}"
+		note "  sha256 before: $(sha256sum "${real_cfg}" | cut -d' ' -f1)"
+	else
+		note "  operator has no ~/.config/civitai/config.yaml (nothing to clobber)"
+	fi
+	check "sandbox config exists" "yes" "$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+	check "binary dir is not writable" "no" "$([ -w "${ROOT}/real" ] && printf yes || printf no)"
+	check "binary file is not writable" "no" "$([ -w "${ROOT}/real/civitai" ] && printf yes || printf no)"
+
+	note ""
+	note "selftest: ${pass} passed, ${fail} failed"
+	[ "${fail}" = 0 ]
+}
+
+cmd_enter() {
+	local root="${DEFAULT_ROOT}"
+	while [ $# -gt 0 ]; do
+		case "$1" in --root) root="$2"; shift 2 ;; *) break ;; esac
+	done
+	ROOT="${root}"; load_policy
+	command -v bwrap >/dev/null 2>&1 || die "enter: bwrap (bubblewrap) is not on PATH"
+
+	local shell_bin="${SHELL:-/bin/sh}"
+	[ $# -gt 0 ] || set -- "${shell_bin}" -i
+
+	# Only what the CLI needs: the Nix store (toolchain + certs), the system
+	# profile, DNS + TLS trust, and the run root. NOTHING under /home is bound,
+	# so the repo checkout does not exist inside.
+	#
+	# 🔴 ORDER IS LOAD-BEARING. bwrap applies these in sequence, so `--tmpfs
+	# /tmp` must come BEFORE the run-root bind: the default run root lives under
+	# /tmp, and a tmpfs mounted afterwards SHADOWS it. Measured — with the bind
+	# first, bwrap died with "Can't chdir to <root>/workspace: No such file or
+	# directory". PATH is set explicitly rather than inherited because the
+	# operator's ~/.nix-profile/bin does not exist inside the jail.
+	exec bwrap \
+		--ro-bind /nix /nix \
+		--ro-bind /run/current-system /run/current-system \
+		--ro-bind /etc/resolv.conf /etc/resolv.conf \
+		--ro-bind /etc/ssl /etc/ssl \
+		--ro-bind /etc/static /etc/static \
+		--ro-bind /usr /usr \
+		--proc /proc --dev /dev --tmpfs /tmp \
+		--bind "${ROOT}" "${ROOT}" \
+		--unshare-pid --die-with-parent \
+		--setenv HOME "${ROOT}/home" \
+		--setenv XDG_CONFIG_HOME "${ROOT}/home/.config" \
+		--setenv XDG_CACHE_HOME "${ROOT}/home/.cache" \
+		--setenv CIVITAI_NO_UPDATE_CHECK 1 \
+		--setenv PATH "${ROOT}/bin:/run/current-system/sw/bin:/usr/bin:/bin" \
+		--chdir "${ROOT}/workspace" \
+		"$@"
+}
+
+cmd_teardown() {
+	local root="${DEFAULT_ROOT}" delete=0 quiet=0
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--delete) delete=1; shift ;;
+			--quiet) quiet=1; shift ;;
+			*) die "teardown: unknown flag $1" ;;
+		esac
+	done
+	[ -e "${root}" ] || { [ "${quiet}" = 1 ] || note "teardown: ${root} does not exist"; return 0; }
+	chmod -R u+w "${root}" 2>/dev/null
+	if [ "${delete}" = 1 ]; then
+		rm -rf "${root}"
+		[ "${quiet}" = 1 ] || note "teardown: deleted ${root}"
+	else
+		[ "${quiet}" = 1 ] || note "teardown: unlocked ${root} (not deleted; pass --delete to remove)"
+	fi
+}
+
+usage() {
+	sed -n '3,30p' "$0"
+	exit 2
+}
+
+main() {
+	local sub="${1:-}"
+	[ $# -gt 0 ] && shift
+	case "${sub}" in
+		init)          cmd_init "$@" ;;
+		guard)         cmd_guard "$@" ;;
+		status)        cmd_status "$@" ;;
+		finish)        cmd_finish "$@" ;;
+		selftest)      cmd_selftest "$@" ;;
+		enter)         cmd_enter "$@" ;;
+		allow-pubreq)  cmd_allow_pubreq "$@" ;;
+		teardown)      cmd_teardown "$@" ;;
+		*)             usage ;;
+	esac
+}
+
+main "$@"

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -368,17 +368,6 @@ cmd_init() {
 	if [ -e "${ROOT}" ] && [ "${force}" != 1 ]; then
 		die "init: ${ROOT} already exists (use --force to supersede it, or \`teardown\` first)"
 	fi
-	if [ -e "${ROOT}" ]; then
-		# 🔴 SUPERSEDE, NEVER DELETE. The ledger is the audit artefact of the
-		# previous run; a mistyped `init --force` used to destroy it before the
-		# new credential had even been validated.
-		local superseded
-		superseded="${ROOT}.superseded-$(date -u +%Y%m%dT%H%M%SZ)"
-		chmod -R u+w "${ROOT}" 2>/dev/null
-		mv "${ROOT}" "${superseded}" || die "init: could not set the previous run aside"
-		note "init: previous run preserved at ${superseded}"
-	fi
-
 	local token=""
 	if [ -n "${token_file}" ]; then
 		[ -r "${token_file}" ] || die "init: cannot read --token-file ${token_file}"
@@ -389,6 +378,20 @@ cmd_init() {
 		die "init: supply the credential via --token-file <path> or the CIVITAI_DOGFOOD_TOKEN environment variable"
 	fi
 	[ -n "${token}" ] || die "init: the supplied credential is empty"
+
+	if [ -e "${ROOT}" ]; then
+		# 🔴 SUPERSEDE, NEVER DELETE — AND ONLY AFTER THE CREDENTIAL IS IN
+		# HAND. The ledger is the previous run's audit artefact. This block used
+		# to run BEFORE the token was read, so `init --force` with an
+		# unreadable or empty token moved the sandbox aside and then died,
+		# leaving no run root and a superseded one still holding both
+		# credentials — measured.
+		local superseded
+		superseded="${ROOT}.superseded-$(date -u +%Y%m%dT%H%M%SZ)"
+		chmod -R u+w "${ROOT}" 2>/dev/null
+		mv "${ROOT}" "${superseded}" || die "init: could not set the previous run aside"
+		note "init: previous run preserved at ${superseded}"
+	fi
 
 	[ -n "${slug_prefix}" ] || slug_prefix="dogfood3-$(date -u +%Y%m%d)-"
 
@@ -603,7 +606,13 @@ classify() {
 	if [ ! -x "${bin}" ]; then
 		GERR="the classifier ${bin} is missing or not executable"; return 1
 	fi
-	out=$("${bin}" -- "$@" 2>/dev/null); rc=$?
+	# Bounded like the balance read: a classifier that hangs must not hang the
+	# gate. It does no I/O beyond writing its verdict, so 30s is generous.
+	if command -v timeout >/dev/null 2>&1; then
+		out=$(timeout 30 "${bin}" -- "$@" 2>/dev/null); rc=$?
+	else
+		out=$("${bin}" -- "$@" 2>/dev/null); rc=$?
+	fi
 	if [ -z "${out}" ]; then
 		GERR="the classifier produced no output (exit ${rc})"; return 1
 	fi
@@ -800,6 +809,19 @@ policy_verdict() {
 				deny "the spend meter stopped agreeing with the account earlier in this run, so spend is no longer being counted — refusing to submit (see ledger/meter_broken)"
 				return 0
 			fi
+			# 🔴 ONE SPEND AT A TIME. Two concurrent generates cannot both be
+			# metered: the balance delta of either is the sum of both, and the
+			# crash record is per-run. The cap arithmetic already reserves, but
+			# refusing outright is the honest bound — and the threat model says
+			# the agent "runs things in parallel because that seems efficient".
+			local inflight_pid
+			if [ -f "${ROOT}/ledger/inflight" ]; then
+				inflight_pid=$(cut -f4 < "${ROOT}/ledger/inflight" 2>/dev/null)
+				if [ -n "${inflight_pid}" ] && kill -0 "${inflight_pid}" 2>/dev/null; then
+					deny "another generation is still running in this sandbox (pid ${inflight_pid}); two concurrent spends cannot both be metered, so this one is refused — wait for it to finish"
+					return 0
+				fi
+			fi
 			if [ "${REQUIRE_CALIBRATION}" = "1" ] && [ ! -f "${ROOT}/ledger/calibration.ok" ]; then
 				deny "the spend meter has not been calibrated against a real generation; run \`dogfood-sandbox.sh calibrate\` (it spends once, deliberately, while you watch) or re-init with --skip-calibration"
 				return 0
@@ -933,7 +955,15 @@ cmd_guard() {
 	# the cap is evadable. This is a no-op rewrite of the current value purely
 	# to establish writability while refusing still costs nothing.
 	case "${VERDICT}" in
-		ALLOW_SPEND)      assert_writable generate_submits "${scrubbed}" ;;
+		# 🔴 THE METER FILE ITSELF, NOT JUST THE COUNTER. Asserting only
+		# `generate_submits` proved the wrong file: with just `observed_spend`
+		# at 0444, 111 Buzz moved, the meter read 0 and nothing latched, while
+		# every invocation row recorded `delta=37` — the spend was observed and
+		# never accumulated. `observed_spend` and `reserved` are what the cap is
+		# computed from, so they are what must be writable before a spend.
+		ALLOW_SPEND)      assert_writable generate_submits "${scrubbed}"
+		                  assert_writable observed_spend "${scrubbed}"
+		                  assert_writable reserved "${scrubbed}" ;;
 		ALLOW_APP_SUBMIT) assert_writable app_submits "${scrubbed}" ;;
 		ALLOW_LISTING)    assert_writable listing_mutations "${scrubbed}" ;;
 	esac
@@ -945,7 +975,7 @@ cmd_guard() {
 		res=$(read_scalar reserved) || refuse "the reservation ledger is unreadable or malformed" "${scrubbed}"
 		write_scalar reserved "$(( res + mc ))" || refuse "could not record the spend reservation — refusing to submit" "${scrubbed}"
 		# A crash between here and the reconciliation must not lose the charge.
-		printf '%s\t%s\t%s\t%s\n' "$(now_iso)" "${mc}" "${before}" "${scrubbed}" \
+		printf '%s\t%s\t%s\t%s\t%s\n' "$(now_iso)" "${mc}" "${before}" "$$" "${scrubbed}" \
 			> "${ROOT}/ledger/inflight"
 		workflow_snapshot
 	fi
@@ -1022,31 +1052,6 @@ settle_spend() {
 	res=$(read_scalar reserved)      || res="${mc}"
 	cum=$(read_scalar observed_spend) || cum=0
 
-	# 🔴 A ZERO DELTA ON A NON-ZERO EXIT IS EXPECTED, NOT A BROKEN METER. The
-	# command failed before spending: the CLI's own `--max-cost` refusal, a
-	# balance-too-low refusal, a 4xx/5xx, a bad `--input`, an `--ecosystem`
-	# typo. Latching on those killed the run at the agent's first likely
-	# mistake — and the brief MANDATES `--max-cost`, which the agent cannot
-	# size without a `--dry-run` first. Measured: `--max-cost 5` against an
-	# estimate of 8 gave rc=2, delta 0, meter_broken latched, and every
-	# subsequent generate refused. It also credited 5 Buzz that never moved.
-	if [ "${rc}" != 0 ]; then
-		after=$(sample_balance "post-generate-failed") || after=""
-		if [ -n "${after}" ] && [ "${after}" != "${before}" ]; then
-			delta=$(( before - after ))
-			if [ "${delta}" -gt 0 ]; then
-				write_scalar observed_spend "$(( cum + delta ))" || true
-				printf '%s\tgenerate\t%s\t%s\t%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${rc}" \
-					>> "${ROOT}/ledger/spend.tsv"
-			fi
-		else
-			delta=0
-		fi
-		write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
-		printf '%s' "${delta:-0}"
-		return 0
-	fi
-
 	after=$(sample_balance "post-generate") || after=""
 
 	if [ -n "${after}" ] && [ "${after}" = "${before}" ] && [ "${METER_SETTLE_SECONDS}" -gt 0 ]; then
@@ -1054,34 +1059,66 @@ settle_spend() {
 		after=$(sample_balance "post-generate-resample") || after=""
 	fi
 
+	# 🔴 THE rc-AWARE SUPPRESSION APPLIES TO EXACTLY ONE CASE: THE READ WORKED
+	# AND THE DELTA REALLY IS 0.
+	#
+	# Suppressing on rc alone was too strong in both directions, and both were
+	# measured. A zero delta on a non-zero exit IS expected — the CLI's own
+	# `--max-cost` refusal, a bad `--input`, an `--ecosystem` typo — and
+	# latching on it killed the run at the agent's first likely mistake. But a
+	# generate can charge and THEN fail: AGENTS item 28(b) refuses to assert
+	# what becomes of a charge, and #279 records submits that quoted `ready` and
+	# produced no outputs. Measured control pair, rc=1 throughout:
+	#   read fails  -> 37 really moved, meter 0, no latch   <- the hole
+	#   credit hides -> 37 really moved, meter 0, no latch   <- the hole
+	#   read healthy -> 37 metered                           <- correct
+	# So an UNREADABLE balance and a NEGATIVE delta latch whatever the exit code
+	# was; only the observable zero is trusted, and only then.
 	if [ -z "${after}" ]; then
-		write_scalar observed_spend "$(( cum + mc ))" || true
-		printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s\n' "$(now_iso)" "${before}" "${mc}" \
+		write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+		printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s (rc=%s)\n' "$(now_iso)" "${before}" "${mc}" "${rc}" \
 			>> "${ROOT}/ledger/spend.tsv"
-		break_meter "the post-submit balance read failed; ${mc} Buzz charged to the ledger as a worst case"
-		printf '%s' "unknown"
+		break_meter "the post-submit balance read failed (rc=${rc}); ${mc} Buzz charged to the ledger as a worst case"
+		delta="unknown"
 	else
 		delta=$(( before - after ))
 		if [ "${delta}" -lt 0 ]; then
-			write_scalar observed_spend "$(( cum + mc ))" || true
-			printf '%s\tgenerate\t%s\t%s\tNEGATIVE(%s)-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${mc}" \
+			write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+			printf '%s\tgenerate\t%s\t%s\tNEGATIVE(%s)-assumed-%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${mc}" "${rc}" \
 				>> "${ROOT}/ledger/spend.tsv"
-			break_meter "the balance went UP across a submit (delta ${delta}); a credit can hide a real charge, so ${mc} Buzz was charged as a worst case"
-			printf '%s' "negative:${delta}"
+			break_meter "the balance went UP across a submit (delta ${delta}, rc=${rc}); a credit can hide a real charge, so ${mc} Buzz was charged as a worst case"
+			delta="negative:${delta}"
 		elif [ "${delta}" = 0 ]; then
-			write_scalar observed_spend "$(( cum + mc ))" || true
-			printf '%s\tgenerate\t%s\t%s\tZERO-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${mc}" \
-				>> "${ROOT}/ledger/spend.tsv"
-			break_meter "a submitted generation moved the balance by 0, so the meter is not seeing charges; ${mc} Buzz charged as a worst case"
-			printf '%s' "zero"
+			if [ "${rc}" != 0 ]; then
+				# Observably nothing moved and the command failed: benign.
+				printf '%s\tgenerate\t%s\t%s\t0 (rc=%s, no charge)\n' "$(now_iso)" "${before}" "${after}" "${rc}" \
+					>> "${ROOT}/ledger/spend.tsv"
+				delta=0
+			else
+				write_scalar observed_spend "$(( cum + mc ))" || meter_write_failed
+				printf '%s\tgenerate\t%s\t%s\tZERO-assumed-%s\n' "$(now_iso)" "${before}" "${after}" "${mc}" \
+					>> "${ROOT}/ledger/spend.tsv"
+				break_meter "a submitted generation moved the balance by 0, so the meter is not seeing charges; ${mc} Buzz charged as a worst case"
+				delta="zero"
+			fi
 		else
-			write_scalar observed_spend "$(( cum + delta ))" || true
-			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
+			write_scalar observed_spend "$(( cum + delta ))" || meter_write_failed
+			printf '%s\tgenerate\t%s\t%s\t%s (rc=%s)\n' "$(now_iso)" "${before}" "${after}" "${delta}" "${rc}" \
 				>> "${ROOT}/ledger/spend.tsv"
-			printf '%s' "${delta}"
 		fi
 	fi
 	write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))" || true
+	printf '%s' "${delta}"
+}
+
+# 🔴 THE METER WRITE IS THE ONE WRITE THAT CANNOT BE REFUSED — it happens after
+# the money has moved. Ignoring its failure with `|| true` meant that with only
+# `observed_spend` at 0444, 111 Buzz moved, the meter read 0 and nothing
+# latched, while every invocation row recorded `delta=37`: the spend was
+# OBSERVED and never accumulated. It cannot be undone, so it latches.
+meter_write_failed() {
+	break_meter "the spend ledger could not be written after a charge; the observed figure is now incomplete"
+	return 0
 }
 
 # Read a counter and write the same value back, so an unreadable or unwritable
@@ -1123,8 +1160,21 @@ verify_provenance() {
 reconcile_inflight() {
 	local f="${ROOT}/ledger/inflight"
 	[ -f "${f}" ] || return 0
-	local ts mc before now cum res delta
-	IFS=$'\t' read -r ts mc before _ < "${f}"
+	local ts mc before pid now cum res delta
+	IFS=$'\t' read -r ts mc before pid _ < "${f}"
+
+	# 🔴 A RUNNING GENERATE IS NOT A CRASHED ONE, AND THIS COULD NOT TELL THEM
+	# APART. The record was one file with no liveness check, so ANY invocation
+	# arriving mid-generate consumed it — deleted the record, released the
+	# reservation and wrote a false RECONCILED row. It takes one read command
+	# inside the window, and a real generate waits up to the 10-minute
+	# `--timeout` default. Measured 3/3 with a `whoami` at t=1s of a 3-second
+	# generate: a RECONCILED row every time. With 8 racers the meter reported
+	# 2064 where 37 had actually moved — one charge counted twice, once by the
+	# bystander and once by the real settlement.
+	if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+		return 0
+	fi
 	rm -f "${f}"
 	case "${mc}" in ''|*[!0-9]*) mc=0 ;; esac
 	case "${before}" in ''|*[!0-9]*) before="" ;; esac
@@ -1443,11 +1493,21 @@ cmd_enter() {
 		path_dirs="${path_dirs}:$(dirname "${p}")"
 	done
 
-	# 🔴 ORDER IS LOAD-BEARING. bwrap applies these in sequence, so `--tmpfs
-	# /tmp` must come BEFORE the run-root bind: the default run root lives under
-	# /tmp, and a tmpfs mounted afterwards SHADOWS it. Measured — with the bind
-	# first, bwrap died with "Can't chdir to <root>/workspace: No such file or
-	# directory".
+	# 🔴 ORDER IS LOAD-BEARING, TWICE OVER. bwrap applies these in sequence, so
+	# `--tmpfs /tmp` must come BEFORE the run-root bind (the default run root
+	# lives under /tmp and a later tmpfs SHADOWS it — measured, bwrap died with
+	# "Can't chdir to <root>/workspace"), and the read-only re-binds of `real/`,
+	# `harness/` and `bin/` must come AFTER the read-write parent bind or the
+	# parent overrides them. Those three re-binds move the `upgrade` refusal and
+	# the harness's own integrity from convention to KERNEL: measured before
+	# them, `chmod u+w $ROOT/real` and `touch $ROOT/real/.civitai.new` both
+	# SUCCEEDED inside the jail.
+	#
+	# 🔴 `--clearenv` IS NOT COSMETIC. Blindness is a mount property; the
+	# environment is not a mount. Measured inside without it: 118 inherited
+	# variables, including a real `CIVITAI_TOKEN` (a second credential sitting
+	# outside every gate), an unrelated `sk-ant-…` key, and a `CDPATH` naming
+	# the very repo the jail exists to hide.
 	exec bwrap \
 		"${binds[@]}" \
 		--ro-bind "${envbin}" /usr/bin/env \
@@ -1455,7 +1515,11 @@ cmd_enter() {
 		${ca:+--ro-bind "${ca}" /etc/ssl/certs/ca-certificates.crt} \
 		--proc /proc --dev /dev --tmpfs /tmp \
 		--bind "${ROOT}" "${ROOT}" \
+		--ro-bind "${ROOT}/real" "${ROOT}/real" \
+		--ro-bind "${ROOT}/harness" "${ROOT}/harness" \
+		--ro-bind "${ROOT}/bin" "${ROOT}/bin" \
 		--unshare-pid --die-with-parent \
+		--clearenv \
 		--setenv HOME "${ROOT}/home" \
 		--setenv XDG_CONFIG_HOME "${ROOT}/home/.config" \
 		--setenv XDG_CACHE_HOME "${ROOT}/home/.cache" \
@@ -1476,14 +1540,59 @@ cmd_teardown() {
 			*) die "teardown: unknown flag $1" ;;
 		esac
 	done
-	[ -e "${root}" ] || { [ "${quiet}" = 1 ] || note "teardown: ${root} does not exist"; return 0; }
-	chmod -R u+w "${root}" 2>/dev/null
-	if [ "${delete}" = 1 ]; then
-		rm -rf "${root}"
-		[ "${quiet}" = 1 ] || note "teardown: deleted ${root}"
+	# 🔴 THE SIBLING SCAN MUST NOT BE BEHIND THE EXISTENCE CHECK. It was, and a
+	# failed `init --force` is exactly the case that leaves NO run root and a
+	# superseded one still holding both credentials — so teardown printed "does
+	# not exist" and returned, leaving the thing it exists to remove.
+	if [ -e "${root}" ]; then
+		chmod -R u+w "${root}" 2>/dev/null
+		if [ "${delete}" = 1 ]; then
+			shred_secrets "${root}"
+			rm -rf "${root}"
+			[ "${quiet}" = 1 ] || note "teardown: deleted ${root}"
+		else
+			[ "${quiet}" = 1 ] || note "teardown: unlocked ${root} (not deleted; pass --delete to remove)"
+		fi
 	else
-		[ "${quiet}" = 1 ] || note "teardown: unlocked ${root} (not deleted; pass --delete to remove)"
+		[ "${quiet}" = 1 ] || note "teardown: ${root} does not exist"
 	fi
+
+	# 🔴 `init --force` LEAVES A SUPERSEDED ROOT, AND IT HOLDS BOTH CREDENTIALS.
+	# The go/no-go is scrupulous about `shred -u` on the operator's own token
+	# file and was silent about the copies the harness itself makes: the Civitai
+	# key in `home/.config/civitai/config.yaml` and, after `--with-claude`, the
+	# Anthropic OAuth token in `home/.claude/.credentials.json`. `teardown
+	# --delete` removed only ${ROOT} and never the siblings.
+	local sib found=0
+	for sib in "${root}".superseded-*; do
+		[ -e "${sib}" ] || continue
+		found=1
+		if [ "${delete}" = 1 ]; then
+			chmod -R u+w "${sib}" 2>/dev/null
+			shred_secrets "${sib}"
+			rm -rf "${sib}"
+			[ "${quiet}" = 1 ] || note "teardown: deleted superseded run ${sib}"
+		else
+			note "teardown: 🔴 ${sib} still holds a credential — re-run with --delete"
+		fi
+	done
+	[ "${found}" = 1 ] || true
+}
+
+# Overwrite credential material before unlinking it. `shred` is best-effort on a
+# journalling or copy-on-write filesystem — it is not a guarantee, it is the
+# difference between "deleted" and "deleted and overwritten once".
+shred_secrets() {
+	local root="$1" f
+	for f in "${root}/home/.config/civitai/config.yaml" \
+	         "${root}/home/.claude/.credentials.json"; do
+		[ -f "${f}" ] || continue
+		if command -v shred >/dev/null 2>&1; then
+			shred -u "${f}" 2>/dev/null || rm -f "${f}"
+		else
+			rm -f "${f}"
+		fi
+	done
 }
 
 # ---------------------------------------------------------------------------
@@ -1597,15 +1706,21 @@ OFFLINE
 	st_reason "a silent non-zero classifier denies" "DENY" "could not be classified" generate cat --dry-run
 	mkfake 'printf "ok\t1\npath\tgenerate\nargc\tnotanumber\n"'
 	st_reason "a non-numeric argument count denies" "DENY" "could not be classified" generate cat --dry-run
-	# These two branches are unreachable through today's command tree — cobra's
-	# ValidateArgs never errors for these commands, and `unknown-command` is
-	# reported as a flag-parse error for the spellings the corpus uses. They are
-	# still gate branches, so they are exercised through an injected classifier
-	# rather than left as unpinned code.
-	mkfake 'printf "ok\t1\npath\tmodels\nargc\t0\nhassubcommands\tfalse\nargserr\taccepts at most 1 arg\n"'
-	st_reason "an argserr from cobra denies" "DENY" "would reject these arguments" models search x
+	# 🔴 THE CLAIM THAT WAS HERE WAS WRONG. It said cobra's ValidateArgs never
+	# errors for these commands. Measured, it does: `workflows cancel` with no
+	# id gives "accepts 1 arg(s), received 0", and `generate a b` gives "accepts
+	# at most 1 arg(s), received 2" — both are now real rows below. Only the
+	# `unknown-command` KIND is unreachable through the corpus (cobra reports
+	# those spellings as flag-parse errors), so it alone is exercised through an
+	# injected classifier.
 	mkfake 'printf "ok\t0\nkind\tunknown-command\nerr\tunknown command \"zzz\"\n"; exit 2'
 	st_reason "an unknown-command kind denies" "DENY" "does not recognise this command" zzz
+	GUARD_BIN=""; rm -f "${fake}"
+	# Real argserr cases, measured against the shipped tree rather than faked.
+	st_reason "workflows cancel with no id denies" "DENY" "would reject these arguments" workflows cancel
+	st_reason "generate with two positionals denies" "DENY" "would reject these arguments" generate a b
+	st_check  "civitai help generate is help"     "ALLOW" "$(vd help generate)"
+	st_check  "civitai help is help"              "ALLOW" "$(vd help)"
 	# A classifier that claims everything is a harmless read must still not be
 	# able to say so from OUTSIDE the sandbox: GUARD_BIN is reset at startup, so
 	# an exported value cannot reach the gate.
@@ -1876,6 +1991,12 @@ printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-
 # binary that charges a known amount. The classifier being right says nothing
 # about whether the guard acts on it.
 # ---------------------------------------------------------------------------
+# grep -c prints "0" AND exits 1 when there are no matches, so `|| printf 0`
+# appends a SECOND zero. Count via a helper that always succeeds.
+reconciled_rows() {
+	grep -c RECONCILED "$1/ledger/invocations.tsv" 2>/dev/null || true
+}
+
 selftest_e2e() {
 	local base="${TMPDIR:-/tmp}/dogfood-e2e-$$"
 	local guard_src="$1"
@@ -1896,6 +2017,8 @@ set -- "${args[@]+"${args[@]}"}"
 case "${1:-}" in
   buzz)
     [ -n "${STUB_BUZZ_ALWAYS_FAILS:-}" ] && { echo boom >&2; exit 5; }
+    # Fail only the POST read (any buzz after the first of this invocation).
+    if [ -n "${STUB_POSTREAD_FAIL:-}" ] && [ "$(cat "${NB}")" -ge 1 ]; then echo boom >&2; exit 5; fi
     # Widen the locked section so the concurrency row is deterministic: the
     # pre-spend balance read happens INSIDE the lock, so without flock the
     # eight racers overlap reliably rather than by luck.
@@ -1916,9 +2039,17 @@ case "${1:-}" in
       [ -f "${XDG_CACHE_HOME}/../../ledger/inflight" ] && echo yes > "${XDG_CACHE_HOME}/saw-inflight" || echo no > "${XDG_CACHE_HOME}/saw-inflight"
     fi
     [ -n "${STUB_WORKFLOWS:-}" ] && : > "${XDG_CACHE_HOME}/wf-submitted"
+    [ -n "${STUB_SLOW_GEN:-}" ] && sleep "${STUB_SLOW_GEN}"
+    # Make the meter unwritable DURING the call, after the pre-flight has
+    # already proved it writable — the only way the post-charge write can fail,
+    # and the reason meter_write_failed exists.
+    [ -n "${STUB_LOCK_METER:-}" ] && chmod 0444 "${XDG_CACHE_HOME}/../../ledger/observed_spend" 2>/dev/null
     if [ -n "${STUB_LAGGY:-}" ]; then :                       # charge never lands
     elif [ -n "${STUB_CREDIT:-}" ]; then echo $(( $(cat "${BAL}") - 37 + 100 )) > "${BAL}"
     else echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; fi
+    # A charge that lands and THEN fails — the shape AGENTS item 28(b) refuses
+    # to make claims about, and the one the rc-aware suppression must not hide.
+    [ -n "${STUB_FAIL_AFTER_CHARGE:-}" ] && { echo "submitted, then failed" >&2; exit 1; }
     echo generated ;;
   app)
     [ -n "${STUB_APP_RC:-}" ] && { echo "validation failed" >&2; exit "${STUB_APP_RC}"; }
@@ -2040,6 +2171,58 @@ POL
 	st_check "e2e the lock is free once released" "acquired" \
 		"$(bash "$(readlink -f "$0")" __locktest --root "${base}" try 2>/dev/null)"
 	rm -f "${base}/ledger/.locktest-held"
+
+	note "--- 🔴 a charge that happens and THEN fails must still latch ---"
+	e2e_reset
+	STUB_POSTREAD_FAIL=1 STUB_FAIL_AFTER_CHARGE=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e rc!=0 + unreadable post-read LATCHES"  "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	st_check "e2e rc!=0 + unreadable charges worst case" "60" "$(cat "${base}/ledger/observed_spend")"
+	e2e_reset
+	STUB_CREDIT=1 STUB_FAIL_AFTER_CHARGE=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e rc!=0 + NEGATIVE delta LATCHES"        "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	e2e_reset
+	STUB_FAIL_AFTER_CHARGE=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e rc!=0 with a REAL charge is metered"   "37" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e rc!=0 with a real charge does not latch" "no" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	# CONTROL: the benign case must still be suppressed.
+	e2e_reset
+	STUB_FAIL_RC=2 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e a failure that spent NOTHING is suppressed" "0" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e that suppression does not latch"           "no" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	note "--- 🔴 the meter file itself must be writable before a spend ---"
+	e2e_reset
+	chmod 0444 "${base}/ledger/observed_spend"
+	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1; rc=$?
+	chmod 0644 "${base}/ledger/observed_spend"
+	st_check "e2e an unwritable METER refuses a spend" "126"   "${rc}"
+	st_check "e2e that refusal spent nothing"          "10000" "$(cat "${base}/home/.cache/bal")"
+
+	note "--- 🔴 a meter write that fails AFTER the charge must latch ---"
+	e2e_reset
+	STUB_LOCK_METER=1 "${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1
+	chmod 0644 "${base}/ledger/observed_spend" 2>/dev/null
+	st_check "e2e a post-charge meter write failure LATCHES" "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+
+	note "--- 🔴 a live generate's crash record must not be consumed ---"
+	e2e_reset
+	STUB_SLOW_GEN=3 "${C}" generate slow --yes --max-cost 50 >/dev/null 2>&1 &
+	local slow=$!
+	sleep 1
+	"${C}" whoami >/dev/null 2>&1
+	st_check "e2e a read mid-generate writes NO reconcile row" "0" \
+		"$(reconciled_rows "${base}")"
+	"${C}" generate second --yes --max-cost 10 >/dev/null 2>&1
+	st_check "e2e a SECOND concurrent generate is refused" "126" "$?"
+	wait "${slow}" 2>/dev/null
+	st_check "e2e the live generate metered exactly once" "37" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e no reconcile row was ever written"      "0" \
+		"$(reconciled_rows "${base}")"
 
 	note "--- 🔴 the three ways the meter can lie, each must LATCH ---"
 

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -574,7 +574,7 @@ BRIEF
 declare -A GBOOL GINT GSTR GCHANGED
 declare -a GARG
 GPATH=""; GARGC=0; GERR=""; GKIND=""
-GRUNNABLE=""; GHASSUB=""; GARGSERR=""; GBLOCKID=""
+GHASSUB=""; GARGSERR=""
 
 # 🔴 ASSIGNED UNCONDITIONALLY AT STARTUP, WHICH IS THE POINT. The selftest
 # swaps in fake classifiers to prove the shim refuses drifted output, and it
@@ -598,7 +598,7 @@ unescape() {
 classify() {
 	GBOOL=(); GINT=(); GSTR=(); GCHANGED=(); GARG=()
 	GPATH=""; GARGC=0; GERR=""; GKIND=""
-	GRUNNABLE=""; GHASSUB=""; GARGSERR=""; GBLOCKID=""
+	GHASSUB=""; GARGSERR=""
 	local bin="${GUARD_BIN:-${ROOT}/real/dogfoodguard}" out rc ok="" k v
 	if [ ! -x "${bin}" ]; then
 		GERR="the classifier ${bin} is missing or not executable"; return 1
@@ -621,10 +621,16 @@ classify() {
 			str.*)       GSTR[${k#str.}]=$(unescape "${v}") ;;
 			raw.*)       GSTR[${k#raw.}]=$(unescape "${v}") ;;
 			changed.*)   GCHANGED[${k#changed.}]="${v}" ;;
-			runnable)    GRUNNABLE="${v}" ;;
+			# `runnable` is informational: it does NOT discriminate an unknown
+			# subcommand (every group parent is runnable — it prints its help),
+			# so the gate uses hassubcommands + argc. Accepted and ignored.
+			runnable)    : ;;
 			hassubcommands) GHASSUB="${v}" ;;
 			argserr)     GARGSERR=$(unescape "${v}") ;;
-			blockid)     GBLOCKID=$(unescape "${v}") ;;
+			# `blockid` is only emitted in the classifier's manifest mode, which
+			# resolve_block_id parses directly; accept and ignore it here so a
+			# stray one is not mistaken for classifier drift.
+			blockid)     : ;;
 			*)           GERR="the classifier emitted an unrecognised field \`${k}\`"; return 1 ;;
 		esac
 	done <<< "${out}"
@@ -1752,6 +1758,7 @@ OFFLINE
 	# without this row the ok-check is an unpinned redundancy.
 	# The fake must SUCCEED for the argv classification and FAIL only for the
 	# blockid lookup, or the run is denied earlier and the row proves nothing.
+	# shellcheck disable=SC2016  # the body is a script; $1/$4 must NOT expand here
 	mkfake 'if [ "$1" = "blockid" ]; then printf "ok\t0\nerr\tno manifest\n"; exit 0; fi
 printf "ok\t1\npath\tapp submit\nhassubcommands\tfalse\nargserr\t\nbool.package-only\tfalse\nargc\t1\narg.0\t%s\n" "$4"'
 	st_reason "a lookup that fails while exiting 0 denies" "DENY" "cannot read a blockId" app submit "${td}/dup" --yes

--- a/scripts/dogfood-sandbox.sh
+++ b/scripts/dogfood-sandbox.sh
@@ -16,63 +16,121 @@
 #   guard        policy gate — invoked by the generated `civitai` shim, not by hand
 #   status       spend so far, invocation counts, remaining budget
 #   finish       sample the closing balance and print the audit report
-#   selftest     positive controls on the FREE surface (spends nothing)
+#   selftest     assertions over the gate; --offline needs no binary or credential
 #   enter        spawn a bubblewrap jail in which the repo does not exist
 #   allow-pubreq record a publish-request id as withdrawable
 #   teardown     unlock the read-only dirs and (optionally) delete the run root
 #
 # Every path is absolute; every `cd` is gated; every variable is braced.
+#
+# 🔴 READ THIS BEFORE CHANGING THE ARGV HANDLING. The gate used to classify on
+# positional $1/$2/$3 and to look for flags with a plain "is this token
+# present?" test. Both were wrong, and both were bypassed by ORDINARY
+# invocations rather than by attacks:
+#   * Cobra strips the root persistent bools (--color/--no-color/
+#     --no-update-check) before resolving the command, so `--no-color generate
+#     … --yes` put `--no-color` in $1 and every gate branch was skipped —
+#     measured: a real charge with the meter untouched, and `--no-update-check
+#     upgrade` allowed outright.
+#   * pflag takes the token after a value-taking flag as its VALUE even when it
+#     starts with `--`, so `--negative-prompt --help` made a "present?" test
+#     see help and allow a real submit, and `--negative-prompt --dry-run` made
+#     it see a free preview while the CLI submitted and charged.
+# So: commands are resolved against a CLOSED VOCABULARY, and flags are resolved
+# by a tokenizer that knows which flags consume the next token. Do not replace
+# either with a `case "$1"` or a `has_flag` scan.
 
 set -uo pipefail
 
 # ---------------------------------------------------------------------------
 # Defaults. Override on `init` via flags, or afterwards by editing
-# ${ROOT}/ledger/policy.env (which `init` writes and every later call reads).
+# ${ROOT}/ledger/policy.env (which `init` writes and every later call reads,
+# VALIDATING it — a missing or malformed key is a refusal, not a default).
 # ---------------------------------------------------------------------------
 DEFAULT_ROOT="/tmp/claude-1000/dogfood3-scratch/run"
-
-# Buzz an ESTIMATE may reach for a single `generate` submit. Enforced by
-# REFUSING a submit that does not carry `--max-cost <= this`. The CLI's own
-# help is explicit that --max-cost is not a spending cap; see the design doc.
 DEFAULT_PER_CALL_MAX_COST=100
-
-# Cumulative OBSERVED spend (start balance minus current) at which further
-# `generate` submits are refused. Checked BEFORE each submit.
 DEFAULT_TOTAL_SPEND_CAP=2000
-
-# Hard ceilings on the number of mutating invocations, independent of cost.
 DEFAULT_MAX_GENERATE_SUBMITS=20
 DEFAULT_MAX_APP_SUBMITS=3
-
-# Only apps whose blockId starts with this may be submitted or have their
-# listing media mutated. `init` derives a dated default.
 DEFAULT_SLUG_PREFIX=""
+DEFAULT_BASE_URL="https://civitai.com"
 
 # ---------------------------------------------------------------------------
-# Small helpers
+# Closed vocabularies. An unrecognised command is DENIED, not passed through:
+# a new subcommand may spend or mutate, and the gate cannot know that it does
+# not.
 # ---------------------------------------------------------------------------
+TOPLEVEL_CMDS="app articles buzz collections completion creators download generate help images login model-versions models tags upgrade users version whoami workflows"
+APP_SUBCMDS="create init validate submit withdraw status list view pull metrics listing dev-token dev-tunnel"
+LISTING_SUBCMDS="status set-icon set-cover add-screenshot rm-screenshot reorder"
+WORKFLOWS_SUBCMDS="list get cancel"
+
+# Root persistent flags. All BOOLEAN — Cobra strips them anywhere they appear
+# and they never consume the following token.
+ROOT_BOOL_FLAGS="--color --no-color --no-update-check --help -h --version -v"
+
+# Boolean flags of the gated commands. Used to decide whether a `--help` is a
+# real help request or the VALUE of a preceding value-taking flag.
+CMD_BOOL_FLAGS="--yes -y --dry-run --print-input --json --force --no-wait --no-download --fail-on-substitution --package-only --skip-validate --strict --no-browser --package-only"
+
+# Flags that CONSUME the next token, per command path.
+VALUE_FLAGS_GENERATE="--checkpoint --lora --image --input --negative-prompt --aspect-ratio --quantity --out-dir --timeout --max-cost --external-id --ecosystem"
+VALUE_FLAGS_APP_SUBMIT="-o --out"
+VALUE_FLAGS_APP_LISTING="--slug --dir --caption --changelog"
+VALUE_FLAGS_APP_WITHDRAW="--id"
+
 err()  { printf 'dogfood-sandbox: %s\n' "$*" >&2; }
 die()  { err "$*"; exit 1; }
 note() { printf '%s\n' "$*"; }
 
-# Machine-readable marker so a refusal from THIS harness can never be mistaken
-# for a civitai CLI error and filed as a dogfood issue against the CLI.
 SANDBOX_TAG="SANDBOX POLICY"
-
 now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
-# Extract "total" from `civitai buzz --json`. Fails LOUDLY on no match: a
-# balance read that silently yields empty must never be read as "spent 0".
+in_list() {
+	local needle="$1" hay="$2" x
+	for x in ${hay}; do [ "${x}" = "${needle}" ] && return 0; done
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Balance parsing
+#
+# 🔴 The pattern is ANCHORED AT BOTH ENDS on purpose. An unanchored
+# `"total":-\?[0-9]\+` matches a PREFIX of the number and returns it as the
+# whole value: measured, `{"total":3.5}` parsed as 3 and `{"total":1e9}` parsed
+# as 1 — and because both samples of a bracketed spend parse to 1, every delta
+# is 0 and the meter reads a constant forever. Same class as the `"total": N`
+# with-a-space bug that made an earlier ad-hoc grep return nothing at all.
+# A negative or absurdly large total is REJECTED rather than truncated, and
+# more than one `total` key is rejected too (Go decodes the last, this reads
+# the first, and a disagreement is not something to guess about).
+# ---------------------------------------------------------------------------
 parse_buzz_total() {
-	local json="$1" v
-	v=$(printf '%s' "${json}" | tr -d ' \n\t' | grep -o '"total":-\?[0-9]\+' | head -1 | cut -d: -f2)
+	local json="$1" compact hits v
+	compact=$(printf '%s' "${json}" | tr -d ' \n\t\r')
+	hits=$(printf '%s' "${compact}" | grep -o '"total":-\?[0-9][0-9]*[,}]' | wc -l)
+	[ "${hits}" = 1 ] || return 1
+	v=$(printf '%s' "${compact}" | grep -o '"total":-\?[0-9][0-9]*[,}]' | head -1 \
+		| sed 's/^"total"://; s/[,}]$//')
 	case "${v}" in
-		''|*[!0-9-]*) return 1 ;;
+		''|*[!0-9]*) return 1 ;;   # rejects "" and any leading '-'
 	esac
+	[ "${#v}" -le 15 ] || return 1  # beyond this, bash 64-bit arithmetic is not trustworthy
 	printf '%s' "${v}"
 }
 
-# Scrub credentials out of an argv before it reaches the audit log.
+# TSV fields must not carry the record or field separator. A newline is a
+# LEGITIMATE character in a prompt, and an unescaped one let a single
+# invocation append a second, forged ledger row.
+tsv_escape() {
+	local s="$1"
+	s="${s//\\/\\\\}"
+	s="${s//$'\n'/\\n}"
+	s="${s//$'\r'/\\r}"
+	s="${s//$'\t'/\\t}"
+	printf '%s' "${s}"
+}
+
 scrub_argv() {
 	local out="" a skip=0
 	for a in "$@"; do
@@ -83,32 +141,134 @@ scrub_argv() {
 		esac
 		out="${out} ${a}"
 	done
-	printf '%s' "${out# }"
+	tsv_escape "${out# }"
 }
+
+# ---------------------------------------------------------------------------
+# Policy + ledger scalars, both VALIDATED on read.
+#
+# 🔴 These used to be sourced and trusted. Under `set -u` an unbound variable
+# inside the verdict subshell killed it, the verdict came back EMPTY, and
+# `"" != "DENY"` executed the command — measured: with one line deleted from
+# the file the header tells the operator to edit, `--max-cost 99999` submitted
+# and charged. A malformed ledger scalar disabled the cap the same way.
+# ---------------------------------------------------------------------------
+POLICY_ERROR=""
 
 load_policy() {
-	[ -f "${ROOT}/ledger/policy.env" ] || die "no policy at ${ROOT}/ledger/policy.env — run \`init\` first"
-	# shellcheck disable=SC1091
-	. "${ROOT}/ledger/policy.env"
+	POLICY_ERROR=""
+	local f="${ROOT}/ledger/policy.env" k v
+	if [ ! -f "${f}" ]; then
+		POLICY_ERROR="no policy at ${f} — run \`init\` first"; return 1
+	fi
+	# 🔴 UNSET FIRST. Sourcing does not clear a key the file no longer defines,
+	# so a value left over from an earlier load masked a deleted key and the
+	# validation below passed on a policy that was missing one.
+	unset PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS SLUG_PREFIX BASE_URL
+	# shellcheck disable=SC1090
+	. "${f}" || { POLICY_ERROR="policy file ${f} could not be read"; return 1; }
+	for k in PER_CALL_MAX_COST TOTAL_SPEND_CAP MAX_GENERATE_SUBMITS MAX_APP_SUBMITS; do
+		eval "v=\${${k}:-}"
+		case "${v}" in
+			''|*[!0-9]*)
+				POLICY_ERROR="policy key ${k} is missing or is not a whole number"; return 1 ;;
+		esac
+	done
+	if [ -z "${SLUG_PREFIX:-}" ]; then
+		POLICY_ERROR="policy key SLUG_PREFIX is missing or empty"; return 1
+	fi
+	[ -n "${BASE_URL:-}" ] || BASE_URL="${DEFAULT_BASE_URL}"
+	return 0
 }
 
-# Run the REAL binary with the sandbox environment, bypassing the guard.
-# Used by init/finish/selftest and by the guard's own balance sampling.
+# A ledger counter. A missing file is 0; a MALFORMED one is an error, never 0.
+read_scalar() {
+	local f="${ROOT}/ledger/$1" v
+	[ -f "${f}" ] || { printf '0'; return 0; }
+	v=$(tr -d ' \n\r\t' < "${f}")
+	[ -n "${v}" ] || { printf '0'; return 0; }
+	case "${v}" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+	printf '%s' "${v}"
+}
+
+write_scalar() { printf '%s\n' "$2" > "${ROOT}/ledger/$1"; }
+
+# ---------------------------------------------------------------------------
+# Running the real binary
+#
+# The environment is PINNED, not inherited: the agent controls the shim's
+# environment, and CIVITAI_BASE_URL would otherwise redirect the very balance
+# read the spend meter uses as its oracle. CIVITAI_TOKEN is cleared so the
+# seeded config file is the only credential.
+# ---------------------------------------------------------------------------
+sandbox_env() {
+	printf '%s\0' \
+		"HOME=${ROOT}/home" \
+		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
+		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
+		"CIVITAI_NO_UPDATE_CHECK=1" \
+		"CIVITAI_BASE_URL=${BASE_URL:-${DEFAULT_BASE_URL}}"
+}
+
 real_cli() {
-	HOME="${ROOT}/home" \
-	XDG_CONFIG_HOME="${ROOT}/home/.config" \
-	XDG_CACHE_HOME="${ROOT}/home/.cache" \
-	CIVITAI_NO_UPDATE_CHECK=1 \
-	"${ROOT}/real/civitai" "$@"
+	env -u CIVITAI_TOKEN -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
+		-u CIVITAI_CHECK_SUBMISSIONS_CAP -u CIVITAI_CHECK_PUBLISHED_PINS \
+		"HOME=${ROOT}/home" \
+		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
+		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
+		"CIVITAI_NO_UPDATE_CHECK=1" \
+		"CIVITAI_BASE_URL=${BASE_URL:-${DEFAULT_BASE_URL}}" \
+		"${ROOT}/real/civitai" "$@"
 }
 
-# Sample the balance. Echoes the total on stdout; non-zero on any failure.
+# Sample the balance, bounded. A hung `buzz` must not hang the gate.
 sample_balance() {
 	local phase="$1" json total
-	json=$(real_cli buzz --json 2>/dev/null)
+	if command -v timeout >/dev/null 2>&1; then
+		json=$(timeout 60 "$0" __buzz --root "${ROOT}" 2>/dev/null)
+	else
+		json=$(real_cli buzz --json 2>/dev/null)
+	fi
 	total=$(parse_buzz_total "${json}") || return 1
-	printf '%s\t%s\t%s\n' "$(now_iso)" "${phase}" "${json}" >> "${ROOT}/ledger/buzz.tsv"
+	printf '%s\t%s\t%s\n' "$(now_iso)" "${phase}" "$(tsv_escape "${json}")" \
+		>> "${ROOT}/ledger/buzz.tsv"
 	printf '%s' "${total}"
+}
+
+# Internal: a `buzz --json` that `timeout` can kill as its own process.
+cmd_buzz_probe() {
+	local root=""
+	while [ $# -gt 0 ]; do
+		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
+	done
+	ROOT="${root:-${DEFAULT_ROOT}}"
+	load_policy || exit 1
+	real_cli buzz --json
+}
+
+# ---------------------------------------------------------------------------
+# Ledger lock. The cap check, the counter bump and the reservation must be one
+# atomic section, or eight concurrent shim invocations each read the same
+# pre-spend total and all pass a cap that should have allowed one — measured:
+# 8 ALLOW_SPEND rows under a cap with 10 Buzz of headroom, the submit counter
+# losing 3 increments, and the meter left holding a number that matched
+# nothing.
+# ---------------------------------------------------------------------------
+LOCK_HELD=0
+lock_ledger() {
+	command -v flock >/dev/null 2>&1 || return 0   # degraded; reported by selftest
+	exec 9>"${ROOT}/ledger/.lock" || return 1
+	flock -x -w 60 9 || return 1
+	LOCK_HELD=1
+	return 0
+}
+unlock_ledger() {
+	[ "${LOCK_HELD}" = 1 ] || return 0
+	flock -u 9 2>/dev/null
+	exec 9>&- 2>/dev/null
+	LOCK_HELD=0
 }
 
 # ---------------------------------------------------------------------------
@@ -121,18 +281,20 @@ cmd_init() {
 	local max_gen="${DEFAULT_MAX_GENERATE_SUBMITS}"
 	local max_app="${DEFAULT_MAX_APP_SUBMITS}"
 	local slug_prefix="${DEFAULT_SLUG_PREFIX}"
+	local base_url="${DEFAULT_BASE_URL}"
 
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			--root)          root="$2"; shift 2 ;;
-			--binary)        binary="$2"; shift 2 ;;
-			--token-file)    token_file="$2"; shift 2 ;;
-			--per-call-max)  per_call="$2"; shift 2 ;;
-			--total-cap)     total_cap="$2"; shift 2 ;;
-			--max-generates) max_gen="$2"; shift 2 ;;
+			--root)            root="$2"; shift 2 ;;
+			--binary)          binary="$2"; shift 2 ;;
+			--token-file)      token_file="$2"; shift 2 ;;
+			--per-call-max)    per_call="$2"; shift 2 ;;
+			--total-cap)       total_cap="$2"; shift 2 ;;
+			--max-generates)   max_gen="$2"; shift 2 ;;
 			--max-app-submits) max_app="$2"; shift 2 ;;
-			--slug-prefix)   slug_prefix="$2"; shift 2 ;;
-			--force)         force=1; shift ;;
+			--slug-prefix)     slug_prefix="$2"; shift 2 ;;
+			--base-url)        base_url="$2"; shift 2 ;;
+			--force)           force=1; shift ;;
 			*) die "init: unknown flag $1" ;;
 		esac
 	done
@@ -142,14 +304,19 @@ cmd_init() {
 	[ -x "${binary}" ] || die "init: ${binary} is not an executable file"
 
 	if [ -e "${ROOT}" ] && [ "${force}" != 1 ]; then
-		die "init: ${ROOT} already exists (use --force to rebuild, or \`teardown\` first)"
+		die "init: ${ROOT} already exists (use --force to supersede it, or \`teardown\` first)"
 	fi
 	if [ -e "${ROOT}" ]; then
-		cmd_teardown --root "${ROOT}" --delete --quiet
+		# 🔴 SUPERSEDE, NEVER DELETE. The ledger is the audit artefact of the
+		# previous run; a mistyped `init --force` used to destroy it before the
+		# new credential had even been validated.
+		local superseded
+		superseded="${ROOT}.superseded-$(date -u +%Y%m%dT%H%M%SZ)"
+		chmod -R u+w "${ROOT}" 2>/dev/null
+		mv "${ROOT}" "${superseded}" || die "init: could not set the previous run aside"
+		note "init: previous run preserved at ${superseded}"
 	fi
 
-	# The token must never arrive as a harness argument (shell history) and must
-	# never be written into the repo.
 	local token=""
 	if [ -n "${token_file}" ]; then
 		[ -r "${token_file}" ] || die "init: cannot read --token-file ${token_file}"
@@ -161,9 +328,7 @@ cmd_init() {
 	fi
 	[ -n "${token}" ] || die "init: the supplied credential is empty"
 
-	if [ -z "${slug_prefix}" ]; then
-		slug_prefix="dogfood3-$(date -u +%Y%m%d)-"
-	fi
+	[ -n "${slug_prefix}" ] || slug_prefix="dogfood3-$(date -u +%Y%m%d)-"
 
 	mkdir -p "${ROOT}/real" "${ROOT}/bin" "${ROOT}/harness" \
 	         "${ROOT}/home/.config" "${ROOT}/home/.cache" \
@@ -172,14 +337,11 @@ cmd_init() {
 
 	cp "${binary}" "${ROOT}/real/civitai" || die "init: could not copy the binary"
 
-	# The harness runs from a COPY so the run is self-contained and so a jail
-	# that does not mount the repo still works.
 	local self
 	self=$(readlink -f "$0")
 	cp "${self}" "${ROOT}/harness/dogfood-sandbox.sh" || die "init: could not copy the harness"
 	chmod 0555 "${ROOT}/harness/dogfood-sandbox.sh"
 
-	# The `civitai` the agent gets is a shim into the policy gate.
 	cat > "${ROOT}/bin/civitai" <<SHIM
 #!/usr/bin/env bash
 exec "${ROOT}/harness/dogfood-sandbox.sh" guard --root "${ROOT}" -- "\$@"
@@ -188,26 +350,31 @@ SHIM
 
 	: > "${ROOT}/ledger/invocations.tsv"
 	: > "${ROOT}/ledger/buzz.tsv"
+	: > "${ROOT}/ledger/spend.tsv"
 	: > "${ROOT}/ledger/pubreq.allow"
-	printf '0\n' > "${ROOT}/ledger/generate_submits"
-	printf '0\n' > "${ROOT}/ledger/app_submits"
+	write_scalar generate_submits 0
+	write_scalar app_submits 0
+	write_scalar observed_spend 0
+	write_scalar reserved 0
+	rm -f "${ROOT}/ledger/meter_broken"
 
 	cat > "${ROOT}/ledger/policy.env" <<POLICY
-# Written by dogfood-sandbox.sh init on $(now_iso). Read by every later call.
+# Written by dogfood-sandbox.sh init on $(now_iso). Read and VALIDATED by every
+# later call — a missing or malformed key is a refusal, not a default.
 ROOT="${ROOT}"
 PER_CALL_MAX_COST=${per_call}
 TOTAL_SPEND_CAP=${total_cap}
 MAX_GENERATE_SUBMITS=${max_gen}
 MAX_APP_SUBMITS=${max_app}
 SLUG_PREFIX="${slug_prefix}"
+BASE_URL="${base_url}"
 BINARY_SOURCE="${binary}"
 BINARY_SHA256="$(sha256sum "${binary}" | cut -d' ' -f1)"
 HARNESS_SHA256="$(sha256sum "${self}" | cut -d' ' -f1)"
 POLICY
 	chmod 0600 "${ROOT}/ledger/policy.env"
+	load_policy || die "init: the policy just written does not validate: ${POLICY_ERROR}"
 
-	# Seed the credential THROUGH the CLI (it is the authority on the config
-	# format) into the sandbox config only.
 	real_cli login --token "${token}" >/dev/null 2>&1 \
 		|| die "init: seeding the credential failed — check the token"
 	token=""
@@ -215,16 +382,12 @@ POLICY
 		|| die "init: no config written at ${ROOT}/home/.config/civitai/config.yaml"
 	chmod 0600 "${ROOT}/home/.config/civitai/config.yaml"
 
-	# Prove the credential works before locking anything down.
 	real_cli whoami >/dev/null 2>&1 || die "init: whoami failed with the seeded credential"
 
 	local start
 	start=$(sample_balance "start") || die "init: could not read the opening Buzz balance — refusing to start a run whose meter does not work"
-	printf '%s\n' "${start}" > "${ROOT}/ledger/start_balance"
+	write_scalar start_balance "${start}"
 
-	# Structural: `upgrade` writes .civitai.new into the binary's directory via
-	# O_CREATE (minio/selfupdate apply.go). A 0500 directory makes that EACCES.
-	# The 0555 on the file itself closes the in-place-write variant.
 	chmod 0555 "${ROOT}/real/civitai"
 	chmod 0500 "${ROOT}/real" "${ROOT}/bin" "${ROOT}/harness"
 
@@ -244,10 +407,7 @@ POLICY
 }
 
 cmd_write_brief() {
-	# The caps live in policy.env, not in init's locals, so source them —
-	# without this the brief renders literal placeholder text and a blind agent
-	# is told the prefix is "the sanctioned prefix".
-	load_policy
+	load_policy || die "brief: ${POLICY_ERROR}"
 	cat > "${ROOT}/AGENT-BRIEF.md" <<BRIEF
 # civitai CLI — evaluation sandbox
 
@@ -273,6 +433,8 @@ The gate:
   allowed. Scaffold your app with a name under that prefix, e.g.
   \`civitai app create ${SLUG_PREFIX}myapp\`.
 - \`upgrade\`, \`login\`, \`app dev-tunnel\` and \`app dev-token\` are refused.
+- A command the gate does not recognise is refused rather than guessed at, so a
+  typo may produce a \`${SANDBOX_TAG}\` line rather than the CLI's own error.
 
 Submitting an app puts it in front of a real human moderator. That is expected
 and approved for this run — but do it deliberately, not to see what happens.
@@ -283,117 +445,208 @@ BRIEF
 }
 
 # ---------------------------------------------------------------------------
-# guard — the policy gate. Invoked as: guard --root <ROOT> -- <civitai argv...>
+# ARGV TOKENIZER
+#
+# Fills TOK_KIND[i] for each argv token: "flag", "value", or "positional".
+# Value-taking flags are resolved per command path. An UNRECOGNISED flag on a
+# spending command is treated as value-taking, which biases the classification
+# toward DENY rather than toward an unmetered submit.
 # ---------------------------------------------------------------------------
-cmd_guard() {
-	local root=""
-	while [ $# -gt 0 ]; do
-		case "$1" in
-			--root) root="$2"; shift 2 ;;
-			--)     shift; break ;;
-			*)      break ;;
-		esac
+declare -a TOK TOK_KIND
+CMD1=""; CMD2=""; CMD3=""
+# The token that SHOULD have been a subcommand but is not in the vocabulary.
+# Without this an unknown verb resolved to the empty string and was
+# indistinguishable from a bare `civitai app`, which the gate allows as a usage
+# request — so `app frobnicate` and `app listing frobnicate` were ALLOWED.
+CMD2_UNKNOWN=""; CMD3_UNKNOWN=""
+IDX1=-1; IDX2=-1; IDX3=-1
+
+value_flags_for_path() {
+	case "${CMD1}:${CMD2}" in
+		generate:*)     printf '%s' "${VALUE_FLAGS_GENERATE}" ;;
+		app:submit)     printf '%s' "${VALUE_FLAGS_APP_SUBMIT}" ;;
+		app:listing)    printf '%s' "${VALUE_FLAGS_APP_LISTING}" ;;
+		app:withdraw)   printf '%s' "${VALUE_FLAGS_APP_WITHDRAW}" ;;
+		*)              printf '%s' "" ;;
+	esac
+}
+
+# Resolve the command path against the closed vocabulary. The FIRST token that
+# is not a flag is the command; root persistent bools never consume a value, so
+# skipping every leading `-*` is correct here and is what fixes the
+# `--no-color generate` bypass.
+# The first token after index `from` that does not start with '-'. Between a
+# parent command and its subcommand Cobra permits only the parent's own flags,
+# and none of `civitai`'s parent commands has a value-taking flag — so "first
+# token not starting with -" is the correct rule here and needs no knowledge of
+# which flags consume a value.
+next_word_after() {
+	local from="$1" i n
+	n=${#TOK[@]}
+	for (( i=from+1; i<n; i++ )); do
+		case "${TOK[i]}" in -*) continue ;; esac
+		printf '%s\t%s' "${TOK[i]}" "${i}"; return 0
 	done
-	ROOT="${root:-${DEFAULT_ROOT}}"
-	load_policy
+	return 1
+}
 
-	local argv=("$@")
-	local scrubbed
-	scrubbed=$(scrub_argv "${argv[@]+"${argv[@]}"}")
+resolve_command() {
+	CMD1=""; CMD2=""; CMD3=""; CMD2_UNKNOWN=""; CMD3_UNKNOWN=""
+	IDX1=-1; IDX2=-1; IDX3=-1
+	local i n t pair word idx
+	n=${#TOK[@]}
+	for (( i=0; i<n; i++ )); do
+		t="${TOK[i]}"
+		case "${t}" in -*) continue ;; esac
+		CMD1="${t}"; IDX1=${i}; break
+	done
+	[ -n "${CMD1}" ] || return 0
 
-	local verdict reason
-	verdict=$(policy_verdict "${argv[@]+"${argv[@]}"}")
-	reason="${verdict#*:}"
-	verdict="${verdict%%:*}"
-
-	if [ "${verdict}" = "DENY" ]; then
-		printf '%s: %s\n' "${SANDBOX_TAG}" "${reason}" >&2
-		log_invocation "DENY" "126" "0" "${scrubbed}" "${reason}"
-		return 126
-	fi
-
-	# A real spend: bracket the call with balance samples.
-	local before="" after="" delta=""
-	if [ "${verdict}" = "ALLOW_SPEND" ]; then
-		before=$(sample_balance "pre-generate") || {
-			printf '%s: %s\n' "${SANDBOX_TAG}" \
-				"could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" >&2
-			log_invocation "DENY" "126" "0" "${scrubbed}" "balance read failed (fail closed)"
-			return 126
-		}
-		bump_counter "generate_submits"
-	fi
-	if [ "${verdict}" = "ALLOW_APP_SUBMIT" ]; then
-		bump_counter "app_submits"
-	fi
-
-	local t0 t1 rc
-	t0=$(date +%s%N)
-	HOME="${ROOT}/home" \
-	XDG_CONFIG_HOME="${ROOT}/home/.config" \
-	XDG_CACHE_HOME="${ROOT}/home/.cache" \
-	CIVITAI_NO_UPDATE_CHECK=1 \
-	"${ROOT}/real/civitai" "${argv[@]+"${argv[@]}"}"
-	rc=$?
-	t1=$(date +%s%N)
-
-	if [ "${verdict}" = "ALLOW_SPEND" ] && [ -n "${before}" ]; then
-		after=$(sample_balance "post-generate") || after=""
-		if [ -n "${after}" ]; then
-			delta=$(( before - after ))
-			local cum
-			cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
-			printf '%s\n' "$(( cum + delta ))" > "${ROOT}/ledger/observed_spend"
-			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
-				>> "${ROOT}/ledger/spend.tsv"
+	if [ "${CMD1}" = "app" ]; then
+		if pair=$(next_word_after "${IDX1}"); then
+			word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
+			if in_list "${word}" "${APP_SUBCMDS}"; then
+				CMD2="${word}"; IDX2="${idx}"
+			else
+				CMD2_UNKNOWN="${word}"; return 0
+			fi
+		fi
+		if [ "${CMD2}" = "listing" ]; then
+			if pair=$(next_word_after "${IDX2}"); then
+				word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
+				if in_list "${word}" "${LISTING_SUBCMDS}"; then
+					CMD3="${word}"; IDX3="${idx}"
+				else
+					CMD3_UNKNOWN="${word}"
+				fi
+			fi
+		fi
+	elif [ "${CMD1}" = "workflows" ]; then
+		if pair=$(next_word_after "${IDX1}"); then
+			word="${pair%%$'\t'*}"; idx="${pair##*$'\t'}"
+			if in_list "${word}" "${WORKFLOWS_SUBCMDS}"; then
+				CMD2="${word}"; IDX2="${idx}"
+			else
+				CMD2_UNKNOWN="${word}"
+			fi
 		fi
 	fi
-
-	log_invocation "${verdict}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" "${delta:-}"
-	return "${rc}"
+	return 0
 }
 
-log_invocation() {
-	printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-		"$(now_iso)" "$1" "$2" "$3" "$4" "${5:-}" >> "${ROOT}/ledger/invocations.tsv"
-}
-
-bump_counter() {
-	local f="${ROOT}/ledger/$1" n
-	n=$(cat "${f}" 2>/dev/null || printf '0')
-	printf '%s\n' "$(( n + 1 ))" > "${f}"
-}
-
-read_counter() {
-	cat "${ROOT}/ledger/$1" 2>/dev/null || printf '0'
-}
-
-# Does argv contain this exact token?
-has_flag() {
-	local want="$1"; shift
-	local a
-	for a in "$@"; do
-		[ "${a}" = "${want}" ] && return 0
+tokenize() {
+	TOK=("$@")
+	TOK_KIND=()
+	resolve_command
+	local vflags spending=0
+	vflags=$(value_flags_for_path)
+	[ "${CMD1}" = "generate" ] && spending=1
+	local i n t expect_value=0
+	n=${#TOK[@]}
+	for (( i=0; i<n; i++ )); do
+		t="${TOK[i]}"
+		if [ "${expect_value}" = 1 ]; then
+			TOK_KIND[i]="value"; expect_value=0; continue
+		fi
+		case "${t}" in
+			--*=*)  TOK_KIND[i]="flag" ;;
+			-*)
+				TOK_KIND[i]="flag"
+				if in_list "${t}" "${vflags}"; then
+					expect_value=1
+				elif in_list "${t}" "${ROOT_BOOL_FLAGS}" || in_list "${t}" "${CMD_BOOL_FLAGS}"; then
+					: # boolean, consumes nothing
+				elif [ "${spending}" = 1 ]; then
+					# Unknown flag on the money path: assume it eats the next
+					# token, so a following --dry-run/--help is NOT mistaken for
+					# a free preview or a help request.
+					expect_value=1
+				fi
+				;;
+			*)      TOK_KIND[i]="positional" ;;
+		esac
 	done
-	return 1
 }
 
-# Value of --flag V or --flag=V; empty if absent.
-flag_value() {
-	local want="$1"; shift
-	local a next=0
-	for a in "$@"; do
-		if [ "${next}" = 1 ]; then printf '%s' "${a}"; return 0; fi
-		case "${a}" in
-			"${want}")   next=1 ;;
-			"${want}"=*) printf '%s' "${a#*=}"; return 0 ;;
+# Is FLAG present as a FLAG (never as another flag's value)?
+tok_has_flag() {
+	local want="$1" i n
+	n=${#TOK[@]}
+	for (( i=0; i<n; i++ )); do
+		[ "${TOK_KIND[i]}" = "flag" ] || continue
+		case "${TOK[i]}" in
+			"${want}"|"${want}"=*) return 0 ;;
 		esac
 	done
 	return 1
 }
 
-# The blockId a mutating app command would act on: --slug wins, else the
-# manifest in --dir (listing) or the positional dir (submit), default ".".
+# Value of FLAG. Returns the LAST occurrence, because pflag does — measured on
+# a free read, `--limit 1 --limit 3` returns three results. Reading the first
+# let `--max-cost 5 --max-cost 99999` show the gate a 5 while the CLI enforced
+# 99999.
+tok_flag_value() {
+	local want="$1" i n found=1 out=""
+	n=${#TOK[@]}
+	for (( i=0; i<n; i++ )); do
+		[ "${TOK_KIND[i]}" = "flag" ] || continue
+		case "${TOK[i]}" in
+			"${want}"=*) out="${TOK[i]#*=}"; found=0 ;;
+			"${want}")
+				if [ $(( i + 1 )) -lt "${n}" ] && [ "${TOK_KIND[i+1]}" = "value" ]; then
+					out="${TOK[i+1]}"; found=0
+				fi ;;
+		esac
+	done
+	[ "${found}" = 0 ] || return 1
+	printf '%s' "${out}"
+}
+
+# Positional arguments AFTER the resolved command path — i.e. every positional
+# token whose index is past the last command word. Indices come from
+# resolve_command, so this needs no re-matching by string value (which used to
+# mis-skip an argument that happened to equal its own command's name).
+tok_positionals_after_command() {
+	local i n last
+	n=${#TOK[@]}
+	last="${IDX1}"
+	[ "${IDX2}" -gt "${last}" ] 2>/dev/null && last="${IDX2}"
+	[ "${IDX3}" -gt "${last}" ] 2>/dev/null && last="${IDX3}"
+	for (( i=last+1; i<n; i++ )); do
+		[ "${TOK_KIND[i]}" = "positional" ] || continue
+		printf '%s\n' "${TOK[i]}"
+	done
+}
+
+# Is there a genuine --help / -h?
+#
+# 🔴 ALLOWLIST, NOT DENYLIST. A `--help` counts only when the token before it
+# is nothing, a command word, or a KNOWN boolean flag. `--negative-prompt
+# --help` is pflag taking `--help` as the prompt VALUE, and the old blanket
+# "is --help anywhere in argv" test turned that into a full bypass of every
+# DENY branch — measured: a real submit, charged, meter untouched.
+tok_is_help_request() {
+	local i n prev
+	n=${#TOK[@]}
+	for (( i=0; i<n; i++ )); do
+		case "${TOK[i]}" in
+			--help|-h|--help=*) ;;
+			*) continue ;;
+		esac
+		[ "${TOK_KIND[i]}" = "flag" ] || continue
+		if [ "${i}" = 0 ]; then return 0; fi
+		prev="${TOK[i-1]}"
+		if in_list "${prev}" "${ROOT_BOOL_FLAGS}" \
+			|| in_list "${prev}" "${CMD_BOOL_FLAGS}" \
+			|| in_list "${prev}" "${TOPLEVEL_CMDS}" \
+			|| in_list "${prev}" "${APP_SUBCMDS}" \
+			|| in_list "${prev}" "${LISTING_SUBCMDS}"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 resolve_block_id() {
 	local dir="$1" slug="$2" manifest id
 	if [ -n "${slug}" ]; then printf '%s' "${slug}"; return 0; fi
@@ -406,149 +659,274 @@ resolve_block_id() {
 	printf '%s' "${id}"
 }
 
-# Echoes "<VERDICT>:<reason>". VERDICT is ALLOW, ALLOW_SPEND, ALLOW_APP_SUBMIT
-# or DENY. Deliberately fails CLOSED: anything it cannot classify but that can
-# mutate or spend is denied.
-policy_verdict() {
-	local c1="${1:-}" c2="${2:-}" c3="${3:-}"
+# ---------------------------------------------------------------------------
+# policy_verdict — sets VERDICT / VERDICT_REASON / VERDICT_MC.
+#
+# It deliberately does NOT run in a subshell: an internal failure under `set -u`
+# must kill the whole gate (so nothing runs) rather than return an empty string
+# the caller reads as "not DENY".
+# ---------------------------------------------------------------------------
+VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
 
-	# Help is always free, on every command, including the forbidden ones —
-	# reading --help must never be blocked, or the agent cannot learn the tool.
-	if has_flag "--help" "$@" || has_flag "-h" "$@"; then
-		printf 'ALLOW:help'; return 0
+deny() { VERDICT="DENY"; VERDICT_REASON="$1"; return 0; }
+allow() { VERDICT="ALLOW"; VERDICT_REASON="${1:-}"; return 0; }
+
+policy_verdict() {
+	VERDICT=""; VERDICT_REASON=""; VERDICT_MC=0
+	tokenize "$@"
+
+	if tok_is_help_request; then allow "help"; return 0; fi
+
+	if [ -z "${CMD1}" ]; then allow "root usage"; return 0; fi
+
+	if ! in_list "${CMD1}" "${TOPLEVEL_CMDS}"; then
+		deny "\`${CMD1}\` is not a command this gate recognises; it fails closed rather than guess whether a new command spends or mutates"
+		return 0
 	fi
 
-	case "${c1}" in
-		upgrade)
-			printf 'DENY:%s' "\`upgrade\` would replace the binary under evaluation mid-run"
-			return 0 ;;
-		login)
-			printf 'DENY:%s' "this sandbox is already authenticated; run \`civitai whoami\` to see as whom"
-			return 0 ;;
+	case "${CMD1}" in
+		upgrade) deny "\`upgrade\` would replace the binary under evaluation mid-run"; return 0 ;;
+		login)   deny "this sandbox is already authenticated; run \`civitai whoami\` to see as whom"; return 0 ;;
 	esac
 
-	if [ "${c1}" = "app" ]; then
-		case "${c2}" in
+	if [ "${CMD1}" = "app" ]; then
+		if [ -n "${CMD2_UNKNOWN}" ]; then
+			deny "unrecognised \`app ${CMD2_UNKNOWN}\`; the gate fails closed rather than guess whether it mutates"
+			return 0
+		fi
+		if [ -z "${CMD2}" ]; then allow "app usage"; return 0; fi
+		case "${CMD2}" in
 			dev-tunnel|dev-token)
-				printf 'DENY:%s' "\`app ${c2}\` is out of scope for this run"
-				return 0 ;;
+				deny "\`app ${CMD2}\` is out of scope for this run"; return 0 ;;
 			withdraw)
-				local id
-				id=$(printf '%s\n' "$@" | grep -m1 '^pubreq_' || true)
-				[ -n "${id}" ] || id=$(flag_value "--id" "$@" || true)
+				local id=""
+				id=$(tok_flag_value "--id") || id=""
 				if [ -z "${id}" ]; then
-					printf 'ALLOW:withdraw with no id (the CLI will refuse it)'; return 0
+					id=$(tok_positionals_after_command | head -1)
 				fi
+				if [ -z "${id}" ]; then
+					allow "withdraw with no id (a usage error the CLI reports)"; return 0
+				fi
+				# 🔴 ANY id, not just a pubreq_-shaped one. app_withdraw.go takes
+				# args[0] with no format validation, so the old "the CLI will
+				# refuse it" fallback was a false statement about a branch that
+				# reaches the network.
 				if grep -qxF "${id}" "${ROOT}/ledger/pubreq.allow" 2>/dev/null; then
-					printf 'ALLOW:withdraw of a submission this sandbox created'; return 0
+					allow "withdraw of a submission this sandbox created"; return 0
 				fi
-				printf 'DENY:%s' "${id} was not created by this sandbox, so it may be one of the account's real pending submissions"
+				deny "\`${id}\` was not created by this sandbox, so it may be one of the account's real pending submissions"
 				return 0 ;;
 			submit)
-				if has_flag "--package-only" "$@"; then
-					printf 'ALLOW:--package-only never submits'; return 0
+				if tok_has_flag "--package-only"; then
+					allow "--package-only never submits"; return 0
 				fi
-				local n dir="" a skipnext=0
-				# positional dir: first non-flag arg after `submit`, skipping -o/--out values
-				for a in "${@:3}"; do
-					if [ "${skipnext}" = 1 ]; then skipnext=0; continue; fi
-					case "${a}" in
-						-o|--out) skipnext=1 ;;
-						-*)       ;;
-						*)        dir="${a}"; break ;;
-					esac
-				done
+				local dir id n
+				dir=$(tok_positionals_after_command | head -1)
 				[ -n "${dir}" ] || dir="."
-				local id
 				if ! id=$(resolve_block_id "${dir}" ""); then
-					printf 'DENY:%s' "cannot read a blockId from ${dir}/block.manifest.json, so the app being submitted cannot be identified"
+					deny "cannot read a blockId from ${dir}/block.manifest.json, so the app being submitted cannot be identified"
 					return 0
 				fi
 				case "${id}" in
 					"${SLUG_PREFIX}"*) ;;
-					*) printf 'DENY:%s' "blockId \`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may only submit its own throwaway app"
-					   return 0 ;;
+					*) deny "blockId \`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may only submit its own throwaway app"; return 0 ;;
 				esac
-				n=$(read_counter "app_submits")
+				n=$(read_scalar app_submits) || { deny "the app-submission counter is unreadable"; return 0; }
 				if [ "${n}" -ge "${MAX_APP_SUBMITS}" ]; then
-					printf 'DENY:%s' "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"
+					deny "the app-submission cap for this run (${MAX_APP_SUBMITS}) is already used"; return 0
+				fi
+				VERDICT="ALLOW_APP_SUBMIT"; VERDICT_REASON="submitting ${id}"; return 0 ;;
+			listing)
+				if [ -n "${CMD3_UNKNOWN}" ]; then
+					deny "unrecognised \`app listing ${CMD3_UNKNOWN}\`; the gate fails closed on anything that might mutate a listing"
 					return 0
 				fi
-				printf 'ALLOW_APP_SUBMIT:submitting %s' "${id}"
-				return 0 ;;
-			listing)
-				case "${c3}" in
-					status|"")
-						printf 'ALLOW:listing read'; return 0 ;;
+				case "${CMD3}" in
+					"") allow "listing usage"; return 0 ;;
+					status) allow "listing read"; return 0 ;;
 					set-icon|set-cover|add-screenshot|rm-screenshot|reorder)
 						local slug dir id
-						slug=$(flag_value "--slug" "$@" || true)
-						dir=$(flag_value "--dir" "$@" || true)
+						slug=$(tok_flag_value "--slug") || slug=""
+						dir=$(tok_flag_value "--dir") || dir=""
 						[ -n "${dir}" ] || dir="."
 						if ! id=$(resolve_block_id "${dir}" "${slug}"); then
-							printf 'DENY:%s' "cannot identify which app \`app listing ${c3}\` would mutate (no --slug, and no readable blockId in ${dir}/block.manifest.json)"
+							deny "cannot identify which app \`app listing ${CMD3}\` would mutate (no --slug, and no readable blockId in ${dir}/block.manifest.json)"
 							return 0
 						fi
 						case "${id}" in
-							"${SLUG_PREFIX}"*)
-								printf 'ALLOW:listing mutation on %s' "${id}"; return 0 ;;
-							*)
-								printf 'DENY:%s' "\`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may not touch the account's real listings"
-								return 0 ;;
+							"${SLUG_PREFIX}"*) allow "listing mutation on ${id}"; return 0 ;;
+							*) deny "\`${id}\` is outside the sanctioned prefix \`${SLUG_PREFIX}\` — this run may not touch the account's real listings"; return 0 ;;
 						esac ;;
-					*)
-						printf 'DENY:%s' "unrecognised \`app listing ${c3}\`; the gate fails closed on anything that might mutate a listing"
-						return 0 ;;
+					*) deny "unrecognised \`app listing ${CMD3}\`; the gate fails closed on anything that might mutate a listing"; return 0 ;;
 				esac ;;
+			create|init|validate|status|list|view|pull|metrics)
+				allow "app read/local"; return 0 ;;
+			*)
+				deny "unrecognised \`app ${CMD2}\`; the gate fails closed"; return 0 ;;
 		esac
-		printf 'ALLOW:app read/local'; return 0
 	fi
 
-	if [ "${c1}" = "generate" ]; then
-		if has_flag "--print-input" "$@" || has_flag "--dry-run" "$@"; then
-			printf 'ALLOW:generate preview (spends nothing)'; return 0
+	if [ "${CMD1}" = "generate" ]; then
+		if tok_has_flag "--print-input" || tok_has_flag "--dry-run"; then
+			allow "generate preview (spends nothing)"; return 0
 		fi
-		local n cum remaining mc
-		# The MONEY cap is checked before the invocation cap: when both are
-		# tripped the spend figure is the more actionable reason to print.
-		cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
-		if [ "${cum}" -ge "${TOTAL_SPEND_CAP}" ]; then
-			printf 'DENY:%s' "the run's total spend cap (${TOTAL_SPEND_CAP} Buzz) is reached — ${cum} observed"
+		if [ -f "${ROOT}/ledger/meter_broken" ]; then
+			deny "the spend meter could not read a balance earlier in this run, so spend is no longer being counted — refusing to submit (see ledger/meter_broken)"
 			return 0
 		fi
-		n=$(read_counter "generate_submits")
+		local cum res committed remaining mc n
+		cum=$(read_scalar observed_spend) || { deny "the spend ledger is unreadable or malformed — refusing to submit"; return 0; }
+		res=$(read_scalar reserved)       || { deny "the reservation ledger is unreadable or malformed — refusing to submit"; return 0; }
+		committed=$(( cum + res ))
+		if [ "${committed}" -ge "${TOTAL_SPEND_CAP}" ]; then
+			deny "the run's total spend cap (${TOTAL_SPEND_CAP} Buzz) is reached — ${cum} observed, ${res} committed in flight"
+			return 0
+		fi
+		n=$(read_scalar generate_submits) || { deny "the submission counter is unreadable"; return 0; }
 		if [ "${n}" -ge "${MAX_GENERATE_SUBMITS}" ]; then
-			printf 'DENY:%s' "the generation cap for this run (${MAX_GENERATE_SUBMITS} submits) is already used"
-			return 0
+			deny "the generation cap for this run (${MAX_GENERATE_SUBMITS} submits) is already used"; return 0
 		fi
-		if ! mc=$(flag_value "--max-cost" "$@"); then
-			printf 'DENY:%s' "a generation that actually submits must carry --max-cost (at most ${PER_CALL_MAX_COST}); use --dry-run to price it first"
+		if ! mc=$(tok_flag_value "--max-cost"); then
+			deny "a generation that actually submits must carry --max-cost (at most ${PER_CALL_MAX_COST}); use --dry-run to price it first"
 			return 0
 		fi
 		case "${mc}" in
-			''|*[!0-9]*)
-				printf 'DENY:%s' "--max-cost must be a whole number of Buzz, got \`${mc}\`"
-				return 0 ;;
+			''|*[!0-9]*) deny "--max-cost must be a whole number of Buzz, got \`${mc}\`"; return 0 ;;
 		esac
 		if [ "${mc}" -gt "${PER_CALL_MAX_COST}" ]; then
-			printf 'DENY:%s' "--max-cost ${mc} exceeds this run's per-invocation ceiling of ${PER_CALL_MAX_COST} Buzz"
-			return 0
+			deny "--max-cost ${mc} exceeds this run's per-invocation ceiling of ${PER_CALL_MAX_COST} Buzz"; return 0
 		fi
-		remaining=$(( TOTAL_SPEND_CAP - cum ))
+		remaining=$(( TOTAL_SPEND_CAP - committed ))
 		if [ "${mc}" -gt "${remaining}" ]; then
-			printf 'DENY:%s' "--max-cost ${mc} exceeds the ${remaining} Buzz left under this run's total cap"
-			return 0
+			deny "--max-cost ${mc} exceeds the ${remaining} Buzz left under this run's total cap"; return 0
 		fi
-		printf 'ALLOW_SPEND:submit with --max-cost %s' "${mc}"
+		VERDICT="ALLOW_SPEND"; VERDICT_REASON="submit with --max-cost ${mc}"; VERDICT_MC="${mc}"
 		return 0
 	fi
 
-	printf 'ALLOW:read-only or local'
+	allow "read-only or local"
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# allow-pubreq / status / finish / selftest / enter / teardown
+# guard
+# ---------------------------------------------------------------------------
+refuse() {
+	printf '%s: %s\n' "${SANDBOX_TAG}" "$1" >&2
+	log_invocation "DENY" "126" "0" "$2" "$1"
+	unlock_ledger
+	exit 126
+}
+
+cmd_guard() {
+	local root=""
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--)     shift; break ;;
+			*)      break ;;
+		esac
+	done
+	ROOT="${root:-${DEFAULT_ROOT}}"
+
+	local argv=("$@")
+	local scrubbed
+	scrubbed=$(scrub_argv "${argv[@]+"${argv[@]}"}")
+
+	if ! load_policy; then
+		printf '%s: %s\n' "${SANDBOX_TAG}" "the sandbox policy is unusable (${POLICY_ERROR}) — refusing to run anything" >&2
+		printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$(now_iso)" "DENY" "126" "0" "${scrubbed}" \
+			"policy invalid: $(tsv_escape "${POLICY_ERROR}")" >> "${ROOT}/ledger/invocations.tsv" 2>/dev/null
+		exit 126
+	fi
+
+	lock_ledger || refuse "could not take the ledger lock within 60s" "${scrubbed}"
+
+	policy_verdict "${argv[@]+"${argv[@]}"}"
+
+	# 🔴 An empty or unrecognised verdict is a DENY. This is the backstop for
+	# any internal failure that leaves VERDICT unset.
+	case "${VERDICT}" in
+		ALLOW|ALLOW_SPEND|ALLOW_APP_SUBMIT|DENY) ;;
+		*) refuse "the gate could not classify this invocation (internal error) — refusing" "${scrubbed}" ;;
+	esac
+
+	if [ "${VERDICT}" = "DENY" ]; then
+		refuse "${VERDICT_REASON}" "${scrubbed}"
+	fi
+
+	local before="" mc="${VERDICT_MC}"
+	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
+		before=$(sample_balance "pre-generate") || \
+			refuse "could not read the Buzz balance, so the spend meter cannot be kept — refusing to submit" "${scrubbed}"
+		local res n
+		res=$(read_scalar reserved) || refuse "the reservation ledger is unreadable" "${scrubbed}"
+		n=$(read_scalar generate_submits) || refuse "the submission counter is unreadable" "${scrubbed}"
+		write_scalar reserved "$(( res + mc ))"
+		write_scalar generate_submits "$(( n + 1 ))"
+	elif [ "${VERDICT}" = "ALLOW_APP_SUBMIT" ]; then
+		local a
+		a=$(read_scalar app_submits) || refuse "the app-submission counter is unreadable" "${scrubbed}"
+		write_scalar app_submits "$(( a + 1 ))"
+	fi
+
+	unlock_ledger
+
+	local t0 t1 rc
+	t0=$(date +%s%N)
+	env -u CIVITAI_TOKEN -u CIVITAI_SUBMIT_PATH -u CIVITAI_ANTIPATTERN_SCAN_DIR \
+		-u CIVITAI_CHECK_SUBMISSIONS_CAP -u CIVITAI_CHECK_PUBLISHED_PINS \
+		"HOME=${ROOT}/home" \
+		"XDG_CONFIG_HOME=${ROOT}/home/.config" \
+		"XDG_CACHE_HOME=${ROOT}/home/.cache" \
+		"CIVITAI_NO_UPDATE_CHECK=1" \
+		"CIVITAI_BASE_URL=${BASE_URL}" \
+		"${ROOT}/real/civitai" "${argv[@]+"${argv[@]}"}"
+	rc=$?
+	t1=$(date +%s%N)
+
+	local delta=""
+	if [ "${VERDICT}" = "ALLOW_SPEND" ]; then
+		local after res cum
+		lock_ledger || err "could not re-take the ledger lock; the spend ledger may be short one entry"
+		after=$(sample_balance "post-generate") || after=""
+		res=$(read_scalar reserved) || res="${mc}"
+		cum=$(read_scalar observed_spend) || cum=0
+		if [ -n "${after}" ]; then
+			delta=$(( before - after ))
+			[ "${delta}" -ge 0 ] || delta=0
+			write_scalar observed_spend "$(( cum + delta ))"
+			printf '%s\tgenerate\t%s\t%s\t%s\n' "$(now_iso)" "${before}" "${after}" "${delta}" \
+				>> "${ROOT}/ledger/spend.tsv"
+		else
+			# 🔴 FAIL CLOSED ON A LOST SAMPLE. Dropping the delta silently let a
+			# flaky balance read under-count forever — measured: 5 submits,
+			# 185 truly spent, meter 0. Charge the worst case the estimate
+			# allowed and stop the money path for the rest of the run.
+			delta="unknown"
+			write_scalar observed_spend "$(( cum + mc ))"
+			printf '%s\tgenerate\t%s\tUNREADABLE\tassumed-%s\n' "$(now_iso)" "${before}" "${mc}" \
+				>> "${ROOT}/ledger/spend.tsv"
+			: > "${ROOT}/ledger/meter_broken"
+			printf '%s: %s\n' "${SANDBOX_TAG}" \
+				"the post-submit balance read failed; ${mc} Buzz has been charged to the ledger as a worst case and no further generation will be allowed this run" >&2
+		fi
+		write_scalar reserved "$(( res - mc < 0 ? 0 : res - mc ))"
+		unlock_ledger
+	fi
+
+	log_invocation "${VERDICT}" "${rc}" "$(( (t1 - t0) / 1000000 ))" "${scrubbed}" "${delta:-}"
+	return "${rc}"
+}
+
+log_invocation() {
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$(now_iso)" "$1" "$2" "$3" "$(tsv_escape "$4")" "$(tsv_escape "${5:-}")" \
+		>> "${ROOT}/ledger/invocations.tsv"
+}
+
+# ---------------------------------------------------------------------------
+# allow-pubreq / status / finish / enter / teardown
 # ---------------------------------------------------------------------------
 cmd_allow_pubreq() {
 	local root="${DEFAULT_ROOT}" id=""
@@ -558,7 +936,7 @@ cmd_allow_pubreq() {
 			*) id="$1"; shift ;;
 		esac
 	done
-	ROOT="${root}"; load_policy
+	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
 	[ -n "${id}" ] || die "allow-pubreq: pass the publish-request id"
 	printf '%s\n' "${id}" >> "${ROOT}/ledger/pubreq.allow"
 	note "recorded ${id} as withdrawable"
@@ -569,17 +947,25 @@ cmd_status() {
 	while [ $# -gt 0 ]; do
 		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
 	done
-	ROOT="${root}"; load_policy
-	local start cum
-	start=$(cat "${ROOT}/ledger/start_balance" 2>/dev/null || printf '?')
-	cum=$(cat "${ROOT}/ledger/observed_spend" 2>/dev/null || printf '0')
+	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
+	local start cum res
+	start=$(read_scalar start_balance) || start="?"
+	cum=$(read_scalar observed_spend)  || cum="MALFORMED"
+	res=$(read_scalar reserved)        || res="MALFORMED"
 	note "run root .............. ${ROOT}"
 	note "opening balance ....... ${start} Buzz"
 	note "observed spend ........ ${cum} / ${TOTAL_SPEND_CAP} Buzz"
-	note "generate submits ...... $(read_counter generate_submits) / ${MAX_GENERATE_SUBMITS}"
-	note "app submits ........... $(read_counter app_submits) / ${MAX_APP_SUBMITS}"
+	note "committed in flight ... ${res} Buzz"
+	note "generate submits ...... $(read_scalar generate_submits) / ${MAX_GENERATE_SUBMITS}"
+	note "app submits ........... $(read_scalar app_submits) / ${MAX_APP_SUBMITS}"
 	note "invocations logged .... $(wc -l < "${ROOT}/ledger/invocations.tsv" 2>/dev/null || printf 0)"
-	note "refusals .............. $(grep -c '	DENY	' "${ROOT}/ledger/invocations.tsv" 2>/dev/null || printf 0)"
+	note "refusals .............. $(grep -c "$(printf '\tDENY\t')" "${ROOT}/ledger/invocations.tsv" 2>/dev/null || printf 0)"
+	if [ -f "${ROOT}/ledger/meter_broken" ]; then
+		note ""
+		note "🔴 THE SPEND METER IS BROKEN — a balance read failed mid-run. The"
+		note "   observed figure above includes a worst-case assumption, not a"
+		note "   measurement. Reconcile against the account before trusting it."
+	fi
 }
 
 cmd_finish() {
@@ -587,14 +973,14 @@ cmd_finish() {
 	while [ $# -gt 0 ]; do
 		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
 	done
-	ROOT="${root}"; load_policy
+	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
 	local start end
-	start=$(cat "${ROOT}/ledger/start_balance" 2>/dev/null) || die "finish: no opening balance recorded"
+	start=$(read_scalar start_balance) || die "finish: no usable opening balance recorded"
 	if ! end=$(sample_balance "end"); then
-		err "finish: could not read the closing balance — the spend total below is the per-call ledger only"
+		err "finish: could not read the closing balance — the figure below is the per-call ledger only"
 		end=""
 	fi
-	printf '%s\n' "${end}" > "${ROOT}/ledger/end_balance"
+	[ -n "${end}" ] && write_scalar end_balance "${end}"
 	note "=== dogfood run audit ==="
 	cmd_status --root "${ROOT}"
 	if [ -n "${end}" ]; then
@@ -606,104 +992,17 @@ cmd_finish() {
 	note "balance samples ....... ${ROOT}/ledger/buzz.tsv"
 }
 
-cmd_selftest() {
-	local root="${DEFAULT_ROOT}"
-	while [ $# -gt 0 ]; do
-		case "$1" in --root) root="$2"; shift 2 ;; *) shift ;; esac
-	done
-	ROOT="${root}"; load_policy
-
-	local pass=0 fail=0
-	check() {
-		local label="$1" want="$2" got="$3"
-		if [ "${want}" = "${got}" ]; then
-			printf '  PASS  %-56s (%s)\n' "${label}" "${got}"; pass=$(( pass + 1 ))
-		else
-			printf '  FAIL  %-56s want=%s got=%s\n' "${label}" "${want}" "${got}"; fail=$(( fail + 1 ))
-		fi
-	}
-
-	note "--- policy verdicts (no CLI is executed) ---"
-	check "upgrade is denied"                 "DENY"             "$(policy_verdict upgrade | cut -d: -f1)"
-	check "upgrade --help is allowed"         "ALLOW"            "$(policy_verdict upgrade --help | cut -d: -f1)"
-	check "login is denied"                   "DENY"             "$(policy_verdict login --token x | cut -d: -f1)"
-	check "dev-tunnel is denied"              "DENY"             "$(policy_verdict app dev-tunnel | cut -d: -f1)"
-	check "dev-token is denied"               "DENY"             "$(policy_verdict app dev-token | cut -d: -f1)"
-	check "generate --dry-run is free"        "ALLOW"            "$(policy_verdict generate x --dry-run | cut -d: -f1)"
-	check "generate --print-input is free"    "ALLOW"            "$(policy_verdict generate x --print-input | cut -d: -f1)"
-	check "generate without --max-cost denied" "DENY"            "$(policy_verdict generate x --yes | cut -d: -f1)"
-	check "generate over per-call cap denied"  "DENY"            "$(policy_verdict generate x --yes --max-cost $(( PER_CALL_MAX_COST + 1 )) | cut -d: -f1)"
-	check "generate at the cap is a spend"     "ALLOW_SPEND"     "$(policy_verdict generate x --yes --max-cost "${PER_CALL_MAX_COST}" | cut -d: -f1)"
-	check "generate --max-cost=N form parsed"  "ALLOW_SPEND"     "$(policy_verdict generate x --yes --max-cost=1 | cut -d: -f1)"
-	check "non-numeric --max-cost denied"      "DENY"            "$(policy_verdict generate x --yes --max-cost abc | cut -d: -f1)"
-	check "withdraw of an unknown id denied"   "DENY"            "$(policy_verdict app withdraw pubreq_UNKNOWN | cut -d: -f1)"
-	check "app list is allowed"                "ALLOW"           "$(policy_verdict app list | cut -d: -f1)"
-	check "models search is allowed"           "ALLOW"           "$(policy_verdict models search --query x | cut -d: -f1)"
-	check "listing status is allowed"          "ALLOW"           "$(policy_verdict app listing status | cut -d: -f1)"
-	check "unknown listing verb denied"        "DENY"            "$(policy_verdict app listing frobnicate | cut -d: -f1)"
-
-	# Identity gating needs real manifests on disk.
-	local td="${ROOT}/ledger/_selftest"
-	rm -rf "${td}"; mkdir -p "${td}/good" "${td}/bad"
-	printf '{"blockId":"%sdemo","name":"d","version":"1.0.0","kind":"page"}\n' "${SLUG_PREFIX}" > "${td}/good/block.manifest.json"
-	printf '{"blockId":"someones-real-app","name":"d","version":"1.0.0","kind":"page"}\n'        > "${td}/bad/block.manifest.json"
-	check "submit of a sanctioned blockId"     "ALLOW_APP_SUBMIT" "$(policy_verdict app submit "${td}/good" --yes | cut -d: -f1)"
-	check "submit of a foreign blockId denied" "DENY"             "$(policy_verdict app submit "${td}/bad" --yes | cut -d: -f1)"
-	check "submit -o value not read as dir"    "ALLOW_APP_SUBMIT" "$(policy_verdict app submit -o "${td}/bad" "${td}/good" | cut -d: -f1)"
-	check "listing on a foreign --slug denied" "DENY"             "$(policy_verdict app listing set-icon i.png --slug someones-real-app | cut -d: -f1)"
-	check "listing on sanctioned --dir"        "ALLOW"            "$(policy_verdict app listing set-icon i.png --dir "${td}/good" | cut -d: -f1)"
-	check "listing with no identity denied"    "DENY"             "$(policy_verdict app listing set-icon i.png --dir "${ROOT}/ledger" | cut -d: -f1)"
-	rm -rf "${td}"
-
-	note ""
-	note "--- balance meter (a real read; spends nothing) ---"
-	local b
-	if b=$(sample_balance "selftest"); then
-		check "buzz --json parses to an integer total" "yes" "$(case "${b}" in ''|*[!0-9]*) printf no ;; *) printf yes ;; esac)"
-		note "  observed balance: ${b} Buzz"
-	else
-		check "buzz --json parses to an integer total" "yes" "no"
-	fi
-	# Negative control: the parser must FAIL on rubbish, not return 0.
-	if parse_buzz_total '{"blue":1}' >/dev/null 2>&1; then
-		check "balance parser rejects a payload with no total" "reject" "accept"
-	else
-		check "balance parser rejects a payload with no total" "reject" "reject"
-	fi
-
-	note ""
-	note "--- isolation ---"
-	local real_cfg="${HOME}/.config/civitai/config.yaml"
-	if [ -f "${real_cfg}" ]; then
-		note "  operator config present at ${real_cfg}"
-		note "  sha256 before: $(sha256sum "${real_cfg}" | cut -d' ' -f1)"
-	else
-		note "  operator has no ~/.config/civitai/config.yaml (nothing to clobber)"
-	fi
-	check "sandbox config exists" "yes" "$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
-	check "binary dir is not writable" "no" "$([ -w "${ROOT}/real" ] && printf yes || printf no)"
-	check "binary file is not writable" "no" "$([ -w "${ROOT}/real/civitai" ] && printf yes || printf no)"
-
-	note ""
-	note "selftest: ${pass} passed, ${fail} failed"
-	[ "${fail}" = 0 ]
-}
-
 cmd_enter() {
 	local root="${DEFAULT_ROOT}"
 	while [ $# -gt 0 ]; do
 		case "$1" in --root) root="$2"; shift 2 ;; *) break ;; esac
 	done
-	ROOT="${root}"; load_policy
+	ROOT="${root}"; load_policy || die "${POLICY_ERROR}"
 	command -v bwrap >/dev/null 2>&1 || die "enter: bwrap (bubblewrap) is not on PATH"
 
 	local shell_bin="${SHELL:-/bin/sh}"
 	[ $# -gt 0 ] || set -- "${shell_bin}" -i
 
-	# Only what the CLI needs: the Nix store (toolchain + certs), the system
-	# profile, DNS + TLS trust, and the run root. NOTHING under /home is bound,
-	# so the repo checkout does not exist inside.
-	#
 	# 🔴 ORDER IS LOAD-BEARING. bwrap applies these in sequence, so `--tmpfs
 	# /tmp` must come BEFORE the run-root bind: the default run root lives under
 	# /tmp, and a tmpfs mounted afterwards SHADOWS it. Measured — with the bind
@@ -749,8 +1048,362 @@ cmd_teardown() {
 	fi
 }
 
+# ---------------------------------------------------------------------------
+# selftest
+# ---------------------------------------------------------------------------
+SELFTEST_PASS=0
+SELFTEST_FAIL=0
+
+st_check() {
+	local label="$1" want="$2" got="$3"
+	if [ "${want}" = "${got}" ]; then
+		printf '  PASS  %-58s (%s)\n' "${label}" "${got}"; SELFTEST_PASS=$(( SELFTEST_PASS + 1 ))
+	else
+		printf '  FAIL  %-58s want=%s got=%s\n' "${label}" "${want}" "${got}"; SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+	fi
+}
+
+vd() { policy_verdict "$@"; printf '%s' "${VERDICT}"; }
+
+# 🔴 A DENY is not evidence that the branch you meant was reached. Measured:
+# with the command resolved positionally again, `--no-color generate … --yes`
+# still DENIED — as an unrecognised command called `--no-color` — so every
+# verdict-only assertion for that bypass stayed green while the gate was blind.
+# These rows pin the REASON, so a refusal from a bystander branch fails.
+st_reason() {
+	local label="$1" needle="$2"; shift 2
+	policy_verdict "$@"
+	case "${VERDICT_REASON}" in
+		*"${needle}"*) st_check "${label}" "match" "match" ;;
+		*)             st_check "${label}" "match" "no-match: ${VERDICT_REASON}" ;;
+	esac
+}
+
+cmd_selftest() {
+	local root="${DEFAULT_ROOT}" offline=0
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--root) root="$2"; shift 2 ;;
+			--offline) offline=1; shift ;;
+			*) shift ;;
+		esac
+	done
+
+	if [ "${offline}" = 1 ]; then
+		root="${TMPDIR:-/tmp}/dogfood-selftest-$$"
+		rm -rf "${root}"; mkdir -p "${root}/ledger" "${root}/workspace"
+		cat > "${root}/ledger/policy.env" <<OFFLINE
+ROOT="${root}"
+PER_CALL_MAX_COST=100
+TOTAL_SPEND_CAP=2000
+MAX_GENERATE_SUBMITS=20
+MAX_APP_SUBMITS=3
+SLUG_PREFIX="sanctioned-"
+BASE_URL="https://civitai.com"
+OFFLINE
+		: > "${root}/ledger/pubreq.allow"
+		printf '0\n' > "${root}/ledger/observed_spend"
+		printf '0\n' > "${root}/ledger/reserved"
+		printf '0\n' > "${root}/ledger/generate_submits"
+		printf '0\n' > "${root}/ledger/app_submits"
+	fi
+
+	ROOT="${root}"
+	load_policy || die "selftest: ${POLICY_ERROR}"
+
+	local td="${ROOT}/ledger/_selftest"
+	rm -rf "${td}"; mkdir -p "${td}/good" "${td}/bad"
+	printf '{"blockId":"%sdemo","name":"d","version":"1.0.0","kind":"page"}\n' "${SLUG_PREFIX}" > "${td}/good/block.manifest.json"
+	printf '{"blockId":"someones-real-app","name":"d","version":"1.0.0","kind":"page"}\n'        > "${td}/bad/block.manifest.json"
+
+	note "--- forbidden commands ---"
+	st_check "upgrade denied"                      "DENY"  "$(vd upgrade)"
+	st_check "login denied"                        "DENY"  "$(vd login --token x)"
+	st_check "app dev-tunnel denied"               "DENY"  "$(vd app dev-tunnel)"
+	st_check "app dev-token denied"                "DENY"  "$(vd app dev-token)"
+	st_check "unknown top-level command denied"    "DENY"  "$(vd frobnicate --yes)"
+	st_check "unknown app subcommand denied"       "DENY"  "$(vd app frobnicate)"
+	st_check "unknown listing verb denied"         "DENY"  "$(vd app listing frobnicate)"
+
+	note "--- FINDING 1: root persistent flags must not hide the command ---"
+	st_check "--no-color generate is still a spend"    "DENY" "$(vd --no-color generate cat --yes)"
+	st_check "--no-color upgrade still denied"         "DENY" "$(vd --no-color upgrade)"
+	st_check "--no-update-check upgrade still denied"  "DENY" "$(vd --no-update-check upgrade)"
+	st_check "--color login still denied"              "DENY" "$(vd --color login --token x)"
+	st_check "app --no-color submit foreign denied"    "DENY" "$(vd app --no-color submit "${td}/bad" --yes)"
+	st_check "--no-color app withdraw denied"          "DENY" "$(vd --no-color app withdraw pubreq_OTHER)"
+	st_check "--no-color generate --max-cost is spend" "ALLOW_SPEND" "$(vd --no-color generate cat --yes --max-cost 5)"
+	note "    the REASON must be the real branch, not the unknown-command fallback"
+	st_reason "--no-color generate refused for the MONEY reason" "--max-cost" \
+		--no-color generate cat --yes
+	st_reason "--no-color upgrade refused AS upgrade" "replace the binary" \
+		--no-color upgrade
+	st_reason "app --no-color submit foreign refused on the PREFIX" "sanctioned prefix" \
+		app --no-color submit "${td}/bad" --yes
+	st_reason "--no-color app withdraw refused on the ALLOWLIST" "not created by this sandbox" \
+		--no-color app withdraw pubreq_OTHER
+
+	note "--- FINDING 2: --help as a flag VALUE is not a help request ---"
+	st_check "genuine generate --help"                 "ALLOW" "$(vd generate --help)"
+	st_check "genuine upgrade --help"                  "ALLOW" "$(vd upgrade --help)"
+	st_check "genuine app listing set-icon --help"     "ALLOW" "$(vd app listing set-icon --help)"
+	st_check "bare --help"                             "ALLOW" "$(vd --help)"
+	st_check "--negative-prompt --help is NOT help"    "DENY"  "$(vd generate cat --yes --negative-prompt --help)"
+	st_check "--ecosystem --help is NOT help"          "DENY"  "$(vd generate cat --yes --ecosystem --help)"
+	st_check "submit -o --help is NOT help"            "DENY"  "$(vd app submit "${td}/bad" --yes -o --help)"
+	st_check "--negative-prompt -h is NOT help"        "DENY"  "$(vd generate cat --yes --negative-prompt -h)"
+	note "    (and the same trick aimed at --dry-run, which the audit did not list)"
+	st_check "--negative-prompt --dry-run is NOT free" "DENY"  "$(vd generate cat --yes --negative-prompt --dry-run)"
+	st_check "--input --print-input is NOT free"       "DENY"  "$(vd generate --yes --input --print-input)"
+	st_check "an unknown flag before --dry-run is not free" "DENY" "$(vd generate cat --yes --mystery --dry-run)"
+
+	note "--- generate money path ---"
+	st_check "real dry-run is free"                "ALLOW"       "$(vd generate cat --dry-run)"
+	st_check "real print-input is free"            "ALLOW"       "$(vd generate cat --print-input)"
+	st_check "no --max-cost denied"                "DENY"        "$(vd generate cat --yes)"
+	st_check "--max-cost over ceiling denied"      "DENY"        "$(vd generate cat --yes --max-cost 101)"
+	st_check "--max-cost at ceiling allowed"       "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 100)"
+	st_check "--max-cost=N form"                   "ALLOW_SPEND" "$(vd generate cat --yes --max-cost=1)"
+	st_check "non-numeric --max-cost denied"       "DENY"        "$(vd generate cat --yes --max-cost abc)"
+	note "    LAST --max-cost wins, as pflag does"
+	st_check "--max-cost 5 then 99999 denied"      "DENY"        "$(vd generate cat --yes --max-cost 5 --max-cost 99999)"
+	st_check "--max-cost 99999 then 5 allowed"     "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 99999 --max-cost 5)"
+
+	note "--- app identity gating ---"
+	st_check "submit sanctioned"                   "ALLOW_APP_SUBMIT" "$(vd app submit "${td}/good" --yes)"
+	st_check "submit foreign denied"               "DENY"             "$(vd app submit "${td}/bad" --yes)"
+	st_check "submit -o value not read as dir"     "ALLOW_APP_SUBMIT" "$(vd app submit -o "${td}/bad" "${td}/good")"
+	st_check "package-only allowed"                "ALLOW"            "$(vd app submit "${td}/bad" --package-only)"
+	st_check "listing foreign --slug denied"       "DENY"             "$(vd app listing set-icon i.png --slug someones-real-app)"
+	st_check "listing sanctioned --dir"            "ALLOW"            "$(vd app listing set-icon i.png --dir "${td}/good")"
+	st_check "listing unidentifiable denied"       "DENY"             "$(vd app listing set-icon i.png --dir "${ROOT}/ledger")"
+	st_check "listing status is a read"            "ALLOW"            "$(vd app listing status)"
+
+	note "--- FINDING 9: withdraw ---"
+	st_check "unknown pubreq id denied"            "DENY"  "$(vd app withdraw pubreq_UNKNOWN)"
+	st_check "non-pubreq-shaped id denied"         "DENY"  "$(vd app withdraw NOT-A-PUBREQ-ID)"
+	st_check "--id form denied"                    "DENY"  "$(vd app withdraw --id NOT-A-PUBREQ-ID)"
+	st_check "no id at all is a CLI usage error"   "ALLOW" "$(vd app withdraw)"
+	printf 'pubreq_MINE\n' >> "${ROOT}/ledger/pubreq.allow"
+	st_check "allowlisted id permitted"            "ALLOW" "$(vd app withdraw pubreq_MINE)"
+
+	note "--- FINDING 3: malformed policy / ledger fails CLOSED ---"
+	printf 'garbage\n' > "${ROOT}/ledger/observed_spend"
+	st_check "malformed observed_spend denies spend" "DENY" "$(vd generate cat --yes --max-cost 5)"
+	printf '0\n' > "${ROOT}/ledger/observed_spend"
+	printf '\n' > "${ROOT}/ledger/reserved"
+	st_check "empty reserved reads as 0"             "ALLOW_SPEND" "$(vd generate cat --yes --max-cost 5)"
+	printf 'x\n' > "${ROOT}/ledger/reserved"
+	st_check "malformed reserved denies spend"       "DENY" "$(vd generate cat --yes --max-cost 5)"
+	printf '0\n' > "${ROOT}/ledger/reserved"
+	local saved_pc="${PER_CALL_MAX_COST}"
+	local pol="${ROOT}/ledger/policy.env" bak="${ROOT}/ledger/policy.bak"
+	cp "${pol}" "${bak}"
+	grep -v '^PER_CALL_MAX_COST=' "${bak}" > "${pol}"
+	if load_policy; then
+		st_check "policy missing a key is rejected" "rejected" "accepted"
+	else
+		st_check "policy missing a key is rejected" "rejected" "rejected"
+	fi
+	printf 'PER_CALL_MAX_COST=notanumber\n' >> "${pol}"
+	if load_policy; then
+		st_check "policy with a non-numeric key is rejected" "rejected" "accepted"
+	else
+		st_check "policy with a non-numeric key is rejected" "rejected" "rejected"
+	fi
+	cp "${bak}" "${pol}"; rm -f "${bak}"
+	load_policy || die "selftest: could not restore the policy"
+	st_check "policy restored" "${saved_pc}" "${PER_CALL_MAX_COST}"
+
+	note "--- FINDING 4: the meter_broken latch stops the money path ---"
+	: > "${ROOT}/ledger/meter_broken"
+	st_check "spend refused once the meter is broken" "DENY"  "$(vd generate cat --yes --max-cost 5)"
+	st_check "dry-run still allowed"                  "ALLOW" "$(vd generate cat --dry-run)"
+	rm -f "${ROOT}/ledger/meter_broken"
+
+	note "--- FINDING 5: the balance parser ---"
+	local j
+	for j in '{"total":3.5}' '{"total":1e9}' '{"total":-500}' '{"total":99999999999999999999}' \
+	         '{"blue":1}' '' '{"total":}' '{"total":1,"total":2}'; do
+		if parse_buzz_total "${j}" >/dev/null 2>&1; then
+			st_check "parser rejects ${j:-<empty>}" "reject" "accept($(parse_buzz_total "${j}"))"
+		else
+			st_check "parser rejects ${j:-<empty>}" "reject" "reject"
+		fi
+	done
+	st_check "parser accepts compact"        "4187454" "$(parse_buzz_total '{"total":4187454}' || printf FAILED)"
+	st_check "parser accepts spaced/pretty"  "4187454" "$(parse_buzz_total '{
+  "blue": 1338425,
+  "green": 999980,
+  "total": 4187454,
+  "yellow": 1849049
+}' || printf FAILED)"
+	st_check "parser accepts a real zero"    "0"       "$(parse_buzz_total '{"total":0}' || printf FAILED)"
+
+	note "--- FINDING 6: the ledger lock exists ---"
+	if command -v flock >/dev/null 2>&1; then
+		st_check "flock is available" "yes" "yes"
+	else
+		st_check "flock is available" "yes" "no"
+	fi
+
+	note "--- FINDING 7: TSV escaping ---"
+	st_check "newline escaped"  'a\nb'  "$(tsv_escape "$(printf 'a\nb')")"
+	st_check "tab escaped"      'a\tb'  "$(tsv_escape "$(printf 'a\tb')")"
+	st_check "argv scrub escapes a newline" 'gen a\nDENY\tx' "$(scrub_argv gen "$(printf 'a\nDENY\tx')")"
+	st_check "token redacted"   'login --token <redacted>' "$(scrub_argv login --token SECRETVALUE)"
+
+	rm -rf "${td}"
+
+	if [ "${offline}" = 1 ]; then
+		selftest_e2e
+		note ""
+		note "--- offline mode: the credentialed checks below were skipped ---"
+		rm -rf "${ROOT}"
+	else
+		note ""
+		note "--- balance meter (a real read; spends nothing) ---"
+		local b
+		if b=$(sample_balance "selftest"); then
+			st_check "buzz --json parses to an integer" "yes" "$(case "${b}" in ''|*[!0-9]*) printf no ;; *) printf yes ;; esac)"
+			note "  observed balance: ${b} Buzz"
+		else
+			st_check "buzz --json parses to an integer" "yes" "no"
+		fi
+		note ""
+		note "--- lockdown ---"
+		st_check "binary dir not writable"  "no" "$([ -w "${ROOT}/real" ] && printf yes || printf no)"
+		st_check "binary file not writable" "no" "$([ -w "${ROOT}/real/civitai" ] && printf yes || printf no)"
+		st_check "sandbox config exists"    "yes" "$([ -f "${ROOT}/home/.config/civitai/config.yaml" ] && printf yes || printf no)"
+	fi
+
+	note ""
+	note "selftest: ${SELFTEST_PASS} passed, ${SELFTEST_FAIL} failed"
+	[ "${SELFTEST_FAIL}" = 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end exercise of the GUARD (not just the classifier), driven by a stub
+# binary that charges a known amount. This is what makes the meter, the lock
+# and the ledger regression-testable without a credential or a network — the
+# classifier being right says nothing about whether the guard acts on it.
+# ---------------------------------------------------------------------------
+selftest_e2e() {
+	local base="${TMPDIR:-/tmp}/dogfood-e2e-$$"
+	rm -rf "${base}"
+	mkdir -p "${base}/real" "${base}/bin" "${base}/ledger" \
+	         "${base}/home/.config" "${base}/home/.cache" "${base}/workspace"
+
+	cat > "${base}/real/civitai" <<'STUB'
+#!/usr/bin/env bash
+set -u
+BAL="${XDG_CACHE_HOME}/bal"; NB="${XDG_CACHE_HOME}/nbuzz"
+[ -f "${BAL}" ] || echo 10000 > "${BAL}"
+[ -f "${NB}" ]  || echo 0 > "${NB}"
+args=()
+for a in "$@"; do
+  case "${a}" in --no-color|--color|--no-update-check) ;; *) args+=("${a}") ;; esac
+done
+set -- "${args[@]+"${args[@]}"}"
+case "${1:-}" in
+  buzz)
+    n=$(cat "${NB}"); echo $(( n + 1 )) > "${NB}"
+    if [ -n "${STUB_FLAKY_BUZZ:-}" ] && [ $(( n % 2 )) = 1 ]; then echo boom >&2; exit 5; fi
+    printf '{\n  "total": %s\n}\n' "$(cat "${BAL}")" ;;
+  generate) echo $(( $(cat "${BAL}") - 37 )) > "${BAL}"; echo generated ;;
+  *) : ;;
+esac
+exit 0
+STUB
+	chmod 0755 "${base}/real/civitai"
+
+	cat > "${base}/bin/civitai" <<SHIM
+#!/usr/bin/env bash
+exec "$(readlink -f "$0")" guard --root "${base}" -- "\$@"
+SHIM
+	chmod 0755 "${base}/bin/civitai"
+
+	cat > "${base}/ledger/policy.env" <<POL
+ROOT="${base}"
+PER_CALL_MAX_COST=100
+TOTAL_SPEND_CAP=2000
+MAX_GENERATE_SUBMITS=50
+MAX_APP_SUBMITS=3
+SLUG_PREFIX="sanctioned-"
+BASE_URL="https://example.invalid"
+POL
+	: > "${base}/ledger/invocations.tsv"; : > "${base}/ledger/buzz.tsv"
+	: > "${base}/ledger/spend.tsv";       : > "${base}/ledger/pubreq.allow"
+	printf '0\n' > "${base}/ledger/observed_spend"
+	printf '0\n' > "${base}/ledger/reserved"
+	printf '0\n' > "${base}/ledger/generate_submits"
+	printf '0\n' > "${base}/ledger/app_submits"
+
+	local C="${base}/bin/civitai"
+	local rc meter lines allow
+
+	note "--- end-to-end through the real guard (stub charges 37) ---"
+
+	"${C}" generate cat --yes --max-cost 50 >/dev/null 2>&1; rc=$?
+	meter=$(cat "${base}/ledger/observed_spend")
+	st_check "e2e allowed spend returns the CLI's rc" "0" "${rc}"
+	st_check "e2e meter moved by the real charge"     "37" "${meter}"
+
+	"${C}" --no-color generate cat --yes >/dev/null 2>&1; rc=$?
+	st_check "e2e --no-color generate refused"        "126" "${rc}"
+
+	"${C}" generate cat --yes --negative-prompt --help >/dev/null 2>&1; rc=$?
+	st_check "e2e --negative-prompt --help refused"   "126" "${rc}"
+
+	"${C}" --no-update-check upgrade >/dev/null 2>&1; rc=$?
+	st_check "e2e --no-update-check upgrade refused"  "126" "${rc}"
+
+	"${C}" frobnicate --yes >/dev/null 2>&1; rc=$?
+	st_check "e2e an unrecognised command refused"    "126" "${rc}"
+
+	# The guard must refuse everything when its own policy will not validate.
+	cp "${base}/ledger/policy.env" "${base}/ledger/policy.keep"
+	grep -v '^TOTAL_SPEND_CAP=' "${base}/ledger/policy.keep" > "${base}/ledger/policy.env"
+	"${C}" whoami >/dev/null 2>&1; rc=$?
+	st_check "e2e a malformed policy refuses even a read" "126" "${rc}"
+	cp "${base}/ledger/policy.keep" "${base}/ledger/policy.env"
+	rm -f "${base}/ledger/policy.keep"
+
+	lines=$(wc -l < "${base}/ledger/invocations.tsv")
+	"${C}" generate "$(printf 'a\nDENY\tinjected')" --yes --max-cost 5 >/dev/null 2>&1
+	st_check "e2e a newline prompt adds ONE ledger row" "1" \
+		"$(( $(wc -l < "${base}/ledger/invocations.tsv") - lines ))"
+
+	# Concurrency: leave exactly 10 Buzz of headroom and fire 8 at once.
+	printf '1990\n' > "${base}/ledger/observed_spend"
+	printf '0\n' > "${base}/ledger/reserved"
+	printf '0\n' > "${base}/ledger/generate_submits"
+	: > "${base}/ledger/invocations.tsv"
+	local i
+	for i in 1 2 3 4 5 6 7 8; do "${C}" generate "p${i}" --yes --max-cost 10 >/dev/null 2>&1 & done
+	wait
+	allow=$(grep -c 'ALLOW_SPEND' "${base}/ledger/invocations.tsv" 2>/dev/null || printf 0)
+	st_check "e2e 8 concurrent submits, 10 Buzz headroom" "1" "${allow}"
+	st_check "e2e submit counter matches the allowed rows" "${allow}" "$(cat "${base}/ledger/generate_submits")"
+
+	# A post-call balance read that fails must charge the worst case and latch.
+	printf '0\n' > "${base}/ledger/observed_spend"
+	printf '0\n' > "${base}/ledger/reserved"
+	printf '0\n' > "${base}/ledger/generate_submits"
+	printf '0\n' > "${base}/home/.cache/nbuzz"
+	rm -f "${base}/ledger/meter_broken"
+	STUB_FLAKY_BUZZ=1 "${C}" generate cat --yes --max-cost 60 >/dev/null 2>&1
+	st_check "e2e a lost post-sample charges the worst case" "60" "$(cat "${base}/ledger/observed_spend")"
+	st_check "e2e a lost post-sample latches meter_broken"   "yes" \
+		"$([ -f "${base}/ledger/meter_broken" ] && printf yes || printf no)"
+	"${C}" generate cat --yes --max-cost 5 >/dev/null 2>&1; rc=$?
+	st_check "e2e spend refused after the latch"            "126" "${rc}"
+
+	rm -rf "${base}"
+}
+
 usage() {
-	sed -n '3,30p' "$0"
+	sed -n '3,25p' "$0"
 	exit 2
 }
 
@@ -766,6 +1419,7 @@ main() {
 		enter)         cmd_enter "$@" ;;
 		allow-pubreq)  cmd_allow_pubreq "$@" ;;
 		teardown)      cmd_teardown "$@" ;;
+		__buzz)        cmd_buzz_probe "$@" ;;
 		*)             usage ;;
 	esac
 }


### PR DESCRIPTION
## Why

Dogfood runs [1](../blob/main/claudedocs/handoff-dogfood-154.md) (#223–#227 → 9 merged PRs) and 2 (#255–#260 → 6 merged PRs) were both deliberately **un-credentialed**. Run 2's own handoff states the consequence:

> Both runs were deliberately un-credentialed, so `civitai generate` — the CLI's only irreversibly money-spending surface, and the subject of AGENTS items 12–22 — is *structurally unreachable* by this harness.

So two clean runs say **nothing** about the spend path — the largest untested surface in the product. This PR is the precondition for a third, credentialed run.

**This is the harness, not the run.** Nothing here has been run against the spending surface, and the go/no-go checklist at the end of the design doc is what gates that.

## What's here

- `scripts/dogfood-sandbox.sh` — `init` / `guard` / `status` / `finish` / `selftest` / `enter` / `allow-pubreq` / `teardown`
- `claudedocs/dogfood-3-sandbox.md` — design, validation transcripts, residuals, go/no-go

The agent gets a `civitai` shim on PATH in front of the real binary. The shim decides ALLOW/DENY, brackets a real spend with balance samples, execs the binary with the sandbox environment, and appends to an audit log.

## The controls, by who actually enforces them

| control | enforced by |
|---|---|
| repo checkout invisible to the agent | **kernel** (mount ns, `bwrap`) |
| operator's `~/.config/civitai` unreachable | **kernel** (mount ns) |
| `upgrade` cannot replace the binary | **kernel** (mode bits) |
| per-call `--max-cost` ceiling, total spend cap, submit caps | guard script |
| `app submit` / listing media limited to a throwaway blockId prefix | guard script |
| `withdraw` limited to ids this run created | guard script |
| `login`, `dev-tunnel`, `dev-token` refused | guard script |

The top two rows are kernel-enforced **only when the agent is launched via `dogfood-sandbox.sh enter`**. That is the single most important operational choice, and the checklist says so.

### `upgrade` is blocked structurally

`minio/selfupdate` `O_CREATE`s `.civitai.new` in `filepath.Dir(targetPath)` (`apply.go:67–72`). The binary's directory is `0500`, so that fails `EACCES`. Measured on this host: a `0500` dir refuses create/rename/unlink **but not an in-place write to an existing file** — which is why the binary is additionally `0555`. The directory mode alone would have left a hole.

### `--max-cost` is not relied on as a cap

The CLI's own help: *"`--max-cost` IS AN ESTIMATE CHECK, NOT A SPENDING CAP … the realized charge can exceed the estimate, and it is not refunded."* So the harness meters the **balance** instead, and 🔴 **fails closed** — an unparseable `buzz --json` read refuses the submit rather than counting as zero spend.

## Validation — free surface only, 0 Buzz moved

**The meter, proved end-to-end against a stub** that charges a known 37/generation (proving it on real money requires spending real money):

| check | result |
|---|---|
| `--dry-run` does not move the meter | `observed_spend=0` |
| submit without `--max-cost` | `rc=126`, meter still 0 |
| **POSITIVE CONTROL** — allowed submit moves the meter | `37`, then `74` |
| remaining-budget / total-cap / invocation-cap refusals, each isolated | distinct reason printed for each |
| **NEGATIVE CONTROL** — unparseable balance | `rc=126`, `balance read failed (fail closed)` |
| token in the audit log | absent; `<redacted>` present |

**Isolation, positive-controlled in both directions** (a one-directional test is satisfied by a write that never happened):

```
operator config: ce75626a… -> ce75626a…   PASS  UNCHANGED
sandbox  config: ce75626a… -> 0fcef8c7…   PASS  DID change (so the above is not vacuous)
sandbox whoami with the bogus key: rc=3   (the bogus key really is in force)
```

Byte-identical at the start and end of the whole session.

**The jail:** inside, `/home` does not exist and the repo path does not exist, while `civitai whoami` still authenticates and the guard still returns 126.

**Exit codes:** all 9 gate refusals are `126`; every allowed command passes the CLI's own code through (`0`, `1`, `2`). `selftest`: **28/28**.

`make ci`: 18 ok packages, **0** `--- FAIL`, **0** `build failed`, **0** timeout panics, counted separately. `gofmt -s -l` clean over 322 files. `shellcheck` clean.

## Three things found while validating, worth reading

1. **A negative control that silently didn't run.** The fail-closed probe couldn't overwrite the stub because the lockdown was already in place — so it ran against the *healthy* stub and reported a pass-shaped `rc=0`. The lockdown blocking the test was itself the evidence the lockdown works; the control had to be rebuilt.
2. **A masked branch.** The invocation cap tripped before the total-spend cap, so a green there was not evidence the spend cap worked. Each branch is now isolated and prints its own reason.
3. **A reassuring zero from an instrument wired to nothing.** `buzz --json` pretty-prints `"total": 4187454` *with a space*, so an ad-hoc `grep -o '"total":[0-9]*'` matched nothing and `$(( B0 - B1 ))` turned two empty strings into a confident `0`. The harness's parser strips whitespace, refuses a non-integer, and is negative-controlled. Re-measured properly: three real `--dry-run` estimates moved the balance by 0.

A fourth, in the harness itself: the AGENT-BRIEF interpolated policy variables `init` had never sourced, so a blind agent would have been told the required prefix was literally `the sanctioned prefix`. Fixed and re-validated.

## Residuals, stated rather than hidden

Full list in the doc; the load-bearing ones:

- **Same Unix user — the guard is a shell script, not a sandbox.** The agent can invoke the real binary directly and can rewrite the ledger. Only the mount-namespace and mode-bit controls are outside its reach.
- **The honest ceiling is `TOTAL_SPEND_CAP` *plus one job's overshoot*,** not the cap — the check runs before each submit and a realized charge can exceed its estimate with no refund.
- **`app submit` reaches a human moderator.** `withdraw` works only while `pending`; an approved app is live and this cannot un-publish it, and the blockId is consumed permanently.
- **The meter samples a balance, not a transaction log** — any other account activity during the run is attributed to it.
- **Four deliberate fidelity distortions** (a `SANDBOX POLICY` prefix + rc 126, mandatory `--max-cost`, `login` refused, update check suppressed). Any issue mentioning these is harness noise, not a finding.
- **The spend path has never been exercised end to end.** That is the gap the go/no-go is for; it should not be read as "the meter is verified".

## Not merging

Opened for review. Do not run the dogfood before the checklist is signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
