### PR TITLE
fix(#280): a queued workflow is not told it was charged one line before being told it has not finished

### DIFF
--- a/internal/cmd/workflows.go
+++ b/internal/cmd/workflows.go
@@ -177,12 +177,25 @@ func printWorkflow(out, errw io.Writer, wf *genapi.Workflow) {
 			fmt.Fprintf(out, "      url:     %s\n", safeTerm(*o.URL))
 		}
 	}
-	reportExcludedOutputs(errw, excluded)
-
+	// 🔴 THE TERMINAL GUARD RUNS FIRST, AND reportExcludedOutputs RUNS ONLY
+	// INSIDE IT. Issue #280: the excluded-output report ends with a CHARGE claim
+	// ("These were still part of the workflow you were charged for — a blocked or
+	// missing output is not refunded"), which is a statement about a job that
+	// RAN. A queued or running workflow whose blob has simply not landed yet is
+	// non-deliverable for a completely different reason, so printing that report
+	// told the user they had been charged and would not be refunded one line
+	// before telling them the workflow had not finished — two contradictory
+	// claims about the same job, and the first of them false.
+	//
+	// The partition itself stays above: the "(N deliverable, M excluded)" header
+	// is a COUNT, not a claim about money, and it is honest at any status.
 	if !genapi.IsTerminalStatus(wf.Status) {
 		fmt.Fprintln(errw, ui.For(errw).Dim(
 			"This workflow has not finished. Re-run this command to check again — it is a read and spends nothing."))
-	} else if len(kept) > 0 {
+		return
+	}
+	reportExcludedOutputs(errw, excluded)
+	if len(kept) > 0 {
 		fmt.Fprintln(errw, ui.For(errw).Dim(
 			"Output URLs are presigned and expire — fetch them promptly, or re-run this command for fresh links."))
 	}

--- a/internal/cmd/workflows_test.go
+++ b/internal/cmd/workflows_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -147,6 +148,136 @@ func TestWorkflowsGet_UnfinishedWorkflowSaysSo(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "spends nothing") {
 		t.Errorf("stderr should say re-checking is free:\n%s", errb.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #280 — the excluded-output report is a CHARGE claim, so it must only be
+// printed for a workflow that actually reached a terminal state.
+//
+// 🔴 The fixture above (TestWorkflowsGet_UnfinishedWorkflowSaysSo) is
+// STRUCTURALLY BLIND to this bug: its payload is `"steps":[]`, i.e. zero
+// outputs, so it only ever exercises the "(none yet — the workflow has not
+// finished)" branch and never reaches reportExcludedOutputs at all. Reproducing
+// #280 needs BOTH conditions at once — a non-terminal status AND a
+// non-deliverable output — or the contradicting line is unreachable.
+// ---------------------------------------------------------------------------
+
+// A running workflow whose blob has not landed yet: non-terminal status AND one
+// non-available output.
+const wfGetRunningWithPendingOutput = `{
+  "id":"wf_280","status":"processing","createdAt":"2026-08-05T12:00:00Z",
+  "steps":[{"$type":"textToImage","name":"s","status":"processing",
+    "output":{"images":[
+      {"id":"pending","type":"image","available":false}
+    ]}}]}`
+
+// The same shape after it finishes, plus one deliverable output so the
+// presigned-URL note also fires and the ORDER of the two stderr blocks can be
+// asserted.
+const wfGetSucceededWithPendingOutput = `{
+  "id":"wf_280t","status":"succeeded","createdAt":"2026-08-05T12:00:00Z","completedAt":"2026-08-05T12:00:30Z",
+  "steps":[{"$type":"textToImage","name":"s","status":"succeeded",
+    "output":{"images":[
+      {"id":"ok","type":"image","available":true,"url":"https://blobs.example/ok.jpeg"},
+      {"id":"pending","type":"image","available":false}
+    ]}}]}`
+
+// excludedOutputReport renders exactly what reportExcludedOutputs prints for
+// payload's excluded outputs.
+//
+// The assertions below pin WHERE that block is printed, not how it is worded:
+// the charge/refund sentence lives in generate_output.go and is being revised
+// separately, so a literal copy of it here would be a spelling assertion that
+// breaks on a rewording and — worse — would silently stop matching while the
+// hazard remained. Deriving the block from the real function keeps the check
+// structural. Two positive controls guard against the derivation going vacuous
+// (`strings.Contains(x, "")` is always true): the fixture must actually have an
+// excluded output, and the rendered block must be non-empty.
+func excludedOutputReport(t *testing.T, payload string) string {
+	t.Helper()
+	var wf genapi.Workflow
+	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
+		t.Fatalf("fixture does not decode: %v", err)
+	}
+	_, excluded := genapi.PartitionOutputs(&wf)
+	if len(excluded) == 0 {
+		t.Fatalf("fixture is blind to #280: it carries no excluded output, so the charge claim is unreachable")
+	}
+	var b bytes.Buffer
+	reportExcludedOutputs(&b, excluded)
+	block := b.String()
+	if strings.TrimSpace(block) == "" {
+		t.Fatalf("positive control failed: reportExcludedOutputs printed nothing for %d excluded output(s)", len(excluded))
+	}
+	return block
+}
+
+// #280: a queued/running workflow must not be told it was charged and will not
+// be refunded one line before being told it has not finished.
+func TestWorkflowsGet_RunningWorkflowIsNotToldItWasChargedAndUnrefunded(t *testing.T) {
+	chargeClaim := excludedOutputReport(t, wfGetRunningWithPendingOutput)
+
+	c, out, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfGetRunningWithPendingOutput, nil), workflowsGetOpts{}, "wf_280"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	stderr := errb.String()
+
+	idxNotFinished := strings.Index(stderr, "has not finished")
+	if idxNotFinished < 0 {
+		t.Fatalf("a non-terminal workflow must be told it has not finished; stderr:\n%s", stderr)
+	}
+	// The charge claim is a statement about a job that RAN. It must be absent
+	// entirely — not merely printed later.
+	if idx := strings.Index(stderr, chargeClaim); idx >= 0 {
+		rel := "before"
+		if idx > idxNotFinished {
+			rel = "after"
+		}
+		t.Errorf("#280: a processing workflow was told it was charged and will not be refunded (index %d, %s "+
+			"the \"has not finished\" line at index %d) — the excluded-output report must run only inside "+
+			"the IsTerminalStatus guard.\nstderr:\n%s", idx, rel, idxNotFinished, stderr)
+	}
+	// State, not spelling: the report's own header must not appear either, so a
+	// reworded final sentence cannot let the block through unnoticed.
+	if strings.Contains(stderr, "will NOT be saved") {
+		t.Errorf("#280: the excluded-output report was printed for a non-terminal workflow:\n%s", stderr)
+	}
+	// The counts themselves are honest at any status and must survive: they are
+	// a count, not a claim about money.
+	if !strings.Contains(out.String(), "Outputs (0 deliverable, 1 excluded)") {
+		t.Errorf("the deliverable/excluded counts must still be printed:\n%s", out.String())
+	}
+}
+
+// The counterpart, so the fix cannot silently delete a real warning: a TERMINAL
+// workflow with a non-deliverable output still gets the excluded-output report,
+// and it still comes before the presigned-URL note.
+func TestWorkflowsGet_TerminalWorkflowStillReportsExcludedOutputs(t *testing.T) {
+	chargeClaim := excludedOutputReport(t, wfGetSucceededWithPendingOutput)
+
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfGetSucceededWithPendingOutput, nil), workflowsGetOpts{}, "wf_280t"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	stderr := errb.String()
+
+	idxClaim := strings.Index(stderr, chargeClaim)
+	if idxClaim < 0 {
+		t.Fatalf("a terminal workflow with a non-deliverable output must still get the excluded-output "+
+			"report; stderr:\n%s", stderr)
+	}
+	idxPresigned := strings.Index(stderr, "presigned and expire")
+	if idxPresigned < 0 {
+		t.Fatalf("the presigned-URL note must still print when a deliverable output exists; stderr:\n%s", stderr)
+	}
+	if idxClaim > idxPresigned {
+		t.Errorf("the excluded-output report (index %d) must precede the presigned-URL note (index %d):\n%s",
+			idxClaim, idxPresigned, stderr)
+	}
+	if strings.Contains(stderr, "has not finished") {
+		t.Errorf("a succeeded workflow must not be told it has not finished:\n%s", stderr)
 	}
 }
 


### PR DESCRIPTION
Fixes #280.

## The defect

`printWorkflow` called `reportExcludedOutputs` **before** the `IsTerminalStatus` guard, so `civitai workflows get` on a queued/running workflow whose blob had not landed yet printed this:

```
⚠ 1 output(s) will NOT be saved — they are not deliverable results:
    - pending: not available (the job finished without producing a usable file)
These were still part of the workflow you were charged for — a blocked or missing output is not refunded.
This workflow has not finished. Re-run this command to check again — it is a read and spends nothing.
```

Two claims about the same job, one line apart, contradicting each other — and the first one is a **charge claim about a job that has not run**. It also asserts non-refund for an output that is simply still in flight.

## The fix

`reportExcludedOutputs` now runs **inside** the terminal-status branch. The non-terminal branch returns immediately after its "has not finished" line.

Deliberately **not** moved:

- **The `kept`/`excluded` partition stays above the guard.** The `Outputs (N deliverable, M excluded)` header is a *count*, not a claim about money, and it is honest at any status. A running workflow now reads `Outputs (0 deliverable, 1 excluded)` followed by the "has not finished" line, with no charge claim — asserted.
- **The "Output URLs are presigned and expire" note keeps its position** relative to the excluded report (report first, note second). Pinned by an index comparison so a future edit cannot reorder them silently.

## Test coverage

🔴 **The pre-existing `TestWorkflowsGet_UnfinishedWorkflowSaysSo` is structurally blind to this bug**: its fixture is `"steps":[]`, i.e. zero outputs, so it only ever exercises the `(none yet …)` branch and never reaches `reportExcludedOutputs`. That is stated in the new test block's comment. Reproducing #280 needs **both** conditions at once — a non-terminal status **and** a non-deliverable output — or the contradicting line is unreachable. Confirmed: that old test passes at base and at HEAD, unchanged.

Two new tests:

| test | asserts |
|---|---|
| `TestWorkflowsGet_RunningWorkflowIsNotToldItWasChargedAndUnrefunded` | on a `processing` workflow with one `available:false` output: the "has not finished" line is present; the excluded-output block is **absent** (index `-1`), reported with the relative position if it appears; the report's own header `will NOT be saved` is absent; the deliverable/excluded counts still print |
| `TestWorkflowsGet_TerminalWorkflowStillReportsExcludedOutputs` | on a `succeeded` workflow with one deliverable + one `available:false` output: the excluded-output block **is** present and **precedes** the presigned-URL note (index comparison); "has not finished" is absent |

**Assertions pin placement, not spelling.** The expected block is produced by calling `reportExcludedOutputs` itself against the fixture's own excluded set, so the separate revision of that charge sentence (`generate_output.go`, another PR) cannot make this check silently stop matching while the hazard remains. Two positive controls guard the derivation against going vacuous — `strings.Contains(x, "")` is always true — by requiring the fixture to actually have an excluded output and the rendered block to be non-empty; the terminal test is itself the third, proving the harness *can* observe the block.

### Red/green matrix

Base ref `9862c1e` is byte-identical to `origin/main` (`5eb9119`) for `internal/cmd/workflows.go`, `internal/cmd/generate_output.go` and `internal/genapi/status.go` — verified with `git diff`, so one measurement covers both.

| test | base `9862c1e` | HEAD |
|---|---|---|
| `…RunningWorkflowIsNotToldItWasChargedAndUnrefunded` | **FAIL**, with its own message (`#280: a processing workflow was told it was charged and will not be refunded (index 0, before the "has not finished" line at index 274) …`) | PASS |
| `…TerminalWorkflowStillReportsExcludedOutputs` | PASS (anti-deletion guard, not a regression test for this bug) | PASS |
| `TestWorkflowsGet_UnfinishedWorkflowSaysSo` (pre-existing) | PASS | PASS — the demonstration that it was blind |

### Mutation controls

1. **Swap the two statements back to the original order** (achieved by restoring `workflows.go` from `9862c1e`) → `…RunningWorkflowIsNotToldItWasChargedAndUnrefunded` goes **red with that test's own message**, at `workflows_test.go:238` and `:245`. Not another test's error.
2. **Delete the `reportExcludedOutputs` call entirely** → `…TerminalWorkflowStillReportsExcludedOutputs` goes **red with its own message** at `workflows_test.go:268` (`a terminal workflow with a non-deliverable output must still get the excluded-output report`). So the fix cannot silently delete a real warning, and the guard is reachable rather than shadowed by an earlier check.

### Gate

- `make ci` — rc 0, **18** `ok` packages, **0** `--- FAIL`, **0** `build failed`, **0** timeout panics.
- `internal/cmd` verbose: **1578 RUN / 1578 PASS / 0 FAIL / 0 SKIP**.
- `gofmt -s -l internal/cmd` → 0 files.
- `make lint` errors on this host (golangci-lint not on PATH — no `.envrc` exists in the base clone). Ran the CI-pinned version directly instead: `golangci-lint 2.12.2` (matches `.github/workflows/ci.yml`) → **0 issues**. Instrument validated: a deliberately unused function in `workflows.go` was reported (`1 issues: * unused: 1`), so the zero is meaningful.

## Scope

Touches only `internal/cmd/workflows.go` and `internal/cmd/workflows_test.go`. No behaviour change to `generate`, no README/AGENTS edit.

Checked and **not** a defect: the other `reportExcludedOutputs` call site, `generate.go:1186`, is reached only after the non-`succeeded` branch above it has already returned an error, so it can only run on a terminal `succeeded` workflow. It has no #280-class ordering hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
