### PR TITLE
fix(#281): --dry-run cannot check the prompt, so it must stop echoing it back

### DIFF
--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -1362,6 +1362,11 @@ func confirmGenerate(cmd *cobra.Command, o generateOpts, built *resolvedGraph, c
 	}
 }
 
+// promptNotChecked replaces the prompt text on the --dry-run quote. It is a
+// LABEL, not a value: nothing downstream parses it, and it exists so the line
+// reports what the estimate did rather than what the user typed.
+const promptNotChecked = "<not checked by --dry-run>"
+
 // printGenerateQuote renders the --dry-run breakdown. Factor and fixed keys are
 // printed VERBATIM — they are server-owned, and inventing friendlier labels is
 // how a vendored mapping starts.
@@ -1372,15 +1377,38 @@ func printGenerateQuote(out, errw io.Writer, built *resolvedGraph, o generateOpt
 	// cheapest to catch.
 	printImageDisclosure(errw, o, built)
 
+	// 🔴 The second thing this estimate structurally cannot tell you, and the
+	// reason the Prompt line below prints a label instead of the text (#281).
+	// `whatIfGraph` STRIPS prompt/negativePrompt before the whatIf call — from a
+	// typed graph and from a raw `--input` one alike — because they do not affect
+	// cost and the server substitutes its own defaults. That strip is correct and
+	// must not change. What was wrong was echoing the prompt back afterwards: the
+	// server never saw it, so a `--dry-run` that printed it read as "checked and
+	// priced". Measured: a real prompt was refused at submit for its content
+	// after a clean `--dry-run`. There is no local repair — a moderation verdict
+	// is server-side and the estimate carries no text to judge — so the honest
+	// answer is to say what was not checked.
+	fmt.Fprintln(errw, ui.For(errw).Dim(
+		"The prompt is not sent with the estimate, so --dry-run cannot tell you whether it passes moderation — a submit can still be refused for prompt content."))
+
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, "Workflow:\t%s\n", generateWorkflow)
 	if built.inputPath != "" {
 		fmt.Fprintf(tw, "Graph:\t%s (sent as-is)\n", safeTerm(built.inputPath))
 	} else {
-		fmt.Fprintf(tw, "Prompt:\t%s\n", safeTerm(o.prompt))
+		// NOT safeTerm(o.prompt) — see the disclosure above. The interactive
+		// confirmation in confirmGenerate DOES echo the real prompt and must keep
+		// doing so: that screen precedes an irreversible spend on a graph that
+		// really does carry the text. This one describes an estimate that did not.
+		fmt.Fprintf(tw, "Prompt:\t%s\n", promptNotChecked)
 	}
 	if o.negativePrompt != "" {
-		fmt.Fprintf(tw, "Negative prompt:\t%s\n", safeTerm(o.negativePrompt))
+		// Same strip, same label. Echoing the negative prompt beside a "not
+		// checked" prompt would say the negative one HAD been evaluated — it is
+		// deleted by the same two lines of `whatIfGraph`. The line still appears
+		// when the flag was set, because dropping it silently would leave the user
+		// wondering whether --negative-prompt registered at all.
+		fmt.Fprintf(tw, "Negative prompt:\t%s\n", promptNotChecked)
 	}
 	if o.quantitySet {
 		fmt.Fprintf(tw, "Quantity:\t%d\n", o.quantity)

--- a/internal/cmd/generate_dryrun_prompt_test.go
+++ b/internal/cmd/generate_dryrun_prompt_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #281 — `--dry-run` structurally CANNOT detect a moderation refusal, and
+// it used to echo the prompt back as though it had checked it.
+//
+// The mechanism: `genapi.whatIfGraph` deletes `prompt` / `negativePrompt`
+// before the cost estimate goes out (pinned wire-side by
+// `TestWhatIf_StripsPrompts` and `TestWhatIf_StripsPromptsFromRawGraphOnly` in
+// internal/genapi). That strip is deliberate and correct — the fields do not
+// affect cost and the server substitutes its own defaults — so the repair had
+// to happen at the RENDERER, not at the strip.
+//
+// A sentinel prompt is used rather than a realistic one on purpose: "a cat"
+// appears in the shared `baseOpts()` fixture and in a dozen other files, so an
+// absence assertion over it could pass or fail for reasons that have nothing to
+// do with this renderer.
+const dryRunPromptSentinel = "zz-sentinel-prompt-8f3a2b"
+
+const dryRunNegativeSentinel = "zz-sentinel-negative-4d1c90"
+
+// fieldValue returns the value column of the first tabwriter row whose label is
+// `label`, or "" if no such row was rendered.
+//
+// It reads the rendered STATE of that row rather than searching the whole blob
+// for a substring: `strings.Contains(out, "<not checked by --dry-run>")` stays
+// green when the placeholder AND the real prompt are both printed, which is
+// exactly the half-applied fix this test has to be able to see.
+func fieldValue(rendered, label string) string {
+	for _, line := range strings.Split(rendered, "\n") {
+		if !strings.HasPrefix(line, label+":") {
+			continue
+		}
+		return strings.TrimSpace(strings.TrimPrefix(line, label+":"))
+	}
+	return ""
+}
+
+// 🔴 The defect. `--dry-run` must not present the prompt as something it
+// evaluated, on EITHER stream.
+func TestGenerateDryRun_DoesNotEchoTheUncheckedPrompt(t *testing.T) {
+	withStdinTTY(t, true)
+	var s genSeams
+	o := baseOpts()
+	o.dryRun = true
+	o.prompt = dryRunPromptSentinel
+	o.negativePrompt = dryRunNegativeSentinel
+
+	c, out, errb := genCmd("y\n")
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("--dry-run: %v", err)
+	}
+	if s.submitCalls != 0 {
+		t.Fatalf("--dry-run: submit called %d times, want 0", s.submitCalls)
+	}
+
+	// (1) The sentinel must not reach the user on either stream. The zero here is
+	// MEASURED, not assumed: TestGenerateConfirm_StillEchoesThePromptBeforeSpend
+	// below drives the same sentinel through the same renderer stack and finds it.
+	if strings.Contains(out.String(), dryRunPromptSentinel) {
+		t.Errorf("--dry-run echoed the prompt on stdout; the estimate never carried it:\n%s", out.String())
+	}
+	if strings.Contains(errb.String(), dryRunPromptSentinel) {
+		t.Errorf("--dry-run echoed the prompt on stderr; the estimate never carried it:\n%s", errb.String())
+	}
+	if strings.Contains(out.String(), dryRunNegativeSentinel) || strings.Contains(errb.String(), dryRunNegativeSentinel) {
+		t.Errorf("--dry-run echoed the negative prompt; `whatIfGraph` strips it too:\nstdout:\n%s\nstderr:\n%s", out.String(), errb.String())
+	}
+
+	// (2) The rows are still rendered, and their VALUE is the label. A row that
+	// vanished would be its own defect: the user could not tell whether
+	// --negative-prompt registered at all.
+	for _, label := range []string{"Prompt", "Negative prompt"} {
+		got := fieldValue(out.String(), label)
+		if got == "" {
+			t.Errorf("--dry-run dropped the %q row entirely:\n%s", label, out.String())
+			continue
+		}
+		if got != promptNotChecked {
+			t.Errorf("%q row = %q, want %q", label, got, promptNotChecked)
+		}
+	}
+
+	// (3) The label alone is cryptic; the reason must be on stderr, and it must
+	// name the failure the user actually hits (a refusal at submit).
+	for _, want := range []string{"not sent with the estimate", "moderation", "refused"} {
+		if !strings.Contains(errb.String(), want) {
+			t.Errorf("--dry-run stderr caveat missing %q:\n%s", want, errb.String())
+		}
+	}
+
+	// (4) The CLI must keep SENDING the prompt — the strip is genapi's job, and
+	// this change is presentational only. If the graph handed to the estimate
+	// seam had lost the prompt, the submit that follows a real run would lose it
+	// too, which would be a far worse bug than the one being fixed.
+	if s.lastGraph.Prompt != dryRunPromptSentinel {
+		t.Errorf("graph handed to the whatIf seam lost the prompt: %q", s.lastGraph.Prompt)
+	}
+	if s.lastGraph.NegativePrompt != dryRunNegativeSentinel {
+		t.Errorf("graph handed to the whatIf seam lost the negative prompt: %q", s.lastGraph.NegativePrompt)
+	}
+}
+
+// 🔴 POSITIVE CONTROL, and the trap this fix walks past.
+//
+// There are TWO prompt echoes in generate.go. `printGenerateQuote` (above) is
+// the defect; `confirmGenerate` is not — it is the screen the user reads
+// immediately before an irreversible spend, on a graph that really does carry
+// the prompt. Silencing that one would gut the money confirmation, and every
+// other test in this package would stay green.
+//
+// This case is also what makes the absence assertions above meaningful: same
+// sentinel, same renderer stack, same buffers — found here, so a zero there is
+// a measurement rather than a harness wired to nothing.
+func TestGenerateConfirm_StillEchoesThePromptBeforeSpend(t *testing.T) {
+	withStdinTTY(t, true)
+	var s genSeams
+	o := baseOpts()
+	o.prompt = dryRunPromptSentinel
+	o.negativePrompt = dryRunNegativeSentinel
+
+	c, _, errb := genCmd("y\n")
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("interactive confirm: %v", err)
+	}
+	if s.submitCalls != 1 {
+		t.Fatalf("interactive confirm: submit called %d times, want 1", s.submitCalls)
+	}
+
+	if !strings.Contains(errb.String(), "[y/N]") {
+		t.Fatalf("this case must exercise the interactive confirmation, not --yes:\n%s", errb.String())
+	}
+	if !strings.Contains(errb.String(), dryRunPromptSentinel) {
+		t.Errorf("the spend confirmation must show the prompt being paid for:\n%s", errb.String())
+	}
+	if !strings.Contains(errb.String(), dryRunNegativeSentinel) {
+		t.Errorf("the spend confirmation must show the negative prompt being paid for:\n%s", errb.String())
+	}
+	if strings.Contains(errb.String(), promptNotChecked) {
+		t.Errorf("the spend confirmation must never print %q — the submit DOES carry the prompt:\n%s", promptNotChecked, errb.String())
+	}
+}
+
+// The `--input` branch never echoed a prompt (the CLI has not interpreted the
+// graph), so it must keep naming the file — the fix must not collapse the two
+// branches into one placeholder and lose which file was priced.
+func TestGenerateDryRun_InputBranchStillNamesTheFile(t *testing.T) {
+	withStdinTTY(t, true)
+	path := writeGraphFile(t, `{"workflow":"txt2img","prompt":"`+dryRunPromptSentinel+`"}`)
+
+	var s genSeams
+	o := inputOpts(path)
+	o.dryRun = true
+	o.assumeYes = false
+
+	c, out, errb := genCmd("y\n")
+	if err := runGenerate(c, s.deps(t), o); err != nil {
+		t.Fatalf("--dry-run --input: %v", err)
+	}
+	if got := fieldValue(out.String(), "Graph"); !strings.Contains(got, "graph.json") {
+		t.Errorf("--input dry-run must name the graph file, got %q:\n%s", got, out.String())
+	}
+	if v := fieldValue(out.String(), "Prompt"); v != "" {
+		t.Errorf("--input dry-run must not render a Prompt row (the CLI did not interpret the graph), got %q", v)
+	}
+	// The prompt inside the file is stripped for the estimate exactly as a typed
+	// one is, so it must not surface here either.
+	if strings.Contains(out.String(), dryRunPromptSentinel) || strings.Contains(errb.String(), dryRunPromptSentinel) {
+		t.Errorf("--input dry-run leaked the file's prompt:\nstdout:\n%s\nstderr:\n%s", out.String(), errb.String())
+	}
+}

--- a/internal/cmd/generate_dryrun_prompt_test.go
+++ b/internal/cmd/generate_dryrun_prompt_test.go
@@ -116,6 +116,11 @@ func TestGenerateDryRun_DoesNotEchoTheUncheckedPrompt(t *testing.T) {
 // This case is also what makes the absence assertions above meaningful: same
 // sentinel, same renderer stack, same buffers — found here, so a zero there is
 // a measurement rather than a harness wired to nothing.
+//
+// Honest labelling: this is an INVARIANT GUARD, not regression coverage. It is
+// green at 9862c1e as well as at HEAD, because #281 never broke this screen —
+// it pins that the fix for #281 does not. Mutation-verified: pointing
+// confirmGenerate at promptNotChecked turns it red with its own message.
 func TestGenerateConfirm_StillEchoesThePromptBeforeSpend(t *testing.T) {
 	withStdinTTY(t, true)
 	var s genSeams
@@ -148,6 +153,9 @@ func TestGenerateConfirm_StillEchoesThePromptBeforeSpend(t *testing.T) {
 // The `--input` branch never echoed a prompt (the CLI has not interpreted the
 // graph), so it must keep naming the file — the fix must not collapse the two
 // branches into one placeholder and lose which file was priced.
+//
+// Also an INVARIANT GUARD, green at 9862c1e and at HEAD. Mutation-verified:
+// replacing the Graph row with promptNotChecked turns it red here.
 func TestGenerateDryRun_InputBranchStillNamesTheFile(t *testing.T) {
 	withStdinTTY(t, true)
 	path := writeGraphFile(t, `{"workflow":"txt2img","prompt":"`+dryRunPromptSentinel+`"}`)


### PR DESCRIPTION
Fixes #281.

## The defect

`genapi.whatIfGraph` (`internal/genapi/graph.go:188-197`) **deletes**
`prompt`/`negativePrompt` before the cost estimate goes out — from a typed graph
and from a raw `--input` one alike. That is deliberate and correct: the fields do
not affect cost, the server substitutes its own defaults, and it stops shipping
the user's prompt on every estimate. **This PR does not touch it.**

What was wrong is what happened *after*: `printGenerateQuote` printed the prompt
back on the quote, which reads as "the server saw this and priced it". It did
not. Measured in the dogfood run: a real prompt was refused at submit for
containing the word `strip`, after a `--dry-run` that gave no signal at all.

There is no local repair available — a moderation verdict is server-side, and
the estimate carries no text for anything to judge. Same shape as items 8, 13
and 19(b): *the CLI cannot know this, so it must not imply it.*

## The change

```
 Workflow:         txt2img
-Prompt:           a cat wearing sunglasses
-Negative prompt:  blurry
+Prompt:           <not checked by --dry-run>
+Negative prompt:  <not checked by --dry-run>
 Generatable:      true
```

plus one stderr line naming the failure the user actually hits:

> The prompt is not sent with the estimate, so `--dry-run` cannot tell you
> whether it passes moderation — a submit can still be refused for prompt
> content.

### The `Negative prompt:` line — decision and reason

**Same treatment, and the row is kept rather than dropped.**

- *Why the same label:* it is deleted by the **same two lines** of
  `whatIfGraph`. A truthful "not checked" on the Prompt row sitting beside an
  echoed negative prompt asserts, by contrast, that the negative one *had* been
  evaluated. That is the identical false implication, one row down.
- *Why the row still renders when the flag was set:* silently dropping it is a
  different defect — the user could no longer tell whether `--negative-prompt`
  registered at all. Absence is not disclosure. When the flag is unset there is
  no row, as before, and nothing to mislead about.

### 🔴 The other prompt echo is unchanged, on purpose

`confirmGenerate` (the `Generate? [y/N]` screen) still echoes the real prompt and
the real negative prompt. It precedes an **irreversible spend** on a graph that
genuinely does carry the text — it is the one screen where the echo is true. See
the positive control below: it is the only thing in the repo that would notice if
that screen were gutted.

## Test matrix

Base for the red column is `9862c1e` (the ref the dispatch names). The branch is
actually cut from `origin/main` = `5eb9119`, one **docs-only** commit ahead.
The base run used a scratch worktree at `9862c1e` with the new test file copied
in plus a one-line shim defining `promptNotChecked`, so the assertions could be
watched to fail **on behaviour** rather than on a missing symbol.

| test | `9862c1e` | HEAD | kind |
|---|---|---|---|
| `TestGenerateDryRun_DoesNotEchoTheUncheckedPrompt` | **RED** (7 assertions) | PASS | regression coverage |
| `TestGenerateConfirm_StillEchoesThePromptBeforeSpend` | PASS | PASS | **invariant guard** (labelled as such in the file) |
| `TestGenerateDryRun_InputBranchStillNamesTheFile` | PASS | PASS | **invariant guard** |

The two green-at-base cases are labelled invariant guards in the source and are
**not** counted as regression coverage — #281 never broke either surface; these
pin that the *fix* does not.

The sentinel is `zz-sentinel-prompt-8f3a2b` / `zz-sentinel-negative-4d1c90`
rather than something like "a cat", which appears in the shared `baseOpts()`
fixture and a dozen other files — an absence assertion over that could pass or
fail for reasons unrelated to this renderer.

Assertions are on **state, not spelling**: `fieldValue()` reads the value column
of the named tabwriter row and compares it, because
`Contains(out, "<not checked by --dry-run>")` stays green when the placeholder
**and** the real prompt are both printed — precisely the half-applied fix.
Absence assertions cover **stdout and stderr**.

## Mutation controls (all at HEAD, each red with *that test's own* message)

| # | mutation | result |
|---|---|---|
| M1 | restore `safeTerm(o.prompt)` on the dry-run Prompt row | RED — `--dry-run echoed the prompt on stdout` + `"Prompt" row = "zz-sentinel-…", want "<not checked by --dry-run>"` |
| M2 | restore `safeTerm(o.negativePrompt)` | RED — `--dry-run echoed the negative prompt` + the row assertion |
| M3 | point `confirmGenerate` at `promptNotChecked` (gut the money screen) | RED — all three confirmation assertions |
| M4 | delete the stderr caveat | RED — caveat missing `not sent with the estimate` / `moderation` / `refused` |
| M5 | replace the `--input` `Graph:` row with the placeholder | RED — `--input dry-run must name the graph file` |

🔴 **M3 is the finding worth reading.** Running the **entire** `internal/cmd`
package under M3, the only test that goes red is
`TestGenerateConfirm_StillEchoesThePromptBeforeSpend`. Without this PR's positive
control, silently gutting the confirmation screen on the CLI's only
irreversible-spend path leaves every test in the package green.

That same case is also the positive control for the absence assertions: same
sentinel, same renderer stack, same buffers — **found** there, so the zero in the
dry-run case is a measurement rather than a harness wired to nothing.

## The strip itself is already guarded

`whatIfGraph`'s deletion is pinned wire-side by `TestWhatIf_StripsPrompts` and
`TestWhatIf_StripsPromptsFromRawGraphOnly` (`internal/genapi`), both asserting
**key absence on a decoded map**. No new guard was added — the existing ones are
the right shape. The new test cross-references them so the next reader does not
"fix" the strip instead of the renderer, and additionally asserts that the graph
handed to the estimate seam **still carries** the prompt: this change is
presentational only, and a CLI that stopped sending the prompt would be a far
worse bug than the one being fixed.

## Gates

- `make ci` — green.
- `go test ./... -count=1 -v`, **counted, not exit-code-read**: `3143` `=== RUN`,
  `1632` `--- PASS`, **`0` `--- FAIL`**, `4` `--- SKIP`, `0` `build failed`,
  `0` `panic: test timed out`, `18` `ok` packages.
- `golangci-lint v2.12.2` (the version `.github/workflows/ci.yml` pins) —
  **0 issues**. Instrument validated: a deliberate ineffassign+unused file made
  it report **2 issues**, so the zero is a measurement.
- `gofmt -s -l .` — clean, over **329** `.go` files found in the tree (the
  minimum-count positive control; a silent zero-file scan prints the same
  nothing).
- `go vet ./...` — clean.

## Notes

- **README:** no change needed for this PR. The README carries no verbatim
  sample of the `--dry-run` quote table (no `Prompt:` or `Workflow:` block), so
  nothing there reproduces the changed output. A "`--dry-run` does not check the
  prompt for moderation" sentence in the *Generate* section would be a good
  addition, but that section is being edited concurrently by the #278/#279 PR —
  leaving it to that PR or a follow-up rather than colliding.
- **`AGENTS.md`:** the item documenting this rationale is being written by the
  #278/#279 PR (new item 28), per the dispatch split. Not duplicated here.
- ⚠ **Rebase note:** this touches `internal/cmd/generate.go` in the same
  function as the concurrent #278/#279 PR (its edits are at the `Generatable:`
  row ~17 lines below, and at `:1181`/`:1199`). Git should merge them, but
  **whichever lands second may need a rebase** — and the merged region should be
  read, not assumed: a clean textual merge here would still leave two adjacent
  edits to the same renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
