### PR TITLE
test(mutate): measure whether a generic Go mutation tester catches vacuous guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-.PHONY: all build install test vet lint fmt clean tidy ci
+.PHONY: all build install test vet lint fmt clean tidy ci mutate
 
 all: build
 
@@ -40,6 +40,17 @@ tidy:
 
 # Mirror CI locally.
 ci: tidy vet test build
+
+# Mutation-test ONE package and print a report corrected for gremlins'
+# non-compiling-mutant misclassification. Local investigation tool only:
+# deliberately NOT part of `ci`, deliberately not a CI job, and it exits 0
+# whatever it finds. `make mutate PKG=internal/blockproto` to point it
+# elsewhere. Read the "what this does not cover" header in scripts/mutate.sh
+# before believing a clean run — in particular, it cannot see a defect that
+# lives in TEST code, which is most of what it would need to see here.
+# Measurements: claudedocs/mutation-testing-experiment.md
+mutate:
+	./scripts/mutate.sh $(PKG)
 
 clean:
 	rm -rf bin dist

--- a/claudedocs/mutation-testing-experiment.md
+++ b/claudedocs/mutation-testing-experiment.md
@@ -1,0 +1,346 @@
+# Experiment: would an off-the-shelf Go mutation tester have caught the nine vacuous guards?
+
+**Date:** 2026-08-09 · **Base:** `origin/main` @ `8ec3cb0` · **Package:** `internal/validate`
+· **Go:** 1.25.12 · **Host:** 24 cores
+
+**Short answer: it would have caught 3 of the 9, and it needs a correction pass
+before any of its own numbers can be quoted.** The tool is worth keeping as a
+*local, on-demand* instrument — 18 seconds, 74% of its survivors are genuine —
+but it is the wrong shape for the problem that motivated the experiment, because
+7 of the 9 shapes are defects in TEST code and mutation testing only mutates
+PRODUCTION code.
+
+**Recommendation: do NOT propose a nightly job. Land the local `make mutate`
+target, and propose a narrower targeted check** (spec in §8).
+
+---
+
+## 1. Tool choice
+
+| candidate | verdict |
+|---|---|
+| **gremlins v0.6.0** | **chosen.** Builds clean under Go 1.25.12, has a machine-readable `-o` JSON report, per-mutator flags, and a coverage pre-pass. |
+| `go-mutesting` | not packaged, effectively unmaintained; skipped once gremlins worked. |
+| nixpkgs | **neither is in nixpkgs.** `nix-env -qaP` matches only a VSCode extension called "gremlins" and `mutmut` (Python). The `nix-shell -p` route this repo uses for golangci-lint is not available. |
+
+**Dependency boundary respected.** gremlins is installed as a standalone binary
+into `$XDG_CACHE_HOME/civitai-cli-mutate` with `go install pkg@version`, which
+runs outside the module and cannot touch `go.mod`/`go.sum`. `go.mod` is
+unchanged; `git diff go.mod go.sum` is empty. No `.github/workflows/*` file was
+touched.
+
+---
+
+## 2. Instrument validation — two controls pass, one FAILS
+
+### 2a. Positive control — PASS
+
+Applied `semantic.go:87:16` `==`→`!=` (`renderMode == "iframe" && !hasIframe`) by
+hand and counted the output rather than reading the exit code:
+
+```
+exit=1  --- FAIL=1  --- PASS=0  build failed=0  test timed out=0
+   > --- FAIL: TestValidateRejectsIframeModeWithoutIframe
+```
+
+A real assertion failure, and gremlins scored that mutant `KILLED`. The tool can
+observe a kill.
+
+### 2b. Negative control — PASS, at single-mutant resolution
+
+The *first* attempt failed to weaken anything: deleting `warnings_test.go`
+entirely left the report **byte-identical** (146/23/67). That file is fully
+redundant for mutation purposes — a finding about the suite, not about the tool,
+and a reminder that "the number didn't move" needed a sharper control rather
+than a conclusion.
+
+Second attempt: `semantic.go:87:16` is killed by exactly **one** test, so that
+test alone was removed and gremlins re-run. Result:
+
+```
+DELTA ('semantic.go', 87, 16, 'CONDITIONALS_NEGATION') KILLED -> LIVED
+   ... and nothing else changed
+```
+
+Exactly one mutant flipped, the right one. The tool tracks suite strength
+precisely.
+
+### 2c. Non-compiling-mutant classification — **FAIL**
+
+This is the finding that matters most. gremlins decides a mutant's fate from
+`go test`'s **exit code**:
+
+```go
+// gremlins@v0.6.0 internal/engine/executor.go
+func getTestFailedStatus(exitCode int) mutator.Status {
+	case 1: return mutator.Killed
+	case 2: return mutator.NotViable
+	default: return mutator.Lived
+}
+```
+
+`go test` exits **1** for a build failure, so **every non-compiling mutant is
+scored KILLED** and the `NOT VIABLE` bucket is dead code. Verified by hand
+first — `parent + "." + name` → `parent - "." + name`:
+
+```
+internal/validate/finding.go:251:9: invalid operation: operator - not defined on parent (variable of type string)
+FAIL github.com/civitai/cli/internal/validate [build failed]
+--- FAIL count = 0     build failed = 1
+```
+
+gremlins reported that mutant as `KILLED`.
+
+Then measured exhaustively by re-applying all 146 claimed kills and asking
+`go build`:
+
+> **36 of 146 "kills" (24.7%) do not compile.** gremlins reported `Not viable: 0`.
+
+Almost all are `ARITHMETIC_BASE` `+`→`-` applied to **string concatenation**,
+which this package is largely made of. `INVERT_BITWISE` on `&`-address-of and
+`INVERT_NEGATIVES` inside slice expressions account for the rest.
+
+**Consequence: never quote gremlins' own numbers.** `scripts/mutate-verify.go`
+exists solely to correct this, and the script prints only the corrected block.
+
+### 2d. A fourth trap: the stock timeout makes the run meaningless
+
+At default settings the first run produced **162 TIMED OUT of 236**. gremlins
+derives a per-mutant timeout from coverage-collection time; this suite runs in
+0.17s, so under 24 parallel workers essentially everything "timed out". That
+number looks like a result and is an artifact. `--workers 8
+--timeout-coefficient 60` gives 0 timeouts. **A run with any TIMED OUT is
+invalid, not informative.**
+
+---
+
+## 3. Raw numbers
+
+Command: `./scripts/mutate.sh internal/validate` (all 11 mutators enabled).
+
+| | gremlins reported | **corrected** |
+|---|---:|---:|
+| Killed | 146 | **110** |
+| Lived (survivors) | 23 | **23** |
+| Not viable (did not compile) | 0 | **36** |
+| Not covered | 67 | 67 |
+| Timed out | 0 | 0 |
+| **Total mutants** | **236** | **236** |
+| Test efficacy | 86.4% | **82.7%** |
+
+**Wall clock: 18.5s end-to-end** (14.7s gremlins + ~4s the 146-build correction
+pass) on 24 cores. This is a 3-minute proposition, not a 40-minute one.
+
+### Integration mode is 61× slower for zero extra information
+
+`gremlins -i` runs the whole module suite against each mutant: **14m58s**, and
+**0 status deltas** versus package-scoped mode. Nothing outside
+`internal/validate` kills any of its mutants. Package-scoped is the right mode.
+
+### Per-mutator yield
+
+| mutator | total | killed | lived | not covered |
+|---|---:|---:|---:|---:|
+| ARITHMETIC_BASE | 82 | 29 | 0 | 53 |
+| CONDITIONALS_NEGATION | 75 | 68 | 3 | 4 |
+| INVERT_LOGICAL | 29 | 18 | 7 | 4 |
+| **CONDITIONALS_BOUNDARY** | **20** | **8** | **11** | **1** |
+| INVERT_LOOPCTRL | 13 | 8 | 2 | 3 |
+| INVERT_BITWISE | 8 | 6 | 0 | 2 |
+| others (4) | 9 | 9 | 0 | 0 |
+
+**`CONDITIONALS_BOUNDARY` is the whole story.** It is 8% of the mutants and 48%
+of the survivors, and it is the only mutator that produced high-value findings.
+`ARITHMETIC_BASE` produced **zero** survivors and **all 36** non-viable mutants —
+it is pure cost in this package.
+
+---
+
+## 4. Triaged survivors (23)
+
+Triage method: each survivor was re-applied and run against a purpose-built
+differential fixture set, then compared **keyed by label** (a positional diff
+misaligns silently). Two full runs agreed byte-for-byte. Fixtures were rebuilt
+twice — round 1's "no delta" verdicts for `readyack.go:455` were an artifact of
+non-discriminating fixtures, which is exactly how a mutant gets wrongly declared
+equivalent.
+
+### 4a. Real gaps — 17 of 23 (74%)
+
+Behaviour demonstrably changes and nothing in the module notices.
+
+| # | site | mutation | consequence |
+|---|---|---|---|
+| 1 | `validate.go:219:17` | `len(build) > buildCommandMaxLength` → `>=` | **a 128-char `buildCommand` — exactly the server's limit — is rejected locally.** Mirror drift against `BUILD_COMMAND_MAX_LENGTH`. |
+| 2 | `semantic.go:241:50` | `n < heightMinFloor` → `<=` | `minHeight: 40` (exactly the floor) rejected. |
+| 3 | `semantic.go:241:72` | `n > heightMaxCeiling` → `>=` | `minHeight: 4000` (exactly the ceiling) rejected. |
+| 4 | `readyack.go:455:18` | `info.Size() > maxAckFileBytes` → `>=` | a file of exactly 2 MiB flips the scan `absent`→`unobservable`. |
+| 5 | `readyack.go:455:47` | `s.files >= maxAckScanFiles` → `>` | the 5000-file budget goes off by one. |
+| 6 | `finding.go:194:4` | `continue` → `break` in `dedupeFindings` | **severe: the first duplicate truncates the whole list.** 4 findings → 1. |
+| 7 | `semantic.go:162:4` | `continue` → `break` in `unjustifiedSensitiveScopes` | a duplicated sensitive scope silently drops every later offender. |
+| 8 | `finding.go:169:20` | `Message != Message` → `==` | `sortFindings` ordering inverted/undefined. |
+| 9 | `finding.go:170:25` | `Message <` → `>=` | text-output order reversed — AGENTS item 23 says this order is deliberate. |
+| 10 | `semantic.go:62:44` | `ok && rm != ""` → `\|\|` | `"renderMode": ""` skips the `iframe block is required` error entirely. |
+| 11 | `semantic.go:241:45` | `!isNum \|\| n < floor` → `&&` | a below-floor `minHeight` stops being rejected. |
+| 12 | `targets.go:84:10` | `!ok \|\| slotID == ""` → `&&` | `"slotId": ""` emits a spurious "not a known slot" finding. |
+| 13 | `warnings.go:56:17` | `hasBudgeted && hasPage` → `\|\|` | the budget warning fires on manifests it should not. |
+| 14 | `finding.go:237:29` | `tok[i] > '9'` → `>=` | `isIndexToken` rejects any index containing the digit 9. |
+| 15 | `readyack.go:635:11` | `extra > 0` → `>=` | the gap report claims TRUNCATED when nothing was truncated. |
+| 16-17 | `readyack.go:641:8` ×2 | `i > 0` → `>=` / `<=` | stray/missing `; ` separator in the gap report. Cosmetic. |
+
+Rows 15–17 are cosmetic message defects; rows 1–5 are the ones worth acting on
+(they are all cap/boundary drift, three of them against numbers the server owns).
+
+### 4b. Equivalent mutants — 4 of 23
+
+Each claim is discharged with an input that *would* have discriminated it, not
+with reasoning alone.
+
+| site | why it cannot change behaviour | discriminating fixture tried |
+|---|---|---|
+| `finding.go:170:25` `<`→`<=` | the branch is guarded by `Message != Message`, so operands are never equal | sorts of n = 2, 13, 20, 40 with many equal messages (crossing Go's n=13 insertion-sort threshold) — identical |
+| `lockfile.go:133:43` `>=`→`>` | differs only when `IndexByte` returns 0, i.e. a leading space; such a string can never equal `pnpm`/`yarn`, so both branches yield npm | all 9 leading-space forms (`" pnpm run build"`, `" yarn"`, `" "`, `"  "`, …) — all `["npm","package-lock.json"]` |
+| `readyack.go:630:16` `>`→`>=` | at `len == cap` the truncation is a no-op and `extra == 0`, so the same lead is chosen | `readyAckGapReport(n)` for n = 0..8 — identical |
+| `semantic.go:206:9` `\|\|`→`&&` | differs only when the map is present-and-empty, which then iterates zero keys and returns the same nil | present-empty / absent / empty-scopes / non-empty — identical |
+
+### 4c. Individually equivalent, jointly a real gap — 2 of 23
+
+`readyack.go:408:13` and `readyack.go:430:14` are the same guard
+(`if s.found || s.partial { return }`) at the top of `walk()` and at the top of
+its entry loop. **Mutating either alone is inert, because the other still
+short-circuits.** Mutating *both* is not:
+
+```
+base            G1 scanForReadyAck(unreadable dir sorted BEFORE the ack) = 2 (unobservable)
+mutate 408 only                                                          = 2
+mutate 430 only                                                          = 2
+mutate BOTH                                                              = 0 (found)
+   → real suite: --- FAIL = 0     (nothing catches it)
+```
+
+Both fixture halves carry positive controls (found-only = 0, unreadable-only =
+2), so the no-deltas are real rather than a fixture that never produced either
+outcome. This is a genuine uncaught gap that **first-order mutation testing
+structurally cannot report as one** — it surfaces as two survivors whose
+individual triage says "equivalent".
+
+### Signal-to-noise
+
+**17/23 real (74%), 4/23 equivalent (17%), 2/23 masked-pair (9%). 3 of the 17 are
+cosmetic.** That is good — better than expected. Hand-triage of 23 survivors took
+roughly an hour, most of it building fixtures that could discriminate.
+
+---
+
+## 5. The headline question: which of the nine shapes would it have caught?
+
+The decisive constraint: **mutation testing mutates production code and asks
+whether any test notices. Seven of the nine shapes are defects in test code.**
+A vacuous guard is only visible if it was the *sole* killer of some production
+mutation *and* that mutation is one gremlins generates.
+
+| # | shape | caught? | why |
+|---|---|:--:|---|
+| f | cap test whose assertions were all *relative to* the constant it pinned | ✅ **YES** | the constant is untouched, but `>`→`>=` against it survives. **Demonstrated live** — rows 1–5 above are exactly this shape, unprompted. |
+| g | size-cap guard that `t.Skipf`'d itself green | ✅ **YES** | `readyack.go:455`'s two cap boundaries are live survivors. Flags the *site*; does not say the cause was a skip. |
+| i | ranking-stability test whose 2-element fixture sat under Go's n=13 insertion-sort threshold | ✅ **YES** | the comparator is production code with `!=` and `<`. **Demonstrated live** — `finding.go:169/170` show `sortFindings` is entirely unpinned. |
+| h | strong-tier leak test whose precondition made the mutation unreachable | ⚠️ **MAYBE** | shows up as LIVED *if* the unreachable mutation is an operator gremlins emits. Not reproduced here. |
+| a | a single skippable row (`t.Skip` on setup failure) | ❌ no | the skip removes coverage, so the line lands in `NOT COVERED` — indistinguishable from "no test was ever written", and there are 67 of those. `go test -cover` says the same thing more cheaply. |
+| b | assertion rendered with a mismatched path so `Contains` can never match | ❌ no | worse than a miss: the production code that builds a path is string concatenation, and gremlins' only operator there (`+`→`-`) **does not compile and is scored KILLED**. The one mutation that could have surfaced it is actively misreported. |
+| c | `POSITIVE CONTROL` block whose condition was `s == s` | ❌ no | pure test-code defect; never mutated. |
+| d | denylist-of-one premise asserting *not* one sentinel instead of asserting reach | ❌ no | pure test-code defect. |
+| e | widening battery where a bystander error carried the sibling row | ❌ no | **by construction.** The mutant *is* killed — by the wrong assertion. Mutation testing cannot attribute a kill to an assertion. |
+
+**Score: 3 clear, 1 maybe, 5 no.** "Some, not most", as expected.
+
+Note the asymmetry: the three it catches are all *boundary/comparator* shapes,
+and all three were found here without anyone looking for them. The five it misses
+are all *test-code* shapes — the ones that motivated the experiment.
+
+---
+
+## 6. Deliverable
+
+- `scripts/mutate.sh` — driver. Header states what it does not cover.
+- `scripts/mutate-verify.go` — the correction pass (`//go:build ignore`, so it
+  stays out of `./...` and `make ci`). Header states what it does not cover.
+- `make mutate` / `make mutate PKG=internal/blockproto`.
+
+Both exit 0 whatever they find. Nothing gates.
+
+---
+
+## 7. Recommendation
+
+### Do NOT propose a nightly job — for three reasons, none of them runtime
+
+1. **It answers the wrong question.** 5 of the 9 shapes are structurally
+   invisible to it, including shape (e), which no mutation tool can ever see.
+   A nightly green would read as "the guards are sound" and would be wrong in
+   precisely the way the nine guards were wrong.
+2. **Survivors need an hour of hand-triage each time, and mostly repeat.** 6 of
+   23 are equivalent/masked and will resurface on every run. A gate needs a
+   suppression ledger before it can be a gate, and a permanently-noisy gate
+   trains everyone to click through it.
+3. **The corrected numbers are not stable enough to threshold on.** gremlins'
+   own efficacy figure is inflated ~4 points by non-viable mutants, and the
+   `NOT COVERED` bucket moves with unrelated coverage changes.
+
+### DO land the local target (this PR)
+
+18 seconds, on demand, when touching a package with real branch logic. It is a
+good instrument for a human who has just written a cap or a comparator.
+
+### DO propose a narrower targeted check (separate PR)
+
+Two deterministic checks would together cover more of the nine shapes than the
+generic mutator does, with no third-party tool, no equivalent-mutant noise, and
+no non-viable-mutant correction:
+
+**(A) A boundary-flip battery — in-repo, ~150 lines.** Flip only `<`↔`<=` and
+`>`↔`>=` in a ledgered set of files; require each flip to be killed; carry an
+asserted suppression ledger for the equivalent ones (with the discriminating
+fixture named, per §4b). This is the *only* mutation class that paid off here
+(48% of survivors, all 5 high-value findings) and it has a property the generic
+tool lacks: **an operator flip on a numeric comparison always compiles**, so the
+non-viable problem disappears. 20 mutants in this package, seconds to run,
+gateable. Covers shapes (f), (g), (i).
+
+**(B) Two AST checks over `_test.go` files** — the shapes a mutator can never
+see, both exactly spellable:
+  - **`t.Skip*` reached from an error branch.** Flag any `t.Skip`/`t.Skipf`
+    inside an `if err != nil`-style block in a test. A guard may fail, it may
+    not excuse itself. Covers shapes (a) and (g) at the *cause*.
+  - **Tautological self-comparison.** Flag any `BinaryExpr` with a comparison
+    operator whose two operands have identical source text (`s == s`,
+    `len(a) == len(a)`). Exact, zero false positives, ~30 lines. Covers shape (c).
+
+Shapes (b), (d), (e) remain uncovered by anything automatic. (e) in particular —
+"the mutant was killed by a bystander assertion" — is only reachable by the kind
+of independent adversarial audit that found these nine, and this experiment is
+evidence that such audits are not replaceable by tooling, only *narrowed* by it.
+
+---
+
+## 8. Reproducing
+
+```bash
+make mutate                          # internal/validate, ~18s
+make mutate PKG=internal/blockproto
+```
+
+Raw artifacts from this run (scratch, not committed):
+`/tmp/claude-1000/mutate-scratch/` — `baseline2.json` (package-scoped),
+`integration.json` (`-i`), `keyed_run{1,2,3}.txt` (triage), `viability.py`,
+`triage_fast.py`.
+
+### Process note worth recording
+
+Mid-experiment, an orphaned triage process — created when a `| head -120` closed
+its pipe but did not kill the writer — kept mutating the working tree for ~30
+minutes. It produced *plausible* results that were internally impossible
+(a mutation in `dedupeFindings` appearing to change `scanForReadyAck`'s answer).
+The tell was the impossibility, not any error. Two lessons applied: keyed rather
+than positional comparison, and a `HARNESS-FAULT` verdict so a missing fixture
+can never read as "no delta". Separately, several waiter loops deadlocked on
+`pgrep -f <pattern>` matching their own command line.

--- a/scripts/mutate-verify.go
+++ b/scripts/mutate-verify.go
@@ -1,0 +1,268 @@
+//go:build ignore
+
+// mutate-verify re-classifies a gremlins mutation report by asking the COMPILER
+// what gremlins cannot ask itself.
+//
+// WHY THIS EXISTS. gremlins decides a mutant's fate from `go test`'s EXIT CODE:
+//
+//	// gremlins@v0.6.0 internal/engine/executor.go
+//	func getTestFailedStatus(exitCode int) mutator.Status {
+//	    case 1: return mutator.Killed
+//	    case 2: return mutator.NotViable
+//	    default: return mutator.Lived
+//	    }
+//
+// `go test` exits 1 for BOTH "a test failed" and "the package did not compile",
+// so every non-compiling mutant is scored KILLED and gremlins' NOT VIABLE bucket
+// is effectively dead code. Measured on internal/validate at 8ec3cb0: gremlins
+// reported 146 KILLED / 0 NOT VIABLE, and 36 of those 146 do not compile —
+// almost all ARITHMETIC_BASE `+`->`-` applied to STRING CONCATENATION, which
+// this package is full of. That is 24.7% of the reported kills, inflating the
+// headline efficacy from a true 82.7% to 86.4%.
+//
+// So: this tool re-applies each mutant gremlins called KILLED, runs `go build`,
+// and demotes the ones that fail to compile to NOT VIABLE. A non-compiling
+// mutant is evidence about neither the tests nor the code.
+//
+// ============================ WHAT THIS DOES NOT COVER ======================
+//
+//  1. IT IS NOT A GUARD AND CANNOT FAIL A BUILD. It reports; it gates nothing.
+//     Nothing here belongs in CI until the signal-to-noise is agreed — see
+//     claudedocs/mutation-testing-experiment.md.
+//
+//  2. IT ONLY MUTATES PRODUCTION CODE, SO IT CANNOT SEE A DEFECT THAT LIVES IN
+//     TEST CODE. A `t.Skip` that skips a whole row, a `POSITIVE CONTROL` block
+//     whose condition is `s == s`, an assertion whose expected path can never
+//     match, a mutant killed by a BYSTANDER assertion in the same test — all of
+//     these leave a green mutation report. Mutation testing answers "is this
+//     line pinned by something?", never "is it pinned by the assertion that
+//     claims to pin it?".
+//
+//  3. IT CANNOT SEE ANY MUTATION GREMLINS DOES NOT GENERATE. gremlins mutates
+//     operators only: arithmetic, comparison boundaries, comparison negation,
+//     &&/||, ++/--, break/continue, bitwise, assignment ops. It does NOT mutate
+//     string literals, numeric CONSTANTS, function arguments, argument ORDER,
+//     struct field selection, or a return value. Most of internal/validate is
+//     message construction, and none of it is reachable by this tool.
+//
+//  4. NOT COVERED != SAFE. gremlins does not execute a mutant on a line no test
+//     covers; those are reported as NOT COVERED and are a coverage question,
+//     not a mutation result. There were 67 of them here.
+//
+//  5. SURVIVORS ARE A TRIAGE QUEUE, NOT A BUG LIST. Some are EQUIVALENT MUTANTS
+//     (provably cannot change behaviour). "Equivalent" is a CLAIM — prove it
+//     with an input that would discriminate, not with reasoning.
+//
+//  6. ONE PACKAGE PER RUN. gremlins' JSON carries a BASENAME (`finding.go`), not
+//     a path, so mutants from two packages holding a same-named file cannot be
+//     told apart. -pkg is therefore a single package directory.
+//
+//  7. THE COMPILE CHECK IS `go build`, NOT `go vet`. A mutant that compiles but
+//     trips a vet check `go test` would run is still counted viable here.
+//
+// ============================================================================
+//
+// Usage: go run scripts/mutate-verify.go -pkg internal/validate -json out.json
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type mutation struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+}
+
+type fileReport struct {
+	FileName  string     `json:"file_name"`
+	Mutations []mutation `json:"mutations"`
+}
+
+type report struct {
+	Files []fileReport `json:"files"`
+}
+
+// tables mirror gremlins' own token maps (internal/engine/tokenmutator.go). A
+// mutant is re-created by rewriting the token at the reported BYTE column.
+var tables = map[string]map[string]string{
+	"ARITHMETIC_BASE":         {"+": "-", "-": "+", "*": "/", "/": "*", "%": "*"},
+	"CONDITIONALS_BOUNDARY":   {">": ">=", "<": "<=", ">=": ">", "<=": "<"},
+	"CONDITIONALS_NEGATION":   {"==": "!=", "!=": "==", "<=": ">", ">=": "<", "<": ">=", ">": "<="},
+	"INVERT_LOGICAL":          {"&&": "||", "||": "&&"},
+	"INCREMENT_DECREMENT":     {"++": "--", "--": "++"},
+	"INVERT_LOOPCTRL":         {"break": "continue", "continue": "break"},
+	"INVERT_ASSIGNMENTS":      {"+=": "-=", "-=": "+=", "*=": "/=", "/=": "*=", "%=": "*="},
+	"REMOVE_SELF_ASSIGNMENTS": {"+=": "=", "-=": "=", "*=": "=", "/=": "=", "%=": "=", "&=": "=", "|=": "=", "^=": "="},
+	"INVERT_BITWISE":          {"&": "|", "|": "&", "^": "&"},
+	"INVERT_BWASSIGN":         {"&=": "|=", "|=": "&=", "^=": "&="},
+	"INVERT_NEGATIVES":        {"-": ""},
+}
+
+// applyAt rewrites the token at 1-based BYTE column col. Go token columns count
+// bytes, and these files contain multi-byte em dashes, so a rune-indexed
+// implementation silently edits the wrong offset.
+func applyAt(line string, col int, mtype string) (string, string, string, bool) {
+	tbl, ok := tables[mtype]
+	if !ok {
+		return "", "", "", false
+	}
+	toks := make([]string, 0, len(tbl))
+	for t := range tbl {
+		toks = append(toks, t)
+	}
+	// Longest first so ">=" is matched before ">".
+	sort.Slice(toks, func(i, j int) bool { return len(toks[i]) > len(toks[j]) })
+
+	b := []byte(line)
+	i := col - 1
+	if i < 0 || i > len(b) {
+		return "", "", "", false
+	}
+	for _, t := range toks {
+		if i+len(t) <= len(b) && string(b[i:i+len(t)]) == t {
+			return string(b[:i]) + tbl[t] + string(b[i+len(t):]), t, tbl[t], true
+		}
+	}
+	return "", "", "", false
+}
+
+type verdict struct {
+	file, mtype, swap, err string
+	line, col              int
+}
+
+func main() {
+	pkg := flag.String("pkg", "", "package directory the report is about, e.g. internal/validate")
+	jsonPath := flag.String("json", "", "gremlins -o JSON report")
+	flag.Parse()
+	if *pkg == "" || *jsonPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: mutate-verify -pkg <dir> -json <report.json>")
+		os.Exit(2)
+	}
+
+	raw, err := os.ReadFile(*jsonPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read report: %v\n", err)
+		os.Exit(1)
+	}
+	var rep report
+	if err := json.Unmarshal(raw, &rep); err != nil {
+		fmt.Fprintf(os.Stderr, "parse report: %v\n", err)
+		os.Exit(1)
+	}
+
+	var killed, lived, notCovered []verdict
+	for _, f := range rep.Files {
+		for _, m := range f.Mutations {
+			v := verdict{file: f.FileName, line: m.Line, col: m.Column, mtype: m.Type}
+			switch m.Status {
+			case "KILLED":
+				killed = append(killed, v)
+			case "LIVED":
+				lived = append(lived, v)
+			case "NOT COVERED":
+				notCovered = append(notCovered, v)
+			}
+		}
+	}
+
+	var nonViable, realKills, unapplied []verdict
+	for _, v := range killed {
+		path := filepath.Join(*pkg, v.file)
+		orig, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
+			os.Exit(1)
+		}
+		lines := strings.Split(string(orig), "\n")
+		if v.line-1 < 0 || v.line-1 >= len(lines) {
+			unapplied = append(unapplied, v)
+			continue
+		}
+		newLine, from, to, ok := applyAt(lines[v.line-1], v.col, v.mtype)
+		if !ok {
+			unapplied = append(unapplied, v)
+			continue
+		}
+		v.swap = from + "->" + to
+		lines[v.line-1] = newLine
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write %s: %v\n", path, err)
+			os.Exit(1)
+		}
+		out, buildErr := exec.Command("go", "build", "./"+*pkg+"/").CombinedOutput()
+		// Restore before doing anything else — a panic here would leave the
+		// tree mutated, which is the one unrecoverable failure mode.
+		if werr := os.WriteFile(path, orig, 0o644); werr != nil {
+			fmt.Fprintf(os.Stderr, "FATAL: could not restore %s: %v\n", path, werr)
+			os.Exit(1)
+		}
+		if buildErr != nil {
+			ls := strings.Split(strings.TrimSpace(string(out)), "\n")
+			v.err = ls[len(ls)-1]
+			nonViable = append(nonViable, v)
+		} else {
+			realKills = append(realKills, v)
+		}
+	}
+
+	fmt.Printf("package            : %s\n", *pkg)
+	fmt.Printf("gremlins reported  : KILLED=%d LIVED=%d NOT_COVERED=%d NOT_VIABLE=0\n",
+		len(killed), len(lived), len(notCovered))
+	fmt.Printf("compiler says      : of %d 'kills', %d DO NOT COMPILE\n", len(killed), len(nonViable))
+	fmt.Println()
+	fmt.Printf("CORRECTED          : KILLED=%d LIVED=%d NOT_VIABLE=%d NOT_COVERED=%d",
+		len(realKills), len(lived), len(nonViable), len(notCovered))
+	if len(unapplied) > 0 {
+		fmt.Printf(" UNVERIFIED=%d", len(unapplied))
+	}
+	fmt.Println()
+	if n := len(realKills) + len(lived); n > 0 {
+		fmt.Printf("corrected efficacy : %.1f%%  (gremlins claimed %.1f%%)\n",
+			100*float64(len(realKills))/float64(n),
+			100*float64(len(killed))/float64(len(killed)+len(lived)))
+	}
+
+	sortV := func(v []verdict) {
+		sort.Slice(v, func(i, j int) bool {
+			if v[i].file != v[j].file {
+				return v[i].file < v[j].file
+			}
+			if v[i].line != v[j].line {
+				return v[i].line < v[j].line
+			}
+			return v[i].col < v[j].col
+		})
+	}
+
+	sortV(lived)
+	fmt.Printf("\n=== SURVIVORS (%d) — triage these by hand ===\n", len(lived))
+	for _, v := range lived {
+		fmt.Printf("  %s:%d:%d  %s\n", v.file, v.line, v.col, v.mtype)
+	}
+
+	sortV(nonViable)
+	fmt.Printf("\n=== NON-VIABLE (%d) — gremlins scored each of these KILLED ===\n", len(nonViable))
+	for _, v := range nonViable {
+		fmt.Printf("  %s:%d:%d  %s (%s)\n     %s\n", v.file, v.line, v.col, v.mtype, v.swap, v.err)
+	}
+
+	if len(unapplied) > 0 {
+		sortV(unapplied)
+		fmt.Printf("\n=== UNVERIFIED (%d) — this tool could not re-create the mutant ===\n", len(unapplied))
+		fmt.Println("  (a gap in THIS tool, not a gremlins finding — its viability is unknown)")
+		for _, v := range unapplied {
+			fmt.Printf("  %s:%d:%d  %s\n", v.file, v.line, v.col, v.mtype)
+		}
+	}
+}

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# mutate.sh — run mutation testing over ONE package and print a CORRECTED report.
+#
+# This is a local investigation tool, not a gate. It is deliberately not wired
+# into `make ci` and there is no CI job for it; see
+# claudedocs/mutation-testing-experiment.md for the measurements behind that.
+#
+#   ./scripts/mutate.sh                      # defaults to internal/validate
+#   ./scripts/mutate.sh internal/blockproto
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS DOES NOT COVER — read before believing a green run
+# ---------------------------------------------------------------------------
+#
+# 1. IT CANNOT SEE A DEFECT THAT LIVES IN TEST CODE. Mutation testing mutates
+#    PRODUCTION code and asks whether any test notices. A test that skips
+#    itself, a "positive control" whose condition is `s == s`, an assertion
+#    whose expected string can never match, or a mutant killed by a BYSTANDER
+#    assertion inside an otherwise-vacuous test all leave this report green.
+#    It answers "is this line pinned by something?", never "is it pinned by the
+#    assertion that claims to pin it?".
+#
+# 2. IT ONLY MUTATES OPERATORS. gremlins rewrites arithmetic, comparison
+#    boundaries, comparison negation, && / ||, ++ / --, break / continue,
+#    bitwise and assignment operators. It does NOT touch string literals,
+#    numeric CONSTANTS, function arguments, argument ORDER, struct fields or
+#    return values. In a package that is mostly message construction and
+#    constant tables, most of the code is simply out of reach.
+#
+# 3. GREMLINS SCORES A NON-COMPILING MUTANT AS "KILLED". It reads `go test`'s
+#    exit code, and exit 1 means both "a test failed" and "the build failed".
+#    That is why every run here is post-processed by scripts/mutate-verify.go,
+#    which re-applies each claimed kill and asks the compiler. On
+#    internal/validate that reclassified 36 of 146 "kills". NEVER quote
+#    gremlins' own Killed / efficacy numbers — quote the CORRECTED block.
+#
+# 4. THE DEFAULT TIMEOUT IS WRONG FOR A FAST SUITE. gremlins derives a per-
+#    mutant timeout from how long coverage collection took. internal/validate
+#    tests in 0.17s, so at stock settings 162 of 236 mutants reported TIMED OUT
+#    — a number that looks like a result and is an artifact. Hence the explicit
+#    --timeout-coefficient / --workers below. If you see TIMED OUT > 0, the run
+#    is invalid; raise the coefficient rather than reading it.
+#
+# 5. "NOT COVERED" IS A COVERAGE FACT, NOT A MUTATION RESULT. Those mutants are
+#    never executed. They are neither killed nor survived.
+#
+# 6. SURVIVORS ARE A QUEUE, NOT A BUG LIST. Some cannot change behaviour at all
+#    (equivalent mutants). "Equivalent" is a CLAIM: discharge it with an input
+#    that would discriminate the mutant from the original, not with reasoning.
+#
+# ---------------------------------------------------------------------------
+# DEPENDENCY POLICY
+# ---------------------------------------------------------------------------
+# gremlins is NOT a module dependency and must never become one (AGENTS.md
+# "Permission boundaries" makes a new third-party dependency ask-first). It is
+# installed as a standalone binary into a cache dir with `go install pkg@ver`,
+# which runs outside this module and does not touch go.mod / go.sum.
+#
+set -euo pipefail
+
+PKG="${1:-internal/validate}"
+GREMLINS_VERSION="v0.6.0"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/civitai-cli-mutate"
+BIN="$CACHE/gremlins"
+REPORT="${MUTATE_REPORT:-$CACHE/$(echo "$PKG" | tr '/' '-').json}"
+
+cd "$(dirname "$0")/.."
+
+if [ ! -d "$PKG" ]; then
+  echo "no such package directory: $PKG" >&2
+  exit 2
+fi
+
+if [ ! -x "$BIN" ]; then
+  echo "==> installing gremlins $GREMLINS_VERSION into $CACHE (not a module dependency)"
+  mkdir -p "$CACHE"
+  # `go install pkg@version` is module-less: it cannot modify go.mod/go.sum.
+  GOBIN="$CACHE" GOFLAGS= go install "github.com/go-gremlins/gremlins/cmd/gremlins@$GREMLINS_VERSION"
+fi
+
+# Positive control on the instrument: the suite must be GREEN before mutating,
+# or every mutant is "killed" by a failure that was already there.
+echo "==> baseline: ./$PKG must be green before mutating"
+if ! go test "./$PKG/" -count=1; then
+  echo "baseline suite is RED — a mutation run against it measures nothing" >&2
+  exit 1
+fi
+
+echo "==> gremlins over ./$PKG (all mutators enabled)"
+"$BIN" unleash "./$PKG" \
+  --invert-assignments --invert-bitwise --invert-bwassign \
+  --invert-logical --invert-loopctrl --remove-self-assignments \
+  --workers "${MUTATE_WORKERS:-8}" \
+  --timeout-coefficient "${MUTATE_TIMEOUT_COEFFICIENT:-60}" \
+  -o "$REPORT" | tail -5
+
+echo
+echo "==> re-classifying: asking the COMPILER which 'kills' actually compile"
+go run scripts/mutate-verify.go -pkg "$PKG" -json "$REPORT"
+
+echo
+echo "report JSON: $REPORT"
+echo "NOTE: this script exits 0 regardless of findings. It is advisory."


### PR DESCRIPTION
**Experiment, not a feature. Do not merge yet — this is for the verdict discussion.**

## Question
Would an off-the-shelf Go mutation tester have caught the nine guards that could not fail, and is its signal-to-noise good enough to run regularly? Measured on `internal/validate` at `8ec3cb0`.

## Answer
**It catches 3 of the 9 shapes, and its own numbers cannot be quoted without a correction pass.**

Full write-up with every measurement: `claudedocs/mutation-testing-experiment.md`.

## Tool
gremlins v0.6.0. **Neither gremlins nor go-mutesting is in nixpkgs** (only a VSCode extension of the same name, and `mutmut` for Python), so the `nix-shell -p` route this repo uses for golangci-lint is unavailable. Installed instead via `go install pkg@version` into a cache dir — that runs outside the module, so **`go.mod`/`go.sum` are unchanged**. **No `.github/workflows/*` file touched.**

## Instrument controls — 2 pass, 1 fails

| control | result |
|---|---|
| **Positive** | **PASS** — a covered mutation produces a real `--- FAIL` (0 build failures), scored KILLED. |
| **Negative** | **PASS at single-mutant resolution.** Deleting the one test that kills `semantic.go:87:16` flipped exactly that mutant KILLED→LIVED and nothing else. (A first attempt — deleting `warnings_test.go` — moved *nothing*: that file is fully redundant for mutation purposes.) |
| **Non-compiling mutants** | **FAIL.** `getTestFailedStatus` maps `go test` exit 1 → KILLED, and a build failure *is* exit 1. **36 of 146 reported "kills" (24.7%) do not compile**, while gremlins reports `Not viable: 0`. |

Also: at stock settings the first run reported **162 TIMED OUT of 236** against a 0.17s suite — an artifact that looks like a result.

## Numbers

| | gremlins | **corrected** |
|---|---:|---:|
| Killed | 146 | **110** |
| Lived | 23 | 23 |
| Not viable | 0 | **36** |
| Not covered | 67 | 67 |
| Efficacy | 86.4% | **82.7%** |

**Wall clock: 18.5s** end-to-end. Integration mode (`-i`) is **14m58s for zero status deltas**.

## Survivor triage — 17 real / 4 equivalent / 2 masked-pair

Real findings include three cap boundaries that **mirror server constants** (`buildCommandMaxLength`, `heightMinFloor`/`heightMaxCeiling`), the two `readyack` scan caps, and a `dedupeFindings` `continue`→`break` that **truncates a finding list to its first entry**.

Each "equivalent" verdict is discharged with an input that *would* have discriminated it. Two survivors (`readyack.go:408`/`430`) are individually inert because they mask each other, but the 2nd-order pair flips `unobservable`→`found` and nothing catches it — a gap first-order mutation testing structurally cannot report.

## Which of the nine shapes

✅ cap-test-relative-to-its-own-constant · size-cap guard that skipped itself · ranking-stability under the n=13 threshold — **all three demonstrated live, unprompted**

⚠️ strong-tier unreachable precondition

❌ `t.Skip` row · mismatched-path `Contains` · `s == s` positive control · denylist-of-one premise · bystander-carried sibling row

The five misses are all **test-code** defects; mutation testing only mutates production code. Shape (e) is unreachable by any mutation tool by construction — the mutant *is* killed, just by the wrong assertion.

## Recommendation

**Do not propose a nightly job.** It answers the wrong question (5/9 invisible), survivors need ~an hour of triage and 6/23 recur every run, and the numbers aren't stable enough to threshold on.

**Do** land the local `make mutate` (18s, on demand), and **propose separately**: a boundary-flip battery (the only mutator class that paid off — 48% of survivors, all 5 high-value findings — and operator flips on numeric comparisons always compile, so the non-viable problem disappears) plus two AST checks over `_test.go` (`t.Skip*` inside an error branch; tautological self-comparison).

## Gates
`make ci` green (18 pkgs ok, 0 `--- FAIL`, 0 `build failed`, 0 timeouts) · `gofmt -s -l .` clean · golangci-lint v2.12.2 → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
