### PR TITLE
docs(agents): evict items 10 and 19 — 19.7% of AGENTS.md — and close two guard blind spots a split would have hidden a defect in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,12 +322,16 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
    `AI workflow submits` there and as `workflow:submit` / `ai:write:budgeted`
    here (`app_metrics.go`, the `Top endpoints` / `Top scopes` sections). That was
    a **deliberate non-mirror**, decided when the web labels landed: reproducing
-   them would add a THIRD vendored mapping to keep in lockstep with the server
-   (alongside `schema/` and the slot registry), and unlike those two it buys no
+   them would add a FIFTH vendored mapping to keep in lockstep with the server
+   (alongside `schema/`, the slot registry, item 10's dev-tunnel dotenv mirror
+   and item 11's ready-ack emitter), and unlike those four it buys no
    correctness — a raw token is accurate, just terse, and the values are already
    bounded so they aggregate readably. The raw form is arguably *better* for the
    CLI's scripting audience, and `--json` must keep emitting raw tokens
-   regardless.
+   regardless. 🔴 The count was stale and read "a THIRD … (alongside `schema/`
+   and the slot registry)": this item predates items 10 and 11, and neither
+   recounted it. Four is the number the closing paragraph and both of those
+   items already state — check it there before quoting it here again.
    Cost to know about: an author reading the same range on both surfaces sees two
    vocabularies, and a legacy pre-bounding row shows here as
    `workflow:submit:<id>` where the web shows `Generations (<id>)`. If you decide
@@ -388,107 +392,19 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 
 10. **The `dev-tunnel` embeddability preflight WARNS and never blocks, and its
     two halves have deliberately different evidentiary strength.**
-    `internal/devtunnel/embedcheck.go` catches the failure mode where the tunnel
-    is perfectly healthy but the browser refuses to run the app — the host
-    iframes the dev server sandboxed (`allow-scripts allow-forms`, no
-    `allow-same-origin`), so it runs at an opaque `null` origin.
-    `CheckEmbeddable` is **evidence**: it GETs `/@vite/client` with
-    `Origin: null` through the same `DialLocalDevServer` the proxy uses, and
-    reads real response headers. `CheckParentOrigins` is a **heuristic** —
-    `VITE_BLOCK_ALLOWED_PARENT_ORIGINS` is inlined into the bundle at transform
-    time and cannot be observed over HTTP, so it is a **vendored mirror** (one of
-    four — `schema/`, the slot registry, this, and item 11's ready-ack emitter):
-    `resolveViteEnv` reproduces Vite's dev env resolution, where `.env.<mode>`
-    beats `.env` and a REAL process env var beats every file (dotenv does not
-    overwrite existing vars) — getting that last rule backwards warns at authors
-    who exported the value in their shell. It is gated to dirs holding a manifest
-    AND a package.json depending on `@civitai/app-sdk`, because `dev-tunnel`
-    takes an explicit blockId and runs from anywhere. Neither check is ever
-    fatal: one HTTP response cannot rule out a proxy, a non-Vite dev server or a
-    deliberately exotic setup, and hard-failing would regress flows that work
-    today — so a check that cannot observe returns NO findings rather than
-    manufacturing advice. Measured on Vite **6.4.3 and 8.2.0 alike**: a stock dev
-    server answers a null-origin module fetch `200` with **no**
-    `Access-Control-Allow-Origin`, and 403s a `dev-*.civit.ai` Host. Two traps if
-    you touch it: the probe's baseline `Host` MUST be the real `host:port` (a
-    placeholder authority trips Vite's own DNS-rebinding check and manufactures
-    findings for a healthy server), and the CLI predicate is pinned to the
-    page-money template by the seam guards in
-    `internal/scaffold/dev_embed_contract_test.go`, which render the real
-    template, extract the values it emits and require the CLI's own check to
-    accept them — so drift on EITHER side fails loudly.
-    Four rules are counter-intuitive and were each measured after a first draft
-    got them wrong — every one produced a FALSE WARNING at a correctly configured
-    project, the worst outcome for advisory output because it teaches authors to
-    ignore it:
-    (a) **`frame-ancestors` OBSOLETES `X-Frame-Options`** (CSP L3) — when both are
-    present browsers enforce frame-ancestors and IGNORE XFO, so XFO is only
-    consulted when NO frame-ancestors directive is present. (b) **Only a 2xx
-    baseline is interpretable**: a 401/403/5xx came from something other than the
-    app (auth proxy, deny gate), so its headers say nothing — reading CORS off
-    one blamed healthy servers, and reading the follow-up 403 blamed
-    `allowedHosts` for a proxy that refuses everything identically. A 3xx is NOT
-    in that list: see (e). (c) **`'none'` is decisive only as the SOLE source**,
-    and every `Content-Security-Policy` header must be evaluated
-    (`Header.Values`, not `Get`) because policies combine restrictively.
-    (d) The **dotenv mirror is verified DIFFERENTIALLY against Vite's own
-    `loadEnv`**, not against assumptions. `KEY: value` is VERSION-DEPENDENT —
-    Vite 8 (dotenv 17) resolves it to nothing while Vite 6 (dotenv 16) accepts
-    it — and the mirror deliberately does not accept it, matching the `vite ^8`
-    that page-money pins; page-vite pins `vite ^6` but carries no SDK, so the
-    parent-origins check is gated off there and the divergence is unreachable.
-    Also established by that differential: an unresolved `${NOPE}` expands to the
-    EMPTY string rather than its own text; backtick quoting is supported; an
-    unquoted `#` starts a comment ANYWHERE, not only after a space; the mirror
-    MERGES every env file before expanding once (`.env` may define what
-    `.env.development` interpolates, and expanding per file resolved that to
-    nothing); a reference resolves against the PROCESS env before the file
-    values; `${X:-default}` is supported; and a self-reference (`K=${K}x`)
-    resolves to the process value or empty, which is what makes it terminate. If
-    you change the parser, re-run that differential — a same-process dotenv
-    harness silently CONTAMINATES itself, because dotenv-expand writes resolved
-    values into `process.env` and later cases then read the earlier answer.
-    (e) The 2xx gate must NOT be reached by refusing redirects. A Vite project
-    with a `base` path 404s `/@vite/client` and 302s `/`, so "don't follow
-    redirects" plus "only 2xx is interpretable" made a genuinely un-embeddable
-    server report CLEAN — the over-strict correction to (b). Same-host redirects
-    are followed (bounded) and the FINAL response is judged; a cross-host
-    Location is never followed, because the transport always dials the local dev
-    server and would just send someone else's Host to it. Two consequences that
-    are easy to get wrong: a 200 reached VIA a redirect is not evidence about the
-    path you asked for (`isVite` must re-check `finalPath`, or an SPA dev server
-    that bounces unknown paths to an index gets classified Vite and handed
-    vite.config.ts advice), and `net/http` DROPS a custom `Request.Host` across an
-    absolute redirect, which silently turns the tunnel-Host probe into an ordinary
-    loopback request unless it is re-applied.
-    🔴 **The findings are printed TWICE on purpose, and the duplicate is the
-    fix — not an oversight to collapse.** Printing them once, immediately before
-    the "open this URL" block, is the right placement — the last thing on screen
-    before the URL should be the reason the URL won't work — but insufficient,
-    because the readiness wait sits in front of it. Measured over three runs
-    against the live endpoint (#226): >60 s (killed), >3:00 (never resolved),
-    ~2:30–3:00 — and the 45-second run produced **zero** preflight output,
-    because the author killed an apparently-hung command. So the check with the
-    best diagnostics in the product was invisible to the user most likely to need
-    it: the silent failure it exists to end, reproduced by the placement meant to
-    fix it. Moving the print EARLIER just swaps which failure you get — on a slow
-    tunnel it scrolls away behind minutes of heartbeat lines. Hence both, and the
-    duplicate is the accepted cost. It was chosen over a "re-print only if the
-    wait was slow" threshold specifically because it carries **no timing
-    dependency**: nothing to tune, no clock to mock, and both placements are
-    pinned by ordering assertions against the injected `probePublic` seam rather
-    than by wall-clock timing. `--no-wait` is the ONE exception and it drops the
-    EARLY print, not the late one — there is no wait to scroll behind, so a
-    second copy would only duplicate an eight-line `vite.config.ts` block a few
-    seconds apart.
-    Related, same issue: the DNS-pending heartbeat's estimate is now the single
-    constant `dnsPublishNote`, shared by the TTY spinner and the non-TTY
-    heartbeat because they held two hand-copied copies of it. It used to say
-    "usually <1 min", which **0 of 3** measured runs met. An estimate the wait
-    routinely blows past is what makes a working command read as a hang — which
-    is what got the run killed in the first place — so it states a range and
-    says longer is normal. Three runs do not support a percentile; do not
-    replace it with one you have not measured.
+    `internal/devtunnel/embedcheck.go` catches the failure where the tunnel is
+    healthy but the browser refuses to run the app, because the host iframes the
+    dev server sandboxed, at an opaque `null` origin. `CheckEmbeddable` reads
+    real response headers off a real probe and is **evidence**;
+    `CheckParentOrigins` cannot observe a value inlined at transform time, so it
+    is a **heuristic** — and one of the four vendored mirrors, reproducing
+    Vite's dotenv resolution. Neither is ever fatal: a check that cannot observe
+    returns NO findings rather than manufacturing advice. That doctrine — cited
+    across this repo as "the failure item 10 spent four measured corrections
+    avoiding" — is what those four corrections bought, each having produced a
+    FALSE WARNING at a correctly configured project, the worst outcome for
+    advisory output because it teaches authors to ignore all of it.
+    → evidence: claudedocs/decisions/10-dev-tunnel-embeddability.md
 
 11. **The scaffold VENDORS the block→host ready-ack (`internal/blockproto/`),
     and it is the FOURTH vendored mirror.** A `page` app is not shown by the
@@ -686,114 +602,15 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 
 19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
     `--ecosystem`, and uploads with NO credential — three things that each read
-    like a bug.**
-
-    (a) **The workflow value stays `txt2img`.** There is no `--workflow` flag and
-    `generateWorkflow` is still the constant `"txt2img"` even when `--image` is
-    present. The server does the promotion itself: `normalizeImageWorkflow`
-    (`civitai/civitai → src/server/services/orchestrator/orchestration-new.service.ts`)
-    rewrites `txt2img` + non-empty `images` to `img2img:edit` *before* graph
-    validation. Sending `img2img:edit` ourselves would mean vendoring which
-    ecosystems offer it (18 of them, gated by `isWorkflowAvailable`) — item 13's
-    prohibition exactly. `--input` still refuses a non-`txt2img` workflow, and
-    that refusal must stay.
-
-    (b) 🔴 **`--image` REFUSES to run without `--ecosystem`, and that refusal is
-    not the local validation item 13 forbids.** It checks a FLAG COMBINATION the
-    CLI owns; it asserts nothing about which ecosystems exist or what any of them
-    allows, and `--ecosystem` itself is passed through unexamined. It is a hard
-    error because without it the flag is a **guaranteed no-op that still
-    charges**: `normalizeImageWorkflow` reads `ecosystem` off the RAW request
-    body, *before* the graph applies its own ecosystem default, so an absent
-    ecosystem skips the promotion — and then the default ecosystem
-    (`ZImageTurbo`) has no `images` node at all, so the graph engine
-    (`data-graph.ts` `_evaluate` → `if (def.when === false)`) **deletes the key
-    with zero diagnostics** and `_buildValidationResult` records no error.
-    Measured against civitai.com: `{workflow:txt2img, images:[<real image>]}`
-    with no ecosystem priced **8** with factors `{base,pixels,steps,quantity}` —
-    byte-identical to the same graph carrying no images, HTTP 200 throughout.
-
-    🔴 **And the CLI still cannot tell you whether the promotion actually
-    fired.** The whatIf reply carries `{ready, cost, transactions,
-    allowMatureContent}` — plus, since item 21, `modelSubstitutions` — and no
-    detector — "did a `factors.images` key appear?" — is WRONG, and a
-    differential estimate ("does the price change when I add the images?") is
-    wrong the same way: measured, `Flux1Kontext`, `NanoBanana` and `Seedream`
-    are all genuinely edit-capable and all price **byte-identically with and
-    without images**, because their cost model is a flat `base`. Only `Qwen`
-    grows an `images` factor. So both detectors would refuse valid img2img on the
-    three most obvious edit ecosystems. **Do not add either one.** The command
-    prints an explicit caveat at the confirmation instead, which is the honest
-    answer: an ecosystem with no images node drops them and bills a plain
-    txt2img, and nothing observable distinguishes that from a real edit job.
-
-    (c) **The reference-image cap is ONE global ceiling (7), not a per-ecosystem
-    table — and the sub-ceiling gap is deliberate, not unfinished.** Real limits
-    span 1..7 and live only inside the per-engine graph files. The server's own
-    helper for this (`src/shared/data-graph/generation/images-limit.ts`) says in
-    its header that a flat constant "would simultaneously over-allow the 1-image
-    ecosystems and under-allow the 7-image ones" and that copying the spread
-    yields "a parallel table that rots the moment a graph file changes" — so it
-    instantiates the real graph. The CLI cannot, and `getImagesLimit` is not
-    exposed over any API, so there is no live lookup to make either. Above 7 the
-    array is truncated for *every* ecosystem, so refusing there cannot block a
-    valid request; below it the CLI genuinely does not know and warns instead.
-    🔴 The truncation is what makes this matter: `imagesNode`'s input transform
-    does `arr.slice(0, max)` **before** the output schema's `.max()` check, so an
-    over-limit list can never trip the server's own "Maximum N images allowed"
-    message — the extras are simply gone and the truncated job is billed.
-    Measured on `Qwen` (max 3): 4, 5, 6 and 12 images all priced 60 with an
-    identical `images: 1.2` factor, byte-identical to 3.
-
-    (d) **`GraphImage.Width`/`Height` are VALUE ints with no `omitempty`, which
-    contradicts item 14 on every other field.** Opposite situation: the server
-    *requires* both. The images node takes them as optional on INPUT and then
-    validates the transformed array against an output schema where both are
-    required numbers, so omitting them is a hard 400 — measured:
-    `images:[{"url":"…"}]` returns `Validation failed: images: Invalid input:
-    expected number, received undefined`. A **bare URL string** fails identically
-    even though the input union accepts one, because the transform turns it into
-    `{url}` with no dimensions. There is no server-side dimension probe on this
-    path (the only `getImageDimensions` is a browser `Image()` loader used by
-    React components). So there is no "unset" state to preserve, and `omitempty`
-    would additionally erase a legitimate 0.
-    Dimensions come from `image.DecodeConfig` — **header only, never `Decode`**,
-    which would materialise every pixel to learn two integers — and the upload's
-    Content-Type comes from the DECODED format, not the filename extension.
-
-    (e) 🔴 **The presigned upload carries NO credential, and item 17 carries the
-    full argument — read it there rather than re-deriving it here.**
-    `UploadPresigned` (`pkg/civitai/upload.go`) is a near-duplicate of
-    `DownloadPresigned` and will attract the same "fold it back in behind a
-    bool". The upload URL is **server-supplied** and lives on a `*.civitai.com`
-    host (observed: `orchestration-new.civitai.com`), which
-    `isTrustedDownloadHost` **matches**, so a token-carrying path would hand a
-    25-scope personal API key to a request its own signature already authorizes.
-    The WILDCARD is the load-bearing fact and the subdomain is incidental. Here
-    the safety is structural rather than conditional: the interface has no token
-    parameter and consults no `TokenSource`. `genapi.UploadImageBlob`'s two hops
-    differ on purpose — hop 1 (presign) is authed, hop 2 (upload) is not — and
-    the test asserts BOTH, since "hop 2 had no auth" alone cannot distinguish
-    correctness from a recorder wired to nothing.
-    Everything genuinely shared IS shared: `UploadPresigned` reuses
-    `downloadHTTPClient()` wholesale (SSRF dial guard, redirect policy,
-    `ResponseHeaderTimeout`) and the https check is the single
-    `requireHTTPSTransfer` predicate the download path also calls — the verb is a
-    message parameter, not a second implementation. Two details that are not
-    style: the method is **POST** (`POST /v2/consumer/blobs`, not PUT), and the
-    body is a `[]byte` rather than a reader so the request carries a real
-    `Content-Length` and is replayable.
-    One more: `getConsumerBlobUploadUrl` is **REST, not tRPC** — the one
-    generation-adjacent route that is. It is a plain GET returning a bare
-    `{uploadUrl, expiresAt}`, so it must never go through `unwrapTRPC`, and
-    reading item 12 as "everything here is tRPC" produces a 404.
-
-    (f) **`--dry-run` and `--print-input` DO upload local `--image` files.** An
-    estimate built on a graph with no `images[]` prices a plain txt2img, and
-    `--print-input` must emit a document `--input` can submit, which means real
-    blob URLs rather than local paths. An upload spends no Buzz, but it is a
-    network write — so `--print-input`'s "reaches no money seam" claim is still
-    true while its "no request at all" claim is not, with `--image`.
+    like a bug.** The server promotes `txt2img` + non-empty `images` to
+    `img2img:edit` itself, so sending the edit workflow would mean vendoring
+    which ecosystems offer it — item 13's prohibition exactly. `--image`
+    without `--ecosystem` is a hard error because the promotion reads the
+    ecosystem off the RAW request body, so an absent one silently skips it and
+    the flag becomes a guaranteed no-op THAT STILL CHARGES. The presigned upload
+    carries no credential, for item 17's reason. 🔴 And the CLI still cannot
+    tell you whether the promotion actually fired — do not add a detector.
+    → evidence: claudedocs/decisions/19-img2img-workflow-and-upload.md
 
 20. **The ready-ack advisory has TWO TIERS, the message names which one ran, and
     that disclosure is the fix — not a nicety.** `validate`'s page-without-ack

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -66,7 +66,7 @@ import (
 // AND THAT IS THE LESSON. It named items 10 and 19 with their byte sizes and
 // asserted "both are byte-identical to agentsSplitBase, so their digests can be
 // taken straight from `git show <base>:AGENTS.md`". By the time anyone read it
-// that was FALSE — #297's compression pass had rewritten both, 23 bytes and 78
+// that was FALSE — #297's compression pass had rewritten both, 22 bytes and 77
 // bytes respectively — so the shortcut it offered would have pinned text that
 // was not what was being moved. A hand-maintained ranking in a comment goes
 // stale silently while reading as current; evictionPlaybook() computes the same
@@ -82,7 +82,7 @@ const agentsMaxBytes = 54_250
 // it is a decision about the whole approach, not a bump.
 //
 // 🔴 IT MOVES DOWN WITH THE ACHIEVED SIZE, OR IT STOPS BOUNDING ANYTHING. Left
-// at the 80,000 that was ~19% above the PRE-wave-2 size, it would sit ~49% above
+// at the 80,000 that was ~19% above the PRE-wave-2 size, it would sit ~48% above
 // the achieved one — enough slack to re-inline both items just moved out and
 // still pass, which is the same "a ceiling nobody bounds" failure one level up.
 // Whoever completes the next wave re-derives this from the new achieved size in

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -36,39 +36,58 @@ import (
 
 // agentsMaxBytes is the ceiling on AGENTS.md.
 //
-// Achieved size: 67,213 bytes. The ceiling is 67,500 — 287 bytes of headroom,
-// deliberately far tighter than the 4,937 it replaced, because a COMPRESSION
-// PASS measured that the old headroom's premise no longer holds.
+// Achieved size: 53,950 bytes, after wave 2 of the evidence split moved items 10
+// and 19 out (13,263 bytes net, 19.7% of the file, in one change). The ceiling is
+// 54,250 — 300 bytes of headroom, the same deliberate tightness as the 287 it
+// replaces and for the same measured reason.
 //
-// 🔴 THE HEADROOM IS SMALL BECAUSE SQUEEZING IS NO LONGER AN OPTION. The old
+// 🔴 THE HEADROOM IS SMALL BECAUSE SQUEEZING IS NO LONGER AN OPTION. An earlier
 // number assumed that when the file got close, prose could be tightened to make
 // room. That was measured and it is false: a full lossless compression pass over
 // every unsplit item and every prose section recovered 586 bytes — 0.86% — and
 // most of that came from ONE genuine cross-item duplication (item 19(e) restated
-// item 17's credential argument in full). Mechanically, the file holds only 23
-// repeated 7-word n-grams in 67 kB, and every one is a deliberate parallel
-// construction rather than accidental redundancy. The prose is at its floor.
+// item 17's credential argument in full). Mechanically the file held only 23
+// repeated 7-word n-grams in 67 kB, every one a deliberate parallel construction
+// rather than accidental redundancy. The prose is at its floor; EVICTION is the
+// only lever with anything left in it, and wave 2 recovered ~25x what the
+// compression pass did.
 //
-// So headroom here no longer means "slack to grow into". It means: THE BUDGET
+// So headroom here does not mean "slack to grow into". It means: THE BUDGET
 // BEFORE AN EVICTION IS MANDATORY.
 //
-//   - 287 bytes absorbs a re-measured number or a corrected sentence.
+//   - 300 bytes absorbs a re-measured number or a corrected sentence.
 //   - It does NOT absorb a new retraction paragraph (300–800 bytes), a new stub
 //     (~600–700), or a new item written as a full body (8.5–28 kB).
 //   - Anything in that second list must be paid for by MOVING a body out, not by
 //     raising this constant. The failure message prints the eviction playbook and
-//     ranks the candidates; items 10 (7,795 bytes) and 19 (7,801) are the two
-//     largest still inline, and both are byte-identical to agentsSplitBase, so
-//     their digests can be taken straight from `git show <base>:AGENTS.md`.
+//     ranks the candidates.
+//
+// 🔴 THE CANDIDATE LIST THAT USED TO SIT HERE IS DELETED RATHER THAN UPDATED,
+// AND THAT IS THE LESSON. It named items 10 and 19 with their byte sizes and
+// asserted "both are byte-identical to agentsSplitBase, so their digests can be
+// taken straight from `git show <base>:AGENTS.md`". By the time anyone read it
+// that was FALSE — #297's compression pass had rewritten both, 23 bytes and 78
+// bytes respectively — so the shortcut it offered would have pinned text that
+// was not what was being moved. A hand-maintained ranking in a comment goes
+// stale silently while reading as current; evictionPlaybook() computes the same
+// ranking from the live file at the moment of failure, which is the copy that
+// cannot rot. Do not reintroduce one here.
 //
 // Do not raise this to make a large item fit. Split the item.
-const agentsMaxBytes = 67_500
+const agentsMaxBytes = 54_250
 
-// agentsMaxBytesCeiling bounds agentsMaxBytes itself. 80,000 is ~19% above the
+// agentsMaxBytesCeiling bounds agentsMaxBytes itself. 64,000 is ~19% above the
 // achieved size: past that the numbered list is back to being a per-session cost
 // large enough that the split bought nothing, so raising agentsMaxBytes beyond
 // it is a decision about the whole approach, not a bump.
-const agentsMaxBytesCeiling = 80_000
+//
+// 🔴 IT MOVES DOWN WITH THE ACHIEVED SIZE, OR IT STOPS BOUNDING ANYTHING. Left
+// at the 80,000 that was ~19% above the PRE-wave-2 size, it would sit ~49% above
+// the achieved one — enough slack to re-inline both items just moved out and
+// still pass, which is the same "a ceiling nobody bounds" failure one level up.
+// Whoever completes the next wave re-derives this from the new achieved size in
+// the same commit.
+const agentsMaxBytesCeiling = 64_000
 
 // agentsMinBytes is the POSITIVE CONTROL. A truncated, empty or wrongly-located
 // AGENTS.md is comfortably under any ceiling, and "0 bytes, well within budget"
@@ -167,7 +186,9 @@ func evictionPlaybook(t *testing.T, size int) string {
 		"     cross-references point into it, and agents_xrefs_test.go enforces that.\n"+
 		"  4. Add the item to agents_split_preserved_test.go's table with the sha256 of\n"+
 		"     its non-blank body lines at the commit you moved it from, so the move is\n"+
-		"     proven lossless rather than asserted.\n"+
+		"     proven lossless rather than asserted. That commit goes in the row's own\n"+
+		"     `base` field — it is NOT shared with the earlier waves, because a body's\n"+
+		"     base is fixed at the moment it was evicted and cannot be re-pointed.\n"+
 		"\nDo NOT raise agentsMaxBytes to make this pass. It is currently %d, the file is\n"+
 		"%d bytes, and agentsMaxBytesCeiling (%d) bounds how far it may ever be raised.\n",
 		evidenceDir, evidenceDir, agentsMaxBytes, size, agentsMaxBytesCeiling)

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -313,6 +313,56 @@ func TestSplitTableCoversEveryEvidenceFile(t *testing.T) {
 
 // --- git-backed reinforcement ------------------------------------------------
 
+// gitEnv distinguishes the two reasons a base blob can fail to resolve, because
+// they demand OPPOSITE answers and conflating them is what broke CI once.
+//
+// 🔴 A SHALLOW CLONE IS AN EXPECTED ABSENCE; AN UNRESOLVABLE SHA IN A FULL CLONE
+// IS A BUG. `actions/checkout@v4` clones at depth 1, so NO base blob exists in
+// CI and skipping is the honest answer — the digests are the contract and they
+// need no git at all. But on a full clone the same empty string means the sha in
+// the table is wrong, and answering THAT with a skip would retire the differ
+// silently, which is the failure mode this whole file exists to prevent. So the
+// environment is interrogated rather than inferred from the absence.
+type gitEnv int
+
+const (
+	gitUsable      gitEnv = iota // full clone: base blobs must resolve
+	gitShallow                   // depth-limited: base blobs are absent by construction
+	gitUnavailable               // no git, or not a repository
+)
+
+var gitEnvOnce struct {
+	done bool
+	env  gitEnv
+}
+
+func detectGitEnv() gitEnv {
+	if gitEnvOnce.done {
+		return gitEnvOnce.env
+	}
+	gitEnvOnce.done = true
+	out, err := exec.Command("git", "rev-parse", "--is-shallow-repository").Output()
+	switch {
+	case err != nil:
+		gitEnvOnce.env = gitUnavailable
+	case strings.TrimSpace(string(out)) == "true":
+		gitEnvOnce.env = gitShallow
+	default:
+		gitEnvOnce.env = gitUsable
+	}
+	return gitEnvOnce.env
+}
+
+func (g gitEnv) String() string {
+	switch g {
+	case gitShallow:
+		return "a shallow (depth-limited) clone"
+	case gitUnavailable:
+		return "an environment with no usable git"
+	}
+	return "a full clone"
+}
+
 // baseAgentsMD returns AGENTS.md at the given commit, or "" when the object is
 // not reachable (a shallow CI clone, or no git at all). Results are cached: with
 // a base per row, an uncached read would re-shell out once per item.
@@ -348,6 +398,12 @@ func baseDocFor(t *testing.T, it splitItem) string {
 	t.Helper()
 	doc := baseAgentsMD(t, it.base)
 	if doc == "" {
+		if env := detectGitEnv(); env == gitUsable {
+			t.Fatalf("item %d's base commit %s is NOT REACHABLE, and this is %s — so history IS available and the object still "+
+				"did not resolve. That means the sha in splitItems is wrong, not that the environment is limited. "+
+				"A base nobody can resolve is a pin nobody can re-derive; fix the sha rather than letting this degrade to a skip.",
+				it.num, it.base, env)
+		}
 		return ""
 	}
 	if len(doc) < agentsMinBytes {
@@ -412,7 +468,26 @@ func baseItemBody(t *testing.T, doc string, num int) []string {
 // CI's object store. TestSplitItemBodiesArePreservedVerbatim is the guard that
 // gates a merge; this one is the reason to believe its constants, and it runs on
 // every developer machine.
+// reachableBases counts how many rows' base blobs this environment can resolve.
+// It is the ONE question both git-backed tests ask before comparing anything, so
+// neither can reach a positive control on input the environment cannot supply.
+func reachableBases(t *testing.T) int {
+	t.Helper()
+	n := 0
+	for _, it := range splitItems {
+		if baseAgentsMD(t, it.base) != "" {
+			n++
+		}
+	}
+	return n
+}
+
 func TestSplitDigestsAreTheBaseCommitsText(t *testing.T) {
+	if reachableBases(t) == 0 {
+		t.Skipf("none of the %d base blob(s) is reachable — this is %s. The pinned digests could not be re-derived here; "+
+			"TestSplitItemBodiesArePreservedVerbatim still holds every one of them without git.",
+			len(splitItems), detectGitEnv())
+	}
 	checked := 0
 	for _, it := range splitItems {
 		t.Run(fmt.Sprintf("item_%d", it.num), func(t *testing.T) {
@@ -474,6 +549,25 @@ func TestSplitBasesAreWellFormed(t *testing.T) {
 //
 // Skips in a shallow clone for the same reason as its sibling.
 func TestEveryBaseBodyLineSurvivedTheMove(t *testing.T) {
+	// 🔴 THE SKIP IS DECIDED HERE, BEFORE ANY COMPARISON, AND THAT PLACEMENT IS
+	// THE WHOLE FIX. When the per-item base landed, this skip moved INTO the
+	// subtest — which reads like a tidy-up and is not one: in a shallow clone
+	// every subtest then skipped, `total` stayed 0, and the zero-line CONTROL at
+	// the bottom fired. CI went red with "the differ compared 0 lines", which is
+	// the control doing its job on an environment it was never meant to judge.
+	// The local `make ci` could not see it, because a full clone resolves every
+	// blob — a true green about an environment CI does not have.
+	//
+	// So: if NOTHING resolves, this test has nothing to say and says so once, at
+	// the top. The digests in TestSplitItemBodiesArePreservedVerbatim are
+	// unaffected — they read the evidence files and need no git.
+	if reachableBases(t) == 0 {
+		t.Skipf("none of the %d base blob(s) is reachable — this is %s, where the line-naming differ CANNOT run. "+
+			"Every body is still pinned by sha256 in TestSplitItemBodiesArePreservedVerbatim, which needs no git; "+
+			"this test is reinforcement that names WHICH line went missing, and it runs on any full clone.",
+			len(splitItems), detectGitEnv())
+	}
+
 	total := 0
 	for _, it := range splitItems {
 		t.Run(fmt.Sprintf("item_%d", it.num), func(t *testing.T) {
@@ -508,8 +602,14 @@ func TestEveryBaseBodyLineSurvivedTheMove(t *testing.T) {
 	}
 	// POSITIVE CONTROL. A differ that compared zero lines would report a serene
 	// pass; requiring a floor makes "no missing lines" a claim about real work.
+	//
+	// It is reached ONLY when at least one base resolved (the guard at the top of
+	// this function), so a 0 here means the comparison itself is broken — a
+	// finding — rather than "the environment cannot supply the input", which is a
+	// skip. Keeping those two apart is the entire lesson of this function.
 	if total == 0 {
-		t.Fatal("CONTROL failure: the differ compared 0 lines, so its clean result says nothing")
+		t.Fatal("CONTROL failure: at least one base blob resolved, yet the differ compared 0 lines. " +
+			"The slicer or the evidence reader is broken; this is NOT the shallow-clone case, which is skipped above.")
 	}
 	t.Logf("checked %d non-blank base lines across %d moved items", total, len(splitItems))
 }

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -25,14 +25,47 @@ import (
 // text it came from, and the person best placed to notice is the person who did
 // the moving and has already stopped looking.
 //
-// # THE CONTRACT: a digest per item, taken from the BASE commit
+// # THE CONTRACT: a digest per item, taken from THAT ITEM'S base commit
 //
 // splitItems pins, for each moved item, the sha256 of its NON-BLANK body lines
-// as they stood at agentsSplitBase — joined with "\n" and newline-terminated.
-// The digests were computed FROM `git show <base>:AGENTS.md`, not from the
-// evidence files, so they are not a restatement of this change's own output.
-// Anyone can re-derive them; TestSplitDigestsAreTheBaseCommitsText does exactly
-// that whenever the base blob is reachable.
+// as they stood at the commit it was moved FROM — joined with "\n" and
+// newline-terminated. The digests were computed FROM `git show <base>:AGENTS.md`,
+// not from the evidence files, so they are not a restatement of this change's
+// own output. Anyone can re-derive them; TestSplitDigestsAreTheBaseCommitsText
+// does exactly that whenever the base blob is reachable.
+//
+// # 🔴 THE BASE IS PER-ITEM, AND A SINGLE GLOBAL CONSTANT IS NOT AVAILABLE
+//
+// This started as one constant, `agentsSplitBase`, because there had been
+// exactly one eviction wave (#290, nine items). The second wave (items 10 and
+// 19) proved that was an accident of history rather than a design, in two
+// independent ways:
+//
+//  1. THE BODIES BEING MOVED HAD CHANGED. #297's compression pass rewrote both
+//     items in AGENTS.md — item 10 by 23 bytes, item 19 by 78 — so neither is
+//     byte-identical to c5c3817 any more. (agents_size_test.go's own comment
+//     asserted the opposite, "both are byte-identical to agentsSplitBase"; it
+//     was written before that pass landed and was already false. Re-measure a
+//     claim like that, do not inherit it.) Digesting them against c5c3817 would
+//     have pinned text that is not what was moved.
+//
+//  2. THE OLD BASE CANNOT BE RE-POINTED FORWARD. The obvious alternative —
+//     re-derive all eleven digests from one NEWER commit — is impossible, not
+//     merely inconvenient: after wave 1, AGENTS.md no longer CONTAINS the nine
+//     moved bodies at any commit. `baseItemBody(c5c3817+1, 3)` returns item 3's
+//     STUB. A body's base commit is therefore fixed forever at the moment it was
+//     evicted, and different evictions have different moments. Per-item is the
+//     only shape that can express that.
+//
+// So `base` is a field on the row, not a package constant, and the two named
+// constants below exist only so a reader can see which wave a row belongs to.
+// A future wave adds a third; it does not touch the first two.
+//
+// 🔴 WHAT DOES NOT CHANGE: the guard still fails if ANY split body is altered,
+// for all eleven items. Splitting the base per row weakens nothing — each row is
+// still compared against a specific immutable blob — and that is the property to
+// re-verify by mutation whenever this table's shape is edited, because "I made
+// the pinning more flexible" is exactly how a pin stops pinning.
 //
 // Blank lines are excluded on purpose. They carry no content, and including them
 // would make the guard fail on a trailing-whitespace tidy — a false failure at
@@ -65,28 +98,38 @@ import (
 // correction fails with a message that says what it reverted rather than a bare
 // hash mismatch.
 
-// agentsSplitBase is the commit the nine bodies were moved from.
+// agentsSplitBase is the commit WAVE 1's nine bodies were moved from (#290).
 const agentsSplitBase = "c5c3817de72ac457cc41839c31b07f8bf1197dce"
+
+// agentsSplitBaseWave2 is the commit items 10 and 19 were moved from: the tip
+// after #297's compression pass, which edited BOTH of them. It is deliberately
+// not agentsSplitBase — see the 🔴 section of this file's doc comment.
+const agentsSplitBaseWave2 = "5cb45f0ff54fe55f5249aade8b0cb9826ade3c58"
 
 type splitItem struct {
 	num      int
 	file     string
+	base     string // the commit whose AGENTS.md still held this item's BODY
 	nonBlank int    // pinned so a failure says "we found N lines, base had M"
 	sha      string // sha256 of the base body's non-blank lines
 }
 
 // splitItems is the table. Adding a row means moving an item; the sha comes from
-// `git show <base>:AGENTS.md`, never from the file you just wrote.
+// `git show <base>:AGENTS.md`, never from the file you just wrote — and `base`
+// is the commit YOU moved it from, which for a new wave is not the constant the
+// rows above it use.
 var splitItems = []splitItem{
-	{num: 3, file: "claudedocs/decisions/03-lockfile-check.md", nonBlank: 116, sha: "88c413758efb22d2db23f849257c9f6ffd8175bb764c71078fd6c7eeadd9ec4d"},
-	{num: 11, file: "claudedocs/decisions/11-vendored-ready-ack.md", nonBlank: 153, sha: "232d2649f45928825e60396d36c4c513a469112d48092ec45686cc2b9ba396bf"},
-	{num: 18, file: "claudedocs/decisions/18-ready-ack-existing-apps.md", nonBlank: 130, sha: "83c49221352702ce161854c729e2663cc67d6ca120090d807f8c504db52baaf5"},
-	{num: 20, file: "claudedocs/decisions/20-ready-ack-advisory-tiers.md", nonBlank: 389, sha: "82de3c61f2fa3b43516ec8112d5ce64e3026ace3a2a60aa2ca723d44cf6bb191"},
-	{num: 21, file: "claudedocs/decisions/21-model-substitution.md", nonBlank: 114, sha: "60ee9ffc115dac34eff068cd270c2d6427c26f84c77bca28388aa60c51c5be67"},
-	{num: 23, file: "claudedocs/decisions/23-finding-field-message.md", nonBlank: 165, sha: "89ad99bb3e9fec0e6a316045d7160362b6fad8f8e340fc20c022dcc91becc13a"},
-	{num: 24, file: "claudedocs/decisions/24-errno-is-a-net-error.md", nonBlank: 327, sha: "baa658929002c871ee2cbf9332d7dcb9d78749fcab21e832b11a659803c42fd8"},
-	{num: 26, file: "claudedocs/decisions/26-project-path-classification.md", nonBlank: 246, sha: "1747de6cf56e85a935367ec118b7e16aecee5fb100d1ebf545ca40576ebbcc11"},
-	{num: 27, file: "claudedocs/decisions/27-blockid-derivation-refuses.md", nonBlank: 105, sha: "5edc575b345db5b459af8d0fc0bd6c826e8102a7588b61aa873092848394796a"},
+	{num: 3, file: "claudedocs/decisions/03-lockfile-check.md", base: agentsSplitBase, nonBlank: 116, sha: "88c413758efb22d2db23f849257c9f6ffd8175bb764c71078fd6c7eeadd9ec4d"},
+	{num: 10, file: "claudedocs/decisions/10-dev-tunnel-embeddability.md", base: agentsSplitBaseWave2, nonBlank: 103, sha: "b2397598f7913fac286f2fb5ee1e1e1ebf85348e365a6e820799d4ff817cab3c"},
+	{num: 11, file: "claudedocs/decisions/11-vendored-ready-ack.md", base: agentsSplitBase, nonBlank: 153, sha: "232d2649f45928825e60396d36c4c513a469112d48092ec45686cc2b9ba396bf"},
+	{num: 18, file: "claudedocs/decisions/18-ready-ack-existing-apps.md", base: agentsSplitBase, nonBlank: 130, sha: "83c49221352702ce161854c729e2663cc67d6ca120090d807f8c504db52baaf5"},
+	{num: 19, file: "claudedocs/decisions/19-img2img-workflow-and-upload.md", base: agentsSplitBaseWave2, nonBlank: 103, sha: "0e1bd1bd9b862123d99e106167e6fc0bc5fca55445f3d34709e8115092fef1ef"},
+	{num: 20, file: "claudedocs/decisions/20-ready-ack-advisory-tiers.md", base: agentsSplitBase, nonBlank: 389, sha: "82de3c61f2fa3b43516ec8112d5ce64e3026ace3a2a60aa2ca723d44cf6bb191"},
+	{num: 21, file: "claudedocs/decisions/21-model-substitution.md", base: agentsSplitBase, nonBlank: 114, sha: "60ee9ffc115dac34eff068cd270c2d6427c26f84c77bca28388aa60c51c5be67"},
+	{num: 23, file: "claudedocs/decisions/23-finding-field-message.md", base: agentsSplitBase, nonBlank: 165, sha: "89ad99bb3e9fec0e6a316045d7160362b6fad8f8e340fc20c022dcc91becc13a"},
+	{num: 24, file: "claudedocs/decisions/24-errno-is-a-net-error.md", base: agentsSplitBase, nonBlank: 327, sha: "baa658929002c871ee2cbf9332d7dcb9d78749fcab21e832b11a659803c42fd8"},
+	{num: 26, file: "claudedocs/decisions/26-project-path-classification.md", base: agentsSplitBase, nonBlank: 246, sha: "1747de6cf56e85a935367ec118b7e16aecee5fb100d1ebf545ca40576ebbcc11"},
+	{num: 27, file: "claudedocs/decisions/27-blockid-derivation-refuses.md", base: agentsSplitBase, nonBlank: 105, sha: "5edc575b345db5b459af8d0fc0bd6c826e8102a7588b61aa873092848394796a"},
 }
 
 // --- the one deliberate delta, item 3 ---------------------------------------
@@ -231,7 +274,7 @@ func TestSplitItemBodiesArePreservedVerbatim(t *testing.T) {
 					"was paid for by a round of work; a summary of it is not the same artefact. If you genuinely need to CHANGE this item, "+
 					"change it — and re-pin the sha here in the same commit, so the edit is reviewable as an edit rather than lost as drift.\n"+
 					"Re-derive the base text with:  git show %s:AGENTS.md",
-					it.file, it.num, got, len(nb), it.sha, it.nonBlank, agentsSplitBase[:7], agentsSplitBase)
+					it.file, it.num, got, len(nb), it.sha, it.nonBlank, it.base[:7], it.base)
 			}
 		})
 	}
@@ -270,15 +313,55 @@ func TestSplitTableCoversEveryEvidenceFile(t *testing.T) {
 
 // --- git-backed reinforcement ------------------------------------------------
 
-// baseAgentsMD returns AGENTS.md at agentsSplitBase, or "" when the object is
-// not reachable (a shallow CI clone, or no git at all).
-func baseAgentsMD(t *testing.T) string {
+// baseAgentsMD returns AGENTS.md at the given commit, or "" when the object is
+// not reachable (a shallow CI clone, or no git at all). Results are cached: with
+// a base per row, an uncached read would re-shell out once per item.
+var baseAgentsMDCache = map[string]string{}
+
+func baseAgentsMD(t *testing.T, ref string) string {
 	t.Helper()
-	out, err := exec.Command("git", "show", agentsSplitBase+":AGENTS.md").Output()
+	if doc, ok := baseAgentsMDCache[ref]; ok {
+		return doc
+	}
+	out, err := exec.Command("git", "show", ref+":AGENTS.md").Output()
 	if err != nil {
+		baseAgentsMDCache[ref] = ""
 		return ""
 	}
+	baseAgentsMDCache[ref] = string(out)
 	return string(out)
+}
+
+// baseDocFor resolves one row's base document and applies the controls that make
+// a comparison against it meaningful. It returns "" when the blob is unreachable
+// (the caller then skips, per the 🔴 note on the git-backed tests).
+//
+// 🔴 THE OLD CONTROL WAS `len(doc) < 150_000` — "this is the big pre-split file"
+// — AND IT CANNOT SURVIVE A SECOND WAVE. Wave 2's base is a POST-split commit of
+// 67 kB, so that assertion would fail on a perfectly correct row. It is replaced
+// by two controls that are true of any wave: the document must be a plausible
+// AGENTS.md at all, and the sliced body must be a BODY rather than a stub — a
+// base commit accidentally pointed AFTER its own eviction yields the 8-line stub,
+// which would otherwise surface as an inscrutable digest mismatch instead of
+// "you named the wrong commit".
+func baseDocFor(t *testing.T, it splitItem) string {
+	t.Helper()
+	doc := baseAgentsMD(t, it.base)
+	if doc == "" {
+		return ""
+	}
+	if len(doc) < agentsMinBytes {
+		t.Fatalf("CONTROL failure: AGENTS.md at %s is %d bytes, below the %d-byte floor. "+
+			"That is not an AGENTS.md; item %d's base commit is wrong or the blob is truncated.",
+			it.base[:7], len(doc), agentsMinBytes, it.num)
+	}
+	if evidencePathRe.MatchString(strings.Join(baseItemBody(t, doc, it.num), "\n")) {
+		t.Fatalf("CONTROL failure: item %d's body at %s is already a STUB — it carries an `→ evidence:` pointer. "+
+			"The base must be a commit whose AGENTS.md still held the BODY, i.e. the commit you moved it FROM. "+
+			"A body's base is fixed at the moment it was evicted and can never be re-pointed forward.",
+			it.num, it.base[:7])
+	}
+	return doc
 }
 
 // baseItemBody slices one item's body out of a whole AGENTS.md.
@@ -330,30 +413,58 @@ func baseItemBody(t *testing.T, doc string, num int) []string {
 // gates a merge; this one is the reason to believe its constants, and it runs on
 // every developer machine.
 func TestSplitDigestsAreTheBaseCommitsText(t *testing.T) {
-	doc := baseAgentsMD(t)
-	if doc == "" {
-		t.Skipf("base blob %s:AGENTS.md is not reachable (shallow clone, or git unavailable) — "+
-			"the pinned digests could not be re-derived here. TestSplitItemBodiesArePreservedVerbatim still holds them.",
-			agentsSplitBase[:7])
-	}
-	// POSITIVE CONTROL for the slicer: the base file is the big one, and if the
-	// checkout resolved to something else every comparison below is meaningless.
-	if len(doc) < 150_000 {
-		t.Fatalf("CONTROL failure: base AGENTS.md is %d bytes, expected the pre-split file (~186 kB). "+
-			"agentsSplitBase does not name the commit these digests came from.", len(doc))
-	}
+	checked := 0
 	for _, it := range splitItems {
 		t.Run(fmt.Sprintf("item_%d", it.num), func(t *testing.T) {
+			doc := baseDocFor(t, it)
+			if doc == "" {
+				t.Skipf("base blob %s:AGENTS.md is not reachable (shallow clone, or git unavailable) — "+
+					"item %d's pinned digest could not be re-derived here. TestSplitItemBodiesArePreservedVerbatim still holds it.",
+					it.base[:7], it.num)
+			}
+			checked++
 			nb := nonBlank(baseItemBody(t, doc, it.num))
 			if len(nb) != it.nonBlank {
 				t.Errorf("base item %d has %d non-blank line(s), table pins %d", it.num, len(nb), it.nonBlank)
 			}
 			if got := digestLines(nb); got != it.sha {
-				t.Fatalf("the pinned sha for item %d does not match the base commit's own text:\n  base %s\n  pin  %s\n"+
+				t.Fatalf("the pinned sha for item %d does not match its base commit's own text:\n  base %s\n  pin  %s\n"+
 					"The pin is wrong, not the evidence file. Re-derive it from `git show %s:AGENTS.md`.",
-					it.num, got, it.sha, agentsSplitBase)
+					it.num, got, it.sha, it.base)
 			}
 		})
+	}
+	if checked > 0 {
+		t.Logf("re-derived %d of %d pinned digest(s) from their own base commits", checked, len(splitItems))
+	}
+}
+
+// TestSplitBasesAreWellFormed is the cheap always-on control on the new per-row
+// field. It runs in a shallow clone where the git-backed tests skip, so a row
+// added with an empty or abbreviated base fails somewhere rather than nowhere.
+//
+// It also asserts the bases are a SMALL set. Every row of one wave shares a
+// commit; a table where each row carried its own would mean somebody re-derived
+// digests against whatever HEAD happened to be, which is the drift this file
+// exists to stop.
+func TestSplitBasesAreWellFormed(t *testing.T) {
+	fullSHA := regexp.MustCompile(`^[0-9a-f]{40}$`)
+	waves := map[string]int{}
+	for _, it := range splitItems {
+		if !fullSHA.MatchString(it.base) {
+			t.Errorf("item %d's base %q is not a full 40-character sha. An abbreviated ref is ambiguous forever; "+
+				"a body's base commit is permanent and must be spelled in full", it.num, it.base)
+			continue
+		}
+		waves[it.base]++
+	}
+	if len(waves) == 0 {
+		t.Fatal("CONTROL failure: no bases parsed at all")
+	}
+	if len(waves) > len(splitItems)/2 {
+		t.Errorf("%d distinct base commits across %d rows. Eviction happens in WAVES — every item moved in one change "+
+			"shares its base — so a table this fragmented means digests were taken against a moving HEAD rather than "+
+			"against the commit each body was moved from", len(waves), len(splitItems))
 	}
 }
 
@@ -363,13 +474,13 @@ func TestSplitDigestsAreTheBaseCommitsText(t *testing.T) {
 //
 // Skips in a shallow clone for the same reason as its sibling.
 func TestEveryBaseBodyLineSurvivedTheMove(t *testing.T) {
-	doc := baseAgentsMD(t)
-	if doc == "" {
-		t.Skipf("base blob %s:AGENTS.md is not reachable — see TestSplitDigestsAreTheBaseCommitsText", agentsSplitBase[:7])
-	}
 	total := 0
 	for _, it := range splitItems {
 		t.Run(fmt.Sprintf("item_%d", it.num), func(t *testing.T) {
+			doc := baseDocFor(t, it)
+			if doc == "" {
+				t.Skipf("base blob %s:AGENTS.md is not reachable — see TestSplitDigestsAreTheBaseCommitsText", it.base[:7])
+			}
 			have := map[string]int{}
 			for _, l := range nonBlank(evidenceBody(t, it.file, it.num)) {
 				have[l]++

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -42,7 +42,7 @@ import (
 // independent ways:
 //
 //  1. THE BODIES BEING MOVED HAD CHANGED. #297's compression pass rewrote both
-//     items in AGENTS.md — item 10 by 23 bytes, item 19 by 78 — so neither is
+//     items in AGENTS.md — item 10 by 22 bytes, item 19 by 77 — so neither is
 //     byte-identical to c5c3817 any more. (agents_size_test.go's own comment
 //     asserted the opposite, "both are byte-identical to agentsSplitBase"; it
 //     was written before that pass landed and was already false. Re-measure a

--- a/agents_xrefs_test.go
+++ b/agents_xrefs_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -49,6 +50,42 @@ import (
 //   - Sub-item letters (`item 19(e)`) are NOT validated. Nothing parses the
 //     `(a)`/`(b)` bullets out of AGENTS.md, so a reference to a sub-item that
 //     does not exist passes.
+//
+// # 🔴 THE SCAN IS PARAGRAPH-WISE, NOT LINE-WISE, AND IT WAS LINE-WISE FOR A
+// # RELEASE
+//
+// This is the same blind spot agents_index_test.go's design decision 2 records,
+// regenerated at the sibling call site — which is exactly the "one rule, one
+// place" shape the repo's own rules warn about, and the reason it went unnoticed
+// is that the index guard was fixed and this one was not. Every corpus this
+// walks is hard-wrapped: AGENTS.md and the evidence files at ~79 columns, Go doc
+// comments at ~77 after the `// `. So a reference straddles a line break
+// routinely — `…and item` / `24 covers…`, `items 12–17, 19, 21` / `and 22`. A
+// per-line scan finds NOTHING there, and finding nothing is indistinguishable
+// from there being nothing.
+//
+// Measured at the commit that fixed it: the line-wise scan saw 390 references
+// and the paragraph-wise scan sees 402. TWELVE references across TEN files were
+// invisible — including four inside this test suite's own siblings — and the
+// suite was green throughout, because a lost reference is a silence and the
+// floor below (40) is nowhere near tight enough to notice twelve. A reflow that
+// splits `item 27` across a wrap does not just go unchecked, it goes unSEEN.
+//
+// collapseParagraphs is the repair. It joins each maximal run of non-blank lines
+// into one whitespace-collapsed string before matching, which is precisely the
+// inverse of a hard wrap, and it strips a leading comment marker (`//`, `#`, `*`)
+// from each line first — without that, `…21` / `// and 22` collapses to
+// `21 // and 22` and the cluster still stops at 21, so the fix would have been
+// half a fix on the Go corpus that carries most of these references.
+// TestItemRefsSurviveLineWraps pins it with fixtures a per-line scan loses, each
+// carrying its own positive control that it really does lose them.
+//
+// The residual, in the widening direction: joining also merges adjacent list
+// items inside one paragraph, so `- …about item` / `- 7 things` yields a
+// spurious reference to 7. Harmless here for the same reason scannedExts can be
+// widened freely — the assertion is "does this number resolve", so an extra
+// reference to an item that EXISTS cannot manufacture a failure, and one to an
+// item that does not is a finding worth having anyway.
 
 // itemsSectionHeading is where the numbered list begins. Items are matched only
 // below it, so an ordinary numbered list elsewhere in AGENTS.md cannot inflate
@@ -66,8 +103,14 @@ const minAgentsItems = 23
 // matching — a changed comment convention, a bad character class, a walk rooted
 // at the wrong directory — finds zero references and validates zero of them,
 // which is indistinguishable from "everything resolves". 46+ references existed
-// when this landed; requiring 40 leaves room for deletions without letting a
-// wired-to-nothing scan pass.
+// when this landed and 402 do now; requiring 40 leaves room for deletions
+// without letting a wired-to-nothing scan pass.
+//
+// 🔴 IT IS A FLOOR AGAINST A DEAD SCAN, NOT A PIN, AND IT CANNOT SEE A PARTIAL
+// ONE. The line-wise scan this file shipped with lost twelve references and
+// still returned 390, so a floor of 40 said nothing about the twelve. Do not
+// read a comfortable margin here as evidence that the corpus is fully seen;
+// that claim rests on TestItemRefsSurviveLineWraps, not on this number.
 const minItemRefs = 40
 
 // itemHeadingRe matches a top-level numbered item in the list: `1. **…`.
@@ -164,6 +207,94 @@ type itemRef struct {
 	num  int
 }
 
+// refMarkerRe strips the leading comment marker off a line before it is joined
+// to its predecessor. `//` covers Go, `#` YAML, `*` a C-style block comment's
+// continuation. It is deliberately NOT extended to `-`: a markdown bullet starts
+// a new list item rather than continuing a wrapped sentence, and stripping it
+// would only make the merged-list-items residual noisier.
+var refMarkerRe = regexp.MustCompile(`^\s*(?://+|#+|\*)\s*`)
+
+// collapsedPara is one paragraph — a maximal run of non-blank lines — flattened
+// to a single whitespace-collapsed string, with enough provenance to map a match
+// back to the source line a maintainer has to open. Without that map the fix
+// would trade a blind spot for an unactionable failure message.
+type collapsedPara struct {
+	text     string
+	tokStart []int // byte offset in text where each token begins
+	tokLine  []int // 1-based source line each token came from
+}
+
+// lineAt maps a byte offset in the collapsed text back to a source line: the
+// line of the last token that begins at or before it.
+func (p collapsedPara) lineAt(off int) int {
+	i := sort.Search(len(p.tokStart), func(i int) bool { return p.tokStart[i] > off }) - 1
+	if i < 0 {
+		i = 0
+	}
+	if len(p.tokLine) == 0 {
+		return 1
+	}
+	return p.tokLine[i]
+}
+
+// collapseParagraphs is the inverse of a hard wrap. See the 🔴 section of this
+// file's doc comment for why a line-wise scan is not an option here.
+func collapseParagraphs(src string) []collapsedPara {
+	var out []collapsedPara
+	var b strings.Builder
+	var tokStart, tokLine []int
+
+	flush := func() {
+		if b.Len() > 0 {
+			out = append(out, collapsedPara{text: b.String(), tokStart: tokStart, tokLine: tokLine})
+		}
+		b.Reset()
+		tokStart, tokLine = nil, nil
+	}
+
+	for i, line := range strings.Split(src, "\n") {
+		fields := strings.Fields(refMarkerRe.ReplaceAllString(line, ""))
+		if len(fields) == 0 {
+			// A blank line (or a line that was nothing but a comment marker)
+			// ends the paragraph. Joining across one would merge unrelated
+			// prose, which is a widening this guard does not need.
+			flush()
+			continue
+		}
+		for _, f := range fields {
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			tokStart = append(tokStart, b.Len())
+			tokLine = append(tokLine, i+1)
+			b.WriteString(f)
+		}
+	}
+	flush()
+	return out
+}
+
+// refsIn returns every item number referenced in one collapsed paragraph,
+// attributed to the source line the reference STARTS on. It is the ONE matcher:
+// the collector and the wrap corpus both call it, so a narrowing fails the
+// corpus by name rather than silently shrinking the set the collector validates.
+func refsIn(p collapsedPara) []itemRef {
+	var out []itemRef
+	for _, loc := range itemRefRe.FindAllStringSubmatchIndex(p.text, -1) {
+		whole := p.text[loc[0]:loc[1]]
+		cluster := p.text[loc[2]:loc[3]]
+		line := p.lineAt(loc[0])
+		for _, ns := range numberRe.FindAllString(cluster, -1) {
+			n, err := strconv.Atoi(ns)
+			if err != nil {
+				continue
+			}
+			out = append(out, itemRef{line: line, text: strings.TrimSpace(whole), num: n})
+		}
+	}
+	return out
+}
+
 // collectItemRefs walks the repo from the module root (which `go test` makes the
 // working directory for this package) and returns every item number referenced.
 func collectItemRefs(t *testing.T) []itemRef {
@@ -188,20 +319,10 @@ func collectItemRefs(t *testing.T) []itemRef {
 			// silently validating a smaller corpus than the repo contains.
 			t.Fatalf("read %s: %v", path, readErr)
 		}
-		for i, line := range strings.Split(string(b), "\n") {
-			for _, m := range itemRefRe.FindAllStringSubmatch(line, -1) {
-				for _, ns := range numberRe.FindAllString(m[1], -1) {
-					n, convErr := strconv.Atoi(ns)
-					if convErr != nil {
-						continue
-					}
-					refs = append(refs, itemRef{
-						file: filepath.ToSlash(path),
-						line: i + 1,
-						text: strings.TrimSpace(m[0]),
-						num:  n,
-					})
-				}
+		for _, para := range collapseParagraphs(string(b)) {
+			for _, r := range refsIn(para) {
+				r.file = filepath.ToSlash(path)
+				refs = append(refs, r)
 			}
 		}
 		return nil
@@ -246,6 +367,97 @@ func TestAgentsItemCrossReferencesResolve(t *testing.T) {
 			len(bad), strings.Join(bad, "\n"))
 	}
 	t.Logf("validated %d item references against AGENTS.md items 1..%d", len(refs), count)
+}
+
+// TestItemRefsSurviveLineWraps is the negative control for the paragraph-wise
+// scan, and the direct analogue of agents_index_test.go's
+// TestIndexClausesSurviveLineWraps — the guard that already existed for the
+// index region and did not exist for the repo-wide walk, which is why this
+// blind spot outlived its own documentation.
+//
+// Every fixture is a reference split across a hard wrap in a shape this repo
+// actually produces, and every one of them yields an INCOMPLETE answer to a
+// per-line scan. Each case carries its own positive control proving that, so a
+// future implementation cannot satisfy this test by being lucky about where
+// today's references happen to wrap.
+func TestItemRefsSurviveLineWraps(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []int
+	}{
+		{"markdown wrap between the token and the number",
+			"every `--json` consumer groups on; and item\n24 covers the ONE transport predicate", []int{24}},
+		{"markdown wrap inside a list cluster",
+			"Items 18 and\n20 cover the checks telling an author", []int{18, 20}},
+		// A range is captured at its endpoints here; filling the interior is
+		// agents_index_test.go's expandItemCluster, deliberately not this
+		// guard's job (see the "two smaller limits" note above).
+		{"markdown wrap inside a range cluster",
+			"read path. Items 12–\n17, 19, 21 and 22 cover `civitai generate`", []int{12, 17, 19, 21, 22}},
+		{"go doc comment wrap, marker on the continuation line",
+			"// bullet (\"Read items 12–17, 19, 21\n//     and 22 before touching it\") is scoped", []int{12, 17, 19, 21, 22}},
+		{"go line comment wrap between the token and the number",
+			"\t// resolveProjectDir — see AGENTS.md item\n\t// 24 for why the walk lives in one place", []int{24}},
+		{"yaml comment wrap",
+			"# the ready-ack runtime guard, items\n# 11 and 18", []int{11, 18}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []int
+			for _, para := range collapseParagraphs(tc.in) {
+				for _, r := range refsIn(para) {
+					got = append(got, r.num)
+				}
+			}
+			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Errorf("paragraph-wise scan of %q\n got: %v\nwant: %v", tc.in, got, tc.want)
+			}
+
+			// POSITIVE CONTROL for the control. Prove the same input read line
+			// by line really does lose part of the reference, so this case is
+			// exercising the hazard it claims to rather than restating the
+			// happy path. Without it, a fixture that wraps somewhere harmless
+			// would sit here looking like coverage.
+			var perLine []int
+			for _, line := range strings.Split(tc.in, "\n") {
+				for _, m := range itemRefRe.FindAllStringSubmatch(line, -1) {
+					for _, ns := range numberRe.FindAllString(m[1], -1) {
+						n, _ := strconv.Atoi(ns)
+						perLine = append(perLine, n)
+					}
+				}
+			}
+			if fmt.Sprint(perLine) == fmt.Sprint(tc.want) {
+				t.Errorf("fixture %q is not a wrap hazard: a per-line scan already returns the full answer %v, so this case proves nothing",
+					tc.in, tc.want)
+			}
+		})
+	}
+}
+
+// TestItemRefsCarryTheLineTheyStartOn keeps the provenance map honest. A
+// paragraph-wise scan that reported every reference at the paragraph's first
+// line would pass TestItemRefsSurviveLineWraps unchanged while making every
+// failure message point at the wrong place — trading a blind spot for an
+// unactionable one, which is how a guard gets ignored rather than fixed.
+func TestItemRefsCarryTheLineTheyStartOn(t *testing.T) {
+	// Line 1 opens the paragraph; the reference begins on line 3 and its
+	// cluster finishes on line 4.
+	src := "a paragraph that opens here\nand continues without any reference\nbefore naming items 18 and\n20 across a wrap\n"
+	paras := collapseParagraphs(src)
+	if len(paras) != 1 {
+		t.Fatalf("expected 1 paragraph, got %d — the fixture is not exercising the mapper", len(paras))
+	}
+	refs := refsIn(paras[0])
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 references, got %d (%v)", len(refs), refs)
+	}
+	for _, r := range refs {
+		if r.line != 3 {
+			t.Errorf("reference to item %d attributed to line %d, want 3 (the line the reference STARTS on)", r.num, r.line)
+		}
+	}
 }
 
 // TestAgentsItemRefRegexMatchesTheSpellingsInUse is the NEGATIVE control for

--- a/claudedocs/decisions/10-dev-tunnel-embeddability.md
+++ b/claudedocs/decisions/10-dev-tunnel-embeddability.md
@@ -1,0 +1,119 @@
+# AGENTS.md item 10 — the dev-tunnel embeddability preflight WARNS and never blocks
+
+Evidence for item 10 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+10. **The `dev-tunnel` embeddability preflight WARNS and never blocks, and its
+    two halves have deliberately different evidentiary strength.**
+    `internal/devtunnel/embedcheck.go` catches the failure mode where the tunnel
+    is perfectly healthy but the browser refuses to run the app — the host
+    iframes the dev server sandboxed (`allow-scripts allow-forms`, no
+    `allow-same-origin`), so it runs at an opaque `null` origin.
+    `CheckEmbeddable` is **evidence**: it GETs `/@vite/client` with
+    `Origin: null` through the same `DialLocalDevServer` the proxy uses, and
+    reads real response headers. `CheckParentOrigins` is a **heuristic** —
+    `VITE_BLOCK_ALLOWED_PARENT_ORIGINS` is inlined into the bundle at transform
+    time and cannot be observed over HTTP, so it is a **vendored mirror** (one of
+    four — `schema/`, the slot registry, this, and item 11's ready-ack emitter):
+    `resolveViteEnv` reproduces Vite's dev env resolution, where `.env.<mode>`
+    beats `.env` and a REAL process env var beats every file (dotenv does not
+    overwrite existing vars) — getting that last rule backwards warns at authors
+    who exported the value in their shell. It is gated to dirs holding a manifest
+    AND a package.json depending on `@civitai/app-sdk`, because `dev-tunnel`
+    takes an explicit blockId and runs from anywhere. Neither check is ever
+    fatal: one HTTP response cannot rule out a proxy, a non-Vite dev server or a
+    deliberately exotic setup, and hard-failing would regress flows that work
+    today — so a check that cannot observe returns NO findings rather than
+    manufacturing advice. Measured on Vite **6.4.3 and 8.2.0 alike**: a stock dev
+    server answers a null-origin module fetch `200` with **no**
+    `Access-Control-Allow-Origin`, and 403s a `dev-*.civit.ai` Host. Two traps if
+    you touch it: the probe's baseline `Host` MUST be the real `host:port` (a
+    placeholder authority trips Vite's own DNS-rebinding check and manufactures
+    findings for a healthy server), and the CLI predicate is pinned to the
+    page-money template by the seam guards in
+    `internal/scaffold/dev_embed_contract_test.go`, which render the real
+    template, extract the values it emits and require the CLI's own check to
+    accept them — so drift on EITHER side fails loudly.
+    Four rules are counter-intuitive and were each measured after a first draft
+    got them wrong — every one produced a FALSE WARNING at a correctly configured
+    project, the worst outcome for advisory output because it teaches authors to
+    ignore it:
+    (a) **`frame-ancestors` OBSOLETES `X-Frame-Options`** (CSP L3) — when both are
+    present browsers enforce frame-ancestors and IGNORE XFO, so XFO is only
+    consulted when NO frame-ancestors directive is present. (b) **Only a 2xx
+    baseline is interpretable**: a 401/403/5xx came from something other than the
+    app (auth proxy, deny gate), so its headers say nothing — reading CORS off
+    one blamed healthy servers, and reading the follow-up 403 blamed
+    `allowedHosts` for a proxy that refuses everything identically. A 3xx is NOT
+    in that list: see (e). (c) **`'none'` is decisive only as the SOLE source**,
+    and every `Content-Security-Policy` header must be evaluated
+    (`Header.Values`, not `Get`) because policies combine restrictively.
+    (d) The **dotenv mirror is verified DIFFERENTIALLY against Vite's own
+    `loadEnv`**, not against assumptions. `KEY: value` is VERSION-DEPENDENT —
+    Vite 8 (dotenv 17) resolves it to nothing while Vite 6 (dotenv 16) accepts
+    it — and the mirror deliberately does not accept it, matching the `vite ^8`
+    that page-money pins; page-vite pins `vite ^6` but carries no SDK, so the
+    parent-origins check is gated off there and the divergence is unreachable.
+    Also established by that differential: an unresolved `${NOPE}` expands to the
+    EMPTY string rather than its own text; backtick quoting is supported; an
+    unquoted `#` starts a comment ANYWHERE, not only after a space; the mirror
+    MERGES every env file before expanding once (`.env` may define what
+    `.env.development` interpolates, and expanding per file resolved that to
+    nothing); a reference resolves against the PROCESS env before the file
+    values; `${X:-default}` is supported; and a self-reference (`K=${K}x`)
+    resolves to the process value or empty, which is what makes it terminate. If
+    you change the parser, re-run that differential — a same-process dotenv
+    harness silently CONTAMINATES itself, because dotenv-expand writes resolved
+    values into `process.env` and later cases then read the earlier answer.
+    (e) The 2xx gate must NOT be reached by refusing redirects. A Vite project
+    with a `base` path 404s `/@vite/client` and 302s `/`, so "don't follow
+    redirects" plus "only 2xx is interpretable" made a genuinely un-embeddable
+    server report CLEAN — the over-strict correction to (b). Same-host redirects
+    are followed (bounded) and the FINAL response is judged; a cross-host
+    Location is never followed, because the transport always dials the local dev
+    server and would just send someone else's Host to it. Two consequences that
+    are easy to get wrong: a 200 reached VIA a redirect is not evidence about the
+    path you asked for (`isVite` must re-check `finalPath`, or an SPA dev server
+    that bounces unknown paths to an index gets classified Vite and handed
+    vite.config.ts advice), and `net/http` DROPS a custom `Request.Host` across an
+    absolute redirect, which silently turns the tunnel-Host probe into an ordinary
+    loopback request unless it is re-applied.
+    🔴 **The findings are printed TWICE on purpose, and the duplicate is the
+    fix — not an oversight to collapse.** Printing them once, immediately before
+    the "open this URL" block, is the right placement — the last thing on screen
+    before the URL should be the reason the URL won't work — but insufficient,
+    because the readiness wait sits in front of it. Measured over three runs
+    against the live endpoint (#226): >60 s (killed), >3:00 (never resolved),
+    ~2:30–3:00 — and the 45-second run produced **zero** preflight output,
+    because the author killed an apparently-hung command. So the check with the
+    best diagnostics in the product was invisible to the user most likely to need
+    it: the silent failure it exists to end, reproduced by the placement meant to
+    fix it. Moving the print EARLIER just swaps which failure you get — on a slow
+    tunnel it scrolls away behind minutes of heartbeat lines. Hence both, and the
+    duplicate is the accepted cost. It was chosen over a "re-print only if the
+    wait was slow" threshold specifically because it carries **no timing
+    dependency**: nothing to tune, no clock to mock, and both placements are
+    pinned by ordering assertions against the injected `probePublic` seam rather
+    than by wall-clock timing. `--no-wait` is the ONE exception and it drops the
+    EARLY print, not the late one — there is no wait to scroll behind, so a
+    second copy would only duplicate an eight-line `vite.config.ts` block a few
+    seconds apart.
+    Related, same issue: the DNS-pending heartbeat's estimate is now the single
+    constant `dnsPublishNote`, shared by the TTY spinner and the non-TTY
+    heartbeat because they held two hand-copied copies of it. It used to say
+    "usually <1 min", which **0 of 3** measured runs met. An estimate the wait
+    routinely blows past is what makes a working command read as a hang — which
+    is what got the run killed in the first place — so it states a range and
+    says longer is normal. Three runs do not support a percentile; do not
+    replace it with one you have not measured.

--- a/claudedocs/decisions/19-img2img-workflow-and-upload.md
+++ b/claudedocs/decisions/19-img2img-workflow-and-upload.md
@@ -1,0 +1,126 @@
+# AGENTS.md item 19 — img2img — txt2img plus images[], --ecosystem, and no credential
+
+Evidence for item 19 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
+    `--ecosystem`, and uploads with NO credential — three things that each read
+    like a bug.**
+
+    (a) **The workflow value stays `txt2img`.** There is no `--workflow` flag and
+    `generateWorkflow` is still the constant `"txt2img"` even when `--image` is
+    present. The server does the promotion itself: `normalizeImageWorkflow`
+    (`civitai/civitai → src/server/services/orchestrator/orchestration-new.service.ts`)
+    rewrites `txt2img` + non-empty `images` to `img2img:edit` *before* graph
+    validation. Sending `img2img:edit` ourselves would mean vendoring which
+    ecosystems offer it (18 of them, gated by `isWorkflowAvailable`) — item 13's
+    prohibition exactly. `--input` still refuses a non-`txt2img` workflow, and
+    that refusal must stay.
+
+    (b) 🔴 **`--image` REFUSES to run without `--ecosystem`, and that refusal is
+    not the local validation item 13 forbids.** It checks a FLAG COMBINATION the
+    CLI owns; it asserts nothing about which ecosystems exist or what any of them
+    allows, and `--ecosystem` itself is passed through unexamined. It is a hard
+    error because without it the flag is a **guaranteed no-op that still
+    charges**: `normalizeImageWorkflow` reads `ecosystem` off the RAW request
+    body, *before* the graph applies its own ecosystem default, so an absent
+    ecosystem skips the promotion — and then the default ecosystem
+    (`ZImageTurbo`) has no `images` node at all, so the graph engine
+    (`data-graph.ts` `_evaluate` → `if (def.when === false)`) **deletes the key
+    with zero diagnostics** and `_buildValidationResult` records no error.
+    Measured against civitai.com: `{workflow:txt2img, images:[<real image>]}`
+    with no ecosystem priced **8** with factors `{base,pixels,steps,quantity}` —
+    byte-identical to the same graph carrying no images, HTTP 200 throughout.
+
+    🔴 **And the CLI still cannot tell you whether the promotion actually
+    fired.** The whatIf reply carries `{ready, cost, transactions,
+    allowMatureContent}` — plus, since item 21, `modelSubstitutions` — and no
+    detector — "did a `factors.images` key appear?" — is WRONG, and a
+    differential estimate ("does the price change when I add the images?") is
+    wrong the same way: measured, `Flux1Kontext`, `NanoBanana` and `Seedream`
+    are all genuinely edit-capable and all price **byte-identically with and
+    without images**, because their cost model is a flat `base`. Only `Qwen`
+    grows an `images` factor. So both detectors would refuse valid img2img on the
+    three most obvious edit ecosystems. **Do not add either one.** The command
+    prints an explicit caveat at the confirmation instead, which is the honest
+    answer: an ecosystem with no images node drops them and bills a plain
+    txt2img, and nothing observable distinguishes that from a real edit job.
+
+    (c) **The reference-image cap is ONE global ceiling (7), not a per-ecosystem
+    table — and the sub-ceiling gap is deliberate, not unfinished.** Real limits
+    span 1..7 and live only inside the per-engine graph files. The server's own
+    helper for this (`src/shared/data-graph/generation/images-limit.ts`) says in
+    its header that a flat constant "would simultaneously over-allow the 1-image
+    ecosystems and under-allow the 7-image ones" and that copying the spread
+    yields "a parallel table that rots the moment a graph file changes" — so it
+    instantiates the real graph. The CLI cannot, and `getImagesLimit` is not
+    exposed over any API, so there is no live lookup to make either. Above 7 the
+    array is truncated for *every* ecosystem, so refusing there cannot block a
+    valid request; below it the CLI genuinely does not know and warns instead.
+    🔴 The truncation is what makes this matter: `imagesNode`'s input transform
+    does `arr.slice(0, max)` **before** the output schema's `.max()` check, so an
+    over-limit list can never trip the server's own "Maximum N images allowed"
+    message — the extras are simply gone and the truncated job is billed.
+    Measured on `Qwen` (max 3): 4, 5, 6 and 12 images all priced 60 with an
+    identical `images: 1.2` factor, byte-identical to 3.
+
+    (d) **`GraphImage.Width`/`Height` are VALUE ints with no `omitempty`, which
+    contradicts item 14 on every other field.** Opposite situation: the server
+    *requires* both. The images node takes them as optional on INPUT and then
+    validates the transformed array against an output schema where both are
+    required numbers, so omitting them is a hard 400 — measured:
+    `images:[{"url":"…"}]` returns `Validation failed: images: Invalid input:
+    expected number, received undefined`. A **bare URL string** fails identically
+    even though the input union accepts one, because the transform turns it into
+    `{url}` with no dimensions. There is no server-side dimension probe on this
+    path (the only `getImageDimensions` is a browser `Image()` loader used by
+    React components). So there is no "unset" state to preserve, and `omitempty`
+    would additionally erase a legitimate 0.
+    Dimensions come from `image.DecodeConfig` — **header only, never `Decode`**,
+    which would materialise every pixel to learn two integers — and the upload's
+    Content-Type comes from the DECODED format, not the filename extension.
+
+    (e) 🔴 **The presigned upload carries NO credential, and item 17 carries the
+    full argument — read it there rather than re-deriving it here.**
+    `UploadPresigned` (`pkg/civitai/upload.go`) is a near-duplicate of
+    `DownloadPresigned` and will attract the same "fold it back in behind a
+    bool". The upload URL is **server-supplied** and lives on a `*.civitai.com`
+    host (observed: `orchestration-new.civitai.com`), which
+    `isTrustedDownloadHost` **matches**, so a token-carrying path would hand a
+    25-scope personal API key to a request its own signature already authorizes.
+    The WILDCARD is the load-bearing fact and the subdomain is incidental. Here
+    the safety is structural rather than conditional: the interface has no token
+    parameter and consults no `TokenSource`. `genapi.UploadImageBlob`'s two hops
+    differ on purpose — hop 1 (presign) is authed, hop 2 (upload) is not — and
+    the test asserts BOTH, since "hop 2 had no auth" alone cannot distinguish
+    correctness from a recorder wired to nothing.
+    Everything genuinely shared IS shared: `UploadPresigned` reuses
+    `downloadHTTPClient()` wholesale (SSRF dial guard, redirect policy,
+    `ResponseHeaderTimeout`) and the https check is the single
+    `requireHTTPSTransfer` predicate the download path also calls — the verb is a
+    message parameter, not a second implementation. Two details that are not
+    style: the method is **POST** (`POST /v2/consumer/blobs`, not PUT), and the
+    body is a `[]byte` rather than a reader so the request carries a real
+    `Content-Length` and is replayable.
+    One more: `getConsumerBlobUploadUrl` is **REST, not tRPC** — the one
+    generation-adjacent route that is. It is a plain GET returning a bare
+    `{uploadUrl, expiresAt}`, so it must never go through `unwrapTRPC`, and
+    reading item 12 as "everything here is tRPC" produces a 404.
+
+    (f) **`--dry-run` and `--print-input` DO upload local `--image` files.** An
+    estimate built on a graph with no `images[]` prices a plain txt2img, and
+    `--print-input` must emit a document `--input` can submit, which means real
+    blob URLs rather than local paths. An upload spends no Buzz, but it is a
+    network write — so `--print-input`'s "reaches no money seam" claim is still
+    true while its "no request at all" claim is not, with `--image`.

--- a/claudedocs/handoff-dogfood-2.md
+++ b/claudedocs/handoff-dogfood-2.md
@@ -248,12 +248,14 @@ ceiling. That is a design task, not a prompt.
    this for real: it drafted a new item (which would have been the 28th), found it did not fit, and correctly refused to fake an
    eviction (the playbook requires pinning a `sha256` at `agentsSplitBase`, where the new item
    never existed, so claiming a verbatim move would be false). Its rationale lives in code doc
-   comments instead. Closed by evicting BOTH items 10 and 19: 67,213 → 53,716 bytes, ceiling
-   re-pinned to 54,000.
+   comments instead. Closed by PR #305, which evicted BOTH items 10 and 19.
+   **The figures above are the pre-#297 state**; #297 then compressed the file to 67,213 and
+   lowered the ceiling to 67,500, and #305 took it from there to **53,950 bytes** (−13,263,
+   19.7%) with the ceiling re-pinned to **54,250** and `agentsMaxBytesCeiling` to **64,000**.
    🔴 **The parenthetical here — "both at the split base, so the playbook works" — was FALSE by
    the time it was read**, and it is left visible rather than deleted because it is the reason
-   that PR's shape changed. #297's compression pass had already rewritten both items (10 by 23
-   bytes, 19 by 78), so neither was byte-identical to `agentsSplitBase` and a digest taken there
+   that PR's shape changed. #297's compression pass had already rewritten both items (10 by 22
+   bytes, 19 by 77), so neither was byte-identical to `agentsSplitBase` and a digest taken there
    would have pinned text that was not what was moved. `agents_size_test.go` carried the same
    false claim in its own comment. The fix was a **per-item `base` field** on the splitItems
    table — a body's base commit is fixed at the moment it is evicted, and after wave 1 the nine

--- a/claudedocs/handoff-dogfood-2.md
+++ b/claudedocs/handoff-dogfood-2.md
@@ -243,14 +243,22 @@ ceiling. That is a design task, not a prompt.
 
 1. ~~**#283 + #285 as one small PR**~~ — **DONE**, and #284 came with them: PR #294 (`9862c1e`)
    shipped all three. Close the three issues; see the follow-ups table.
-2. 🔴 **`AGENTS.md` is 201 bytes from its hard ceiling** — 67,799 of 68,000
-   (`agents_size_test.go`). **The next person who needs an item cannot add one**, and #294 hit
+2. ✅ **DONE — `AGENTS.md` was 201 bytes from its hard ceiling** — 67,799 of 68,000
+   (`agents_size_test.go`). **The next person who needed an item could not add one**, and #294 hit
    this for real: it drafted a new item (which would have been the 28th), found it did not fit, and correctly refused to fake an
    eviction (the playbook requires pinning a `sha256` at `agentsSplitBase`, where the new item
    never existed, so claiming a verbatim move would be false). Its rationale lives in code doc
-   comments instead. Unblocking means deliberately evicting item 19 or 10 (~7.8 kB each, both
-   at the split base, so the playbook works) — a change on its own, never folded into an
-   unrelated PR.
+   comments instead. Closed by evicting BOTH items 10 and 19: 67,213 → 53,716 bytes, ceiling
+   re-pinned to 54,000.
+   🔴 **The parenthetical here — "both at the split base, so the playbook works" — was FALSE by
+   the time it was read**, and it is left visible rather than deleted because it is the reason
+   that PR's shape changed. #297's compression pass had already rewritten both items (10 by 23
+   bytes, 19 by 78), so neither was byte-identical to `agentsSplitBase` and a digest taken there
+   would have pinned text that was not what was moved. `agents_size_test.go` carried the same
+   false claim in its own comment. The fix was a **per-item `base` field** on the splitItems
+   table — a body's base commit is fixed at the moment it is evicted, and after wave 1 the nine
+   moved bodies do not exist in `AGENTS.md` at ANY later commit, so one global constant was
+   never going to survive a second wave.
 3. 🔴 **#267 shipped a breaking change under a `fix:` subject with no `!`.** It refuses
    non-ASCII names that previously scaffolded. `.goreleaser.yaml` filters release notes on
    subjects, so the `BREAKING CHANGE:` footer in the commit body will **not** surface. The

--- a/layout_ledger_test.go
+++ b/layout_ledger_test.go
@@ -73,9 +73,50 @@ const layoutMinPackages = 8
 // uses all three spellings.
 var internalPkgRe = regexp.MustCompile(`internal/(\{[^}]*\}|[a-z][a-z0-9_]*)`)
 
-// codeSpanRe matches a single-backtick code span. AGENTS.md uses no triple-backtick
-// fences inside the Layout section, so the simple form is sufficient there.
-var codeSpanRe = regexp.MustCompile("`([^`\n]+)`")
+// codeSpanRe matches a single-backtick code span. AGENTS.md uses no
+// triple-backtick fences inside the Layout section, so the simple form is
+// sufficient there.
+//
+// 🔴 IT ALLOWS ONE NEWLINE INSIDE THE SPAN, AND IT DID NOT FOR A RELEASE. The
+// Layout section is hard-wrapped at ~79 columns like the rest of the file, and
+// markdown lets a code span straddle a wrap (the line ending renders as a
+// space). A pattern that excluded `\n` therefore stopped seeing a span the
+// moment a reflow broke it — and the failure is SILENT IN THE DANGEROUS
+// DIRECTION: the package drops out of the ledgered set, and the guard then
+// reports "internal/<pkg> exists but the Layout section never names it" about a
+// bullet that is sitting right there. A maintainer meeting that message reads it
+// as a false positive and the cheapest fix is to delete the guard — which is the
+// outcome this file's own doc comment says a docs guard must never invite.
+// Worse, a span whose opening backtick lost its partner re-pairs with the NEXT
+// backtick on the line, so one wrap can also invent a span that was never
+// written.
+//
+// The newline is bounded to ONE on purpose. A span that wraps twice does not
+// occur in this section, and an unbounded `[^`]+` would let a single stray
+// backtick swallow whole paragraphs — which would satisfy the ledger from PROSE
+// and quietly repeal design decision 2, the rule that a name counts only inside
+// backticks. TestLayoutLedgerParserHandlesEverySpelling carries both the wrapped
+// spellings and that bound.
+var codeSpanRe = regexp.MustCompile("`([^`\n]+(?:\n[^`\n]+)?)`")
+
+// spanWhitespaceRe and afterInternalRe normalise a span that wrapped. Markdown
+// renders the line ending as a space, so the whitespace run (including the
+// continuation line's indent) collapses to one — which is all `internal/{a, b}`
+// needs, since the parser already accepts a space after the comma. The second
+// rule handles the harsher case where the break landed INSIDE the path
+// (`internal/` / `devtunnel`): a space there defeats internalPkgRe entirely, and
+// re-joining is unambiguous because no real package name begins with a space.
+var (
+	spanWhitespaceRe = regexp.MustCompile(`\s+`)
+	afterInternalRe  = regexp.MustCompile(`internal/\s+`)
+)
+
+// normaliseSpan undoes a hard wrap inside a code span. It is applied by
+// ledgeredPackages and by the spelling corpus alike, so a narrowing of it fails
+// the corpus by name instead of silently shrinking the ledger.
+func normaliseSpan(span string) string {
+	return afterInternalRe.ReplaceAllString(spanWhitespaceRe.ReplaceAllString(span, " "), "internal/")
+}
 
 func layoutSection(t *testing.T) string {
 	t.Helper()
@@ -122,14 +163,26 @@ func parseInternalRefs(span string, into map[string]bool) {
 	}
 }
 
+// parseLayoutPackages is the WHOLE extraction — find the code spans, undo any
+// hard wrap inside one, pull the package names out. It is the ONE pipeline: the
+// ledger and the spelling corpus both call it, so a narrowing anywhere along it
+// (the span pattern, the normaliser, the name regex) fails the corpus by name
+// rather than silently shrinking the ledger and blaming the filesystem. Splitting
+// the corpus off the first two stages is exactly how the newline blind spot
+// survived — the corpus tested parseInternalRefs alone, and the defect was in
+// the stage above it.
+func parseLayoutPackages(md string, into map[string]bool) {
+	for _, span := range codeSpanRe.FindAllStringSubmatch(md, -1) {
+		parseInternalRefs(normaliseSpan(span[1]), into)
+	}
+}
+
 // ledgeredPackages parses the package names the Layout section spells.
 func ledgeredPackages(t *testing.T) map[string]bool {
 	t.Helper()
 
 	got := map[string]bool{}
-	for _, span := range codeSpanRe.FindAllStringSubmatch(layoutSection(t), -1) {
-		parseInternalRefs(span[1], got)
-	}
+	parseLayoutPackages(layoutSection(t), got)
 	return got
 }
 
@@ -232,5 +285,85 @@ func TestLayoutLedgerParserHandlesEverySpelling(t *testing.T) {
 				t.Errorf("parsing %q: got %v, want %v", tc.span, sortedKeys(got), tc.want)
 			}
 		})
+	}
+}
+
+// TestLayoutLedgerSeesSpansThatWrap drives the FULL pipeline over markdown, not
+// just the name regex, because that is where the blind spot was: the corpus
+// above exercised parseInternalRefs and was serenely green while a code span
+// broken across a wrap was invisible to the stage in front of it.
+//
+// Each case carries its own positive control asserting that the single-line span
+// pattern this replaced really does lose the package — so a fixture that is not
+// actually a wrap hazard fails here instead of sitting in the table looking like
+// coverage.
+func TestLayoutLedgerSeesSpansThatWrap(t *testing.T) {
+	// singleLineSpanRe is the pattern that shipped: the control, kept here
+	// deliberately so the hazard is pinned rather than described.
+	singleLineSpanRe := regexp.MustCompile("`([^`\n]+)`")
+
+	for _, tc := range []struct {
+		name string
+		md   string
+		want []string
+	}{
+		{
+			"wrap between two names in one brace expansion",
+			"- `internal/{scaffold,validate,pkgzip,manifest,\n  config,auth}` — the building blocks.",
+			[]string{"auth", "config", "manifest", "pkgzip", "scaffold", "validate"},
+		},
+		{
+			"wrap after a comma-space inside a brace expansion",
+			"- `internal/{devtunnel, \n  dnsprobe}` — `app dev-tunnel`.",
+			[]string{"devtunnel", "dnsprobe"},
+		},
+		{
+			"wrap inside the path itself",
+			"- `internal/\n  blockproto` — the vendored ready-ack.",
+			[]string{"blockproto"},
+		},
+		{
+			"wrap between the path and its file suffix",
+			"- `internal/ui/\n  CONVENTION.md` is the rule set.",
+			[]string{"ui"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := map[string]bool{}
+			parseLayoutPackages(tc.md, got)
+			if strings.Join(sortedKeys(got), ",") != strings.Join(tc.want, ",") {
+				t.Errorf("parsing %q\n got: %v\nwant: %v", tc.md, sortedKeys(got), tc.want)
+			}
+
+			// POSITIVE CONTROL for the control.
+			old := map[string]bool{}
+			for _, span := range singleLineSpanRe.FindAllStringSubmatch(tc.md, -1) {
+				parseInternalRefs(normaliseSpan(span[1]), old)
+			}
+			if strings.Join(sortedKeys(old), ",") == strings.Join(tc.want, ",") {
+				t.Errorf("fixture %q is not a wrap hazard: the single-line span pattern already returns the full answer %v, so this case proves nothing",
+					tc.md, tc.want)
+			}
+		})
+	}
+}
+
+// TestLayoutCodeSpanBoundIsOneNewline pins the bound in design decision 2's
+// direction. An unbounded span pattern would let one stray backtick swallow
+// paragraphs of prose and satisfy the ledger from running text — repealing the
+// "backticks only" rule while every existing test stayed green, since widening
+// can only ever ADD names to the ledgered set and the ledger's growth direction
+// only fires on names that do not exist on disk.
+func TestLayoutCodeSpanBoundIsOneNewline(t *testing.T) {
+	// A lone backtick, then two paragraph breaks, then a closing backtick. A
+	// pattern allowing unlimited newlines pairs these and reads `internal/nope`
+	// out of the prose between them.
+	md := "an opening ` that never closes on its line\n\nprose naming internal/nope in running text\n\nand a stray ` much later"
+	got := map[string]bool{}
+	parseLayoutPackages(md, got)
+	if got["nope"] {
+		t.Errorf("the span pattern paired backticks across %d lines and read a package name out of PROSE. "+
+			"Design decision 2 says a name counts only inside a code span; an unbounded pattern repeals that silently.",
+			strings.Count(md, "\n")+1)
 	}
 }


### PR DESCRIPTION
`AGENTS.md` is imported wholesale by `CLAUDE.md` (`@AGENTS.md`), so every byte is paid on **every session**. #297 measured that compression is exhausted — a full lossless pass over every unsplit item recovered **586 bytes (0.86%)**, and an n-gram scan found only 23 repeated 7-grams in 67 kB. Eviction is the only lever with anything left in it.

## Before / after

| | bytes | tokens (~4 B/tok) |
|---|---|---|
| `origin/main` (5cb45f0) | 67,213 | ~16,800 |
| this branch | **53,950** | ~13,500 |
| saved | **13,263 (19.7%)** | **~3,300 per session** |

That is ~23x what the compression pass recovered, for the same file.

The ceiling moves with it: `agentsMaxBytes` **67,500 → 54,250** (300 bytes of headroom, the same deliberate tightness as the 287 it replaces), and `agentsMaxBytesCeiling` **80,000 → 64,000** — left at 80,000 it would sit ~48% above the achieved size, enough slack to re-inline both items just moved out and still pass, which is the "a ceiling nobody bounds" failure one level up.

## Line preservation

The move is **verbatim**. Neither body was retyped: both were sliced out of `git show <base>:AGENTS.md` by the same algorithm `baseItemBody()` uses, so "nothing was summarised" is true by construction rather than by care.

| item | evidence file | body lines | non-blank | sha256 (non-blank) |
|---|---|---|---|---|
| 10 | `claudedocs/decisions/10-dev-tunnel-embeddability.md` | 103 | 103 | `b2397598…cab3c` |
| 19 | `claudedocs/decisions/19-img2img-workflow-and-upload.md` | 110 | 103 | `0e1bd1bd…ef1ef` |

`TestEveryBaseBodyLineSurvivedTheMove` now line-differs **1,950 non-blank base lines across all 11 moved items**, 0 missing. Cross-checked independently with `diff` (a second tool that fails differently): the only difference from the base text is the trailing blank separator line — `104d103 < ` — with a positive control showing the same differ reports 213 differing lines between two *different* items.

Stubs are 12 and 11 lines including the pointer, matching the existing nine. Every `item 10` / `item 19` reference in the repo still resolves, including the sub-item ones (`19(a)`–`19(f)`), which now reach their text through the pointer exactly as items 3/11/18/20/21/23/24/26/27 already do.

## 🔴 The `agentsSplitBase` decision: per-item, and it could not be anything else

**The brief for this change said item 19 was still byte-identical to `agentsSplitBase`. It is not, and neither is item 10.** #297 rewrote both — item 10 by 22 bytes, item 19 by 77 (19(e) was the "one genuine cross-item duplication" that pass removed). `agents_size_test.go` asserted the same false thing in its own comment: *"both are byte-identical to agentsSplitBase, so their digests can be taken straight from `git show <base>:AGENTS.md`"*. Following that shortcut would have pinned text that was not what was being moved.

The obvious alternative — re-derive all eleven digests from one newer commit — is **impossible, not merely inconvenient**: after wave 1, `AGENTS.md` no longer *contains* the nine moved bodies at any commit. `baseItemBody(c5c3817+1, 3)` returns item 3's **stub**. A body's base commit is therefore fixed forever at the moment it was evicted, and different evictions have different moments. One global constant was an accident of there having been exactly one wave.

So `base` is a field on the `splitItems` row:

- rows 3, 11, 18, 20, 21, 23, 24, 26, 27 → `agentsSplitBase` (`c5c3817`, #290)
- rows 10, 19 → `agentsSplitBaseWave2` (`5cb45f0`, post-#297)

**The guard is not weakened** — each row is still compared against a specific immutable blob, and that is mutation-verified for all eleven, not just the two added. Two new controls come with the field: `baseDocFor()` fails loudly when a base is pointed *after* its own eviction (the body comes back as a stub, which would otherwise surface as an inscrutable digest mismatch instead of "you named the wrong commit"), and `TestSplitBasesAreWellFormed` runs in a shallow clone where the git-backed tests skip, rejecting an abbreviated base and a table fragmented across too many commits.

The old `len(doc) < 150_000` positive control had to go: wave 2's base is a *post*-split 67 kB commit, so that assertion would fail on a correct row. It is replaced by two controls true of any wave (the doc is a plausible AGENTS.md; the sliced body is a body, not a stub).

## Two guard blind spots, closed FIRST

#297's own edits introduced both, and all six guards missed them. A large text move is exactly what they would hide a defect in.

**1. `agents_xrefs_test.go` scanned line by line.** Every corpus it walks is hard-wrapped (AGENTS.md and the evidence files at ~79 columns, Go doc comments at ~77 after the `// `), so a reference straddling a break was invisible. Measured: the line-wise scan saw **390** references, the paragraph-wise scan sees **402** — **twelve lost across ten files**, four of them inside this suite's own siblings, and the `minItemRefs` floor of 40 is nowhere near tight enough to notice. This is the blind spot `agents_index_test.go` documents at length in its design decision 2 and had already fixed *for its own region* — the same rule regenerated at a second call site, which is why nobody caught it.

`collapseParagraphs` is the repair. Comment-marker stripping (`//`, `#`, `*`) is not cosmetic: without it `…21` / `// and 22` collapses to `21 // and 22` and the cluster still stops at 21, so it would have been half a fix on the Go corpus carrying most of these references. A token→line map keeps failures actionable (`TestItemRefsCarryTheLineTheyStartOn`).

**2. `layout_ledger_test.go` required a code span on one line.** A wrapped span drops the package from the ledgered set, which defeats the **stale-entry** direction silently — the `internal/api` shape #172 left behind, the exact bug this ledger exists to catch — and manufactures a false *"exists but the Layout section never names it"* on the other direction, which a maintainer most cheaply "fixes" by deleting the guard. Bounded to **one** newline on purpose: an unbounded `[^\`]+` would let one stray backtick swallow paragraphs and satisfy the ledger from **prose**, repealing design decision 2 while every existing test stayed green (`TestLayoutCodeSpanBoundIsOneNewline`).

## Item 8's stale ordinal

Item 8 said humanising the analytics labels *"would add a **THIRD** vendored mapping (alongside `schema/` and the slot registry)"*. Verified against the file rather than the brief: there are **four** mirrors — `schema/`, the slot registry, item 10's dev-tunnel dotenv mirror, item 11's ready-ack emitter (line 400 says "one of four", line 494 "the FOURTH", line 758 "all four"). Item 8 predates items 10 and 11 and nothing recounted it. Corrected to FIFTH with the full list, and the correction is recorded in the repo's retraction style rather than silently swapped.

`claudedocs/handoff-dogfood-2.md`'s open action #2 is marked done, and its own *"both at the split base, so the playbook works"* is left visible and marked false — it is the reason this PR's shape changed.

## Mutation matrix

`--- FAIL` leaves counted from output, never an exit code. **Every mutation checksum-gated**, so an edit that silently failed to apply cannot read as a survivor; each revert is checksum-verified too.

| # | mutation | repaired | control |
|---|---|---|---|
| M1 | wrapped **dangling** `item 99` in AGENTS.md | **1** | pre-fix scanner: **0** (390 refs, reference invisible) |
| M2a | wrapped **stale** ledger entry (`internal/api`) | **1** | pre-fix span pattern: **0** — the silent shape |
| M2b | wrapped **real** span (`internal/appapi`) | **0** (correct) | pre-fix span pattern: **1** — false positive at a documented package |
| M3a | evidence body line **DROPPED**, ×11 items | **4 each, 44 total** | — |
| M3b | evidence body line **REWORDED**, ×11 items | **4 each, 44 total** | — |
| M7 | base pointed *after* its own eviction (item 3 → wave-2 base) | **4** | fires the new STUB control by name |
| M8 | item 19 re-pointed at the wave-1 base (body exists, 78 B different) | **4** | — |
| M9 | abbreviated base sha | **1** | — |
| M4 | +400 bytes vs the new **54,250** ceiling | **1** | same +400 under the old 67,500: **0** — proves the re-pin fires, not the growth |
| M5 | `agentsMaxBytes` → 64,001 | **1** | anti-loosening bound |
| M6 | truncated AGENTS.md (12 bytes) | **1** | the **floor** fires, not the ceiling |

M3a/M3b are the load-bearing rows: **all eleven** split bodies still fail the guard when altered, in both the "dropped residual" and "summarised paragraph" shapes.

## Verification

- `make ci` — **18 ok packages, 0 `--- FAIL` leaves**, build succeeded.
- `make lint` — run separately (`make ci` omits it): **0 issues**. Note this config's zero does not cover staticcheck S1002.
- **Merged tree**: `origin/main` was re-fetched at commit time and is still `5cb45f0`, the commit this branch is based on — so the branch tip *is* the merged tree, and no integration merge was needed. Re-check before merging; main has moved several times today.
- All six AGENTS guards green: index, xrefs, size, evidence ledger, split-preserved, layout ledger.

---

## Addendum — a numbers correction (2nd commit, `dd8f296`)

Review caught this PR publishing four stale figures about **itself**, which is the defect class it exists to eliminate:

| where | said | ships |
|---|---|---|
| `handoff-dogfood-2.md` | 67,213 → **53,716** bytes | **53,950** |
| `handoff-dogfood-2.md` | ceiling **54,000** | **54,250** |
| handoff + `agents_size_test.go` + `agents_split_preserved_test.go` | "#297 rewrote both, **23** and **78** bytes" | **−22** and **−77** |
| `agents_size_test.go` | 80,000 would sit **~49%** above | **48.3%** |

The first two predate a late stub edit that added 234 bytes and were never re-derived. The 22/77 pair was off by one in *both* values (it came from a measurement including a trailing newline) and had propagated into three files by being copied rather than recomputed — the same inheritance failure, at a smaller scale.

Every figure is now re-derived from the tree (`wc -c`, the constants parsed out of the Go source, per-item deltas recomputed with the same slicer `baseItemBody()` uses). A harness prints each claim beside its computed value: **11/11 rows agree**. The handoff's arithmetic is also made followable — it opened on the pre-#297 state and jumped to a post-#297 number with no intermediate, so the chain is now explicit: 67,799/68,000 → #297 → 67,213/67,500 → #305 → 53,950/54,250.

No constant, digest, guard or evidence body changed, so the mutation matrix above still stands as measured.

**Merged-tree re-gate** against the new `origin/main` (`576e5d2`, #303): merged on a scratch branch (`25b88d0`) — `make ci` **18 ok packages, 0 `--- FAIL` leaves, 0 timeout panics**; `make lint` **0 issues**; AGENTS.md still 53,950 in the merged tree. `mergeable=MERGEABLE`.

---

## Addendum 2 — `build-test` failed in CI, and the fix is environment-independence (3rd commit, `b1de940`)

The 2nd commit went red on `build-test`, one of the five required contexts. Only the root package:

```
--- FAIL: TestEveryBaseBodyLineSurvivedTheMove
    CONTROL failure: the differ compared 0 lines, so its clean result says nothing
```

**The control was right.** It is the only reason this did not merge as a vacuous green.

**What I broke.** Before the per-item base, the whole test skipped at the **top** when the base blob was unreachable, so the zero-line control was never reached in a shallow clone. Making `base` per-row moved that skip **into the subtest** — which reads like a tidy-up and is not one. `actions/checkout@v4` clones at depth 1, so in CI every subtest skips, `total` stays 0, and the outer control fatals. This is precisely the trap PR #290 documented in this file's own header.

**Why I did not see it.** My `make ci` *and* my merged-tree gate were both full clones, where every blob resolves. "18 ok, 0 FAIL" was a true statement about an environment CI does not have. Reporting it as "no content problem" was also a straight violation of this repo's own check-reading rule — I read `mergeable` instead of the conclusions.

**The fix.** The skip is decided **before any comparison**, at the outer level, on whether any base resolves (`reachableBases()`, asked by both git-backed tests). The digests are untouched and remain the contract — they read the evidence files and need no git. **No workflow file is touched**; CI is not made to fetch full history.

The skip is also made strictly better than it was, because "unreachable" had two causes with opposite correct answers and the old code conflated them. `detectGitEnv()` asks `git rev-parse --is-shallow-repository`:

| environment | base unreachable means | answer |
|---|---|---|
| shallow clone / no git | absent by construction | **SKIP**, naming the environment |
| **full clone** | the sha is **wrong** | **FATAL** |

Previously a typo'd base sha on a developer machine degraded to a silent skip, retiring the differ with nothing to show for it.

### Measured in a real depth-1 clone

`git clone --depth 1 file://…`, `rev-parse --is-shallow-repository` = `true` — reproduced, not reasoned about:

| | root package | suite |
|---|---|---|
| before | **FAIL**, byte-identical to CI | 18 ok / 1 FAIL pkg |
| after | **ok** | **18 ok, 0 `--- FAIL`, 0 timeout panics** |

Both git-backed tests SKIP with the environment named; all 11 `TestSplitItemBodiesArePreservedVerbatim` subtests PASS.

### Mutation re-measured *in that shallow clone*

Where only the digests can catch it (checksum-gated, both loss shapes):

| shape | items killed | `--- FAIL` leaves each |
|---|---|---|
| body line **DROPPED** | **11/11** | 2 |
| body line **REWORDED** | **11/11** | 2 |

Two leaves rather than the full clone's four, because the differ correctly skips and the digest carries it alone — the designed division of labour.

And the new tri-state, same mutation in both environments:

| environment | base sha → all-zeros |
|---|---|
| full clone | **6 `--- FAIL` leaves** — "is NOT REACHABLE, and this is a full clone" |
| shallow clone | 0 FAIL, 2 SKIP |

### Re-verification

Merged tree (`origin/main` = `576e5d2`) checked in **both** environments: `make ci` 18 ok / 0 FAIL, `make lint` 0 issues, and a depth-1 clone of the merged tree also 18 ok / 0 FAIL / 0 timeout panics.

**All 12 checks hold a terminal conclusion, 0 failures**, including all five required contexts (`build-test`, `pins-vs-published`, `ready-ack-runtime`, `template-page-vite`, `scaffold-currency`). `mergeStateStatus` is now **CLEAN**.


🤖 Generated with [Claude Code](https://claude.com/claude-code)