### PR TITLE
docs(agents): evict items 9, 13, 17, 22 and 25 — 21.4% of AGENTS.md — and fix a playbook that ranked an already-split stub first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,55 +340,14 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
    `recordScopeInvocation` call sites, and note that `pending` is a "no id
    captured" sentinel — **not** a status.
 9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
-   redundant with `notOwned`.** The `App loads` section of `app metrics` is the
-   only part of the payload the server reads from **ClickHouse** (`blockRenders`)
-   rather than Postgres, so its store can be unconfigured, SLOW (the server-side
-   read is time-bounded and a timeout degrades to this flag) or down while every
-   other counter in the same response is genuinely measured. Hence the flag is
-   per-SECTION: flagging the whole payload would discard good data, and dropping
-   it would recreate the fabricated zero item 6 exists to prevent — an author
-   reading `Impressions 0` as "nobody looked at my app" when the truth is "we
-   could not ask". `printAppMetrics` therefore prints `unavailable` plus an
-   explicit caveat instead of any number, and `--json` passes the field through
-   while **still exiting 0**, so a script must branch on `views.unavailable`
-   exactly as it must already branch on `notOwned`. Whoever changes the server
-   payload has to keep the field
-   (`civitai/civitai → src/server/services/blocks/app-views.service.ts`).
-   🔴 `AppAnalytics.Views` is a **pointer** for the same reason and must stay
-   one: there are THREE states, not two — measured, unavailable, and *absent*
-   (a server predating the impressions reader omits the key). A value type
-   collapses "absent" into "measured zero", because `encoding/json` leaves the
-   zero value in place and the renderer then prints `Impressions 0`. That was
-   **measured, not theorised** — the value-typed version rendered exactly
-   `Impressions     0` for a payload with no `views` key. So `nil` means unknown
-   and renders like `unavailable`, never as `0`.
-   Related gotcha: unique viewers deliberately do **not** dedup on
-   `blockInstanceId`. Despite the name it is not per-mount — it is
-   `page_apb_<ULID>`, roughly one per app (measured on prod: 28 distinct ids
-   across 27 distinct apps) — so deduping on it would report ~1 viewer per app.
-   Anonymous rows all carry `userId = 0`, so the server sums distinct authed
-   `userId` with distinct anon `ip`.
-   🔴 **`installs` has a THIRD state too, and it is a different KIND of flag.**
-   `installs.notApplicable` means "the question does not apply", not "we could
-   not ask": a page app is stateless by design and has no install slot, so a
-   subscription record cannot exist for it. Rendering `0` there reads as "nobody
-   installed my app" when the truth is "installs do not exist for this app
-   type" — the same fabricated-zero class as items 6 and 9, from a third
-   direction. The distinction that matters when editing this: a TRUTHFUL zero
-   (an installable app nobody has installed yet) arrives with the flag ABSENT
-   and must keep printing `0`. The server owns that call — do NOT re-derive it
-   in the CLI from the counters, because `total == 0` is true in both states.
-   Measured on prod: every approved app is a page app (0 installs possible),
-   while the model-slot apps that CAN be installed hold real rows, so the two
-   populations are disjoint and the bare `0` was never a measurement of user
-   behaviour.
-   Two more things the label has to keep straight, both of which read wrong if
-   you shorten them: `AnonCount` is signed-out **LOADS**, not viewers, and is
-   NOT a subset of `UniqueViewers` — one anonymous visitor reloading ten times
-   is 10 there and 1 unique viewer, so it can legitimately be the larger number.
-   And the section is called **App loads**, not Views, because the server writes
-   a row even when a mount FAILS (a failed launch's only beacon) and the table
-   has no status column — so a permanently-broken app still reports loads.
+   redundant with `notOwned`.** The `App loads` section is the only part of the
+   payload the server reads from **ClickHouse** rather than Postgres, so its
+   store can be unconfigured, slow or down while every other counter in the
+   same response is genuinely measured — which is why the flag is per-SECTION.
+   🔴 `AppAnalytics.Views` is a **pointer** because there are THREE states, not
+   two, and `installs.notApplicable` is a third state of a different KIND. All
+   of it exists to stop the fabricated zero item 6 exists to prevent.
+   → evidence: claudedocs/decisions/09-views-unavailable-discriminator.md
 
 10. **The `dev-tunnel` embeddability preflight WARNS and never blocks, and its
     two halves have deliberately different evidentiary strength.**
@@ -441,45 +400,13 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 13. **The CLI deliberately validates NOTHING about the generation graph, and
     that is the feature.** `internal/genapi/graph.go` models a handful of fields
     and `--input` passes a caller's graph through byte-for-byte. It does not
-    vendor, and must never vendor: the ecosystem keys, the ~51 per-engine
-    graphs, the sampler enum, the resolution/aspect-ratio buckets, the
-    per-ecosystem defaults, the tier limits, or any cost table. The server
-    re-derives every one of them at submit time from state the CLI cannot see —
-    a caller's usable (non-disabled, non-memberOnly) ecosystem set, for one, so
-    even the *default* model differs between a free and a member account — so a
-    vendored copy buys no correctness, goes stale, and starts **refusing valid
-    new inputs**, which is worse than the gap it closes. This is the same
-    anti-mirror judgement as item 8, with money on it.
-    Two consequences that look like missing features:
-    (a) `KnownGraphKeys()` (`graph.go`) is derived by REFLECTION over the struct
-    tags, never hand-listed, and it answers *"does the CLI model this key?"* —
-    **not** *"does the server accept it?"*. `unknownKeyWarning`
-    (`internal/cmd/generate_input.go`) is worded to say exactly that and must
-    stay worded that way; a warning phrased as "invalid key" would be a
-    validation claim this CLI has no authority to make.
-    (b) The one bounded exception is `serverQuantityClamp` in
-    `internal/cmd/generate.go` — a **warn-only** constant, currently 10, that
-    **fails soft**: it warns and sends anyway. It exists because the server
-    silently CLAMPS an out-of-range quantity (measured: 10000 → 10, −5 → 1) with
-    no error, so a `--quantity 40` typo charges for 10 and gives the user no
-    signal at all. Because it only warns, a stale number produces a needless
-    note, never a blocked valid request. Do not promote it to validation, and do
-    not add siblings for the other clamped fields without the same fail-soft
-    shape.
-    **Live lookups are not mirrors**, which is why one is allowed:
-    `ResolveModelVersion` (`internal/genapi/versions.go`) resolves
-    `--checkpoint` / `--lora` ids against the existing public
-    `GET /api/v1/model-versions/{id}` before submitting. It is a round-trip, so
-    it carries no drift cost, and it buys two things nothing else can. A
-    **nonexistent** checkpoint id is otherwise accepted with HTTP 200, the
-    ecosystem default silently substituted, and **billed** (measured on one
-    ecosystem: the correct id priced 160, while a nonexistent id, a
-    foreign-ecosystem id, and no model at all ALL priced 60 — the server's own
-    comment says this correction is visible on-site and invisible through a
-    non-browser path). And `Graph.Resources` entries **require** `model:{type}`,
-    which is not derivable from a version id — a bare id and `{id}` alone are
-    both 400s, while a *wrong* type is silently accepted. The type must come
-    from the lookup, never a guess.
+    vendor, and must never vendor, the ecosystem keys, the ~51 per-engine
+    graphs, the sampler enum, the buckets, the per-ecosystem defaults, the tier
+    limits or any cost table: the server re-derives every one of them from state
+    the CLI cannot see, so a vendored copy buys no correctness and starts
+    **refusing valid new inputs**. Live lookups are not mirrors, which is why
+    `ResolveModelVersion` is allowed.
+    → evidence: claudedocs/decisions/13-generation-graph-not-validated.md
 
 14. **Unset flags must be ABSENT from the payload, never Go zero values.** Every
     optional field on `genapi.Graph` is a pointer or carries `omitempty`. This
@@ -557,38 +484,13 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 
 17. **`DownloadPresigned` exists so a blob fetch carries NO credential, and it is
     the thing in this feature most likely to be "simplified" away.** It is a
-    near-duplicate of `DownloadFile` in `pkg/civitai/download.go` differing only
-    in passing an empty token, and every instinct says to fold it back in behind
-    a bool. 🔴 Doing that leaks a full-scope personal API key.
-    `isTrustedDownloadHost` attaches the bearer token to `civitai.com` and to
-    **any** `*.civitai.com` subdomain — correct for the model-download route it
-    was written for — and orchestrator output blobs are served from a
-    `*.civitai.com` host (observed: `orchestration-new.civitai.com`), which
-    **matches**. So `DownloadFile` would send a 25-scope key (including
-    `ModelsDelete` and `VaultWrite`) to the orchestrator, on a request already
-    authorized by its own signature that needs no token whatsoever.
-    🔴 **The specific subdomain is incidental to the argument, and must not be
-    written as if it were the load-bearing fact.** An earlier revision of this
-    item named `orchestration.civitai.com`; the host observed in a real upload
-    reply is `orchestration-new.civitai.com`. BOTH match the `*.civitai.com`
-    wildcard, so the credential-free seam is required either way — which is why
-    the reasoning is stated over the wildcard rather than over a hostname a
-    server-side rename can invalidate. Do not "fix" this seam because the
-    subdomain you see does not match the one written here.
-    Weakening `isTrustedDownloadHost` is not the alternative: `civitai download`
-    depends on it attaching the token. The fix is a **seam that never has a
-    credential to attach** — `DownloadPresigned` passes `""` to `doDownload`,
-    whose guard is `token != "" && isTrustedDownloadHost(...)`, so the empty
-    token short-circuits before the host predicate is consulted. That ordering is
-    deliberate: it cannot be defeated by a change to the predicate. Everything
-    genuinely shared is still shared — the SSRF dial guard, the
-    https-per-redirect-hop policy and 10-hop cap, the `ResponseHeaderTimeout` —
-    so there is no duplicated security logic to drift. It also skips the
-    401-refresh replay on purpose: there is no credential to refresh, and a 401
-    from a presigned URL means the signature is wrong or **expired**, which a
-    token would not fix. `internal/cmd/generate.go` wires
-    `deps.downloadBlob = reader.DownloadPresigned`; if you ever see that wired to
-    `DownloadFile`, it is a credential leak, not a cleanup.
+    near-duplicate of `DownloadFile` differing only in passing an empty token,
+    and every instinct says to fold it back in behind a bool. 🔴 Doing that
+    leaks a full-scope personal API key: `isTrustedDownloadHost` attaches the
+    token to **any** `*.civitai.com` subdomain, which is where orchestrator
+    output blobs live. The fix is a seam that never HAS a credential to attach —
+    the empty token short-circuits before the host predicate is consulted.
+    → evidence: claudedocs/decisions/17-download-presigned-no-credential.md
 
 18. **The ready-ack checks for EXISTING apps are two deliberately different
     tiers, and neither is allowed to be a hard failure.** #206 fixed the
@@ -635,51 +537,15 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 
 22. **`--input` refuses every workflow but `txt2img`, and that refusal is NOT the
     local validation item 13 forbids — it is a CONTENT-AUDIT gate over a
-    CONFIRMED server-side gap.** This is the item most likely to be read as an
-    unfinished feature, because item 13 says in bold that the CLI validates
-    nothing about the graph and `--input` exists precisely to pass one through
-    untouched. The reconciliation: item 13 forbids reproducing the server's
-    *judgement* about which graphs are valid, and this check makes no such
-    claim — it is the same shape as item 19(b), a flag combination the CLI owns,
-    asserting nothing about which ecosystems exist or what any of them allows.
-
-    🔴 **THE GAP IS CONFIRMED, NOT SUSPECTED, AND A PRIOR SESSION RECORDED THE
-    OPPOSITE.** The server audits at `'prompt' in data && typeof data.prompt ===
-    'string'` (`orchestration-new.service.ts:1460`) over a `data` REBUILT FROM
-    DECLARED GRAPH NODES ONLY. An earlier revision of the code comment called
-    exploitability an open question; a later handoff went further and wrote
-    "ruled out — no known bypass", reasoning that graphs lacking a `prompt` node
-    *compose* a shared `promptGraph`. True of the image graphs, and false as a
-    generalisation — it says nothing about graphs that opt out of the shared node
-    names. Verified at `civitai@a7e0bcd668`, two shipped ecosystems do:
-    **Hunyuan3D declares no `prompt` node at all**, only `hunyuanPrompt`
-    (`hunyuan3d-graph.ts:71`, prefixed because the bare names "collide with the
-    standard image Controllers in `GenerationForm.tsx`"), so the audit never runs
-    — and the handler then maps it back for the generator,
-    `prompt: hunyuanPrompt ? hunyuanPrompt : undefined`
-    (`hunyuan3d-graph.handler.ts:58`). **PolyGen's `texturePrompt`**
-    (`polygen-graph.ts:162`) is covered by no audit block at all, and on
-    `img2model3d` is the only text in the request because that workflow's
-    `prompt` node is gated `when: workflow.startsWith('txt')` and is deleted.
-    Sweep basis: all 79 declared node keys under
-    `src/shared/data-graph/generation`, every node whose input is a bare
-    `z.string()`. Note both are MULTI-LINE `.node(\n  'name',` declarations that
-    a single-line grep misses. Tracked at civitai/civitai#3667.
-
-    🔴 **KEEP THE CLAIM THIS SIZE — the overclaim and the dismissal are both
-    available and both wrong.** The CLI is not what holds the line: the same
-    fields are reachable from the first-party form and from any direct tRPC
-    caller with a personal API key, so the gate stops accidents, not adversaries.
-    That is an argument for fixing the platform, **not** for opening `--input`.
-    What the gate buys is that we do not add a second client to a confirmed
-    unaudited path while it is open. Equally, no live generation probe has been
-    run — this is reachability by code path, not a demonstrated exploit, and
-    writing it up as a shipped vulnerability would be the overclaim.
-
-    **Lift it when the server closes the coverage, not when the next workflow
-    looks like it would work.** Unblocking the other ~50 ecosystems through
-    `--input` is the single biggest capability unlock left in this command, which
-    is exactly why the bar is written down rather than left to judgement.
+    CONFIRMED server-side gap.** Item 13 forbids reproducing the server's
+    *judgement* about which graphs are valid; this claims nothing of the kind,
+    and is the same shape as item 19(b) — a flag combination the CLI owns.
+    🔴 The gap is confirmed, not suspected: two shipped ecosystems declare
+    prompt nodes the audit never runs over (civitai/civitai#3667). Keep the
+    claim that size — the gate stops accidents, not adversaries — and lift it
+    when the server closes the coverage, not when the next workflow looks like
+    it would work.
+    → evidence: claudedocs/decisions/22-input-refuses-non-txt2img.md
 23. **A validation finding is a `Finding{Field, Message}`, and the Field is
     carried from the CHECK — never re-derived at the printer.** `validate.Result`
     holds `[]Finding`, not `[]string`. This looks like ceremony around what used
@@ -701,39 +567,13 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
 25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,
     and must NOT become a local check.** `civitai app listing set-icon` /
     `set-cover` / `add-screenshot` validate the **format** and the **byte size**
-    of the source file (`maxIconBytes` / `maxCoverBytes` /
-    `maxScreenshotBytes`) and nothing else. The platform additionally enforces a
-    per-kind aspect range and a minimum dimension at ATTACH time
-    (`civitai/civitai → src/server/schema/blocks/app-listing.schema.ts`,
-    `validateListingImage`), returning a `BAD_REQUEST` that names the bound and
-    the measured value. Those numbers are documented in README →
-    *Listing media requirements* and in the scaffolded `assets/README.md`, and
-    that is deliberately as far as they go.
-    - **Why prose and not a check.** This is item 4's argument, applied to a
-      different constant set: stale *guidance* costs one round-trip carrying the
-      server's current bound, while a stale *gate* refuses valid images and the
-      author cannot override it. A local dimension check would also have to
-      re-derive the icon rescale below to avoid being wrong on day one. So do
-      not add a `LISTING_ICON_ASPECT_MIN` to `internal/cmd`, and do not "fix"
-      the docs by promoting the table into `internal/validate`. The CLI already
-      decodes width/height (`appapi.DecodeImageInfo`) — the omission is a
-      decision, not a missing feature.
-    - **The icon byte cap and the server's icon byte cap measure DIFFERENT
-      bytes, and the docs must not conflate them.** `maxIconBytes` (2 MiB) is
-      the SOURCE file, mirroring the server's `INLINE_ICON_MAX_DECODED_BYTES`
-      on the data-URI path the icon rides. The listing schema's
-      `MAX_LISTING_ICON_SIZE_BYTES` (1 MiB) is checked against
-      `Image.metadata.size`, which for that path is the byte length of the
-      **re-encoded** PNG the server produces after downscaling to ≤1024 px on
-      the longer side (`listing-meta.service.ts`) — not the file the author
-      passed. Cover and screenshot take the full-res path, where the CLI sends
-      `sizeBytes: len(data)`, so there the two caps DO describe the same bytes.
-    - **Never scaffold a placeholder icon or cover.** A placeholder passes every
-      format and byte check and uploads cleanly, so it can reach a public store
-      listing; a missing file fails loudly at the step that can still fix it.
-      `assets/` therefore ships with a README and no images, and
-      `internal/scaffold/assets_dir_test.go` fails if an image file appears
-      under it.
+    of the source file and nothing else; the platform enforces a per-kind aspect
+    range and a minimum dimension at ATTACH time. This is item 4's argument
+    applied to a different constant set: stale *guidance* costs one round-trip,
+    while a stale *gate* refuses valid images and the author cannot override it.
+    🔴 Never scaffold a placeholder icon or cover — it passes every check and can
+    reach a public store listing.
+    → evidence: claudedocs/decisions/25-listing-media-bounds.md
 
 26. **`civitai app validate <dir>` / `app submit <dir>` CLASSIFY THE PATH THE
     USER NAMED BEFORE VALIDATING ANYTHING, and that gate is deliberately NOT

--- a/agents_evidence_test.go
+++ b/agents_evidence_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AGENTS.md's numbered list is loaded into every session through CLAUDE.md's
-// `@AGENTS.md` import, so its size is a per-session cost. The nine largest items
+// `@AGENTS.md` import, so its size is a per-session cost. The largest items
 // keep their THESIS in AGENTS.md and have their bodies — the RSS tables, the
 // mutation matrices, the retractions, the enumerated residuals — in
 // `claudedocs/decisions/NN-<slug>.md`, reached through a `→ evidence: <path>`
@@ -48,10 +48,14 @@ const evidenceDir = "claudedocs/decisions"
 // minEvidencePointers is the POSITIVE CONTROL. Without it, a pointer regex that
 // has stopped matching — a changed arrow glyph, a reflowed line, a wrong working
 // directory — finds zero pointers, compares the empty set with an empty
-// expectation and reports a serene pass while the ledger checks nothing. Nine
-// items are split today; 5 leaves room for re-inlining a couple without letting
-// a wired-to-nothing scan through.
-const minEvidencePointers = 5
+// expectation and reports a serene pass while the ledger checks nothing.
+//
+// It rises with each wave, or it stops being a control. Sixteen items are split
+// today; a floor of 5 was set when nine were, and against sixteen it would let a
+// regex that had lost TWO THIRDS of the corpus through — the "comfortable
+// margin" the sibling xrefs guard warns is not evidence of a healthy scan. 10
+// leaves room to re-inline six without weakening the control that far.
+const minEvidencePointers = 10
 
 // evidencePointerRe matches the pointer line a stub ends with. The path is
 // captured as a non-space run, so a pointer that has been wrapped across a line
@@ -221,8 +225,8 @@ func TestEvidencePointersAndFilesAreTheSameSet(t *testing.T) {
 // This is the guard against the failure mode the split most invites — replacing
 // an item with a bare "see the evidence file". A reader deciding whether an item
 // bears on the change they are making must be able to decide it from AGENTS.md;
-// a pointer alone forces nine file reads per session, which is worse than the
-// cost the split removed.
+// a pointer alone forces one file read per split item per session — sixteen of
+// them now — which is worse than the cost the split removed.
 func TestEvidenceStubsCarryAThesisAndAPointer(t *testing.T) {
 	b, err := os.ReadFile("AGENTS.md")
 	if err != nil {

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -36,31 +36,44 @@ import (
 
 // agentsMaxBytes is the ceiling on AGENTS.md.
 //
-// Achieved size: 53,950 bytes, after wave 2 of the evidence split moved items 10
-// and 19 out (13,263 bytes net, 19.7% of the file, in one change). The ceiling is
-// 54,250 — 300 bytes of headroom, the same deliberate tightness as the 287 it
-// replaces and for the same measured reason.
+// Achieved size: 42,635 bytes, after wave 3 of the evidence split moved items 9,
+// 13, 17, 22 and 25 out (11,596 bytes net, 21.4% of the file, in one change).
+// The ceiling is 45,135 — 2,500 bytes of headroom.
 //
-// 🔴 THE HEADROOM IS SMALL BECAUSE SQUEEZING IS NO LONGER AN OPTION. An earlier
-// number assumed that when the file got close, prose could be tightened to make
-// room. That was measured and it is false: a full lossless compression pass over
-// every unsplit item and every prose section recovered 586 bytes — 0.86% — and
-// most of that came from ONE genuine cross-item duplication (item 19(e) restated
-// item 17's credential argument in full). Mechanically the file held only 23
-// repeated 7-word n-grams in 67 kB, every one a deliberate parallel construction
-// rather than accidental redundancy. The prose is at its floor; EVICTION is the
-// only lever with anything left in it, and wave 2 recovered ~25x what the
-// compression pass did.
+// 🔴 THE HEADROOM IS A BUDGET FOR ORDINARY EDITS, AND THE TWO NUMBERS BEFORE IT
+// WERE NOT. 287 bytes, then 300: each evaporated on the very next commit that
+// touched this file (#308 consumed 94% of the 300, leaving 19), and a ceiling
+// with 19 bytes under it is indistinguishable from a frozen file. It converts
+// every routine correction into an eviction project, which is a much worse
+// failure than the one the ceiling exists to prevent — the guard stops being a
+// budget and becomes a reason not to fix the docs.
 //
-// So headroom here does not mean "slack to grow into". It means: THE BUDGET
-// BEFORE AN EVICTION IS MANDATORY.
+// 2,500 is DERIVED, not picked. Measured over the last 40 commits touching
+// AGENTS.md, the ten docs-only ones changed it by +70, +245, +281, +1,337,
+// +1,456, +2,371, +2,760, +2,890, +3,399 and +3,474 bytes — median 1,913. So
+// 2,500 buys roughly ONE median docs-only correction, or two or three small
+// ones, or one retraction paragraph (300–800 bytes, measured on the ones in the
+// file) plus change.
 //
-//   - 300 bytes absorbs a re-measured number or a corrected sentence.
-//   - It does NOT absorb a new retraction paragraph (300–800 bytes), a new stub
-//     (~600–700), or a new item written as a full body (8.5–28 kB).
-//   - Anything in that second list must be paid for by MOVING a body out, not by
-//     raising this constant. The failure message prints the eviction playbook and
-//     ranks the candidates.
+// What it deliberately does NOT buy:
+//
+//   - A new item written as a full body. The modern ones run 1.5–3.7 kB inline
+//     and the largest evicted bodies were 8.5–28 kB, so a new decision still has
+//     to be paid for by MOVING one out, which is the whole point.
+//   - Re-inlining this wave's work. Restoring item 9, 13 or 22 costs 2,284–3,035
+//     bytes net and breaks this ceiling on its own. (Items 17 and 25 are the two
+//     cheapest at 1,868 and 1,857, and would fit — that is the honest cost of a
+//     headroom big enough to be useful, and it is what agentsMaxBytesCeiling is
+//     sized to bound.)
+//
+// 🔴 SQUEEZING IS STILL NOT AN OPTION, which is why the budget has to be real
+// rather than aspirational. A full lossless compression pass over every unsplit
+// item and every prose section recovered 586 bytes — 0.86% — most of it from ONE
+// genuine cross-item duplication (item 19(e) restated item 17's credential
+// argument in full). Mechanically the file held only 23 repeated 7-word n-grams
+// in 67 kB, every one a deliberate parallel construction rather than accidental
+// redundancy. EVICTION is the only lever with anything left in it: wave 2
+// recovered ~23x what the compression pass did and wave 3 ~20x.
 //
 // 🔴 THE CANDIDATE LIST THAT USED TO SIT HERE IS DELETED RATHER THAN UPDATED,
 // AND THAT IS THE LESSON. It named items 10 and 19 with their byte sizes and
@@ -74,20 +87,27 @@ import (
 // cannot rot. Do not reintroduce one here.
 //
 // Do not raise this to make a large item fit. Split the item.
-const agentsMaxBytes = 54_250
+const agentsMaxBytes = 45_135
 
-// agentsMaxBytesCeiling bounds agentsMaxBytes itself. 64,000 is ~19% above the
-// achieved size: past that the numbered list is back to being a per-session cost
-// large enough that the split bought nothing, so raising agentsMaxBytes beyond
-// it is a decision about the whole approach, not a bump.
+// agentsMaxBytesCeiling bounds agentsMaxBytes itself, so the budget above cannot
+// be turned into unlimited slack by editing one number.
+//
+// 48,600 is ~14% above the achieved size, and it is chosen against a property
+// that can be re-derived rather than a round percentage: re-inlining any THREE
+// of wave 3's five bodies costs at least 6,009 bytes net, landing at 48,644 —
+// just above this bound. So agentsMaxBytes cannot be raised far enough to undo
+// the majority of this wave without a second, deliberate, reviewable edit to
+// this constant. (Any two of them, at 3,725–5,587 net, would still fit; a bound
+// tight enough to block a pair would sit 1,165 bytes above agentsMaxBytes and
+// leave the next wave no room to re-derive anything.)
 //
 // 🔴 IT MOVES DOWN WITH THE ACHIEVED SIZE, OR IT STOPS BOUNDING ANYTHING. Left
-// at the 80,000 that was ~19% above the PRE-wave-2 size, it would sit ~48% above
-// the achieved one — enough slack to re-inline both items just moved out and
-// still pass, which is the same "a ceiling nobody bounds" failure one level up.
-// Whoever completes the next wave re-derives this from the new achieved size in
-// the same commit.
-const agentsMaxBytesCeiling = 64_000
+// at the 64,000 that was ~19% above the PRE-wave-3 size, it would sit ~50% above
+// the achieved one — enough slack to re-inline all five items just moved out
+// (54,231) and still pass, which is the same "a ceiling nobody bounds" failure
+// one level up. Whoever completes the next wave re-derives this from the new
+// achieved size in the same commit.
+const agentsMaxBytesCeiling = 48_600
 
 // agentsMinBytes is the POSITIVE CONTROL. A truncated, empty or wrongly-located
 // AGENTS.md is comfortably under any ceiling, and "0 bytes, well within budget"
@@ -102,6 +122,17 @@ var evidencePathRe = regexp.MustCompile(`→ evidence: \S+`)
 
 // agentsItemSizes returns each item's byte size in AGENTS.md, largest first,
 // together with whether it already has an evidence pointer.
+//
+// 🔴 THE LAST ITEM ENDS AT THE LIST, NOT AT THE END OF THE FILE, AND FORGETTING
+// THAT MADE THE PLAYBOOK RANK A STUB FIRST. There is no item heading after the
+// final one, so a naive slice runs to EOF and swallows the closing
+// vendored-mirrors paragraph plus the Permission boundaries, Release process and
+// License sections. Measured on the wave-3 tree: item 27 is a 683-byte STUB and
+// was reported at 4,789 bytes — 7x its real size, and top of the ranking, so the
+// first advice a maintainer got at the ceiling was to evict something already
+// evicted. The cut is the same one baseItemBody in agents_split_preserved_test.go
+// already applies: stop at the first line that leaves the list's indentation.
+// TestEvictionPlaybookSizesTheLastItemCorrectly pins it.
 func agentsItemSizes(t *testing.T) []struct {
 	num    int
 	bytes  int
@@ -140,7 +171,19 @@ func agentsItemSizes(t *testing.T) []struct {
 		if idx+1 < len(heads) {
 			end = heads[idx+1].line
 		}
-		block := strings.Join(lines[h.line:end], "\n")
+		item := lines[h.line:end]
+		// See the 🔴 note above: the final item has no following heading, so it
+		// is bounded by the first line that leaves the list's indentation.
+		for i, l := range item {
+			if i > 0 && l != "" && !strings.HasPrefix(l, " ") {
+				item = item[:i]
+				break
+			}
+		}
+		for len(item) > 0 && strings.TrimSpace(item[len(item)-1]) == "" {
+			item = item[:len(item)-1]
+		}
+		block := strings.Join(item, "\n")
 		out = append(out, struct {
 			num    int
 			bytes  int
@@ -219,6 +262,80 @@ func TestAgentsMDStaysUnderItsCeiling(t *testing.T) {
 			size, agentsMaxBytes, size-agentsMaxBytes, evictionPlaybook(t, size))
 	}
 	t.Logf("AGENTS.md is %d bytes, %d under the %d-byte ceiling", size, agentsMaxBytes-size, agentsMaxBytes)
+}
+
+// TestEvictionPlaybookSizesTheLastItemCorrectly pins the fix described in
+// agentsItemSizes' 🔴 note, and pins it as a SEAM rather than as a number.
+//
+// Two slicers in this package answer "where does item N end": agentsItemSizes
+// (which decides what the ceiling failure tells a maintainer to evict) and
+// baseItemBody (which decides what the verbatim digest covers). They had
+// diverged on exactly one input — the final item, which has no following heading
+// — and the divergence was invisible because each looked right on its own. So
+// the assertion is that they AGREE, for every item, which is the property that
+// was actually broken. A hardcoded size for whichever item is currently last
+// would go stale the day the next one is appended — and could not even be
+// written here, since the repo-wide xrefs guard reads this file and would flag
+// the number as a dangling reference.
+func TestEvictionPlaybookSizesTheLastItemCorrectly(t *testing.T) {
+	b, err := os.ReadFile("AGENTS.md")
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	doc := string(b)
+	sizes := agentsItemSizes(t)
+	if len(sizes) < minAgentsItems {
+		t.Fatalf("CONTROL failure: agentsItemSizes returned %d item(s), want >= %d — it is not seeing the list",
+			len(sizes), minAgentsItems)
+	}
+
+	last := 0
+	for _, s := range sizes {
+		if s.num > last {
+			last = s.num
+		}
+	}
+	for _, s := range sizes {
+		want := len(strings.Join(baseItemBody(t, doc, s.num), "\n"))
+		if s.bytes != want {
+			t.Errorf("item %d: the playbook measures %d bytes, baseItemBody slices %d (delta %+d).\n"+
+				"The two slicers disagree about where this item ends. Whichever is wrong, the cost is real: the playbook's number "+
+				"is the ranking a maintainer evicts by, and baseItemBody's slice is what the verbatim digest covers.",
+				s.num, s.bytes, want, s.bytes-want)
+		}
+	}
+
+	// POSITIVE CONTROL. The agreement above is only evidence if the last item is
+	// genuinely the hazard case — i.e. if a naive to-EOF slice really would
+	// swallow the sections below the list. Without this, a document whose final
+	// item happened to sit at EOF would satisfy the loop while proving nothing.
+	lines := strings.Split(doc, "\n")
+	start := -1
+	for i, l := range lines {
+		if m := itemHeadingRe.FindStringSubmatch(l); m != nil {
+			if n, _ := strconv.Atoi(m[1]); n == last {
+				start = i
+			}
+		}
+	}
+	if start < 0 {
+		t.Fatalf("CONTROL failure: item %d's heading was not found", last)
+	}
+	naive := strings.Join(lines[start:], "\n")
+	if !strings.Contains(naive, "\n## ") {
+		t.Fatalf("CONTROL failure, not a finding: a naive to-EOF slice of the last item (%d) contains no `## ` heading, "+
+			"so this test is not exercising the over-count it exists to pin. AGENTS.md's structure changed; re-derive the control.", last)
+	}
+	for _, s := range sizes {
+		if s.num != last {
+			continue
+		}
+		if strings.Contains(naive[:s.bytes], "\n## ") {
+			t.Errorf("item %d is measured at %d bytes, which still reaches a `## ` section heading — the playbook is counting "+
+				"the document's trailing sections as part of the last item and will rank it first whatever its real size", last, s.bytes)
+		}
+		t.Logf("last item %d measures %d bytes; the naive to-EOF slice would have measured %d", last, s.bytes, len(naive))
+	}
 }
 
 // TestAgentsSizeGuardCanStillFire is the "can it go red" control for the

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 )
 
-// The evidence split moved nine item BODIES out of AGENTS.md and left stubs
-// behind. The whole value of the split rests on one claim: the move was
-// VERBATIM. Every measured RSS table, every mutation matrix, every retraction
-// and every enumerated residual is still there, byte for byte, in the file the
-// pointer names.
+// The evidence split has moved sixteen item BODIES out of AGENTS.md, over three
+// waves, and left stubs behind. The whole value of the split rests on one
+// claim: the move was VERBATIM. Every measured RSS table, every mutation
+// matrix, every retraction and every enumerated residual is still there, byte
+// for byte, in the file the pointer names.
 //
 // 🔴 THAT CLAIM MUST BE PROVED MECHANICALLY, NOT ASSERTED, because the failure it
 // guards against is invisible by construction. A summarised paragraph reads
@@ -50,19 +50,21 @@ import (
 //     have pinned text that is not what was moved.
 //
 //  2. THE OLD BASE CANNOT BE RE-POINTED FORWARD. The obvious alternative —
-//     re-derive all eleven digests from one NEWER commit — is impossible, not
+//     re-derive every digest from one NEWER commit — is impossible, not
 //     merely inconvenient: after wave 1, AGENTS.md no longer CONTAINS the nine
 //     moved bodies at any commit. `baseItemBody(c5c3817+1, 3)` returns item 3's
 //     STUB. A body's base commit is therefore fixed forever at the moment it was
 //     evicted, and different evictions have different moments. Per-item is the
 //     only shape that can express that.
 //
-// So `base` is a field on the row, not a package constant, and the two named
+// So `base` is a field on the row, not a package constant, and the three named
 // constants below exist only so a reader can see which wave a row belongs to.
-// A future wave adds a third; it does not touch the first two.
+// Wave 3 (items 9, 13, 17, 22 and 25) added the third and touched neither of the
+// first two, which is the property the per-item field was introduced for. A
+// fourth wave adds a fourth.
 //
 // 🔴 WHAT DOES NOT CHANGE: the guard still fails if ANY split body is altered,
-// for all eleven items. Splitting the base per row weakens nothing — each row is
+// for all sixteen items. Splitting the base per row weakens nothing — each row is
 // still compared against a specific immutable blob — and that is the property to
 // re-verify by mutation whenever this table's shape is edited, because "I made
 // the pinning more flexible" is exactly how a pin stops pinning.
@@ -106,6 +108,12 @@ const agentsSplitBase = "c5c3817de72ac457cc41839c31b07f8bf1197dce"
 // not agentsSplitBase — see the 🔴 section of this file's doc comment.
 const agentsSplitBaseWave2 = "5cb45f0ff54fe55f5249aade8b0cb9826ade3c58"
 
+// agentsSplitBaseWave3 is the commit items 9, 13, 17, 22 and 25 were moved
+// from. It is the third distinct base, which is the shape the per-item field
+// exists for: each of the three is the tip at the moment ITS wave ran, and none
+// of them can be re-pointed at either of the others.
+const agentsSplitBaseWave3 = "6e31b4b29a0eb15c83e951a114db2345877d38bd"
+
 type splitItem struct {
 	num      int
 	file     string
@@ -120,14 +128,19 @@ type splitItem struct {
 // rows above it use.
 var splitItems = []splitItem{
 	{num: 3, file: "claudedocs/decisions/03-lockfile-check.md", base: agentsSplitBase, nonBlank: 116, sha: "88c413758efb22d2db23f849257c9f6ffd8175bb764c71078fd6c7eeadd9ec4d"},
+	{num: 9, file: "claudedocs/decisions/09-views-unavailable-discriminator.md", base: agentsSplitBaseWave3, nonBlank: 50, sha: "6bd481b9d65e560c4e02ce8aec2d7d14ce4b37f3e84c933562b9800374330624"},
 	{num: 10, file: "claudedocs/decisions/10-dev-tunnel-embeddability.md", base: agentsSplitBaseWave2, nonBlank: 103, sha: "b2397598f7913fac286f2fb5ee1e1e1ebf85348e365a6e820799d4ff817cab3c"},
+	{num: 13, file: "claudedocs/decisions/13-generation-graph-not-validated.md", base: agentsSplitBaseWave3, nonBlank: 42, sha: "0b875b35411e58cd61c66b16dd64fc20d4fb5d1f787d838912ed1d3fa2074df2"},
+	{num: 17, file: "claudedocs/decisions/17-download-presigned-no-credential.md", base: agentsSplitBaseWave3, nonBlank: 34, sha: "18d1888d11bf5359fa25dcc1fe0d86418e9b9b349bb297d54876afd5d5d5ef21"},
 	{num: 11, file: "claudedocs/decisions/11-vendored-ready-ack.md", base: agentsSplitBase, nonBlank: 153, sha: "232d2649f45928825e60396d36c4c513a469112d48092ec45686cc2b9ba396bf"},
 	{num: 18, file: "claudedocs/decisions/18-ready-ack-existing-apps.md", base: agentsSplitBase, nonBlank: 130, sha: "83c49221352702ce161854c729e2663cc67d6ca120090d807f8c504db52baaf5"},
 	{num: 19, file: "claudedocs/decisions/19-img2img-workflow-and-upload.md", base: agentsSplitBaseWave2, nonBlank: 103, sha: "0e1bd1bd9b862123d99e106167e6fc0bc5fca55445f3d34709e8115092fef1ef"},
 	{num: 20, file: "claudedocs/decisions/20-ready-ack-advisory-tiers.md", base: agentsSplitBase, nonBlank: 389, sha: "82de3c61f2fa3b43516ec8112d5ce64e3026ace3a2a60aa2ca723d44cf6bb191"},
 	{num: 21, file: "claudedocs/decisions/21-model-substitution.md", base: agentsSplitBase, nonBlank: 114, sha: "60ee9ffc115dac34eff068cd270c2d6427c26f84c77bca28388aa60c51c5be67"},
+	{num: 22, file: "claudedocs/decisions/22-input-refuses-non-txt2img.md", base: agentsSplitBaseWave3, nonBlank: 44, sha: "25ddad01439c67ae7d3ef3362c095a0885db409f77b6d3ea62c1008a7c95ce1a"},
 	{num: 23, file: "claudedocs/decisions/23-finding-field-message.md", base: agentsSplitBase, nonBlank: 165, sha: "89ad99bb3e9fec0e6a316045d7160362b6fad8f8e340fc20c022dcc91becc13a"},
 	{num: 24, file: "claudedocs/decisions/24-errno-is-a-net-error.md", base: agentsSplitBase, nonBlank: 327, sha: "baa658929002c871ee2cbf9332d7dcb9d78749fcab21e832b11a659803c42fd8"},
+	{num: 25, file: "claudedocs/decisions/25-listing-media-bounds.md", base: agentsSplitBaseWave3, nonBlank: 36, sha: "91069724894cd2b602034aa89cb61349096567f4e18a2ec40353146ac3dac249"},
 	{num: 26, file: "claudedocs/decisions/26-project-path-classification.md", base: agentsSplitBase, nonBlank: 246, sha: "1747de6cf56e85a935367ec118b7e16aecee5fb100d1ebf545ca40576ebbcc11"},
 	{num: 27, file: "claudedocs/decisions/27-blockid-derivation-refuses.md", base: agentsSplitBase, nonBlank: 105, sha: "5edc575b345db5b459af8d0fc0bd6c826e8102a7588b61aa873092848394796a"},
 }

--- a/claudedocs/decisions/09-views-unavailable-discriminator.md
+++ b/claudedocs/decisions/09-views-unavailable-discriminator.md
@@ -1,0 +1,66 @@
+# AGENTS.md item 9 — `views.unavailable` is a SECOND unavailability discriminator
+
+Evidence for item 9 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
+   redundant with `notOwned`.** The `App loads` section of `app metrics` is the
+   only part of the payload the server reads from **ClickHouse** (`blockRenders`)
+   rather than Postgres, so its store can be unconfigured, SLOW (the server-side
+   read is time-bounded and a timeout degrades to this flag) or down while every
+   other counter in the same response is genuinely measured. Hence the flag is
+   per-SECTION: flagging the whole payload would discard good data, and dropping
+   it would recreate the fabricated zero item 6 exists to prevent — an author
+   reading `Impressions 0` as "nobody looked at my app" when the truth is "we
+   could not ask". `printAppMetrics` therefore prints `unavailable` plus an
+   explicit caveat instead of any number, and `--json` passes the field through
+   while **still exiting 0**, so a script must branch on `views.unavailable`
+   exactly as it must already branch on `notOwned`. Whoever changes the server
+   payload has to keep the field
+   (`civitai/civitai → src/server/services/blocks/app-views.service.ts`).
+   🔴 `AppAnalytics.Views` is a **pointer** for the same reason and must stay
+   one: there are THREE states, not two — measured, unavailable, and *absent*
+   (a server predating the impressions reader omits the key). A value type
+   collapses "absent" into "measured zero", because `encoding/json` leaves the
+   zero value in place and the renderer then prints `Impressions 0`. That was
+   **measured, not theorised** — the value-typed version rendered exactly
+   `Impressions     0` for a payload with no `views` key. So `nil` means unknown
+   and renders like `unavailable`, never as `0`.
+   Related gotcha: unique viewers deliberately do **not** dedup on
+   `blockInstanceId`. Despite the name it is not per-mount — it is
+   `page_apb_<ULID>`, roughly one per app (measured on prod: 28 distinct ids
+   across 27 distinct apps) — so deduping on it would report ~1 viewer per app.
+   Anonymous rows all carry `userId = 0`, so the server sums distinct authed
+   `userId` with distinct anon `ip`.
+   🔴 **`installs` has a THIRD state too, and it is a different KIND of flag.**
+   `installs.notApplicable` means "the question does not apply", not "we could
+   not ask": a page app is stateless by design and has no install slot, so a
+   subscription record cannot exist for it. Rendering `0` there reads as "nobody
+   installed my app" when the truth is "installs do not exist for this app
+   type" — the same fabricated-zero class as items 6 and 9, from a third
+   direction. The distinction that matters when editing this: a TRUTHFUL zero
+   (an installable app nobody has installed yet) arrives with the flag ABSENT
+   and must keep printing `0`. The server owns that call — do NOT re-derive it
+   in the CLI from the counters, because `total == 0` is true in both states.
+   Measured on prod: every approved app is a page app (0 installs possible),
+   while the model-slot apps that CAN be installed hold real rows, so the two
+   populations are disjoint and the bare `0` was never a measurement of user
+   behaviour.
+   Two more things the label has to keep straight, both of which read wrong if
+   you shorten them: `AnonCount` is signed-out **LOADS**, not viewers, and is
+   NOT a subset of `UniqueViewers` — one anonymous visitor reloading ten times
+   is 10 there and 1 unique viewer, so it can legitimately be the larger number.
+   And the section is called **App loads**, not Views, because the server writes
+   a row even when a mount FAILS (a failed launch's only beacon) and the table
+   has no status column — so a permanently-broken app still reports loads.

--- a/claudedocs/decisions/13-generation-graph-not-validated.md
+++ b/claudedocs/decisions/13-generation-graph-not-validated.md
@@ -1,0 +1,58 @@
+# AGENTS.md item 13 — the CLI deliberately validates NOTHING about the generation graph
+
+Evidence for item 13 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+13. **The CLI deliberately validates NOTHING about the generation graph, and
+    that is the feature.** `internal/genapi/graph.go` models a handful of fields
+    and `--input` passes a caller's graph through byte-for-byte. It does not
+    vendor, and must never vendor: the ecosystem keys, the ~51 per-engine
+    graphs, the sampler enum, the resolution/aspect-ratio buckets, the
+    per-ecosystem defaults, the tier limits, or any cost table. The server
+    re-derives every one of them at submit time from state the CLI cannot see —
+    a caller's usable (non-disabled, non-memberOnly) ecosystem set, for one, so
+    even the *default* model differs between a free and a member account — so a
+    vendored copy buys no correctness, goes stale, and starts **refusing valid
+    new inputs**, which is worse than the gap it closes. This is the same
+    anti-mirror judgement as item 8, with money on it.
+    Two consequences that look like missing features:
+    (a) `KnownGraphKeys()` (`graph.go`) is derived by REFLECTION over the struct
+    tags, never hand-listed, and it answers *"does the CLI model this key?"* —
+    **not** *"does the server accept it?"*. `unknownKeyWarning`
+    (`internal/cmd/generate_input.go`) is worded to say exactly that and must
+    stay worded that way; a warning phrased as "invalid key" would be a
+    validation claim this CLI has no authority to make.
+    (b) The one bounded exception is `serverQuantityClamp` in
+    `internal/cmd/generate.go` — a **warn-only** constant, currently 10, that
+    **fails soft**: it warns and sends anyway. It exists because the server
+    silently CLAMPS an out-of-range quantity (measured: 10000 → 10, −5 → 1) with
+    no error, so a `--quantity 40` typo charges for 10 and gives the user no
+    signal at all. Because it only warns, a stale number produces a needless
+    note, never a blocked valid request. Do not promote it to validation, and do
+    not add siblings for the other clamped fields without the same fail-soft
+    shape.
+    **Live lookups are not mirrors**, which is why one is allowed:
+    `ResolveModelVersion` (`internal/genapi/versions.go`) resolves
+    `--checkpoint` / `--lora` ids against the existing public
+    `GET /api/v1/model-versions/{id}` before submitting. It is a round-trip, so
+    it carries no drift cost, and it buys two things nothing else can. A
+    **nonexistent** checkpoint id is otherwise accepted with HTTP 200, the
+    ecosystem default silently substituted, and **billed** (measured on one
+    ecosystem: the correct id priced 160, while a nonexistent id, a
+    foreign-ecosystem id, and no model at all ALL priced 60 — the server's own
+    comment says this correction is visible on-site and invisible through a
+    non-browser path). And `Graph.Resources` entries **require** `model:{type}`,
+    which is not derivable from a version id — a bare id and `{id}` alone are
+    both 400s, while a *wrong* type is silently accepted. The type must come
+    from the lookup, never a guess.

--- a/claudedocs/decisions/17-download-presigned-no-credential.md
+++ b/claudedocs/decisions/17-download-presigned-no-credential.md
@@ -1,0 +1,50 @@
+# AGENTS.md item 17 — `DownloadPresigned` exists so a blob fetch carries NO credential
+
+Evidence for item 17 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+17. **`DownloadPresigned` exists so a blob fetch carries NO credential, and it is
+    the thing in this feature most likely to be "simplified" away.** It is a
+    near-duplicate of `DownloadFile` in `pkg/civitai/download.go` differing only
+    in passing an empty token, and every instinct says to fold it back in behind
+    a bool. 🔴 Doing that leaks a full-scope personal API key.
+    `isTrustedDownloadHost` attaches the bearer token to `civitai.com` and to
+    **any** `*.civitai.com` subdomain — correct for the model-download route it
+    was written for — and orchestrator output blobs are served from a
+    `*.civitai.com` host (observed: `orchestration-new.civitai.com`), which
+    **matches**. So `DownloadFile` would send a 25-scope key (including
+    `ModelsDelete` and `VaultWrite`) to the orchestrator, on a request already
+    authorized by its own signature that needs no token whatsoever.
+    🔴 **The specific subdomain is incidental to the argument, and must not be
+    written as if it were the load-bearing fact.** An earlier revision of this
+    item named `orchestration.civitai.com`; the host observed in a real upload
+    reply is `orchestration-new.civitai.com`. BOTH match the `*.civitai.com`
+    wildcard, so the credential-free seam is required either way — which is why
+    the reasoning is stated over the wildcard rather than over a hostname a
+    server-side rename can invalidate. Do not "fix" this seam because the
+    subdomain you see does not match the one written here.
+    Weakening `isTrustedDownloadHost` is not the alternative: `civitai download`
+    depends on it attaching the token. The fix is a **seam that never has a
+    credential to attach** — `DownloadPresigned` passes `""` to `doDownload`,
+    whose guard is `token != "" && isTrustedDownloadHost(...)`, so the empty
+    token short-circuits before the host predicate is consulted. That ordering is
+    deliberate: it cannot be defeated by a change to the predicate. Everything
+    genuinely shared is still shared — the SSRF dial guard, the
+    https-per-redirect-hop policy and 10-hop cap, the `ResponseHeaderTimeout` —
+    so there is no duplicated security logic to drift. It also skips the
+    401-refresh replay on purpose: there is no credential to refresh, and a 401
+    from a presigned URL means the signature is wrong or **expired**, which a
+    token would not fix. `internal/cmd/generate.go` wires
+    `deps.downloadBlob = reader.DownloadPresigned`; if you ever see that wired to
+    `DownloadFile`, it is a credential leak, not a cleanup.

--- a/claudedocs/decisions/22-input-refuses-non-txt2img.md
+++ b/claudedocs/decisions/22-input-refuses-non-txt2img.md
@@ -1,0 +1,63 @@
+# AGENTS.md item 22 — `--input` refuses every workflow but `txt2img`
+
+Evidence for item 22 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+22. **`--input` refuses every workflow but `txt2img`, and that refusal is NOT the
+    local validation item 13 forbids — it is a CONTENT-AUDIT gate over a
+    CONFIRMED server-side gap.** This is the item most likely to be read as an
+    unfinished feature, because item 13 says in bold that the CLI validates
+    nothing about the graph and `--input` exists precisely to pass one through
+    untouched. The reconciliation: item 13 forbids reproducing the server's
+    *judgement* about which graphs are valid, and this check makes no such
+    claim — it is the same shape as item 19(b), a flag combination the CLI owns,
+    asserting nothing about which ecosystems exist or what any of them allows.
+
+    🔴 **THE GAP IS CONFIRMED, NOT SUSPECTED, AND A PRIOR SESSION RECORDED THE
+    OPPOSITE.** The server audits at `'prompt' in data && typeof data.prompt ===
+    'string'` (`orchestration-new.service.ts:1460`) over a `data` REBUILT FROM
+    DECLARED GRAPH NODES ONLY. An earlier revision of the code comment called
+    exploitability an open question; a later handoff went further and wrote
+    "ruled out — no known bypass", reasoning that graphs lacking a `prompt` node
+    *compose* a shared `promptGraph`. True of the image graphs, and false as a
+    generalisation — it says nothing about graphs that opt out of the shared node
+    names. Verified at `civitai@a7e0bcd668`, two shipped ecosystems do:
+    **Hunyuan3D declares no `prompt` node at all**, only `hunyuanPrompt`
+    (`hunyuan3d-graph.ts:71`, prefixed because the bare names "collide with the
+    standard image Controllers in `GenerationForm.tsx`"), so the audit never runs
+    — and the handler then maps it back for the generator,
+    `prompt: hunyuanPrompt ? hunyuanPrompt : undefined`
+    (`hunyuan3d-graph.handler.ts:58`). **PolyGen's `texturePrompt`**
+    (`polygen-graph.ts:162`) is covered by no audit block at all, and on
+    `img2model3d` is the only text in the request because that workflow's
+    `prompt` node is gated `when: workflow.startsWith('txt')` and is deleted.
+    Sweep basis: all 79 declared node keys under
+    `src/shared/data-graph/generation`, every node whose input is a bare
+    `z.string()`. Note both are MULTI-LINE `.node(\n  'name',` declarations that
+    a single-line grep misses. Tracked at civitai/civitai#3667.
+
+    🔴 **KEEP THE CLAIM THIS SIZE — the overclaim and the dismissal are both
+    available and both wrong.** The CLI is not what holds the line: the same
+    fields are reachable from the first-party form and from any direct tRPC
+    caller with a personal API key, so the gate stops accidents, not adversaries.
+    That is an argument for fixing the platform, **not** for opening `--input`.
+    What the gate buys is that we do not add a second client to a confirmed
+    unaudited path while it is open. Equally, no live generation probe has been
+    run — this is reachability by code path, not a demonstrated exploit, and
+    writing it up as a shipped vulnerability would be the overclaim.
+
+    **Lift it when the server closes the coverage, not when the next workflow
+    looks like it would work.** Unblocking the other ~50 ecosystems through
+    `--input` is the single biggest capability unlock left in this command, which
+    is exactly why the bar is written down rather than left to judgement.

--- a/claudedocs/decisions/25-listing-media-bounds.md
+++ b/claudedocs/decisions/25-listing-media-bounds.md
@@ -1,0 +1,52 @@
+# AGENTS.md item 25 — the listing-media dimension and aspect bounds stay prose in the README
+
+Evidence for item 25 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
+enough to tell you whether this item bears on what you are about to change.
+Everything below the rule is that item's body, moved here VERBATIM: the
+measurements, mutation matrices, retractions and residuals are consulted when
+editing the code they are about, not on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, and `agents_split_preserved_test.go` pins the body
+against the text it was moved from.
+
+---
+
+25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,
+    and must NOT become a local check.** `civitai app listing set-icon` /
+    `set-cover` / `add-screenshot` validate the **format** and the **byte size**
+    of the source file (`maxIconBytes` / `maxCoverBytes` /
+    `maxScreenshotBytes`) and nothing else. The platform additionally enforces a
+    per-kind aspect range and a minimum dimension at ATTACH time
+    (`civitai/civitai → src/server/schema/blocks/app-listing.schema.ts`,
+    `validateListingImage`), returning a `BAD_REQUEST` that names the bound and
+    the measured value. Those numbers are documented in README →
+    *Listing media requirements* and in the scaffolded `assets/README.md`, and
+    that is deliberately as far as they go.
+    - **Why prose and not a check.** This is item 4's argument, applied to a
+      different constant set: stale *guidance* costs one round-trip carrying the
+      server's current bound, while a stale *gate* refuses valid images and the
+      author cannot override it. A local dimension check would also have to
+      re-derive the icon rescale below to avoid being wrong on day one. So do
+      not add a `LISTING_ICON_ASPECT_MIN` to `internal/cmd`, and do not "fix"
+      the docs by promoting the table into `internal/validate`. The CLI already
+      decodes width/height (`appapi.DecodeImageInfo`) — the omission is a
+      decision, not a missing feature.
+    - **The icon byte cap and the server's icon byte cap measure DIFFERENT
+      bytes, and the docs must not conflate them.** `maxIconBytes` (2 MiB) is
+      the SOURCE file, mirroring the server's `INLINE_ICON_MAX_DECODED_BYTES`
+      on the data-URI path the icon rides. The listing schema's
+      `MAX_LISTING_ICON_SIZE_BYTES` (1 MiB) is checked against
+      `Image.metadata.size`, which for that path is the byte length of the
+      **re-encoded** PNG the server produces after downscaling to ≤1024 px on
+      the longer side (`listing-meta.service.ts`) — not the file the author
+      passed. Cover and screenshot take the full-res path, where the CLI sends
+      `sizeBytes: len(data)`, so there the two caps DO describe the same bytes.
+    - **Never scaffold a placeholder icon or cover.** A placeholder passes every
+      format and byte check and uploads cleanly, so it can reach a public store
+      listing; a missing file fails loudly at the step that can still fix it.
+      `assets/` therefore ships with a README and no images, and
+      `internal/scaffold/assets_dir_test.go` fails if an image file appears
+      under it.


### PR DESCRIPTION
## What and why

`CLAUDE.md` does `@AGENTS.md`, so every byte is paid on every session. #297
measured that compression is exhausted (586 bytes, 0.86%, from a full lossless
pass; 23 repeated 7-grams in 67 kB). The ceiling had **19 bytes** of headroom
left, which is not a ceiling — it is a frozen file, where the next ordinary
correction fails CI.

Wave 3 evicts the five largest remaining bodies. **Eviction is now nearly
exhausted too** — see the floor section at the bottom.

### Before / after

| | bytes | tokens (cl100k) |
|---|---|---|
| before (`6e31b4b`) | 54,231 | 13,965 |
| after | **42,635** | **11,078** |
| delta | −11,596 (−21.4%) | −2,887 (−20.7%) |

Token counts are a real `tiktoken` `cl100k_base` encode of the whole file, not a
bytes/4 estimate.

### The set, and why five

| item | body | stub | net recovered |
|---|---|---|---|
| 9 — `views.unavailable` | 3,736 | 701 | 3,035 |
| 22 — `--input` refuses non-`txt2img` | 3,342 | 790 | 2,552 |
| 13 — the graph is not validated | 3,019 | 735 | 2,284 |
| 17 — `DownloadPresigned` | 2,573 | 705 | 1,868 |
| 25 — listing-media bounds | 2,596 | 739 | 1,857 |
| | | | **11,596** |

These are every inline item at ≥2,500 bytes, i.e. ≥3.5× a stub, so eviction
recovers 72–81% of each. **The brief's projected 39.4 kB assumed stubs are
free; they are not** — a stub costs 638–790 bytes, so the honest landing point
is 42.6 kB. Going further in this PR was rejected on arithmetic, not taste: the
next candidate (item 15, 1,827 B) recovers only 61%, and four items are
*smaller* than a stub, so evicting them would grow the file.

## The move is VERBATIM, proven twice, two different ways

1. **Digest.** Each body was sliced out of `git show 6e31b4b:AGENTS.md` by the
   same algorithm `baseItemBody` uses — never retyped — and pinned by sha256
   over its non-blank lines in `splitItems`.
2. **Independent differ.** A separately built harness (sed/awk line ranges +
   `cmp`/`diff`, rather than a python slicer + a digest) reported all five
   byte-identical: items 9/13/17/22/25 at 50/42/34/47/36 lines. It was shown to
   go **red** on an injected one-word change (`do:` → `DO:` in item 22) before
   its zero was believed.
3. **Diff audit.** A third check walked the `AGENTS.md` diff itself: all 198
   removed lines belong to the five moved bodies, all 38 added lines belong to
   the five stubs, zero collateral edits. (198/38 rather than 209/49 because 11
   stub lines reuse the item's own opening thesis verbatim and diff scores them
   as context.) Its own positive control confirms it can see a stray line.

## The base commit

`agentsSplitBaseWave3 = 6e31b4b…`, the tip when this wave ran. It touches
neither wave 1's rows (`c5c3817`) nor wave 2's (`5cb45f0`). A body's base is
fixed at the moment it is evicted — after eviction AGENTS.md no longer contains
that body at any later commit — so the per-item `base` field #305 introduced is
what makes a third wave expressible at all. This is the first wave to actually
exercise that property rather than assert it.

## The ceiling is a budget now, derived rather than picked

287 bytes, then 300: each evaporated on the very next commit that touched the
file (#308 consumed 94% of the 300). A ceiling with 19 bytes under it converts
every routine doc correction into an eviction project — a worse failure than
the growth it stops, because it makes the guard a reason not to fix the docs.

**`agentsMaxBytes = 45,135` — 2,500 bytes of headroom.** Derived: over the last
40 commits touching AGENTS.md, the ten docs-only ones changed it by +70, +245,
+281, +1,337, +1,456, +2,371, +2,760, +2,890, +3,399 and +3,474 bytes, **median
1,913**. So 2,500 buys roughly one median docs-only correction, or two or three
small ones, or a retraction paragraph (300–800 B) plus change.

It deliberately does **not** buy a new item written as a body (1.5–3.7 kB
inline today), nor re-inlining item 9, 13 or 22 (2,284–3,035 B net, each
breaking it alone). Stated honestly in the constant's comment: it *would* absorb
re-inlining item 17 or 25, the two cheapest at ~1,860 — that is the real cost of
headroom big enough to be useful, and bounding it is the ceiling's job.

**`agentsMaxBytesCeiling` 64,000 → 48,600.** Chosen against a re-derivable
property rather than a round percentage: re-inlining any *three* of this wave's
five bodies costs ≥6,009 B net and lands at 48,644, just above the bound. Left
at 64,000 it would have permitted re-inlining all five (54,231) — the "a ceiling
nobody bounds" failure one level up, which its own comment warns about.

**`minEvidencePointers` 5 → 10.** A floor set when nine items were split would
let a regex that had lost two thirds of a sixteen-item corpus through.

## A defect found on the way: the playbook ranked an already-split stub first

`agentsItemSizes` sliced the **last** item to EOF, so it swallowed the closing
vendored-mirrors paragraph plus the Permission boundaries, Release process and
License sections. Measured: item 27 is a **683-byte stub** and was reported at
**4,789 bytes** — 7× its real size, and top of the ranking. The first advice a
maintainer got at the ceiling was to evict something already evicted.

Two slicers in this package answer "where does item N end", and they had
diverged on the one input with no following heading. So the fix is the **seam**,
not the number: `TestEvictionPlaybookSizesTheLastItemCorrectly` asserts
`agentsItemSizes` and `baseItemBody` agree for *every* item, with a positive
control that a naive to-EOF slice really would reach a `## ` heading (so the
test is exercising the hazard, not restating the happy path). A per-item size
assertion was rejected: it would go stale on the next appended item — and could
not even be written, since the repo-wide xrefs guard reads this file and flags a
future item number as a dangling reference. It caught exactly that during
development.

## Mutation matrix

Counted from `--- FAIL` **leaf lines**, never an exit code. Every mutation
**checksum-gated**, so an edit that silently failed to apply reads as
NOT-APPLIED rather than as a survivor.

**Body preservation — all 16 split items × 2 loss shapes (a dropped line, a
reworded line):**

| environment | mutations | not-applied | survivors | kills each |
|---|---|---|---|---|
| full clone | 32 | 0 | **0** | 2 leaf + 2 top |
| depth-1 clone | 32 | 0 | **0** | 1 leaf + 1 top |

The shallow figure is 1 rather than 2 by design: the line-naming differ skips
where base blobs are unreachable, and the always-on digest guard carries every
body on its own. **That is the claim CI rests on, measured in CI's actual
environment.**

**Ceiling and slicer:**

| mutant | full clone | depth-1 | killed by |
|---|---|---|---|
| raise `agentsMaxBytes` past its bound | 1 top | 1 top | `TestAgentsSizeGuardCanStillFire` |
| lower `agentsMaxBytes` below achieved size | 1 top | 1 top | `TestAgentsMDStaysUnderItsCeiling` |
| raise `agentsMinBytes` above the file | 10 leaf / 4 top | 2 top | ceiling + `baseDocFor`'s control |
| revert the playbook slicer to to-EOF | 1 top | 1 top | the new seam test |
| raise **both** constants together | **survives** | **survives** | — by design |

The last row is intentional and is what the two-constant design is *for*:
loosening the bound is meant to be a deliberate, reviewable second edit, not
something a guard silently permits or silently blocks.

## Verified in a real depth-1 clone

#305 shipped a green local run and a failing CI because a git-reading test could
not resolve its base blobs, and its local gate and merged-tree gate were the same
environment. So this was checked in a genuine shallow clone
(`git rev-parse --is-shallow-repository` = `true`, 1 commit, all three base
commits confirmed unreachable):

- `go test ./...` → **19 `ok` packages, 0 `--- FAIL` leaves, 0 timeout panics**
- root package → **95 PASS, 0 FAIL, 2 SKIP**
- both SKIPs are the git-backed tests, and both **name the environment**:
  *"none of the 16 base blob(s) is reachable — this is a shallow
  (depth-limited) clone"*. Neither fails, neither silently passes.
- a mutated body is still caught there with no git at all (32/32 above)

## Local gate

- `make ci` — 19 `ok` packages, 0 `--- FAIL`
- `make lint` (`golangci-lint` via `nix-shell`) — **0 issues**, run separately
  because `make ci` omits it
- `gofmt -s -l .` — 0 files
- merged tree: `origin/main` is `6e31b4b` and this branch is based exactly on
  it with **0 commits behind**, so the merge is a fast-forward and the tree
  tested here *is* the merged tree.

## Where the floor is, for whoever runs wave 4

Measured on the post-wave tree — non-item prose is now **18,387 bytes, 43% of
the file**, and eviction has **5,310 bytes left in it, total**:

| remaining inline item | size | recovers |
|---|---|---|
| 15, 8, 16, 14, 12 | 1,540–1,827 | +835 … +1,122 each (**5,008 total**) |
| 1, 7, 5, 6 | 718–831 | +13 … +126 each — noise |
| 4, 2 | 301–500 | **−205, −404 — evicting them GROWS the file** |

So **wave 4 is items 15, 8, 16, 14 and 12, it is worth ~5.0 kB, and it is the
last one.** It lands at ~37.6 kB against a hard full-eviction floor of 37,325.
After it, every remaining item is at or below stub size and eviction as a lever
is finished — the next lever would have to be the 18.4 kB of non-item prose
(Stack, Shell & CI gotchas, Layout, House conventions, Release process), which
is a different and much more judgement-heavy change.

My read: wave 4 is worth doing as one change, and the ceiling should be
re-derived to ~40 kB with the same 2,500-byte budget when it lands. After that
the ceiling should stop moving, because there is nothing left to pay it with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
