### PR TITLE
test(ci): `make ci-shallow` — run the suite in the depth-1 clone CI actually has

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,61 @@ make ci     # go mod tidy + go vet + go test ./... + go build ./...
 Common targets:
 
 ```bash
-make build   # build ./bin/civitai
-make test    # go test ./...
-make vet     # go vet ./...
-make fmt     # gofmt -s -w .
-make lint    # golangci-lint if installed, else go vet
+make build       # build ./bin/civitai
+make test        # go test ./...
+make vet         # go vet ./...
+make fmt         # gofmt -s -w .
+make lint        # golangci-lint if installed, else go vet
+make ci-shallow  # go test ./... in a depth-1 clone — what CI actually sees
 ```
+
+## `make ci-shallow` — the environment your local `make ci` cannot be
+
+CI checks out with `actions/checkout@v4`, which clones at **depth 1**. Several
+tests in this repo read git history — the AGENTS.md split guards resolve
+`git show <base-commit>:AGENTS.md` — and a base blob that resolves fine in your
+full clone is simply **not in the object store** at depth 1.
+
+That divergence is not hypothetical. PR #305 shipped a green local `make ci`
+(18 packages ok) and a red `build-test` in CI:
+
+```
+--- FAIL: TestEveryBaseBodyLineSurvivedTheMove
+    agents_split_preserved_test.go:512: CONTROL failure: the differ compared 0
+    lines, so its clean result says nothing
+```
+
+The author's local gate and their merged-tree gate were the *same* environment,
+so neither could observe a defect that only exists in the other.
+`make ci-shallow` is that missing environment, as one command: it clones the
+current branch at depth 1 into a temporary directory, runs `go test ./...`
+there, and removes the clone afterwards.
+
+**It sees committed state only.** A depth-1 clone carries what you would
+*push*, not what you have — uncommitted working-tree changes are invisible to
+it. That is the right semantics for a pre-push check, but it is a sharp edge,
+so the target prints the ref and sha it cloned and warns when your tree is
+dirty. Commit before you rely on it.
+
+It also runs the test suite *only*, not `go vet` / `go build` / `gofmt`. None
+of those read git history, so `make ci` already covers them.
+
+**Cost:** measured on a 24-core Linux box, **26.9 s / 27.4 s** with a warm Go
+build cache and **33.0 s** with an empty one, against **27.6 s** for `make ci`
+on the same tree — so it is roughly a second `make ci`, and the depth-1 clone
+itself is a rounding error next to `go test`. Run it before pushing a change
+that touches a history-reading test; it is deliberately *not* a prerequisite of
+`make ci`, which would slow down every run for a check most changes do not
+need.
+
+If it fails, `CI_SHALLOW_KEEP=1 make ci-shallow` keeps the clone so you can
+poke at it.
+
+The target refuses to fall back to your working tree if the clone fails, and
+asserts its own positive controls: the clone really is shallow, its HEAD is the
+sha you asked for, and the expected number of packages reported `ok` — because
+a shallow gate that silently tests nothing would read as reassurance while
+catching exactly as much as no gate at all.
 
 ## Before you open a PR
 
@@ -31,6 +80,10 @@ go test ./...
 go vet ./...
 gofmt -s -l .        # must print nothing
 ```
+
+If your change touches a test that reads git history, also run
+`make ci-shallow` (see above) — a full clone cannot observe that class of
+failure.
 
 New behaviour should come with tests. Cover error paths, not just the happy
 path — see the existing `*_test.go` files for the table-driven / httptest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-.PHONY: all build install test vet lint fmt clean tidy ci mutate
+.PHONY: all build install test vet lint fmt clean tidy ci ci-shallow mutate
 
 all: build
 
@@ -40,6 +40,18 @@ tidy:
 
 # Mirror CI locally.
 ci: tidy vet test build
+	@echo
+	@echo "make ci passed — note this is a FULL clone. CI checks out at depth 1,"
+	@echo "where tests that read git history cannot resolve their base blobs."
+	@echo "Before you push a change that touches those, run: make ci-shallow"
+
+# Run the test suite in a DEPTH-1 clone of the current branch, which is what
+# `actions/checkout@v4` gives CI. Deliberately NOT a prerequisite of `ci`: it
+# costs a clone plus an uncached test run, and most changes do not need it.
+# Committed state only — uncommitted work is invisible to it, and the target
+# says so on stdout. See scripts/ci-shallow.sh for the controls it asserts.
+ci-shallow:
+	./scripts/ci-shallow.sh
 
 # Mutation-test ONE package and print a report corrected for gremlins'
 # non-compiling-mutant misclassification. Local investigation tool only:

--- a/scripts/ci-shallow.sh
+++ b/scripts/ci-shallow.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# ci-shallow.sh — run the test suite in a DEPTH-1 clone of this repo.
+#
+# WHY THIS EXISTS
+#
+# GitHub Actions checks out with `actions/checkout@v4`, which clones at
+# **depth 1**. Several tests in this repo read git history — the AGENTS.md
+# split guards resolve `git show <base-commit>:AGENTS.md` — and a base blob
+# that resolves fine in a developer's full clone is simply NOT IN THE OBJECT
+# STORE at depth 1. PR #305 shipped a green local `make ci` (18 packages ok)
+# and a red `build-test` in CI for exactly that reason:
+#
+#     --- FAIL: TestEveryBaseBodyLineSurvivedTheMove
+#         agents_split_preserved_test.go:512: CONTROL failure: the differ
+#         compared 0 lines, so its clean result says nothing
+#
+# The author's local gate and their merged-tree gate were the SAME
+# environment, so neither could observe a defect that only exists in the
+# other. This script is the missing environment, as one command.
+#
+# WHAT IT DOES AND DOES NOT COVER
+#
+# It clones the CURRENT BRANCH AT ITS COMMITTED TIP over `file://` (which
+# forces the real transport, so `--depth` is honoured — a plain local path
+# clone hardlinks the whole object store and is never shallow), then runs
+# `go test ./...` inside that clone. So:
+#
+#   * UNCOMMITTED WORKING-TREE CHANGES ARE INVISIBLE TO IT. That is the
+#     correct semantics for a pre-push check — CI will only ever see what you
+#     pushed — but it is a sharp edge, so the script prints the ref and sha it
+#     cloned and warns loudly when your tree is dirty.
+#   * It runs the TEST SUITE only, not `go vet` / `go build` / `gofmt`. Those
+#     do not read git history, so `make ci` already covers them and running
+#     them twice buys nothing.
+#
+# POSITIVE CONTROLS
+#
+# A shallow gate that silently does nothing — wrong directory, failed clone,
+# zero packages tested — is precisely the failure class it exists to catch,
+# and it would be WORSE than not having it, because it would read as
+# reassurance. So this script:
+#
+#   1. asserts the clone really is shallow (`--is-shallow-repository` = true);
+#   2. asserts the clone's HEAD is the sha we asked for;
+#   3. derives the expected package count from `go list` IN THE CLONE and
+#      requires that many `ok` lines — with an absolute floor underneath it so
+#      a `go list` returning nothing cannot set the bar to zero;
+#   4. reads the test OUTPUT rather than the exit code alone: it counts `ok` /
+#      `--- FAIL` / `FAIL` lines, greps for `panic: test timed out` (which
+#      truncates the run while still reporting no failures) and for
+#      `no tests to run` (which a package count cannot see, because a filtered
+#      run still prints one `ok` per package);
+#   5. FAILS on a broken clone instead of falling back to the working tree — a
+#      silent fallback would make this an ordinary `make test` in a disguise.
+#
+# Set CI_SHALLOW_KEEP=1 to keep the clone directory for debugging.
+
+set -euo pipefail
+
+# The smallest number of test-bearing packages this repo can plausibly have.
+# Measured at 932c5e9: `go list -f '{{if or .TestGoFiles .XTestGoFiles}}…'`
+# reports 19 of 19 packages. The floor is deliberately well below that so it
+# does not need bumping every time a package is added, and well above zero so
+# a clone whose `go list` came back empty cannot report a serene pass.
+readonly MIN_TEST_PACKAGES=15
+
+progname="ci-shallow"
+
+die() {
+	printf '%s: %s\n' "$progname" "$*" >&2
+	exit 1
+}
+
+note() {
+	printf '%s: %s\n' "$progname" "$*"
+}
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) ||
+	die "not inside a git repository — nothing to clone"
+
+head_sha=$(git rev-parse HEAD 2>/dev/null) ||
+	die "HEAD does not resolve (an empty repository?)"
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "HEAD" ]; then
+	die "HEAD is detached at ${head_sha:0:12}. A depth-1 clone needs a named ref to ask for; check out a branch first."
+fi
+
+short_sha=${head_sha:0:12}
+
+# Committed state only. Say so HERE, in the output, not just in the docs —
+# someone running this with dirty WIP will otherwise believe it covered their
+# changes.
+dirty_count=$(git status --porcelain | grep -c . || true)
+note "cloning ${branch} at ${short_sha} (committed state only) — depth 1"
+if [ "$dirty_count" -gt 0 ]; then
+	note ""
+	note "  WARNING: your working tree has ${dirty_count} uncommitted change(s)."
+	note "  They are NOT in this run. A depth-1 clone carries committed state"
+	note "  only, so this checks what you would PUSH, not what you have."
+	note ""
+fi
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/civitai-ci-shallow.XXXXXXXXXX") ||
+	die "could not create a temporary directory"
+
+cleanup() {
+	if [ -n "${CI_SHALLOW_KEEP:-}" ]; then
+		printf '%s: kept the clone at %s (CI_SHALLOW_KEEP is set)\n' "$progname" "$work_dir" >&2
+		return
+	fi
+	rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+clone_dir="$work_dir/clone"
+log_file="$work_dir/go-test.out"
+
+# `file://` is load-bearing: given a plain path, git treats the clone as local,
+# hardlinks the entire object store and IGNORES --depth, which would hand us a
+# full clone that passes every test the shallow one fails.
+if ! git clone --quiet --depth 1 --branch "$branch" "file://$repo_root" "$clone_dir" 2>"$work_dir/clone.err"; then
+	sed 's/^/  /' "$work_dir/clone.err" >&2 || true
+	die "the depth-1 clone failed (see above). Refusing to fall back to the working tree — that would test the wrong thing."
+fi
+
+# CONTROL 1: it has to actually be shallow, or this whole exercise is a slow
+# `make test`.
+is_shallow=$(git -C "$clone_dir" rev-parse --is-shallow-repository 2>/dev/null || echo unknown)
+if [ "$is_shallow" != "true" ]; then
+	die "the clone reports --is-shallow-repository=${is_shallow}, want true. It is not a shallow clone, so it proves nothing about CI."
+fi
+
+# CONTROL 2: it has to be the commit we asked for.
+clone_sha=$(git -C "$clone_dir" rev-parse HEAD 2>/dev/null || echo none)
+if [ "$clone_sha" != "$head_sha" ]; then
+	die "the clone is at ${clone_sha}, but ${branch} is at ${head_sha}. Refusing to report on a tree that is not yours."
+fi
+
+depth=$(git -C "$clone_dir" rev-list --count HEAD)
+note "clone ok: shallow=true, HEAD=${clone_sha:0:12}, ${depth} commit(s) of history"
+
+# CONTROL 3: how many packages MUST report ok. Derived from the clone itself,
+# with a floor underneath so an empty answer cannot become the bar.
+expected_ok=$(cd "$clone_dir" && go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... 2>/dev/null | grep -c . || true)
+if [ "$expected_ok" -lt "$MIN_TEST_PACKAGES" ]; then
+	die "the clone reports only ${expected_ok} package(s) with tests, below the floor of ${MIN_TEST_PACKAGES}. Something is wrong with the clone, not with your change."
+fi
+note "expecting ${expected_ok} package(s) to report ok"
+note ""
+
+set +e
+(cd "$clone_dir" && go test ./...) 2>&1 | tee "$log_file"
+go_test_rc=${PIPESTATUS[0]}
+set -e
+
+# CONTROL 4: read the OUTPUT, never the exit code alone. A truncating
+# `panic: test timed out` still reports no `--- FAIL` lines, and a wrapper's
+# trailing command can swallow a non-zero status entirely.
+ok_count=$(grep -c '^ok[[:space:]]' "$log_file" || true)
+fail_case_count=$(grep -c -- '--- FAIL' "$log_file" || true)
+fail_pkg_count=$(grep -c '^FAIL' "$log_file" || true)
+timeout_count=$(grep -c 'panic: test timed out' "$log_file" || true)
+# A package count alone cannot see `-run <no match>`: every package still
+# reports `ok`, just with this marker appended. It is the one cheap signal that
+# distinguishes "all green" from "nothing ran".
+empty_run_count=$(grep -c 'no tests to run' "$log_file" || true)
+
+note ""
+note "results: ok=${ok_count}/${expected_ok}  failing-tests=${fail_case_count}  failing-packages=${fail_pkg_count}  timeouts=${timeout_count}  filtered-empty=${empty_run_count}  go-test-rc=${go_test_rc}"
+
+problems=0
+if [ "$timeout_count" -gt 0 ]; then
+	note "  a test timed out — the run was TRUNCATED, so everything after it is unmeasured"
+	problems=1
+fi
+if [ "$empty_run_count" -gt 0 ]; then
+	note "  ${empty_run_count} package(s) reported 'no tests to run' — an ok line that measured nothing"
+	problems=1
+fi
+if [ "$fail_case_count" -gt 0 ] || [ "$fail_pkg_count" -gt 0 ]; then
+	problems=1
+fi
+if [ "$ok_count" -ne "$expected_ok" ]; then
+	note "  ${expected_ok} package(s) have tests but only ${ok_count} reported ok — some package did not run to a verdict"
+	problems=1
+fi
+if [ "$go_test_rc" -ne 0 ]; then
+	problems=1
+fi
+
+if [ "$problems" -ne 0 ]; then
+	note ""
+	die "FAILED in a depth-1 clone. This is what CI sees. If it passes under \`make ci\`, the difference is git history: a full clone resolves base blobs that CI cannot."
+fi
+
+note ""
+note "PASSED in a depth-1 clone: ${ok_count} package(s) ok, 0 failures, 0 timeouts."


### PR DESCRIPTION
## The gap

A developer's full clone and GitHub Actions' `actions/checkout@v4` are different environments, and the difference is **git history**. Tests here read it — the AGENTS.md split guards resolve `git show <base-commit>:AGENTS.md` — and at depth 1 that blob is simply not in the object store.

PR #305 shipped a green local `make ci` (18 packages ok) and a red `build-test`:

```
--- FAIL: TestEveryBaseBodyLineSurvivedTheMove
    agents_split_preserved_test.go:512: CONTROL failure: the differ compared 0
    lines, so its clean result says nothing
```

The author's local gate and their merged-tree gate were the *same* environment, so neither could observe a defect that only exists in the other. `make ci-shallow` is that missing environment, as one command.

## The target

`make ci-shallow` → `scripts/ci-shallow.sh`. Depth-1 clone of the current branch into `$(mktemp -d)`, `go test ./...` inside it, cleanup on exit (including on failure; `CI_SHALLOW_KEEP=1` keeps it for debugging).

Design decisions, stated:

- **`file://` is load-bearing.** Given a plain path, git treats the clone as local, hardlinks the whole object store and **ignores `--depth`** — you get a full clone that passes everything the shallow one fails. Control 1 exists because of this; see the mutation results below, where it is the only thing between a broken gate and a serene "PASSED".
- **Committed state only.** A depth-1 clone carries what you would *push*, not what you have. That is the right semantics for a pre-push check and it is a sharp edge, so the target prints the ref and sha it cloned and **warns on a dirty tree in its own output**, not only in the docs.
- **Where the clone lands:** `mktemp -d` under `$TMPDIR` — not in the repo, unique per run so two concurrent runs cannot collide.
- **Tests only**, not `go vet` / `go build` / `gofmt`. None of those read git history, so `make ci` already covers them.
- **Not a prerequisite of `ci`** — it costs about a second `make ci` and most changes do not need it. `make ci` now *mentions* it in its trailing output, which is the moment someone is about to claim "CI is green locally"; that is a line of text, not a runtime cost.

## Positive controls

A shallow gate that silently tests nothing is exactly the failure class it exists to catch, and would be worse than no gate because it reads as reassurance. The script asserts:

1. `git rev-parse --is-shallow-repository` = `true`, else hard fail;
2. the clone's HEAD is the sha we asked for;
3. a package count derived from `go list` **in the clone** (19 today), with an absolute floor of 15 underneath so an empty `go list` cannot become the bar;
4. counts of `ok` / `--- FAIL` / `FAIL`, plus greps for `panic: test timed out` and `no tests to run` — **output, never the exit code alone**;
5. a failed clone is a hard error, never a fallback to the working tree.

## Measured results

**GREEN** — unmodified tree, `make ci-shallow`:

```
clone ok: shallow=true, HEAD=f004960cd975, 1 commit(s) of history
results: ok=19/19  failing-tests=0  failing-packages=0  timeouts=0  filtered-empty=0  go-test-rc=0
PASSED in a depth-1 clone: 19 package(s) ok, 0 failures, 0 timeouts.
```

**RED** — a throwaway commit adding a test that reads `6e31b4b:AGENTS.md` (main's parent — resolvable in any full clone, absent at depth 1), the #305 shape. Both gates on the same commit:

| gate | rc | ok | `--- FAIL` |
|---|---|---|---|
| `make ci` | **0** | 19 | 0 |
| `make ci-shallow` | **1** | 18/19 | 1 |

```
--- FAIL: TestRedControlReadsABaseCommit
    redcontrol_test.go:22: could not read 6e31b4b:AGENTS.md: exit status 128
...
results: ok=18/19  failing-tests=1  failing-packages=3  timeouts=0  filtered-empty=0  go-test-rc=1
  19 package(s) have tests but only 18 reported ok — some package did not run to a verdict
```

That divergence — green under `make ci`, red under `make ci-shallow`, same commit — is the whole value proposition.

**CAN'T-NO-OP** — three deliberate breakages of the script itself, each checksum-gated so a silently-unapplied edit cannot read as a survivor:

| mutation | result |
|---|---|
| **A.** clone a nonexistent ref | `rc=1`, prints git's own `fatal: Remote branch … not found`, then `the depth-1 clone failed … Refusing to fall back to the working tree`. No test run, no success line. |
| **B.** drop `file://` (plain local path → clone is not shallow) | `rc=1` at control 1: `the clone reports --is-shallow-repository=false, want true`. |
| **B2.** mutation B **plus** control 1 disabled | **`PASSED in a depth-1 clone: 19 package(s) ok`** — on the red-control branch, i.e. a branch that genuinely fails in CI. This is the reassurance failure in the flesh, and control 1 is what stops it. |
| **C.** `go test -run zzzNoSuchTest ./...` | `ok=19/19`, `failing-tests=0`, `go-test-rc=0` — every other signal says green — and it still **fails** on `filtered-empty=19`: `19 package(s) reported 'no tests to run' — an ok line that measured nothing`. |

## Cost

Measured on a 24-core Linux box:

| | wall clock |
|---|---|
| `make ci-shallow`, warm Go build cache | **26.9 s** / 27.4 s (two runs) |
| `make ci-shallow`, empty `GOCACHE` | **33.0 s** |
| `make ci` (same tree, for comparison) | **27.6 s** |

The depth-1 clone itself is a rounding error next to `go test`.

## Limitation, stated plainly

**It sees committed state only.** Uncommitted working-tree changes are invisible to it. Commit before you rely on it — the target warns when your tree is dirty and names the ref and sha it actually cloned, so this cannot be discovered the hard way.

## Docs

`CONTRIBUTING.md` — what it does, the committed-state-only limitation, the measured cost, `CI_SHALLOW_KEEP=1`, and a pointer from the pre-PR checklist.

**Not added to `AGENTS.md`.** That file is at a byte ceiling with limited headroom and a parallel PR may be consuming some. Its "Build / test / lint / run" table lists the make targets, so `ci-shallow` is arguably missing from it — **maintainer's call**; one line there would cost roughly 80 bytes of the headroom, and I would rather you spend that deliberately than have me spend it for you. Nothing under `claudedocs/decisions/` was touched.

## Gate

`make ci` green (19/19), `make lint` (golangci-lint) **0 issues**, `gofmt -s -l .` silent, `shellcheck` clean on the new script. `origin/main` had not moved from `932c5e9` at push time, so this branch tip **is** the merged tree — those runs are merged-tree runs, not branch-only ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
