### PR TITLE
fix(ci): the vendorHash bot's `nix build` is SUPPOSED to fail, and errexit killed it every time

### DIFF
--- a/.github/workflows/bump-flake-vendorhash.yml
+++ b/.github/workflows/bump-flake-vendorhash.yml
@@ -14,6 +14,41 @@
 # back. On a run with no drift the recomputed hash equals the committed one, the
 # write-back is a no-op, `git status --porcelain` is empty, and NO PR is opened.
 #
+# 🔴 THAT DANCE IS BUILT ON A COMMAND THAT IS *SUPPOSED* TO FAIL, AND FOR ITS
+# WHOLE LIFE `set -e` KILLED THE STEP THE INSTANT IT DID. Every run of this
+# workflow since it was added failed — 6 for 6, on BOTH triggers (schedule and
+# push), zero successes ever. GitHub invokes a `run:` block as `bash -e {0}`, so
+# errexit is on before the first line and `set -uo pipefail` does NOT clear it;
+# `pipefail` then propagated `nix build`'s deliberate non-zero through the
+# `GOT="$(nix build … | grep … )"` pipeline, and errexit aborted the step AT THE
+# ASSIGNMENT — before the parse it had already done could be used. This is the
+# identical trap #313 hit in `release-homebrew.yml`; read that workflow's notes
+# too, because knowing about it there did not prevent it here.
+#
+# The failure was also SILENT, which is why it survived a month: `nix build`'s
+# entire output was captured into the command substitution, so nothing reached
+# the log. The step printed literally nothing — not even its own `::error::`,
+# which is downstream of the assignment that killed it — and the run showed only
+# `Process completed with exit code 1` after ~19s. So the two fixes below are a
+# pair, and neither is optional:
+#
+#   1. `nix build`'s failure is EXPECTED and is handled explicitly (`|| true`),
+#      never left to errexit.
+#   2. Its output goes to a FILE that is parsed and, on any parse failure,
+#      PRINTED. A step that cannot recompute the hash now says what nix actually
+#      said instead of exiting 1 with an empty log.
+#
+# Nothing here may rely on errexit to catch an error it can predict. If you add
+# a command that is expected to fail, handle its status where you write it.
+#
+# A RED RUN OF THIS WORKFLOW NOW FILES ITS OWN ISSUE — see the `signal` job.
+# That is the second half of the same lesson: this bot was broken for a month
+# and nothing said so, because a failing scheduled run notifies only whoever
+# last edited the `cron` line. #313 built that reporting mechanism for the
+# Homebrew cask check, CITING this workflow's unbroken run of failures as the
+# evidence; the generic core now lives in `failure-issue.yml` and this is its
+# first caller.
+#
 # Run manually anytime via the Actions tab → this workflow → "Run workflow"
 # (workflow_dispatch). It also runs weekly and on any push to main that touches
 # go.mod/go.sum/flake.nix/flake.lock (so a dep change gets a prompt fix, not
@@ -26,7 +61,12 @@ on:
     # (bump-scaffold-pins 07:17, revendor-canonical-schema 07:37). Cron literal
     # in YAML needs quoting so the `*` isn't parsed as a YAML alias.
     - cron: "47 7 * * 1"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "Fire drill: skip the real nix build and feed the parser a canned unparseable log, so the FAILURE path and the issue it files can be rehearsed. Opens a REAL issue — close it when you are done. It cannot open a PR: the drill fails at the recompute step, which is upstream of every step that writes anything."
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
@@ -42,6 +82,14 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    # Read by the `signal` job to describe WHAT went wrong. `state` is empty
+    # when the job died before the classifier ran (a runner failure, a checkout
+    # failure, nix failing to install) — which `signal` resolves to `unknown`,
+    # a real and different state from any verdict this job produces.
+    outputs:
+      state: ${{ steps.classify.outputs.state }}
+      title: ${{ steps.classify.outputs.title }}
+      body: ${{ steps.classify.outputs.body }}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,18 +103,97 @@ jobs:
       # write it back into flake.nix. On a no-drift run the parsed hash equals
       # the committed one, so this leaves flake.nix byte-identical (no-op) and
       # the detect-changes gate below opens no PR.
+      #
+      # Read the errexit note in this file's header before editing this step:
+      # `nix build` failing IS the mechanism, and letting the shell treat that
+      # as an error is what broke every run of this workflow.
       - name: recompute flake vendorHash
+        id: recompute
+        env:
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || false }}
         run: |
-          set -euo pipefail
+          # Deliberately NOT `set -e`. GitHub already runs this as `bash -e {0}`
+          # so errexit is on regardless — the point is that no line below may
+          # DEPEND on it, because the one command that matters here is expected
+          # to exit non-zero. `pipefail` is also gone: it existed only to make
+          # the old single-pipeline parse strict, and it is what turned that
+          # expected failure into a dead step.
+          set -u
+
           FAKE='sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
-          sed -i "s#vendorHash = \"sha256-[^\"]*\";#vendorHash = \"$FAKE\";#" flake.nix
-          GOT="$(nix build .#default 2>&1 | grep -oE 'sha256-[A-Za-z0-9+/=]{40,}' | grep -v "$FAKE" | tail -1)"
-          if [ -z "$GOT" ]; then
-            echo "::error::failed to parse a recomputed vendorHash from the nix build output" >&2
+          LOG="$RUNNER_TEMP/nix-build.log"
+
+          # Read the committed hash BEFORE overwriting it, so a failure can
+          # report expected-vs-got rather than just "something went wrong".
+          COMMITTED="$(sed -n 's/^[[:space:]]*vendorHash = "\(sha256-[^"]*\)";.*/\1/p' flake.nix | head -1)"
+          if [ -z "$COMMITTED" ]; then
+            echo "::error::no \`vendorHash = \"sha256-…\";\` line in flake.nix — the sed pattern this job relies on no longer matches. flake.nix's vendorHash line was reshaped; update both seds in this step."
+            grep -n 'vendorHash' flake.nix || echo "(no vendorHash line at all)"
             exit 1
           fi
-          echo "recomputed vendorHash = $GOT"
+          echo "committed   vendorHash = $COMMITTED"
+
+          sed -i "s#vendorHash = \"sha256-[^\"]*\";#vendorHash = \"$FAKE\";#" flake.nix
+
+          # EXPECTED to exit non-zero: the fake hash is what forces the mismatch
+          # we parse. `|| true` is load-bearing — without it errexit ends the
+          # step here, which is exactly what this workflow did 6 runs running.
+          # Output goes to a FILE so it can be parsed AND shown on failure; the
+          # old version piped it into `$( … )`, which is why the log was empty.
+          if [ "$DRILL" = "true" ]; then
+            # Fire drill: feed the REAL parser a log with no hash mismatch in
+            # it, so the genuine failure branch below runs. Rehearsing the
+            # report against a stub of the report would prove nothing.
+            echo "⚠️  FIRE DRILL — skipping the real nix build and using a canned unparseable log."
+            {
+              echo "error: this is a fire drill fixture, not a real nix failure"
+              echo "       dispatched by hand to rehearse the reporting path"
+            } >"$LOG"
+          else
+            nix build .#default >"$LOG" 2>&1 || true
+          fi
+
+          # Parse the `got:` that PAIRS with our own `specified:` line, rather
+          # than "the last sha256- token anywhere in the output". Nix prints
+          #     specified: sha256-<fake>
+          #        got:    sha256-<real>
+          # and pairing them means a DIFFERENT fixed-output derivation failing
+          # in the same build cannot donate its hash to our vendorHash.
+          # Format verified identical on nix 2.22.3 (the 2.22.1 family
+          # install-nix-action@v27 pins) and on nix 2.31.3.
+          GOT="$(awk -v fake="$FAKE" '
+            $1 == "specified:" { pending = ($2 == fake); next }
+            pending && $1 == "got:" { print $2; pending = 0 }
+          ' "$LOG" | tail -1)"
+
+          if [ -z "$GOT" ]; then
+            git checkout -- flake.nix
+            echo "::error::could not parse a recomputed vendorHash from the nix build output — no \`got:\` line paired with our \`specified: $FAKE\`. Either the build failed before reaching the vendor fetch, or nix changed the hash-mismatch wording. The full output follows; flake.nix has been restored."
+            echo "--- nix build output ($(wc -l <"$LOG") lines) ---"
+            cat "$LOG"
+            echo "--- end nix build output ---"
+            exit 1
+          fi
+
+          if [ "$GOT" = "$COMMITTED" ]; then
+            echo "recomputed  vendorHash = $GOT"
+            echo "no drift — the committed hash is already correct"
+          else
+            echo "recomputed  vendorHash = $GOT"
+            echo "::notice::vendorHash drift: committed $COMMITTED, recomputed $GOT"
+          fi
+
           sed -i "s#vendorHash = \"sha256-[^\"]*\";#vendorHash = \"$GOT\";#" flake.nix
+
+          # Never leave the FAKE hash in the tree. Without this a write-back
+          # that silently failed to match would hand the steps below a flake.nix
+          # containing the fake hash — which `detect changes` would read as
+          # drift and propose as a PR.
+          if ! grep -qF "vendorHash = \"$GOT\";" flake.nix; then
+            git checkout -- flake.nix
+            echo "::error::write-back failed — flake.nix does not contain the recomputed hash $GOT after the substitution. flake.nix has been restored; no PR will be opened."
+            exit 1
+          fi
 
       # Only validate + open a PR when the recompute actually rewrote the hash —
       # a no-op run (hash already correct) skips everything downstream.
@@ -85,14 +212,17 @@ jobs:
       # defense-in-depth: the recomputed hash must produce a flake that builds
       # and yields a runnable binary.
       - name: validate — flake builds with the new vendorHash
+        id: validate_build
         if: steps.changed.outputs.changed == 'true'
         run: nix build .#default
 
       - name: validate — the built binary runs
+        id: validate_run
         if: steps.changed.outputs.changed == 'true'
         run: ./result/bin/civitai version
 
       - name: open PR if vendorHash changed
+        id: pr
         if: steps.changed.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
@@ -124,3 +254,89 @@ jobs:
             (`secrets.BUMP_SCAFFOLD_PINS_TOKEN`, Contents + Pull requests RW on
             this repo only), not the default `GITHUB_TOKEN` — so the repo's
             `flake` check re-runs the build on it as an independent confirmation.
+
+      # Name WHICH step failed, for the issue the `signal` job files. `always()`
+      # so it still runs after a failed step — without it this is skipped
+      # exactly when it is needed, and `signal` would only ever see `unknown`.
+      # Each phase gets its own state because they call for different actions: a
+      # parse failure is this job's own bug, a validate failure means the
+      # recomputed hash is wrong, and a PR failure is usually the token.
+      - name: classify the outcome
+        id: classify
+        if: always()
+        env:
+          R_RECOMPUTE: ${{ steps.recompute.outcome }}
+          R_CHANGED: ${{ steps.changed.outcome }}
+          R_VALIDATE_BUILD: ${{ steps.validate_build.outcome }}
+          R_VALIDATE_RUN: ${{ steps.validate_run.outcome }}
+          R_PR: ${{ steps.pr.outcome }}
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || false }}
+        run: |
+          set -uo pipefail
+
+          if [ "$R_RECOMPUTE" != "success" ]; then
+            state=recompute-failed
+            title="the Nix flake vendorHash bot cannot recompute the hash"
+            detail="The \`recompute flake vendorHash\` step failed. It could not parse a hash out of \`nix build\`'s output, or the build never reached the vendor fetch. **The step prints nix's full output on this path — read the run log, the reason is in it.**"
+          elif [ "$R_CHANGED" != "success" ]; then
+            state=detect-failed
+            title="the Nix flake vendorHash bot failed while checking for changes"
+            detail="The \`detect changes\` step failed, which is unusual — it only runs \`git status\`."
+          elif [ "$R_VALIDATE_BUILD" = "failure" ] || [ "$R_VALIDATE_RUN" = "failure" ]; then
+            state=validate-failed
+            title="the Nix flake vendorHash bot recomputed a hash that does not build"
+            detail="A new vendorHash was computed, but \`nix build .#default\` or the built binary then failed with it. **No PR was opened.** This means the recompute produced a hash the flake cannot use — treat the flake as broken for \`nix run\` until a human looks."
+          elif [ "$R_PR" = "failure" ]; then
+            state=pr-failed
+            title="the Nix flake vendorHash bot could not open its PR"
+            detail="The hash was recomputed and validated, but opening the PR failed — usually \`secrets.BUMP_SCAFFOLD_PINS_TOKEN\` being expired or missing. **The fix is still un-merged**, so \`nix run github:civitai/cli\` stays broken until someone bumps the hash by hand or repairs the token."
+          else
+            state=green
+            title=""
+            detail=""
+          fi
+
+          DRILL_NOTE=""
+          if [ "$DRILL" = "true" ]; then
+            DRILL_NOTE="> ⚠️ **This is a fire drill**, dispatched by hand with \`drill=true\`. The nix build was skipped and the parser was handed a canned unparseable log, so this is NOT a real failure of the bot — it exists to prove this reporting path works. Close it when you are done."
+          fi
+
+          echo "state=$state"
+          {
+            echo "state=$state"
+            echo "title=[vendorhash-bot] $title"
+            echo "body<<VENDORHASH_BODY_EOF"
+            if [ -n "$DRILL_NOTE" ]; then
+              echo "$DRILL_NOTE"
+              echo
+            fi
+            echo "$detail"
+            echo
+            echo "While this is failing, a \`vendorHash\` that drifts from \`go.sum\` will NOT be fixed automatically, and \`nix run github:civitai/cli\` breaks silently for anyone installing that way. The \`flake\` check on a PR touching \`go.mod\`/\`go.sum\` still DETECTS the drift — only the remediation is down."
+            echo
+            echo "To recompute by hand: set \`vendorHash\` in \`flake.nix\` to \`lib.fakeHash\`, run \`nix build\`, and copy the \`got: sha256-…\` value out of the error."
+            echo "VENDORHASH_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  # File a report when the bot is broken, and close it when it recovers. See
+  # `failure-issue.yml` for why this is an issue rather than email, and for the
+  # rules that stop it becoming noise.
+  #
+  # `always()` so a red `bump` job still reports; `!= 'cancelled'` so a hand
+  # cancellation is not filed as a defect.
+  signal:
+    needs: [bump]
+    if: always() && needs.bump.result != 'cancelled'
+    uses: ./.github/workflows/failure-issue.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      marker: "[vendorhash-bot]"
+      failing: ${{ needs.bump.result != 'success' }}
+      # Empty when `bump` died before the classifier ran — a runner failure, a
+      # failed checkout, nix failing to install. That is its own state and must
+      # not borrow the wording of a verdict this job never reached.
+      state: ${{ needs.bump.outputs.state || 'unknown' }}
+      title: "${{ needs.bump.outputs.title || '[vendorhash-bot] the Nix flake vendorHash bot could not run' }}"
+      body: "${{ needs.bump.outputs.body || 'The `bump` job failed before it could classify what went wrong, so it did not reach the end of the recompute step. Check the run log — the usual causes are the runner dying, the checkout failing, or `install-nix-action` failing.' }}"

--- a/.github/workflows/failure-issue.yml
+++ b/.github/workflows/failure-issue.yml
@@ -1,0 +1,188 @@
+# A reusable "file your own report" job for unattended workflows.
+#
+# WHY THIS EXISTS. A red SCHEDULED run reaches almost nobody: GitHub sends
+# scheduled-workflow failure mail only to whoever last edited the `cron` line,
+# through that person's own per-user Actions setting, and there is no org, team
+# or repo-level Actions failure notification to widen it. #313 measured that in
+# this repo and built the mechanism below for the daily Homebrew cask check —
+# using `bump-flake-vendorhash.yml` as its evidence, because that workflow had
+# failed every scheduled run for three weeks while 30+ issues were filed by hand
+# and not one was about it.
+#
+# It then took another month for anyone to notice that bot was broken, which is
+# the argument for this file rather than a second copy of that job: the pattern
+# is not cask-specific and the next unattended workflow should not have to
+# re-derive it. `release-homebrew.yml` still carries its OWN copy — see the
+# migration note at the bottom.
+#
+# THE ANTI-SPAM RULES, which are the whole design (mechanism and rationale from
+# #313; read that job's header comment for the longer form):
+#   * ONE open issue at a time, found by the caller's title MARKER over a plain
+#     issue LIST — never a search query, whose index is eventually consistent
+#     and would let two runs each conclude "there isn't one yet".
+#   * A repeat failure REWRITES the body. Editing a body notifies nobody, so a
+#     workflow failing daily for a week is one issue, zero comments, and a body
+#     that always describes the most recent run.
+#   * A comment — the one notifying update — is posted ONLY when the `state`
+#     changes, because that is the only change that alters what a human should
+#     do. The previous state is read from a marker in the BODY, not the title,
+#     so renaming the issue by hand does not fake a change.
+#   * A green run CLOSES the issue. That is not cosmetic: it resets the
+#     mechanism so the NEXT failure opens a fresh issue and notifies again,
+#     instead of silently deduping into a stale thread.
+#
+# The caller owns WHAT to say (title/body/state); this workflow owns only WHEN
+# to open, edit, comment or close. Keep it that way — the moment it starts
+# composing messages it stops being reusable.
+name: failure-issue
+
+on:
+  workflow_call:
+    inputs:
+      marker:
+        description: "Title prefix identifying this reporter's issue, e.g. `[vendorhash-bot]`. Must be unique per caller — two callers sharing a marker would fight over one issue."
+        required: true
+        type: string
+      failing:
+        description: "true = something is wrong and should be reported; false = green, close any open report."
+        required: true
+        type: boolean
+      title:
+        description: "Issue title. MUST start with `marker` (asserted below). Ignored when failing=false."
+        required: false
+        type: string
+        default: ""
+      body:
+        description: "Markdown body describing the failure. Ignored when failing=false."
+        required: false
+        type: string
+        default: ""
+      state:
+        description: "Short key for the KIND of failure (e.g. `recompute-failed`). A change between runs posts the one notifying comment."
+        required: false
+        type: string
+        default: "failing"
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The only elevated permission here, scoped to this job.
+      issues: write
+    steps:
+      - name: Open, update or close the report issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          MARKER: ${{ inputs.marker }}
+          FAILING: ${{ inputs.failing }}
+          TITLE: ${{ inputs.title }}
+          BODY: ${{ inputs.body }}
+          STATE: ${{ inputs.state }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Note the errexit shape: GitHub runs this as `bash -e {0}`, so
+          # errexit is already on and `set -uo pipefail` does NOT clear it.
+          # That trap broke #313's own drill and every run of
+          # bump-flake-vendorhash.yml. Nothing below is expected to fail, so
+          # errexit is welcome here — but do not add a command that IS expected
+          # to fail without handling its status where you write it.
+          set -uo pipefail
+
+          STATE_MARK_PREFIX="<!-- failure-issue-state:"
+
+          if [ -z "$MARKER" ]; then
+            echo "::error::failure-issue was called with an empty marker — it would match every issue in the repo"
+            exit 1
+          fi
+
+          # ONE open issue, found by LISTING. See the header: a search query's
+          # index is eventually consistent and would open duplicates.
+          existing="$(gh issue list --state open --limit 500 --json number,title \
+            --jq "[.[] | select(.title | startswith(\"$MARKER\"))] | first | .number // empty")"
+
+          # ---- green ---------------------------------------------------------
+          if [ "$FAILING" != "true" ]; then
+            if [ -n "$existing" ]; then
+              cat >"$RUNNER_TEMP/recovered.md" <<EOF
+          ✅ Green again as of [this run]($RUN_URL) (trigger: \`$EVENT_NAME\`).
+
+          Closing. The next failure opens a **new** issue rather than reusing this one — that is deliberate, so a
+          fresh failure notifies rather than silently deduping into a closed-then-reopened thread.
+          EOF
+              gh issue comment "$existing" --body-file "$RUNNER_TEMP/recovered.md"
+              gh issue close "$existing" --reason completed
+              echo "closed #$existing"
+            else
+              echo "green, and no open report issue — nothing to do."
+            fi
+            exit 0
+          fi
+
+          # ---- failing -------------------------------------------------------
+          if [ -z "$TITLE" ] || [ -z "$BODY" ]; then
+            echo "::error::failure-issue was called with failing=true but an empty title or body — it cannot file a report that says nothing"
+            exit 1
+          fi
+          case "$TITLE" in
+            "$MARKER"*) ;;
+            *)
+              echo "::error::the title must start with the marker ($MARKER), or the dedupe lookup cannot find this issue again and every run would open a new one. Got: $TITLE"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "$STATE_MARK_PREFIX $STATE -->"
+            echo "<!-- This body is REWRITTEN by every failing run. Put notes in a COMMENT;"
+            echo "     anything typed into the body is overwritten by the next run. -->"
+            echo
+            echo "$BODY"
+            echo
+            echo "---"
+            echo "[Run log]($RUN_URL) (trigger: \`$EVENT_NAME\`). Run logs expire after 90 days; this issue does not."
+            echo
+            echo "Filed automatically via \`.github/workflows/failure-issue.yml\`, which keeps ONE open issue at a"
+            echo "time: a repeat failure rewrites this body (notifying nobody) and a green run closes the issue."
+          } >"$RUNNER_TEMP/body.md"
+
+          if [ -z "$existing" ]; then
+            num="$(gh issue create --title "$TITLE" --body-file "$RUNNER_TEMP/body.md" | sed 's#.*/##')"
+            echo "opened #$num (state=$STATE)"
+            exit 0
+          fi
+
+          # Read the PREVIOUS state out of the body marker, so a hand-renamed
+          # issue does not read as a state change.
+          prev="$(gh issue view "$existing" --json body --jq .body \
+            | sed -n "s#^$STATE_MARK_PREFIX \(.*\) -->#\1#p" | head -1)"
+
+          gh issue edit "$existing" --body-file "$RUNNER_TEMP/body.md" >/dev/null
+          if [ "$TITLE" != "$(gh issue view "$existing" --json title --jq .title)" ]; then
+            gh issue edit "$existing" --title "$TITLE" >/dev/null
+          fi
+
+          if [ -n "$prev" ] && [ "$prev" != "$STATE" ]; then
+            cat >"$RUNNER_TEMP/changed.md" <<EOF
+          ⚠️ The failure changed kind: \`$prev\` → \`$STATE\` ([run]($RUN_URL)).
+
+          The body above now describes the new state. This comment is posted only on a CHANGE of kind, so a
+          workflow failing the same way every day stays a single silent update.
+          EOF
+            gh issue comment "$existing" --body-file "$RUNNER_TEMP/changed.md"
+            echo "updated #$existing and commented ($prev -> $STATE)"
+          else
+            echo "updated #$existing (state=$STATE, unchanged — no comment posted)"
+          fi
+
+# MIGRATION NOTE. `release-homebrew.yml`'s `signal` job predates this file and
+# still carries its own copy of the mechanism. It was deliberately NOT migrated
+# in the PR that added this workflow: that job is on the RELEASE path, it was
+# merged and fire-drilled days earlier, and its extra machinery (a kind taxonomy
+# with six states, an artifact download, and body composition keyed to
+# caskcheck's output) would all have to move into its caller first. Migrating it
+# is a good follow-up — do it as its own change, and re-run its `drill=broken`
+# dispatch afterwards, because that is the only thing that proves the reporting
+# path still works.


### PR DESCRIPTION
## The bug

`bump-flake-vendorhash.yml` has **never once succeeded**. Six runs, six failures, on both triggers, since the day it was added:

```
2026-08-10  schedule  failure     2026-07-27  schedule  failure
2026-08-06  push      failure     2026-07-20  schedule  failure
2026-08-03  schedule  failure     2026-07-18  push      failure
```

The failing step ran ~19s and printed **nothing** — not even its own `::error::`. Run 31372677765:

```
09:01:36.8  ##[group]Run set -euo pipefail          <- step starts
09:01:55.7  ##[error]Process completed with exit code 1
```

Zero output lines between them.

## Root cause

The recompute is the `lib.fakeHash` dance: write a known-fake hash, let `nix build` fail, read the real hash out of nix's `got: sha256-…` line. **It is built on a command that is supposed to exit non-zero.**

GitHub invokes a `run:` block as `bash -e {0}`, so errexit is on before the script's first line and `set -uo pipefail` does not clear it. `pipefail` then propagated `nix build`'s deliberate failure through

```bash
GOT="$(nix build .#default 2>&1 | grep -oE 'sha256-…' | grep -v "$FAKE" | tail -1)"
```

and errexit aborted the step **at the assignment** — throwing away a hash the pipeline had already parsed correctly. The `if [ -z "$GOT" ]` error branch below it was unreachable, which is why the log was empty.

It was silent for the same reason it was broken: all of nix's output went into the command substitution, so none of it reached the log.

This is the identical trap **#313** hit in `release-homebrew.yml` ("errexit is already on before the script's first line, and `set -uo pipefail` does not clear it"). Knowing about it there did not prevent it here — so the fix is written as a rule in this file's header, not just as a patch.

## Reproduction

Locally, on NixOS, in both directions.

**1. The shell semantics, isolated** — a stub emitting nix's exact error shape:

| script | result |
|---|---|
| `set -euo pipefail` (as shipped) | **rc=1, zero output**, end of script not reached |
| `set -eu` (pipefail removed), otherwise identical | **rc=0**, parsed `sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=` |

The only difference is `pipefail`, which is the discriminating control: the parse itself was always correct.

**2. The real `nix build`**, at `dfdcc97` with the fake hash planted — rc=1 in 4s (deps cached), emitting exactly what the regex expects:

```
error: hash mismatch in fixed-output derivation '…-go-modules.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=
```

So the parse format was never the problem, and **there is no actual drift** — the committed hash is correct.

**3. The shipped step body, verbatim**, extracted from the YAML with a parser (not hand-copied) and run under `bash -e` as GitHub does: **rc=1, zero output, and `flake.nix` left holding the FAKE hash.** Byte-identical to CI.

### Things the brief floated that the evidence ruled out

- **Not a nix version change.** Message format verified **identical** on nix **2.22.3** (the 2.22.1 family `install-nix-action@v27` pins) and on **2.31.3** — two measurement points.
- **Not a stale hash.** The recomputed hash equals the committed one.
- **Not `vendorHash` needing to be `null`/`fakeHash` first** — the step already writes the fake itself.
- **Not failing before computing anything.** It ran the full ~19s build and got the right answer, then discarded it.

## The fix

Two halves, neither optional:

1. `nix build`'s failure is handled explicitly (`|| true`) and `pipefail` is gone from that step. Nothing there may rely on errexit to catch an error it can predict.
2. Its output goes to a **file** that is parsed and, on any parse failure, **printed** — with committed-vs-recomputed hashes named on every path.

The parse is also no longer "the last `sha256-` token in the output". It pairs `got:` with **our own** `specified:` line, so a different fixed-output derivation failing in the same build cannot donate its hash to `vendorHash`. Measured on a log holding a foreign FOD mismatch *after* ours: the old parse harvested `sha256-DEADBEEF…`; the new one takes ours.

Every failure path runs `git checkout -- flake.nix`, so the fake hash can never reach a PR.

## Proof

**On CI, on this branch, on the real nix 2.22.1** — [run 31416146303](https://github.com/civitai/cli/actions/runs/31416146303) — **success, the first green run this workflow has ever had**:

```
committed   vendorHash = sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=
recomputed  vendorHash = sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=
no drift — the committed hash is already correct
vendorHash already current — nothing to do
```

Locally, against a real `nix build`, driving the step extracted from the shipped YAML:

| case | result |
|---|---|
| no drift | rc=0, both hashes printed, `flake.nix` byte-identical, no PR |
| **drift committed to HEAD** | rc=0, correct hash written back, `git status` dirty → PR would open with the right 1-line diff |
| nix fails with no hash mismatch | rc=1, **full nix output printed**, `flake.nix` restored |
| foreign FOD mismatch only | rc=1, hash **not** harvested, output printed |
| no `vendorHash` line in flake.nix | rc=1, names the reshaped line |

The drift row matters: that path had never executed in CI or anywhere else.

Classifier driven across all 8 step-outcome combinations (green ×2, recompute / detect / validate-build / validate-run / PR failures, drill) — all correct, every title carries the dedupe marker, the drill note appears only on drills.

`make ci` **19 ok / 0 `--- FAIL`**, `make lint` **0 issues**, `make ci-shallow` **19/19 ok**. `actionlint` clean on both workflows — with a positive control (it caught a real `: `-in-scalar break in this very PR, and goes red on an injected error), because a clean verdict from an instrument nobody has seen fail is not evidence.

## Failure visibility

Included, because this is the second half of the same lesson: the bot was broken for a month precisely because **nothing said so** — a failing scheduled run notifies only whoever last edited the `cron` line. #313 built that mechanism for the cask check *citing this workflow's unbroken run of failures as its evidence*, and then this workflow stayed broken anyway.

**I factored rather than copied.** The generic core is now `.github/workflows/failure-issue.yml` (`workflow_call`): one open issue found by *listing*, a repeat failure rewrites the body (notifying nobody), a state change posts the one comment, a green run closes it. The caller owns *what* to say; the reusable workflow owns only *when* to open/edit/comment/close.

**`release-homebrew.yml` deliberately keeps its own copy in this PR.** It is on the release path, was merged and fire-drilled days ago, and its extra machinery (a six-state kind taxonomy, an artifact download, body composition keyed to `caskcheck`) has to move into its caller first. Migrating it is a good follow-up and is noted in the new file — it should be its own change, re-running its `drill=broken` dispatch afterwards.

### The reporting path was rehearsed, not assumed

`drill=true` on a hand dispatch feeds the **real** parser a canned unparseable log, so the genuine failure branch runs. It cannot open a PR — it fails at the recompute step, upstream of every step that writes anything.

| run | what it proved |
|---|---|
| [31416249290](https://github.com/civitai/cli/actions/runs/31416249290) drill | step failed, printed the captured output, **opened #315** |
| [31416341677](https://github.com/civitai/cli/actions/runs/31416341677) drill again | **still exactly 1 open issue, 0 comments** — body rewritten silently |
| [31416417222](https://github.com/civitai/cli/actions/runs/31416417222) green | **closed #315** with a recovery comment |

**Issue consumed by testing: #315 — opened by the drill and closed by the green run, which is itself the proof the recovery path works.** Zero `[vendorhash-bot]` issues remain open.

## What I could not verify

- **The scheduled trigger** (Mondays 07:47 UTC) — only reachable on `main` on its cron. The dispatch and schedule paths run the same job, and the failure was in the step body, not the trigger, so there is no trigger-specific risk; but I did not observe a scheduled run.
- **A real drift PR end-to-end.** There is no drift today, so `create-pull-request` and `secrets.BUMP_SCAFFOLD_PINS_TOKEN` were never exercised — those steps `skipped` on every green run. I proved the drift path locally (correct hash written, `git status` dirty), which is everything up to the PR action itself. **Watch the next run that follows a `go.mod`/`go.sum` change**; if the token has expired it now reports `pr-failed` and files an issue rather than failing quietly.
- `install-nix-action@v27` / nix 2.22.1 are **left alone** — they were not the cause, and bumping them would change `flake.yml`'s environment too. Worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
