### PR TITLE
docs(agents): the numbered list is a TRIGGER INDEX — 45,027 → 25,258 bytes, and a guard for the failure that hides an item

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,41 +244,41 @@ every `item N` / `items N–M` here and confirm each still points at what it mea
 — the index clauses above break first, and both sides of a collision tend to have
 edited them differently, so the correct merged sentence is usually neither one's.
 
-**Where an item's evidence lives:** this file is imported into every session, so
-the largest items keep their THESIS here and carry their body — the
-measurements, mutation matrices, retractions and enumerated residuals — in
-`claudedocs/decisions/NN-<slug>.md`, named by a `→ evidence:` line closing the
-stub. Read the evidence before touching the code that item is about, and edit it
-there rather than re-inlining it here. The move is verbatim and pinned as such
-(`agents_split_preserved_test.go`); the pointer/file set is a bidirectional
-ledger (`agents_evidence_test.go`); and this file has a byte ceiling
+🔴 **THE LIST BELOW IS A TRIGGER INDEX, NOT A SUMMARY — EACH LINE IS A QUESTION
+ABOUT WHAT YOU ARE ABOUT TO DO.** This file is imported into every session, so an
+item's body is a per-session cost paid by every agent whether or not the session
+touches it. So the body — the thesis, the measurements, the mutation matrices,
+the retractions, the enumerated residuals — lives in
+`claudedocs/decisions/NN-<slug>.md`, and what stays here is one line asking
+whether you are in the situation that item governs.
+
+**If a trigger matches what you are about to change, OPEN ITS FILE BEFORE you
+change it.** A trigger is deliberately not enough to act on: it names the
+situation, never the conclusion, so "I read the trigger" is not "I know the
+rule". If no trigger matches, you have read the whole list and you are done —
+that is what the list is for. Items with no pointer (2 and 4) are shorter than a
+trigger plus a file read would be, so they are stated here in full; there is
+nothing further to open.
+
+The move is verbatim and pinned as such (`agents_split_preserved_test.go`); the
+pointer/file set is a bidirectional ledger (`agents_evidence_test.go`); every
+item must carry a trigger that is a routing question rather than a label
+(`agents_trigger_test.go`); and this file has a byte ceiling
 (`agents_size_test.go`) whose failure message prints the eviction playbook.
 
-1. **`civitai app validate` is a best-effort LOCAL mirror, not the authority.**
-   The server-side `BlockManifestValidator`
-   (`civitai/civitai → src/server/services/block-manifest-validator.service.ts`)
-   is the source of truth at review time. The vendored
-   `schema/app-block.manifest.schema.json` covers only **syntactic** rules; the
-   **semantic** rules the schema can't express (sandbox trust-tier allowlist,
-   `page ⇒ iframe`, required iframe sub-fields, the `renderMode` tier gate,
-   `targets[].slotId` registry membership) are **ported into Go** in
-   `internal/validate/{semantic.go,targets.go}`. Some checks are *deliberately
-   not* reproduced locally (origin-binding, scope⊆client) because they need
-   per-app server state the CLI can't see — this fidelity split is intentional,
-   not a missing feature.
+1. **Adding or changing a rule in `internal/validate`, or wondering why a
+   server-side check has no local counterpart?**
+   → evidence: claudedocs/decisions/01-validate-is-a-local-mirror.md
+
 2. **The slot registry is VENDORED, not imported.** `internal/validate/targets.go`
    hard-codes `vendoredSlotIDs` (4 entries) mirroring
    `civitai/civitai → src/shared/constants/slot-registry.ts`. Go can't import the
    TS registry; the set is small and historically stable, so vendoring is cheap.
-3. **The lockfile check in `internal/validate/lockfile.go` mirrors the PLATFORM
-   BUILD RECIPE, not `BlockManifestValidator`.** It is the one build-time rule
-   `validate` reproduces, because the platform build installs *strictly* from
-   the committed lockfile and a mismatch surfaces only as an opaque server-side
-   "build failed". It fires only when `package.json` exists; static blocks never
-   install and must never be flagged. 🔴 It is FATAL, and since #255 it reads
-   the required lockfile's BYTES rather than only its presence — read the
-   evidence before touching `packageManagerFor`, the BOM strip or the 64 MiB cap.
+
+3. **Touching `internal/validate/lockfile.go` — `packageManagerFor`, the BOM
+   strip, the 64 MiB cap — or adding a package manager to the build recipe?**
    → evidence: claudedocs/decisions/03-lockfile-check.md
+
 4. **The CLI does NOT vendor the server's token-scope bitmask — and shouldn't.**
    The `whoami` / `dev-token` "can spend Buzz" capability check decodes the JWT
    `scopes` (a **string array**) and looks for the `ai:write:budgeted` scope
@@ -286,347 +286,105 @@ ledger (`agents_evidence_test.go`); and this file has a byte ceiling
    reproduce the server's numeric scope bit positions — all bit/scope authority
    stays server-side. Don't "helpfully" add a vendored bitmask; the string check
    is deliberate.
-5. **`civitai app metrics` calls tRPC, not REST — because there is no REST route
-   to call.** Owner analytics exist only as `blocks.getMyAppAnalytics`
-   (`civitai/civitai → src/server/routers/blocks.router.ts`); there is no
-   `/api/v1` equivalent. So `internal/cmd/app_metrics.go` resolves `<slug>` →
-   `appBlockId` through the *existing REST* route `GET /api/v1/blocks/submissions`
-   and then issues the non-batched tRPC GET in `internal/appapi/analytics.go`
-   (input rides in `?input={"json":{…}}`, success unwraps `result.data.json`),
-   reusing the `authedDo` + envelope-unwrap pattern `GetForgejoCloneInfo` already
-   established. The two-hop shape is deliberate, not an oversight — don't "fix"
-   the tRPC call into a REST call that does not exist.
-6. **`notOwned` is a cross-repo contract, and the human view MUST keep branching
-   on it.** The proc sits behind the `appBlocksAuthor` feature flag and answers a
-   caller who is not entitled — or does not own the app — with **HTTP 200 and
-   every counter zeroed**, not an error. A renderer that ignores the field
-   therefore prints a plausible, fully-populated-looking empty dashboard for what
-   is really a permission failure, so `runAppMetrics` refuses to render when
-   `notOwned` is true. Whoever changes that payload server-side has to keep the
-   field. `--json` deliberately passes the payload through **and still exits 0**,
-   so a script must branch on `notOwned` itself rather than trust the counts.
-7. **The exit-code contract is pinned by `errors.Is`, never by message text.**
-   The classification sentinels carry no visible text — `civitai.Tag`/`TagStatus`
-   attach them while `Error()` stays byte-for-byte unchanged (see
-   `pkg/civitai/errkind.go`) — so a test that asserts on the message says nothing
-   about the exit code. Measured on the `metrics` PR: stripping the
-   classification while leaving every message identical left the **entire suite
-   green**, and the README's 403 → exit 3 / not-found → exit 4 promise was
-   unpinned. Assert `errors.Is(err, civitai.ErrUnauthorized)` /
-   `civitai.ErrNotFound` / `cmd.ErrUsage` (note: usage lives in `internal/cmd`,
-   the HTTP kinds in `pkg/civitai`). This applies to **every** command that
-   claims an exit code, not just `metrics`.
-8. **`app metrics` prints RAW endpoint/scope tokens, and the web deliberately does
-   not — this divergence is on purpose.** The web analytics panel humanises the
-   two "top N" rollups (`civitai/civitai → src/components/AppBlocks/`
-   `analytics-bucket-labels.ts`), so the same data reads as `Generations` /
-   `AI workflow submits` there and as `workflow:submit` / `ai:write:budgeted`
-   here (`app_metrics.go`, the `Top endpoints` / `Top scopes` sections). That was
-   a **deliberate non-mirror**, decided when the web labels landed: reproducing
-   them would add a FIFTH vendored mapping to keep in lockstep with the server
-   (alongside `schema/`, the slot registry, item 10's dev-tunnel dotenv mirror
-   and item 11's ready-ack emitter), and unlike those four it buys no
-   correctness — a raw token is accurate, just terse, and the values are already
-   bounded so they aggregate readably. The raw form is arguably *better* for the
-   CLI's scripting audience, and `--json` must keep emitting raw tokens
-   regardless. 🔴 The count was stale and read "a THIRD … (alongside `schema/`
-   and the slot registry)": this item predates items 10 and 11, and neither
-   recounted it. Four is the number the closing paragraph and both of those
-   items already state — check it there before quoting it here again.
-   Cost to know about: an author reading the same range on both surfaces sees two
-   vocabularies, and a legacy pre-bounding row shows here as
-   `workflow:submit:<id>` where the web shows `Generations (<id>)`. If you decide
-   to close the gap, mirror `analytics-bucket-labels.ts` wholesale rather than
-   hand-rolling labels, add a drift check against the server's
-   `recordScopeInvocation` call sites, and note that `pending` is a "no id
-   captured" sentinel — **not** a status.
-9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
-   redundant with `notOwned`.** The `App loads` section is the only part of the
-   payload the server reads from **ClickHouse** rather than Postgres, so its
-   store can be unconfigured, slow or down while every other counter in the
-   same response is genuinely measured — which is why the flag is per-SECTION.
-   🔴 `AppAnalytics.Views` is a **pointer** because there are THREE states, not
-   two, and `installs.notApplicable` is a third state of a different KIND. All
-   of it exists to stop the fabricated zero item 6 exists to prevent.
+
+5. **Replacing `app metrics`' slug→id→tRPC two-hop with a REST route, or
+   editing `internal/appapi/analytics.go`?**
+   → evidence: claudedocs/decisions/05-app-metrics-trpc-not-rest.md
+
+6. **Rendering the `app metrics` payload, dropping a field from it, or
+   scripting against its `--json`?**
+   → evidence: claudedocs/decisions/06-notowned-is-a-cross-repo-contract.md
+
+7. **Asserting an exit code, or testing an error's classification, in ANY
+   command?**
+   → evidence: claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md
+
+8. **Tempted to humanise `app metrics`' raw endpoint/scope tokens into what the
+   web shows?**
+   → evidence: claudedocs/decisions/08-raw-tokens-are-a-non-mirror.md
+
+9. **Printing an analytics counter that may never have been measured —
+   `views.unavailable`, `installs.notApplicable`, an absent `views` key?**
    → evidence: claudedocs/decisions/09-views-unavailable-discriminator.md
 
-10. **The `dev-tunnel` embeddability preflight WARNS and never blocks, and its
-    two halves have deliberately different evidentiary strength.**
-    `internal/devtunnel/embedcheck.go` catches the failure where the tunnel is
-    healthy but the browser refuses to run the app, because the host iframes the
-    dev server sandboxed, at an opaque `null` origin. `CheckEmbeddable` reads
-    real response headers off a real probe and is **evidence**;
-    `CheckParentOrigins` cannot observe a value inlined at transform time, so it
-    is a **heuristic** — and one of the four vendored mirrors, reproducing
-    Vite's dotenv resolution. Neither is ever fatal: a check that cannot observe
-    returns NO findings rather than manufacturing advice. That doctrine — cited
-    across this repo as "the failure item 10 spent four measured corrections
-    avoiding" — is what those four corrections bought, each having produced a
-    FALSE WARNING at a correctly configured project, the worst outcome for
-    advisory output because it teaches authors to ignore all of it.
+10. **Editing the `dev-tunnel` embeddability preflight or its Vite dotenv
+    mirror, making an advisory check fatal, or collapsing its duplicated print?**
     → evidence: claudedocs/decisions/10-dev-tunnel-embeddability.md
 
-11. **The scaffold VENDORS the block→host ready-ack (`internal/blockproto/`),
-    and it is the FOURTH vendored mirror.** A `page` app is not shown by the
-    host until it posts `BLOCK_READY`; `page-money` gets that free from
-    `@civitai/blocks-react`, but the deliberately SDK-free `static` and
-    `page-vite` templates have to say hello themselves. They didn't — issue
-    #206. `ready-ack.js` is `go:embed`ed and written VERBATIM (never templated),
-    acks on `BLOCK_INIT` rather than on load, and is pinned by three guards
-    none of which subsumes the others.
+11. **Editing the vendored ready-ack emitter, adding or SDK-ifying a scaffold
+    template, or about to call a CI job a merge gate?**
     → evidence: claudedocs/decisions/11-vendored-ready-ack.md
 
-12. **`civitai generate` calls tRPC, not REST — because there is no REST
-    generation route to call.** Exactly the situation item 5 documents for
-    `app metrics`, and it will attract the same "fix". Generation exists only as
-    the tRPC procedures `orchestrator.whatIfFromGraph` (the cost estimate, a
-    GET) and `orchestrator.generateFromGraph` (the submit, a POST) in
-    `civitai/civitai → src/server/routers/orchestrator.router.ts`; there is no
-    `/api/v1` equivalent, and the same is true of the reads behind
-    `civitai workflows list|get|cancel`. So `internal/genapi` speaks tRPC — path
-    constants in `generate.go`, and the same `authedDo` + envelope-unwrap shape
-    (`?input={"json":{…}}`, success unwrapping `result.data.json`) that
-    `internal/appapi` established for item 5.
-    Don't "simplify" any of it into a REST call that does not exist.
-    Two things in there are load-bearing and look like oversights. `unwrapTRPC`
-    rejects a literal `null` payload as malformed rather than unmarshalling it:
-    `null` decodes CLEANLY into a zero `WhatIfResult`, which renders as
-    **total 0** — a fabricated free quote, on the one screen a user reads before
-    approving a charge. And `CancelWorkflow` deliberately does NOT go through
-    that unwrap, because the server's successful cancel reply has no
-    `result.data.json` at all (`workflows.ts`) — routing it through the standard
-    path would turn **every successful cancel** into "unexpected response". HTTP
-    200 is the success signal there.
+12. **Simplifying `internal/genapi` toward REST, or routing a tRPC reply
+    through `unwrapTRPC`?**
+    → evidence: claudedocs/decisions/12-generate-speaks-trpc.md
 
-13. **The CLI deliberately validates NOTHING about the generation graph, and
-    that is the feature.** `internal/genapi/graph.go` models a handful of fields
-    and `--input` passes a caller's graph through byte-for-byte. It does not
-    vendor, and must never vendor, the ecosystem keys, the ~51 per-engine
-    graphs, the sampler enum, the buckets, the per-ecosystem defaults, the tier
-    limits or any cost table: the server re-derives every one of them from state
-    the CLI cannot see, so a vendored copy buys no correctness and starts
-    **refusing valid new inputs**. Live lookups are not mirrors, which is why
-    `ResolveModelVersion` is allowed.
+13. **Adding any check, table, enum or default to the generation path —
+    ecosystems, samplers, buckets, costs, limits — or wording a warning about a
+    key the CLI does not model?**
     → evidence: claudedocs/decisions/13-generation-graph-not-validated.md
 
-14. **Unset flags must be ABSENT from the payload, never Go zero values.** Every
-    optional field on `genapi.Graph` is a pointer or carries `omitempty`. This
-    reads as a missing-`omitempty` nit or gratuitous pointer-itis; it is a
-    correctness requirement, and the server is what makes it one. Measured:
-    `steps: 0` is **accepted**, and prices a degenerate, cheaper, WRONG job (the
-    steps cost factor drops to 0.333 from 1) — HTTP 200, billed. `cfgScale: 0`
-    goes the same way, and `quantity: 0` is clamped rather than rejected. So a
-    value-typed field silently converts *"the user did not pass `--steps`"* into
-    *"the user asked for a broken job"*, at half price, with no error anywhere.
-    The pointers also keep "unset" distinguishable from "explicitly zero", which
-    a `--print-input` → edit → `--input` round-trip depends on. The parsed
-    invocation carries `quantitySet` / `checkpointSet` / `maxCostSet` off
-    `cmd.Flags().Changed(...)` for the same reason.
-    🔴 **The guard asserts KEY ABSENCE on a decoded `map[string]any`** — see
-    `TestGraph_UnsetFieldsAreAbsent` in `internal/genapi/generate_test.go`, which
-    marshals the real outgoing bytes and checks `_, ok := m["steps"]`. It is
-    explicitly **not** a `strings.Contains` search, and rewriting it as one would
-    make it vacuous in a way that reads fine: `"cfg"` substring-matches
-    `"cfgScale"`, so a text search cannot tell the two keys apart. The same test
-    also pins that a zero-valued `Graph` marshals to zero keys, so a newly added
-    value-typed field fails immediately rather than at the first user's expense.
+14. **Adding a field to `genapi.Graph`, or replacing one of its pointers or
+    `omitempty` tags with a value type?**
+    → evidence: claudedocs/decisions/14-unset-flags-must-be-absent.md
 
-15. **`whatIf` and `generate` take DIFFERENT tRPC envelopes for the SAME graph,
-    and both shapes are pinned by tests.** The query takes the graph **flat**
-    (`{"json": <graph>}`); the mutation takes it **NESTED** under `.input`
-    (`{"json":{"input": <graph>, "externalId": …}}`), because the server
-    destructures the graph out of a wrapper on the mutation and not on the query.
-    The web mirrors the asymmetry deliberately. This looks like an obvious
-    duplication to collapse into one builder. Do not.
-    🔴 **The mismatch is SILENT and returns HTTP 200 with a plausible wrong
-    cost.** Measured: a nested payload sent to whatIf is never parsed at all —
-    every nested body prices the server's default job (total 8) byte-identically
-    to `{}`, while the same graph sent flat priced 60. The discriminating control
-    was an ecosystem that 500s "Unknown ecosystem" when sent flat and returns a
-    clean `200 ready:true` when sent nested. So a builder wired to the wrong
-    nesting quotes a **constant** while every "did it 200?" assertion stays
-    green — and `--max-cost 50` would wave through an arbitrarily expensive job
-    while the confirmation prints "cost 8". That is the spend-safety feature
-    failing open, inside itself. A test that only checks the request succeeded
-    cannot see this; the tests assert the envelope SHAPE on the decoded body, on
-    both procedures.
-    Related, and easy to undo by accident: `whatIfGraph` strips
-    `prompt`/`negativePrompt` from the estimate (they do not affect cost, and the
-    server substitutes its own defaults), and it strips them from a RAW `--input`
-    graph by deleting the two keys from the decoded object — never by
-    re-marshalling through the typed struct, which would silently DELETE every
-    key the struct does not model.
+15. **Collapsing the `whatIf` and `generate` envelope builders into one, or
+    editing what `whatIfGraph` strips?**
+    → evidence: claudedocs/decisions/15-two-trpc-envelopes.md
 
-16. **`externalId` is minted unconditionally on every submit, and must never be
-    sent on a whatIf.** `generateInput.ExternalID` deliberately has **no**
-    `omitempty`, and `GenerateFromGraph` mints a UUIDv4 when the caller passes
-    none. This looks like a field that should be optional. It is the idempotency
-    key, and without it a single user action can be charged up to **three
-    times**: the platform's submit wrapper retries 3× on a 5xx *and* on a network
-    error / no response, reusing the same body, adds no idempotency key of its
-    own, and has no server-side minting fallback. The orchestrator dedupes on
-    `(userId, externalId)`. The web client is safe only because it always mints
-    one.
-    It is also what makes the CLI's own 401-refresh replay in
-    `genapi/client.go` safe to point at a mutation — the key is minted *before*
-    the body is marshalled, so a replay re-sends byte-identical bytes and gets
-    the pre-existing workflow back. **Do not add a mutation to that package that
-    omits it.**
-    🔴 **Never send it on `whatIfFromGraph`.** A matching key returns the
-    pre-existing workflow, so a quote would BURN the key the subsequent submit
-    needs — which is why the server's own whatIf body omits it. And because a
-    duplicate key returns **HTTP 200 with the pre-existing workflow** rather than
-    a 409, re-attachment has to be inferred locally: that is why the key is
-    written to a local record *before* the POST goes out
-    (`internal/cmd/generate_state.go`) and why `--external-id` exists at all. It
-    overrides; it does not enable.
-    A `--input` file supplying its own `externalId` is REFUSED, not honoured —
-    see the envelope whitelist below.
+16. **Adding a mutation to `internal/genapi`, making `externalId` optional, or
+    sending one on a quote?**
+    → evidence: claudedocs/decisions/16-externalid-is-the-idempotency-key.md
 
-17. **`DownloadPresigned` exists so a blob fetch carries NO credential, and it is
-    the thing in this feature most likely to be "simplified" away.** It is a
-    near-duplicate of `DownloadFile` differing only in passing an empty token,
-    and every instinct says to fold it back in behind a bool. 🔴 Doing that
-    leaks a full-scope personal API key: `isTrustedDownloadHost` attaches the
-    token to **any** `*.civitai.com` subdomain, which is where orchestrator
-    output blobs live. The fix is a seam that never HAS a credential to attach —
-    the empty token short-circuits before the host predicate is consulted.
+17. **Folding a credential-free blob transfer back into the token-carrying one,
+    or touching `isTrustedDownloadHost`?**
     → evidence: claudedocs/decisions/17-download-presigned-no-credential.md
 
-18. **The ready-ack checks for EXISTING apps are two deliberately different
-    tiers, and neither is allowed to be a hard failure.** #206 fixed the
-    templates; every app scaffolded before `4018e2c` is still broken and nothing
-    told its author. `internal/antipattern`'s `resize-iframe-page` rule is a
-    GATE, because it fires on a literal that is present in the file — no
-    inference. `validate`'s page-without-ack check is a WARNING and must stay
-    one, because it infers RUNTIME behaviour from STATIC TEXT. Item 20 is the
-    reachability repair to this item's presence-only scan.
+18. **Adding a rule to `internal/antipattern`, promoting an inferred `validate`
+    warning to a hard error, or deciding which packages ack?**
     → evidence: claudedocs/decisions/18-ready-ack-existing-apps.md
 
-19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
-    `--ecosystem`, and uploads with NO credential — three things that each read
-    like a bug.** The server promotes `txt2img` + non-empty `images` to
-    `img2img:edit` itself, so sending the edit workflow would mean vendoring
-    which ecosystems offer it — item 13's prohibition exactly. `--image`
-    without `--ecosystem` is a hard error because the promotion reads the
-    ecosystem off the RAW request body, so an absent one silently skips it and
-    the flag becomes a guaranteed no-op THAT STILL CHARGES. The presigned upload
-    carries no credential, for item 17's reason. 🔴 And the CLI still cannot
-    tell you whether the promotion actually fired — do not add a detector.
+19. **Touching `--image` — the workflow value, the `--ecosystem` refusal, the
+    image cap, the dimensions, or the upload `--dry-run` still performs?**
     → evidence: claudedocs/decisions/19-img2img-workflow-and-upload.md
 
-20. **The ready-ack advisory has TWO TIERS, the message names which one ran, and
-    that disclosure is the fix — not a nicety.** `validate`'s page-without-ack
-    check (item 18) used to ask only "does any file in this tree mention
-    `BLOCK_READY`", so a pre-fix scaffold with the emitter copied in but never
-    referenced printed `✓ … is valid` and exited **0**. 🔴 A green check earned
-    by obeying our own advice is worse than the silence it replaced.
-    REACHABILITY (strong) runs on a completely resolved entry graph; PRESENCE
-    ONLY (weak) falls back to the whole-tree scan, names the resolver's own
-    reason, and must keep saying what it did NOT check.
+20. **Editing the ready-ack advisory or `blockproto`'s entry-graph resolver —
+    its two tiers, gap reasons, cap, ranking — or how a long finding is wrapped
+    for the terminal?**
     → evidence: claudedocs/decisions/20-ready-ack-advisory-tiers.md
 
-21. **A reported model substitution is a WARNING by default, not a failure — and
-    that is a deliberate product decision, not laziness.** The server accepts a
-    checkpoint version id that is not valid for a `modelLocked` ecosystem,
-    substitutes the ecosystem default, runs the job and bills for what ran
-    (civitai/civitai#3665), reporting each swap as
-    `modelSubstitutions: [{requested, applied, reason}]`. Warn-and-continue
-    keeps working automation working; `--fail-on-substitution` is the opt-in for
-    callers who would rather fail than get a different model.
+21. **Reporting or refusing a model substitution — its phase, its ordering
+    against the workflow handle, the superseded checkpoint?**
     → evidence: claudedocs/decisions/21-model-substitution.md
 
-22. **`--input` refuses every workflow but `txt2img`, and that refusal is NOT the
-    local validation item 13 forbids — it is a CONTENT-AUDIT gate over a
-    CONFIRMED server-side gap.** Item 13 forbids reproducing the server's
-    *judgement* about which graphs are valid; this claims nothing of the kind,
-    and is the same shape as item 19(b) — a flag combination the CLI owns.
-    🔴 The gap is confirmed, not suspected: two shipped ecosystems declare
-    prompt nodes the audit never runs over (civitai/civitai#3667). Keep the
-    claim that size — the gate stops accidents, not adversaries — and lift it
-    when the server closes the coverage, not when the next workflow looks like
-    it would work.
+22. **Tempted to let `--input` carry a workflow other than `txt2img`, or
+    reading the server's content audit as closed?**
     → evidence: claudedocs/decisions/22-input-refuses-non-txt2img.md
-23. **A validation finding is a `Finding{Field, Message}`, and the Field is
-    carried from the CHECK — never re-derived at the printer.** `validate.Result`
-    holds `[]Finding`, not `[]string`. This looks like ceremony around what used
-    to be a string; it is the fix for issue #225, where 7 of 11 findings on a
-    six-ways-broken manifest came back `field: null` — precisely the semantic
-    ones, the checks a local pre-check exists for. 🔴 DO NOT close a future gap
-    with more prefix heuristics at the printer: the field has to come from the
-    producer, and `newFinding` is the only constructor.
+
+23. **Adding a finding to `internal/validate`, changing how findings dedupe, or
+    deciding which `field` a `--json` consumer groups on?**
     → evidence: claudedocs/decisions/23-finding-field-message.md
-24. **`syscall.Errno` IS a `net.Error`, so the obvious spelling of the transport
-    check silently classified EVERY filesystem failure in the CLI as a network
-    failure — in TWO places, and the first fix reached only one of them.** A bare
-    `var netErr net.Error; return errors.As(err, &netErr)` walks straight PAST
-    the `*fs.PathError` wrapper and matches the Errno underneath, so every
-    untagged `os.ReadFile` / `os.Stat` error landed on exit **5** — the code the
-    README tells scripts to RETRY on (#241). The walk now lives in ONE place,
-    `pkg/civitai/transport_error.go`, with four callers held by an asserted ledger.
+
+24. **Writing a `net.Error` check, or deciding whether a failure is transport
+    or filesystem?**
     → evidence: claudedocs/decisions/24-errno-is-a-net-error.md
-25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,
-    and must NOT become a local check.** `civitai app listing set-icon` /
-    `set-cover` / `add-screenshot` validate the **format** and the **byte size**
-    of the source file and nothing else; the platform enforces a per-kind aspect
-    range and a minimum dimension at ATTACH time. This is item 4's argument
-    applied to a different constant set: stale *guidance* costs one round-trip,
-    while a stale *gate* refuses valid images and the author cannot override it.
-    🔴 Never scaffold a placeholder icon or cover — it passes every check and can
-    reach a public store listing.
+
+25. **Adding a dimension or aspect check to `app listing`, reconciling the two
+    icon byte caps, or scaffolding a placeholder image?**
     → evidence: claudedocs/decisions/25-listing-media-bounds.md
 
-26. **`civitai app validate <dir>` / `app submit <dir>` CLASSIFY THE PATH THE
-    USER NAMED BEFORE VALIDATING ANYTHING, and that gate is deliberately NOT
-    item 24's transport predicate — it is a separate rule that happens to live
-    next door on the exit-code contract.** Issue #256. `resolveProjectDir`
-    (`internal/cmd/project_dir.go`) branches three ways on the path the user
-    NAMED: nonexistent → 2, exists-but-not-a-directory → 2, a real directory →
-    unchanged. It runs ahead of `--skip-validate` and ahead of the `--json`
-    block, and both call sites are held by an asserted ledger.
+26. **Adding a command that takes a user-named project directory, gating a path
+    FLAG, or moving the check that runs before `app validate` / `app submit` do
+    anything?**
     → evidence: claudedocs/decisions/26-project-path-classification.md
 
-27. **The blockId derivation REFUSES rather than transliterates, and the
-    exemption that makes refusing safe is "LOWERCASES INTO ASCII" — never a
-    character allowlist.** `scaffold.Slugify` used to replace every run of
-    non-`[a-z0-9]` with a hyphen, which silently DROPPED content — `"Café App"`
-    minted `caf-app` — for an identity that **cannot be renamed afterwards**. It
-    now refuses and names the offending characters, with `--slug` as the escape
-    hatch (#259). 🔴 It NARROWS #259; it does not close it, and the residuals it
-    knowingly ships with are enumerated in the evidence.
+27. **Editing `scaffold.Slugify`, its lossy-character exemption, what `--slug`
+    suppresses, or what `app create` echoes about the id it minted?**
     → evidence: claudedocs/decisions/27-blockid-derivation-refuses.md
 
-28. **The CLI must not make CLAIMS about a spend it cannot observe.** Same shape
-    as items 8, 13 and 19(b), on the money path; the measurements live in the
-    code comments at each site.
-    (a) **`--dry-run` reports RESOURCE READINESS** — the server's *"every job's
-    `queuePosition.support` is `available`"*, a job with no `queuePosition` being
-    **skipped**. Not generatability, not moderation (the prompt is stripped
-    before the estimate, item 15). As `Generatable` it promised a predicate it
-    cannot carry: 8 submits across 3 checkpoints all quoting `ready: true`
-    produced **0** outputs (#279). No surface says "generatable" — three senses
-    of it once shared one screen. Scripts gate on **false** via a `case`, so an
-    ABSENT key fails closed. 🔴 `false` buys OUR OWN refusal, not the server's:
-    none was found, and #279's bad checkpoints returned HTTP 400s.
-    (b) **No fate-of-charge copy asserts a direction, cancel included.** That a
-    charge HAPPENED stays; what BECAME of it goes. The platform's own client says
-    the orchestrator auto-refunds `failed`/`expired`/`canceled` and two balance
-    reads across 29 submits moved by the SUCCESS count (#278) — yet the opposite
-    is equally unevidenced, the rule living in the orchestrator SERVICE, absent
-    from the monorepo. Cancel keeps the accrued-cost half; civitai/cli#307 owns
-    the substance.
-    🔴 **TWO GUARD SHAPES DIED HERE — DO NOT REACH FOR A THIRD PHRASE LIST.** A
-    banned-substring ledger lost twice: to a paraphrase paying no banned word
-    ("your Buzz returns to your balance automatically"), then to five mutants
-    that kept every required sentence and APPENDED a claim — `Nothing is
-    refunded`, missed while `not refunded` was banned. Both rounds: 18 packages
-    green; the property is not computable from text. The guards are
-    (1) one constant `buzzLedgerUnknownNote` rendered verbatim, (2) an asserted
-    ledger of its call sites, (3) **golden-output pinning of every spend
-    surface**, which closes ADDITION — cosmetic reflows breaking a golden is the
-    accepted cost; re-approve with `-update` and read the diff.
-    🔴 Residual: a NEW file printing its own refund claim is invisible to all
-    three — measured, survived, 18 ok — unless it lands on a golden surface.
+28. **Wording anything about a charge — readiness, refunds, cancel — adding a
+    surface that prints one, or reaching for a banned-phrase guard?**
+    → evidence: claudedocs/decisions/28-no-claims-about-unobservable-spend.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/agents_evidence_test.go
+++ b/agents_evidence_test.go
@@ -12,11 +12,16 @@ import (
 )
 
 // AGENTS.md's numbered list is loaded into every session through CLAUDE.md's
-// `@AGENTS.md` import, so its size is a per-session cost. The largest items
-// keep their THESIS in AGENTS.md and have their bodies — the RSS tables, the
-// mutation matrices, the retractions, the enumerated residuals — in
+// `@AGENTS.md` import, so its size is a per-session cost. The list is now a
+// TRIGGER INDEX: each item is one line asking whether the reader is about to do
+// what that item governs, and the item ITSELF — the thesis, the RSS tables, the
+// mutation matrices, the retractions, the enumerated residuals — lives in
 // `claudedocs/decisions/NN-<slug>.md`, reached through a `→ evidence: <path>`
 // pointer. That evidence costs nothing until someone opens the code it is about.
+//
+// The trigger's own shape is guarded in agents_trigger_test.go, which also
+// records why the stub-thesis rule that used to live at the bottom of this file
+// was replaced rather than relaxed.
 //
 // A split like that creates exactly one new failure mode, and it is silent: the
 // pointer and the file drift apart. This file is the ledger that closes it.
@@ -50,12 +55,14 @@ const evidenceDir = "claudedocs/decisions"
 // directory — finds zero pointers, compares the empty set with an empty
 // expectation and reports a serene pass while the ledger checks nothing.
 //
-// It rises with each wave, or it stops being a control. Sixteen items are split
-// today; a floor of 5 was set when nine were, and against sixteen it would let a
-// regex that had lost TWO THIRDS of the corpus through — the "comfortable
-// margin" the sibling xrefs guard warns is not evidence of a healthy scan. 10
-// leaves room to re-inline six without weakening the control that far.
-const minEvidencePointers = 10
+// It rises with each wave, or it stops being a control. TWENTY-SIX items are
+// split today — every item but 2 and 4, which are smaller than a trigger plus a
+// file read would cost. A floor of 5 was set when nine were and 10 when sixteen
+// were; against twenty-six, 10 would let a regex that had lost SIXTY PERCENT of
+// the corpus through — the "comfortable margin" the sibling xrefs guard warns is
+// not evidence of a healthy scan. 16 leaves room to re-inline ten without
+// weakening the control that far.
+const minEvidencePointers = 16
 
 // evidencePointerRe matches the pointer line a stub ends with. The path is
 // captured as a non-space run, so a pointer that has been wrapped across a line
@@ -219,58 +226,18 @@ func TestEvidencePointersAndFilesAreTheSameSet(t *testing.T) {
 	t.Logf("evidence ledger: %d pointer(s) and %d file(s) agree", len(pointers), len(files))
 }
 
-// TestEvidenceStubsCarryAThesisAndAPointer asserts the shape of a stub: the
-// pointer must not be the whole of what AGENTS.md says about a split item.
+// 🔴 TestEvidenceStubsCarryAThesisAndAPointer USED TO LIVE HERE, AND WAS
+// REPLACED RATHER THAN DELETED — agents_trigger_test.go is where it went.
 //
-// This is the guard against the failure mode the split most invites — replacing
-// an item with a bare "see the evidence file". A reader deciding whether an item
-// bears on the change they are making must be able to decide it from AGENTS.md;
-// a pointer alone forces one file read per split item per session — sixteen of
-// them now — which is worse than the cost the split removed.
-func TestEvidenceStubsCarryAThesisAndAPointer(t *testing.T) {
-	b, err := os.ReadFile("AGENTS.md")
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	lines := strings.Split(string(b), "\n")
-
-	// The minimum is deliberately low: it is a floor against a DEGENERATE stub,
-	// not a style rule. A thesis sentence hard-wrapped at ~79 columns runs to
-	// several lines, so 120 characters of prose before the pointer is a bar an
-	// honest stub clears without trying and a bare pointer cannot clear at all.
-	const minThesisChars = 120
-
-	starts := map[int]int{}
-	for i, line := range lines {
-		if m := itemHeadingRe.FindStringSubmatch(line); m != nil {
-			n, _ := strconv.Atoi(m[1])
-			starts[n] = i
-		}
-	}
-
-	pointers := collectEvidencePointers(t)
-	if len(pointers) < minEvidencePointers {
-		t.Fatalf("CONTROL failure, not a finding: %d pointer(s) found, want >= %d — see TestEvidencePointersAndFilesAreTheSameSet",
-			len(pointers), minEvidencePointers)
-	}
-
-	var thin []string
-	for _, p := range pointers {
-		s, ok := starts[p.item]
-		if !ok {
-			continue // reported by the ledger test
-		}
-		body := strings.Join(lines[s:p.line-1], " ")
-		if n := len(strings.TrimSpace(body)); n < minThesisChars {
-			thin = append(thin, fmt.Sprintf(
-				"  item %d (AGENTS.md:%d) carries only %d character(s) of prose before its pointer, want >= %d",
-				p.item, s+1, n, minThesisChars))
-		}
-	}
-	if len(thin) > 0 {
-		t.Fatalf("%d stub(s) that are a pointer and little else:\n%s\n\n"+
-			"A stub has to carry the item's THESIS — enough for a reader to know the item exists and whether it bears on what they are "+
-			"about to change. The evidence file carries the measurements. A bare pointer moves the cost instead of removing it.",
-			len(thin), strings.Join(thin, "\n"))
-	}
-}
+// It required 120 characters of prose before a pointer, so that an item could
+// not decay into a bare "see the evidence file". That hazard is real and is
+// still guarded; the RULE was incompatible with the fix. A trigger line is
+// deliberately shorter than that floor, because what routes a reader to an item
+// is a question about their situation, not a compressed conclusion — so left in
+// place the old guard would have failed every correct trigger, which is the
+// false-failure-at-correct-content shape that gets a docs guard deleted.
+//
+// The replacement is stricter in the direction that matters: it applies to EVERY
+// item rather than only the split ones, it rejects a label as well as a blank,
+// and it bounds an inline item's size so the list cannot revert to bodies. Do
+// not reintroduce a prose-length floor here.

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // AGENTS.md is imported wholesale by CLAUDE.md (`@AGENTS.md`), so every byte in
@@ -72,13 +73,18 @@ import (
 // WHY IT CAN BE A REAL BUDGET. Under the stub regime the ceiling was doing two
 // jobs: bounding growth AND making a restored body break CI. It can no longer do
 // the second — every item is now small, so any useful headroom absorbs a few of
-// them — and it does not need to. Restoring a body means deleting that item's
-// trigger, which fails TestEveryAgentsItemCarriesATrigger and orphans a file in
-// TestEvidencePointersAndFilesAreTheSameSet whatever the byte count says; and an
-// item written inline above maxInlineItemBytes fails
-// TestInlineAgentsItemsStayUnderTheBreakEven. Those are structural and
-// byte-free. Read a size failure here as "the prose grew", not as "someone
-// re-inlined an item" — a different test says that, by name.
+// them — and it does not need to. MEASURED, restoring item 6's full body over
+// its trigger reddens TWO tests and neither is this one:
+// TestEvidencePointersAndFilesAreTheSameSet (the evidence file is now an orphan)
+// and TestInlineAgentsItemsStayUnderTheBreakEven (an inline item over
+// maxInlineItemBytes). Both are structural and byte-free.
+//
+// 🔴 Say the measured thing, not the tidy one: it does NOT redden
+// TestEveryAgentsItemCarriesATrigger, which an earlier revision of this comment
+// claimed. That test only judges items that still carry a pointer, so an item
+// re-inlined WITH its pointer removed is outside its scope by construction.
+// Read a size failure here as "the prose grew", not as "someone re-inlined an
+// item" — two different tests say that, by name.
 //
 // 🔴 SQUEEZING IS STILL NOT AN OPTION. A full lossless compression pass over the
 // whole file recovered 586 bytes — 0.86% — most of it from ONE genuine
@@ -235,13 +241,19 @@ func evictionPlaybook(t *testing.T, size int) string {
 		}
 		state := "IN AGENTS.md"
 		if s.split {
-			state = "already split (stub only)"
+			state = "trigger only (body already split out)"
 		}
-		title := s.firstL
+		// 🔴 TRUNCATE BY RUNE, NEVER BY BYTE. `title[:72]` splits a multi-byte
+		// rune whenever one straddles the boundary, and the playbook then emits
+		// INVALID UTF-8 in a failure message — measured: the trigger lines carry
+		// em-dashes, and the byte-sliced version produced output a UTF-8 decoder
+		// rejects outright. The old stubs happened not to have one at that offset,
+		// which is the only reason this never fired before.
+		title := []rune(s.firstL)
 		if len(title) > 72 {
-			title = title[:72] + "…"
+			s.firstL = string(title[:72]) + "…"
 		}
-		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-25s  %s\n", s.num, s.bytes, state, title)
+		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-36s  %s\n", s.num, s.bytes, state, s.firstL)
 		shown++
 	}
 	fmt.Fprintf(&b, "\n🔴 THE LIST IS A TRIGGER INDEX, SO AN ITEM OVER ~%d BYTES IS ALREADY THE BUG.\n"+
@@ -408,12 +420,53 @@ func TestAgentsSizeGuardCanStillFire(t *testing.T) {
 		// The playbook has to teach the SHAPE, not just the mechanics: a
 		// maintainer who evicts a body and leaves a label behind has moved the
 		// bytes and hidden the item.
-		"TRIGGER",
-		"over-narrow trigger",
+		//
+		// 🔴 THESE ARE PHRASES, NOT THE WORD "TRIGGER", AND THAT IS A MEASURED
+		// CORRECTION. The first version asked for the bare token; reverting step
+		// 2 to the old stub instruction left it SATISFIED by the unrelated
+		// "TRIGGER INDEX" sentence at the top of the same message, so the mutant
+		// survived with the advice reverted. A guard answered by a bystander is
+		// the shape this repo keeps meeting; assert the instruction, not a word
+		// another sentence can spell.
+		"Leave a TRIGGER in AGENTS.md",
+		"ONE question asking whether",
+		"over-narrow trigger HIDES the",
 		"agents_trigger_test.go",
 	} {
 		if !strings.Contains(pb, want) {
 			t.Errorf("the eviction playbook no longer mentions %q; a size failure that does not say where the bytes GO gets the ceiling raised instead\n---\n%s", want, pb)
 		}
+	}
+
+	// 🔴 THE PLAYBOOK MUST BE VALID UTF-8, AND IT WAS NOT. It truncated an item's
+	// first line with `title[:72]` — a BYTE slice — which splits a multi-byte rune
+	// whenever one straddles the boundary. Found by a harness that could not decode
+	// the test output at all. Under the old stubs no item happened to carry a
+	// multi-byte character at offset 72; every trigger line does, because they are
+	// written with em-dashes, so the latent defect became live the moment the list
+	// changed shape.
+	if !utf8.ValidString(pb) {
+		t.Errorf("the eviction playbook is not valid UTF-8 — it is truncating a title mid-rune, and the advice a maintainer reads at the ceiling is mojibake\n---\n%q", pb)
+	}
+	// POSITIVE CONTROL. "It is valid UTF-8" is also true of a playbook that never
+	// truncates anything, so prove the corpus actually exercises the hazard: at
+	// least one item's first line must be longer than the cut AND carry a
+	// multi-byte rune that a byte slice at that offset would break.
+	// The condition mirrors the BUGGY code exactly — `len(title) > 72` on bytes,
+	// then `title[:72]` — because that is the input that has to still be present
+	// for the assertion above to mean anything. Item 13's trigger is the live
+	// example: 73 bytes, 71 runes, with an em-dash straddling byte 72.
+	exercised := ""
+	for _, s := range agentsItemSizes(t) {
+		if len(s.firstL) > 72 && !utf8.ValidString(s.firstL[:72]) {
+			exercised = s.firstL
+			break
+		}
+	}
+	if exercised == "" {
+		t.Errorf("CONTROL failure, not a finding: no item's first line is both over 72 BYTES and broken by a byte slice at that offset, " +
+			"so the UTF-8 assertion above is passing on input that could not fail. Re-derive the control against AGENTS.md's current headings.")
+	} else {
+		t.Logf("UTF-8 control exercised by: %s", exercised)
 	}
 }

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -36,44 +36,58 @@ import (
 
 // agentsMaxBytes is the ceiling on AGENTS.md.
 //
-// Achieved size: 42,635 bytes, after wave 3 of the evidence split moved items 9,
-// 13, 17, 22 and 25 out (11,596 bytes net, 21.4% of the file, in one change).
-// The ceiling is 45,135 — 2,500 bytes of headroom.
+// Achieved size: 25,258 bytes, after wave 4 turned the numbered list into a
+// TRIGGER INDEX — twenty-six items reduced to a one-line routing question plus a
+// pointer, ten bodies evicted in the process, items 2 and 4 left inline because
+// they are smaller than a trigger plus a file read would cost. The item list
+// went from 26,571 bytes to 6,109 (−77%) and the file from 45,027 to 25,258
+// (−43.9%). The ceiling is 28,758 — 3,500 bytes of headroom.
 //
-// 🔴 THE HEADROOM IS A BUDGET FOR ORDINARY EDITS, AND THE TWO NUMBERS BEFORE IT
-// WERE NOT. 287 bytes, then 300: each evaporated on the very next commit that
-// touched this file (#308 consumed 94% of the 300, leaving 19), and a ceiling
-// with 19 bytes under it is indistinguishable from a frozen file. It converts
-// every routine correction into an eviction project, which is a much worse
-// failure than the one the ceiling exists to prevent — the guard stops being a
-// budget and becomes a reason not to fix the docs.
+// 🔴 THE HEADROOM IS A BUDGET FOR ORDINARY EDITS, AND THE THREE NUMBERS BEFORE
+// IT WERE NOT. 287 bytes, then 300, then 2,500: the first two evaporated on the
+// very next commit touching this file (#308 consumed 94% of the 300, leaving 19)
+// and the 2,500 was consumed by one ordinary correction (#304, +2,392). A
+// ceiling with 19 bytes under it is indistinguishable from a frozen file: it
+// converts every routine correction into an eviction project, which is a much
+// worse failure than the one the ceiling exists to prevent, because the guard
+// stops being a budget and becomes a reason not to fix the docs.
 //
-// 2,500 is DERIVED, not picked. Measured over the last 40 commits touching
-// AGENTS.md, the ten docs-only ones changed it by +70, +245, +281, +1,337,
-// +1,456, +2,371, +2,760, +2,890, +3,399 and +3,474 bytes — median 1,913. So
-// 2,500 buys roughly ONE median docs-only correction, or two or three small
-// ones, or one retraction paragraph (300–800 bytes, measured on the ones in the
-// file) plus change.
+// 🔴 3,500 IS DERIVED FROM THE CHURN THAT REMAINS, WHICH IS NOT THE CHURN THAT
+// HAPPENED. Every earlier derivation measured WHOLE-FILE deltas — median 3,399
+// over the 39 non-zero commits touching AGENTS.md — and that number is now
+// irrelevant, because it is dominated by item bodies growing, and item bodies no
+// longer live here. #304's +2,392 was an edit to item 28's body; under the
+// trigger index the same correction costs this file ZERO bytes.
 //
-// What it deliberately does NOT buy:
+// So the budget is derived from the NON-ITEM region instead — the prose sections
+// plus the index preamble, which is what an in-file edit can still touch.
+// Measured over the same history, |delta| of that region on the 28 commits that
+// moved it: 1, 2, 2, 2, 4, 6, 8, 32, 34, 69, 70, 80, 97, 101, 105, 111, 114,
+// 147, 164, 261, 281, 347, 691, 778, 1,127, 1,337, 2,890 and 3,399 — median
+// 103, p90 1,127, max 3,399 (#289's Layout-ledger rewrite). 3,500 buys the
+// worst prose rewrite this file has ever had, or ~17 new items at one trigger
+// block each (162–265 bytes, mean 204), or ~34 median corrections.
 //
-//   - A new item written as a full body. The modern ones run 1.5–3.7 kB inline
-//     and the largest evicted bodies were 8.5–28 kB, so a new decision still has
-//     to be paid for by MOVING one out, which is the whole point.
-//   - Re-inlining this wave's work. Restoring item 9, 13 or 22 costs 2,284–3,035
-//     bytes net and breaks this ceiling on its own. (Items 17 and 25 are the two
-//     cheapest at 1,868 and 1,857, and would fit — that is the honest cost of a
-//     headroom big enough to be useful, and it is what agentsMaxBytesCeiling is
-//     sized to bound.)
+// 🔴 THE ANTI-RE-INLINING PROPERTY HAS MOVED OUT OF THIS CONSTANT, AND THAT IS
+// WHY IT CAN BE A REAL BUDGET. Under the stub regime the ceiling was doing two
+// jobs: bounding growth AND making a restored body break CI. It can no longer do
+// the second — every item is now small, so any useful headroom absorbs a few of
+// them — and it does not need to. Restoring a body means deleting that item's
+// trigger, which fails TestEveryAgentsItemCarriesATrigger and orphans a file in
+// TestEvidencePointersAndFilesAreTheSameSet whatever the byte count says; and an
+// item written inline above maxInlineItemBytes fails
+// TestInlineAgentsItemsStayUnderTheBreakEven. Those are structural and
+// byte-free. Read a size failure here as "the prose grew", not as "someone
+// re-inlined an item" — a different test says that, by name.
 //
-// 🔴 SQUEEZING IS STILL NOT AN OPTION, which is why the budget has to be real
-// rather than aspirational. A full lossless compression pass over every unsplit
-// item and every prose section recovered 586 bytes — 0.86% — most of it from ONE
-// genuine cross-item duplication (item 19(e) restated item 17's credential
-// argument in full). Mechanically the file held only 23 repeated 7-word n-grams
-// in 67 kB, every one a deliberate parallel construction rather than accidental
-// redundancy. EVICTION is the only lever with anything left in it: wave 2
-// recovered ~23x what the compression pass did and wave 3 ~20x.
+// 🔴 SQUEEZING IS STILL NOT AN OPTION. A full lossless compression pass over the
+// whole file recovered 586 bytes — 0.86% — most of it from ONE genuine
+// cross-item duplication, and mechanically the file held 23 repeated 7-word
+// n-grams in 67 kB, every one a deliberate parallel construction. Eviction was
+// the lever, and wave 4 has now pulled it as far as it goes: 19,149 of the
+// remaining 25,258 bytes are non-item prose, and the twenty-six triggers cost
+// 5,308 bytes in total. The next lever is the prose sections themselves, which
+// is a different and much more judgement-heavy change.
 //
 // 🔴 THE CANDIDATE LIST THAT USED TO SIT HERE IS DELETED RATHER THAN UPDATED,
 // AND THAT IS THE LESSON. It named items 10 and 19 with their byte sizes and
@@ -86,34 +100,47 @@ import (
 // ranking from the live file at the moment of failure, which is the copy that
 // cannot rot. Do not reintroduce one here.
 //
-// Do not raise this to make a large item fit. Split the item.
-const agentsMaxBytes = 45_135
+// Do not raise this to make an item fit. Write its trigger and move its body.
+const agentsMaxBytes = 28_758
 
 // agentsMaxBytesCeiling bounds agentsMaxBytes itself, so the budget above cannot
 // be turned into unlimited slack by editing one number.
 //
-// 48,600 is ~14% above the achieved size, and it is chosen against a property
-// that can be re-derived rather than a round percentage: re-inlining any THREE
-// of wave 3's five bodies costs at least 6,009 bytes net, landing at 48,644 —
-// just above this bound. So agentsMaxBytes cannot be raised far enough to undo
-// the majority of this wave without a second, deliberate, reviewable edit to
-// this constant. (Any two of them, at 3,725–5,587 net, would still fit; a bound
-// tight enough to block a pair would sit 1,165 bytes above agentsMaxBytes and
-// leave the next wave no room to re-derive anything.)
+// 30,600 is ~21% above the achieved size, and it is chosen against a property
+// that can be re-derived rather than a round percentage: re-inlining the THREE
+// largest bodies wave 4 evicted — items 28, 15 and 8, which were 2,323 + 1,827 +
+// 1,809 bytes inline against trigger blocks of 231 + 180 + 167 — costs 5,381
+// bytes net and lands the file at 30,639, just above this bound. So
+// agentsMaxBytes cannot be raised far enough to undo the bulk of this wave
+// without a second, deliberate, reviewable edit to this constant.
+//
+// Stated honestly rather than hidden: the two largest (3,739 net, landing at
+// 28,997) WOULD still fit. That is the cost of headroom big enough to be useful,
+// and it is why the byte ceiling is no longer the thing standing between this
+// file and a restored body — see the 🔴 note on agentsMaxBytes. The structural
+// guards catch a re-inline at one item, not three.
 //
 // 🔴 IT MOVES DOWN WITH THE ACHIEVED SIZE, OR IT STOPS BOUNDING ANYTHING. Left
-// at the 64,000 that was ~19% above the PRE-wave-3 size, it would sit ~50% above
-// the achieved one — enough slack to re-inline all five items just moved out
-// (54,231) and still pass, which is the same "a ceiling nobody bounds" failure
-// one level up. Whoever completes the next wave re-derives this from the new
+// at the 48,600 that was ~14% above the PRE-wave-4 size, it would sit ~92% above
+// the achieved one — enough slack to re-inline every body this wave moved out
+// and still pass, which is the same "a ceiling nobody bounds" failure one level
+// up. Whoever changes the shape of this file again re-derives this from the new
 // achieved size in the same commit.
-const agentsMaxBytesCeiling = 48_600
+const agentsMaxBytesCeiling = 30_600
 
 // agentsMinBytes is the POSITIVE CONTROL. A truncated, empty or wrongly-located
 // AGENTS.md is comfortably under any ceiling, and "0 bytes, well within budget"
 // is the reassuring-zero shape: the guard reports success having measured a file
-// that no longer contains the content it is guarding. 20,000 is far below the
-// achieved size and far above anything a truncation would leave.
+// that no longer contains the content it is guarding.
+//
+// It was set when the achieved size was 42,635 and is deliberately UNCHANGED at
+// 25,258, which makes it tighter than it was — it now catches any truncation of
+// more than 21%. That is a real bar rather than a formality, and the cost is
+// explicit: a future change that legitimately takes this file below 20,000 (the
+// only lever left is the prose sections) has to lower this constant on purpose,
+// which is exactly the review that shrinking the file that far deserves. It is
+// also the floor baseDocFor applies to a BASE commit's AGENTS.md, all four of
+// which are 45 kB or larger.
 const agentsMinBytes = 20_000
 
 // evidencePathRe recognises an item that has ALREADY been evicted, so the
@@ -217,14 +244,21 @@ func evictionPlaybook(t *testing.T, size int) string {
 		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-25s  %s\n", s.num, s.bytes, state, title)
 		shown++
 	}
-	fmt.Fprintf(&b, "\nTo evict an item:\n"+
+	fmt.Fprintf(&b, "\n🔴 THE LIST IS A TRIGGER INDEX, SO AN ITEM OVER ~%d BYTES IS ALREADY THE BUG.\n"+
+		"Every item but 2 and 4 is one routing question plus a pointer. If the ranking above\n"+
+		"shows a large item, convert it; if it shows only trigger-sized ones, the growth is in\n"+
+		"the PROSE sections and no eviction will fix it — see the note on agentsMaxBytes.\n"+
+		"\nTo convert an item:\n"+
 		"  1. Move its BODY verbatim to %s/NN-<slug>.md — byte-for-byte, nothing\n"+
 		"     summarised and nothing dropped. The measurements, mutation matrices,\n"+
 		"     retractions and residuals are the point of the item; the size problem is\n"+
 		"     PLACEMENT, not existence.\n"+
-		"  2. Leave a 4–8 line stub in AGENTS.md: the `NN. **…**` heading with its thesis\n"+
-		"     sentence (lift it from the item's own opening), then a final line reading\n"+
-		"     `→ evidence: %s/NN-<slug>.md`.\n"+
+		"  2. Leave a TRIGGER in AGENTS.md: `NN. **…?**` — ONE question asking whether the\n"+
+		"     reader is about to do what the item governs, naming EVERY situation it\n"+
+		"     governs rather than the most obvious one — then a line reading\n"+
+		"     `→ evidence: %s/NN-<slug>.md`. It is not a label and not a thesis: derive it\n"+
+		"     from the item's own argument, and remember an over-narrow trigger HIDES the\n"+
+		"     item with every other guard still green. agents_trigger_test.go pins the shape.\n"+
 		"  3. Keep the NUMBER. The list is append-only and is never renumbered — 300+\n"+
 		"     cross-references point into it, and agents_xrefs_test.go enforces that.\n"+
 		"  4. Add the item to agents_split_preserved_test.go's table with the sha256 of\n"+
@@ -234,7 +268,7 @@ func evictionPlaybook(t *testing.T, size int) string {
 		"     base is fixed at the moment it was evicted and cannot be re-pointed.\n"+
 		"\nDo NOT raise agentsMaxBytes to make this pass. It is currently %d, the file is\n"+
 		"%d bytes, and agentsMaxBytesCeiling (%d) bounds how far it may ever be raised.\n",
-		evidenceDir, evidenceDir, agentsMaxBytes, size, agentsMaxBytesCeiling)
+		maxInlineItemBytes, evidenceDir, evidenceDir, agentsMaxBytes, size, agentsMaxBytesCeiling)
 	return b.String()
 }
 
@@ -371,6 +405,12 @@ func TestAgentsSizeGuardCanStillFire(t *testing.T) {
 		"append-only",
 		"Do NOT raise agentsMaxBytes",
 		"item ",
+		// The playbook has to teach the SHAPE, not just the mechanics: a
+		// maintainer who evicts a body and leaves a label behind has moved the
+		// bytes and hidden the item.
+		"TRIGGER",
+		"over-narrow trigger",
+		"agents_trigger_test.go",
 	} {
 		if !strings.Contains(pb, want) {
 			t.Errorf("the eviction playbook no longer mentions %q; a size failure that does not say where the bytes GO gets the ceiling raised instead\n---\n%s", want, pb)

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -228,6 +228,31 @@ func agentsItemSizes(t *testing.T) []struct {
 	return out
 }
 
+// truncateRunes shortens a display string to n RUNES, never n bytes.
+//
+// 🔴 THE BYTE VERSION EMITTED INVALID UTF-8, AND IT WAS LIVE. The playbook used
+// `title[:72]`, which splits a multi-byte rune whenever one straddles the
+// boundary — item 13's trigger is 73 bytes and 71 runes with an em-dash across
+// byte 72, so the advice a maintainer reads at the ceiling was mojibake, and a
+// harness reading the test output could not decode it at all. The old stubs
+// happened to carry no multi-byte character at that offset, which is the only
+// reason the defect was latent rather than visible; it went live the moment the
+// list changed shape, without anything about the truncation changing.
+//
+// It is a named function rather than three inline lines so the property can be
+// driven over a corpus that ALWAYS contains the hazard —
+// TestPlaybookTruncationIsRuneSafe — instead of depending on whichever live
+// heading happens to straddle the boundary this week. That dependency was real:
+// pinning it against AGENTS.md made rewording item 13's trigger fail a UTF-8
+// control, which is a false failure at correct content.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 // evictionPlaybook renders the advice a size failure has to carry: which items
 // are largest, which are already split, and the mechanical steps to move one.
 func evictionPlaybook(t *testing.T, size int) string {
@@ -243,17 +268,7 @@ func evictionPlaybook(t *testing.T, size int) string {
 		if s.split {
 			state = "trigger only (body already split out)"
 		}
-		// 🔴 TRUNCATE BY RUNE, NEVER BY BYTE. `title[:72]` splits a multi-byte
-		// rune whenever one straddles the boundary, and the playbook then emits
-		// INVALID UTF-8 in a failure message — measured: the trigger lines carry
-		// em-dashes, and the byte-sliced version produced output a UTF-8 decoder
-		// rejects outright. The old stubs happened not to have one at that offset,
-		// which is the only reason this never fired before.
-		title := []rune(s.firstL)
-		if len(title) > 72 {
-			s.firstL = string(title[:72]) + "…"
-		}
-		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-36s  %s\n", s.num, s.bytes, state, s.firstL)
+		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-36s  %s\n", s.num, s.bytes, state, truncateRunes(s.firstL, 72))
 		shown++
 	}
 	fmt.Fprintf(&b, "\n🔴 THE LIST IS A TRIGGER INDEX, SO AN ITEM OVER ~%d BYTES IS ALREADY THE BUG.\n"+
@@ -438,35 +453,72 @@ func TestAgentsSizeGuardCanStillFire(t *testing.T) {
 		}
 	}
 
-	// 🔴 THE PLAYBOOK MUST BE VALID UTF-8, AND IT WAS NOT. It truncated an item's
-	// first line with `title[:72]` — a BYTE slice — which splits a multi-byte rune
-	// whenever one straddles the boundary. Found by a harness that could not decode
-	// the test output at all. Under the old stubs no item happened to carry a
-	// multi-byte character at offset 72; every trigger line does, because they are
-	// written with em-dashes, so the latent defect became live the moment the list
-	// changed shape.
+	// Belt-and-braces on the live message. The property is PINNED by
+	// TestPlaybookTruncationIsRuneSafe, which supplies the hazard itself; this
+	// only says the rendered advice is readable today.
 	if !utf8.ValidString(pb) {
 		t.Errorf("the eviction playbook is not valid UTF-8 — it is truncating a title mid-rune, and the advice a maintainer reads at the ceiling is mojibake\n---\n%q", pb)
 	}
-	// POSITIVE CONTROL. "It is valid UTF-8" is also true of a playbook that never
-	// truncates anything, so prove the corpus actually exercises the hazard: at
-	// least one item's first line must be longer than the cut AND carry a
-	// multi-byte rune that a byte slice at that offset would break.
-	// The condition mirrors the BUGGY code exactly — `len(title) > 72` on bytes,
-	// then `title[:72]` — because that is the input that has to still be present
-	// for the assertion above to mean anything. Item 13's trigger is the live
-	// example: 73 bytes, 71 runes, with an em-dash straddling byte 72.
-	exercised := ""
-	for _, s := range agentsItemSizes(t) {
-		if len(s.firstL) > 72 && !utf8.ValidString(s.firstL[:72]) {
-			exercised = s.firstL
-			break
-		}
+}
+
+// TestPlaybookTruncationIsRuneSafe is the negative control for truncateRunes.
+//
+// 🔴 THE CORPUS CARRIES THE HAZARD RATHER THAN BORROWING IT FROM AGENTS.md, and
+// that is a correction, not a preference. The first version asserted the live
+// playbook was valid UTF-8 and controlled it by requiring some heading in the
+// file to be a byte-slice hazard — which made REWORDING item 13's trigger fail a
+// UTF-8 control, a false failure at correct content. Every row here supplies its
+// own input and ASSERTS ITS OWN PREMISE: that a byte slice at the same offset
+// really would produce invalid UTF-8. Without that premise a row could sit here
+// looking like coverage while exercising nothing.
+func TestPlaybookTruncationIsRuneSafe(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		n      int
+		hazard bool // a byte slice at n would split a rune
+	}{
+		{"item 13's real shape: 73 bytes, 71 runes",
+			"13. **Adding any check, table, enum or default to the generation path —", 72, true},
+		{"a 3-byte rune straddling the cut",
+			strings.Repeat("a", 71) + "—" + strings.Repeat("b", 20), 72, true},
+		{"a 4-byte rune straddling the cut",
+			strings.Repeat("a", 70) + "🔴" + strings.Repeat("b", 20), 72, true},
+		{"pure ASCII, longer than the cut",
+			strings.Repeat("a", 200), 72, false},
+		{"shorter than the cut is returned unchanged",
+			"3. **Touching `internal/validate/lockfile.go` —", 72, false},
 	}
-	if exercised == "" {
-		t.Errorf("CONTROL failure, not a finding: no item's first line is both over 72 BYTES and broken by a byte slice at that offset, " +
-			"so the UTF-8 assertion above is passing on input that could not fail. Re-derive the control against AGENTS.md's current headings.")
-	} else {
-		t.Logf("UTF-8 control exercised by: %s", exercised)
+	hazards := 0
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			byteHazard := len(tc.in) > tc.n && !utf8.ValidString(tc.in[:tc.n])
+			if byteHazard != tc.hazard {
+				t.Fatalf("PREMISE BROKEN: the row claims hazard=%v, but a byte slice at %d yields %s. "+
+					"The row is not testing what it says it is.", tc.hazard, tc.n,
+					map[bool]string{true: "invalid UTF-8", false: "valid UTF-8"}[byteHazard])
+			}
+			if byteHazard {
+				hazards++
+			}
+			got := truncateRunes(tc.in, tc.n)
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateRunes(%q, %d) is not valid UTF-8: %q", tc.in, tc.n, got)
+			}
+			if r := []rune(tc.in); len(r) <= tc.n {
+				if got != tc.in {
+					t.Errorf("a string shorter than the cut must be returned unchanged, got %q", got)
+				}
+			} else if want := string(r[:tc.n]) + "…"; got != want {
+				t.Errorf("truncateRunes(%q, %d)\n got: %q\nwant: %q", tc.in, tc.n, got, want)
+			}
+		})
+	}
+	// POSITIVE CONTROL for the corpus: at least two rows must be genuine
+	// byte-slice hazards, or every assertion above passed on input a byte-slicing
+	// implementation would have survived too.
+	if hazards < 2 {
+		t.Fatalf("CONTROL failure, not a finding: only %d row(s) are byte-slice hazards. "+
+			"A byte-slicing implementation would pass this table, so it pins nothing.", hazards)
 	}
 }

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 )
 
-// The evidence split has moved sixteen item BODIES out of AGENTS.md, over three
-// waves, and left stubs behind. The whole value of the split rests on one
-// claim: the move was VERBATIM. Every measured RSS table, every mutation
-// matrix, every retraction and every enumerated residual is still there, byte
-// for byte, in the file the pointer names.
+// The evidence split has moved TWENTY-SIX item BODIES out of AGENTS.md, over
+// four waves, and left first stubs and now TRIGGER LINES behind. The whole value
+// of the split rests on one claim: the move was VERBATIM. Every measured RSS
+// table, every mutation matrix, every retraction and every enumerated residual
+// is still there, byte for byte, in the file the pointer names.
 //
 // 🔴 THAT CLAIM MUST BE PROVED MECHANICALLY, NOT ASSERTED, because the failure it
 // guards against is invisible by construction. A summarised paragraph reads
@@ -57,17 +57,27 @@ import (
 //     evicted, and different evictions have different moments. Per-item is the
 //     only shape that can express that.
 //
-// So `base` is a field on the row, not a package constant, and the three named
+// So `base` is a field on the row, not a package constant, and the four named
 // constants below exist only so a reader can see which wave a row belongs to.
 // Wave 3 (items 9, 13, 17, 22 and 25) added the third and touched neither of the
-// first two, which is the property the per-item field was introduced for. A
-// fourth wave adds a fourth.
+// first two, which is the property the per-item field was introduced for. Wave 4
+// — the trigger index — added the fourth and touched none of the first three.
 //
 // 🔴 WHAT DOES NOT CHANGE: the guard still fails if ANY split body is altered,
-// for all sixteen items. Splitting the base per row weakens nothing — each row is
-// still compared against a specific immutable blob — and that is the property to
-// re-verify by mutation whenever this table's shape is edited, because "I made
+// for all twenty-six items. Splitting the base per row weakens nothing — each row
+// is still compared against a specific immutable blob — and that is the property
+// to re-verify by mutation whenever this table's shape is edited, because "I made
 // the pinning more flexible" is exactly how a pin stops pinning.
+//
+// 🔴 WAVE 4 MOVED TEN BODIES AND REWROTE SIXTEEN EVIDENCE HEADERS, AND ONLY THE
+// FIRST HALF IS PINNED HERE. The sixteen files split by waves 1–3 kept their
+// digested bodies byte-identical — the header above each file's `---` rule is
+// outside evidenceBody's slice, which is what made adding the replaced stub text
+// to it safe. That the bodies were untouched was verified independently, by
+// comparing each committed blob's post-`---` region against the working copy
+// rather than by re-deriving anything through this file; the fifteen unchanged
+// shas below are the standing evidence for it. (Item 3's differs only because
+// reverseKnownDelta is applied before digesting, as it always was.)
 //
 // Blank lines are excluded on purpose. They carry no content, and including them
 // would make the guard fail on a trailing-whitespace tidy — a false failure at
@@ -114,6 +124,12 @@ const agentsSplitBaseWave2 = "5cb45f0ff54fe55f5249aade8b0cb9826ade3c58"
 // of them can be re-pointed at either of the others.
 const agentsSplitBaseWave3 = "6e31b4b29a0eb15c83e951a114db2345877d38bd"
 
+// agentsSplitBaseWave4 is the commit items 1, 5, 6, 7, 8, 12, 14, 15, 16 and 28
+// were moved from — the tip when the trigger index landed. Wave 4 is the wave
+// that converted the list itself: every remaining inline body was evicted except
+// items 2 and 4, which are smaller than a trigger plus a file read would cost.
+const agentsSplitBaseWave4 = "dfdcc974976ef4d8104f273b28b1f702c5a7f839"
+
 type splitItem struct {
 	num      int
 	file     string
@@ -143,6 +159,16 @@ var splitItems = []splitItem{
 	{num: 25, file: "claudedocs/decisions/25-listing-media-bounds.md", base: agentsSplitBaseWave3, nonBlank: 36, sha: "91069724894cd2b602034aa89cb61349096567f4e18a2ec40353146ac3dac249"},
 	{num: 26, file: "claudedocs/decisions/26-project-path-classification.md", base: agentsSplitBase, nonBlank: 246, sha: "1747de6cf56e85a935367ec118b7e16aecee5fb100d1ebf545ca40576ebbcc11"},
 	{num: 27, file: "claudedocs/decisions/27-blockid-derivation-refuses.md", base: agentsSplitBase, nonBlank: 105, sha: "5edc575b345db5b459af8d0fc0bd6c826e8102a7588b61aa873092848394796a"},
+	{num: 1, file: "claudedocs/decisions/01-validate-is-a-local-mirror.md", base: agentsSplitBaseWave4, nonBlank: 12, sha: "683542d055f8a80e875d439a4aca82a98f341606283a05770afe24f096a5a291"},
+	{num: 5, file: "claudedocs/decisions/05-app-metrics-trpc-not-rest.md", base: agentsSplitBaseWave4, nonBlank: 10, sha: "7667f72c8ac6401741ef6ee35c5d6db45cca24309f74b2f5b6f33dde8ad6fb34"},
+	{num: 6, file: "claudedocs/decisions/06-notowned-is-a-cross-repo-contract.md", base: agentsSplitBaseWave4, nonBlank: 9, sha: "65c638326f5058c3ef024e0940769b5a7749bf40c91bbc4fa3f6d92b44a2d7a6"},
+	{num: 7, file: "claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md", base: agentsSplitBaseWave4, nonBlank: 11, sha: "accbedbfa5e72549447b3e69787a090c5f30ed3e3f6c42181a1f9defd1e9d140"},
+	{num: 8, file: "claudedocs/decisions/08-raw-tokens-are-a-non-mirror.md", base: agentsSplitBaseWave4, nonBlank: 24, sha: "8a813151963da668be1cb2a0308ad7e2e1ad218413e529c5bebcf2934e55eec1"},
+	{num: 12, file: "claudedocs/decisions/12-generate-speaks-trpc.md", base: agentsSplitBaseWave4, nonBlank: 21, sha: "a3cdf52894cab892d1b5fc6626990fe013edbd7af08075154bdd5bfd238201ce"},
+	{num: 14, file: "claudedocs/decisions/14-unset-flags-must-be-absent.md", base: agentsSplitBaseWave4, nonBlank: 21, sha: "90f229c4135bb79c9a3419d90e3bb69e8cf3662ec8155c32e7231a61e65c9447"},
+	{num: 15, file: "claudedocs/decisions/15-two-trpc-envelopes.md", base: agentsSplitBaseWave4, nonBlank: 25, sha: "74a0d1e7746bec2ccec78bfae7616b7398f7c6a44b995cd7ddc3b58e27425fbb"},
+	{num: 16, file: "claudedocs/decisions/16-externalid-is-the-idempotency-key.md", base: agentsSplitBaseWave4, nonBlank: 25, sha: "cf7f2bd23cf64b0421fad49ace38df6dcdef3d3c3104aecef19e7657935caa4f"},
+	{num: 28, file: "claudedocs/decisions/28-no-claims-about-unobservable-spend.md", base: agentsSplitBaseWave4, nonBlank: 31, sha: "41387de27265146eb9c9fc8a507621b27b8b20cdf0db8d7eb9d4903021707478"},
 }
 
 // --- the one deliberate delta, item 3 ---------------------------------------

--- a/agents_trigger_test.go
+++ b/agents_trigger_test.go
@@ -413,6 +413,38 @@ func TestInlineAgentsItemsStayUnderTheBreakEven(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: no inline items were found, so the break-even rule was applied to nothing. " +
 			"Either every item is now converted (in which case delete this control deliberately) or the pointer scan is broken.")
 	}
+
+	// 🔴 THE CONSTANT IS BOUNDED BY A MEASUREMENT, NOT BY A SECOND MAGIC NUMBER,
+	// AND IT WAS UNBOUNDED FOR A ROUND. Raising maxInlineItemBytes to 99,999 was
+	// a SURVIVING mutant: nothing exceeded the new value, so the whole suite
+	// stayed green while the rule that keeps this list an index had been
+	// deleted — the "a ceiling nobody bounds" failure agentsMaxBytesCeiling
+	// exists to stop, regenerated one file over.
+	//
+	// The bound is re-derived from the live file rather than pinned: a trigger
+	// block is what an item costs once converted, so an inline item worth
+	// keeping must be within a small multiple of one. 3x is deliberately loose —
+	// it is a bound on ABSURDITY, not a restatement of the break-even — and at
+	// today's largest trigger block it puts the ceiling at ~795 against the
+	// constant's 600.
+	largestTrigger := 0
+	for _, it := range items {
+		if !it.converted {
+			continue
+		}
+		if n := byNum[it.num]; n > largestTrigger {
+			largestTrigger = n
+		}
+	}
+	if largestTrigger == 0 {
+		t.Fatalf("CONTROL failure, not a finding: no converted item had a measurable size, so the bound below was computed from nothing")
+	}
+	if bound := 3 * largestTrigger; maxInlineItemBytes > bound {
+		t.Errorf("maxInlineItemBytes is %d, above %d — three times the largest trigger block in the file (%d bytes).\n"+
+			"At that size an item can be written inline as a BODY and this guard will wave it through, which is the whole thing it exists to prevent. "+
+			"If the break-even genuinely moved, re-derive it from the measured trigger cost and say so in the constant's comment; do not raise it to make one item fit.",
+			maxInlineItemBytes, bound, largestTrigger)
+	}
 	t.Logf("%d inline item(s), all within the %d-byte break-even", inline, maxInlineItemBytes)
 }
 

--- a/agents_trigger_test.go
+++ b/agents_trigger_test.go
@@ -1,0 +1,504 @@
+package cli_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// AGENTS.md's numbered list is a TRIGGER INDEX. Each item is one line asking
+// whether the reader is about to do the thing that item governs, plus a pointer
+// at the file holding the item itself. That shape replaced the multi-line STUBS
+// waves 1–3 of the evidence split (#290, #305, #310) left behind, and it creates
+// a failure mode this repo has not had before — which is what this file guards.
+//
+// # 🔴 A TRIGGER IS A NEW CLAIM, AND A WRONG ONE SILENTLY HIDES ITS ITEM
+//
+// A stub was a compressed CONCLUSION: it restated what the item decided, so a
+// reader who skipped the evidence still carried away something true. A trigger
+// is a claim about the reader's SITUATION — "you are about to touch X" — and it
+// is the only thing routing anyone to the item at all. Get it too narrow and the
+// item is not reached by the person it was written for; the file is still there,
+// the ledger still balances, the digest still matches, and nothing fails. The
+// item has been hidden rather than lost, which is the failure that looks most
+// like success.
+//
+// Nothing automated can tell you a trigger is TRUE of its item. That is the same
+// limitation agents_xrefs_test.go states for a reference to a valid-but-wrong
+// item and agents_index_test.go states for a clause that misdescribes the items
+// it names: the SHAPE is checkable, the CLAIM is not. Reading a trigger against
+// the item it points at is a manual audit, and an over-narrow trigger is the
+// expensive direction — so when an item governs more than one situation, name
+// them all.
+//
+// # WHAT IS CHECKABLE, AND WHY EACH RULE IS HERE
+//
+//  1. EVERY item has a trigger. Not just the split ones — an item with no
+//     routing line is unreachable by the only navigation the list now has.
+//
+//  2. A TRIGGER ENDS IN `?`. This is the rule that separates a routing signal
+//     from a label, and it is structural rather than stylistic: a question is
+//     about the reader, a statement is about the subject. The brief's own
+//     worked example of the failure —
+//     "17. **`DownloadPresigned` exists so a blob fetch carries no credential.**"
+//     — is a perfectly good sentence and a useless trigger, and it is caught
+//     here by its full stop. It is not sufficient on its own (a label with a
+//     question mark bolted on passes), which is why rules 3–5 exist; no one of
+//     them subsumes the others.
+//
+//  3. A LENGTH BAND. The floor catches a blanked or one-word trigger. The
+//     ceiling is the more interesting half: without it the list grows a body
+//     back one clause at a time, and every individual edit looks reasonable.
+//
+//  4. A DEGENERATE-PHRASE DENYLIST — "see the evidence file", "TBD", a bare
+//     restatement of the item number. These pass rules 2 and 3 while carrying no
+//     routing information at all.
+//
+//  5. NOT THE EVIDENCE FILE'S OWN TITLE. A title is a label by construction, so
+//     a trigger that normalises to its file's H1 is a restatement wearing a
+//     question mark.
+//
+//  6. A CONVERTED ITEM IS THE TRIGGER AND THE POINTER, NOTHING ELSE. Any other
+//     line in the block is a body creeping back inline.
+//
+//  7. AN INLINE ITEM STAYS UNDER THE BREAK-EVEN. Two items (2 and 4) are stated
+//     in full because a trigger plus a file read costs more than they do; see
+//     maxInlineItemBytes. Without this rule the next item is written inline
+//     "just this once" and the index silently reverts to a list of bodies.
+//
+// # 🔴 WHAT THIS FILE SUPERSEDES, AND THE PROPERTY THAT MOVED
+//
+// It replaces TestEvidenceStubsCarryAThesisAndAPointer, which required 120
+// characters of prose before a pointer so that an item could not decay into a
+// bare "see the evidence file". That guard was right about the hazard and is
+// incompatible with the fix: a trigger is deliberately SHORTER than its floor,
+// because the routing information a reader needs is not a compressed thesis. The
+// hazard it named is covered here by rules 1, 4 and 5 — a bare pointer now fails
+// for having no trigger at all, rather than for being short.
+//
+// The other property that moved here is ANTI-RE-INLINING. Under the stub regime
+// that was the byte ceiling's job: agentsMaxBytes was sized so that restoring a
+// large body broke it. Under the trigger index it is structural and byte-free —
+// restoring item 6's body means deleting its trigger, which fails rule 1 and
+// rule 6 here and orphans an evidence file in agents_evidence_test.go, whatever
+// the file's size. That is why agentsMaxBytes can now be a genuine budget for
+// ordinary prose edits instead of a second lock.
+
+// minTriggerChars / maxTriggerChars bound the trigger text (the bolded question,
+// whitespace-collapsed, excluding the `N. ` numbering and the `**` markers).
+//
+// Measured over the twenty-six triggers in the file: min 77 (item 7), mean 120,
+// max 169 (item 13).
+//
+// The floor catches the degenerate shapes rule 4 does not enumerate — a blank, a
+// single word, a bare "Why?". At 40 it sits well under the shortest real trigger,
+// so it is a floor an honest one clears without being written to clear it.
+//
+// The ceiling is what stops the list growing bodies back. 220 leaves the longest
+// trigger 51 characters of room — enough for an item that genuinely governs four
+// situations, not enough for a paragraph. 🔴 Raising it is not a formatting
+// decision; it is a decision to let the per-session cost grow, which is the whole
+// thing the index exists to bound.
+const (
+	minTriggerChars = 40
+	maxTriggerChars = 220
+)
+
+// maxInlineItemBytes is the break-even, expressed as a rule rather than as a
+// judgement made once.
+//
+// A trigger block (the wrapped question plus its pointer line) measures 162–265
+// bytes in AGENTS.md today, mean 204. So converting an item recovers
+// (its size − ~204) bytes and costs one file read whenever its subject comes up.
+// The two items left inline are 301 and 500 bytes — they would recover 97 and
+// 296 — and they are also the only two whose bodies carry nothing to defer: no
+// measurement, no mutation matrix, no retraction, no enumerated residual, no
+// second sub-rule. Their evidence files would hold exactly the text the list
+// already shows, so the trigger would promise something to open and deliver a
+// restatement.
+//
+// 600 sits above item 4 (500) and below the smallest converted body (item 11's
+// 638-byte stub, which recovered 441). The two tests agree at this line, which
+// is why it is drawn here: everything under it saves less than 300 bytes AND has
+// nothing to defer; everything over it fails both ways.
+//
+// 🔴 THIS IS THE RULE THAT KEEPS THE INDEX AN INDEX. A new item written inline
+// as a full body fails here by name, and the fix is to write the trigger and
+// move the body — not to raise this number.
+const maxInlineItemBytes = 600
+
+// minTriggersRequired is the POSITIVE CONTROL. A parser that has stopped seeing
+// the bolded question — a changed wrap, a lost `**`, the wrong working directory
+// — returns an empty set, iterates over nothing and reports a serene pass. 26
+// items carry a trigger today; 20 leaves room to re-inline six without letting a
+// scanner wired to nothing through.
+const minTriggersRequired = 20
+
+// triggerRe captures the bolded question that opens a converted item. It matches
+// against the item block with newlines already collapsed, because AGENTS.md is
+// hard-wrapped at ~79 columns and every trigger longer than about seventy
+// characters straddles a line break — the same hazard agents_index_test.go's
+// design decision 2 and agents_xrefs_test.go's paragraph-wise scan record, which
+// is why neither of them reads a line at a time either.
+var triggerRe = regexp.MustCompile(`^[0-9]+\. \*\*(.+?)\*\*`)
+
+// degenerateTriggers are shapes that satisfy the question mark and the length
+// band while routing nobody. Matched against the whitespace-collapsed,
+// lower-cased trigger.
+var degenerateTriggers = []string{
+	"see the evidence",
+	"see below",
+	"see the file",
+	"read the evidence",
+	"tbd",
+	"todo",
+	"this item",
+}
+
+// itemNumberRestatementRe catches "item 17?" and its dressings — a trigger whose
+// entire content is the number a reader would have to already know to look up.
+var itemNumberRestatementRe = regexp.MustCompile(`^(agents\.?md )?items? [0-9]+\??$`)
+
+type agentsItem struct {
+	num       int
+	line      int      // 1-based line of the heading, so a failure names where to look
+	block     []string // the item's lines, as agentsItemSizes slices them
+	trigger   string   // the bolded question, whitespace-collapsed ("" if none)
+	pointer   string   // the `→ evidence:` path ("" if the item is inline)
+	converted bool
+}
+
+// agentsItems slices AGENTS.md's numbered list into items, using the same
+// boundary rule as agentsItemSizes and baseItemBody — the two slicers whose
+// disagreement TestEvictionPlaybookSizesTheLastItemCorrectly exists to catch. A
+// third spelling of that rule would be a third thing to keep in step, so this
+// one is written to match them exactly and is asserted to agree below.
+func agentsItems(t *testing.T) []agentsItem {
+	t.Helper()
+	b, err := os.ReadFile("AGENTS.md")
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v (CONTROL failure — nothing below this line checked anything)", err)
+	}
+	body := string(b)
+	if !strings.Contains(body, itemsSectionHeading) {
+		t.Fatalf("CONTROL failure, not a finding: AGENTS.md has no %q heading, so no items could be located",
+			itemsSectionHeading)
+	}
+	lines := strings.Split(body, "\n")
+	type head struct{ num, line int }
+	var heads []head
+	for n, line := range lines {
+		if m := itemHeadingRe.FindStringSubmatch(line); m != nil {
+			num, _ := strconv.Atoi(m[1])
+			heads = append(heads, head{num, n})
+		}
+	}
+	var out []agentsItem
+	for idx, h := range heads {
+		end := len(lines)
+		if idx+1 < len(heads) {
+			end = heads[idx+1].line
+		}
+		block := lines[h.line:end]
+		for i, l := range block {
+			if i > 0 && l != "" && !strings.HasPrefix(l, " ") {
+				block = block[:i]
+				break
+			}
+		}
+		for len(block) > 0 && strings.TrimSpace(block[len(block)-1]) == "" {
+			block = block[:len(block)-1]
+		}
+		it := agentsItem{num: h.num, line: h.line + 1, block: block}
+		joined := strings.Join(strings.Fields(strings.Join(block, " ")), " ")
+		if m := triggerRe.FindStringSubmatch(joined); m != nil {
+			it.trigger = strings.TrimSpace(m[1])
+		}
+		for _, l := range block {
+			if m := evidencePointerRe.FindStringSubmatch(l); m != nil {
+				it.pointer = m[1]
+				it.converted = true
+			}
+		}
+		out = append(out, it)
+	}
+	return out
+}
+
+// triggerDefect returns the reason a trigger is not a routing signal, or "" if
+// it is one. It is the ONE classifier: the live check and the control corpus
+// below both call it, so a narrowing fails the corpus by name instead of quietly
+// shrinking what the live check rejects.
+func triggerDefect(trigger, evidenceTitle string) string {
+	t := strings.Join(strings.Fields(trigger), " ")
+	if t == "" {
+		return "there is no trigger at all — the item opens with no bolded question, so nothing routes a reader to it"
+	}
+	low := strings.ToLower(t)
+	if itemNumberRestatementRe.MatchString(low) {
+		return "the trigger is a restatement of the item number; a reader who already knew the number would not need the index"
+	}
+	for _, d := range degenerateTriggers {
+		if strings.Contains(low, d) {
+			return fmt.Sprintf("the trigger says %q, which routes nobody — it names the file, not the situation that should send someone to it", d)
+		}
+	}
+	if n := len([]rune(t)); n < minTriggerChars {
+		return fmt.Sprintf("the trigger is %d characters, under the %d-character floor — too short to name a situation", n, minTriggerChars)
+	} else if n > maxTriggerChars {
+		return fmt.Sprintf("the trigger is %d characters, over the %d-character ceiling — that is a body growing back one clause at a time", n, maxTriggerChars)
+	}
+	if !strings.HasSuffix(t, "?") {
+		return "the trigger is a LABEL, not a trigger: it states what the item concluded instead of asking whether the reader is about to do the thing it governs. " +
+			"A trigger ends in `?` because it is a question about the reader's situation"
+	}
+	if evidenceTitle != "" && normaliseForTitle(t) == normaliseForTitle(evidenceTitle) {
+		return "the trigger is the evidence file's own title with a question mark on it — a title is a label by construction, so this restates the conclusion rather than naming the situation"
+	}
+	return ""
+}
+
+// normaliseForTitle strips the decoration a title and a trigger can differ by
+// without differing in content: markup, punctuation and case.
+func normaliseForTitle(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// evidenceTitleFor reads the H1 out of an evidence file, for rule 5.
+func evidenceTitleFor(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "" // the evidence ledger reports a missing file; do not double-report it
+	}
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(l, "# ") {
+			return strings.TrimPrefix(l, "# ")
+		}
+	}
+	return ""
+}
+
+// TestEveryAgentsItemCarriesATrigger is the guard for the failure the trigger
+// index introduces: an item nobody is routed to.
+func TestEveryAgentsItemCarriesATrigger(t *testing.T) {
+	count := parseAgentsItems(t)
+	items := agentsItems(t)
+	if len(items) != count {
+		t.Fatalf("CONTROL failure, not a finding: this file's slicer found %d item(s) and parseAgentsItems found %d. "+
+			"Two slicers disagreeing about where the list is means one of them is reading something else; fix that before reading any result below.",
+			len(items), count)
+	}
+
+	converted := 0
+	for _, it := range items {
+		if it.converted {
+			converted++
+		}
+	}
+	if converted < minTriggersRequired {
+		t.Fatalf("CONTROL failure, not a finding: only %d of %d items carry an `→ evidence:` pointer, want >= %d.\n"+
+			"A scan that finds almost no triggers validates almost nothing and would otherwise pass. Check triggerRe (%s) and evidencePointerRe (%s), "+
+			"and that this test's working directory is the module root.",
+			converted, len(items), minTriggersRequired, triggerRe, evidencePointerRe)
+	}
+
+	var problems []string
+	for _, it := range items {
+		if !it.converted {
+			// An inline item is allowed to be a statement — it IS the rule, and
+			// there is nothing to route to. It is bounded by size instead.
+			continue
+		}
+		if d := triggerDefect(it.trigger, evidenceTitleFor(t, it.pointer)); d != "" {
+			problems = append(problems, fmt.Sprintf("  AGENTS.md:%d: item %d — %s\n      trigger: %q", it.line, it.num, d, it.trigger))
+		}
+		// Rule 6: the block is the trigger and the pointer, nothing else.
+		if extra := blockResidue(it); len(extra) > 0 {
+			problems = append(problems, fmt.Sprintf(
+				"  AGENTS.md:%d: item %d carries %d line(s) that are neither its trigger nor its pointer:\n      %s",
+				it.line, it.num, len(extra), strings.Join(extra, "\n      ")))
+		}
+	}
+	if len(problems) > 0 {
+		t.Fatalf("%d item(s) whose trigger does not route anyone:\n%s\n\n"+
+			"The numbered list is a TRIGGER INDEX: each line asks whether the reader is about to do the thing the item governs, and the pointer says "+
+			"where the item itself lives. A line that states a conclusion instead is a label — it reads fine and routes nobody, and the item it hides "+
+			"stays hidden with every other guard green.",
+			len(problems), strings.Join(problems, "\n"))
+	}
+	t.Logf("all %d items carry a trigger or stay inline (%d converted, %d inline)", len(items), converted, len(items)-converted)
+}
+
+// blockResidue returns the lines of a converted item that belong to neither the
+// trigger heading nor the pointer — rule 6.
+func blockResidue(it agentsItem) []string {
+	// The trigger heading runs from the first line to the line closing the `**`.
+	closed := false
+	var extra []string
+	for _, l := range it.block {
+		s := strings.TrimSpace(l)
+		if s == "" {
+			continue
+		}
+		if !closed {
+			// Every line up to and including the one closing the bold marker
+			// belongs to the trigger. A heading that never closes yields no
+			// trigger at all, which triggerDefect reports rather than this.
+			if strings.HasSuffix(s, "**") {
+				closed = true
+			}
+			continue
+		}
+		if evidencePointerRe.MatchString(l) {
+			continue
+		}
+		extra = append(extra, s)
+	}
+	return extra
+}
+
+// TestInlineAgentsItemsStayUnderTheBreakEven is rule 7. Without it the index
+// reverts to a list of bodies one reasonable-looking commit at a time, and the
+// byte ceiling would report that as a budget being spent rather than as a
+// convention being abandoned.
+func TestInlineAgentsItemsStayUnderTheBreakEven(t *testing.T) {
+	items := agentsItems(t)
+	sizes := agentsItemSizes(t)
+	byNum := map[int]int{}
+	for _, s := range sizes {
+		byNum[s.num] = s.bytes
+	}
+
+	inline := 0
+	var over []string
+	for _, it := range items {
+		if it.converted {
+			continue
+		}
+		inline++
+		n, ok := byNum[it.num]
+		if !ok {
+			t.Fatalf("CONTROL failure: item %d has no size from agentsItemSizes — the two slicers disagree about the list", it.num)
+		}
+		if n > maxInlineItemBytes {
+			over = append(over, fmt.Sprintf(
+				"  item %d is %d bytes inline, over the %d-byte break-even by %d (AGENTS.md:%d)",
+				it.num, n, maxInlineItemBytes, n-maxInlineItemBytes, it.line))
+		}
+	}
+	if len(over) > 0 {
+		t.Fatalf("%d item(s) written inline that are large enough to pay for a trigger:\n%s\n\n"+
+			"An item this size costs every session its full length whether or not the session touches it. Write a TRIGGER — one line asking whether "+
+			"the reader is about to do what the item governs — and move the body to %s/NN-<slug>.md verbatim, with a row in splitItems pinning it. "+
+			"Do NOT raise maxInlineItemBytes: it is the point at which converting starts paying, not a style preference.",
+			len(over), strings.Join(over, "\n"), evidenceDir)
+	}
+
+	// POSITIVE CONTROL. If every item were converted this test would iterate
+	// over nothing and pass having measured nothing, so the inline path has to
+	// be exercised by at least one real item — and if a future wave converts
+	// them both, this control is the thing that says so out loud.
+	if inline == 0 {
+		t.Fatalf("CONTROL failure, not a finding: no inline items were found, so the break-even rule was applied to nothing. " +
+			"Either every item is now converted (in which case delete this control deliberately) or the pointer scan is broken.")
+	}
+	t.Logf("%d inline item(s), all within the %d-byte break-even", inline, maxInlineItemBytes)
+}
+
+// TestTriggerClassifierRejectsLabelsAndPasses is the NEGATIVE CONTROL for
+// triggerDefect: it drives the classifier over shapes that MUST be rejected and
+// shapes that must NOT be, so a future narrowing fails here by name instead of
+// silently widening what the live list may contain.
+//
+// Without it, "every trigger in AGENTS.md passes" is satisfiable by a classifier
+// that rejects nothing — the reassuring-zero shape this repo keeps meeting.
+func TestTriggerClassifierRejectsLabelsAndPasses(t *testing.T) {
+	const title = "AGENTS.md item 17 — `DownloadPresigned` exists so a blob fetch carries NO credential"
+
+	reject := []struct {
+		name string
+		in   string
+	}{
+		{"blank", ""},
+		{"whitespace only", "   \n  "},
+		{"the brief's own label example", "`DownloadPresigned` exists so a blob fetch carries no credential."},
+		{"a label with no terminator at all", "`DownloadPresigned` exists so a blob fetch carries no credential"},
+		{"a bare item-number restatement", "item 17?"},
+		{"a dressed item-number restatement", "AGENTS.md item 17?"},
+		{"a pointer in prose", "See the evidence file for item 17?"},
+		{"a TODO", "TBD — write a trigger for this one later, it is about downloads?"},
+		{"one word", "Downloads?"},
+		{"under the floor by a hair", strings.Repeat("a", minTriggerChars-2) + "?"},
+		{"over the ceiling — a body growing back", strings.Repeat("situation, ", 30) + "?"},
+		{"the evidence file's own title with a question mark", title + "?"},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if d := triggerDefect(tc.in, title); d == "" {
+				t.Errorf("triggerDefect accepted %q, which routes nobody", tc.in)
+			}
+		})
+	}
+
+	accept := []struct {
+		name string
+		in   string
+	}{
+		{"the real item 17 trigger",
+			"Folding a credential-free blob transfer back into the token-carrying one, or touching `isTrustedDownloadHost`?"},
+		{"a trigger naming several situations",
+			"Touching `--image` — the workflow value, the `--ecosystem` refusal, the image cap, the dimensions, or the upload `--dry-run` still performs?"},
+		{"a trigger wrapped across lines (collapsed by the caller)",
+			"Asserting an exit code, or testing an error's classification, in ANY command?"},
+		{"exactly at the floor", strings.Repeat("a", minTriggerChars-1) + "?"},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if d := triggerDefect(tc.in, title); d != "" {
+				t.Errorf("triggerDefect rejected a good trigger %q: %s", tc.in, d)
+			}
+		})
+	}
+
+	// POSITIVE CONTROL for the corpus itself: the accept set must not be empty
+	// and the reject set must not be, or "the classifier agreed with every case"
+	// is a claim about an empty table.
+	if len(reject) < 8 || len(accept) < 3 {
+		t.Fatalf("CONTROL failure: the corpus is %d reject / %d accept case(s); a table this small cannot pin the classifier",
+			len(reject), len(accept))
+	}
+}
+
+// TestEveryTriggerIsDistinct catches the copy-paste failure the shape invites:
+// two items whose trigger is the same question route a reader to whichever they
+// read first, and the second item is hidden exactly as if it had no trigger.
+func TestEveryTriggerIsDistinct(t *testing.T) {
+	seen := map[string][]int{}
+	for _, it := range agentsItems(t) {
+		if !it.converted {
+			continue
+		}
+		k := normaliseForTitle(it.trigger)
+		seen[k] = append(seen[k], it.num)
+	}
+	if len(seen) < minTriggersRequired {
+		t.Fatalf("CONTROL failure, not a finding: only %d distinct trigger(s) parsed, want >= %d — the parser is not seeing the list",
+			len(seen), minTriggersRequired)
+	}
+	for _, nums := range seen {
+		if len(nums) > 1 {
+			t.Errorf("items %v share one trigger. A reader routed by it reaches the first and never learns the others exist", nums)
+		}
+	}
+}

--- a/claudedocs/decisions/01-validate-is-a-local-mirror.md
+++ b/claudedocs/decisions/01-validate-is-a-local-mirror.md
@@ -1,0 +1,30 @@
+# AGENTS.md item 1 — civitai app validate is a best-effort LOCAL mirror, not the authority
+
+Evidence for item 1 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+1. **`civitai app validate` is a best-effort LOCAL mirror, not the authority.**
+   The server-side `BlockManifestValidator`
+   (`civitai/civitai → src/server/services/block-manifest-validator.service.ts`)
+   is the source of truth at review time. The vendored
+   `schema/app-block.manifest.schema.json` covers only **syntactic** rules; the
+   **semantic** rules the schema can't express (sandbox trust-tier allowlist,
+   `page ⇒ iframe`, required iframe sub-fields, the `renderMode` tier gate,
+   `targets[].slotId` registry membership) are **ported into Go** in
+   `internal/validate/{semantic.go,targets.go}`. Some checks are *deliberately
+   not* reproduced locally (origin-binding, scope⊆client) because they need
+   per-app server state the CLI can't see — this fidelity split is intentional,
+   not a missing feature.

--- a/claudedocs/decisions/03-lockfile-check.md
+++ b/claudedocs/decisions/03-lockfile-check.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 3 — the lockfile check mirrors the platform build recipe
 
 Evidence for item 3 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 3. **The lockfile check in `internal/validate/lockfile.go` mirrors the PLATFORM
+>    BUILD RECIPE, not `BlockManifestValidator`.** It is the one build-time rule
+>    `validate` reproduces, because the platform build installs *strictly* from
+>    the committed lockfile and a mismatch surfaces only as an opaque server-side
+>    "build failed". It fires only when `package.json` exists; static blocks never
+>    install and must never be flagged. 🔴 It is FATAL, and since #255 it reads
+>    the required lockfile's BYTES rather than only its presence — read the
+>    evidence before touching `packageManagerFor`, the BOM strip or the 64 MiB cap.
 
 ---
 

--- a/claudedocs/decisions/05-app-metrics-trpc-not-rest.md
+++ b/claudedocs/decisions/05-app-metrics-trpc-not-rest.md
@@ -1,0 +1,28 @@
+# AGENTS.md item 5 — civitai app metrics calls tRPC, not REST — because there is no REST route
+
+Evidence for item 5 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+5. **`civitai app metrics` calls tRPC, not REST — because there is no REST route
+   to call.** Owner analytics exist only as `blocks.getMyAppAnalytics`
+   (`civitai/civitai → src/server/routers/blocks.router.ts`); there is no
+   `/api/v1` equivalent. So `internal/cmd/app_metrics.go` resolves `<slug>` →
+   `appBlockId` through the *existing REST* route `GET /api/v1/blocks/submissions`
+   and then issues the non-batched tRPC GET in `internal/appapi/analytics.go`
+   (input rides in `?input={"json":{…}}`, success unwraps `result.data.json`),
+   reusing the `authedDo` + envelope-unwrap pattern `GetForgejoCloneInfo` already
+   established. The two-hop shape is deliberate, not an oversight — don't "fix"
+   the tRPC call into a REST call that does not exist.

--- a/claudedocs/decisions/06-notowned-is-a-cross-repo-contract.md
+++ b/claudedocs/decisions/06-notowned-is-a-cross-repo-contract.md
@@ -1,0 +1,27 @@
+# AGENTS.md item 6 — notOwned is a cross-repo contract, and the human view MUST keep branching
+
+Evidence for item 6 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+6. **`notOwned` is a cross-repo contract, and the human view MUST keep branching
+   on it.** The proc sits behind the `appBlocksAuthor` feature flag and answers a
+   caller who is not entitled — or does not own the app — with **HTTP 200 and
+   every counter zeroed**, not an error. A renderer that ignores the field
+   therefore prints a plausible, fully-populated-looking empty dashboard for what
+   is really a permission failure, so `runAppMetrics` refuses to render when
+   `notOwned` is true. Whoever changes that payload server-side has to keep the
+   field. `--json` deliberately passes the payload through **and still exits 0**,
+   so a script must branch on `notOwned` itself rather than trust the counts.

--- a/claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md
+++ b/claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md
@@ -1,0 +1,29 @@
+# AGENTS.md item 7 — the exit-code contract is pinned by errors.Is, never by message text
+
+Evidence for item 7 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+7. **The exit-code contract is pinned by `errors.Is`, never by message text.**
+   The classification sentinels carry no visible text — `civitai.Tag`/`TagStatus`
+   attach them while `Error()` stays byte-for-byte unchanged (see
+   `pkg/civitai/errkind.go`) — so a test that asserts on the message says nothing
+   about the exit code. Measured on the `metrics` PR: stripping the
+   classification while leaving every message identical left the **entire suite
+   green**, and the README's 403 → exit 3 / not-found → exit 4 promise was
+   unpinned. Assert `errors.Is(err, civitai.ErrUnauthorized)` /
+   `civitai.ErrNotFound` / `cmd.ErrUsage` (note: usage lives in `internal/cmd`,
+   the HTTP kinds in `pkg/civitai`). This applies to **every** command that
+   claims an exit code, not just `metrics`.

--- a/claudedocs/decisions/08-raw-tokens-are-a-non-mirror.md
+++ b/claudedocs/decisions/08-raw-tokens-are-a-non-mirror.md
@@ -1,0 +1,42 @@
+# AGENTS.md item 8 — app metrics prints RAW endpoint/scope tokens, and the web deliberately does
+
+Evidence for item 8 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+8. **`app metrics` prints RAW endpoint/scope tokens, and the web deliberately does
+   not — this divergence is on purpose.** The web analytics panel humanises the
+   two "top N" rollups (`civitai/civitai → src/components/AppBlocks/`
+   `analytics-bucket-labels.ts`), so the same data reads as `Generations` /
+   `AI workflow submits` there and as `workflow:submit` / `ai:write:budgeted`
+   here (`app_metrics.go`, the `Top endpoints` / `Top scopes` sections). That was
+   a **deliberate non-mirror**, decided when the web labels landed: reproducing
+   them would add a FIFTH vendored mapping to keep in lockstep with the server
+   (alongside `schema/`, the slot registry, item 10's dev-tunnel dotenv mirror
+   and item 11's ready-ack emitter), and unlike those four it buys no
+   correctness — a raw token is accurate, just terse, and the values are already
+   bounded so they aggregate readably. The raw form is arguably *better* for the
+   CLI's scripting audience, and `--json` must keep emitting raw tokens
+   regardless. 🔴 The count was stale and read "a THIRD … (alongside `schema/`
+   and the slot registry)": this item predates items 10 and 11, and neither
+   recounted it. Four is the number the closing paragraph and both of those
+   items already state — check it there before quoting it here again.
+   Cost to know about: an author reading the same range on both surfaces sees two
+   vocabularies, and a legacy pre-bounding row shows here as
+   `workflow:submit:<id>` where the web shows `Generations (<id>)`. If you decide
+   to close the gap, mirror `analytics-bucket-labels.ts` wholesale rather than
+   hand-rolling labels, add a drift check against the server's
+   `recordScopeInvocation` call sites, and note that `pending` is a "no id
+   captured" sentinel — **not** a status.

--- a/claudedocs/decisions/09-views-unavailable-discriminator.md
+++ b/claudedocs/decisions/09-views-unavailable-discriminator.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 9 — `views.unavailable` is a SECOND unavailability discriminator
 
 Evidence for item 9 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 9. **`views.unavailable` is a SECOND unavailability discriminator, and it is not
+>    redundant with `notOwned`.** The `App loads` section is the only part of the
+>    payload the server reads from **ClickHouse** rather than Postgres, so its
+>    store can be unconfigured, slow or down while every other counter in the
+>    same response is genuinely measured — which is why the flag is per-SECTION.
+>    🔴 `AppAnalytics.Views` is a **pointer** because there are THREE states, not
+>    two, and `installs.notApplicable` is a third state of a different KIND. All
+>    of it exists to stop the fabricated zero item 6 exists to prevent.
 
 ---
 

--- a/claudedocs/decisions/10-dev-tunnel-embeddability.md
+++ b/claudedocs/decisions/10-dev-tunnel-embeddability.md
@@ -1,16 +1,40 @@
 # AGENTS.md item 10 — the dev-tunnel embeddability preflight WARNS and never blocks
 
 Evidence for item 10 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 10. **The `dev-tunnel` embeddability preflight WARNS and never blocks, and its
+>     two halves have deliberately different evidentiary strength.**
+>     `internal/devtunnel/embedcheck.go` catches the failure where the tunnel is
+>     healthy but the browser refuses to run the app, because the host iframes the
+>     dev server sandboxed, at an opaque `null` origin. `CheckEmbeddable` reads
+>     real response headers off a real probe and is **evidence**;
+>     `CheckParentOrigins` cannot observe a value inlined at transform time, so it
+>     is a **heuristic** — and one of the four vendored mirrors, reproducing
+>     Vite's dotenv resolution. Neither is ever fatal: a check that cannot observe
+>     returns NO findings rather than manufacturing advice. That doctrine — cited
+>     across this repo as "the failure item 10 spent four measured corrections
+>     avoiding" — is what those four corrections bought, each having produced a
+>     FALSE WARNING at a correctly configured project, the worst outcome for
+>     advisory output because it teaches authors to ignore all of it.
 
 ---
 

--- a/claudedocs/decisions/11-vendored-ready-ack.md
+++ b/claudedocs/decisions/11-vendored-ready-ack.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 11 — the vendored block-to-host ready-ack
 
 Evidence for item 11 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 11. **The scaffold VENDORS the block→host ready-ack (`internal/blockproto/`),
+>     and it is the FOURTH vendored mirror.** A `page` app is not shown by the
+>     host until it posts `BLOCK_READY`; `page-money` gets that free from
+>     `@civitai/blocks-react`, but the deliberately SDK-free `static` and
+>     `page-vite` templates have to say hello themselves. They didn't — issue
+>     #206. `ready-ack.js` is `go:embed`ed and written VERBATIM (never templated),
+>     acks on `BLOCK_INIT` rather than on load, and is pinned by three guards
+>     none of which subsumes the others.
 
 ---
 

--- a/claudedocs/decisions/12-generate-speaks-trpc.md
+++ b/claudedocs/decisions/12-generate-speaks-trpc.md
@@ -1,0 +1,39 @@
+# AGENTS.md item 12 — civitai generate calls tRPC, not REST — because there is no REST
+
+Evidence for item 12 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+12. **`civitai generate` calls tRPC, not REST — because there is no REST
+    generation route to call.** Exactly the situation item 5 documents for
+    `app metrics`, and it will attract the same "fix". Generation exists only as
+    the tRPC procedures `orchestrator.whatIfFromGraph` (the cost estimate, a
+    GET) and `orchestrator.generateFromGraph` (the submit, a POST) in
+    `civitai/civitai → src/server/routers/orchestrator.router.ts`; there is no
+    `/api/v1` equivalent, and the same is true of the reads behind
+    `civitai workflows list|get|cancel`. So `internal/genapi` speaks tRPC — path
+    constants in `generate.go`, and the same `authedDo` + envelope-unwrap shape
+    (`?input={"json":{…}}`, success unwrapping `result.data.json`) that
+    `internal/appapi` established for item 5.
+    Don't "simplify" any of it into a REST call that does not exist.
+    Two things in there are load-bearing and look like oversights. `unwrapTRPC`
+    rejects a literal `null` payload as malformed rather than unmarshalling it:
+    `null` decodes CLEANLY into a zero `WhatIfResult`, which renders as
+    **total 0** — a fabricated free quote, on the one screen a user reads before
+    approving a charge. And `CancelWorkflow` deliberately does NOT go through
+    that unwrap, because the server's successful cancel reply has no
+    `result.data.json` at all (`workflows.ts`) — routing it through the standard
+    path would turn **every successful cancel** into "unexpected response". HTTP
+    200 is the success signal there.

--- a/claudedocs/decisions/13-generation-graph-not-validated.md
+++ b/claudedocs/decisions/13-generation-graph-not-validated.md
@@ -1,16 +1,35 @@
 # AGENTS.md item 13 — the CLI deliberately validates NOTHING about the generation graph
 
 Evidence for item 13 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 13. **The CLI deliberately validates NOTHING about the generation graph, and
+>     that is the feature.** `internal/genapi/graph.go` models a handful of fields
+>     and `--input` passes a caller's graph through byte-for-byte. It does not
+>     vendor, and must never vendor, the ecosystem keys, the ~51 per-engine
+>     graphs, the sampler enum, the buckets, the per-ecosystem defaults, the tier
+>     limits or any cost table: the server re-derives every one of them from state
+>     the CLI cannot see, so a vendored copy buys no correctness and starts
+>     **refusing valid new inputs**. Live lookups are not mirrors, which is why
+>     `ResolveModelVersion` is allowed.
 
 ---
 

--- a/claudedocs/decisions/14-unset-flags-must-be-absent.md
+++ b/claudedocs/decisions/14-unset-flags-must-be-absent.md
@@ -1,0 +1,39 @@
+# AGENTS.md item 14 — unset flags must be ABSENT from the payload, never Go zero values. Every
+
+Evidence for item 14 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+14. **Unset flags must be ABSENT from the payload, never Go zero values.** Every
+    optional field on `genapi.Graph` is a pointer or carries `omitempty`. This
+    reads as a missing-`omitempty` nit or gratuitous pointer-itis; it is a
+    correctness requirement, and the server is what makes it one. Measured:
+    `steps: 0` is **accepted**, and prices a degenerate, cheaper, WRONG job (the
+    steps cost factor drops to 0.333 from 1) — HTTP 200, billed. `cfgScale: 0`
+    goes the same way, and `quantity: 0` is clamped rather than rejected. So a
+    value-typed field silently converts *"the user did not pass `--steps`"* into
+    *"the user asked for a broken job"*, at half price, with no error anywhere.
+    The pointers also keep "unset" distinguishable from "explicitly zero", which
+    a `--print-input` → edit → `--input` round-trip depends on. The parsed
+    invocation carries `quantitySet` / `checkpointSet` / `maxCostSet` off
+    `cmd.Flags().Changed(...)` for the same reason.
+    🔴 **The guard asserts KEY ABSENCE on a decoded `map[string]any`** — see
+    `TestGraph_UnsetFieldsAreAbsent` in `internal/genapi/generate_test.go`, which
+    marshals the real outgoing bytes and checks `_, ok := m["steps"]`. It is
+    explicitly **not** a `strings.Contains` search, and rewriting it as one would
+    make it vacuous in a way that reads fine: `"cfg"` substring-matches
+    `"cfgScale"`, so a text search cannot tell the two keys apart. The same test
+    also pins that a zero-valued `Graph` marshals to zero keys, so a newly added
+    value-typed field fails immediately rather than at the first user's expense.

--- a/claudedocs/decisions/15-two-trpc-envelopes.md
+++ b/claudedocs/decisions/15-two-trpc-envelopes.md
@@ -1,0 +1,43 @@
+# AGENTS.md item 15 — whatIf and generate take DIFFERENT tRPC envelopes for the SAME graph,
+
+Evidence for item 15 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+15. **`whatIf` and `generate` take DIFFERENT tRPC envelopes for the SAME graph,
+    and both shapes are pinned by tests.** The query takes the graph **flat**
+    (`{"json": <graph>}`); the mutation takes it **NESTED** under `.input`
+    (`{"json":{"input": <graph>, "externalId": …}}`), because the server
+    destructures the graph out of a wrapper on the mutation and not on the query.
+    The web mirrors the asymmetry deliberately. This looks like an obvious
+    duplication to collapse into one builder. Do not.
+    🔴 **The mismatch is SILENT and returns HTTP 200 with a plausible wrong
+    cost.** Measured: a nested payload sent to whatIf is never parsed at all —
+    every nested body prices the server's default job (total 8) byte-identically
+    to `{}`, while the same graph sent flat priced 60. The discriminating control
+    was an ecosystem that 500s "Unknown ecosystem" when sent flat and returns a
+    clean `200 ready:true` when sent nested. So a builder wired to the wrong
+    nesting quotes a **constant** while every "did it 200?" assertion stays
+    green — and `--max-cost 50` would wave through an arbitrarily expensive job
+    while the confirmation prints "cost 8". That is the spend-safety feature
+    failing open, inside itself. A test that only checks the request succeeded
+    cannot see this; the tests assert the envelope SHAPE on the decoded body, on
+    both procedures.
+    Related, and easy to undo by accident: `whatIfGraph` strips
+    `prompt`/`negativePrompt` from the estimate (they do not affect cost, and the
+    server substitutes its own defaults), and it strips them from a RAW `--input`
+    graph by deleting the two keys from the decoded object — never by
+    re-marshalling through the typed struct, which would silently DELETE every
+    key the struct does not model.

--- a/claudedocs/decisions/16-externalid-is-the-idempotency-key.md
+++ b/claudedocs/decisions/16-externalid-is-the-idempotency-key.md
@@ -1,0 +1,43 @@
+# AGENTS.md item 16 — externalId is minted unconditionally on every submit, and must never be
+
+Evidence for item 16 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+16. **`externalId` is minted unconditionally on every submit, and must never be
+    sent on a whatIf.** `generateInput.ExternalID` deliberately has **no**
+    `omitempty`, and `GenerateFromGraph` mints a UUIDv4 when the caller passes
+    none. This looks like a field that should be optional. It is the idempotency
+    key, and without it a single user action can be charged up to **three
+    times**: the platform's submit wrapper retries 3× on a 5xx *and* on a network
+    error / no response, reusing the same body, adds no idempotency key of its
+    own, and has no server-side minting fallback. The orchestrator dedupes on
+    `(userId, externalId)`. The web client is safe only because it always mints
+    one.
+    It is also what makes the CLI's own 401-refresh replay in
+    `genapi/client.go` safe to point at a mutation — the key is minted *before*
+    the body is marshalled, so a replay re-sends byte-identical bytes and gets
+    the pre-existing workflow back. **Do not add a mutation to that package that
+    omits it.**
+    🔴 **Never send it on `whatIfFromGraph`.** A matching key returns the
+    pre-existing workflow, so a quote would BURN the key the subsequent submit
+    needs — which is why the server's own whatIf body omits it. And because a
+    duplicate key returns **HTTP 200 with the pre-existing workflow** rather than
+    a 409, re-attachment has to be inferred locally: that is why the key is
+    written to a local record *before* the POST goes out
+    (`internal/cmd/generate_state.go`) and why `--external-id` exists at all. It
+    overrides; it does not enable.
+    A `--input` file supplying its own `externalId` is REFUSED, not honoured —
+    see the envelope whitelist below.

--- a/claudedocs/decisions/17-download-presigned-no-credential.md
+++ b/claudedocs/decisions/17-download-presigned-no-credential.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 17 — `DownloadPresigned` exists so a blob fetch carries NO credential
 
 Evidence for item 17 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 17. **`DownloadPresigned` exists so a blob fetch carries NO credential, and it is
+>     the thing in this feature most likely to be "simplified" away.** It is a
+>     near-duplicate of `DownloadFile` differing only in passing an empty token,
+>     and every instinct says to fold it back in behind a bool. 🔴 Doing that
+>     leaks a full-scope personal API key: `isTrustedDownloadHost` attaches the
+>     token to **any** `*.civitai.com` subdomain, which is where orchestrator
+>     output blobs live. The fix is a seam that never HAS a credential to attach —
+>     the empty token short-circuits before the host predicate is consulted.
 
 ---
 

--- a/claudedocs/decisions/18-ready-ack-existing-apps.md
+++ b/claudedocs/decisions/18-ready-ack-existing-apps.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 18 — the ready-ack checks for EXISTING apps
 
 Evidence for item 18 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 18. **The ready-ack checks for EXISTING apps are two deliberately different
+>     tiers, and neither is allowed to be a hard failure.** #206 fixed the
+>     templates; every app scaffolded before `4018e2c` is still broken and nothing
+>     told its author. `internal/antipattern`'s `resize-iframe-page` rule is a
+>     GATE, because it fires on a literal that is present in the file — no
+>     inference. `validate`'s page-without-ack check is a WARNING and must stay
+>     one, because it infers RUNTIME behaviour from STATIC TEXT. Item 20 is the
+>     reachability repair to this item's presence-only scan.
 
 ---
 

--- a/claudedocs/decisions/19-img2img-workflow-and-upload.md
+++ b/claudedocs/decisions/19-img2img-workflow-and-upload.md
@@ -1,16 +1,36 @@
 # AGENTS.md item 19 — img2img — txt2img plus images[], --ecosystem, and no credential
 
 Evidence for item 19 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 19. **img2img sends `workflow: "txt2img"` PLUS `images[]`, requires
+>     `--ecosystem`, and uploads with NO credential — three things that each read
+>     like a bug.** The server promotes `txt2img` + non-empty `images` to
+>     `img2img:edit` itself, so sending the edit workflow would mean vendoring
+>     which ecosystems offer it — item 13's prohibition exactly. `--image`
+>     without `--ecosystem` is a hard error because the promotion reads the
+>     ecosystem off the RAW request body, so an absent one silently skips it and
+>     the flag becomes a guaranteed no-op THAT STILL CHARGES. The presigned upload
+>     carries no credential, for item 17's reason. 🔴 And the CLI still cannot
+>     tell you whether the promotion actually fired — do not add a detector.
 
 ---
 

--- a/claudedocs/decisions/20-ready-ack-advisory-tiers.md
+++ b/claudedocs/decisions/20-ready-ack-advisory-tiers.md
@@ -1,16 +1,35 @@
 # AGENTS.md item 20 — the ready-ack advisory's two tiers
 
 Evidence for item 20 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 20. **The ready-ack advisory has TWO TIERS, the message names which one ran, and
+>     that disclosure is the fix — not a nicety.** `validate`'s page-without-ack
+>     check (item 18) used to ask only "does any file in this tree mention
+>     `BLOCK_READY`", so a pre-fix scaffold with the emitter copied in but never
+>     referenced printed `✓ … is valid` and exited **0**. 🔴 A green check earned
+>     by obeying our own advice is worse than the silence it replaced.
+>     REACHABILITY (strong) runs on a completely resolved entry graph; PRESENCE
+>     ONLY (weak) falls back to the whole-tree scan, names the resolver's own
+>     reason, and must keep saying what it did NOT check.
 
 ---
 

--- a/claudedocs/decisions/21-model-substitution.md
+++ b/claudedocs/decisions/21-model-substitution.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 21 — a reported model substitution is a WARNING
 
 Evidence for item 21 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 21. **A reported model substitution is a WARNING by default, not a failure — and
+>     that is a deliberate product decision, not laziness.** The server accepts a
+>     checkpoint version id that is not valid for a `modelLocked` ecosystem,
+>     substitutes the ecosystem default, runs the job and bills for what ran
+>     (civitai/civitai#3665), reporting each swap as
+>     `modelSubstitutions: [{requested, applied, reason}]`. Warn-and-continue
+>     keeps working automation working; `--fail-on-substitution` is the opt-in for
+>     callers who would rather fail than get a different model.
 
 ---
 

--- a/claudedocs/decisions/22-input-refuses-non-txt2img.md
+++ b/claudedocs/decisions/22-input-refuses-non-txt2img.md
@@ -1,16 +1,36 @@
 # AGENTS.md item 22 — `--input` refuses every workflow but `txt2img`
 
 Evidence for item 22 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 22. **`--input` refuses every workflow but `txt2img`, and that refusal is NOT the
+>     local validation item 13 forbids — it is a CONTENT-AUDIT gate over a
+>     CONFIRMED server-side gap.** Item 13 forbids reproducing the server's
+>     *judgement* about which graphs are valid; this claims nothing of the kind,
+>     and is the same shape as item 19(b) — a flag combination the CLI owns.
+>     🔴 The gap is confirmed, not suspected: two shipped ecosystems declare
+>     prompt nodes the audit never runs over (civitai/civitai#3667). Keep the
+>     claim that size — the gate stops accidents, not adversaries — and lift it
+>     when the server closes the coverage, not when the next workflow looks like
+>     it would work.
 
 ---
 

--- a/claudedocs/decisions/23-finding-field-message.md
+++ b/claudedocs/decisions/23-finding-field-message.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 23 — a validation finding is a Finding{Field, Message}
 
 Evidence for item 23 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 23. **A validation finding is a `Finding{Field, Message}`, and the Field is
+>     carried from the CHECK — never re-derived at the printer.** `validate.Result`
+>     holds `[]Finding`, not `[]string`. This looks like ceremony around what used
+>     to be a string; it is the fix for issue #225, where 7 of 11 findings on a
+>     six-ways-broken manifest came back `field: null` — precisely the semantic
+>     ones, the checks a local pre-check exists for. 🔴 DO NOT close a future gap
+>     with more prefix heuristics at the printer: the field has to come from the
+>     producer, and `newFinding` is the only constructor.
 
 ---
 

--- a/claudedocs/decisions/24-errno-is-a-net-error.md
+++ b/claudedocs/decisions/24-errno-is-a-net-error.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 24 — syscall.Errno IS a net.Error
 
 Evidence for item 24 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 24. **`syscall.Errno` IS a `net.Error`, so the obvious spelling of the transport
+>     check silently classified EVERY filesystem failure in the CLI as a network
+>     failure — in TWO places, and the first fix reached only one of them.** A bare
+>     `var netErr net.Error; return errors.As(err, &netErr)` walks straight PAST
+>     the `*fs.PathError` wrapper and matches the Errno underneath, so every
+>     untagged `os.ReadFile` / `os.Stat` error landed on exit **5** — the code the
+>     README tells scripts to RETRY on (#241). The walk now lives in ONE place,
+>     `pkg/civitai/transport_error.go`, with four callers held by an asserted ledger.
 
 ---
 

--- a/claudedocs/decisions/25-listing-media-bounds.md
+++ b/claudedocs/decisions/25-listing-media-bounds.md
@@ -1,16 +1,35 @@
 # AGENTS.md item 25 — the listing-media dimension and aspect bounds stay prose in the README
 
 Evidence for item 25 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,
+>     and must NOT become a local check.** `civitai app listing set-icon` /
+>     `set-cover` / `add-screenshot` validate the **format** and the **byte size**
+>     of the source file and nothing else; the platform enforces a per-kind aspect
+>     range and a minimum dimension at ATTACH time. This is item 4's argument
+>     applied to a different constant set: stale *guidance* costs one round-trip,
+>     while a stale *gate* refuses valid images and the author cannot override it.
+>     🔴 Never scaffold a placeholder icon or cover — it passes every check and can
+>     reach a public store listing.
 
 ---
 

--- a/claudedocs/decisions/26-project-path-classification.md
+++ b/claudedocs/decisions/26-project-path-classification.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 26 — classifying the project path the user named
 
 Evidence for item 26 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 26. **`civitai app validate <dir>` / `app submit <dir>` CLASSIFY THE PATH THE
+>     USER NAMED BEFORE VALIDATING ANYTHING, and that gate is deliberately NOT
+>     item 24's transport predicate — it is a separate rule that happens to live
+>     next door on the exit-code contract.** Issue #256. `resolveProjectDir`
+>     (`internal/cmd/project_dir.go`) branches three ways on the path the user
+>     NAMED: nonexistent → 2, exists-but-not-a-directory → 2, a real directory →
+>     unchanged. It runs ahead of `--skip-validate` and ahead of the `--json`
+>     block, and both call sites are held by an asserted ledger.
 
 ---
 

--- a/claudedocs/decisions/27-blockid-derivation-refuses.md
+++ b/claudedocs/decisions/27-blockid-derivation-refuses.md
@@ -1,16 +1,34 @@
 # AGENTS.md item 27 — the blockId derivation refuses
 
 Evidence for item 27 of the *Intentional decisions that look wrong* list in
-[`AGENTS.md`](../../AGENTS.md). AGENTS.md keeps the stub — the thesis, plus
-enough to tell you whether this item bears on what you are about to change.
-Everything below the rule is that item's body, moved here VERBATIM: the
-measurements, mutation matrices, retractions and residuals are consulted when
-editing the code they are about, not on every session.
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
 
 The list is append-only and never renumbered, so this file's number is stable.
 Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
-pointer and the file agree, and `agents_split_preserved_test.go` pins the body
-against the text it was moved from.
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## The stub thesis this item's trigger replaced
+
+Waves 1–3 of the evidence split (#290, #305, #310) left a multi-line STUB in
+AGENTS.md here. That stub was prose written for the split — a compression of the
+body below, not a slice of it — so the trigger index preserves it rather than
+deleting it:
+
+> 27. **The blockId derivation REFUSES rather than transliterates, and the
+>     exemption that makes refusing safe is "LOWERCASES INTO ASCII" — never a
+>     character allowlist.** `scaffold.Slugify` used to replace every run of
+>     non-`[a-z0-9]` with a hyphen, which silently DROPPED content — `"Café App"`
+>     minted `caf-app` — for an identity that **cannot be renamed afterwards**. It
+>     now refuses and names the offending characters, with `--slug` as the escape
+>     hatch (#259). 🔴 It NARROWS #259; it does not close it, and the residuals it
+>     knowingly ships with are enumerated in the evidence.
 
 ---
 

--- a/claudedocs/decisions/28-no-claims-about-unobservable-spend.md
+++ b/claudedocs/decisions/28-no-claims-about-unobservable-spend.md
@@ -1,0 +1,49 @@
+# AGENTS.md item 28 — the CLI must not make CLAIMS about a spend it cannot observe. Same shape
+
+Evidence for item 28 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the mutation matrices, the retractions and the enumerated
+residuals, consulted when editing the code they are about rather than on every
+session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+---
+
+28. **The CLI must not make CLAIMS about a spend it cannot observe.** Same shape
+    as items 8, 13 and 19(b), on the money path; the measurements live in the
+    code comments at each site.
+    (a) **`--dry-run` reports RESOURCE READINESS** — the server's *"every job's
+    `queuePosition.support` is `available`"*, a job with no `queuePosition` being
+    **skipped**. Not generatability, not moderation (the prompt is stripped
+    before the estimate, item 15). As `Generatable` it promised a predicate it
+    cannot carry: 8 submits across 3 checkpoints all quoting `ready: true`
+    produced **0** outputs (#279). No surface says "generatable" — three senses
+    of it once shared one screen. Scripts gate on **false** via a `case`, so an
+    ABSENT key fails closed. 🔴 `false` buys OUR OWN refusal, not the server's:
+    none was found, and #279's bad checkpoints returned HTTP 400s.
+    (b) **No fate-of-charge copy asserts a direction, cancel included.** That a
+    charge HAPPENED stays; what BECAME of it goes. The platform's own client says
+    the orchestrator auto-refunds `failed`/`expired`/`canceled` and two balance
+    reads across 29 submits moved by the SUCCESS count (#278) — yet the opposite
+    is equally unevidenced, the rule living in the orchestrator SERVICE, absent
+    from the monorepo. Cancel keeps the accrued-cost half; civitai/cli#307 owns
+    the substance.
+    🔴 **TWO GUARD SHAPES DIED HERE — DO NOT REACH FOR A THIRD PHRASE LIST.** A
+    banned-substring ledger lost twice: to a paraphrase paying no banned word
+    ("your Buzz returns to your balance automatically"), then to five mutants
+    that kept every required sentence and APPENDED a claim — `Nothing is
+    refunded`, missed while `not refunded` was banned. Both rounds: 18 packages
+    green; the property is not computable from text. The guards are
+    (1) one constant `buzzLedgerUnknownNote` rendered verbatim, (2) an asserted
+    ledger of its call sites, (3) **golden-output pinning of every spend
+    surface**, which closes ADDITION — cosmetic reflows breaking a golden is the
+    accepted cost; re-approve with `-update` and read the diff.
+    🔴 Residual: a NEW file printing its own refund claim is invisible to all
+    three — measured, survived, 18 ok — unless it lands on a golden surface.


### PR DESCRIPTION
## What and why

`CLAUDE.md` does `@AGENTS.md`, so every byte is paid on every session. Waves 1–3
(#290, #305, #310) moved sixteen bodies out and left multi-line **stubs** behind.
The stubs were still 11,792 bytes and twelve items were still fully inline at
14,779 — 26,571 bytes of item list, 59% of the file.

A stub restates what an item **decided**. That is the wrong artefact for a file
loaded unconditionally: an agent does not need the conclusion of every decision
in the repo, it needs to know **which decision bears on the thing it is about to
change**. So each item is now one line asking exactly that, plus its pointer:

```
17. **Folding a credential-free blob transfer back into the token-carrying one,
    or touching `isTrustedDownloadHost`?**
    → evidence: claudedocs/decisions/17-download-presigned-no-credential.md
```

### Before / after

| | bytes | tokens (cl100k) |
|---|---|---|
| before (`dfdcc97`) | 45,027 | 11,684 |
| after | **25,258** | **6,778** |
| delta | −19,769 (−43.9%) | −4,906 (−42.0%) |

Token counts are a real `tiktoken` `cl100k_base` encode of the whole file, not a
bytes/4 estimate. Region breakdown, re-derived from the tree at HEAD:

| region | before | after |
|---|---|---|
| the numbered list (28 items) | 26,571 | **6,109** (−77.0%) |
| everything else (prose + index preamble) | 18,456 | 19,149 (+693) |

**The brief projected ~18 kB and this lands at 25.3 kB. Where the 7 kB went, so
you can judge whether I made the wrong trade:** a trigger block measures 162–265
bytes (mean 204), not the ~107 the "items ~3,000 B" projection implies. The
pointer line alone is 50–66 bytes, and a trigger that names *every* situation an
item governs wraps to two lines. 26 × 204 = 5.3 kB is the floor for this shape
unless triggers get terser, and terser is exactly the over-narrow direction the
brief calls the expensive one. The other +693 is the paragraph explaining the
convention — without it the index does not work, because a reader has to know
that a matching trigger means *open the file*.

## The break-even, and the two items left inline

**Byte break-even:** converting recovers `item bytes − ~204`. No item is below
204, so a pure byte test excludes nothing — items 2 and 4 would recover 97 and
296 bytes.

**The line I actually drew is content, and it agrees with the bytes.** An item is
worth converting when its body carries something a trigger cannot: a measurement,
a mutation matrix, a retraction, an enumerated residual, or a second sub-rule.

| item | inline bytes | would recover | has deferrable evidence? |
|---|---|---|---|
| 2 — the slot registry is vendored | 301 | 97 | no — four lines, one rule, one reason |
| 4 — no vendored scope bitmask | 500 | 296 | no — one rule plus its reason |
| 11 (smallest converted) | 638 | 441 | yes |

Converting 2 or 4 produces an evidence file holding exactly the text the list
already shows: the trigger would promise something to open and deliver a
restatement, for 0.4% and 1.2% of the file. So they stay inline, and
`maxInlineItemBytes = 600` makes that a rule rather than a judgement made once —
it sits above item 4 (500) and below the smallest converted body (638), where
both tests agree.

## Line preservation, per item

Ten bodies moved out this wave, verbatim, digest-pinned at `dfdcc97` as
`agentsSplitBaseWave4`:

| item | non-blank body lines | recovered |
|---|---|---|
| 1 | 12 | 638 |
| 5 | 10 | 579 |
| 6 | 9 | 533 |
| 7 | 11 | 641 |
| 8 | 24 | 1,642 |
| 12 | 21 | 1,374 |
| 14 | 21 | 1,446 |
| 15 | 25 | 1,647 |
| 16 | 25 | 1,535 |
| 28 | 31 | 2,092 |
| | **189 lines** | **12,127** |

The sixteen files split by waves 1–3 kept their digested bodies **byte-identical**
— 15 of 16 shas in `splitItems` are unchanged, and item 3's differs only because
`reverseKnownDelta` is applied before digesting, as it always was. Verified
independently, by a comparator that asks git for each committed blob and diffs
the post-`---` region byte-for-byte rather than re-deriving anything through the
Go slicers: **16 checked, 0 with a changed body**, with a positive control showing
it sees a one-byte change. Their stubs recovered a further **8,335 bytes**
(12,127 + 8,335 = 20,462 = the item-list delta above).

**The stub prose is preserved, not deleted.** Those sixteen theses were authored
for the split rather than sliced from a body, so each evidence file gained a
blockquoted copy in its header — 141 lines across 16 files — above the `---` rule,
which is outside `evidenceBody`'s slice and therefore outside the digest.

**Diff audit.** A third check walked the `AGENTS.md` diff itself: all 338 removed
lines belong to the twenty-six converted bodies, all 96 added lines belong to a
trigger block or to the one paragraph deliberately rewritten, **0 collateral
edits** — and it was shown to go red on an injected stray line before its zero
was believed.

## The new guard, for the new failure mode

🔴 **A trigger is a NEW CLAIM.** A stub was a compressed conclusion, so a reader
who skipped the evidence still carried away something true. A trigger is a claim
about the reader's *situation*, and it is the only thing routing anyone to the
item. Too narrow and the item is not reached by the person it was written for —
while the ledger balances, the digest matches and **nothing fails**. The item is
hidden rather than lost, which is the failure that looks most like success.

`agents_trigger_test.go` pins the shape, in seven rules none of which subsumes
the others: every item carries a trigger; a trigger **ends in `?`**, because a
question is about the reader and a statement is about the subject; a length band
(measured min 77 / mean 120 / max 169, floor 40, ceiling 220); a
degenerate-phrase denylist; not the evidence file's own H1; nothing in the block
but the trigger and the pointer; and an inline item under the break-even. What it
cannot do is say a trigger is **true** of its item — the same limitation
`agents_xrefs_test.go` states for a valid-but-wrong reference — and it says so.

It **supersedes** `TestEvidenceStubsCarryAThesisAndAPointer`, whose 120-character
prose floor a trigger is shorter than by construction; left in place it would
fail every correct trigger. The deletion is recorded where the test used to be,
with what the replacement covers instead.

**Anti-re-inlining moved out of the byte ceiling.** It used to be
`agentsMaxBytes`' second job. Every item is now small, so any useful headroom
absorbs a few of them — and it does not need to: restoring item 6's full body
over its trigger reddens `TestEvidencePointersAndFilesAreTheSameSet` and
`TestInlineAgentsItemsStayUnderTheBreakEven`, structurally and whatever the file
weighs. Measured, not assumed: it does *not* redden
`TestEveryAgentsItemCarriesATrigger`, which an earlier draft of that comment
claimed, because that test only judges items still carrying a pointer.

## Mutation results

Counted from `--- FAIL` lines in the test **output**, never an exit code. Every
mutation **checksum-gated**, so an edit that silently failed to apply reads as
NOT-APPLIED rather than as a survivor.

**Body preservation — all 26 split items × 2 loss shapes (a dropped line, a
reworded line):**

| environment | mutations | not-applied | survivors | kills each |
|---|---|---|---|---|
| full clone | 52 | 0 | **0** | 2 leaf + 2 top |
| depth-1 clone | 52 | 0 | **0** | 1 leaf + 1 top |

The shallow figure is 1 by design: the line-naming differ skips where base blobs
are unreachable, and the always-on digest guard carries every body on its own.

**Triggers — all 26 × 3 shapes.** `blank` empties the trigger; `label` replaces it
with the evidence file's own title as a statement (the brief's worked example);
`thesis` replaces it with the item's own opening thesis, i.e. **exactly the stub
this change removed** — so undoing the conversion one item at a time is caught.

| environment | mutations | not-applied | survivors | kills each |
|---|---|---|---|---|
| full clone | 78 | 0 | **0** | 1 top |
| depth-1 clone | 78 | 0 | **0** | 1 top |

(`TestEveryAgentsItemCarriesATrigger` aggregates every defect into one failure
naming the items, so a kill is one top-level line rather than a leaf.)

**One-offs — identical in both environments, 12 mutants, 0 not-applied,
1 survivor:**

| mutant | leaf | top | killed by |
|---|---|---|---|
| trigger line deleted, bare pointer left | 0 | 4 | evidence ledger + index + trigger + xrefs |
| item 6 re-inlined (full body restored) | 0 | 2 | evidence ledger + break-even |
| inline item 4 grown past the break-even | 0 | 1 | `TestInlineAgentsItemsStayUnderTheBreakEven` |
| two items sharing one trigger | 0 | 1 | `TestEveryTriggerIsDistinct` |
| `triggerDefect` accepts everything | 12 | 1 | the classifier's control corpus |
| `maxInlineItemBytes` raised to 99,999 | 0 | 1 | the measured bound (see below) |
| `agentsMaxBytes` raised past its ceiling | 0 | 1 | `TestAgentsSizeGuardCanStillFire` |
| `agentsMaxBytes` lowered below achieved | 0 | 1 | `TestAgentsMDStaysUnderItsCeiling` |
| `agentsMinBytes` raised above the file | 0 | 2 | ceiling + `baseDocFor`'s control |
| `truncateRunes` reverted to a byte slice | 3 | 2 | the truncation corpus + playbook |
| playbook loses its trigger instructions | 0 | 1 | `TestAgentsSizeGuardCanStillFire` |
| **both size constants raised together** | 0 | 0 | **survives — by design** |

The last row is intentional and is what the two-constant design is *for*:
loosening the bound is meant to be a deliberate, reviewable second edit.

### Three gaps the battery found, all fixed in `340d3e1` / `04c0842`

1. **`evictionPlaybook` emitted invalid UTF-8.** It truncated a title with
   `title[:72]` — a **byte** slice — which splits a multi-byte rune whenever one
   straddles the boundary. Item 13's trigger is 73 bytes and 71 runes with an
   em-dash across byte 72, so the advice a maintainer reads *at the ceiling* was
   mojibake; the harness reading the test output could not decode it at all. It
   was latent under the old stubs only because none of them carried a multi-byte
   character at that offset — it went live the moment the list changed shape,
   with nothing about the truncation changing.
2. **The playbook check was satisfied by a bystander.** It asked for the bare
   token `"TRIGGER"`; reverting step 2 to the old stub instruction left it
   satisfied by the unrelated `"TRIGGER INDEX"` sentence at the top of the same
   message. Surviving mutant; now asserts the instruction phrases.
3. **`maxInlineItemBytes` was unbounded.** Raising it to 99,999 survived the whole
   suite because nothing exceeded the new value — the "a ceiling nobody bounds"
   failure `agentsMaxBytesCeiling` exists to stop, regenerated one file over. It
   is now bounded by a **measurement** (3× the largest trigger block in the live
   file), not a second magic number.

A fourth correction came from fixing #1: the first cut controlled the UTF-8
assertion by requiring *some live heading* to be a byte-slice hazard, which made
rewording item 13's trigger fail a control — a false failure at correct content.
The corpus now carries its own hazards, each row asserting its own premise, with
a floor of two so a byte-slicing implementation cannot pass the table.

## The new ceiling, and why the old derivation is no longer relevant

**`agentsMaxBytes` 45,135 → 28,758 — 3,500 bytes of headroom.**

Every earlier derivation measured **whole-file** deltas (median 3,399 over the 39
non-zero commits touching AGENTS.md). That number is now irrelevant, because it
is dominated by item bodies growing and item bodies no longer live here: #304's
+2,392 — which ate the entire previous 2,500-byte budget — was an edit to item
28's body, and under the trigger index it costs this file **zero**.

So the budget comes from the **non-item region's** own history, which is what an
in-file edit can still touch. |delta| on the 28 commits that moved it: 1, 2, 2,
2, 4, 6, 8, 32, 34, 69, 70, 80, 97, 101, 105, 111, 114, 147, 164, 261, 281, 347,
691, 778, 1,127, 1,337, 2,890, 3,399 — **median 103, p90 1,127, max 3,399**
(#289's Layout-ledger rewrite). 3,500 buys the worst prose rewrite this file has
ever had, or ~17 new items at one trigger block each, or ~34 median corrections.

**`agentsMaxBytesCeiling` 48,600 → 30,600**, chosen against a re-derivable
property: re-inlining the three largest evicted bodies (items 28, 15, 8) costs
5,381 bytes net and lands at 30,639, just above the bound. Stated honestly in the
constant rather than hidden: the two largest (3,739 net, 28,997) *would* still
fit — that is the cost of headroom big enough to be useful, and it is why the
structural guards, not the byte ceiling, are what stand between this file and a
restored body.

**`minEvidencePointers` 10 → 16** (26 items split; 10 would let a regex that had
lost 60% of the corpus through). `agentsMinBytes` deliberately **unchanged** at
20,000, which makes it tighter than it was — it now catches any truncation over
21%.

## A sample of triggers, with the thesis each came from

| item | thesis (the item's own argument) | trigger |
|---|---|---|
| 17 | `DownloadPresigned` exists so a blob fetch carries NO credential; folding it back behind a bool leaks a 25-scope key | *Folding a credential-free blob transfer back into the token-carrying one, or touching `isTrustedDownloadHost`?* |
| 13 | The CLI validates NOTHING about the generation graph, and must never vendor the ecosystem/sampler/cost tables | *Adding any check, table, enum or default to the generation path — ecosystems, samplers, buckets, costs, limits — or wording a warning about a key the CLI does not model?* |
| 7 | The exit-code contract is pinned by `errors.Is`, never message text — and applies to **every** command | *Asserting an exit code, or testing an error's classification, in ANY command?* |
| 22 | `--input` refuses non-`txt2img`; it is a content-audit gate over a CONFIRMED server gap, lift it when the server closes coverage | *Tempted to let `--input` carry a workflow other than `txt2img`, or reading the server's content audit as closed?* |
| 24 | `syscall.Errno` IS a `net.Error`, so the obvious spelling mis-sorts every filesystem failure; one predicate, four ledgered callers | *Writing a `net.Error` check, or deciding whether a failure is transport or filesystem?* |
| 11 | The scaffold vendors the ready-ack; it also carries the measured list of required CI contexts and the instruction to re-measure | *Editing the vendored ready-ack emitter, adding or SDK-ifying a scaffold template, or about to call a CI job a merge gate?* |

Item 11 is the one to check the design against: it governs three unrelated
situations, and the Build section elsewhere in the file routes to it for the
third. Naming only the emitter would have hidden the other two — the over-narrow
failure, in the shape it actually takes.

## Gate

- `make ci` — **19/19 `ok`**, 0 `--- FAIL`
- `make lint` (`golangci-lint` via `nix-shell`) — **0 issues**, run separately
  because `make ci` omits lint
- `gofmt -s -l .` — 0 files
- `make ci-shallow` — **PASSED in a depth-1 clone: 19/19 `ok`**, 0 failures, 0
  timeouts. Root package there: **130 PASS, 0 FAIL, 2 SKIP**, and both SKIPs are
  the git-backed tests naming the environment (*"none of the 26 base blob(s) is
  reachable — this is a shallow (depth-limited) clone"*). Neither fails, neither
  silently passes, and a mutated body is still caught there with no git at all
  (52/52 above).
- **Merged tree:** `origin/main` moved to `ce56cd9` mid-work; this branch was
  rebased onto it and every number above was re-measured afterwards, so the tree
  gated here *is* the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
