### PR TITLE
ci: the last two scheduled bots now file their own issue when they break

### DIFF
--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -6,6 +6,30 @@
 # three places. This job runs `bump-pins` (which rewrites the literals in the
 # template + README + the scaffold_test.go canary), validates the result IN THIS
 # JOB, and opens a PR when anything changed — so the hand-fix never recurs.
+#
+# A RED RUN OF THIS WORKFLOW NOW FILES ITS OWN ISSUE — see the `classify` and
+# `signal` jobs. A failing SCHEDULED run notifies almost nobody (GitHub mails
+# only whoever last edited the `cron` line, through that person's own per-user
+# Actions setting), which is how `bump-flake-vendorhash.yml` failed every run
+# for three weeks with nobody noticing (#316). This workflow was green
+# throughout — so was that one, right up until it wasn't. The reporting
+# mechanism is the shared `failure-issue.yml`; read its header for the anti-spam
+# rules it enforces (one open issue, a repeat failure rewrites the body rather
+# than commenting, a green run closes the issue).
+#
+# BOTH jobs below report, and that is the point: `ready-ack-runtime` is an
+# independent drift alarm on `main` that could go red on its own for weeks
+# without `bump` noticing, or vice versa. `classify` is where the two verdicts
+# are combined into the one message `failure-issue.yml` files.
+#
+# ERREXIT NOTE, because this is the trap that caused #316 and #313. GitHub runs
+# every `run:` block as `bash -e {0}`, so errexit is ON before the first line and
+# `set -uo pipefail` does NOT clear it. Audited: NO step in this workflow runs a
+# command that is expected to fail as part of its logic — every `go`, `npm` and
+# `git` invocation here is expected to succeed, and the one deliberate failure
+# (the fire drill) exits explicitly rather than leaning on the shell. So errexit
+# is welcome here. If you add a command that IS expected to fail, handle its
+# status where you write it; do not leave it to the shell.
 name: bump-scaffold-pins
 
 on:
@@ -34,7 +58,17 @@ on:
     # `detect changes` gates every downstream step, so an already-current sweep
     # is just checkout + setup-go + the bumper's npm metadata reads.
     - cron: "17 7 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "Fire drill: fail one or both jobs on purpose so the FAILURE path and the issue it files can be rehearsed. Opens a REAL issue — close it when you are done. It cannot open a PR or rewrite a pin: the drill fails at the bumper step, which is upstream of every step that writes anything."
+        type: choice
+        default: none
+        options:
+          - none
+          - bump
+          - ready-ack
+          - both
 
 permissions:
   contents: write
@@ -57,6 +91,9 @@ jobs:
   # interaction, a node bump, an npm-side change), and is deliberately
   # independent of the `bump` job below so it runs on every sweep, including the
   # usual no-op ones where the pins are already current.
+  #
+  # "Surface up to 24h later" was itself optimistic until now: nothing read this
+  # job's colour. It reports through `classify` → `signal` below.
   ready-ack-runtime:
     runs-on: ubuntu-latest
     permissions:
@@ -77,12 +114,54 @@ jobs:
       # both driven through the same assertions and must be rejected) rather than
       # just an exit code.
       - name: scaffolded ready-ack actually fires
+        id: readyack
         env:
           CIVITAI_CHECK_SCAFFOLD_RUNTIME: "1"
-        run: go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || 'none' }}
+        run: |
+          set -uo pipefail
+
+          if [ "$DRILL" = "ready-ack" ] || [ "$DRILL" = "both" ]; then
+            # Fire drill. Failing this step is the SAME input the classifier
+            # reads on a real regression — there is no sub-verdict here to stub,
+            # so the rehearsal drives the genuine path rather than a mock of it.
+            echo "⚠️  FIRE DRILL — failing the ready-ack runtime check on purpose to rehearse the reporting path."
+            echo "    No test was run and nothing on disk was touched."
+            exit 1
+          fi
+
+          go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v 2>&1 \
+            | tee "$RUNNER_TEMP/ready-ack.log"
+
+          # POSITIVE CONTROL, and it is not decoration. `go test -run <name>`
+          # exits 0 when the pattern matches NOTHING — it prints "testing:
+          # warning: no tests to run" and "ok … [no tests to run]" — and this
+          # test body additionally only runs behind the
+          # CIVITAI_CHECK_SCAFFOLD_RUNTIME gate. So a renamed test, a moved
+          # file, or a changed env-var name turns this whole job into a green
+          # that checked nothing, and a check whose red can never be seen is
+          # exactly what the reporting below is for. Require the test's own PASS
+          # line, so this job's colour is a claim about the ack.
+          if ! grep -q -- '--- PASS: TestScaffoldedReadyAckActuallyFires' "$RUNNER_TEMP/ready-ack.log"; then
+            echo "::error::the ready-ack runtime check exited 0 without running TestScaffoldedReadyAckActuallyFires — the -run pattern matched no test (renamed? moved? CIVITAI_CHECK_SCAFFOLD_RUNTIME gate changed?). A green here would have been a claim about nothing."
+            exit 1
+          fi
 
   bump:
     runs-on: ubuntu-latest
+    # Read by `classify` to describe WHICH phase went wrong. These are the raw
+    # step outcomes, deliberately not prose: ALL the wording lives in one place
+    # (`classify`), so the two jobs' verdicts cannot end up worded by two
+    # different authors. Every one of these is EMPTY when the job died before
+    # the step existed — which `classify` resolves to its own `bump-unknown`
+    # state rather than borrowing a verdict it never reached.
+    outputs:
+      r_bump: ${{ steps.bump.outcome }}
+      r_changed: ${{ steps.changed.outcome }}
+      r_pins: ${{ steps.validate_pins.outcome }}
+      r_suite: ${{ steps.validate_suite.outcome }}
+      r_build: ${{ steps.validate_build.outcome }}
+      r_pr: ${{ steps.pr.outcome }}
     steps:
       - uses: actions/checkout@v4
 
@@ -92,7 +171,20 @@ jobs:
           cache: true
 
       - name: bump stale @civitai/* scaffold pins
-        run: go run ./internal/scaffold/cmd/bump-pins
+        id: bump
+        env:
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || 'none' }}
+        run: |
+          set -u
+          if [ "$DRILL" = "bump" ] || [ "$DRILL" = "both" ]; then
+            # Fire drill, placed here on purpose: this step is upstream of
+            # `detect changes` and of every step that writes anything, so a
+            # drill can neither rewrite a pin nor open a PR.
+            echo "⚠️  FIRE DRILL — failing the pin bumper on purpose to rehearse the reporting path."
+            echo "    No npm lookup was made and no pin was rewritten."
+            exit 1
+          fi
+          go run ./internal/scaffold/cmd/bump-pins
 
       # Only validate + open a PR when the bumper actually rewrote something — a
       # no-op run (pins already current) skips everything downstream.
@@ -114,12 +206,14 @@ jobs:
       # else regressed (incl. the scaffold_test.go pin assertions the bumper
       # rewrote).
       - name: validate — pins now satisfy published (network guard)
+        id: validate_pins
         if: steps.changed.outputs.changed == 'true'
         env:
           CIVITAI_CHECK_PUBLISHED_PINS: "1"
         run: go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -v
 
       - name: validate — full scaffold suite (offline)
+        id: validate_suite
         if: steps.changed.outputs.changed == 'true'
         run: go test ./internal/scaffold/...
 
@@ -135,6 +229,7 @@ jobs:
           node-version: "22"
 
       - name: validate — scaffold builds against the bumped SDK
+        id: validate_build
         if: steps.changed.outputs.changed == 'true'
         run: |
           go run ./cmd/civitai app init "Bump Validation" --dir "$RUNNER_TEMP/bump-validate" --template page-money
@@ -144,6 +239,7 @@ jobs:
           npm run build
 
       - name: open PR if pins changed
+        id: pr
         if: steps.changed.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
@@ -182,3 +278,158 @@ jobs:
             suite, AND a fresh `civitai app init` scaffold that installs +
             typechecks + **builds** against the bumped SDK (catching a
             removed/renamed export).
+
+  # Compose ONE report out of the two independent jobs above.
+  #
+  # It is a separate job rather than a step inside `bump` because it has to see
+  # BOTH results, and it is the only place that writes prose — `bump` exports
+  # raw step outcomes precisely so there is a single author for the message.
+  #
+  # `always()` so it still runs after a failed job; `!= 'cancelled'` on both
+  # needs so a hand cancellation is not filed as a defect.
+  classify:
+    needs: [ready-ack-runtime, bump]
+    if: always() && needs.ready-ack-runtime.result != 'cancelled' && needs.bump.result != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      state: ${{ steps.classify.outputs.state }}
+      title: ${{ steps.classify.outputs.title }}
+      body: ${{ steps.classify.outputs.body }}
+    steps:
+      - name: classify the outcome
+        id: classify
+        env:
+          J_READY: ${{ needs.ready-ack-runtime.result }}
+          J_BUMP: ${{ needs.bump.result }}
+          R_BUMP: ${{ needs.bump.outputs.r_bump }}
+          R_CHANGED: ${{ needs.bump.outputs.r_changed }}
+          R_PINS: ${{ needs.bump.outputs.r_pins }}
+          R_SUITE: ${{ needs.bump.outputs.r_suite }}
+          R_BUILD: ${{ needs.bump.outputs.r_build }}
+          R_PR: ${{ needs.bump.outputs.r_pr }}
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || 'none' }}
+        run: |
+          set -uo pipefail
+
+          # ---- the ready-ack drift runner's verdict ---------------------------
+          ready_state=""
+          ready_title=""
+          ready_detail=""
+          if [ "$J_READY" != "success" ]; then
+            ready_state=ready-ack-failed
+            ready_title="the scaffolded ready-ack handshake no longer fires on \`main\`"
+            ready_detail="The \`ready-ack-runtime\` job failed. It runs the vendored emitter in node against a fake host and asserts one correctly-addressed \`{type:'BLOCK_READY',payload:{height:0}}\` goes out — the ONLY check in the repo that proves the handshake actually fires rather than that the file is present.
+
+          A red here means a \`page\` app scaffolded from \`main\` today may never reach \`ready\` in the host and would end at a failure card, which is issue #206 all over again. It can also mean the job's own positive control fired: it refuses to pass unless \`--- PASS: TestScaffoldedReadyAckActuallyFires\` is in the output, so a renamed/moved test reports here too. **The run log distinguishes them.**"
+          fi
+
+          # ---- the pin bumper's verdict ---------------------------------------
+          bump_state=""
+          bump_title=""
+          bump_detail=""
+          if [ "$J_BUMP" != "success" ]; then
+            if [ "$R_BUMP" = "failure" ]; then
+              bump_state=bump-failed
+              bump_title="the scaffold pin bumper could not run the bumper"
+              bump_detail="The \`bump stale @civitai/* scaffold pins\` step failed — \`go run ./internal/scaffold/cmd/bump-pins\` exited non-zero. It exits 2 only on a hard error (the template holds no \`@civitai/*\` pins at all, or one of the three literal sites could not be read/written); a transient npm lookup failure is a per-package SKIP inside the tool, not a failure, so this is not a network blip."
+            elif [ "$R_CHANGED" = "failure" ]; then
+              bump_state=detect-failed
+              bump_title="the scaffold pin bumper failed while checking for changes"
+              bump_detail="The \`detect changes\` step failed, which is unusual — it only runs \`git status\`."
+            elif [ "$R_PINS" = "failure" ]; then
+              bump_state=validate-pins-failed
+              bump_title="the scaffold pin bumper produced pins that still do not satisfy npm"
+              bump_detail="Pins were rewritten, but the network guard (\`CIVITAI_CHECK_PUBLISHED_PINS=1 go test -run TestScaffoldPinsSatisfyPublished\`) then said they still do not admit npm's published latest. **No PR was opened.** Either \`scaffold.DesiredPin\` and \`CaretAdmits\` disagree, or a package published again mid-run."
+            elif [ "$R_SUITE" = "failure" ]; then
+              bump_state=validate-suite-failed
+              bump_title="the scaffold pin bumper broke the offline scaffold suite"
+              bump_detail="Pins were rewritten and satisfy npm, but \`go test ./internal/scaffold/...\` then failed. **No PR was opened.** The usual cause is the bumper rewriting only some of the three literal sites, leaving the \`scaffold_test.go\` \`mustContain\` canary disagreeing with the template."
+            elif [ "$R_BUILD" = "failure" ]; then
+              bump_state=validate-build-failed
+              bump_title="the newly-published @civitai/* SDK no longer builds the scaffold"
+              bump_detail="Pins were rewritten and satisfy npm, but a fresh \`civitai app init … --template page-money\` then failed to install, typecheck or build against them. **No PR was opened**, on purpose — this is the removed/renamed SDK export case, and it is a real upstream break rather than a bot bug. Every newly-scaffolded page-money app is affected until the template is adapted or the SDK is fixed."
+            elif [ "$R_PR" = "failure" ]; then
+              bump_state=pr-failed
+              bump_title="the scaffold pin bumper could not open its PR"
+              bump_detail="The pins were bumped and fully validated, but opening the PR failed — usually \`secrets.BUMP_SCAFFOLD_PINS_TOKEN\` being expired or missing. **The fix is still un-merged**, so \`pins-vs-published\` (a REQUIRED check on \`main\`) stays red and blocks EVERY open PR regardless of its content, until someone bumps the pins by hand or repairs the token."
+            else
+              # No step recorded a failure, yet the job is not green: it died
+              # before/outside its own steps (runner failure, checkout failure,
+              # setup-go failure). That is a real and different state.
+              bump_state=bump-unknown
+              bump_title="the scaffold pin bumper could not run"
+              bump_detail="The \`bump\` job did not succeed, but none of its steps recorded a failure — so it died before or outside them. The usual causes are the runner dying, the checkout failing, or \`setup-go\` failing. Check the run log."
+            fi
+          fi
+
+          # ---- combine ---------------------------------------------------------
+          if [ -n "$ready_state" ] && [ -n "$bump_state" ]; then
+            state="$ready_state+$bump_state"
+            title="both scheduled scaffold checks are failing"
+            detail="**Two independent failures in one run.** They are unrelated jobs; treat them as two problems.
+
+          ## 1. ready-ack runtime
+
+          $ready_detail
+
+          ## 2. pin bumper
+
+          $bump_detail"
+          elif [ -n "$ready_state" ]; then
+            state="$ready_state"
+            title="$ready_title"
+            detail="$ready_detail"
+          elif [ -n "$bump_state" ]; then
+            state="$bump_state"
+            title="$bump_title"
+            detail="$bump_detail"
+          else
+            state=green
+            title=""
+            detail=""
+          fi
+
+          DRILL_NOTE=""
+          if [ "$DRILL" != "none" ]; then
+            DRILL_NOTE="> ⚠️ **This is a fire drill**, dispatched by hand with \`drill=$DRILL\`. The named job(s) were failed on purpose before doing any work — no npm lookup, no test, no pin rewritten — so this is NOT a real failure of the bot. It exists to prove this reporting path works. Close it when you are done."
+          fi
+
+          echo "state=$state"
+          {
+            echo "state=$state"
+            echo "title=[scaffold-pins-bot] $title"
+            echo "body<<SCAFFOLD_PINS_BODY_EOF"
+            if [ -n "$DRILL_NOTE" ]; then
+              echo "$DRILL_NOTE"
+              echo
+            fi
+            echo "$detail"
+            echo
+            echo "---"
+            echo "This workflow runs two independent daily checks: \`ready-ack-runtime\` (does the scaffolded handshake still fire on \`main\`) and \`bump\` (are the template's \`@civitai/*\` pins still current). Either one failing files this issue."
+            echo "SCAFFOLD_PINS_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  # File a report when either check is broken, and close it when both recover.
+  # See `failure-issue.yml` for why this is an issue rather than email, and for
+  # the rules that stop it becoming noise.
+  #
+  # `failing` is computed from the JOB results rather than from `classify`'s
+  # output, so a `classify` job that itself dies still reports — as `unknown`,
+  # which is a real state and not silence. "The check could not run" must be as
+  # visible as "the check failed".
+  signal:
+    needs: [ready-ack-runtime, bump, classify]
+    if: always() && needs.ready-ack-runtime.result != 'cancelled' && needs.bump.result != 'cancelled' && needs.classify.result != 'cancelled'
+    uses: ./.github/workflows/failure-issue.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      marker: "[scaffold-pins-bot]"
+      failing: ${{ needs.ready-ack-runtime.result != 'success' || needs.bump.result != 'success' || needs.classify.result != 'success' }}
+      state: ${{ needs.classify.outputs.state || 'unknown' }}
+      title: "${{ needs.classify.outputs.title || '[scaffold-pins-bot] the scaffold bots failed and could not say why' }}"
+      body: "${{ needs.classify.outputs.body || 'The `classify` job did not produce a verdict, so this report cannot name which of `ready-ack-runtime` / `bump` went wrong, or how. Open the run and read both jobs. This state is itself a defect in the reporting path — `classify` only runs a shell script over the two job results.' }}"

--- a/.github/workflows/revendor-canonical-schema.yml
+++ b/.github/workflows/revendor-canonical-schema.yml
@@ -7,6 +7,29 @@
 # job runs the re-vendor script, validates the result IN THIS JOB, and opens a
 # PR when the schema changed — so the hand-resync never recurs. Sibling of the
 # `bump-scaffold-pins` workflow (the pin-drift automation).
+#
+# A RED RUN OF THIS WORKFLOW NOW FILES ITS OWN ISSUE — see the `signal` job.
+# A failing SCHEDULED run notifies almost nobody (GitHub mails only whoever last
+# edited the `cron` line, through that person's own per-user Actions setting),
+# which is how `bump-flake-vendorhash.yml` failed every run for three weeks with
+# nobody noticing (#316). This workflow was green throughout — so was that one,
+# right up until it wasn't. The reporting mechanism is the shared
+# `failure-issue.yml`; read its header for the anti-spam rules it enforces (one
+# open issue, a repeat failure rewrites the body rather than commenting, a green
+# run closes the issue).
+#
+# ERREXIT NOTE, because this is the trap that caused #316 and #313. GitHub runs
+# every `run:` block as `bash -e {0}`, so errexit is ON before the first line and
+# `set -uo pipefail` does NOT clear it. Audited: NO step in this workflow runs a
+# command that is expected to fail as part of its logic — the re-vendor script
+# owns its own exit contract (0 = re-vendored or already current or transient
+# skip; 1 = the canonical URL moved or served junk) and every other step is
+# expected to succeed. So errexit is welcome here. If you add a command that IS
+# expected to fail, handle its status where you write it; do not leave it to the
+# shell.
+#
+# Run manually anytime via the Actions tab → this workflow → "Run workflow"
+# (workflow_dispatch), including the `drill` fire drill described on the input.
 name: revendor-canonical-schema
 
 on:
@@ -15,7 +38,12 @@ on:
     # two automations don't open PRs in the same minute. Cron literal quoted so
     # the `*` isn't parsed as a YAML alias.
     - cron: "37 7 * * 1"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "Fire drill: fail the re-vendor step on purpose so the FAILURE path and the issue it files can be rehearsed. Opens a REAL issue — close it when you are done. It cannot open a PR or touch the schema: it fails before the script runs, upstream of every step that writes anything."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -24,6 +52,21 @@ permissions:
 jobs:
   revendor:
     runs-on: ubuntu-latest
+    # ONE definition of the canonical URL for the whole job. The re-vendor
+    # script reads `CANONICAL_URL` from the environment (falling back to this
+    # same literal), so the reachability probe below and the script that
+    # actually fetches provably ask the same URL — there is no second constant
+    # to drift.
+    env:
+      CANONICAL_URL: https://civitai.com/schemas/app-block/v1.json
+    # Read by the `signal` job to describe WHAT went wrong. Empty when the job
+    # died before the classifier ran (a runner failure, a checkout failure) —
+    # which `signal` resolves to `unknown`, a real and different state from any
+    # verdict this job produces.
+    outputs:
+      state: ${{ steps.classify.outputs.state }}
+      title: ${{ steps.classify.outputs.title }}
+      body: ${{ steps.classify.outputs.body }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,8 +75,57 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # Is the canonical schema actually reachable? The re-vendor script treats
+      # a transient fetch failure (network / DNS / timeout / 5xx / 429) as a
+      # SKIP — `exit 0`, no change — which is the right call for the JOB (a blip
+      # must not fail a scheduled run or open a broken PR) and is exactly the
+      # silence this PR exists to end for the REPORT: a green run and a run that
+      # never looked at the canonical are otherwise byte-identical from outside.
+      #
+      # So the reachability question is answered here, independently, and fed to
+      # the classifier as its own state (`canonical-unreachable`). The job still
+      # succeeds; only the report says the mirror was not checked.
+      #
+      # KNOWN COST, stated rather than hidden: a single transient blip at 07:37
+      # on a Monday opens an issue that sits until the next weekly run closes it.
+      # That is one issue and zero comments (failure-issue.yml's rules), and the
+      # backstop for the underlying risk is the `schema-drift` CI job, which
+      # reds on every PR once the mirror actually drifts. If the false alarms
+      # outweigh that, delete the `canonical-unreachable` arm in `classify` —
+      # it is one `elif`, and nothing else depends on it.
+      - name: probe — is the canonical schema reachable
+        id: probe
+        run: |
+          set -u
+          # `|| true` because a network failure exits curl non-zero and errexit
+          # would end the step before the code could be reported. `-w` still
+          # prints a code (`000`) on failure; `tail -1` keeps the last line so a
+          # curl that prints both cannot produce a two-line value.
+          code="$(curl -sS -o /dev/null -w '%{http_code}\n' --max-time 30 "$CANONICAL_URL" 2>&1 | tail -1 || true)"
+          case "$code" in
+            [0-9][0-9][0-9]) ;;
+            *) code=000 ;;
+          esac
+          echo "canonical $CANONICAL_URL -> HTTP $code"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
       - name: re-vendor embedded schema from the live canonical
-        run: ./scripts/revendor-canonical-schema.sh
+        id: revendor
+        env:
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || false }}
+        run: |
+          set -u
+          if [ "$DRILL" = "true" ]; then
+            # Fire drill. This fails the step the classifier reads, which is the
+            # SAME input a real re-vendor failure produces — there is no parser
+            # or sub-verdict here to stub, so the rehearsal drives the genuine
+            # path rather than a mock of it. It runs BEFORE the script, so the
+            # drill can neither rewrite the schema nor open a PR.
+            echo "⚠️  FIRE DRILL — failing the re-vendor step on purpose to rehearse the reporting path."
+            echo "    The canonical schema was NOT fetched and nothing on disk was touched."
+            exit 1
+          fi
+          ./scripts/revendor-canonical-schema.sh
 
       # Only validate + open a PR when the re-vendor actually changed the file —
       # a no-op run (already in sync) skips everything downstream.
@@ -53,6 +145,7 @@ jobs:
       # (a human handles the incompatible change); an additive/optional change
       # validates cleanly → the PR opens.
       - name: validate — schema compiles + examples validate
+        id: validate
         if: steps.changed.outputs.changed == 'true'
         # Full suite so the ROOT-package examples test (examples_test.go —
         # `TestExampleManifestsValidateClean`, which validates the shipped
@@ -60,6 +153,7 @@ jobs:
         run: go test ./...
 
       - name: open PR if schema changed
+        id: pr
         if: steps.changed.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
@@ -91,3 +185,110 @@ jobs:
             (e.g. a new manifest key), consider whether `internal/validate/` (the
             Go semantic checks / friendly messages) should track it too — that
             part is a deliberate human call.
+
+      # Name WHICH step failed, for the issue the `signal` job files. `always()`
+      # so it still runs after a failed step — without it this is skipped
+      # exactly when it is needed, and `signal` would only ever see `unknown`.
+      # Each phase gets its own state because they call for different actions: a
+      # re-vendor failure means the canonical URL moved or served junk, a
+      # validate failure means the new canonical is incompatible and needs a
+      # human, and a PR failure is usually the token.
+      - name: classify the outcome
+        id: classify
+        if: always()
+        env:
+          R_PROBE: ${{ steps.probe.outcome }}
+          R_PROBE_CODE: ${{ steps.probe.outputs.code }}
+          R_REVENDOR: ${{ steps.revendor.outcome }}
+          R_CHANGED: ${{ steps.changed.outcome }}
+          R_VALIDATE: ${{ steps.validate.outcome }}
+          R_PR: ${{ steps.pr.outcome }}
+          DRILL: ${{ (github.event_name == 'workflow_dispatch' && inputs.drill) || false }}
+        run: |
+          set -uo pipefail
+
+          # The probe arm is FIRST and is not decoration: if the probe step
+          # itself dies, every later step is `skipped`, and without this arm a
+          # skipped re-vendor would be reported as "the re-vendor failed" —
+          # confident wording built on a step that never ran.
+          if [ "$R_PROBE" != "success" ]; then
+            state=probe-failed
+            title="the canonical-schema re-vendor bot failed before it started"
+            detail="The \`probe — is the canonical schema reachable\` step failed. It only runs \`curl\` and writes one output, so this is either a runner problem or a change to that step that broke it. **Nothing downstream ran**, so the mirror was neither checked nor changed."
+          elif [ "$R_REVENDOR" != "success" ]; then
+            state=revendor-failed
+            title="the canonical-schema re-vendor bot could not re-vendor"
+            detail="The \`re-vendor embedded schema from the live canonical\` step failed. The script fails loudly for exactly two reasons: the canonical URL answered **404/410** (it moved — a real contract break), or it served a body that is empty or not a JSON object. **The step's output is in the run log and names which.**"
+          elif [ "$R_PROBE_CODE" != "200" ]; then
+            state=canonical-unreachable
+            title="the canonical-schema re-vendor bot could not reach the canonical schema"
+            detail="The canonical schema URL answered HTTP \`${R_PROBE_CODE:-000}\`, not 200, so the re-vendor script took its transient-skip path: **the embedded mirror was not compared against anything on this run.** The job itself is green, deliberately — a blip must not fail a scheduled run or open a broken PR — but a green run and a run that never looked are otherwise indistinguishable, which is what this report exists to fix.
+
+          If this is a one-off blip, the next scheduled run closes this issue by itself. If it repeats, the canonical schema is genuinely unreachable from GitHub-hosted runners and the mirror is frozen until it is not."
+          elif [ "$R_CHANGED" != "success" ]; then
+            state=detect-failed
+            title="the canonical-schema re-vendor bot failed while checking for changes"
+            detail="The \`detect changes\` step failed, which is unusual — it only runs \`git status\`."
+          elif [ "$R_VALIDATE" = "failure" ]; then
+            state=validate-failed
+            title="the canonical schema changed in a way the CLI cannot accept"
+            detail="The canonical schema changed and was re-vendored, but \`go test ./...\` then failed with it — the new schema does not compile under the CLI's jsonschema engine, or the bundled example manifests no longer validate against it. **No PR was opened**, on purpose: this is an incompatible canonical change and needs a human, not a bytes-only bump. Expect \`internal/validate/\` and/or \`examples/\` to need work alongside the re-vendor."
+          elif [ "$R_PR" = "failure" ]; then
+            state=pr-failed
+            title="the canonical-schema re-vendor bot could not open its PR"
+            detail="The schema was re-vendored and validated, but opening the PR failed — usually \`secrets.BUMP_SCAFFOLD_PINS_TOKEN\` being expired or missing. **The re-vendor is still un-merged**, so the embedded mirror stays stale and \`schema-drift\` stays red until someone re-vendors by hand or repairs the token."
+          else
+            state=green
+            title=""
+            detail=""
+          fi
+
+          DRILL_NOTE=""
+          if [ "$DRILL" = "true" ]; then
+            DRILL_NOTE="> ⚠️ **This is a fire drill**, dispatched by hand with \`drill=true\`. The re-vendor step was failed on purpose and the canonical schema was never fetched, so this is NOT a real failure of the bot — it exists to prove this reporting path works. Close it when you are done."
+          fi
+
+          echo "state=$state"
+          {
+            echo "state=$state"
+            echo "title=[schema-revendor-bot] $title"
+            echo "body<<REVENDOR_BODY_EOF"
+            if [ -n "$DRILL_NOTE" ]; then
+              echo "$DRILL_NOTE"
+              echo
+            fi
+            echo "$detail"
+            echo
+            echo "While this is failing, a canonical schema change will NOT be mirrored into the CLI's \`go:embed\`ed copy automatically. The \`schema-drift\` CI job still DETECTS the drift on every PR — only the remediation is down — so the visible symptom is a red \`schema-drift\` that nothing clears."
+            echo
+            echo "To re-vendor by hand: run \`./scripts/revendor-canonical-schema.sh\`, then \`go test ./...\`, and open the PR yourself."
+            echo "REVENDOR_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  # File a report when the bot is broken, and close it when it recovers. See
+  # `failure-issue.yml` for why this is an issue rather than email, and for the
+  # rules that stop it becoming noise.
+  #
+  # `always()` so a red `revendor` job still reports; `!= 'cancelled'` so a hand
+  # cancellation is not filed as a defect.
+  #
+  # `failing` is deliberately NOT just `result != 'success'`: the
+  # `canonical-unreachable` verdict is reached on a job that SUCCEEDED, because
+  # "the check could not run" and "the check failed" are different facts and
+  # only one of them is visible in the job's own colour.
+  signal:
+    needs: [revendor]
+    if: always() && needs.revendor.result != 'cancelled'
+    uses: ./.github/workflows/failure-issue.yml
+    permissions:
+      contents: read
+      issues: write
+    with:
+      marker: "[schema-revendor-bot]"
+      failing: ${{ needs.revendor.result != 'success' || needs.revendor.outputs.state == 'canonical-unreachable' }}
+      # Empty when `revendor` died before the classifier ran — a runner failure
+      # or a failed checkout. That is its own state and must not borrow the
+      # wording of a verdict this job never reached.
+      state: ${{ needs.revendor.outputs.state || 'unknown' }}
+      title: "${{ needs.revendor.outputs.title || '[schema-revendor-bot] the canonical-schema re-vendor bot could not run' }}"
+      body: "${{ needs.revendor.outputs.body || 'The `revendor` job failed before it could classify what went wrong, so it did not reach the end of the run. Check the run log — the usual causes are the runner dying, the checkout failing, or `setup-go` failing.' }}"


### PR DESCRIPTION
Four workflows here run on a schedule. Two could tell anyone when they broke; these are the other two.

`bump-flake-vendorhash.yml` was red on **every run from 18 July to 10 August** — three consecutive scheduled failures plus push failures, zero successes — and nobody noticed, because a failing scheduled run notifies only whoever last edited the `cron` line, through that person's own per-user Actions setting. #316 fixed that bot and extracted the reporting mechanism into the reusable `failure-issue.yml`. This wires the last two callers in.

| workflow | scheduled | failure visible before | after |
|---|---|---|---|
| `bump-flake-vendorhash.yml` | yes | yes (#316) | unchanged |
| `release-homebrew.yml` | yes | yes (own copy) | **unchanged — deliberately not touched, see below** |
| `bump-scaffold-pins.yml` | daily 07:17 | **no** | `[scaffold-pins-bot]` |
| `revendor-canonical-schema.yml` | weekly Mon 07:37 | **no** | `[schema-revendor-bot]` |

Both were green today. So was the vendorhash bot, right up until it wasn't.

## What was wired

### `bump-scaffold-pins.yml` → marker `[scaffold-pins-bot]`

* `bump` gains step ids and exports **raw step outcomes**, not prose. A new `classify` job turns those plus both job results into the one message; `signal` calls `failure-issue.yml`. All wording lives in one place, so the two jobs' verdicts cannot end up authored by two different people.
* **Both jobs report, and neither masks the other.** `ready-ack-runtime` is an independent drift alarm on `main` whose colour nothing read — it could sit red for weeks while `bump` stayed green. When both fail the state is `ready-ack-failed+bump-failed` and the body carries two sections.
* Per-phase states so the report says what to do: `bump-failed`, `detect-failed`, `validate-pins-failed`, `validate-suite-failed`, `validate-build-failed`, `pr-failed`, `ready-ack-failed`, and `bump-unknown` for a job that died before its own steps.
* **`ready-ack-runtime` gains a positive control.** `go test -run <name>` **exits 0 when the pattern matches nothing**, and this test body only runs behind `CIVITAI_CHECK_SCAFFOLD_RUNTIME` — so a renamed test, a moved file or a changed env-var name turned the whole job into a green that checked nothing, and a check whose red can never be seen is exactly what this PR is about. It now requires the test's own `--- PASS:` line. Measured both ways locally: the real run prints `--- PASS: TestScaffoldedReadyAckActuallyFires (0.89s)`; a typo'd `-run` prints `ok … [no tests to run]` at **exit 0** and the guard fires. Confirmed on the runner too — the line is in run [31422842996](https://github.com/civitai/cli/actions/runs/31422842996).

### `revendor-canonical-schema.yml` → marker `[schema-revendor-bot]`

* Step ids + a `classify` step + `signal`, matching #316's single-job shape. States: `probe-failed`, `revendor-failed`, `canonical-unreachable`, `detect-failed`, `validate-failed`, `pr-failed`, `unknown`.
* **A reachability probe runs first, and it is the one judgement call here.** `scripts/revendor-canonical-schema.sh` treats a transient fetch failure as `exit 0` — right for the *job* (a blip must not fail a scheduled run or open a broken PR) — but that makes "green" and "never looked at the canonical" byte-identical from outside. `canonical-unreachable` is now its own reported state **on a job that succeeded**, because "the check could not run" and "the check failed" are different facts and only one of them is visible in the job's colour.
  The cost is stated in the file rather than hidden: one transient blip at 07:37 on a Monday opens one auto-closing issue that sits until the next weekly run. The backstop for the underlying risk is `schema-drift`, which reds on every PR once the mirror actually drifts. **If that trade is wrong, delete the `canonical-unreachable` arm in `classify` — it is one `elif` and nothing else depends on it.**
  The URL is now declared once at job level and inherited by both the probe and the script (which reads `CANONICAL_URL`), so the two provably ask the same URL.
* The `probe-failed` arm sits *ahead* of `revendor-failed` on purpose: if the probe dies, every later step is `skipped`, and without it a skipped re-vendor would be reported as "the re-vendor failed" — confident wording built on a step that never ran.

### Errexit

Audited per #316/#313. GitHub runs every `run:` as `bash -e {0}`, so errexit is on before the first line and `set -uo pipefail` does not clear it — that was the entire root cause of the vendorhash bot's three-week outage. **No step in either workflow runs a command that is expected to fail as part of its logic**; the one deliberate failure (the fire drill) exits explicitly rather than leaning on the shell. Recorded in both files' headers so the next editor does not have to re-derive it.

## Lifecycle proof — issues consumed: **#322 and #323, both closed**

Drilled through `workflow_dispatch` on this branch (`drill` is a choice `none|bump|ready-ack|both` for pins, a boolean for revendor). Both drills fail **upstream of every step that writes anything**, so a drill can neither rewrite a pin nor re-vendor a schema nor open a PR — and none did.

| # | run | dispatch | observed |
|---|---|---|---|
| 1 | [31422842996](https://github.com/civitai/cli/actions/runs/31422842996) | pins `drill=bump` | **opened #322**, `state=bump-failed`, 0 comments. `ready-ack-runtime` ran for real and passed its positive control. |
| 2 | [31422931451](https://github.com/civitai/cli/actions/runs/31422931451) | revendor `drill=true` | **opened #323**, `state=revendor-failed`, 0 comments |
| 3 | [31422939848](https://github.com/civitai/cli/actions/runs/31422939848) | pins `drill=bump` (repeat) | `updated #322 (state=bump-failed, unchanged — no comment posted)`. **Still exactly one `[scaffold-pins-bot]` issue across all states; comment count still 0.** |
| 4 | [31423036142](https://github.com/civitai/cli/actions/runs/31423036142) | revendor `drill=true` (repeat) | `updated #323 (state=revendor-failed, unchanged — no comment posted)`. One issue, 0 comments. |
| 5 | [31423033348](https://github.com/civitai/cli/actions/runs/31423033348) | pins `drill=both` | state changed to `ready-ack-failed+bump-failed`. Title **rewritten in place** on #322, body replaced with the two-section form, and **exactly one** comment posted — the designed single notifying update on a change of kind. |
| 6 | [31423151701](https://github.com/civitai/cli/actions/runs/31423151701) | pins `drill=none` (green) | real run, `state=green`, **`closed #322`** with the recovery comment |
| 7 | [31423154842](https://github.com/civitai/cli/actions/runs/31423154842) | revendor `drill=false` (green) | real run, probe `-> HTTP 200`, `embedded schema already matches`, `state=green`, **`closed #323`** |

So: **opens on failure ✅ · does not duplicate or comment on a repeat ✅ · one comment on a change of kind ✅ · a green run closes it ✅.** Both issues are closed; no other issue was created or touched; no PR was opened by any drill (`gh pr list` is empty).

Run 7 also doubles as the false-positive check on the new arm: on a healthy run the probe returns 200 and the state is `green`, not `canonical-unreachable`.

### Verified before pushing

* `actionlint` 1.7.12 **with shellcheck 0.11.0 wired in** — clean on both files. Both instruments were negative-controlled first: a bad `needs:` reference reddens actionlint (rc=1), and an injected `rm -rf $UNQUOTED/*` reddens shellcheck (SC2086/SC2115) *through* actionlint, so the clean verdict is a fact about the files and not about a linter that was skipping the `run:` bodies.
* Both `classify` scripts were **executed locally under `bash -e`** against 11 fabricated input combinations, with a `GITHUB_OUTPUT` parser that reads the values back the way the runner does. Every non-green case was asserted to produce a title starting with its marker, a non-empty multi-line body and a single-line title — i.e. the three things `failure-issue.yml` itself refuses. The harness carries a positive control (≥1 non-green case must yield a multi-line body) so a wiring mistake cannot read as a pass.
* The probe step was run locally under `bash -e` against the real URL (`-> HTTP 200`) and an unreachable host (`-> HTTP 000`), **rc=0 both times** — it must never fail the step.
* `make ci` (20 pkg `ok`, 0 `--- FAIL`), `make lint` separately under `nix-shell -p golangci-lint` (`0 issues`), `make ci-shallow` (`19/19 ok, 0 failures, 0 timeouts`). No Go source changed; the tree diff is exactly two workflow files.

## What I could NOT verify, and what to watch

1. **Nothing about the SCHEDULE is provable from a branch.** Scheduled runs only ever use the **default branch's** copy of a workflow, so every drill above ran on a `workflow_dispatch` trigger. The drill guards are written `(github.event_name == 'workflow_dispatch' && inputs.drill) || 'none'`, which resolves to `none`/`false` on a schedule — exercised in the local harness, not on a real cron. **Watch the first scheduled runs after merge:** `bump-scaffold-pins` at 07:17 UTC the next day, `revendor-canonical-schema` at 07:37 UTC the next Monday. Both should be green with no issue filed.
2. **`canonical-unreachable` has never fired on a runner** — I cannot make civitai.com unreachable from GitHub. It is proven in the local harness (fabricated `000` → correct state/title/body) and the probe's own `000` path is proven locally, but the end-to-end path is unrehearsed.
3. **`validate-pins-failed` / `validate-suite-failed` / `validate-build-failed` / `pr-failed` / `validate-failed` are unrehearsed end to end** — each needs a genuine pin or schema change to reach. Their classifier logic was exercised locally; their *inputs* (the step outcomes) come from the same mechanism the drilled arms proved.
4. **`bump-unknown` / the `unknown` fallback** likewise: exercised locally, but reaching it on a runner needs the job to die outside its own steps.
5. The `bump-scaffold-pins` PR-opening path was not exercised, because the pins were current (re-checked immediately before the green dispatch, specifically so a bump PR could not open off this branch as a stacked PR).

## Not touched

**`release-homebrew.yml` was deliberately left on its own copy of the mechanism**, per the migration note at the bottom of `failure-issue.yml` and issue #320 — it is on the release path and its six-state taxonomy has to move into the caller first. I did not edit, tidy, dispatch or re-run it. `release.yml` and `release-npm.yml` were likewise untouched (a release is being cut concurrently). `git diff --stat` against `main` is exactly `.github/workflows/bump-scaffold-pins.yml` and `.github/workflows/revendor-canonical-schema.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
