### PR TITLE
fix!(scaffold): refuse a name whose blockId would be truncated, and stop the residual list claiming three classes (#291)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,8 +379,9 @@ item must carry a trigger that is a routing question rather than a label
     anything?**
     → evidence: claudedocs/decisions/26-project-path-classification.md
 
-27. **Editing `scaffold.Slugify`, its lossy-character exemption, what `--slug`
-    suppresses, or what `app create` echoes about the id it minted?**
+27. **Editing `scaffold.Slugify`, its lossy-character exemption, the 40-char
+    length refusal, what `--slug` suppresses, or what `app create` echoes about
+    the id it minted?**
     → evidence: claudedocs/decisions/27-blockid-derivation-refuses.md
 
 28. **Wording anything about a charge — readiness, refunds, cancel — adding a

--- a/README.md
+++ b/README.md
@@ -351,9 +351,23 @@ so name, blockId and directory are three fully independent axes.
 > a script passing a non-ASCII name, it must now pass `--slug <slug>`.** The old
 > output was wrong, so the break is the point — but it is a break.
 
-What derivation refuses is **letters, digits and marks** above ASCII that the
-slug alphabet cannot carry. Three things still derive rather than refuse, and
-they are deliberate:
+> **Breaking change.** Derivation also used to **truncate**. A name whose blockId
+> ran past the **40-character** cap was silently cut to fit, at exit 0 — so
+> `civitai app create "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee"`
+> and the same 54-character name ending `ZZZZZZZZZZ` **both** minted
+> `aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd`: two apps competing for one id that
+> cannot be renamed, with nothing local to tell the author it happened. An
+> **explicit** `--slug` of that length was already refused (`must be 3-40
+> chars`), so the derived path — the one a first-time author walks — was the
+> inconsistent one. It now refuses too, exiting **2** and naming the length.
+> **If you have a script passing a long name, it must now pass `--slug
+> <slug>`.** A name deriving **exactly 40** characters is *at* the cap, not over
+> it, and still derives byte-identically.
+
+Derivation refuses two things: **letters, digits and marks** above ASCII that the
+slug alphabet cannot carry, and a name whose blockId would **exceed 40
+characters**. Both refusals exit `2` and both are settled the same way — pass
+`--slug`. Three things still derive rather than refuse, and they are deliberate:
 
 | input | blockId | why |
 | --- | --- | --- |
@@ -2164,6 +2178,7 @@ a hand-written list does.)
 | --- | --- | --- |
 | `cannot derive a slug from` / `cannot appear in a blockId` | The name holds characters the blockId alphabet cannot carry, and dropping them would mint a **different permanent public id** than you typed. Choose one yourself with `--slug <slug>`. | [The blockId](#the-blockid) |
 | `is not valid UTF-8` | The same refusal one step earlier: the name's bytes cannot be read at all. Pass `--slug`, and a `--name` that is valid UTF-8. | [The blockId](#the-blockid) |
+| `… and the limit is …` | The name derives a blockId longer than the 40-character cap. It is **not** truncated — two names sharing the first 40 characters would be given the same un-renameable id. Pick a shorter one with `--slug <slug>`. | [The blockId](#the-blockid) |
 | `refusing to overwrite. Scaffold somewhere else` | `app create` / `app init` will not clobber a non-empty directory, and there is deliberately **no `--force`** — overwriting a directory you already have is not recoverable. Use `--dir <new path>`, or remove the directory first. | [Templates](#templates) |
 
 ### Validating and submitting

--- a/claudedocs/decisions/27-blockid-derivation-refuses.md
+++ b/claudedocs/decisions/27-blockid-derivation-refuses.md
@@ -30,6 +30,96 @@ deleting it:
 >     hatch (#259). 🔴 It NARROWS #259; it does not close it, and the residuals it
 >     knowingly ships with are enumerated in the evidence.
 
+## Amendment — #291: a FOURTH class existed, the list said three, and it is now closed
+
+🔴 **THE BODY BELOW THE RULE IS DIGEST-PINNED VERBATIM** against the AGENTS.md
+commit it was moved from (`agents_split_preserved_test.go`, re-derived from
+`git show <base>:AGENTS.md`). So a later correction to this item is written HERE,
+above the rule, and the historical body is left alone — that is the same
+convention the replaced stub above follows, and it keeps "the move was verbatim"
+a fact instead of a thing that used to be true.
+
+**What #291 found.** The residual enumeration in `internal/scaffold/slug.go`
+opened with "Three classes of input still derive a slug that quietly differs from
+the name, and all three are stated here". There were **four**. Missing was
+LENGTH: `Slugify` ended with `if len(s) > 40 { s = strings.Trim(s[:40], "-") }`,
+so a name whose blockId ran past the cap was silently cut, at rc 0. The issue
+reproduced it on `main` at `c5c3817`; it was re-measured here at `03c3863` by
+running the new tests against unmodified code, where
+`"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee"` and the same
+54-character name ending `ZZZZZZZZZZ` — differing from character 44, well inside
+the region cut away — **both** minted
+`aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd`, and `app create` scaffolded a project
+around it rather than erroring.
+
+🔴 **THE ENUMERATION WAS FILED AS THE DEFECT, SEPARATELY FROM THE TRUNCATION IT
+HID.** By this repo's own doctrine — item 20's "residuals this check knowingly
+ships with", and "a comment is a claim too" — a list that presents itself as
+complete and is not costs a reader more than no list, because it is the artefact
+they use to decide they have finished looking. The issue says so explicitly:
+whichever policy was chosen, "the enumeration must stop claiming three classes"
+was not optional.
+
+**The decision: REFUSE (option 1 of the three the issue offered), not warn.** The
+same 3–40 bound was already **enforced** on an explicit `--slug` (`slug %q must
+be 3-40 chars`, exit 2) and **silently applied** on the derived one. That
+asymmetry is what makes this a bug rather than a policy: the derived path is the
+one a first-time author walks. Refusing makes the two agree, and it is the same
+answer #259/#267 gave the non-ASCII case — refuse and ask for `--slug` rather
+than silently mint an identity the author did not type. Warn-and-continue was
+rejected for the reason the issue names: truncation alone is recoverable, but two
+apps competing for one un-renameable id is not something the author can detect
+locally, so a warning would leave the unrecoverable half in place.
+
+🔴 **THE SEAM IS `Slugify`, AND `SuffixSlug`'S TRUNCATION IS A DIFFERENT FEATURE
+THAT MUST NOT BE "FIXED" ALONGSIDE IT.** `SuffixSlug` deliberately shortens its
+base (`maxBase := maxSlugLen - 1 - len(suffix)`) so `base-<suffix>` fits. Both
+non-test callers were enumerated before choosing:
+
+- `Slugify` — ONE caller, `runAppScaffold` in `internal/cmd/app_init.go`, which
+  wraps the error in `asUsageError` (exit 2). It is the only place a NAME becomes
+  a blockId nobody has chosen yet, which is exactly where cutting substitutes a
+  different permanent public id.
+- `SuffixSlug` — ONE caller, `mintDevTokenWithRename` in
+  `internal/cmd/app_dev_token.go`. It is handed a slug the author ALREADY has
+  (read from `block.manifest.json`) which the server has just reported as
+  registered to another account; shortening the base to make room for the suffix
+  IS the operation, the author is told which slug replaced which, and the
+  manifest is rewritten. It does **not** call `Slugify`, so the two paths are
+  disjoint: the refusal cannot break it and it cannot bypass the refusal.
+
+**The four literal `40`s became one constant.** `maxSlugLen` (with `minSlugLen`)
+now backs `ValidateSlug`, `SuffixSlug`'s reservation and the new refusal.
+`ValidateSlug`'s message is rendered from them and is byte-identical
+(`must be 3-40 chars`), which a control test pins — #291 is what a disagreement
+between two copies of one bound costs, so "both paths cap at the same number" is
+made a fact rather than a claim.
+
+**Mutation matrix** (each mutant confirmed to die on THIS guard's error, not a
+neighbour's):
+
+| mutant | dies on |
+| --- | --- |
+| delete the refusal, restore `s = strings.Trim(s[:40], "-")` | 4 tests; the collision test names the pre-fix id `aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd` and that BOTH names produced it |
+| invert to refuse every derived slug | 14 tests, including `TestAsciiDerivationIsUnchanged` and `TestSlugifyAsciiDerivationIsByteIdentical` — the positive control that ordinary names still derive |
+| `> maxSlugLen` → `>= maxSlugLen` | the exactly-40 tests only, with the length refusal's own message quoting a 40-character blockId |
+| `> maxSlugLen` → `> maxSlugLen+1` | the 41-character test only |
+
+**Residuals this refusal knowingly ships with** — stated because that is the
+whole lesson of this item:
+
+- **The CLI offers no suggested shorter slug.** Deliberate: the obvious
+  suggestion is the truncation, which is the colliding value the refusal exists
+  to avoid printing as if it were safe. The author is told the derived length,
+  the limit, and the flag.
+- **Collision with an app owned by SOMEONE ELSE is still not detectable at
+  scaffold time.** `app create` talks to no server; only `app dev-token` /
+  `app submit` learn the slug is taken (and `SuffixSlug` is the auto-rename that
+  answers it). #291 is only about the CLI minting a collision with *itself*.
+- **The bound is a vendored mirror.** `40` is the server's `SLUG_REGEX` bound,
+  not a CLI policy; if the platform widens it, this constant and `schema/` move
+  together.
+
 ---
 
 27. **The blockId derivation REFUSES rather than transliterates, and the

--- a/internal/cmd/app_init_length_test.go
+++ b/internal/cmd/app_init_length_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #291, through the real command. The unit-level pins live in
+// internal/scaffold/slug_length_test.go; what is asserted HERE is the half the
+// scaffold package cannot see — the exit code the user gets, and that nothing is
+// written to disk when the name is refused.
+//
+// 🔴 THE EXIT CODE IS PINNED WITH errors.Is, NEVER MESSAGE TEXT (AGENTS item 7).
+// The classification sentinel carries no visible text, so a message assertion
+// says nothing about whether this exits 2 — measured in this repo: stripping a
+// classification while leaving every message identical left the whole suite
+// green. The message substring below identifies WHICH guard fired; `ErrUsage` is
+// what pins the published exit code.
+
+// oneNameShortOfForty and its siblings are the same fixtures the unit tests use,
+// restated here so the command-level rows are readable on their own.
+const (
+	cmdLongNameA = "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee"
+	cmdLongNameB = "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd ZZZZZZZZZZ"
+	cmdCollided  = "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd"
+
+	cmdFortyName = "aaaaaaaaaa bbbbbbbbbb cccccccccc ddddddd"
+	cmdFortySlug = "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd"
+)
+
+// TestScaffoldRefusesANameThatWouldTruncateTheBlockID: `app create` with a name
+// whose derived blockId runs past 40 chars exits 2 and writes nothing, instead of
+// scaffolding a project around a truncated permanent id.
+func TestScaffoldRefusesANameThatWouldTruncateTheBlockID(t *testing.T) {
+	for i, name := range []string{cmdLongNameA, cmdLongNameB} {
+		t.Run(map[int]string{0: "first", 1: "second"}[i], func(t *testing.T) {
+			tmp := t.TempDir()
+			dest := filepath.Join(tmp, "out")
+			stdout, _, err := run(t, "app", "create", name, "--dir", dest, "--template", "static")
+			if err == nil {
+				t.Fatalf("app create %q should be refused; it scaffolded instead:\n%s", name, stdout)
+			}
+			if !errors.Is(err, ErrUsage) {
+				t.Errorf("an over-length derived blockId is a bad VALUE, i.e. a usage error (exit 2): "+
+					"errors.Is(err, ErrUsage) = false (%v)", err)
+			}
+			if !strings.Contains(err.Error(), "the limit is 40") {
+				t.Errorf("the refusal must be the LENGTH guard's, not another guard that happens to fire: %v", err)
+			}
+			if _, statErr := os.Stat(dest); statErr == nil {
+				t.Error("the name was refused but a project was still written")
+			}
+			// The pre-fix id must not appear anywhere on stdout either: the
+			// echo line is what made #291 visible, and re-printing the
+			// truncation would be the same silent claim in a new place.
+			if strings.Contains(stdout, cmdCollided) {
+				t.Errorf("output still names the truncated blockId %q:\n%s", cmdCollided, stdout)
+			}
+		})
+	}
+}
+
+// TestScaffoldAtExactlyFortyCharsStillScaffolds is the BOUNDARY CONTROL through
+// the command: 40 is at the cap, not over it. It asserts the manifest, not just
+// the printed line — the manifest is the authority on the app's identity.
+func TestScaffoldAtExactlyFortyCharsStillScaffolds(t *testing.T) {
+	if len(cmdFortySlug) != 40 {
+		t.Fatalf("CONTROL failure: fixture slug is %d chars, want 40", len(cmdFortySlug))
+	}
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "out")
+	stdout, _, err := run(t, "app", "create", cmdFortyName, "--dir", dest, "--template", "static")
+	if err != nil {
+		t.Fatalf("app create %q (derives exactly 40 chars): %v\n%s", cmdFortyName, err, stdout)
+	}
+	if got := manifestBlockID(t, dest); got != cmdFortySlug {
+		t.Errorf("blockId = %q, want %q", got, cmdFortySlug)
+	}
+	if !strings.Contains(stdout, cmdFortySlug) {
+		t.Errorf("output must echo the 40-char blockId:\n%s", stdout)
+	}
+}
+
+// TestOverLengthExplicitSlugIsUnchanged is the CONTROL for the behaviour #291
+// makes the derived path agree with. It must not move: same exit class, same
+// message. (TestSlugFlagRejectsAnInvalidValue already carries a 41-char row for
+// the exit code; this one additionally pins the WORDING, because "make the two
+// paths consistent" is exactly the change that tempts someone to rewrite it.)
+func TestOverLengthExplicitSlugIsUnchanged(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "out")
+	over := strings.Repeat("a", 41)
+	_, _, err := run(t, "app", "create", "My Block", "--slug", over, "--dir", dest, "--template", "static")
+	if err == nil {
+		t.Fatal("an over-length explicit --slug must still be refused")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("an over-length --slug must stay a usage error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "must be 3-40 chars") {
+		t.Errorf("the explicit --slug message moved: %v", err)
+	}
+	if _, statErr := os.Stat(dest); statErr == nil {
+		t.Error("--slug was refused but a project was still written")
+	}
+}

--- a/internal/scaffold/slug.go
+++ b/internal/scaffold/slug.go
@@ -37,13 +37,25 @@ func RandomSuffix(n int) string {
 // server slug contract. suffix must be lowercase-alphanumeric (as RandomSuffix
 // produces). It is used to auto-rename a slug that collides with an app owned by
 // another account.
+//
+// 🔴 THE TRUNCATION HERE IS NOT THE ONE #291 REFUSED, AND THE DIFFERENCE IS THE
+// INPUT. Slugify turns a NAME into an identity nobody has chosen yet, so cutting
+// it silently substitutes a different permanent public id — it refuses instead.
+// SuffixSlug is handed a slug the author ALREADY has (its only caller,
+// mintDevTokenWithRename in internal/cmd/app_dev_token.go, reads it out of
+// block.manifest.json), which the server has just told us is taken; shortening
+// the base to make room for `-<suffix>` is the whole point of the operation, the
+// author is told which slug replaced which, and the manifest is rewritten so
+// nothing is left pointing at the old one. It does NOT call Slugify, so the two
+// paths are disjoint: the refusal cannot break this, and this cannot bypass the
+// refusal.
 func SuffixSlug(original, suffix string) (string, error) {
 	suffix = strings.ToLower(strings.TrimSpace(suffix))
 	if suffix == "" || nonSlugChars.MatchString(suffix) || strings.Contains(suffix, "-") {
 		return "", fmt.Errorf("slug suffix %q must be lowercase-alphanumeric", suffix)
 	}
 	// Reserve room for the hyphen + suffix within the 40-char cap.
-	maxBase := 40 - 1 - len(suffix)
+	maxBase := maxSlugLen - 1 - len(suffix)
 	if maxBase < 1 {
 		return "", fmt.Errorf("slug suffix %q is too long", suffix)
 	}
@@ -65,6 +77,18 @@ func SuffixSlug(original, suffix string) (string, error) {
 // slugPattern mirrors the server SLUG_REGEX: starts with a letter, lowercase,
 // hyphen-separated, ends alphanumeric, 3-40 chars.
 var slugPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+
+// minSlugLen / maxSlugLen are the server's slug length bounds, in ONE place.
+// They used to be four literal `40`s across three sites — ValidateSlug (the
+// explicit --slug path), SuffixSlug's reservation, and Slugify's truncation
+// (twice) — and #291 is what a disagreement between two of them costs: the
+// explicit path REFUSED at 41 while the derived path silently cut to 40, so two
+// names could mint one un-renameable blockId. A shared constant is what makes
+// "both paths cap at the same number" a fact rather than a claim.
+const (
+	minSlugLen = 3
+	maxSlugLen = 40
+)
 
 var nonSlugChars = regexp.MustCompile(`[^a-z0-9]+`)
 
@@ -202,10 +226,19 @@ func quoteChars(cs []string) string {
 // error if it cannot produce one within the length bounds — or if deriving one
 // would silently DISCARD characters the author typed (see LossyChars).
 //
-// 🔴 THIS NARROWS ISSUE #259, IT DOES NOT CLOSE IT. Three classes of input still
-// derive a slug that quietly differs from the name, and all three are stated
-// here rather than implied away — a residual nobody writes down is
-// indistinguishable from a bug nobody noticed:
+// 🔴 THIS NARROWS ISSUE #259, IT DOES NOT CLOSE IT. FOUR classes of input have
+// derived a slug that quietly differs from the name. Two are now CLOSED by a
+// refusal — (a) and (d) — and two still derive; all four are stated here rather
+// than implied away, because a residual nobody writes down is indistinguishable
+// from a bug nobody noticed.
+//
+// 🔴 THIS LIST SAID "THREE" AND OMITTED (d) FROM THE DAY IT WAS WRITTEN, AND THE
+// OMISSION WAS FILED AS A DEFECT IN ITS OWN RIGHT (#291) — separately from the
+// truncation it hid, precisely because an enumeration that presents itself as
+// complete and is not costs a reader more than no enumeration at all: it is the
+// artefact they use to decide they have finished looking. When you close a class
+// here, or find a new one, re-count the sentence above; "all N are stated here"
+// is a claim, and it is the first thing that goes stale.
 //
 //   - (a) INVALID UTF-8 — CLOSED. `caf\xe9 app` used to derive `caf-app` with
 //     rc 0, because `for _, r := range` yields U+FFFD per bad byte and U+FFFD is
@@ -228,6 +261,18 @@ func quoteChars(cs []string) string {
 //     arguably NOT what an author means by an emoji — but an emoji has no
 //     lossless ASCII form either, so refusing would only trade a silent drop for
 //     a dead end. Left as-is deliberately, tracked separately.
+//   - (d) A NAME WHOSE SLUG RUNS PAST 40 CHARACTERS — CLOSED (#291). Derivation
+//     used to CUT it (`s = strings.Trim(s[:40], "-")`) at rc 0. Measured:
+//     `"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee"` and the same
+//     name ending `ZZZZZZZZZZ` — 54 characters each, differing from character 44
+//     — both minted `aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd`. Truncation alone
+//     is recoverable; two apps competing for ONE un-renameable public id is not,
+//     and nothing local tells the author it happened. An EXPLICIT `--slug` of the
+//     same length was already refused ("must be 3-40 chars"), so the derived path
+//     — the one a first-time author walks — was the inconsistent one. It refuses
+//     now too, with the same `--slug` escape hatch as (a) and the lossy-character
+//     case. Exactly 40 is AT the cap, not over it, and still derives
+//     byte-identically.
 func Slugify(name string) (string, error) {
 	// 🔴 BEFORE anything ranges over the string. `for _, r := range` silently
 	// substitutes U+FFFD for each invalid byte, and U+FFFD classifies as a
@@ -246,11 +291,14 @@ func Slugify(name string) (string, error) {
 	for strings.Contains(s, "--") {
 		s = strings.ReplaceAll(s, "--", "-")
 	}
-	if len(s) < 3 {
-		return "", fmt.Errorf("cannot derive a valid slug from %q (need ≥3 chars; use lowercase letters/numbers/hyphens)", name)
+	if len(s) < minSlugLen {
+		return "", fmt.Errorf("cannot derive a valid slug from %q (need ≥%d chars; use lowercase letters/numbers/hyphens)", name, minSlugLen)
 	}
-	if len(s) > 40 {
-		s = strings.Trim(s[:40], "-")
+	// 🔴 REFUSE, DO NOT TRUNCATE — residual (d) above. This is the SAME cap
+	// ValidateSlug applies to an explicit --slug, deliberately reached through
+	// the same constant, so the two paths cannot drift apart again.
+	if len(s) > maxSlugLen {
+		return "", fmt.Errorf("cannot derive a slug from %q: it derives the %d-character blockId %q and the limit is %d, and cutting it to fit would give your app a different permanent public id than you typed — one that every other name sharing those first %d characters would be given too — so choose one yourself with --slug <slug>", name, len(s), s, maxSlugLen, maxSlugLen)
 	}
 	if !slugPattern.MatchString(s) {
 		return "", fmt.Errorf("derived slug %q is invalid (must start with a letter, be lowercase, hyphen-separated)", s)
@@ -260,8 +308,8 @@ func Slugify(name string) (string, error) {
 
 // ValidateSlug checks an explicit slug against the server contract.
 func ValidateSlug(slug string) error {
-	if len(slug) < 3 || len(slug) > 40 {
-		return fmt.Errorf("slug %q must be 3-40 chars", slug)
+	if len(slug) < minSlugLen || len(slug) > maxSlugLen {
+		return fmt.Errorf("slug %q must be %d-%d chars", slug, minSlugLen, maxSlugLen)
 	}
 	if !slugPattern.MatchString(slug) {
 		return fmt.Errorf("slug %q must start with a letter, be lowercase, and contain only letters, numbers, and hyphens", slug)

--- a/internal/scaffold/slug_length_test.go
+++ b/internal/scaffold/slug_length_test.go
@@ -1,0 +1,203 @@
+package scaffold
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #291. Derivation used to TRUNCATE a name whose slug ran past the 40-char
+// cap (`s = strings.Trim(s[:40], "-")`), while an EXPLICIT `--slug` of the same
+// length was refused with "must be 3-40 chars". The asymmetry is the bug: the
+// derived path is the one a first-time author walks, and the value being cut is
+// the app's PERMANENT public id.
+//
+// 🔴 THE COLLISION IS WHAT RAISES THIS ABOVE COSMETIC. A truncation on its own is
+// ugly but recognisable; two DIFFERENT names silently minting the SAME id is not
+// something the author can detect locally, and a blockId cannot be renamed.
+//
+// The tests below pin the refusal from BOTH sides of the boundary, because a
+// one-sided length guard is where an off-by-one lives:
+//   - exactly 40 must still derive, byte-identical (positive control), and
+//   - 41 must be refused.
+
+// #291's own reproduction: two 54-character names that differ only from
+// character 44 onward — well inside the region the old code cut away.
+const (
+	longNameA = "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee"
+	longNameB = "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd ZZZZZZZZZZ"
+	// collidingSlug is what BOTH of the above derived before the refusal, at
+	// exit 0. It is spelled out rather than described so a row here is evidence
+	// about THIS defect and not merely "an error came back".
+	collidingSlug = "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd"
+
+	// exactlyFortyName derives a 40-character slug — the boundary that must keep
+	// working untouched.
+	exactlyFortyName = "aaaaaaaaaa bbbbbbbbbb cccccccccc ddddddd"
+	exactlyFortySlug = "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd"
+
+	// fortyOneName derives a 41-character slug — one past the cap.
+	fortyOneName = "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddd"
+)
+
+// TestOverLengthNamesDoNotSilentlyMintTheSameBlockID is the headline of #291.
+func TestOverLengthNamesDoNotSilentlyMintTheSameBlockID(t *testing.T) {
+	// The fixture has to actually BE the collision, or this test is about
+	// nothing. Both controls run before any assertion about the refusal.
+	if longNameA == longNameB {
+		t.Fatal("CONTROL failure: the two names must differ")
+	}
+	if len(collidingSlug) != 40 {
+		t.Fatalf("CONTROL failure: the pre-fix id is %d chars, want the 40-char truncation", len(collidingSlug))
+	}
+	for _, n := range []string{longNameA, longNameB} {
+		if got := legacyTruncate(n); got != collidingSlug {
+			t.Fatalf("CONTROL failure: %q used to derive %q, not the pinned %q — the fixture no longer reproduces #291",
+				n, got, collidingSlug)
+		}
+	}
+
+	var derived []string
+	for _, name := range []string{longNameA, longNameB} {
+		got, err := Slugify(name)
+		if err == nil {
+			derived = append(derived, got)
+			t.Errorf("Slugify(%q) = %q with no error — an over-length name must be refused, not truncated into a "+
+				"permanent public id the author did not type", name, got)
+			if got == collidingSlug {
+				t.Errorf("…and it is the pre-fix truncation %q, which the OTHER name derives too: two apps, one "+
+					"un-renameable blockId", collidingSlug)
+			}
+			continue
+		}
+		assertLengthRefusal(t, name, err)
+	}
+	if len(derived) == 2 && derived[0] == derived[1] {
+		t.Fatalf("two different names minted the identical blockId %q", derived[0])
+	}
+}
+
+// TestSlugifyRefusalNamesTheLengthAndTheEscapeHatch: the refusal is only useful
+// if the author can act on it. It must say how long the derived id was, what the
+// limit is, and which flag settles it.
+func TestSlugifyRefusalNamesTheLengthAndTheEscapeHatch(t *testing.T) {
+	_, err := Slugify(longNameA)
+	if err == nil {
+		t.Fatalf("Slugify(%q) should be refused", longNameA)
+	}
+	assertLengthRefusal(t, longNameA, err)
+}
+
+// TestSlugifyAtExactlyFortyStillDerives is the BOUNDARY CONTROL. `>= 40` instead
+// of `> 40` is the off-by-one this pins, and it is invisible to every other test
+// in the suite.
+func TestSlugifyAtExactlyFortyStillDerives(t *testing.T) {
+	if len(exactlyFortySlug) != 40 {
+		t.Fatalf("CONTROL failure: the fixture slug is %d chars, want exactly 40", len(exactlyFortySlug))
+	}
+	got, err := Slugify(exactlyFortyName)
+	if err != nil {
+		t.Fatalf("Slugify(%q) = %v — a 40-char derivation is AT the cap, not over it, and must still succeed",
+			exactlyFortyName, err)
+	}
+	if got != exactlyFortySlug {
+		t.Errorf("Slugify(%q) = %q, want %q", exactlyFortyName, got, exactlyFortySlug)
+	}
+	if err := ValidateSlug(got); err != nil {
+		t.Errorf("the derived 40-char slug %q must pass the same contract an explicit --slug does: %v", got, err)
+	}
+}
+
+// TestSlugifyAtFortyOneIsRefused pins the other side of the same boundary, so a
+// mutant that widens the cap (`> 40` -> `> 41`) has somewhere to die.
+func TestSlugifyAtFortyOneIsRefused(t *testing.T) {
+	if got := legacyTruncate(fortyOneName); len(got) != 40 {
+		t.Fatalf("CONTROL failure: %q used to derive %d chars, want a 41-char slug truncated to 40", fortyOneName, len(got))
+	}
+	got, err := Slugify(fortyOneName)
+	if err == nil {
+		t.Fatalf("Slugify(%q) = %q — 41 chars is one PAST the cap and must be refused", fortyOneName, got)
+	}
+	assertLengthRefusal(t, fortyOneName, err)
+}
+
+// TestShortAsciiDerivationIsUntouchedByTheLengthGuard is the positive control for
+// the inverted mutant ("refuse every derived slug"). These rows have always been
+// green; their job is to go RED if the refusal ever fires on an ordinary name.
+func TestShortAsciiDerivationIsUntouchedByTheLengthGuard(t *testing.T) {
+	for name, want := range map[string]string{
+		"My Cool Block":     "my-cool-block",
+		"Notepad":           "notepad",
+		"  Spaced   Out  ":  "spaced-out",
+		"Widget (v2) — Pro": "widget-v2-pro",
+	} {
+		got, err := Slugify(name)
+		if err != nil {
+			t.Errorf("Slugify(%q) = %v — the length guard must not touch a short name", name, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("Slugify(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestExplicitSlugKeepsItsOwnLengthMessage is the CONTROL for the behaviour the
+// derived path is being made consistent WITH: it must not move. ValidateSlug is
+// the server contract's mirror and answers on the slug, not on a name.
+func TestExplicitSlugKeepsItsOwnLengthMessage(t *testing.T) {
+	over := strings.Repeat("a", 41)
+	err := ValidateSlug(over)
+	if err == nil {
+		t.Fatalf("ValidateSlug(%q) must refuse a 41-char slug", over)
+	}
+	if !strings.Contains(err.Error(), "must be 3-40 chars") {
+		t.Errorf("the explicit-slug message moved: %q — #291 makes the DERIVED path agree with this one, it does not "+
+			"rewrite this one", err)
+	}
+	// And the boundary on this side too, so the two paths provably share a cap.
+	if err := ValidateSlug(strings.Repeat("a", 40)); err != nil {
+		t.Errorf("ValidateSlug(40 chars) = %v, want nil — both paths cap at 40", err)
+	}
+}
+
+// assertLengthRefusal checks the error is THIS guard's, not another one that
+// happens to fire on the same input. A mutation test whose mutant dies on a
+// different guard's error is green for the wrong reason.
+func assertLengthRefusal(t *testing.T, name string, err error) {
+	t.Helper()
+	msg := err.Error()
+	for _, want := range []string{
+		"cannot derive a slug from", // the derivation family
+		"the limit is 40",           // THIS guard: the length cap
+		"--slug",                    // the escape hatch, named as the next thing to do
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal of %q does not contain %q — got: %s", name, want, msg)
+		}
+	}
+	if strings.Contains(msg, "cannot appear in a blockId") {
+		t.Errorf("the refusal of %q came from the LOSSY-CHARACTER guard, not the length guard: %s", name, msg)
+	}
+	if strings.Contains(msg, "not valid UTF-8") {
+		t.Errorf("the refusal of %q came from the UTF-8 guard, not the length guard: %s", name, msg)
+	}
+}
+
+// legacyTruncate reproduces the pre-#291 derivation tail — lowercase, fold
+// non-slug runs to a hyphen, collapse, then CUT to 40 — so every "this used to
+// produce X" claim above is a MEASUREMENT of the old algorithm rather than a
+// remembered string. (Same reason `legacySlugify` exists in slug_lossy_test.go;
+// this one is deliberately the length half only, so it stays readable next to
+// the guard it is about.)
+func legacyTruncate(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonSlugChars.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	if len(s) > 40 {
+		s = strings.Trim(s[:40], "-")
+	}
+	return s
+}

--- a/internal/scaffold/slug_test.go
+++ b/internal/scaffold/slug_test.go
@@ -18,19 +18,12 @@ func TestTitleFromSlug(t *testing.T) {
 	}
 }
 
-func TestSlugifyTooLongTrims(t *testing.T) {
-	long := "this-is-a-really-long-name-that-exceeds-the-forty-char-limit"
-	got, err := Slugify(long)
-	if err != nil {
-		t.Fatalf("Slugify: %v", err)
-	}
-	if len(got) > 40 {
-		t.Errorf("slug %q exceeds 40 chars (%d)", got, len(got))
-	}
-	if err := ValidateSlug(got); err != nil {
-		t.Errorf("trimmed slug %q should be valid: %v", got, err)
-	}
-}
+// TestSlugifyTooLongTrims is GONE, and its deletion is the behaviour change of
+// #291 rather than a tidy-up: it asserted that an over-length name derives a
+// trimmed slug with no error, which is exactly the silent truncation that let two
+// names mint one un-renameable blockId. Derivation now refuses. The replacement
+// coverage — the collision, both sides of the 40-char boundary, and the explicit
+// --slug control it was made consistent with — is in slug_length_test.go.
 
 func TestSlugifyAllPunctuationFails(t *testing.T) {
 	if _, err := Slugify("!!!"); err == nil {


### PR DESCRIPTION
Closes #291.

`scaffold.Slugify` ended with `if len(s) > 40 { s = strings.Trim(s[:40], "-") }`, so a name whose derived blockId ran past the cap was silently **cut**, at rc 0. A blockId is the app's permanent public identity (`https://<blockId>.civit.ai/`) and cannot be renamed. Truncation alone is recoverable; **two apps competing for one id is not**, and nothing local tells the author it happened.

The same 3–40 bound was already **enforced** on an explicit `--slug` (`must be 3-40 chars`, exit 2) and **silently applied** on the derived one. That asymmetry is the bug — the derived path is the one a first-time author walks. This is **option 1 of the issue: refuse**, the same answer #259/#267 gave the non-ASCII case.

```console
$ civitai app create "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee" --dir ./t1 -y -t static
Error: cannot derive a slug from "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee": it derives the
54-character blockId "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee" and the limit is 40, and
cutting it to fit would give your app a different permanent public id than you typed — one that every
other name sharing those first 40 characters would be given too — so choose one yourself with --slug <slug>
rc=2

$ civitai app create "aaaaaaaaaa bbbbbbbbbb cccccccccc ddddddd" --dir ./t2 -y -t static   # exactly 40
  blockId: aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd  —  your app's permanent public id (it cannot be renamed later)
rc=0
```

## The seam, and the caller enumeration behind it

`SuffixSlug` deliberately truncates its base (`maxBase := maxSlugLen - 1 - len(suffix)`), which is a **different feature** and must not be caught by the refusal. Both non-test callers were enumerated before choosing where the guard goes:

| function | non-test callers | why it does / doesn't get the guard |
| --- | --- | --- |
| `Slugify` | **one** — `runAppScaffold`, `internal/cmd/app_init.go:203` (wraps the error in `asUsageError` → exit 2) | The **only** place a NAME becomes a blockId nobody has chosen yet. Cutting here substitutes a different permanent public id. **Guard goes here.** |
| `SuffixSlug` | **one** — `mintDevTokenWithRename`, `internal/cmd/app_dev_token.go:490` | Handed a slug the author **already has** (read from `block.manifest.json`) that the server just reported as registered to another account. Shortening the base to make room for `-<suffix>` *is* the operation; the author is told which slug replaced which and the manifest is rewritten. It does **not** call `Slugify`. |

The two paths are disjoint: the refusal cannot break `SuffixSlug`, and `SuffixSlug` cannot bypass the refusal. Its doc comment now states that, since a future reader will otherwise "fix" the inconsistency.

Test callers checked too (`slug_test.go`, `slug_lossy_test.go`, `scaffold_test.go`, `app_init_echo_test.go`, `app_init_identity_test.go`). `legacySlugify` in `slug_lossy_test.go` is a pinned snapshot of the `e800129`-era algorithm and is deliberately left alone.

Also collapses the four literal `40`s across three sites into `minSlugLen`/`maxSlugLen`, so "both paths cap at the same number" is a fact rather than a claim. `ValidateSlug`'s message renders byte-identically (`must be 3-40 chars`) and a control test pins that.

## Test matrix — red at base, green at HEAD

Base = `origin/main` @ `03c3863`, new tests applied to **unmodified** production code.

| test | at base | at HEAD |
| --- | --- | --- |
| `TestOverLengthNamesDoNotSilentlyMintTheSameBlockID` (#291 headline) | **FAIL** — both names returned `aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd`, no error | PASS |
| `TestSlugifyRefusalNamesTheLengthAndTheEscapeHatch` | **FAIL** | PASS |
| `TestSlugifyAtFortyOneIsRefused` | **FAIL** | PASS |
| `TestScaffoldRefusesANameThatWouldTruncateTheBlockID` (2 subtests, `errors.Is(err, ErrUsage)`) | **FAIL** — "should be refused; it scaffolded instead" | PASS |
| `TestSlugifyAtExactlyFortyStillDerives` (boundary control) | PASS | PASS |
| `TestScaffoldAtExactlyFortyCharsStillScaffolds` (boundary control) | PASS | PASS |
| `TestShortAsciiDerivationIsUntouchedByTheLengthGuard` (control) | PASS | PASS |
| `TestExplicitSlugKeepsItsOwnLengthMessage` (control) | PASS | PASS |
| `TestOverLengthExplicitSlugIsUnchanged` (control, `ErrUsage` + wording) | PASS | PASS |

The four controls were green at base **on purpose** — they are invariant guards for the mutants below, and are labelled as such in the source rather than counted as regression coverage.

Exit code is pinned with `errors.Is(err, ErrUsage)` per AGENTS item 7, never message text; the message substring assertions exist only to identify **which** guard fired.

`TestSlugifyTooLongTrims` is **deleted** — it asserted the silent truncation. Its removal is the behaviour change, and `slug_test.go` says so where it stood.

## Mutation matrix — each mutant confirmed to die on THIS guard's error

| mutant | `--- FAIL` count | killed by, and how it died |
| --- | --- | --- |
| delete the refusal, restore `s = strings.Trim(s[:maxSlugLen], "-")` | 4 | `…= "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-ddddddd" with no error` + `…and it is the pre-fix truncation …, which the OTHER name derives too` + `two different names minted the identical blockId` |
| invert → refuse **every** derived slug (`len(s) >= 0`) | 14 | positive controls: `TestAsciiDerivationIsUnchanged`, `TestSlugifyAsciiDerivationIsByteIdentical`, `TestSlugifyAtExactlyFortyStillDerives`, `TestScaffoldAtExactlyFortyCharsStillScaffolds`, … |
| off-by-one `> maxSlugLen` → `>= maxSlugLen` | 2 (exactly-40 only) | died on **this guard's own message**: `cannot derive a slug from "…": it derives the 40-character blockId "…" and the limit is 40` |
| widened `> maxSlugLen` → `> maxSlugLen+1` | 1 (41 only) | `= "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddd" — 41 chars is one PAST the cap and must be refused` |

`assertLengthRefusal` explicitly rejects the lossy-character and UTF-8 guards' messages, so a mutant cannot be killed by a neighbouring guard and read as green for the wrong reason. The harness restores `slug.go` from a backup after every mutant and the final `git diff --stat` was checked.

## Gate counts (numbers, not exit codes)

- **`make ci`** — `--- FAIL`: **0**; `build failed`: **0**; `^FAIL` lines: **0**; packages `ok`: **19**; `panic: test timed out`: **0**. (One `[no test files]`: `internal/dogfoodguard`.)
- **`make lint`** — **0 issues**, run as `golangci-lint v2.12.2`, the exact version `.github/workflows/ci.yml` pins. Instrument validated: injecting `recieve` into a comment made it report `1 issues: misspell: 1`, so the zero is a real zero.

`make lint` errors on this host (golangci-lint is not on PATH); it was run via `nix-shell -p golangci-lint`, which supplies the same v2.12.2.

## Docs — half of #291

The issue is partly a **documentation** defect, filed separately from the truncation it hid: `slug.go`'s residual enumeration opened *"Three classes of input still derive a slug that quietly differs from the name, and all three are stated here"* — and there were four.

- **`internal/scaffold/slug.go`** — the enumeration now states **four** classes with their status ((a) and (d) **closed** by a refusal, (b) and (c) still deriving), rather than appending a fourth bullet to a "three" sentence. It also carries the instruction to re-count that sentence whenever a class is closed or found.
- **`README.md`** — "The blockId" gains the breaking-change note (with the measured collision), the "derivation refuses two things" sentence, and a Troubleshooting row. The three deliberate *derive-rather-than-refuse* rows are unchanged.
- **`claudedocs/decisions/27-blockid-derivation-refuses.md`** — an **Amendment** section: what was found, why refuse rather than warn, the caller enumeration, the mutation matrix, and the residuals this refusal knowingly ships with (no suggested shorter slug — the obvious suggestion *is* the colliding truncation; cross-account collisions are still server-only; `40` is a vendored server bound).

  🔴 The amendment is written **above the `---` rule**, not into the body. `agents_split_preserved_test.go` digest-pins each moved body against `git show <base>:AGENTS.md`, and `TestSplitDigestsAreTheBaseCommitsText` re-derives that digest from the base commit on any full clone — so re-pinning a changed body would fail rather than pass. The header region is outside `evidenceBody`'s slice, which is the file's own documented place for this.
- **`AGENTS.md`** — item 27's trigger gains "the 40-char length refusal"; it stays a routing question (164 chars, under the 220 ceiling), and the file is 25,370 bytes against the 28,758 ceiling.

## Not verified

- Only local gates were run; CI's other six jobs (`schema-drift`, `pins-vs-published`, `ready-ack-runtime`, the two template jobs, `scaffold-currency`) have not been observed on this branch.
- No server round-trip: `app create` talks to nothing, so the claim that 40 is the server's bound rests on the existing vendored mirror, not on a fresh check against `civitai/civitai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
