### PR TITLE
fix(generate)!: the default --timeout (10m) was shorter than the measured queue latency (11m41s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1878,6 +1878,11 @@ collision is refused *before any bytes move*.
 
 - `--no-wait` submits, prints the workflow id and exits `0`.
 - `--no-download` waits and prints the output URLs instead of writing files.
+- `--timeout` bounds how long the CLI waits, and defaults to **30m**. That is
+  deliberately generous: the wait has to outlast the **queue**, not just the
+  execution. A healthy job has been measured sitting in `scheduled` for
+  **11m41s** before execution even began, so a shorter default walks away from a
+  run that has already been charged.
 - `civitai workflows get <workflow-id>` shows a workflow at any time. It is the
   re-attach path for every case where the CLI stopped early, and it spends
   nothing.

--- a/internal/cmd/generate_wait.go
+++ b/internal/cmd/generate_wait.go
@@ -45,7 +45,26 @@ const (
 	// defaultWaitTimeout bounds the default wait. It is a WAITING bound: an
 	// unattended run must not block forever, and the re-attach path
 	// (`civitai workflows get <id>`) makes giving up recoverable.
-	defaultWaitTimeout = 10 * time.Minute
+	//
+	// 🔴 IT MUST OUTLAST THE QUEUE, NOT JUST THE EXECUTION — and it did not.
+	// This was 10m, and the blind dogfood run of 2026-08-07 measured a healthy
+	// job sitting in `scheduled` for 11m41s BEFORE execution began (created
+	// 17:17:25.589Z, started 17:29:06.848Z, completed 17:31:11.339Z — 13m46s
+	// end-to-end). So the default gave up 2m5s before the job even started,
+	// and per this command's own help — "--timeout STOPS WAITING. IT DOES NOT
+	// STOP PAYING" — the charge stood. The default put a user in exactly the
+	// state the help exists to warn about, on nothing more unusual than a busy
+	// queue. 30m is ~2.2x the measured p100. See civitai/cli#326.
+	//
+	// 🔴 REJECTED: excluding time spent in `scheduled` from the budget (the
+	// dogfood report's other suggestion). The budget exists to stop an
+	// unattended run blocking forever, and a job that never leaves the queue is
+	// precisely the case that would then never time out — it removes the bound
+	// in the one situation that motivated changing it. Raise the number; keep
+	// the bound a bound. Both halves are pinned by
+	// TestPollWorkflow_DefaultTimeoutOutlastsTheMeasuredQueueLatency and
+	// TestPollWorkflow_DefaultTimeoutIsStillABound.
+	defaultWaitTimeout = 30 * time.Minute
 )
 
 // pollConfig is the poll loop's cadence, with the clock and the sleep injected

--- a/internal/cmd/generate_wait_test.go
+++ b/internal/cmd/generate_wait_test.go
@@ -332,6 +332,164 @@ func TestPollWorkflow_TimeoutReturnsTheLastStatus(t *testing.T) {
 	}
 }
 
+// --- the DEFAULT wait budget -------------------------------------------------
+
+// The queue latency this CLI has actually been measured against, from the blind
+// credentialed dogfood run of 2026-08-07 (the Juggernaut control workflow):
+//
+//	Created:   2026-08-07T17:17:25.589Z
+//	Started:   2026-08-07T17:29:06.848Z   -> 11m41s sitting in `scheduled`
+//	Completed: 2026-08-07T17:31:11.339Z   -> 13m46s end-to-end
+//
+// The queue alone outlasted the old 10m default, so a run left on the default
+// gave up on a healthy job it had already paid for. See civitai/cli#326.
+const (
+	observedQueueLatency = 11*time.Minute + 41*time.Second
+	observedEndToEnd     = 13*time.Minute + 46*time.Second
+)
+
+// unboundedPollCap is the getter's escape hatch, and it is a 404 rather than a
+// bare error ON PURPOSE: pollWorkflow retries a status-0 error forever (a
+// transport failure on a job the user has already paid for is exactly what it
+// should keep polling through), so a plain sentinel would HANG instead of
+// failing. A 404 is non-retryable and returns immediately, which is what turns
+// "the wait is not bounded" into a red test rather than a stuck one.
+func unboundedPollCap(t *testing.T) error {
+	t.Helper()
+	return apiErrorWithStatus(t, http.StatusNotFound)
+}
+
+// timedWorkflows returns a getWorkflowFn whose reply depends on the VIRTUAL
+// CLOCK rather than on a call count, so a test states "queued for 11m41s"
+// instead of hand-computing how many backoff steps that takes.
+//
+// It fails the getter after callCap calls so a mutation that removes the
+// deadline entirely ("wait forever") surfaces as that cap rather than as a hung
+// test.
+func timedWorkflows(t *testing.T, clock *fakeClock, calls *int, callCap int, capErr error) getWorkflowFn {
+	t.Helper()
+	start := clock.Now()
+	return func(ctx context.Context, id string) (*genapi.Workflow, json.RawMessage, error) {
+		*calls++
+		if *calls > callCap {
+			return nil, nil, capErr
+		}
+		status := genapi.StatusSucceeded
+		switch elapsed := clock.Now().Sub(start); {
+		case elapsed < observedQueueLatency:
+			status = genapi.StatusScheduled
+		case elapsed < observedEndToEnd:
+			status = genapi.StatusProcessing
+		}
+		raw := wfJSON(status)
+		var wf genapi.Workflow
+		if err := json.Unmarshal([]byte(raw), &wf); err != nil {
+			return nil, nil, err
+		}
+		return &wf, json.RawMessage(raw), nil
+	}
+}
+
+// 🔴 The DEFAULT wait must outlast the queue latency this CLI has been measured
+// against. This is the regression for civitai/cli#326: at the old 10m default
+// the job below was abandoned 2m5s before it even started executing, and per
+// `generate --help` ("--timeout STOPS WAITING. IT DOES NOT STOP PAYING") the
+// charge stood.
+//
+// It drives the REAL poll loop — real 5s..60s backoff, real deadline arithmetic
+// — over a virtual clock, so it fails when the default stops covering that
+// measured run, not merely when someone edits a number.
+func TestPollWorkflow_DefaultTimeoutOutlastsTheMeasuredQueueLatency(t *testing.T) {
+	clock := newFakeClock()
+	cfg := clock.cfg()
+	cfg.timeout = defaultWaitTimeout // the shipped default, not a test-local number
+
+	calls := 0
+	capErr := unboundedPollCap(t)
+	get := timedWorkflows(t, clock, &calls, 500, capErr)
+	wf, _, err := pollWorkflow(context.Background(), get, "wf_1", cfg,
+		&quietPollReporter{w: &bytes.Buffer{}, now: clock.Now, heartbeat: time.Hour})
+
+	if errors.Is(err, capErr) {
+		t.Fatalf("the poll never terminated: %v", err)
+	}
+	if errors.Is(err, errWaitTimeout) {
+		t.Fatalf("the default wait of %s gave up on a job that finished after %s "+
+			"(queued %s) — a default run abandons a healthy job it has already paid for",
+			defaultWaitTimeout, observedEndToEnd, observedQueueLatency)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf == nil || wf.Status != genapi.StatusSucceeded {
+		t.Fatalf("want the succeeded workflow back, got %+v", wf)
+	}
+}
+
+// …and it is still a BOUND. Raising the default must not become "wait forever":
+// the constant's whole justification is that an unattended run cannot block
+// indefinitely, with `civitai workflows get <id>` making giving up recoverable.
+//
+// A job that never leaves the queue must therefore still return errWaitTimeout,
+// with the last-seen status intact so the caller can report it. This is the
+// mutation guard on the fix: setting defaultWaitTimeout to 0 makes this fail
+// with the getter's sentinel instead of hanging.
+func TestPollWorkflow_DefaultTimeoutIsStillABound(t *testing.T) {
+	clock := newFakeClock()
+	cfg := clock.cfg()
+	cfg.timeout = defaultWaitTimeout
+
+	calls := 0
+	capErr := unboundedPollCap(t)
+	// A job that NEVER leaves the queue: every reply is `scheduled`, forever.
+	get := func(ctx context.Context, id string) (*genapi.Workflow, json.RawMessage, error) {
+		calls++
+		if calls > 500 {
+			return nil, nil, capErr
+		}
+		raw := wfJSON(genapi.StatusScheduled)
+		var wf genapi.Workflow
+		if err := json.Unmarshal([]byte(raw), &wf); err != nil {
+			return nil, nil, err
+		}
+		return &wf, json.RawMessage(raw), nil
+	}
+
+	wf, _, err := pollWorkflow(context.Background(), get, "wf_1", cfg,
+		&quietPollReporter{w: &bytes.Buffer{}, now: clock.Now, heartbeat: time.Hour})
+
+	if errors.Is(err, capErr) {
+		t.Fatalf("the default wait is not bounded — a permanently queued job polled forever")
+	}
+	if !errors.Is(err, errWaitTimeout) {
+		t.Fatalf("want errWaitTimeout for a permanently queued job, got %v", err)
+	}
+	if wf == nil || wf.Status != genapi.StatusScheduled {
+		t.Errorf("the last-seen workflow must come back so the caller can report its status, got %+v", wf)
+	}
+	var total time.Duration
+	for _, d := range clock.slept {
+		total += d
+	}
+	if total > defaultWaitTimeout {
+		t.Errorf("slept %s in total, overshooting the %s default", total, defaultWaitTimeout)
+	}
+}
+
+// Wiring guard (an invariant, NOT regression coverage): the --timeout flag's
+// default must be the constant the two tests above reason about. A literal
+// pasted into the flag registration would make both of them claims about dead
+// code.
+func TestGenerateTimeoutFlagDefaultsToTheConstant(t *testing.T) {
+	f := newGenerateCmd().Flags().Lookup("timeout")
+	if f == nil {
+		t.Fatal("--timeout flag is missing")
+	}
+	if f.DefValue != defaultWaitTimeout.String() {
+		t.Errorf("--timeout defaults to %q, but defaultWaitTimeout is %q", f.DefValue, defaultWaitTimeout)
+	}
+}
+
 // Ctrl-C (a cancelled context) unblocks the wait promptly.
 func TestPollWorkflow_ContextCancellationStopsTheWait(t *testing.T) {
 	clock := newFakeClock()


### PR DESCRIPTION
Closes #326. First of the F6–F13 dogfood set (#324–#331) to be implemented — see the index
comment on any of those issues for the full triage.

## The defect

`defaultWaitTimeout` was **10m**. The blind, credentialed dogfood run of 2026-08-07 measured a
**healthy** job sitting in `scheduled` for **11m41s before execution even began**:

```
Created:   2026-08-07T17:17:25.589Z
Started:   2026-08-07T17:29:06.848Z     ← 11m41s queued
Completed: 2026-08-07T17:31:11.339Z     ← 13m46s end-to-end
```

The queue alone outlasted the entire default wait by 17%. Cover generations in the same run
took 428s each — ~71% of the old budget, no headroom.

This matters because `generate --help` is emphatic that **"🔴 --timeout STOPS WAITING. IT DOES
NOT STOP PAYING."** The *default* configuration therefore walked a user into precisely the
state that warning exists for — paid, job still running, CLI gone — on nothing more unusual
than a busy queue.

**Raised to 30m**, ~2.2x the measured p100.

## Explicitly rejected

The report's other suggestion — *"don't count time spent in `scheduled` against a wait budget
that exists to bound execution"*. That removes the bound in the exact case that motivated
changing it (a job that never leaves the queue would then never time out), and contradicts the
constant's stated purpose: an unattended run must not block forever, with
`civitai workflows get <id>` making giving up recoverable. **Raise the number; keep the bound a
bound.** The rejection is recorded at the constant so it is not re-litigated.

## Doctrine

Clean against [item 13](../blob/main/claudedocs/decisions/13-generation-graph-not-validated.md):
this is a **client-side wait bound**, not part of the generation graph. It adds no check,
table, enum, default or range to the payload; it sends nothing and spends nothing.

**No spend-surface golden moves.** `generate_flag_usage_timeout.txt` pins the flag's *usage
string* (unchanged) and `generate_help_long.txt` pins `.Long` (which states no number).
Verified: `git status internal/cmd/testdata/` is empty. This deliberately stays clear of #307,
which is moving spend-surface copy.

## Tests — red-at-base / green-at-HEAD

| Test | At base (10m) | At HEAD (30m) | Kind |
|---|---|---|---|
| `TestPollWorkflow_DefaultTimeoutOutlastsTheMeasuredQueueLatency` | **RED** | green | regression |
| `TestPollWorkflow_DefaultTimeoutIsStillABound` | green | green | mutation guard |
| `TestGenerateTimeoutFlagDefaultsToTheConstant` | green | green | wiring invariant |

The regression test drives the **real** poll loop — real 5s→60s backoff, real deadline
arithmetic — over a virtual clock against the measured timings, so it fails when the default
stops covering that run, not merely when someone edits a number. Watched red at base with its
own message: *"the default wait of 10m0s gave up on a job that finished after 13m46s (queued
11m41s)"*.

The two that pass at base are labelled in-source as what they are and were **mutation-tested**,
each failing with its own specific message:

- constant → `0` (wait forever) ⇒ `DefaultTimeoutIsStillABound` fails *"the default wait is not
  bounded — a permanently queued job polled forever"*.
- a `10*time.Minute` literal pasted into the flag registration ⇒
  `TimeoutFlagDefaultsToTheConstant` fails *"--timeout defaults to "10m0s", but
  defaultWaitTimeout is "30m0s""*.

One trap worth recording: the getter's call cap is a **404**, not a bare sentinel error.
`pollWorkflow` retries a status-0 error forever (correctly — a transport failure on a job the
user has already paid for should keep polling), so a plain sentinel made the mutation **hang**
instead of going red. A first attempt at the `= 0` mutant also failed to *compile* (untyped
int), which produces `0 --- FAIL` and reads exactly like a clean pass — caught only by counting
`build failed` rather than reading an exit code.

## Gates

- `make ci` — **19** packages `ok`, **0** `--- FAIL`, **0** `build failed`, **0** panics, **0**
  test timeouts.
- `make lint` — **0 issues** at the CI-pinned **golangci-lint v2.12.2**. `make lint` errored
  with "golangci-lint not found" first (the deliberate hard error, not a pass), so it was run
  under `nix-shell -p golangci-lint`. Positive control: a deliberate misspelling in the new test
  file produced **1 issue**, confirming the linter observes the changed file — 1 on the control,
  0 under test.

## Breaking change

`civitai generate` now waits up to 30 minutes by default instead of 10. A run that previously
gave up at 10 minutes — leaving a paid job running server-side — now keeps waiting and
downloads the result. Callers depending on the old bound should pass `--timeout 10m`.
**Nothing about what is charged changes**: `--timeout` never stopped the generation or the
charge, only the CLI's waiting.

README updated in lockstep (the published user contract now states the default and why it is
generous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
