### PR TITLE
fix(caskcheck): the tap read was a CDN variant, not the tap — pin it to a commit

### DIFF
--- a/tools/caskcheck/main.go
+++ b/tools/caskcheck/main.go
@@ -76,6 +76,62 @@
 // A caller that finds NO kind file after a non-zero exit has learned something
 // real — this command did not reach its own exit path — and must report that as
 // its own state rather than as any verdict here.
+//
+// # The cask is read at a PINNED COMMIT, because a mutable ref served STALE
+//
+// raw.githubusercontent.com sits behind Fastly and answers
+// `vary: Authorization,Accept-Encoding`, so `.../homebrew-tap/HEAD/Casks/civitai.rb`
+// is not one cached object but one PER ENCODING PER EDGE NODE. Measured on
+// 2026-08-10, minutes after v0.1.92 was published and the cask bumped, with
+// `git ls-remote` giving the tap's true HEAD as df4801b:
+//
+//	curl                        -> version "0.1.92"  etag  "a2ee…"  x-cache HIT
+//	curl --compressed           -> version "0.1.91"  etag W/"a4d5…"  x-cache HIT
+//	net/http (adds gzip itself)  -> version "0.1.91"
+//	caskcheck                    -> OK: cask version 0.1.91 … all downloadable
+//
+// Go's transport adds `Accept-Encoding: gzip` unless the caller set the header,
+// so this command always read the gzip variant, and the gzip variant was a
+// release behind. That is green straight through the outage this command was
+// built to catch: if a cask push introduces a BROKEN version, a run reading the
+// previous variant validates the previous, working version's URLs and exits 0.
+// It did exactly that above — reporting "cask version 0.1.91, all publicly
+// downloadable" while the cask said 0.1.92.
+//
+// Three things were measured and rejected as the fix, each of which looks like
+// it should work:
+//
+//   - `Accept-Encoding: identity`. Reads the OTHER variant, and there is no
+//     evidence that variant is systematically fresher. Staleness here is per
+//     EDGE NODE: in the same minute, `cache-yyz4539` served the gzip variant a
+//     release behind on a HIT while `cache-yyz4528` MISSed and fetched 0.1.92
+//     from the origin. Picking a variant picks a different lottery ticket.
+//   - A cache-busting query parameter. raw.githubusercontent.com does not put
+//     the query string in its cache key: `?cb=…` returned the same stale body
+//     and the same weak ETag as the bare URL, under both encodings.
+//   - `Cache-Control: no-cache` (with and without `Pragma`) on the request.
+//     Fastly does not honour it here; same stale body, same ETag.
+//
+// So the fix does not try to defeat the cache — it removes the mutable object.
+// `-cask-url` carries a `{commit}` placeholder, and the run first resolves the
+// tap's HEAD over git's smart-HTTP ref advertisement, which is served by
+// GitHub's git backend rather than Fastly and is explicitly uncacheable
+// (`cache-control: no-cache, max-age=0, must-revalidate`, `expires` in 1980, no
+// `via: varnish` and no `x-cache` on the response). The cask is then read at
+// `.../homebrew-tap/<40-hex sha>/Casks/civitai.rb`, whose content is IMMUTABLE
+// by construction: there is no earlier body for that cache key to be stale
+// from, so a HIT is correct by definition and every encoding variant agrees.
+// Verified live — both variants of the pinned URL returned 0.1.92.
+//
+// This is still exactly what a reader of the tap gets, and still as a stranger:
+// same file, same host, no Authorization on either request. It is one extra
+// unauthenticated GET, and it buys a property the mutable URL cannot have. The
+// resolved commit is printed, so a run says which snapshot it judged.
+//
+// A `-cask-url` with NO placeholder is used verbatim and skips the lookup. That
+// is what the fire drill in release-homebrew.yml passes, and those fixtures are
+// already pinned to a commit sha themselves; a run says which mode it took
+// rather than degrading silently.
 package main
 
 import (
@@ -94,10 +150,25 @@ import (
 )
 
 const (
-	// defaultCaskURL is the file `brew` itself reads, on the tap's default
-	// branch. `HEAD` rather than `main` so a tap that renames its default branch
-	// does not turn this into a 404 that reads like a real finding.
-	defaultCaskURL = "https://raw.githubusercontent.com/civitai/homebrew-tap/HEAD/Casks/civitai.rb"
+	// caskCommitPlaceholder is what a -cask-url puts where a git ref goes. It is
+	// replaced by the tap's HEAD commit before anything is fetched — see the
+	// package comment for the stale-variant measurement that requires it. A URL
+	// without it is used verbatim.
+	caskCommitPlaceholder = "{commit}"
+
+	// defaultCaskURL is the file `brew` itself reads, read at the commit the
+	// tap's default branch points at right now rather than at the mutable
+	// `HEAD` ref, which measured a release behind. Resolving the ref rather
+	// than naming `main` also keeps a tap that renames its default branch from
+	// turning this into a 404 that reads like a real finding.
+	defaultCaskURL = "https://raw.githubusercontent.com/civitai/homebrew-tap/" + caskCommitPlaceholder + "/Casks/civitai.rb"
+
+	// defaultTapRefsURL is git's smart-HTTP ref advertisement for the tap — what
+	// `git ls-remote` reads. Unauthenticated (the tap is public) and served by
+	// GitHub's git backend, which sets `cache-control: no-cache, max-age=0,
+	// must-revalidate` and sits behind no CDN, so unlike the raw host it cannot
+	// answer with a previous revision.
+	defaultTapRefsURL = "https://github.com/civitai/homebrew-tap.git/info/refs?service=git-upload-pack"
 
 	// defaultLatestURL resolves the latest NON-draft, non-prerelease release.
 	// It feeds the failure MESSAGE and the lag finding — never the invariant.
@@ -135,8 +206,12 @@ var (
 // checker carries the seams. Every field is injectable so the tests drive the
 // real code against httptest servers rather than a reimplementation of it.
 type checker struct {
-	caskURL   string
-	latestURL string
+	// caskURL may carry caskCommitPlaceholder, in which case tapRefsURL is
+	// consulted first and the placeholder replaced by the resolved commit.
+	caskURL string
+	// tapRefsURL is read with NO credential, exactly like the cask itself.
+	tapRefsURL string
+	latestURL  string
 	// apiToken is attached to the releases API request and to NOTHING else.
 	apiToken     string
 	client       *http.Client
@@ -189,7 +264,12 @@ type release struct {
 
 // report is what a run learned, whether or not it is a finding.
 type report struct {
-	caskVersion     string
+	caskVersion string
+	// caskURL is the URL actually requested, and caskCommit the tap commit it
+	// was pinned to — empty when -cask-url named no placeholder. Both are
+	// printed: a verdict about a snapshot has to say which snapshot.
+	caskURL         string
+	caskCommit      string
 	latestPublished string // "" when the diagnostic lookup failed
 	probes          []probe
 	// lagEvaluated records whether the lag question could be ASKED at all. A
@@ -258,19 +338,77 @@ func (c *checker) get(ctx context.Context, url string, auth bool) (*http.Respons
 	return c.client.Do(req)
 }
 
-// fetchCask reads the cask exactly as a reader of the tap would.
-func (c *checker) fetchCask(ctx context.Context) (string, error) {
-	resp, err := c.get(ctx, c.caskURL, false)
+// advHeadCommitRe reads the commit HEAD points at out of a smart-HTTP ref
+// advertisement. A ref line is `<4-hex pkt length><40-hex sha> <name>` with an
+// optional NUL-separated capability list, and HEAD is the first one. The match
+// is anchored on the literal " HEAD" terminator rather than on an offset,
+// because the pkt-line length prefix is itself hex and runs straight into the
+// sha (`00000159df4801…`) — the 40 characters ending immediately before " HEAD"
+// are the sha and nothing else can be. A ref merely NAMED HEAD
+// (`<sha> refs/heads/HEAD`) does not match: the sha is not adjacent to " HEAD".
+var advHeadCommitRe = regexp.MustCompile(`([0-9a-f]{40}) HEAD(\x00|\n|$)`)
+
+// tapCommit resolves the tap's default branch to a commit, over the endpoint
+// `git ls-remote` uses. Its failure is errUnreachableTap — not a new kind —
+// because "we could not resolve the tap" and "we could not read the cask" are
+// the same state to a caller: nothing was measured. There is deliberately no
+// fallback to the mutable ref, which would be a silent return to the defect.
+func (c *checker) tapCommit(ctx context.Context) (string, error) {
+	resp, err := c.get(ctx, c.tapRefsURL, false)
 	if err != nil {
-		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, c.caskURL, err)
+		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, c.tapRefsURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%w (%s): HTTP %d", errUnreachableTap, c.caskURL, resp.StatusCode)
+		return "", fmt.Errorf("%w (%s): HTTP %d", errUnreachableTap, c.tapRefsURL, resp.StatusCode)
 	}
 	b, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, c.caskURL, err)
+		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, c.tapRefsURL, err)
+	}
+	adv := string(b)
+	// Assert the INSTRUMENT before reading its answer: an HTML error page, a
+	// login redirect or a protocol-v2 reply would all simply fail to match
+	// below, and "no HEAD found" is a much worse diagnosis than "that was not a
+	// ref advertisement".
+	if !strings.Contains(adv, "# service=git-upload-pack") {
+		return "", fmt.Errorf("%w (%s): the response is not a git ref advertisement (no `# service=git-upload-pack` banner) — this run resolved no tap commit and has measured nothing", errUnreachableTap, c.tapRefsURL)
+	}
+	m := advHeadCommitRe.FindStringSubmatch(adv)
+	if m == nil {
+		return "", fmt.Errorf("%w (%s): the ref advertisement names no HEAD commit", errUnreachableTap, c.tapRefsURL)
+	}
+	return m[1], nil
+}
+
+// resolveCaskURL turns -cask-url into the URL this run will actually request,
+// pinning it to a commit when it carries the placeholder. The returned commit is
+// "" for a verbatim URL, which the report prints rather than hides.
+func (c *checker) resolveCaskURL(ctx context.Context) (url, commit string, err error) {
+	if !strings.Contains(c.caskURL, caskCommitPlaceholder) {
+		return c.caskURL, "", nil
+	}
+	commit, err = c.tapCommit(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	return strings.ReplaceAll(c.caskURL, caskCommitPlaceholder, commit), commit, nil
+}
+
+// fetchCask reads the cask exactly as a reader of the tap would — same file,
+// same host, no credential — at the immutable URL resolveCaskURL produced.
+func (c *checker) fetchCask(ctx context.Context, url string) (string, error) {
+	resp, err := c.get(ctx, url, false)
+	if err != nil {
+		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w (%s): HTTP %d", errUnreachableTap, url, resp.StatusCode)
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("%w (%s): %w", errUnreachableTap, url, err)
 	}
 	return string(b), nil
 }
@@ -369,16 +507,20 @@ func (c *checker) lagFinding(rep *report, rel release) error {
 // check runs the whole assertion. A non-nil error is a finding OR a control
 // failure; the two are told apart by the sentinels above, via classify.
 func (c *checker) check(ctx context.Context) (*report, error) {
-	body, err := c.fetchCask(ctx)
+	caskURL, commit, err := c.resolveCaskURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.fetchCask(ctx, caskURL)
 	if err != nil {
 		return nil, err
 	}
 
 	m := caskVersionRe.FindStringSubmatch(body)
 	if m == nil {
-		return nil, fmt.Errorf("%w: the cask at %s has no `version \"...\"` stanza — this check cannot read it, which is not the same as it being fine", errUnreadableCask, c.caskURL)
+		return nil, fmt.Errorf("%w: the cask at %s has no `version \"...\"` stanza — this check cannot read it, which is not the same as it being fine", errUnreadableCask, caskURL)
 	}
-	rep := &report{caskVersion: m[1]}
+	rep := &report{caskVersion: m[1], caskURL: caskURL, caskCommit: commit}
 
 	var urls []string
 	for _, u := range caskURLRe.FindAllStringSubmatch(body, -1) {
@@ -387,7 +529,7 @@ func (c *checker) check(ctx context.Context) (*report, error) {
 		urls = append(urls, strings.ReplaceAll(u[1], "#{version}", rep.caskVersion))
 	}
 	if len(urls) == 0 {
-		return rep, fmt.Errorf("%w (%s) — a run that asks for nothing cannot fail, so this is a broken check, not a clean pipeline", errNothingChecked, c.caskURL)
+		return rep, fmt.Errorf("%w (%s) — a run that asks for nothing cannot fail, so this is a broken check, not a clean pipeline", errNothingChecked, caskURL)
 	}
 
 	// Read up front rather than lazily: the lag finding needs it on the GREEN
@@ -440,20 +582,23 @@ func writeKind(path, kind string) error {
 }
 
 func main() {
-	caskURL := flag.String("cask-url", defaultCaskURL, "URL of the cask file as published by the tap")
+	caskURL := flag.String("cask-url", defaultCaskURL, "URL of the cask file as published by the tap; `"+caskCommitPlaceholder+"` is replaced by the tap's current HEAD commit, and a URL without it is used verbatim")
+	tapRefsURL := flag.String("tap-refs-url", defaultTapRefsURL, "git smart-HTTP ref advertisement used to resolve the tap's HEAD commit (only read when -cask-url carries the placeholder)")
 	latestURL := flag.String("latest-url", defaultLatestURL, "GitHub API URL for the latest published release (the failure message, and the lag finding)")
 	lagThreshold := flag.Duration("lag-threshold", defaultLagThreshold, "how long after a release is PUBLISHED a cask that has not followed it becomes a finding")
 	kindFile := flag.String("kind-file", "", "write the verdict's kind (green|broken|lagging|unmeasurable|unclassified) to this file")
-	// The overall budget has to cover the cask fetch plus one probe per archive,
-	// each of which can take the per-request 30s. Four archives at 30s is 120s,
-	// so 60s here would let a slow-but-healthy github.com produce a red run —
-	// the false-red that trains people to ignore a gate. 3m is comfortably over
-	// the worst case and still bounded.
-	timeout := flag.Duration("timeout", 3*time.Minute, "overall timeout")
+	// The overall budget has to cover the ref lookup, the cask fetch and one
+	// probe per archive, each of which can take the per-request 30s. Four
+	// archives at 30s is 120s, plus 60s for the two tap reads, so the worst case
+	// is now exactly 180s and a 3m budget would make a slow-but-healthy
+	// github.com produce a red run — the false-red that trains people to ignore
+	// a gate. 4m keeps headroom over the worst case and is still bounded.
+	timeout := flag.Duration("timeout", 4*time.Minute, "overall timeout")
 	flag.Parse()
 
 	c := &checker{
 		caskURL:      *caskURL,
+		tapRefsURL:   *tapRefsURL,
 		latestURL:    *latestURL,
 		apiToken:     os.Getenv("GITHUB_TOKEN"),
 		client:       &http.Client{Timeout: 30 * time.Second},
@@ -474,10 +619,21 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf("OK: cask version %s; %d archive URL(s) checked, all publicly downloadable\n", rep.caskVersion, len(rep.probes))
+	fmt.Printf("read: %s\n", readProvenance(rep))
 	for _, p := range sortedProbes(rep.probes) {
 		fmt.Printf("  %s\n", p)
 	}
 	fmt.Printf("lag: %s\n", rep.lagWhy)
+}
+
+// readProvenance says WHICH bytes the verdict above is about. A run that reads
+// a mutable ref can be a release behind (see the package comment), so "pinned to
+// commit X" versus "read verbatim" is part of the verdict, not decoration.
+func readProvenance(rep *report) string {
+	if rep.caskCommit == "" {
+		return rep.caskURL + " (verbatim — -cask-url named no " + caskCommitPlaceholder + " placeholder, so no tap commit was resolved)"
+	}
+	return rep.caskURL + " (pinned to tap commit " + rep.caskCommit + ")"
 }
 
 // sortedProbes keeps the success output stable run to run. Map iteration is not

--- a/tools/caskcheck/main_test.go
+++ b/tools/caskcheck/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -43,11 +45,71 @@ func caskFixture(version, releaseHost string) string {
 	return b.String()
 }
 
+// tapCommitFixture is the commit the fixture tap's HEAD points at. A real
+// 40-hex sha, because the advertisement parser is anchored on that width.
+const tapCommitFixture = "df4801ba7479cbe1c8d267481705de617a71cc77"
+
+// staleCaskVersion is the version served at the fixture tap's MUTABLE ref path.
+//
+// 🔴 EVERY fixture serves a decoy there, because the live CDN does: measured on
+// 2026-08-10, `.../homebrew-tap/HEAD/Casks/civitai.rb` answered 0.1.92 to an
+// identity request and 0.1.91 to a gzip one, in the same minute, both `x-cache:
+// HIT`. So a checker that reads the mutable ref reads THIS, whose archives are
+// never published — which makes the regression loud in whichever test trips
+// over it rather than quietly plausible.
+const staleCaskVersion = "0.0.0-stale-cdn-variant"
+
+// refAdvertisement renders a git smart-HTTP ref advertisement in the pkt-line
+// shape github.com actually serves, capabilities and all.
+//
+// It is built rather than hard-coded for one reason: the 4-hex pkt-line LENGTH
+// prefix runs straight into the 40-hex sha (`00000159df4801…`), which is the
+// hazard the parser has to survive. A fixture that omitted the prefix would let
+// an offset-based parser pass.
+func refAdvertisement(commit string) string {
+	var b strings.Builder
+	b.WriteString("001e# service=git-upload-pack\n")
+	b.WriteString("0000")
+	for _, line := range []string{
+		commit + " HEAD\x00multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since no-progress include-tag multi_ack_detailed symref=HEAD:refs/heads/main object-format=sha1 agent=git/github-fixture\n",
+		commit + " refs/heads/main\n",
+	} {
+		fmt.Fprintf(&b, "%04x%s", len(line)+4, line)
+	}
+	b.WriteString("0000")
+	return b.String()
+}
+
+// gzipped is what the CDN's gzip variant is: a real `Content-Encoding: gzip`
+// body, so Go's transparent decompression is exercised rather than sidestepped.
+func gzipped(s string) []byte {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	// Writing to a bytes.Buffer cannot fail, and neither can closing over one.
+	_, _ = zw.Write([]byte(s))
+	_ = zw.Close()
+	return buf.Bytes()
+}
+
+// serveCask writes a cask body the way the CDN serves it: gzip-encoded when the
+// client said it accepts gzip (which Go's transport says by itself unless the
+// caller set the header), plain otherwise.
+func serveCask(rw http.ResponseWriter, req *http.Request, body string) {
+	if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+		rw.Header().Set("Content-Encoding", "gzip")
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write(gzipped(body))
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	_, _ = rw.Write([]byte(body))
+}
+
 // recorder captures what each request carried, so a test can assert on the
 // SHAPE of the request and not merely on the answer.
 type recorder struct {
 	mu   sync.Mutex
-	auth map[string][]string // path -> Authorization header per request
+	auth map[string][]string // path+query -> Authorization header per request
 	hits map[string]int
 }
 
@@ -58,30 +120,53 @@ func newRecorder() *recorder {
 func (r *recorder) record(req *http.Request) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.auth[req.URL.Path] = append(r.auth[req.URL.Path], req.Header.Get("Authorization"))
-	r.hits[req.URL.Path]++
+	key := req.URL.Path
+	r.auth[key] = append(r.auth[key], req.Header.Get("Authorization"))
+	r.hits[key]++
 }
 
-func (r *recorder) authFor(prefix string) []string {
+// authForPathContaining matches by SUBSTRING, not prefix.
+//
+// 🔴 It was a prefix match, and pinning the cask to a commit moved the cask
+// request from `/Casks/civitai.rb` to `/<sha>/Casks/civitai.rb` — under which
+// the credential assertion in TestArchiveProbesCarryNoCredential would have
+// matched nothing and passed vacuously. A guard whose matcher silently stops
+// selecting anything is the reassuring zero.
+func (r *recorder) authForPathContaining(substr string) []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var out []string
 	for p, vals := range r.auth {
-		if strings.HasPrefix(p, prefix) {
+		if strings.Contains(p, substr) {
 			out = append(out, vals...)
 		}
 	}
 	return out
 }
 
+func (r *recorder) hitsForPathContaining(substr string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for p, c := range r.hits {
+		if strings.Contains(p, substr) {
+			n += c
+		}
+	}
+	return n
+}
+
 // world is a fixture pipeline: a tap serving one cask, and a release host that
 // serves archives for exactly the versions that have been PUBLISHED.
 type world struct {
-	tap       *httptest.Server
-	releases  *httptest.Server
-	api       *httptest.Server
-	rec       *recorder
-	caskBody  string
+	tap      *httptest.Server
+	releases *httptest.Server
+	api      *httptest.Server
+	rec      *recorder
+	caskBody string
+	// staleBody is what the MUTABLE ref path serves — the decoy the live CDN
+	// had. See staleCaskVersion.
+	staleBody string
 	published map[string]bool // version -> archives are publicly downloadable
 	latestTag string
 	// publishedAt is emitted as the release payload's `published_at` only when
@@ -128,10 +213,26 @@ func newWorldAt(t *testing.T, caskVersion string, published []string, latestTag 
 	t.Cleanup(w.releases.Close)
 
 	w.caskBody = caskFixture(caskVersion, w.releases.URL)
+	w.staleBody = caskFixture(staleCaskVersion, w.releases.URL)
+	// The tap mirrors the two objects the real host exposes for one file: an
+	// IMMUTABLE one at /<commit>/…, and a MUTABLE one at /HEAD/… that is allowed
+	// to be a release behind. Everything else is the ref advertisement.
 	w.tap = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		w.rec.record(req)
-		rw.WriteHeader(http.StatusOK)
-		_, _ = rw.Write([]byte(w.caskBody))
+		switch {
+		case strings.Contains(req.URL.Path, "/info/refs"):
+			rw.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(refAdvertisement(tapCommitFixture)))
+		case strings.HasPrefix(req.URL.Path, "/"+tapCommitFixture+"/"):
+			// Immutable: every encoding variant agrees, by construction.
+			serveCask(rw, req, w.caskBody)
+		case strings.HasPrefix(req.URL.Path, "/HEAD/"):
+			serveCask(rw, req, w.staleBody)
+		default:
+			// A verbatim -cask-url (the fire-drill shape) still gets the cask.
+			serveCask(rw, req, w.caskBody)
+		}
 	}))
 	t.Cleanup(w.tap.Close)
 
@@ -149,12 +250,16 @@ func newWorldAt(t *testing.T, caskVersion string, published []string, latestTag 
 	return w
 }
 
+// checker drives the DEFAULT shape: a -cask-url carrying the commit
+// placeholder, so every test in this package exercises the ref lookup and the
+// pinned read rather than only the new guards below.
 func (w *world) checker() *checker {
 	return &checker{
-		caskURL:   w.tap.URL + "/Casks/civitai.rb",
-		latestURL: w.api.URL + "/repos/civitai/cli/releases/latest",
-		apiToken:  "fixture-token",
-		client:    &http.Client{Timeout: 10 * time.Second},
+		caskURL:    w.tap.URL + "/" + caskCommitPlaceholder + "/Casks/civitai.rb",
+		tapRefsURL: w.tap.URL + "/info/refs?service=git-upload-pack",
+		latestURL:  w.api.URL + "/repos/civitai/cli/releases/latest",
+		apiToken:   "fixture-token",
+		client:     &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
@@ -338,18 +443,36 @@ func TestArchiveProbesCarryNoCredential(t *testing.T) {
 		t.Fatal("PREMISE BROKEN: this fixture must be the failing one, or the releases-API call below is never made")
 	}
 
-	for _, got := range w.rec.authFor("/civitai/cli/releases/download/") {
+	for _, got := range w.rec.authForPathContaining("/civitai/cli/releases/download/") {
 		if got != "" {
 			t.Errorf("an archive probe carried Authorization %q — it must ask exactly what an unauthenticated `brew install` asks", got)
 		}
 	}
-	for _, got := range w.rec.authFor("/Casks/") {
+	// PREMISE: the substring matchers below must SELECT something. A prefix
+	// match on "/Casks/" silently stopped selecting when the cask moved to
+	// /<commit>/Casks/…, which would have made this whole block vacuous.
+	if n := w.rec.hitsForPathContaining("/Casks/"); n == 0 {
+		t.Fatal("PREMISE BROKEN: no cask request was recorded, so 'the cask fetch carried no credential' is a claim about nothing")
+	}
+	if n := w.rec.hitsForPathContaining("/info/refs"); n == 0 {
+		t.Fatal("PREMISE BROKEN: no ref-advertisement request was recorded, so the tap-resolution credential assertion below is vacuous")
+	}
+	for _, got := range w.rec.authForPathContaining("/Casks/") {
 		if got != "" {
 			t.Errorf("the cask fetch carried Authorization %q; the tap is public and brew reads it anonymously", got)
 		}
 	}
+	// The ref lookup is part of reading the tap and must be as anonymous as the
+	// cask itself — raw.githubusercontent.com varies its cache on Authorization,
+	// so an authenticated tap read is a different object as well as a different
+	// posture.
+	for _, got := range w.rec.authForPathContaining("/info/refs") {
+		if got != "" {
+			t.Errorf("the tap ref lookup carried Authorization %q; resolving a public tap's HEAD needs no credential", got)
+		}
+	}
 
-	api := w.rec.authFor("/repos/civitai/cli/releases/latest")
+	api := w.rec.authForPathContaining("/repos/civitai/cli/releases/latest")
 	if len(api) == 0 {
 		t.Fatal("POSITIVE CONTROL failed: the releases API was never called, so 'no Authorization on the archive' is vacuous")
 	}

--- a/tools/caskcheck/stale_variant_test.go
+++ b/tools/caskcheck/stale_variant_test.go
@@ -1,0 +1,417 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// 🔴 A CHECK THAT READS A STALE COPY IS GREEN ABOUT A STATE THAT NO LONGER
+// EXISTS, AND THAT IS INDISTINGUISHABLE FROM BEING RIGHT.
+//
+// Measured on 2026-08-10, minutes after v0.1.92 published and the cask bumped,
+// with `git ls-remote` giving the tap's true HEAD as df4801b:
+//
+//	curl                 .../homebrew-tap/HEAD/Casks/civitai.rb -> version "0.1.92"
+//	curl --compressed    (same URL)                              -> version "0.1.91"
+//	net/http             (adds Accept-Encoding: gzip itself)     -> version "0.1.91"
+//	go run ./tools/caskcheck                                     -> OK: cask version 0.1.91 …
+//
+// raw.githubusercontent.com answers `vary: Authorization,Accept-Encoding` behind
+// Fastly, so that one URL is one cached object PER ENCODING PER EDGE NODE, and
+// the gzip one was a release behind. The expensive direction is the first test
+// below: if a cask push introduces a BROKEN version, a run reading the previous
+// variant validates the PREVIOUS, WORKING version's archive URLs and exits 0 —
+// green straight through the outage this command exists to catch.
+//
+// The fix is not to prefer a variant. Staleness is per edge node — in the same
+// minute `cache-yyz4539` served the gzip variant a release behind on a HIT while
+// `cache-yyz4528` MISSed and fetched 0.1.92 from the origin — so "read the
+// identity variant" is a different lottery ticket, not a fix. The cask is read
+// at a resolved commit instead, whose bytes are immutable.
+//
+// # What the mutation battery actually measured, including one claim it refuted
+//
+// Leaf `--- FAIL` lines counted from `go test -v`, never an exit code; each
+// mutation checksum-gated so an edit that failed to apply is reported broken
+// rather than read as a survivor. Base is 45 `--- PASS`, 0 `--- FAIL`.
+//
+//	M1  revert: resolve nothing, read the mutable ref            21
+//	M2  half-fix: mutable ref + `Accept-Encoding: identity`      21
+//	M3  degraded mode: fall back to the mutable ref on failure    4
+//	M4  the shipped default reverted to a /HEAD/ URL              1
+//	M5  parser takes the first 40-hex run (a shifted sha)         8
+//	M6  the tap ref lookup starts carrying the credential         1
+//	M7  the ref-advertisement instrument check removed            2
+//	M8  the provenance line stops naming the verbatim mode        1
+//	M0  NULL MUTANT (comment only)                                0 — survives
+//
+// 🔴 M1 AND M2 KILL THE **IDENTICAL** 21 LEAVES, so no test here distinguishes
+// the do-nothing regression from the prefer-a-variant half-fix. An earlier
+// revision of this comment claimed the test below separated them; it does not,
+// and the separation was never needed — both are one defect, reading a mutable
+// ref. Stating the sets are identical is the honest version, and it is what
+// stops someone counting two mutants as two independent pieces of evidence.
+//
+// 🔴 THE `mutableHits() == 0` ASSERTIONS ARE REDUNDANCY, NOT THE COVERAGE.
+// Re-measured with all three of them deleted: M1 and M2 still kill the same 21
+// leaves. They are kept because they state the rule structurally and would
+// catch a future "read both and compare" design that the behavioural
+// assertions would let through — but they must not be counted as what makes
+// these tests work.
+
+// encodingSplitTap is the live host's behaviour in a fixture: one path serving
+// DIFFERENT bodies per Accept-Encoding, and an immutable per-commit path that
+// cannot. Every mutable-ref hit is counted, so a test can assert the resolver
+// never touched it.
+type encodingSplitTap struct {
+	srv *httptest.Server
+	rec *recorder
+}
+
+func newEncodingSplitTap(t *testing.T, rec *recorder, pinned, identityVariant, gzipVariant, advertisement string) *encodingSplitTap {
+	t.Helper()
+	tap := &encodingSplitTap{rec: rec}
+	tap.srv = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+		switch {
+		case strings.Contains(req.URL.Path, "/info/refs"):
+			rw.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(advertisement))
+		case strings.HasPrefix(req.URL.Path, "/"+tapCommitFixture+"/"):
+			// Immutable by construction: one body, whatever the encoding.
+			serveCask(rw, req, pinned)
+		case strings.HasPrefix(req.URL.Path, "/HEAD/"):
+			// Mutable, and sharded on Accept-Encoding exactly like the CDN.
+			if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+				rw.Header().Set("Content-Encoding", "gzip")
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write(gzipped(gzipVariant))
+				return
+			}
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(identityVariant))
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(tap.srv.Close)
+	return tap
+}
+
+func (t *encodingSplitTap) mutableHits() int { return t.rec.hitsForPathContaining("/HEAD/") }
+
+// checkerFor wires a checker at this tap, taking the releases API and the
+// archive host from an existing world.
+func (t *encodingSplitTap) checkerFor(w *world) *checker {
+	return &checker{
+		caskURL:    t.srv.URL + "/" + caskCommitPlaceholder + "/Casks/civitai.rb",
+		tapRefsURL: t.srv.URL + "/info/refs?service=git-upload-pack",
+		latestURL:  w.api.URL + "/repos/civitai/cli/releases/latest",
+		apiToken:   "fixture-token",
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// TestAStaleVariantCannotHideABrokenCask is the proven failure for this defect,
+// and it is the OUTAGE shape rather than a cosmetic version mismatch.
+//
+// The tap's real HEAD names 0.1.92, whose archives are NOT downloadable — the
+// 2026-08-09 state, the one thing this command exists to detect. The mutable
+// ref still serves 0.1.91 to a gzip client, whose archives are all fine. A
+// checker that reads the mutable ref therefore probes four URLs, gets four
+// 200s, and exits 0 while `brew install` is broken for every user.
+//
+// The variants here reproduce the measured live split exactly — identity
+// CURRENT, gzip a release behind — so this is the incident, not an invented
+// shape. Note what that means for the VERSION assertion specifically: a fix
+// that merely preferred the identity variant would satisfy it, because in this
+// fixture the identity variant happens to be right. It is the next test that
+// removes that safe harbour. (Both mutants die here anyway, on the recorded
+// commit; see the file comment for why the kill sets are identical.)
+func TestAStaleVariantCannotHideABrokenCask(t *testing.T) {
+	// 0.1.91 is downloadable; 0.1.92 is the unpublished draft.
+	w := newWorld(t, "0.1.92", []string{"0.1.90", "0.1.91"}, "v0.1.91")
+	tap := newEncodingSplitTap(t, w.rec,
+		caskFixture("0.1.92", w.releases.URL), // pinned: the truth, and it is broken
+		caskFixture("0.1.92", w.releases.URL), // identity variant: current, as measured
+		caskFixture("0.1.91", w.releases.URL), // gzip variant: a release behind
+		refAdvertisement(tapCommitFixture),
+	)
+
+	rep, err := run(t, tap.checkerFor(w))
+	if err == nil {
+		t.Fatalf("the cask names 0.1.92, whose archives 404, and this run reported CLEAN.\n"+
+			"That is the 2026-08-09 outage passing the detector built for it, because the bytes judged came from a\n"+
+			"stale CDN variant naming the previous, working release. report=%+v", rep)
+	}
+	if !errors.Is(err, errArchivesNotDownloadable) {
+		t.Fatalf("want the archives finding, got %v", err)
+	}
+	// The verdict has to be ABOUT the current cask. A run that went red for
+	// some other reason while still reading 0.1.91 has not fixed anything.
+	if rep == nil || rep.caskVersion != "0.1.92" {
+		t.Fatalf("this run judged cask version %q; the tap's HEAD commit names 0.1.92, and any other value means the mutable ref was read", caskVersionOf(rep))
+	}
+	if tap.mutableHits() != 0 {
+		t.Errorf("the mutable ref was requested %d time(s); it must not be read at all", tap.mutableHits())
+	}
+	if rep.caskCommit != tapCommitFixture {
+		t.Errorf("report records commit %q, want %q — the verdict must say which snapshot it is about", rep.caskCommit, tapCommitFixture)
+	}
+}
+
+// TestNeitherEncodingVariantOfTheMutableRefIsTrusted removes the safe harbour
+// the test above leaves standing.
+//
+// 🔴 BOTH variants are deliberately WRONG here, and that is not an unrealistic
+// fixture — it is the honest one. Which variant is stale is a property of the
+// Fastly edge node that answers, measured to differ between two nodes in the
+// same minute, so there is no variant a checker may trust. A fix that pinned
+// `Accept-Encoding: identity` would read 0.1.90 here and go red on a healthy
+// pipeline, which is the point: preferring a variant is not a fix, it is a
+// different way to be wrong.
+func TestNeitherEncodingVariantOfTheMutableRefIsTrusted(t *testing.T) {
+	w := newWorld(t, "0.1.92", []string{"0.1.92"}, "v0.1.92")
+	tap := newEncodingSplitTap(t, w.rec,
+		caskFixture("0.1.92", w.releases.URL), // pinned: the truth
+		caskFixture("0.1.90", w.releases.URL), // identity variant: stale one way
+		caskFixture("0.1.91", w.releases.URL), // gzip variant: stale another way
+		refAdvertisement(tapCommitFixture),
+	)
+
+	rep, err := run(t, tap.checkerFor(w))
+	if err != nil {
+		t.Fatalf("the tap's HEAD names 0.1.92 and 0.1.92 is downloadable, so this must be green: %v", err)
+	}
+	if rep.caskVersion != "0.1.92" {
+		t.Fatalf("judged cask version %q, want 0.1.92 — %q is what the mutable ref serves, so this run read the cached copy",
+			rep.caskVersion, rep.caskVersion)
+	}
+	if tap.mutableHits() != 0 {
+		t.Errorf("the mutable ref was requested %d time(s); no encoding of it is evidence about the current cask", tap.mutableHits())
+	}
+	// POSITIVE CONTROL on the fixture itself: if the mutable path did not
+	// actually serve two different bodies, this test would pass against a
+	// checker that reads it, and would be proving nothing.
+	idBody, gzBody := fetchVariants(t, tap.srv.URL+"/HEAD/Casks/civitai.rb")
+	if idBody == gzBody {
+		t.Fatal("PREMISE BROKEN: the fixture's mutable path served identical bodies to both encodings, so it does not mirror the CDN and this test cannot fail for the right reason")
+	}
+	for _, b := range []string{idBody, gzBody} {
+		if strings.Contains(b, `version "0.1.92"`) {
+			t.Fatal("PREMISE BROKEN: a mutable variant carries the CURRENT version, so reading it would pass and the test would be satisfied by the defect")
+		}
+	}
+}
+
+// fetchVariants asks one URL both ways, as the two CDN clients do.
+func fetchVariants(t *testing.T, url string) (identity, gzip string) {
+	t.Helper()
+	get := func(ae string) string {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		if ae != "" {
+			req.Header.Set("Accept-Encoding", ae)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", url, err)
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		return string(b)
+	}
+	// "" lets Go's transport add gzip itself, which is the whole point.
+	return get("identity"), get("")
+}
+
+func caskVersionOf(rep *report) string {
+	if rep == nil {
+		return "<no report>"
+	}
+	return rep.caskVersion
+}
+
+// TestTheShippedCaskURLIsPinnedToACommit pins the DEFAULT, because every other
+// test in this package injects its own URLs and so says nothing about what a
+// real run reads. Reverting the default to a mutable ref is the whole defect.
+func TestTheShippedCaskURLIsPinnedToACommit(t *testing.T) {
+	if !strings.Contains(defaultCaskURL, caskCommitPlaceholder) {
+		t.Fatalf("defaultCaskURL = %q, which carries no %s placeholder — a real run would read a mutable ref, which measured a release behind on 2026-08-10",
+			defaultCaskURL, caskCommitPlaceholder)
+	}
+	// A mutable ref segment must not survive alongside the placeholder.
+	for _, mutable := range []string{"/HEAD/", "/main/", "/master/", "/refs/heads/"} {
+		if strings.Contains(defaultCaskURL, mutable) {
+			t.Errorf("defaultCaskURL = %q still names the mutable ref %q", defaultCaskURL, mutable)
+		}
+	}
+	if !strings.HasPrefix(defaultTapRefsURL, "https://") || !strings.Contains(defaultTapRefsURL, "/info/refs") || !strings.Contains(defaultTapRefsURL, "service=git-upload-pack") {
+		t.Errorf("defaultTapRefsURL = %q, want the git smart-HTTP ref advertisement — it is the one tap read that is served with `cache-control: no-cache` and behind no CDN", defaultTapRefsURL)
+	}
+	// Both must name the same repository, or a run pins the cask of one tap to
+	// the HEAD of another and the whole guarantee is void.
+	if !strings.Contains(defaultCaskURL, "civitai/homebrew-tap") || !strings.Contains(defaultTapRefsURL, "civitai/homebrew-tap") {
+		t.Errorf("the cask URL (%q) and the ref URL (%q) must resolve the same repo", defaultCaskURL, defaultTapRefsURL)
+	}
+}
+
+// TestAnUnresolvableTapIsLoudAndNeverFallsBack — "we could not resolve the tap"
+// is the same state as "we could not read the cask": nothing was measured.
+//
+// 🔴 The fallback assertion is the important half. Reading the mutable ref when
+// the lookup fails would be a degraded mode that reintroduces the defect on
+// exactly the days something is wrong, and it would look like resilience.
+func TestAnUnresolvableTapIsLoudAndNeverFallsBack(t *testing.T) {
+	notAnAdvertisement := "<!DOCTYPE html><html><body>404 Not Found</body></html>"
+	emptyRepo := func() string {
+		line := "0000000000000000000000000000000000000000 capabilities^{}\x00multi_ack agent=git/github-fixture\n"
+		return "001e# service=git-upload-pack\n0000" + fmt.Sprintf("%04x%s", len(line)+4, line) + "0000"
+	}()
+
+	for _, tc := range []struct {
+		name string
+		adv  string
+		// refused points the checker at a dead port instead of the fixture.
+		refused bool
+		wantMsg string
+	}{
+		{name: "refs endpoint refused", refused: true, wantMsg: ""},
+		{name: "response is not a ref advertisement", adv: notAnAdvertisement, wantMsg: "not a git ref advertisement"},
+		{name: "advertisement names no HEAD", adv: emptyRepo, wantMsg: "names no HEAD"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newWorld(t, "0.1.92", []string{"0.1.92"}, "v0.1.92")
+			tap := newEncodingSplitTap(t, w.rec,
+				caskFixture("0.1.92", w.releases.URL),
+				caskFixture("0.1.90", w.releases.URL),
+				caskFixture("0.1.91", w.releases.URL),
+				tc.adv,
+			)
+			c := tap.checkerFor(w)
+			if tc.refused {
+				c.tapRefsURL = "http://127.0.0.1:1/info/refs?service=git-upload-pack"
+			}
+
+			_, err := run(t, c)
+			if err == nil {
+				t.Fatal("a tap whose HEAD could not be resolved reported CLEAN — 'we could not ask' must never look like 'we asked and it was fine'")
+			}
+			if !errors.Is(err, errUnreachableTap) {
+				t.Fatalf("want errUnreachableTap, got %v", err)
+			}
+			if got := classify(err); got != kindUnmeasurable {
+				t.Errorf("classify = %q, want %q — a caller keys its wording on this", got, kindUnmeasurable)
+			}
+			if tc.wantMsg != "" && !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("the message does not say what went wrong (want %q):\n%v", tc.wantMsg, err)
+			}
+			if tap.mutableHits() != 0 {
+				t.Errorf("the run fell back to the mutable ref %d time(s) after failing to resolve HEAD; that degraded mode is the defect, wearing resilience as a hat", tap.mutableHits())
+			}
+		})
+	}
+}
+
+// TestAVerbatimCaskURLSkipsTheRefLookup covers the fire drill in
+// release-homebrew.yml, which points -cask-url at a fixture already pinned to a
+// commit sha of THIS repo. Such a URL is immutable already; making it depend on
+// resolving the tap would make the drill fail whenever the tap is unreachable,
+// which is a state the drill is supposed to be able to rehearse.
+func TestAVerbatimCaskURLSkipsTheRefLookup(t *testing.T) {
+	w := newWorld(t, "0.1.92", []string{"0.1.92"}, "v0.1.92")
+	c := w.checker()
+	c.caskURL = w.tap.URL + "/some/pinned/fixture/civitai.rb" // no placeholder
+	c.tapRefsURL = "http://127.0.0.1:1/info/refs"             // must never be reached
+
+	rep, err := run(t, c)
+	if err != nil {
+		t.Fatalf("a verbatim -cask-url must be usable with no tap lookup at all: %v", err)
+	}
+	if n := w.rec.hitsForPathContaining("/info/refs"); n != 0 {
+		t.Errorf("the ref advertisement was requested %d time(s) for a URL carrying no placeholder", n)
+	}
+	if rep.caskCommit != "" {
+		t.Errorf("report records commit %q for a verbatim URL; there is no commit to record", rep.caskCommit)
+	}
+	// 🔴 It must SAY it was unpinned. A verbatim read carries none of the
+	// freshness guarantee the pinned one does, so a run that took this path and
+	// printed nothing about it would be the silent degrade.
+	prov := readProvenance(rep)
+	if !strings.Contains(prov, "verbatim") || !strings.Contains(prov, c.caskURL) {
+		t.Errorf("provenance line = %q, want it to name the URL and say the read was unpinned", prov)
+	}
+	// And the pinned path must say the opposite, or "says which mode" is
+	// satisfied by a constant.
+	pinnedProv := readProvenance(&report{caskURL: "u", caskCommit: tapCommitFixture})
+	if strings.Contains(pinnedProv, "verbatim") || !strings.Contains(pinnedProv, tapCommitFixture) {
+		t.Errorf("pinned provenance line = %q, want it to name the commit and not claim a verbatim read", pinnedProv)
+	}
+}
+
+// TestTheRefAdvertisementParserReadsTheRealShape.
+//
+// 🔴 The pkt-line LENGTH PREFIX is hex and runs straight into the sha
+// (`00000159df4801…`), so an offset-based or greedy parser can read a shifted
+// 40-character window and return a plausible wrong "commit" — which would then
+// 404 at the raw host and read as an unreachable tap forever. Each row is a
+// shape github.com really serves.
+func TestTheRefAdvertisementParserReadsTheRealShape(t *testing.T) {
+	const other = "0123456789abcdef0123456789abcdef01234567"
+
+	pkt := func(s string) string { return fmt.Sprintf("%04x%s", len(s)+4, s) }
+
+	for _, tc := range []struct {
+		name string
+		adv  string
+		want string
+	}{
+		{
+			name: "HEAD first, with capabilities",
+			adv:  refAdvertisement(tapCommitFixture),
+			want: tapCommitFixture,
+		},
+		{
+			name: "a branch literally named HEAD must not be mistaken for it",
+			adv: "001e# service=git-upload-pack\n0000" +
+				pkt(tapCommitFixture+" HEAD\x00symref=HEAD:refs/heads/main\n") +
+				pkt(other+" refs/heads/HEAD\n") + "0000",
+			want: tapCommitFixture,
+		},
+		{
+			name: "HEAD is not the first ref line",
+			adv: "001e# service=git-upload-pack\n0000" +
+				pkt(other+" refs/heads/topic\n") +
+				pkt(tapCommitFixture+" HEAD\n") + "0000",
+			want: tapCommitFixture,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+				_, _ = rw.Write([]byte(tc.adv))
+			}))
+			t.Cleanup(srv.Close)
+			c := &checker{tapRefsURL: srv.URL, client: &http.Client{Timeout: 5 * time.Second}}
+
+			got, err := c.tapCommit(t.Context())
+			if err != nil {
+				t.Fatalf("tapCommit: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolved %q, want %q — a shifted window is a well-formed sha that names no commit", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`tools/caskcheck` read the cask at the **mutable** ref
`raw.githubusercontent.com/civitai/homebrew-tap/HEAD/Casks/civitai.rb`. That host
answers `vary: Authorization,Accept-Encoding` behind Fastly, so the URL is not one
cached object but **one per encoding per edge node** — and Go's `net/http` adds
`Accept-Encoding: gzip` by itself unless the caller sets the header, so this
command always read the gzip variant. The gzip variant was a release behind.

## The measurement

Taken 2026-08-10 ~19:04Z, minutes after v0.1.92 published and the cask was bumped.
`git ls-remote https://github.com/civitai/homebrew-tap HEAD` → `df4801b`, whose
`Casks/civitai.rb` says `0.1.92`:

```
curl -sS  <url>              -> version "0.1.92"   etag  "a2ee…"   x-cache: HIT
curl -sS --compressed <url>  -> version "0.1.91"   etag W/"a4d5…"  x-cache: HIT
go net/http Get(<url>)       -> version "0.1.91"
go run ./tools/caskcheck     -> OK: cask version 0.1.91; 4 archive URL(s) … all publicly downloadable
```

**The expensive direction is not the wrong number in the log.** The cask being
validated was not the cask. If a cask push introduces a *broken* version, a run
reading the previous variant validates the **previous, working** version's archive
URLs and exits 0 — green straight through the outage #308 built this command to
catch. The daily 13:23Z run is less exposed than a manual one only because the cask
usually has not moved in the last few minutes; "usually" is not the property this is
supposed to have, and the moment a human most wants to run it is right after a
release.

## Three mechanisms measured and rejected

Two of these were in the brief as plausible. Both are refuted:

| candidate | measured |
|---|---|
| `Accept-Encoding: identity` | Reads the *other* variant. No evidence it is systematically fresher — staleness is per **edge node**: in the same minute `cache-yyz4539` served the gzip variant a release behind on a HIT while `cache-yyz4528` MISSed and fetched 0.1.92 from the origin. A different lottery ticket, not a fix. |
| cache-busting query param | **No effect.** The raw host does not put the query string in its cache key: `?cb=…` returned the same stale body and the same weak ETag, under both encodings. |
| `Cache-Control: no-cache` (± `Pragma`) | **No effect.** Not honoured here; same stale body, same ETag. |

The GitHub contents API was rejected on a different axis: it is a different surface
from the one `brew` reads, it is rate-limited, and moving the *cask* read toward an
authenticated path is the direction `TestArchiveProbesCarryNoCredential` exists to
prevent.

## The mechanism chosen: don't defeat the cache, remove the mutable object

`-cask-url` now carries a `{commit}` placeholder. A run first resolves the tap's HEAD
over **git's smart-HTTP ref advertisement** — what `git ls-remote` reads:

```
GET https://github.com/civitai/homebrew-tap.git/info/refs?service=git-upload-pack
  server: GitHub-Babel/3.0
  cache-control: no-cache, max-age=0, must-revalidate
  pragma: no-cache
  expires: Fri, 01 Jan 1980 00:00:00 GMT
  (no `via: varnish`, no `x-cache`, no `x-served-by` — no CDN layer at all)
```

then reads the cask at `.../homebrew-tap/<40-hex sha>/Casks/civitai.rb`, whose
content is **immutable by construction**. There is no earlier body for that cache key
to be stale from, so a HIT is correct by definition and every encoding variant agrees
— verified live: both variants of the pinned URL returned `0.1.92`.

This is still exactly what a reader of the tap gets, and still **as a stranger**:
same file, same host, no `Authorization` on either request. The ref lookup is now
covered by `TestArchiveProbesCarryNoCredential` alongside the cask and archive reads.

- Resolution failure is `errUnreachableTap` → kind `unmeasurable`. There is
  deliberately **no fallback** to the mutable ref: a degraded mode there would
  reintroduce the defect on exactly the days something is wrong, while looking like
  resilience. Asserted.
- The resolved commit is printed, so a run says which snapshot it judged.
- A `-cask-url` with no placeholder is used **verbatim** and skips the lookup — that
  is what the fire drill in `release-homebrew.yml` passes, and those fixtures are
  already pinned to a commit sha. All three drill modes re-run unchanged, so
  **that workflow needs no edit** (I stayed out of `.github/workflows/` entirely).
- The overall timeout moved 3m → 4m: the worst case is now four archive probes at 30s
  plus two tap reads at 30s = exactly 180s, and a 3m budget would make a
  slow-but-healthy github.com produce a false red.

## Live before / after

```
BEFORE (origin/main, 19:04Z)  OK: cask version 0.1.91; … all publicly downloadable
                              (tap HEAD df4801b actually said 0.1.92)

AFTER  (this branch, 19:21Z)  OK: cask version 0.1.92; 4 archive URL(s) checked, all publicly downloadable
                              read: https://raw.githubusercontent.com/civitai/homebrew-tap/df4801ba7479cbe1c8d267481705de617a71cc77/Casks/civitai.rb (pinned to tap commit df4801ba…)
                              lag: cask matches the latest published release v0.1.92
                              rc=0
```

🔴 **What I could not re-verify, stated rather than hidden.** The stale window closed
during the investigation: at 19:07Z a `curl --compressed` MISSed on a different Fastly
node (`cache-yyz4528`) and refetched from the origin, after which both variants
returned 0.1.92. So the base binary re-run at 19:21Z now *also* reports 0.1.92 —
**the "before" row above is the 19:04Z measurement and cannot be re-taken on demand.**
What that closure demonstrates is the point of the fix rather than an argument
against it: which variant is stale is a per-edge-node property that changes under you.

## The guard

`tools/caskcheck/stale_variant_test.go`, plus the existing `world` fixture rewired so
**every** test in the package now drives the ref lookup and the pinned read.

The fixture mirrors the host rather than a tidy version of it:

- the mutable `/HEAD/` path serves **different bodies per `Accept-Encoding`**, and the
  gzip one is a real `Content-Encoding: gzip` body so Go's transparent decompression is
  exercised rather than sidestepped;
- the ref advertisement is built with genuine **pkt-line length prefixes**, because the
  4-hex prefix runs straight into the 40-hex sha (`00000159df4801…`) and that adjacency
  is what an offset-based parser gets wrong;
- `TestAStaleVariantCannotHideABrokenCask` is the **outage** shape, not a cosmetic
  version mismatch: the tap's real HEAD names a version whose archives 404 while the
  stale variant names the previous working one, so a checker reading the variant probes
  four URLs, gets four 200s, and exits 0 while `brew install` is broken.

### Mutation battery

Leaf `--- FAIL` lines counted from `go test -v` output, never an exit code. Each
mutation **checksum-gated** (the file's sha256 must change, or the row is reported
`APPLY-FAILED` rather than read as a survivor), with a ≥40-leaf floor so a build
failure — which emits zero `--- FAIL` lines — is reported `BUILD-BROKEN` instead of as
a survivor. Base: **45 `--- PASS`, 0 `--- FAIL`**.

| # | mutation | FAIL leaves |
|---|---|---|
| M1 | revert: resolve nothing, read the mutable ref | **21** |
| M2 | half-fix: mutable ref + `Accept-Encoding: identity` | **21** |
| M3 | degraded mode: fall back to the mutable ref on failure | **4** |
| M4 | shipped default reverted to a `/HEAD/` URL | **1** |
| M5 | parser takes the first 40-hex run (a shifted sha) | **8** |
| M6 | the tap ref lookup starts carrying the credential | **1** |
| M7 | the ref-advertisement instrument check removed | **2** |
| M8 | provenance stops naming the verbatim mode | **1** |
| M0 | **null mutant** (comment only) | **0 — survives** |

🔴 **Two things the battery refuted, recorded because a mutation number nobody
re-ran is just a claim.**

1. **M1 and M2 kill the *identical* 21 leaves.** An earlier draft of the test comment
   claimed one test separated the do-nothing regression from the prefer-a-variant
   half-fix. It does not, and the separation was never needed — both are one defect,
   reading a mutable ref. The comment now says the sets are identical, which is what
   stops someone counting two mutants as two independent pieces of evidence.
2. **The `mutableHits() == 0` assertions are redundancy, not the coverage.**
   Re-measured with all three of them deleted: M1 and M2 still kill the same 21 leaves
   each. They are kept because they state the rule structurally and would catch a
   future "read both and compare" design, but they are labelled so nobody counts them
   as what makes these tests work.

One matcher fix that is **not** cosmetic: `recorder.authFor` was a *prefix* match on
`/Casks/`, and pinning moved the cask request to `/<sha>/Casks/…` — under which the
credential assertion would have selected nothing and passed **vacuously**. It is a
substring match now, with premise assertions that it actually selected something.

## Sibling reads — examined, and left alone deliberately

**`defaultLatestURL` (`api.github.com/.../releases/latest`) — not exposed.** Measured:
`server: github.com` with **no Fastly layer at all** (no `via`, no `x-cache`, no
`x-served-by`, no `source-age`), and the identity and gzip requests returned the *same*
weak ETag `W/"7faf33…"` and the same `last-modified` — i.e. the `vary: Accept-Encoding`
it advertises is not backed by a shared edge cache that could shard the way the raw host
does. Even granting worst-case staleness, its `max-age` is **60s** against a **24h** lag
threshold — 0.07% of the window — and it is diagnostic only: `latestRelease` swallows its
own failure, so it can never turn a healthy pipeline red.

**The archive probes — not exposed, structurally.** The verdict is decided at the
first hop, `github.com/civitai/cli/releases/download/…`, which answers
`cache-control: no-cache` with no CDN in front. Measured on **both** outcomes the
verdict turns on: the `302` for a published asset and the `404` for a version that does
not exist. Only *after* that decisive hop does the redirect reach
`release-assets.githubusercontent.com` (Azure blob behind varnish, `x-cache: MISS, HIT`),
and that URL is per-request signed. `probeArchive` also reads only the status line and
closes the body, so a stale body could not reach the verdict even if one existed.

## Verification

- `make ci` — **19/19 packages `ok`, 0 `--- FAIL`**
- `make lint` (golangci-lint, run separately per `CLAUDE.md`) — **0 issues**
- `make ci-shallow` — **`ok=19/19 failing-tests=0 failing-packages=0 timeouts=0`**
- All three gates re-run on the **merged tree** (rebased onto `ca9c4f4`, which landed
  during this work; its two files are disjoint from these three).
- Live run against the real tap, and all three `release-homebrew.yml` drill modes
  (`broken` → `kind=broken` rc 1, `lagging` → `kind=lagging` rc 1, `unmeasurable` →
  `kind=unmeasurable` rc 1) re-run against the real fixture URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
