### PR TITLE
ci: four required gates could go green having checked nothing — close the class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,48 @@ on:
 permissions:
   contents: read
 
+# ─────────────────────────────────────────────────────────────────────────────
+# VACUOUS GREEN — the shared rationale every positive control below points at.
+#
+# A job here is a merge gate, and a gate that reports success without having
+# checked anything is worse than no gate: it trains everyone to trust it. Every
+# `run:` block in this file that reads a tool's verdict therefore has to answer
+# "could this have gone green without the thing it checks having run?" The three
+# shapes that have actually appeared in this repo:
+#
+#   (1) `go test -run <name>` EXITS 0 WHEN THE PATTERN MATCHES NOTHING.
+#       Measured on this tree:
+#         $ go test -run 'TestThisPatternMatchesNothingAtAll' ./internal/scaffold/
+#         ok  github.com/civitai/cli/internal/scaffold  0.003s [no tests to run]
+#         rc=0
+#       With -v it prints "testing: warning: no tests to run" and a bare `PASS`
+#       — so a control keyed on the word PASS is satisfied by that bystander
+#       line. Every such site here now requires the TEST'S OWN result line,
+#       `--- PASS: <Name>`, anchored to the line start. Renaming the test, moving
+#       the file, or changing the env-var gate its body sits behind then reds the
+#       job instead of silently emptying it.
+#
+#   (2) A TOOL'S SILENCE IS NOT A CLEAN VERDICT. `gofmt -s -l .` over zero files
+#       and `go test ./...` over zero packages both print nothing useful and exit
+#       0, exactly like a clean tree. Those sites carry a count FLOOR (did it
+#       look at our code?) and, where cheap, a NEGATIVE control (can it still go
+#       red at all?).
+#
+#   (3) A `-count=1`-LESS TEST CAN BE REPLAYED FROM GOCACHE, which
+#       `actions/setup-go` with `cache: true` restores across runs. That matters
+#       for the NETWORK guards, whose entire value is the round-trip; see the
+#       measurement at `pins-vs-published`.
+#
+# ERREXIT NOTE, the trap behind #316 and #313: GitHub runs every `run:` block as
+# `bash -e {0}`, so errexit is ON before the first line and `set -uo pipefail`
+# does NOT clear it. Two consequences relied on below. A `cmd | tee log` whose
+# `cmd` fails kills the step AT THE PIPE — which is what we want for a genuine
+# test failure (the test's own output is already in the log), but it means the
+# `::error::` annotation after it only ever prints for the vacuous case it is
+# about. And `n=$(… | grep …)` DIES when grep matches nothing, so every counting
+# grep here ends in `|| true` and is judged by its floor, never by its status.
+# ─────────────────────────────────────────────────────────────────────────────
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -37,8 +79,34 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      # Shape (2): `gofmt -s -l .` prints NOTHING and exits 0 both when every
+      # file is clean AND when it walked zero files, so its silence is not by
+      # itself evidence about this repo. Two controls, closing different halves.
       - name: gofmt
         run: |
+          set -uo pipefail
+
+          # POSITIVE CONTROL — did it look at our code? Measured on this tree:
+          # 340 .go files. The floor is deliberately loose; it exists to catch
+          # "walked the wrong tree / walked nothing", not to track a count.
+          n=$(find . -path ./.git -prune -o -name '*.go' -print 2>/dev/null | wc -l || true)
+          echo "gofmt scope: $n .go file(s) under ."
+          if [ "$n" -lt 100 ]; then
+            echo "::error::gofmt found only $n .go file(s) to check — it is not looking at this repo, so a clean verdict here would be a statement about nothing"
+            exit 1
+          fi
+
+          # NEGATIVE CONTROL — can it still go red? A tool that reports nothing
+          # whatever you feed it is indistinguishable from a clean tree. The
+          # control file lives in RUNNER_TEMP, outside the '.' walk below, so it
+          # cannot contaminate the real verdict.
+          ctl="$RUNNER_TEMP/gofmt-control.go"
+          printf 'package ctl\n\nfunc F(  ) {\n}\n' > "$ctl"
+          if [ -z "$(gofmt -s -l "$ctl" || true)" ]; then
+            echo "::error::gofmt did not flag a deliberately mis-formatted file — the tool is not working, so its silence about this repo means nothing"
+            exit 1
+          fi
+
           unformatted=$(gofmt -s -l .)
           if [ -n "$unformatted" ]; then
             echo "These files are not gofmt-ed:"
@@ -46,8 +114,31 @@ jobs:
             exit 1
           fi
 
+      # Shape (2) again: `go test ./...` is green over ZERO packages, and a
+      # package with no test files reports `?  … [no test files]` — also green.
+      # So the exit code cannot tell "the suite passed" from "the suite did not
+      # run", which is the state a broken build tag, a bad -tags flag or a
+      # mis-scoped pattern produces. Count what actually reported ok.
+      #
+      # `go vet ./...` and `go build ./...` are deliberately left bare: both are
+      # whole-module walks with no name pattern and no silence-means-clean
+      # ambiguity of their own, and the floor below already proves the module
+      # resolves to ~19 real packages in this same job. A third floor would
+      # assert the same fact a third time.
       - name: test
-        run: go test ./...
+        run: |
+          set -uo pipefail
+
+          go test ./... 2>&1 | tee "$RUNNER_TEMP/gotest.log"
+
+          # Measured on this tree: 19 packages report ok, 1 has no test files.
+          # The floor sits below that so ordinary churn does not trip it.
+          ok=$(grep -c '^ok' "$RUNNER_TEMP/gotest.log" || true)
+          echo "packages reporting ok: $ok"
+          if [ "$ok" -lt 15 ]; then
+            echo "::error::only $ok package(s) reported ok — the suite exited 0 without running, so this green is not a claim about the code"
+            exit 1
+          fi
 
       - name: build
         run: go build ./...
@@ -101,7 +192,47 @@ jobs:
       - name: check scaffold pins vs npm latest
         env:
           CIVITAI_CHECK_PUBLISHED_PINS: "1"
-        run: go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -v
+        run: |
+          set -uo pipefail
+
+          # 🔴 `-count=1` IS LOAD-BEARING HERE, NOT HYGIENE — shape (3). Measured
+          # locally, this exact command run twice in a row:
+          #     --- PASS: TestScaffoldPinsSatisfyPublished (0.46s)
+          #     ok  github.com/civitai/cli/internal/scaffold  0.460s
+          #     --- PASS: TestScaffoldPinsSatisfyPublished (0.46s)
+          #     ok  github.com/civitai/cli/internal/scaffold  (cached)
+          # The second run contacted npm ZERO times and replayed the first run's
+          # timing and PASS line verbatim out of GOCACHE — which `setup-go` with
+          # `cache: true` restores across runs, keyed on go.sum. Go's test cache
+          # tracks the env vars a test reads; it does NOT track what npm
+          # published. So the NETWORK half of the scaffold guard — a required
+          # check whose whole value is the round-trip — could report green on a
+          # pin that had already gone stale.
+          #
+          # Note the two devices close DIFFERENT holes and neither substitutes
+          # for the other: a cached result replays the `--- PASS:` line too, so
+          # the control below cannot see a stale cache, and `-count=1` cannot see
+          # a renamed test.
+          go test ./internal/scaffold -run TestScaffoldPinsSatisfyPublished -count=1 -v 2>&1 \
+            | tee "$RUNNER_TEMP/pins.log"
+
+          # POSITIVE CONTROL — shape (1). Require the test's own result line.
+          #
+          # SKIP is accepted here, and ONLY here in this file: this guard skips
+          # by design when npm is unreachable (pins_guard_test.go returns a
+          # t.Skipf rather than false-failing on DNS/timeout/5xx/429). What is
+          # NOT acceptable is neither line appearing, which is what a rename, a
+          # moved file or a changed CIVITAI_CHECK_PUBLISHED_PINS gate produces.
+          if ! grep -Eq -- '^ *--- (PASS|SKIP): TestScaffoldPinsSatisfyPublished( |/|$)' "$RUNNER_TEMP/pins.log"; then
+            echo "::error::the pins guard exited 0 without running TestScaffoldPinsSatisfyPublished — the -run pattern matched no test (renamed? moved? CIVITAI_CHECK_PUBLISHED_PINS gate changed?). A green here would have been a claim about nothing."
+            exit 1
+          fi
+
+          # A skip is a legitimate green, but it is not a statement about the
+          # pins — say so in the run rather than letting the colour imply it.
+          if grep -Eq -- '^ *--- SKIP: TestScaffoldPinsSatisfyPublished' "$RUNNER_TEMP/pins.log"; then
+            echo "::notice title=pins-vs-published::the guard SKIPPED — npm was unreachable, so this green says nothing about whether the scaffold pins still admit npm's published latest. Re-run later."
+          fi
 
   # Guard B for the block->host ready-ack (issue #206) — the RUNTIME half.
   #
@@ -146,7 +277,36 @@ jobs:
       - name: scaffolded ready-ack actually fires
         env:
           CIVITAI_CHECK_SCAFFOLD_RUNTIME: "1"
-        run: go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v
+        run: |
+          set -uo pipefail
+
+          go test ./internal/scaffold -run TestScaffoldedReadyAckActuallyFires -count=1 -v 2>&1 \
+            | tee "$RUNNER_TEMP/ready-ack.log"
+
+          # 🔴 POSITIVE CONTROL — shape (1), and this is the one job in the file
+          # where the consequence is a repeat of #206. `go test -run <name>`
+          # exits 0 when the pattern matches NOTHING, and this test body sits
+          # behind the CIVITAI_CHECK_SCAFFOLD_RUNTIME gate on top of that. So a
+          # renamed test, a moved file, or a changed env-var name turns a
+          # REQUIRED merge gate permanently, silently green — and this is Guard
+          # B, the only check in the repo that proves the handshake FIRES rather
+          # than that the emitter file is present (Guard A cannot: an inverted
+          # `event.source` check passes every static assertion while being
+          # completely inert). Disarming it would remove the last thing standing
+          # between `main` and a page app that never reaches `ready`.
+          #
+          # A SKIP is a FAILURE here, unlike pins-vs-published: there is no
+          # legitimate skip path when the gate env var is set — the test even
+          # t.Fatal()s rather than skipping when node is missing, on purpose.
+          # Requiring PASS specifically is what encodes that.
+          #
+          # Same control as the daily drift runner in bump-scaffold-pins.yml
+          # (#332). Two copies on purpose: they guard two different runners, and
+          # the daily one cannot block a merge.
+          if ! grep -Eq -- '^ *--- PASS: TestScaffoldedReadyAckActuallyFires( |/|$)' "$RUNNER_TEMP/ready-ack.log"; then
+            echo "::error::the ready-ack runtime check exited 0 without running TestScaffoldedReadyAckActuallyFires — the -run pattern matched no test (renamed? moved? CIVITAI_CHECK_SCAFFOLD_RUNTIME gate changed?). A green here would have been a claim about nothing, on the only check that proves the scaffolded handshake actually fires (issue #206)."
+            exit 1
+          fi
 
   # Rot-guard: build the page-vite template. It is the only SDK-free template
   # with a build step, and nothing else in CI builds it — `template-page-money`
@@ -333,7 +493,25 @@ jobs:
       - name: anti-pattern scan (scaffolded app)
         env:
           CIVITAI_ANTIPATTERN_SCAN_DIR: ${{ github.workspace }}/_ci-currency
-        run: go test ./internal/antipattern -run TestScanDirFromEnv -count=1 -v
+        run: |
+          set -uo pipefail
+
+          go test ./internal/antipattern -run TestScanDirFromEnv -count=1 -v 2>&1 \
+            | tee "$RUNNER_TEMP/antipattern.log"
+
+          # POSITIVE CONTROL — shape (1), with a SECOND way in. Besides the
+          # `-run` pattern matching nothing, `TestScanDirFromEnv` SKIPS when
+          # CIVITAI_ANTIPATTERN_SCAN_DIR is EMPTY (so the default `go test ./...`
+          # stays hermetic). So a renamed env key, or a `github.workspace` that
+          # expands to nothing, produces `--- SKIP` at exit 0: the scan never
+          # opens the scaffolded app and this required job goes green anyway.
+          # Requiring PASS rather than PASS-or-SKIP is what makes that visible —
+          # unlike pins-vs-published, this check has no network to be
+          # unreachable and no legitimate reason to skip once CI has set the var.
+          if ! grep -Eq -- '^ *--- PASS: TestScanDirFromEnv( |/|$)' "$RUNNER_TEMP/antipattern.log"; then
+            echo "::error::the anti-pattern scan exited 0 without PASSing TestScanDirFromEnv — either the -run pattern matched no test (renamed? moved?) or the test SKIPPED because CIVITAI_ANTIPATTERN_SCAN_DIR was empty. Either way the scaffolded app was never scanned."
+            exit 1
+          fi
 
       # (b) Build against the LATEST published SDK, not just the pinned caret.
       #     Probe npm first; if the registry is unreachable (network/DNS/5xx/429)
@@ -353,6 +531,33 @@ jobs:
           else
             echo "reachable=false" >> "$GITHUB_OUTPUT"
             echo "::notice title=scaffold-currency::skipped latest-SDK build check — npm registry unreachable (HTTP $code); not a real failure, re-run later"
+          fi
+
+      # 🔴 A GATE IS A PLACE A REQUIRED JOB CAN GO GREEN HAVING DONE NOTHING.
+      # The four steps below are all `if:`-gated on one output of one step. If
+      # that key is ever renamed or misspelled, or the probe step dies before
+      # reaching its `>> "$GITHUB_OUTPUT"` lines, the condition is false for a
+      # reason that has nothing to do with npm: all four SKIP, GitHub paints
+      # them grey, and this required job reports success having run only the
+      # offline anti-pattern scan — permanently, and looking exactly like a
+      # normal npm outage. The skip-on-unreachable contract is deliberate (see
+      # the job header); "skipped because the probe is broken" is not, and
+      # nothing else in the job could tell them apart.
+      #
+      # Assert the probe actually published one of its two verdicts. This does
+      # NOT re-decide reachability — it only refuses the third state.
+      - name: the reachability verdict exists
+        env:
+          REACHABLE: ${{ steps.npmprobe.outputs.reachable }}
+        run: |
+          set -uo pipefail
+          echo "npm reachability verdict: '$REACHABLE'"
+          if [ "$REACHABLE" != "true" ] && [ "$REACHABLE" != "false" ]; then
+            echo "::error::the npm reachability probe published no verdict (got '$REACHABLE'). The four latest-SDK steps are gated on it and would ALL have skipped silently, leaving this required job green having run only the offline anti-pattern scan."
+            exit 1
+          fi
+          if [ "$REACHABLE" != "true" ]; then
+            echo "::notice title=scaffold-currency::the latest-SDK build check did not run this time — npm was unreachable. This job's green is a statement about the offline anti-pattern scan only."
           fi
 
       - name: install (pinned)


### PR DESCRIPTION
## The defect, reproduced

`go test -run <pattern that matches nothing>` exits **0**. Measured by me on this tree:

```
$ go test -run 'TestThisPatternMatchesNothingAtAll' ./internal/scaffold/
ok  	github.com/civitai/cli/internal/scaffold	0.003s [no tests to run]
rc=0
```

With `-v` it prints `testing: warning: no tests to run` and a bare `PASS` — so a control keyed on the word "PASS" is satisfied by that bystander line. The controls added here require the **test's own result line**, `--- PASS: <Name>`, anchored to the start of line.

`ready-ack-runtime` is one of five required status checks on `main` (re-measured today: `["pins-vs-published","scaffold-currency","build-test","ready-ack-runtime","template-page-vite"]`, no rulesets), and per AGENTS item 11 it is **Guard B** — the only check in the repo that proves a scaffolded app's `BLOCK_READY` handshake actually *fires*. Guard A is explicitly documented as unable to. Renaming the test, moving the file, or changing the `CIVITAI_CHECK_SCAFFOLD_RUNTIME` gate its body sits behind turned that gate permanently, silently green.

#332 closed the same shape in `bump-scaffold-pins.yml`'s daily-drift copy. This closes the gate, and then audits the rest of the file for the class rather than the instance.

## Every job in `ci.yml`, with its verdict

| job | required? | verdict |
|---|---|---|
| `build-test` | ✅ | **2 holes fixed** — `gofmt` and `go test ./...` silence |
| `lint` | — | fine, measured |
| `schema-drift` | — | fine, measured |
| `pins-vs-published` | ✅ | **2 holes fixed** — `-run` floor **and a GOCACHE replay** |
| `ready-ack-runtime` | ✅ | **1 hole fixed** — the headline defect |
| `template-page-vite` | ✅ | fine, measured — already the best-controlled step in the file |
| `template-page-money` | — | fine, measured |
| `scaffold-currency` | ✅ | **2 holes fixed** — `-run`/SKIP floor, and four `if:`-gated steps |

### Findings

**1. `ready-ack-runtime` — `-run` matches nothing → permanent silent green.** Fixed with #332's approach (`tee` to a log, then require `--- PASS: TestScaffoldedReadyAckActuallyFires`). A `SKIP` is a **failure** here, unlike `pins-vs-published`: there is no legitimate skip path once the gate env var is set — the test even `t.Fatal()`s rather than skipping when node is missing, on purpose. Requiring `PASS` specifically is what encodes that.

**2. `pins-vs-published` — same `-run` hole, plus a second one I did not expect: no `-count=1`, so the network guard is served from GOCACHE.** Measured, two consecutive runs of the *exact* CI command:

```
--- PASS: TestScaffoldPinsSatisfyPublished (0.46s)
ok  	github.com/civitai/cli/internal/scaffold	0.460s
--- PASS: TestScaffoldPinsSatisfyPublished (0.46s)
ok  	github.com/civitai/cli/internal/scaffold	(cached)
```

The second run contacted npm **zero** times and replayed the first run's timing *and its `--- PASS:` line* out of the build cache — which `actions/setup-go` with `cache: true` restores across runs, keyed on `go.sum`. Go's test cache tracks the env vars a test reads; it does not track what npm published. So the *network* half of the scaffold guard — a required check whose entire value is the round-trip — could report green on a pin that had already gone stale. **The two devices close different holes and neither substitutes for the other**: a cached result replays the PASS line, so the control cannot see a stale cache; and `-count=1` cannot see a renamed test. Both are now present.

A `SKIP` **is** accepted here and only here — `pins_guard_test.go` skips by design when npm is unreachable — but the run now emits a `::notice` saying so, because a skip is a legitimate green that is not a statement about the pins.

**3. `scaffold-currency` — two independent holes.**
- `go test ./internal/antipattern -run TestScanDirFromEnv` has the same `-run` hole, **plus** `TestScanDirFromEnv` skips when `CIVITAI_ANTIPATTERN_SCAN_DIR` is empty. A renamed env key, or a `github.workspace` expanding to nothing, produced `--- SKIP` at exit 0: the scaffolded app was never scanned and the required job went green. Fixed by requiring `--- PASS:` (not PASS-or-SKIP).
- **Four steps are `if:`-gated on one output of one step.** If that key is renamed/misspelled, or the probe dies before its `>> "$GITHUB_OUTPUT"` lines, the condition is false for a reason unrelated to npm: all four skip, GitHub paints them grey, and the job reports success having run only the offline scan — permanently, and looking exactly like a normal npm outage, which nothing else in the job could distinguish. A new `the reachability verdict exists` step refuses the third state (neither `true` nor `false`). It does **not** re-decide reachability; a real outage still skips and stays green, now with a `::notice` saying what the green covers.

**4. `build-test` — silence is not a clean verdict.**
- `gofmt -s -l .` prints nothing and exits 0 both when the tree is clean and when it walked zero files. AGENTS.md documents this exact trap; the job had no defence. Two controls: a **file-count floor** (measured: 340 `.go` files; floor 100 — it catches "walked the wrong tree", not a count), and a **negative control** — a deliberately mis-formatted file in `RUNNER_TEMP` that `gofmt` must flag before its silence about the repo is believed.
- `go test ./...` is green over zero packages, and `? … [no test files]` is also green. Added an `ok`-package floor (measured: 19 ok, 1 no-test-files; floor 15).
- `go vet ./...` and `go build ./...` are deliberately left bare, and this is stated in the file: both are whole-module walks with no name pattern, and the `test` floor already proves the module resolves to ~19 real packages *in the same job*. A third floor would assert the same fact a third time.

### The four jobs I did **not** change, and why — each verified by feeding it its own vacuous state, not by reading it

- **`template-page-vite`** — the bundle step already carries a JS-file floor and a positive control. I drove the **real step body** (extracted from `ci.yml`) against four hand-built `dist/` trees: ack present → `rc=0`; ack missing (the real #206 defect) → `rc=1`; no JS emitted → `rc=1` via the floor; positive control absent → `rc=1`. All four as intended. Genuinely controlled.
- **`schema-drift`** — fails **closed** in every vacuous state I could construct, measured against the real script: canonical URL 404s → `rc=1`; URL serves valid-but-wrong JSON → `rc=1`; URL serves an **empty body** → `rc=1` (caught by the diff, not by `jq empty`); the vendored copy is missing → `rc=1`. Baseline against the live URL → `rc=0`, `OK: vendored schema matches the canonical`.
- **`lint`** — `golangci-lint` v2.12.2 (the pinned CI version) over a directory with zero Go files exits **7**, not 0, so a mis-scoped run cannot read as clean. Stated residual: a `.golangci.yml` that disabled every linter would still be green — but that is a visible config diff and a deliberate act, not silent rot.
- **`template-page-money`** — `npm test` is `vitest run`, and `passWithNoTests` is not set. Measured in a scratch project: `vitest run` with zero test files exits **1** (`No test files found, exiting with code 1`). Fails closed. (My first measurement of this reported `rc=0` because I piped to `tail` and read `tail`'s status — the exact `cmd | head; echo rc=$?` trap AGENTS.md warns about. Re-measured without the pipe.)

## Proving the fixes red

Each fix was proven by applying the mutation that produces the vacuous state, then running the **real step body extracted from `ci.yml`** (never hand-copied) under GitHub's own execution model — `bash -e` with the step's `env:` — against **both** `origin/main`'s version of that step and this branch's. The claim is the pair: **base green, head red**. A head-red alone would not show the fix is what caught it.

Every mutation is checksum-gated (`sha256` before/after; the harness `exit 9`s if the edit did not apply, so a failed edit cannot read as a survivor). Re-run in full on the rebased/merged tree.

| # | mutation | base rc | head rc | |
|---|---|---|---|---|
| M1 | rename `TestScaffoldedReadyAckActuallyFires` | 0 | **1** | ✅ |
| M1b | rename the `CIVITAI_CHECK_SCAFFOLD_RUNTIME` gate → test SKIPs | 0 | **1** | ✅ |
| M2 | rename `TestScaffoldPinsSatisfyPublished` | 0 | **1** | ✅ |
| M2b | force the pins guard to SKIP (npm unreachable) | — | **0** | ✅ legitimate skip stays green, `::notice` emitted |
| M3 | rename `TestScanDirFromEnv` | 0 | **1** | ✅ |
| M3b | rename the env-var gate the antipattern test reads → SKIP | 0 | **1** | ✅ |
| M4a | `gofmt` step over an empty tree (mis-scoped checkout) | 0 | **1** | ✅ floor |
| M4b | `gofmt` shimmed on `PATH` to always exit 0 silently | 0 | **1** | ✅ negative control |
| M5 | `go test ./...` over a module with 0 tested packages | 0 | **1** | ✅ floor |
| M6 | the reachability output is empty/unwritten | 0 (no such step on `main`) | **1** | ✅ |
| — | **null mutant** (comment text only) | — | **0** | ✅ survives, as it must |

Each red row was also confirmed to fail with **this control's own `::error::` message**, not some other guard's — e.g. M1 prints `the ready-ack runtime check exited 0 without running TestScaffoldedReadyAckActuallyFires …`, M4a prints `gofmt found only 0 .go file(s) to check …`, M4b prints `gofmt did not flag a deliberately mis-formatted file …`. And the unmutated baseline of every changed step is green, so none of these is a build that simply refuses everything.

Two rows initially read `⚠️ base already red` and one read `❌ survivor`. **Both were harness bugs, not fix bugs**, and both are worth recording:
- The harness re-exported the step's own `env:` without expanding `${{ github.workspace }}` / `${{ steps.npmprobe.outputs.reachable }}`, so the literal `${{ … }}` text overrode it and the rows failed on an `lstat` error rather than on the branch under test — an empty-result mechanism confusion. Fixed by substituting the expressions; rows then came out clean.
- M2b's first mutation was `if true {`, which left `os` imported and unused, so the row went red on a **compile error** rather than on the skip path. Re-mutated to `… != "1" || true` and it came out green as designed.

## Validation

- `actionlint` 1.7.12 on `ci.yml`: **rc=0**. Negative-controlled first against a deliberately broken workflow — it reported an undefined `steps.*` reference and four shellcheck findings, `rc=1`, so its clean verdict is not the verdict of a linter that cannot fail.
- `make ci`: **rc=0**, 19 packages `ok`, 0 `--- FAIL`, 0 timeout panics (counted from output, not read off an exit code).
- `make lint` under `nix-shell -p golangci-lint`: **rc=0**, `0 issues.`
- `make ci-shallow`: **rc=0**, `ok=19/19 failing-tests=0 failing-packages=0 timeouts=0`.
- Rebased onto `d684dc1` (main moved 4 commits mid-work; no overlap with `ci.yml`) and **every measurement above re-run on that merged tree**.

### Bystander-immunity of the control regexes

"Cannot be satisfied by a bystander" was checked against the exact regex, on lines a real `go test -v` run emits — 10/10 as intended:

| line | verdict |
|---|---|
| `--- PASS: TestScanDirFromEnv (0.00s)` | match ✅ |
| `    --- PASS: TestScanDirFromEnv/sub (0.00s)` | match ✅ |
| bare `PASS` (what the no-tests-to-run case prints) | no match ✅ |
| `ok  …/internal/antipattern  0.002s [no tests to run]` | no match ✅ |
| `--- PASS: TestScanDirFromEnvExtra (0.00s)` (longer sibling) | no match ✅ |
| `--- PASS: TestScanDirFromEnvironment (0.00s)` | no match ✅ |
| the name inside a `t.Logf` line | no match ✅ |
| the name inside **this control's own `::error::` text** | no match ✅ |
| `--- SKIP: …` / `--- FAIL: …` | no match ✅ |

## Verified on a real runner

Run [31425206914](https://github.com/civitai/cli/actions/runs/31425206914): **8/8 jobs success**, 12/12 checks terminal, 0 failing. All five required contexts green. And the controls did not merely sit there — they printed their own numbers:

```
build-test        / gofmt   gofmt scope: 343 .go file(s) under .
build-test        / test    packages reporting ok: 19
scaffold-currency         npm reachability verdict: 'true'
ready-ack-runtime         --- PASS: TestScaffoldedReadyAckActuallyFires (0.95s)
pins-vs-published         --- PASS: TestScaffoldPinsSatisfyPublished (0.99s)
scaffold-currency         --- PASS: TestScanDirFromEnv (0.01s)
```

And `-count=1` did its job on the runner: `pins-vs-published` reported `ok …/internal/scaffold 0.992s`, **not** `(cached)`.

Zero `::error::` annotations were emitted. (`grep -c '::error::'` over the run log says **11** — every one of them is GitHub echoing the `echo "::error::…"` source line of a `run:` block, confirmed by reading all 11, not by trusting the count.)

## What I could not verify

- **The red paths have not been observed on a real runner**, only locally. The green path now has runner evidence (above); the mutated/red path is proven only under the local `bash -e` replication. Deliberately not pushed — reddening a required gate to demonstrate it is not worth the noise, and the local replication drives the same extracted bytes.
- **`schema-drift` and `pins-vs-published` were exercised against the live network as it is today.** Their skip/fail behaviour under a real npm or civitai.com outage is reasoned from the code, not observed.
- **The `-lt 100` and `-lt 15` floors are judgement calls**, set below today's measured 340 and 19. They are sized to catch "walked nothing / ran nothing", not to track a count, and are documented as such in the file so nobody later reads them as assertions about the repo's size.

## Notes

- Reasoning lives in `ci.yml`'s own comments, per the brief — `AGENTS.md` and `claudedocs/decisions/*` untouched. One shared rationale block near the top names the three shapes; each site points at it rather than restating it.
- `tools/caskcheck/` untouched. No release workflow touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
