### PR TITLE
chore(release): the tag-time job no longer carries a key to the tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,21 +95,37 @@ jobs:
         with:
           version: "~> v2"
           args: release --clean
+        # 🔴 THIS JOB HOLDS EXACTLY ONE CREDENTIAL, AND IT CANNOT WRITE TO THE
+        # TAP. `HOMEBREW_TAP_GITHUB_TOKEN` used to be here beside GITHUB_TOKEN;
+        # #319 removed it once a real release had gone out under #308's flow,
+        # where this run only RENDERS the cask and `release-homebrew.yml`
+        # pushes it on `release: published`. Nothing in this job can now reach
+        # `civitai/homebrew-tap`.
+        #
+        # Why dropping it is safe, read out of goreleaser v2.17.1's source
+        # rather than inferred from a green run — both halves of the cask pipe
+        # are token-free while `skip_upload: true` stands:
+        #   - render: internal/pipe/cask/cask.go `doRun` hands the repository
+        #     to client.TemplateRef, and internal/client/config.go returns
+        #     `Token: ref.Token` UNTEMPLATED — so the `{{ .Env.… }}` string in
+        #     .goreleaser.yaml is never resolved on this path;
+        #   - publish: `doPublish` returns `pipe.Skip("brew.skip_upload is
+        #     set")` on its FIRST statement, well above the one call that does
+        #     resolve it (client.NewIfToken → tmpl.ApplySingleEnvOnly).
+        #
+        # 🔴 A LOCAL SNAPSHOT CANNOT CONFIRM THIS, so do not treat one as
+        # evidence: `--snapshot` never runs the publish pipe at all, so it
+        # exercises only the first bullet. The second is a source reading, and
+        # the first release cut after this change is what tests it.
+        #
+        # 🔴 RE-ADD IT IF `skip_upload` EVER GOES AWAY. Deleting that line is
+        # already forbidden — it restores the 2026-08-09 outage, see
+        # .goreleaser.yaml — but were it deleted, `doPublish` would reach
+        # ApplySingleEnvOnly on a variable this job no longer sets and the
+        # release would die on a `missingkey=error` template failure.
         env:
           # Used to create the release on this repo. Provided automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # 🔴 THIS RUN NO LONGER WRITES TO THE TAP. `release-homebrew.yml`
-          # does, after the release is published (see `skip_upload` in
-          # .goreleaser.yaml). It is kept here deliberately rather than removed:
-          # two independent lines of evidence say the render path never reads it
-          # — goreleaser v2.17.1's TemplateRef (internal/client/config.go:50)
-          # copies `Token` through UNRESOLVED, and a local
-          # `goreleaser release --snapshot` renders the cask fine with the
-          # variable unset — but neither is a real non-snapshot `release` run,
-          # and a wrong guess here fails a release rather than a test. Dropping
-          # it (so the tag-time run holds no tap-write credential at all) is a
-          # good follow-up; verify it on a real release, not on a reading.
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       # The cask goreleaser just rendered, carried to the publish-time workflow.
       #

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -113,6 +113,23 @@ homebrew_casks:
     repository:
       owner: civitai
       name: homebrew-tap
+      # 🔴 THIS TEMPLATE IS DELIBERATELY DANGLING, AND MUST STAY THAT WAY.
+      # #319 removed HOMEBREW_TAP_GITHUB_TOKEN from release.yml's goreleaser
+      # step, so the variable is NOT set when this config is read. That is
+      # inert, not broken: `skip_upload: true` above makes doPublish return on
+      # its first statement, and the render path (doRun → client.TemplateRef)
+      # copies `token` through UNTEMPLATED — the only code that resolves it is
+      # client.NewIfToken, reached from doPublish AFTER the skip. Verified in
+      # goreleaser v2.17.1 source, not inferred from a green snapshot: a
+      # snapshot run skips publishing entirely and so cannot tell the two
+      # apart.
+      #
+      # The line stays because it names the credential the tap push actually
+      # uses — `release-homebrew.yml` reads the same secret directly — and
+      # because it is the tripwire: anyone deleting `skip_upload` (which
+      # restores the 2026-08-09 outage) gets a loud template error on the next
+      # release instead of a silent fallback to this repo's GITHUB_TOKEN, which
+      # has no write access to civitai/homebrew-tap.
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/civitai/cli"
     description: "Civitai CLI — author and ship Apps"

--- a/README.md
+++ b/README.md
@@ -2330,8 +2330,10 @@ This cross-compiles for linux/darwin/windows × amd64/arm64, stamps
 version/commit/date, and creates a **draft** GitHub Release with archives +
 `checksums.txt`. It also *renders* the Homebrew cask and attaches it to the
 release, but does not push it to the tap — see below. See
-[`AGENTS.md`](AGENTS.md) for the full process and the secrets it needs
-(`HOMEBREW_TAP_GITHUB_TOKEN`).
+[`AGENTS.md`](AGENTS.md) for the full process. The tap-write secret
+(`HOMEBREW_TAP_GITHUB_TOKEN`) belongs to
+`.github/workflows/release-homebrew.yml`, which runs at *publish* time; the
+tag-time run holds no credential that can write to the tap.
 
 🔴 **There are three publication channels, and clicking "Publish release" fires
 the other two.** `.github/workflows/release-npm.yml` publishes the `npm/`


### PR DESCRIPTION
Closes #319.

## What changed

`.github/workflows/release.yml` — the goreleaser step's `env:` no longer sets `HOMEBREW_TAP_GITHUB_TOKEN`. `secrets.GITHUB_TOKEN` is now the **only** secret referenced anywhere in that workflow (`grep -o 'secrets\.[A-Z_]*' .github/workflows/release.yml | sort -u` → one line).

`.goreleaser.yaml` — comment only, no behaviour change. The `token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"` line **stays**, now documented as deliberately dangling (see "Why the token line stays" below).

`README.md` — the Releasing section said the tag-time run needs `HOMEBREW_TAP_GITHUB_TOKEN`. It doesn't any more; the secret now belongs to `release-homebrew.yml` at publish time.

## The precondition #319 deferred on, re-verified

#319 said "do this only after a real release has succeeded under the new flow". Checked directly, not taken on report:

| Claim | How | Result |
| --- | --- | --- |
| #308 merged | `gh pr view 308 --json mergedAt` | `2026-08-10T03:33:06Z`, `MERGED` |
| a real release went out under the new flow | `gh release view v0.1.92 --json publishedAt,isDraft` | published `2026-08-10T19:02:40Z`, `isDraft: false` |
| the publish-time tap push ran and succeeded | `gh run list --workflow=release-homebrew.yml --json ...` | `v0.1.92`, event `release`, `success`, created `19:02:42Z` |
| the tap actually moved | **unauthenticated** `curl https://raw.githubusercontent.com/civitai/homebrew-tap/main/Casks/civitai.rb` (no token, HTTP 200) | `version "0.1.92"` |

## Why it is safe to drop — a source reading, not a green run

Both halves of goreleaser's cask pipe are token-free while `skip_upload: true` stands. Read out of **v2.17.1** (the version `version: "~> v2"` currently resolves to, and the same version used for the checks below):

- **render** — `doRun` (`internal/pipe/cask/cask.go`) hands the repository to `client.TemplateRef`, which returns `Token: ref.Token` **untemplated** (`internal/client/config.go`). The `{{ .Env.… }}` string is never resolved on this path.
- **publish** — `doPublish` returns `pipe.Skip("brew.skip_upload is set")` on its **first statement**, above the only call that resolves the token (`client.NewIfToken` → `tmpl.ApplySingleEnvOnly`, which is the `missingkey=error` template).

## What I ran, and what each does *not* show

- `goreleaser check` with the variable unset → "1 configuration file(s) validated". Shows the config still **parses**. Says nothing about a release.
- `goreleaser release --snapshot --clean` with the variable explicitly unset → cask rendered to `dist/homebrew/Casks/civitai.rb`, rc 0. **This proves only the first bullet above.** `--snapshot` never runs the publish pipe at all, so it cannot distinguish "publish skips before reading the token" from "publish would fail" — exactly the trap #319 called out. It is not evidence for this change.

## 🔴 The honest residual

**v0.1.92 succeeded with the token still present.** Removing it is validated by the **next** release, not by anything in this PR. No test here can exercise a non-snapshot goreleaser publish run, and none is added that pretends to. After the next release, confirm `release-homebrew.yml` still succeeds and the tap cask names the new version.

## Why the token line stays in `.goreleaser.yaml`

Deleting it too would look tidier and is worse. With the line present and the variable unset, anyone who deletes `skip_upload` (already forbidden — it restores the 2026-08-09 outage) gets a loud `missingkey=error` failure on the next release. With the line deleted, `client.NewIfToken` falls back to the default client, i.e. this repo's `GITHUB_TOKEN`, which has no write access to `civitai/homebrew-tap` — a quieter failure at a worse moment. The line also documents which credential the tap push actually uses.

## Every consumer of the secret, before and after

| Location | Before | After |
| --- | --- | --- |
| `.github/workflows/release.yml` (goreleaser step env) | set from `secrets.HOMEBREW_TAP_GITHUB_TOKEN` | **removed** |
| `.github/workflows/release-homebrew.yml:197` (`TAP_TOKEN`) | set from `secrets.HOMEBREW_TAP_GITHUB_TOKEN` | unchanged — gets its own credential independently, and fails closed on line 202 if it is unset |
| `.goreleaser.yaml` (`repository.token` template) | `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}` | unchanged (now dangling by design) |
| `release-homebrew.yml:530,553`, `tools/caskcheck/main.go:499`, `README.md:2394` | prose naming the secret in failure guidance | unchanged and still correct |

## Gates

| Gate | Result |
| --- | --- |
| `make ci` | rc 0 — 19 packages `ok`, `--- FAIL` = **0**, `^FAIL` = **0**, `grep -c 'build failed'` = **0** |
| `go test ./... -count=1 -v` | `=== RUN` = **3396**, `--- PASS` = **3392**, `--- FAIL` = **0**, `--- SKIP` = 4, `panic: test timed out` = 0 |
| `make lint` (golangci-lint **2.12.2**, the CI pin, via `nix-shell -p golangci-lint`) | rc 0 — **0 issues** |

Lint's zero is a validated zero: a planted `ineffassign` + `unused` file made it report `2 issues` and exit 2, and was removed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
