### PR TITLE
docs(readme): document CIVITAI_DEVTUNNEL_DEBUG as a debug-only escape hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,33 @@ most authors pass none of these:
 > you Ctrl-C out of it you also lose the embeddability warnings, which is why
 > they are printed once *before* the wait as well as again after it.
 
+**`CIVITAI_DEVTUNNEL_DEBUG` — a debug-only escape hatch.** ⚠️ Not supported
+surface: it is a diagnostic for *this* CLI's tunnel plumbing, and its output
+format, its trigger and its existence may change or be removed in any release.
+Don't build anything on it.
+
+Set it to **any non-empty value** before running `civitai app dev-tunnel` and
+the tunnel writes one extra `[debug]` line to **stderr for each inbound
+connection** the sish endpoint forwards — naming the address/port and *origin*
+address/port sish stamped on that SSH channel, the subdomain label the CLI
+bound, and whether Go's `x/crypto/ssh` built-in listener would have **rejected**
+the channel. That last field is the point: the built-in listener parses the
+origin as an IP address and sish sends a hostname, which is why this CLI accepts
+every forwarded channel itself rather than using `client.Listen`. Reach for it
+when the tunnel reports ready and the public URL still `502`s — it tells you
+whether requests are arriving at the CLI at all, and what they look like when
+they do.
+
+```bash
+CIVITAI_DEVTUNNEL_DEBUG=1 civitai app dev-tunnel
+```
+
+It is **output only** — nothing about how the tunnel behaves changes. The value
+is never parsed, so `CIVITAI_DEVTUNNEL_DEBUG=0` and `=false` switch it *on* just
+like `=1`; leaving it **unset** is the only way to switch it off. It is read once
+as the tunnel is established, and prints nothing until traffic actually arrives,
+so a tunnel nobody has loaded stays as quiet as it was before.
+
 ### Examples
 
 Two real example manifests live under [`examples/`](examples/) (copied from the
@@ -2137,10 +2164,18 @@ is attached.
 | dev-tunnel SSH endpoint | — | `CIVITAI_DEV_TUNNEL_ENDPOINT` | `sish.civitai.com:2224` |
 | Disable colour | — | `NO_COLOR`, `CIVITAI_NO_COLOR` | unset |
 | Force colour | — | `CLICOLOR_FORCE`, `CIVITAI_COLOR` | unset |
+| ⚠️ dev-tunnel channel debug log — **debug only, not supported surface** | — | `CIVITAI_DEVTUNNEL_DEBUG` | unset (no debug output) |
 
 Where a setting also has a flag — `--token`, `--tunnel-endpoint`, and the colour
 and update-check flags — the flag wins over the environment. See
 [Global flags](#global-flags) for the full colour precedence.
+
+Everything in this table except the last row is supported surface.
+`CIVITAI_DEVTUNNEL_DEBUG` is listed only so it is findable: it is a diagnostic
+for the `app dev-tunnel` plumbing, any non-empty value turns it on, and its
+output and its existence may change or be removed in any release. See
+[Preview in the real host](#preview-in-the-real-host-app-dev-tunnel) for what it
+actually prints.
 
 Config lives at `~/.config/civitai/config.yaml` (honours `XDG_CONFIG_HOME`),
 written owner-readable only.


### PR DESCRIPTION
Closes #321.

Docs only — no code change.

## The decision

`CIVITAI_DEVTUNNEL_DEBUG` is read in production code (`internal/devtunnel/ssh_dialer.go`) and appeared nowhere in the README. #321 asked whether it is supported surface. **It is not** — it is a diagnostic for this CLI's own tunnel plumbing, and promising stability for it costs more than it is worth. So it is documented as a **debug-only escape hatch**, labelled as such in both places it now appears.

## What it actually does — read out of the code, not inferred from the name

`internal/devtunnel/ssh_dialer.go`:

- read **once**, as the tunnel is established (`debug: os.Getenv(devTunnelDebugEnv) != ""` when the `sshTunnel` is built), not per connection;
- when on, `serve()` writes **one extra `[debug]` line per inbound `forwarded-tcpip` channel** to the dialer's log writer, which is `cmd.ErrOrStderr()` — **stderr**;
- that line names the `Addr`/`Port` and `OriginAddr`/`OriginPort` sish stamped on the channel, the subdomain label the CLI bound, and **whether `x/crypto/ssh`'s built-in `client.Listen` handler would have rejected it**. That last field is the whole point: the built-in handler runs `netip.ParseAddr` on the origin and sish sends a hostname, which is the historical cause of the 502s this CLI works around by accepting every forwarded channel itself;
- there is a second form for the case where the payload will not unmarshal ("could not parse ExtraData … accepting anyway");
- **output only** — no behavioural branch anywhere else reads `t.debug`;
- the value is **never parsed** (`!= ""`), so `=0` and `=false` switch it **on**. Unsetting is the only way off. That is a real trap and it is documented rather than smoothed over;
- silent until traffic arrives — an unloaded tunnel prints nothing.

Only `civitai app dev-tunnel` reaches this code (`NewSSHDialer` has one production caller, `internal/cmd/app_dev_tunnel.go:391`).

## Where it went

**Two places, because there are two ways someone arrives at it:**

1. **`### Preview in the real host (app dev-tunnel)`** — the full description: what it prints, why the rejection field matters, the `=0` trap, and when to reach for it (tunnel reports ready, public URL still 502s). Someone debugging a tunnel is already in this section.
2. **`## Configuration`** — one table row, prefixed ⚠️ and marked "debug only, not supported surface", plus a sentence under the table stating that every other row *is* supported surface and linking to (1). Someone scanning for env vars looks here and would otherwise conclude it does not exist.

## Gates

Full suite, not a spot check — README claims in this repo are asserted by tests (43 test names matching `README` ran).

| Gate | Result |
| --- | --- |
| `make ci` | rc 0 — 19 packages `ok`, `--- FAIL` = **0**, `^FAIL` = **0**, `grep -c 'build failed'` = **0** |
| `go test ./... -count=1 -v` | `=== RUN` = **3396**, `--- PASS` = **3392**, `--- FAIL` = **0**, `--- SKIP` = 4, `panic: test timed out` = 0 |
| `make lint` (golangci-lint **2.12.2**, the CI pin, via `nix-shell -p golangci-lint`) | rc 0 — **0 issues** |

Those greens are validated, not assumed:

- **README guard, negative control** — the new cross-reference anchor was mutated to a non-existent heading and `TestREADMEAnchorLinksResolve` went red naming it: `README anchor link(s) point at no heading: [preview-in-the-real-host-app-dev-tunnelZZZ]`. So the guard does see this PR's link, and the anchor spelling matches the one the TOC and the command table already use. README restored and re-run green before commit.
- **Lint, negative control** — a planted `ineffassign` + `unused` file made `make lint` report `2 issues` and exit 2. Removed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
