### PR TITLE
test(validate): three guards that could not fail — #301, #302 and #309

### DIFF
--- a/internal/validate/finding_contract_test.go
+++ b/internal/validate/finding_contract_test.go
@@ -693,6 +693,60 @@ func TestDedupeFindingsKeysOnTheFieldMessagePAIR(t *testing.T) {
 	}
 }
 
+// TestDedupeFindingsKeepsEveryFindingAfterADuplicate pins the LOOP CONTROL,
+// which the test above does not and structurally cannot.
+//
+// 🔴 ISSUE #301, A SURVIVING MUTANT: `continue` -> `break` in dedupeFindings
+// survives the whole suite. TestDedupeFindingsKeysOnTheFieldMessagePAIR pins the
+// KEY — which pairs collapse — and every fixture it uses either holds no
+// duplicate at all or holds nothing AFTER the duplicate, which is exactly the
+// shape that renders `continue` and `break` indistinguishable.
+//
+// The mutant is not abstract. `Dir` SORTS before it dedupes (validate.go), so
+// duplicates are adjacent and one duplicated pair early in the sorted order
+// truncates the entire remainder: `app validate` prints a SUBSET of the real
+// findings with the same exit code and the same `--json` shape, the author fixes
+// what they were shown, re-runs, and meets a set of errors nothing ever told them
+// about. So the fixture is ordered unique / duplicate-of-1 / more uniques, and
+// the assertion is that everything past the duplicate survives.
+func TestDedupeFindingsKeepsEveryFindingAfterADuplicate(t *testing.T) {
+	dup := Finding{Field: "iframe.minHeight", Message: "iframe.minHeight is required"}
+	in := []Finding{
+		dup,
+		dup, // the duplicate: it must be SKIPPED, never end the loop
+		{Field: "page.buzzBudgetPerGen", Message: "page.buzzBudgetPerGen is not set"},
+		{Field: "targets[0].slotId", Message: "unknown slotId"},
+		{Field: FieldProject, Message: "no lockfile is committed"},
+	}
+	want := []Finding{in[0], in[2], in[3], in[4]}
+
+	got := dedupeFindings(in)
+	if len(got) != len(want) {
+		t.Fatalf("dedupeFindings kept %d of %d distinct findings — a duplicate must SKIP that one entry, never "+
+			"STOP the loop, or every finding after the first duplicate is silently dropped and `app validate` "+
+			"reports a subset with an unchanged exit code (issue #301)\n got: %v\nwant: %v",
+			len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("dedupeFindings()[%d] = %v, want %v — order must be first-occurrence order", i, got[i], want[i])
+		}
+	}
+
+	// A duplicate in the MIDDLE of a long run, so the assertion above cannot be
+	// satisfied by a loop that merely happens to survive one early pair.
+	late := []Finding{
+		{Field: "blockId", Message: "blockId is required"},
+		{Field: "version", Message: "version is required"},
+		dup,
+		dup,
+		{Field: "name", Message: "name is required"},
+	}
+	if got := dedupeFindings(late); len(got) != 4 {
+		t.Errorf("a duplicate at index 3 dropped the findings after it: kept %d of 4: %v", len(got), got)
+	}
+}
+
 // TestMessagesPreservesOrderAndText pins the text seam: the human-readable
 // renderers print Message and nothing else, so Messages must be a pure
 // projection. If this ever needed to compose Field into the line, the byte-for-

--- a/internal/validate/readyack.go
+++ b/internal/validate/readyack.go
@@ -404,6 +404,29 @@ type ackScanner struct {
 	partial bool
 }
 
+// walk descends dir, stopping at the first ack and at the first thing it cannot
+// read.
+//
+// 🔴 THE TWO `s.found || s.partial` SHORT-CIRCUITS BELOW ARE A MASKING PAIR, NOT
+// A DUPLICATED GUARD — ISSUE #302, AND THE ASYMMETRY IS THE POINT. Measured, not
+// reasoned:
+//   - THIS one (on entry) has a condition that is never true as the code stands.
+//     walk is entered only from scanForReadyAck (both flags false) and from the
+//     recursion below, which sits after the per-entry guard and after an os.Stat
+//     that returns on error. A probe panicking in its body fired 0 times across
+//     this package's 332 test leaves — and 1 time the moment the per-entry guard
+//     was removed. So deleting it ALONE is an equivalent mutation, and it is not
+//     dead code either: it is the line that becomes load-bearing when the other
+//     one breaks.
+//   - The PER-ENTRY one is load-bearing today: delete it alone and a scan that
+//     already set `partial` walks on to a sibling FILE and reports ackFound.
+//   - Delete BOTH and it also walks into a sibling DIRECTORY.
+//
+// Either flip reports an ack in a tree we did not finish reading, which is the
+// direction AGENTS.md item 18 refuses: reading only PART is not finding nothing.
+// All three deletions survived the whole repo (0 `--- FAIL` over 19 packages)
+// until TestPartialScanNeverBecomesFound, which carries one fixture row per
+// guard because a single-mutation sweep cannot see the pair by construction.
 func (s *ackScanner) walk(dir string) {
 	if s.found || s.partial {
 		return

--- a/internal/validate/readyack_gaps_test.go
+++ b/internal/validate/readyack_gaps_test.go
@@ -468,6 +468,60 @@ func TestGapReportUnitCap(t *testing.T) {
 	}
 }
 
+// TestGapReportSeparatorSitsBETWEENGaps pins the SHAPE of the joined list, which
+// nothing else in this file does.
+//
+// 🔴 ISSUE #309, A SURVIVING MUTANT that PR #300 had classified as EQUIVALENT on
+// a spot-check rather than by execution. `if i > 0` -> `if i >= 0` around the
+// "; " separator survives all 18 packages: the tests here assert that the report
+// NAMES the right things, that the cap truncates, that the lead switches when it
+// does, and that no printed line exceeds the wrap width — none of which can see a
+// separator emitted in the wrong POSITION. The rendered difference is
+//
+//	original:  "… usually the actual bug: (1) alpha."
+//	mutant:    "… usually the actual bug: ; (1) alpha."
+//
+// i.e. a stray separator before the FIRST reason, in the user-facing advisory
+// that #258/#269 rewrote precisely so it would point at the real cause legibly.
+//
+// The assertion is EXACT EQUALITY against the lead plus a hand-written body, not
+// a Contains: a substring check for "(1) alpha" passes under the mutant, and
+// composing the expectation from the loop would be a restatement of the code.
+func TestGapReportSeparatorSitsBETWEENGaps(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		gaps []string
+		body string
+	}{
+		{"one gap takes no separator at all", []string{"alpha"}, "(1) alpha."},
+		{"two gaps are joined by exactly one separator", []string{"alpha", "beta"}, "(1) alpha; (2) beta."},
+		{"a full, untruncated list", []string{"alpha", "beta", "gamma"}, "(1) alpha; (2) beta; (3) gamma."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.gaps) > readyAckGapCap {
+				t.Fatalf("this row renders %d gaps but the cap is %d, so it would exercise the truncated lead "+
+					"instead of the one it asserts", len(tc.gaps), readyAckGapCap)
+			}
+			want := readyAckGapLead + tc.body
+			got := readyAckGapReport(tc.gaps)
+			if got != want {
+				t.Fatalf("readyAckGapReport rendered the wrong list shape (issue #309)\n got: %q\nwant: %q\n"+
+					"the separator belongs BETWEEN reasons; emitting it before the first one puts a stray "+
+					"%q in front of reason (1) in the advisory the author reads", got, want, "; ")
+			}
+		})
+	}
+
+	// The truncated lead takes the same loop, so it has the same hazard.
+	t.Run("the truncated list starts at its first reason too", func(t *testing.T) {
+		got := readyAckGapReport([]string{"alpha", "beta", "gamma", "delta"})
+		want := readyAckGapLeadTruncated + "(1) alpha"
+		if !strings.HasPrefix(got, want) {
+			t.Fatalf("the truncated report does not begin at reason (1)\n got: %q\nwant prefix: %q", got, want)
+		}
+	})
+}
+
 // TestGapReportIsOneLine pins the wire contract. `Finding.Message` is a `--json`
 // string field; the human layout happens at the printer (internal/cmd), and a
 // newline here would break a consumer without breaking any assertion about the

--- a/internal/validate/readyack_test.go
+++ b/internal/validate/readyack_test.go
@@ -850,6 +850,120 @@ func TestReadyAckCapsAreUnobservable(t *testing.T) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// The two short-circuits that mask each other (issue #302).
+// ---------------------------------------------------------------------------
+
+// ackPartialTree builds a project whose FIRST entry is a subdirectory the scan
+// cannot finish reading, and whose LAST entry holds the ack.
+//
+// Entry order is the whole fixture: os.ReadDir sorts, so `a-partial` is walked
+// before `z-emitter…`. Inside `a-partial` an oversized file trips the size cap
+// and sets the sticky `partial` flag; the ack then sits BEHIND that flag, where
+// only a scanner that kept walking after giving up could reach it.
+//
+// `partial` false is the POSITIVE CONTROL: the same tree with the oversized file
+// shrunk to nothing, which must scan to ackFound. Without it, "unobservable" is
+// equally satisfied by a scanner that never sees the emitter at all — the
+// reassuring-zero shape.
+//
+// ackInSubdir chooses which of the two guards the fixture reaches; see
+// TestPartialScanNeverBecomesFound.
+func ackPartialTree(t *testing.T, partial, ackInSubdir bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	blob := "var x=1;\n"
+	if partial {
+		blob = strings.Repeat("x", maxAckFileBytes+1)
+	}
+	write("a-partial/bundle.js", blob)
+	// Real emitter source, so the fixture cannot drift from the token the
+	// scanner actually looks for.
+	if ackInSubdir {
+		write("z-emitter/civitai-host.js", realEmitter())
+	} else {
+		write("z-emitter.js", realEmitter())
+	}
+	return dir
+}
+
+// ackResultName renders the three-valued verdict for a failure message. It is a
+// TEST helper rather than a String() on ackScanResult, which would be production
+// code no production path calls.
+func ackResultName(r ackScanResult) string {
+	switch r {
+	case ackFound:
+		return "ackFound"
+	case ackAbsent:
+		return "ackAbsent"
+	case ackUnobservable:
+		return "ackUnobservable"
+	}
+	return fmt.Sprintf("ackScanResult(%d)", int(r))
+}
+
+// TestPartialScanNeverBecomesFound pins the THREE-VALUED verdict against issue
+// #302: a scan that gave up part-way must stay ackUnobservable and must never be
+// promoted to ackFound by evidence it only reached because it ignored its own
+// stop flag.
+//
+// 🔴 THE TWO GUARDS MASK EACH OTHER, WHICH IS WHY THIS NEEDS TWO ROWS.
+// ackScanner.walk short-circuits on `s.found || s.partial` twice — once on entry
+// and once per directory entry — and a single-mutation sweep scores both as
+// killed while the PAIR goes unexamined:
+//   - "the ack is a sibling FILE" reaches the PER-ENTRY guard. Drop that one
+//     alone and the root loop walks straight on to `z-emitter.js` after
+//     `a-partial` has already set `partial`, and the verdict flips.
+//   - "the ack is a sibling DIRECTORY" needs BOTH gone. With only the per-entry
+//     guard dropped, the loop reaches `z-emitter/` and calls walk(), where the
+//     ENTRY guard still returns — so this row is the one that requires the pair,
+//     and it is the row single-mutation testing cannot see.
+//
+// The flip is the expensive direction, per AGENTS.md item 18: "Reading NOTHING is
+// not finding nothing, and neither is reading only PART." A tree we could not
+// finish reading, reported as having the ack, silences the advisory on a project
+// that may be exactly as broken as #206.
+func TestPartialScanNeverBecomesFound(t *testing.T) {
+	// The size cap is what makes this fixture partial; a raised cap would make it
+	// allocate rather than fail. See TestReadyAckCapValues.
+	if maxAckFileBytes > 8<<20 {
+		t.Fatalf("maxAckFileBytes=%d is too large to build a partial fixture from", maxAckFileBytes)
+	}
+	for _, tc := range []struct {
+		name        string
+		ackInSubdir bool
+	}{
+		{"the ack sits in a sibling FILE behind the partial directory", false},
+		{"the ack sits in a sibling DIRECTORY behind the partial directory", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// POSITIVE CONTROL first: the identical tree that is NOT partial must
+			// reach the ack, or the assertion below is about a scanner that was
+			// never going to find anything.
+			if got := scanForReadyAck(ackPartialTree(t, false, tc.ackInSubdir)); got != ackFound {
+				t.Fatalf("positive control: a fully readable copy of this tree scanned to %s, want ackFound — "+
+					"the emitter is not where this fixture thinks it is, so the partial case below proves nothing",
+					ackResultName(got))
+			}
+			if got := scanForReadyAck(ackPartialTree(t, true, tc.ackInSubdir)); got != ackUnobservable {
+				t.Fatalf("a scan that hit the size cap in `a-partial` reported %s, want ackUnobservable — the "+
+					"stop flag is sticky, so evidence found only by walking PAST it must not promote the verdict "+
+					"to ackFound (issue #302)", ackResultName(got))
+			}
+		})
+	}
+}
+
 // TestReadyAckAdviceIsActionable pins the message CONTENT. hasReadyAckWarning
 // compares against the readyAckAdvice variable, which is self-referential —
 // replacing the whole advisory with "something may be wrong" passes every other


### PR DESCRIPTION
Closes #301, closes #302, closes #309 — three surviving mutants from the mutation-testing experiment (#300), all in `internal/validate`, all one class: **a guard nothing could observe**. One agent, one harness, because three would each rebuild it.

Every claim below was **re-measured here**, not taken from the issues. Counts are read from test OUTPUT (`--- FAIL` / `=== RUN` leaves), never from an exit code.

## Was each really surviving?

Each mutant applied to this branch's tree with only the three new tests `-skip`ped by name, over `./...`:

| mutant | `--- FAIL` | packages |
|---|---|---|
| #301 `continue` → `break` | **0** | 19 ok |
| #302 entry guard deleted | **0** | 19 ok |
| #302 per-entry guard deleted | **0** | 19 ok |
| #302 **both** deleted | **0** | 19 ok |
| #309 `i > 0` → `i >= 0` | **0** | 19 ok |

`=== RUN` was 3396 in every skipped run vs 3405 at HEAD — a difference of exactly the 9 new leaves, so `-skip` removed my tests and nothing else. Each mutation is checksum-gated and asserts its anchor occurs **exactly once** before editing; the tree was verified byte-restored after every run.

## Kill matrix

| mutant | `--- FAIL` | which test | the error it carries |
|---|---|---|---|
| #301 `continue` → `break` | 1 | `TestDedupeFindingsKeepsEveryFindingAfterADuplicate` | `dedupeFindings kept 1 of 4 distinct findings — a duplicate must SKIP that one entry, never STOP the loop…` |
| #302 per-entry guard alone | 2 | `TestPartialScanNeverBecomesFound` / **sibling FILE** row | `a scan that hit the size cap in `a-partial` reported ackFound, want ackUnobservable…` |
| #302 **both** guards | 3 | same test, **FILE + DIRECTORY** rows | same message, both rows |
| #302 entry guard alone | 0 | — | **equivalent mutant, see below** |
| #309 `i > 0` → `i >= 0` | 5 | `TestGapReportSeparatorSitsBETWEENGaps`, all four rows | `got: "… actual bug: ; (1) alpha."` / `want: "… actual bug: (1) alpha."` |

Every failure carries **that guard's own message**, and in the #301 run `TestDedupeFindingsKeysOnTheFieldMessagePAIR` **passed** alongside it — so the kill is not a neighbouring guard going red for the wrong reason.

## #302 is asymmetric, and the issue could not have known

The issue describes two guards that mask each other. Measured, the pair is **not symmetric**:

- The **entry** guard's condition is **never true as the code stands**. `walk` is entered only from `scanForReadyAck` (both flags false) and from the recursion, which sits *after* the per-entry guard and after an `os.Stat` that returns on error. A probe panicking in its body fired **0 times over 332 leaves** — and **1 time** the moment the per-entry guard was removed (that pairing is the probe's positive control: a probe that cannot fire proves nothing). So deleting it alone is an **equivalent mutant**, and it is not dead code either — it is the line that becomes load-bearing when the other one breaks.
- The **per-entry** guard is load-bearing today: delete it alone and a scan that already set `partial` walks on to a sibling **FILE** and reports `ackFound`.
- Delete **both** and it also walks into a sibling **DIRECTORY** — the row single-mutation testing cannot see by construction.

So the test carries **one fixture row per guard**, each with a **positive control** asserting the identical *non*-partial tree scans to `ackFound`. Without that control, "unobservable" is equally satisfied by a scanner that never sees the emitter at all.

Either flip reports an ack in a tree we did not finish reading — the direction item 18 refuses ("reading only PART is not finding nothing").

## Test-only, except one comment

No behaviour changed. The one non-test edit is `ackScanner.walk`'s doc comment, which now records the asymmetry above: the entry guard reads as a duplicated no-op, and the next reader is one tidy-up away from turning a masked pair into a live flip. **No tier, cap, ranking or message was retuned** — items 18/20/23 were read first and are untouched.

## Gates

- `make ci` — **19** ok packages, **0** `FAIL`, **0** `build failed`
- `go test -v ./...` — **3405** `=== RUN` / **3401** `--- PASS` / **0** `--- FAIL` / 4 pre-existing `SKIP`
- `make ci-shallow` — depth-1 clone, **19/19** ok, 0 failures, 0 timeouts
- `make lint` — golangci-lint **v2.12.2** (the exact CI pin), **`0 issues.`**

**Lint positive control.** The first control did **not** compile (`declared and not used: n`) and produced a *typecheck* error — which proves the compiler runs, not the linters. Replaced with a compiling defect, which produced **4 issues across 4 linters** (gofmt 1, ineffassign 1, misspell 1, unused 1). Removed; re-ran; back to `0 issues.` So that zero is a measured zero.

## Unverified

The survival and kill runs are `go test` measurements on this host. The other CI jobs (`schema-drift`, `pins-vs-published`, `ready-ack-runtime`, the template/scaffold jobs) were not run locally — this change touches no schema, pin, template or scaffold input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
