### PR TITLE
fix(listing): the icon rejection quoted bytes nobody could see, while the CLI held the pixels (#344, #295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,7 +1255,14 @@ Two different things check your listing images, and it is worth knowing which is
 which before you open an image editor.
 
 **What the CLI checks, locally, before anything is uploaded:** the file's
-**format** and its **byte size**. That is all.
+**format** and its **byte size**. That is all — and for an **icon** that is
+deliberately not the whole story, because the platform measures an image the CLI
+never sees (the re-encode note below). What the CLI *does* do is show you the
+quantity every server-side bound is a function of, on the line it uploads:
+
+```text
+Uploading icon (37.3 KiB, 1024×1024)…
+```
 
 | kind | how many | format | byte cap (the file you pass) |
 | --- | --- | --- | --- |
@@ -1278,15 +1285,21 @@ Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
 
 Four behaviours that are not obvious from the numbers:
 
-- **Icons are re-encoded server-side.** Whatever you upload is downscaled to at
-  most **1024 px** on its longer side and re-encoded to PNG — aspect preserved,
-  and **never enlarged**. So an oversized icon is harmless, but an undersized one
-  is not: the 128 px floor still bites, because nothing is ever scaled up.
-  One consequence to know about: the platform also caps the **re-encoded** icon
-  at 1 MiB, and that is a different measurement from the 2 MiB the CLI applies to
-  the file you pass. A detailed photographic icon can clear the local check and
-  still be refused for the size of the PNG the server made from it — the message
-  quotes bytes, not pixels. Flat, simple artwork re-encodes far smaller.
+- **Icons are re-encoded server-side, and that re-encode is what gets capped.**
+  Whatever you upload is downscaled to at most **1024 px** on its longer side and
+  re-encoded to PNG — aspect preserved, and **never enlarged**, so an undersized
+  icon is not rescued: the 128 px floor still bites. The platform then caps that
+  **re-encoded** image at 1 MiB, a different measurement from the 2 MiB the CLI
+  applies to the file you pass — **and it is not a corner case.** Measured on
+  2026-08-10: a **1024 × 1024** photographic JPEG of **37.3 KiB** — under 2% of
+  the local cap — was refused at attach, because the PNG the platform made from it
+  was about **1.15 MiB**. A second source at the same 1024 px ceiling re-encoded
+  to about **2.1 MiB**; a **512 × 512** icon in the same run went through. So the
+  bytes in that rejection are the platform's, not your file's, and the lever is
+  **pixel dimensions, not heavier compression**. The CLI cannot predict the
+  number — the re-encoded size depends on how compressible your artwork is, and
+  flat, simple artwork re-encodes far smaller — so it prints the dimensions it
+  decoded and repeats this mechanism in the error rather than guessing a bound.
 - **An icon's upper bound is a PIXEL count, not a file size.** The decoder that
   re-encodes it refuses a source above roughly **16 megapixels** — about
   4096 × 4096 — and it refuses it *regardless of how small the file is*. A flat

--- a/claudedocs/decisions/25-listing-media-bounds.md
+++ b/claudedocs/decisions/25-listing-media-bounds.md
@@ -31,6 +31,45 @@ deleting it:
 >     🔴 Never scaffold a placeholder icon or cover — it passes every check and can
 >     reach a public store listing.
 
+## 2026-08-10 — the icon re-encode cap is REACHABLE, and routinely (#344, #295)
+
+The body below already said the two icon byte caps measure different bytes.
+What nobody had was evidence that the second one bites in ordinary use — #286
+closed with the reachability recorded as **unmeasured**. A credentialed dogfood
+run measured it. This section is appended ABOVE the pinned body on purpose:
+`agents_split_preserved_test.go` digests the item verbatim from its `25. **`
+heading down, so new evidence goes here, not into the body.
+
+**Observed.** `civitai app listing set-icon ./icon1024_q15.jpg` on a 1024×1024
+JPEG of **38,201 bytes** was refused by `appListings.setIcon` with a 400 naming
+**1,202,233 bytes** against a **1,048,576** cap. Reproduced 3×. A second source
+at the same ≤1024 px ceiling reported **2,201,537**. A 512×512 JPEG (79.2 KiB)
+attached cleanly.
+
+**What that rules out, and what it does not.** The two rejections sit at the
+same ≤1024 px re-encode ceiling yet report **1.15** and **2.10 bytes per pixel**.
+A raw decoded buffer is a *constant* 3 or 4 bytes/px, so a content-dependent
+ratio rules raw decoding out: the quantity is a **compressed re-encode**, which
+is what the body already reads `listing-meta.service.ts` as doing. That is the
+**effect**, measured end-to-end through the public API. The encoder's exact
+settings are **not** knowable from this repo — no server source is checked out
+here — so nothing was verified about *how* the number is produced, only that it
+tracks content as a compressed encode must. The 512×512 pass is **one point**,
+not a bound.
+
+**Why no local gate was added.** Predicting the number requires reproducing the
+server's PNG encoder; a bound picked from these two samples would be exactly the
+stale *gate* the body argues against — refusing valid images while still failing
+to predict the case it was added for. `maxIconBytes` therefore stays at 2 MiB:
+lowering it to 1 MiB would refuse a 1.5 MiB 512×512 source that re-encodes far
+under the server's cap. What shipped instead — the decoded dimensions are
+printed on the upload line (#295), and a BAD_REQUEST from a listing-media
+ingest/attach is annotated with the source file's own measurements plus the
+re-encode mechanism, so the server's byte count acquires visible units
+(`attachRejectionAdvice`, `internal/cmd/app_listing.go`). Every number in that
+annotation comes from the author's file; the platform's sentence is still
+relayed verbatim ahead of it.
+
 ---
 
 25. **The listing-media DIMENSION and ASPECT bounds live in the README as prose,

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -19,9 +20,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Per-kind source-file byte caps, mirroring the server's listing-asset caps:
+// Per-kind SOURCE-FILE byte caps, mirroring the server's listing-asset caps:
 //   - icon uses the inline data-URI path (server decoded cap 2 MiB).
 //   - cover / screenshot use the mint+persist full-res path (4 MiB / 2 MiB).
+//
+// 🔴 FOR AN ICON THIS IS NOT THE BINDING CAP, AND CALLING IT "THE" CAP IS WHAT
+// ISSUE #344 WAS. The listing schema separately caps the icon the SERVER made —
+// the PNG it re-encodes after downscaling to at most 1024 px on the longer side —
+// at 1 MiB, and that is a different measurement from the file the author passed.
+// maxIconBytes is deliberately NOT lowered to match it: the two count different
+// bytes, so a 1 MiB source gate would refuse valid images (a 1.5 MiB 512x512
+// source re-encodes far under 1 MiB) while still not predicting the rejection it
+// was lowered for. See AGENTS.md item 25 and attachRejectionAdvice below.
 const (
 	maxIconBytes       = 2 * 1024 * 1024
 	maxCoverBytes      = 4 * 1024 * 1024
@@ -84,8 +94,8 @@ early to clear the publish floor before you go live.
 
 Source files are checked locally BEFORE any upload — ` + listingImageFormats + `, at most
 ` + humanBytes(maxIconBytes) + ` for an icon, ` + humanBytes(maxCoverBytes) + ` for a cover, ` + humanBytes(maxScreenshotBytes) + ` for a screenshot.
-A file in the wrong format, or over its cap, is refused before anything is
-uploaded.`,
+That reads the SOURCE FILE only: an icon is re-encoded server-side and the
+platform caps the image IT made — it can pass here and be refused at attach.`,
 		Example: `  civitai app listing status
   civitai app listing set-icon ./assets/icon.png
   civitai app listing set-cover ./assets/cover.png
@@ -308,6 +318,11 @@ then ingested and attached, and the content scan is waited on afterwards.
 Nothing is uploaded if the local check fails. The platform validates the
 image's dimensions and aspect at the ATTACH step, so a wrongly-shaped image is
 refused in seconds rather than after the scan.
+
+An icon is also RE-ENCODED server-side to PNG (downscaled to at most 1024px on
+the longer side) and the platform caps that re-encoded image — a different
+measurement from the cap above, which is on your file. A detailed 1024x1024
+icon can pass here and be refused there; the lever is smaller pixel dimensions.
 See "Listing media requirements" in the README for the platform's bounds.
 
 On a listing that is already LIVE this opens a REVISION for moderator re-review
@@ -462,7 +477,15 @@ func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc li
 	}
 
 	// 4. Ingest bytes -> imageId (icon: inline data-URI; cover/screenshot: full-res).
-	fmt.Fprintf(out, "Uploading %s (%s)…\n", kind, humanBytes(int64(len(data))))
+	//
+	// The PIXEL DIMENSIONS are printed beside the byte count (issue #295). They
+	// cost nothing — loadAndValidateImage already decoded them from the header to
+	// pick the MIME type, and threw them away on the icon path. They assert no
+	// threshold and vendor no constant (AGENTS.md item 25 forbids that); they make
+	// the ONE quantity every server-side listing-media bound is a function of
+	// legible, so an author can compare it against the README's documented bounds
+	// instead of reading a rejection that names a number their file does not have.
+	fmt.Fprintf(out, "Uploading %s (%s, %d×%d)…\n", kind, humanBytes(int64(len(data))), info.Width, info.Height)
 	var imageID int
 	if kind == kindIcon {
 		imageID, err = client.IngestAssetFromDataURI(ctx, data, info.MimeType)
@@ -470,7 +493,7 @@ func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc li
 		imageID, err = client.IngestAssetFullRes(ctx, data, info)
 	}
 	if err != nil {
-		return err
+		return attachRejectionAdvice(err, kind, file, len(data), info)
 	}
 
 	// 5. Attach — direct for draft/pending, via a shadow revision when live.
@@ -499,7 +522,7 @@ func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc li
 	}
 	res, err := attachMedia(ctx, client, kind, targetID, imageID, caption)
 	if err != nil {
-		return err
+		return attachRejectionAdvice(err, kind, file, len(data), info)
 	}
 
 	// 6. Poll the scan AFTER the attach, so success is still never reported while
@@ -520,7 +543,7 @@ func runSetMedia(cmd *cobra.Command, kind mediaKind, file, caption string, lc li
 			return scanFailure(out, err, kind, live, res)
 		}
 		if res, err = attachMedia(ctx, client, kind, targetID, imageID, caption); err != nil {
-			return err
+			return attachRejectionAdvice(err, kind, file, len(data), info)
 		}
 		if res.Status == attachStatusPending {
 			return fmt.Errorf("the server did not attach the %s — it still reports the image as scanning; try again shortly", kind)
@@ -790,6 +813,57 @@ func loadAndValidateImage(kind mediaKind, file string) ([]byte, appapi.ImageInfo
 		return nil, appapi.ImageInfo{}, asUsageError(fmt.Errorf("%s: %w", file, err))
 	}
 	return data, info, nil
+}
+
+// attachRejectionAdvice annotates a server BAD_REQUEST from a listing-media
+// ingest or attach with what the CLI measured about the file it sent. It is a
+// pass-through for every other error, and for nil.
+//
+// 🔴 IT VENDORS NO BOUND (AGENTS.md item 25). It adds no threshold, no dimension
+// check and no constant the server owns: every NUMBER it prints was measured
+// from the author's own file, and the server's sentence is still relayed
+// verbatim ahead of it. The only claim it makes about the platform is the
+// MECHANISM — that an icon is re-encoded before it is measured — which is what
+// makes the server's number legible rather than a second bound to keep in sync.
+//
+// Why it exists (issue #344). `appListings.setIcon` refused a 38,201-byte
+// 1024x1024 JPEG with "icon is 1202233 bytes (max 1048576)": a byte count
+// matching nothing the author can see — not the file (37.3 KiB), not the cap the
+// CLI enforces (2 MiB), not even the cap quoted in the message (1 MiB) as
+// applied to anything they hold. There was no path from that number to "shrink
+// the image", so the fix is to name the units, not to guess the formula.
+//
+// What the 2026-08-10 credentialed dogfood run established, and what it did NOT.
+// Two rejections at the SAME <=1024px re-encode ceiling reported 1,202,233 and
+// 2,201,537 bytes — 1.15 and 2.10 bytes per pixel. A RAW decoded buffer is a
+// CONSTANT 3 or 4 bytes/px, so a content-dependent ratio rules raw decoding out:
+// the quantity is a compressed re-encode, matching item 25's reading of
+// listing-meta.service.ts. That is the EFFECT, measured. The encoder's exact
+// settings are NOT knowable from this repo, and a 512x512 source (79.2 KiB) that
+// passed is one point, not a bound — which is exactly why this names the LEVER
+// (pixel dimensions) instead of predicting the number, and why no local gate was
+// added. #286 recorded this reachability as unmeasured; it is now measured.
+func attachRejectionAdvice(err error, kind mediaKind, file string, srcBytes int, info appapi.ImageInfo) error {
+	if err == nil || !errors.Is(err, civitai.ErrBadRequest) {
+		return err
+	}
+	// Every value below comes from the source file, so this line is true whichever
+	// bound the server applied — geometry, aspect, MIME or size.
+	sent := fmt.Sprintf("what was sent: %s — %s on disk, %d×%d px, %s",
+		file, humanBytes(int64(srcBytes)), info.Width, info.Height, info.MimeType)
+	if kind != kindIcon {
+		// Cover and screenshot ride the full-res path, where the CLI sends
+		// sizeBytes: len(data) — the server measures the same bytes the CLI does, so
+		// the re-encode paragraph would be false here.
+		return fmt.Errorf("%w\n  %s\n  see \"Listing media requirements\" in the README for the platform's bounds", err, sent)
+	}
+	return fmt.Errorf("%w\n  %s\n%s", err, sent, strings.Join([]string{
+		"  an icon is re-encoded server-side to PNG (downscaled to at most 1024px on",
+		"  the longer side) and the platform validates THAT image, so a byte count",
+		"  above is the size of the server's PNG and not of your file",
+		"  the lever is smaller PIXEL dimensions, not heavier compression — see",
+		"  \"Listing media requirements\" in the README for the platform's bounds",
+	}, "\n"))
 }
 
 func kindByteCap(kind mediaKind) int {

--- a/internal/cmd/app_listing_reencode_test.go
+++ b/internal/cmd/app_listing_reencode_test.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/appapi"
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// ---------------------------------------------------------------------------
+// Issues #295 and #344 — the icon's binding cap is on an image the CLI never
+// sees, and the numbers on screen did not add up.
+//
+// The measured symptom (credentialed dogfood run, 2026-08-10): a 1024x1024 JPEG
+// of 38,201 bytes uploaded as `Uploading icon (37.3 KiB)…` and came back with a
+// 400 naming 1,202,233 bytes against a 1,048,576 cap. FOUR numbers, none of them
+// each other's: the file, the printed size, the server's count, the documented
+// 2 MiB cap. The server counts the PNG it re-encodes from the DECODED PIXELS, so
+// the missing link is the pixel dimensions — which the CLI decodes and threw
+// away (#295) — and the units of the server's number (#344).
+//
+// These guards pin the PAIR, because either half alone leaves the author
+// stranded: dimensions with no explanation are a silent number, and an
+// explanation with no dimensions has nothing to compare against.
+//
+// 🔴 What they deliberately do NOT pin: any threshold. AGENTS.md item 25 keeps
+// the platform's dimension/aspect/decoded bounds out of this CLI, and nothing
+// here vendors one. Every number asserted below is derived from the test's own
+// source file.
+// ---------------------------------------------------------------------------
+
+// iconAttachStub is a listingHandler whose setIcon reply is supplied by the
+// caller and whose scan, if it is ever reached, settles immediately.
+func iconAttachStub(log *callLog, imageID int, setIcon func(http.ResponseWriter)) listingHandler {
+	return listingHandler{
+		log:     log,
+		imageID: imageID,
+		setIcon: setIcon,
+		scanStat: func(w http.ResponseWriter, _ int) {
+			trpcData(w, map[string]any{"statuses": []map[string]any{{"imageId": imageID, "status": "scanned"}}})
+		},
+	}
+}
+
+// uploadLine returns the single "Uploading …" line out of a command's stdout,
+// failing when there is not exactly one. Extracting the line rather than
+// searching the whole buffer is what stops a match somewhere else in the output
+// from standing in for the line under test.
+func uploadLine(t *testing.T, out string) string {
+	t.Helper()
+	var hits []string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "Uploading ") {
+			hits = append(hits, strings.TrimSpace(l))
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("want exactly one `Uploading …` line, got %d, in:\n%s", len(hits), out)
+	}
+	return hits[0]
+}
+
+// TestUploadLineNamesTheDecodedDimensions is the #295 regression guard.
+//
+// The dimensions are asserted as a PAIR of DIFFERENT numbers (700x300, neither a
+// factor of the other, neither equal to the byte count) so a transposed
+// width/height reddens. A square fixture would pass a swapped format string.
+//
+// The byte count is asserted too: the contract is "dimensions ALONGSIDE the
+// size", and replacing one quantity with the other is the other way to make a
+// naive "does it mention 700" check pass.
+func TestUploadLineNamesTheDecodedDimensions(t *testing.T) {
+	fastScanPoll(t)
+	log := &callLog{}
+	h := iconAttachStub(log, 4242, func(w http.ResponseWriter) {
+		trpcData(w, map[string]any{"status": "attached", "iconId": 4242})
+	})
+	srv := httptest.NewServer(h.serve(t))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	const wantW, wantH = 700, 300
+	icon := writePNG(t, wantW, wantH)
+	fi, err := os.Stat(icon)
+	if err != nil {
+		t.Fatalf("stat fixture: %v", err)
+	}
+
+	out, _, err := run(t, "app", "listing", "set-icon", icon, "--slug", "my-app")
+	if err != nil {
+		t.Fatalf("set-icon: %v", err)
+	}
+	line := uploadLine(t, out)
+	if want := fmt.Sprintf("%d×%d", wantW, wantH); !strings.Contains(line, want) {
+		t.Errorf("the upload line must name the dimensions the CLI already decoded (issue #295).\n"+
+			"want %q in: %q\n"+
+			"They are free — loadAndValidateImage decodes them from the header to pick the MIME "+
+			"type — and they are the quantity every server-side listing bound is a function of.",
+			want, line)
+	}
+	if want := humanBytes(fi.Size()); !strings.Contains(line, want) {
+		t.Errorf("the upload line must still name the byte count (%q), not swap it for the "+
+			"dimensions — the author needs both to read a size rejection: %q", want, line)
+	}
+}
+
+// TestIconRejectionSaysWhoseBytesTheServerCounted is the #344 regression guard.
+//
+// It drives the measured symptom: a size-shaped 400 out of `appListings.setIcon`
+// whose byte count is ~32x the file. The assertions are the four things an author
+// needed and did not get, plus the one thing they DID get and must keep.
+func TestIconRejectionSaysWhoseBytesTheServerCounted(t *testing.T) {
+	neverSettlingScanPoll(t)
+	// Shaped like the real rejection but not vendored as a bound: the CLI never
+	// reads these numbers, it only has to stop them reading as the author's.
+	const serverMsg = "icon is 1202233 bytes (max 1048576)"
+	log := &callLog{}
+	h := iconAttachStub(log, 77, func(w http.ResponseWriter) { trpcBadRequest(w, serverMsg) })
+	srv := httptest.NewServer(h.serve(t))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	const wantW, wantH = 700, 300
+	icon := writePNG(t, wantW, wantH)
+	fi, err := os.Stat(icon)
+	if err != nil {
+		t.Fatalf("stat fixture: %v", err)
+	}
+
+	_, _, err = run(t, "app", "listing", "set-icon", icon, "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected the server's size rejection to surface")
+	}
+	got := err.Error()
+
+	// 1. The server still speaks for itself, verbatim and first. The annotation is
+	//    an addition, never a replacement — the CLI vendors none of those bounds.
+	if !strings.Contains(got, serverMsg) {
+		t.Fatalf("the server's own message must still be relayed verbatim; got:\n%s", got)
+	}
+	// 2. The file the author passed, by name and by both of its measurements.
+	for _, want := range []string{icon, humanBytes(fi.Size()), fmt.Sprintf("%d×%d", wantW, wantH)} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the rejection must name %q — the whole defect is a byte count that matches "+
+				"nothing the author can see (file, printed size, or documented cap); got:\n%s", want, got)
+		}
+	}
+	// 3. The UNITS of the server's number. Without this the two byte counts read as
+	//    the same quantity and the author re-compresses, which cannot help.
+	for _, want := range []string{"re-encoded server-side", "1024px"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the rejection must say the server measured an image IT made (want %q), or the "+
+				"1202233 stays unattributable; got:\n%s", want, got)
+		}
+	}
+	// 4. The lever. "Your image is too big" with no next action is what #344 called
+	//    unactionable.
+	if !strings.Contains(got, "PIXEL dimensions") {
+		t.Errorf("the rejection must name the lever (smaller pixel dimensions, not heavier "+
+			"compression); got:\n%s", got)
+	}
+	// 5. Classification is pinned by errors.Is, never by message text (AGENTS item 7).
+	//    Wrapping an error is exactly how a tag gets dropped.
+	if !errors.Is(err, civitai.ErrBadRequest) {
+		t.Errorf("annotating must not drop the BAD_REQUEST tag the exit-code classifier reads; got: %v", err)
+	}
+}
+
+// TestNonIconRejectionOmitsTheReEncodeExplanation is the other half of the pair,
+// and it is a CORRECTNESS guard rather than a tidiness one.
+//
+// Cover and screenshot ride the mint+persist full-res path, where the CLI sends
+// `sizeBytes: len(data)` — the server measures the SAME bytes the CLI does. The
+// re-encode paragraph would therefore be FALSE there, and a false explanation of
+// a byte count is worse than none. The "what was sent" line still applies,
+// because it is measured from the source file whatever the server checked.
+func TestNonIconRejectionOmitsTheReEncodeExplanation(t *testing.T) {
+	neverSettlingScanPoll(t)
+	const serverMsg = "screenshot must be at least 320px on the shorter side (got 300px)"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{"appListingId": "listing_1", "status": "draft"})
+		case strings.Contains(r.URL.Path, "image-upload"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "uuid-1", "uploadURL": "http://" + r.Host + "/upload-sink",
+			})
+		case strings.Contains(r.URL.Path, "/upload-sink"):
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "persistAssetImage"):
+			trpcData(w, map[string]any{"imageId": 91})
+		case strings.Contains(r.URL.Path, "addScreenshot"):
+			trpcBadRequest(w, serverMsg)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	const wantW, wantH = 700, 300
+	shot := writePNG(t, wantW, wantH)
+	_, _, err := run(t, "app", "listing", "add-screenshot", shot, "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected the server's screenshot rejection to surface")
+	}
+	got := err.Error()
+
+	if !strings.Contains(got, serverMsg) {
+		t.Fatalf("the server's own message must still be relayed verbatim; got:\n%s", got)
+	}
+	// Positive control for this test's own instrument: the annotation IS reached on
+	// this path, so the absence asserted below is a measurement and not a case that
+	// never ran.
+	if want := fmt.Sprintf("%d×%d", wantW, wantH); !strings.Contains(got, want) {
+		t.Fatalf("a non-icon rejection must still name what was sent (%q) — if it does not, the "+
+			"absence assertion below proves nothing; got:\n%s", want, got)
+	}
+	for _, unwanted := range []string{"re-encoded server-side", "1024px", "PIXEL dimensions"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("a %s is NOT re-encoded (the CLI sends sizeBytes: len(data) on the full-res "+
+				"path, so the server counts the same bytes) — saying %q here is a false explanation "+
+				"of the server's number; got:\n%s", kindScreenshot, unwanted, got)
+		}
+	}
+}
+
+// TestNonBadRequestRejectionIsPassedThroughUnannotated proves the annotation is a
+// BRANCH on the classification, not something applied to every failure.
+//
+// A 500 says nothing about the image, so appending the author's file size and a
+// paragraph about re-encoding would invent a diagnosis. This is the negative
+// control for the two tests above: without it, "the annotation appeared" is
+// equally true of code that annotates unconditionally.
+//
+// 🔴 IT IS AN INVARIANT GUARD, NOT A REGRESSION GUARD, and it is labelled as
+// such because it is GREEN on origin/main — where nothing is annotated at all,
+// so every absence it asserts holds vacuously. It earns its place by being red
+// under mutation (drop the errors.Is branch in attachRejectionAdvice and it
+// fails with this test's own message), not by having failed before the fix.
+func TestNonBadRequestRejectionIsPassedThroughUnannotated(t *testing.T) {
+	neverSettlingScanPoll(t)
+	log := &callLog{}
+	h := iconAttachStub(log, 5, func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"json":{"message":"internal","code":-32603}}}`))
+	})
+	srv := httptest.NewServer(h.serve(t))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "listing", "set-icon", writePNG(t, 700, 300), "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected the 500 to surface")
+	}
+	got := err.Error()
+	for _, unwanted := range []string{"what was sent", "re-encoded server-side", "700×300"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("a non-BAD_REQUEST failure carries no verdict about the image, so %q must not "+
+				"be appended to it; got:\n%s", unwanted, got)
+		}
+	}
+}
+
+// TestAttachRejectionAdviceIsATaggedBranch exercises the predicate directly, at
+// the two edges the end-to-end tests cannot cheaply reach: a nil error, and a
+// tagged error that is not BAD_REQUEST.
+func TestAttachRejectionAdviceIsATaggedBranch(t *testing.T) {
+	info := appapi.ImageInfo{Width: 700, Height: 300, MimeType: "image/png"}
+	if got := attachRejectionAdvice(nil, kindIcon, "x.png", 10, info); got != nil {
+		t.Errorf("nil must pass through, got %v", got)
+	}
+	notFound := civitai.Tag(civitai.ErrNotFound, errors.New("no listing"))
+	if got := attachRejectionAdvice(notFound, kindIcon, "x.png", 10, info); got.Error() != notFound.Error() {
+		t.Errorf("a non-BAD_REQUEST error must pass through unchanged, got: %v", got)
+	}
+	bad := civitai.Tag(civitai.ErrBadRequest, errors.New("icon is 1202233 bytes (max 1048576)"))
+	annotated := attachRejectionAdvice(bad, kindIcon, "x.png", 10, info)
+	if annotated.Error() == bad.Error() {
+		t.Fatal("a BAD_REQUEST must be annotated — this test's premise is that the branch fires")
+	}
+	if !errors.Is(annotated, civitai.ErrBadRequest) {
+		t.Error("the classification tag must survive the annotation")
+	}
+}

--- a/internal/scaffold/templates/page-money/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/assets/README.md.tmpl
@@ -38,9 +38,13 @@ Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
 ## Who checks what
 
 The CLI checks the **format and the byte size** of the file you hand it, before
-anything is uploaded. It does **not** check dimensions or aspect ratio — those
-are validated by the platform when the image is attached, and the platform is
-the authority. A rejection names the bound and your value, e.g.:
+anything is uploaded — and for an **icon** that is not the whole story, because
+the platform measures an image the CLI never sees (first bullet below). The CLI
+does **not** check dimensions or aspect ratio — those are validated by the
+platform when the image is attached, and the platform is the authority. It does
+print what it decoded, so the dimensions every server-side bound depends on are
+on screen before the upload (`Uploading icon (37.3 KiB, 1024×1024)…`). A
+rejection names the bound and your value, e.g.:
 
 ```text
 icon must be square-ish (aspect 2.00 outside 0.9–1.1)
@@ -50,11 +54,15 @@ cover must be at least 640px wide (got 512px)
 Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
-  on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real. The platform
-  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
-  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
-  and still be refused there. Flat artwork re-encodes far smaller.
+  on the longer side (aspect preserved, never enlarged), and the platform caps
+  that *re-encoded* PNG at 1 MiB — a different measurement from the 2 MiB the CLI
+  applies to your file. A **small** icon stays small, so the 128 px floor is
+  real; a **large** one is not automatically fine either. Measured 2026-08-10: a
+  1024 × 1024 photographic JPEG of 37.3 KiB was refused because the PNG the
+  platform made from it came to ~1.15 MiB, while a 512 × 512 icon in the same run
+  went through. The bytes in that rejection are the platform's, not your file's —
+  the lever is **pixel dimensions, not heavier compression**. Flat artwork
+  re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 

--- a/internal/scaffold/templates/page-vite/assets/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/assets/README.md.tmpl
@@ -38,9 +38,13 @@ Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
 ## Who checks what
 
 The CLI checks the **format and the byte size** of the file you hand it, before
-anything is uploaded. It does **not** check dimensions or aspect ratio — those
-are validated by the platform when the image is attached, and the platform is
-the authority. A rejection names the bound and your value, e.g.:
+anything is uploaded — and for an **icon** that is not the whole story, because
+the platform measures an image the CLI never sees (first bullet below). The CLI
+does **not** check dimensions or aspect ratio — those are validated by the
+platform when the image is attached, and the platform is the authority. It does
+print what it decoded, so the dimensions every server-side bound depends on are
+on screen before the upload (`Uploading icon (37.3 KiB, 1024×1024)…`). A
+rejection names the bound and your value, e.g.:
 
 ```text
 icon must be square-ish (aspect 2.00 outside 0.9–1.1)
@@ -50,11 +54,15 @@ cover must be at least 640px wide (got 512px)
 Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
-  on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real. The platform
-  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
-  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
-  and still be refused there. Flat artwork re-encodes far smaller.
+  on the longer side (aspect preserved, never enlarged), and the platform caps
+  that *re-encoded* PNG at 1 MiB — a different measurement from the 2 MiB the CLI
+  applies to your file. A **small** icon stays small, so the 128 px floor is
+  real; a **large** one is not automatically fine either. Measured 2026-08-10: a
+  1024 × 1024 photographic JPEG of 37.3 KiB was refused because the PNG the
+  platform made from it came to ~1.15 MiB, while a 512 × 512 icon in the same run
+  went through. The bytes in that rejection are the platform's, not your file's —
+  the lever is **pixel dimensions, not heavier compression**. Flat artwork
+  re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 

--- a/internal/scaffold/templates/static/assets/README.md.tmpl
+++ b/internal/scaffold/templates/static/assets/README.md.tmpl
@@ -38,9 +38,13 @@ Easy starting points: a **512 × 512** icon and a **1600 × 900** cover.
 ## Who checks what
 
 The CLI checks the **format and the byte size** of the file you hand it, before
-anything is uploaded. It does **not** check dimensions or aspect ratio — those
-are validated by the platform when the image is attached, and the platform is
-the authority. A rejection names the bound and your value, e.g.:
+anything is uploaded — and for an **icon** that is not the whole story, because
+the platform measures an image the CLI never sees (first bullet below). The CLI
+does **not** check dimensions or aspect ratio — those are validated by the
+platform when the image is attached, and the platform is the authority. It does
+print what it decoded, so the dimensions every server-side bound depends on are
+on screen before the upload (`Uploading icon (37.3 KiB, 1024×1024)…`). A
+rejection names the bound and your value, e.g.:
 
 ```text
 icon must be square-ish (aspect 2.00 outside 0.9–1.1)
@@ -50,11 +54,15 @@ cover must be at least 640px wide (got 512px)
 Two behaviours worth knowing:
 
 - **Icons are re-encoded server-side** to PNG and downscaled to at most 1024 px
-  on the longer side (aspect preserved, never enlarged). So a large icon is
-  fine, but a **small** one stays small — the 128 px floor is real. The platform
-  caps that *re-encoded* PNG at 1 MiB, which is a different measurement from the
-  2 MiB the CLI applies to your file: detailed photographic artwork can pass here
-  and still be refused there. Flat artwork re-encodes far smaller.
+  on the longer side (aspect preserved, never enlarged), and the platform caps
+  that *re-encoded* PNG at 1 MiB — a different measurement from the 2 MiB the CLI
+  applies to your file. A **small** icon stays small, so the 128 px floor is
+  real; a **large** one is not automatically fine either. Measured 2026-08-10: a
+  1024 × 1024 photographic JPEG of 37.3 KiB was refused because the PNG the
+  platform made from it came to ~1.15 MiB, while a 512 × 512 icon in the same run
+  went through. The bytes in that rejection are the platform's, not your file's —
+  the lever is **pixel dimensions, not heavier compression**. Flat artwork
+  re-encodes far smaller.
 - **Covers and screenshots are not rescaled.** What you upload is what the store
   shows, so ship them at the size you want rendered.
 


### PR DESCRIPTION
Fixes #344. Fixes #295. They are two sides of one defect and only work together:
#295 is the quantity that makes #344's error actionable.

## The symptom (credentialed dogfood run, 2026-08-10)

```console
$ civitai app listing set-icon ./icon1024_q15.jpg --slug <slug>
Uploading icon (37.3 KiB)…
Error: appListings.setIcon rejected the request (400): icon is 1202233 bytes (max 1048576)
```

Four numbers for one file — **38,201** bytes on disk, **37.3 KiB** printed,
**1,202,233** counted by the server, **2.0 MiB** documented as the cap — and no
path from any of them to "shrink your image".

## What the real constraint is, and how that was established

`appListings.setIcon` validates the icon the **server** made: the PNG it
re-encodes after downscaling to at most 1024 px on the longer side, capped at
1 MiB. That mechanism was already recorded in AGENTS.md item 25; what was missing
was evidence it bites in ordinary use — #286 closed with exactly that recorded as
**unmeasured**. This run measured it.

Two rejections sit at the same ≤1024 px re-encode ceiling and report **1.15** and
**2.10 bytes per pixel** (1,202,233 and 2,201,537). A raw decoded buffer is a
*constant* 3 or 4 bytes/px, so a content-dependent ratio **rules raw decoding
out**: the quantity is a compressed re-encode. A 512×512 JPEG (79.2 KiB) attached
cleanly in the same run.

**That is the effect, not the rule.** No server source is checked out here, so
nothing was verified about *how* the number is produced — only that it tracks
content the way a compressed encode must. The 512×512 pass is one data point, not
a bound. Accordingly **no local gate was added and no bound was vendored**, per
AGENTS.md item 25.

## What changed

- **#295** — the upload line names the dimensions the CLI already decoded for
  free: `Uploading icon (37.3 KiB, 1024×1024)…`. No threshold, no constant.
- **#344** — a `BAD_REQUEST` from a listing-media ingest/attach is annotated with
  the source file's own measurements and, **for an icon only**, the re-encode
  mechanism and the lever:

  ```text
  Error: appListings.setIcon rejected the request (400): icon is 1202233 bytes (max 1048576)
    what was sent: ./icon1024_q15.jpg — 37.3 KiB on disk, 1024×1024 px, image/jpeg
    an icon is re-encoded server-side to PNG (downscaled to at most 1024px on
    the longer side) and the platform validates THAT image, so a byte count
    above is the size of the server's PNG and not of your file
    the lever is smaller PIXEL dimensions, not heavier compression — see
    "Listing media requirements" in the README for the platform's bounds
  ```

  The server's sentence is still relayed **verbatim and first**; the annotation is
  an addition, never a replacement. Cover and screenshot ride the full-res path
  where the CLI sends `sizeBytes: len(data)`, so they get the "what was sent" line
  and **not** the re-encode paragraph, which would be false there.
- **The promise** — `app listing --help` said "a file in the wrong format, or over
  its cap, is refused before anything is uploaded", which reads as a guarantee it
  cannot make for an icon. It now says the local check reads the source file only.
  `README.md` and the scaffolded `assets/README.md` replace "a large icon is fine"
  with the measurement.

## What deliberately did NOT change

`maxIconBytes` stays **2 MiB**. Lowering it to 1 MiB to "match what is enforced"
would be wrong twice: the two caps count **different bytes**, so it would refuse
valid images (a 1.5 MiB 512×512 source re-encodes far under the server's cap)
while *still* failing to predict the rejection it was lowered for. That is exactly
the stale-*gate*-vs-stale-*guidance* asymmetry item 25 exists to preserve.

## Verification

- **Regression matrix** — 3 guards red at `origin/main` (3156b80), green at HEAD:
  `TestUploadLineNamesTheDecodedDimensions`,
  `TestIconRejectionSaysWhoseBytesTheServerCounted`,
  `TestNonIconRejectionOmitsTheReEncodeExplanation`.
  `TestNonBadRequestRejectionIsPassedThroughUnannotated` is labelled in-file as an
  **invariant** guard — it is green at base, where nothing is annotated at all —
  and `TestAttachRejectionAdviceIsATaggedBranch` cannot exist at base.
- **Mutation sweep** — 8/8 killed, each by its own guard's message: dimensions
  dropped, width/height transposed, byte count dropped, `errors.Is` branch
  removed, icon paragraph given to every kind, attach returning the raw error,
  `%w`→`%v` (tag dropped), non-icon "what was sent" line dropped.
- **Exit codes** — classification is pinned with `errors.Is(err,
  civitai.ErrBadRequest)`, never message text (AGENTS.md item 7). The `%w` wrap
  preserves it, so the published exit code is unchanged.
- **Gates** — `make ci`: 3401 `=== RUN`, 3397 `--- PASS`, **0 `--- FAIL`**, 4
  SKIP, 0 `build failed`, 0 timeout panics, 19/19 packages ok.
  `make ci-shallow` (this branch touches an evidence file a git-history test
  reads): 19/19 ok, 0 failures. `make lint` under golangci-lint **v2.12.2**
  (CI's pin): **0 issues** — positive-controlled with a *compiling* defect
  (`go build` clean) that reported **2 issues** (ineffassign + unused), then
  reverted to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
