### PR TITLE
fix(workflows): the one view that disclaimed the Buzz ledger was the one view that discarded it (#346)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,8 @@ item must carry a trigger that is a routing question rather than a label
     → evidence: claudedocs/decisions/27-blockid-derivation-refuses.md
 
 28. **Wording anything about a charge — readiness, refunds, cancel — adding a
-    surface that prints one, or reaching for a banned-phrase guard?**
+    surface that prints one, rendering a workflow's OWN transactions, or
+    reaching for a banned-phrase guard?**
     → evidence: claudedocs/decisions/28-no-claims-about-unobservable-spend.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--out-name <template>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
 | `civitai workflows list [--limit <n>] [--cursor <c>] [--tag <t>] [--json]` | **List the generation workflows you have submitted**, newest first — status, when, cost, and `deliverable/total` outputs. Cursor-paged: the next cursor is printed on stdout when more results exist. Reading spends nothing. See [Generate](#listing-and-cancelling-workflows). |
-| `civitai workflows get <workflow-id> [--json]` | **Look up one generation workflow** — status, steps and outputs. This is how you re-attach after `--no-wait`, a `--timeout` expiry or a Ctrl-C. Outputs that are blocked, unavailable or hidden are listed **with the reason** rather than omitted. Output URLs are presigned and expire; re-run for fresh links. Reading spends nothing. See [Generate](#waiting-downloading-and-re-attaching). |
+| `civitai workflows get <workflow-id> [--json]` | **Look up one generation workflow** — status, steps, outputs, and the Buzz transactions the server recorded for it. This is how you re-attach after `--no-wait`, a `--timeout` expiry or a Ctrl-C. Outputs that are blocked, unavailable or hidden are listed **with the reason** rather than omitted. Output URLs are presigned and expire; re-run for fresh links. Reading spends nothing. See [Generate](#waiting-downloading-and-re-attaching) and [Reading a workflow's Buzz transactions](#reading-a-workflows-buzz-transactions). |
 | `civitai workflows cancel <workflow-id> [--yes] [--json]` | **Stop a running generation.** 🔴 **You are billed for what it already delivered**; the orchestrator re-prices the rest server-side and this CLI cannot report the figure. Cancel because you no longer want the output. Asks for confirmation (default **no**); `--yes` skips the prompt and a non-TTY without it refuses. See [Generate](#listing-and-cancelling-workflows). |
 | `civitai upgrade [--force]` | **Self-update this binary in place** — resolve the latest GitHub release, verify its SHA-256 against `checksums.txt`, and replace the running executable. A Homebrew install delegates to `brew upgrade` instead; `--force` reinstalls anyway (and self-replaces a Homebrew install). See [Upgrading](#upgrading). |
 | `civitai version` | Print version / commit / build date. |
@@ -1591,14 +1591,28 @@ generator.
 > back — not `--timeout`, not Ctrl-C, not `civitai workflows cancel`. Price it
 > with `--dry-run` first — that calls the cost estimator and spends nothing.
 
-> 🔴 **What the LEDGER does with a charge is not something this CLI reports, in
-> either direction.** If a run fails, expires, or you cancel it, whether any
-> Buzz comes back is decided server-side; this CLI cannot see your Buzz ledger — `civitai buzz` reports a balance, not a history, so settle it against your Buzz transaction history (`/user/transactions`). The CLI states the outcome and
-> stops there. It does **not** tell you the charge stands, and it does **not**
-> tell you it was refunded — earlier versions asserted the first, which the
-> platform's own client contradicts for `failed`/`expired`/`canceled`. The rule
-> itself lives in the orchestrator service and is not readable from the civitai
-> monorepo, so neither claim is made. Tracked at civitai/cli#307.
+> 🔴 **The CLI states no RULE about what becomes of a charge, in either
+> direction — but it does report the transactions the server hands it.** Two
+> different things, and the difference is the whole point:
+>
+> - **Your account Buzz ledger** is not readable from here. `civitai buzz`
+>   reports a balance, not a history, so a balance alone cannot settle "did
+>   *this* run come back" unless you noted it beforehand. Where no per-workflow
+>   record is available the CLI says exactly that and points you at your
+>   [transaction history](https://civitai.com/user/transactions).
+> - **One workflow's own transactions** often *are* in the payload. When they
+>   are, `civitai workflows get <id>` — and `civitai generate` on a failed run —
+>   print them: each `debit` and `credit` the server recorded for that workflow,
+>   and the net. See [Reading a workflow's Buzz
+>   transactions](#reading-a-workflows-buzz-transactions).
+>
+> The CLI does **not** tell you the charge stands, and does **not** tell you it
+> was refunded — earlier versions asserted the first, which the platform's own
+> client contradicts for `failed`/`expired`/`canceled`. Reading civitai/cli#307
+> established the server RE-PRICES a failed or cancelled run by the share of its
+> outputs that never landed; the CLI still promises no *amount*, because the
+> amount depends on how far the run got. Tracked at civitai/cli#307 and
+> civitai/cli#346.
 
 ```bash
 # Price it. Spends nothing.
@@ -1998,9 +2012,12 @@ the per-output reason.
 > So cancel a job because you no longer want its *output*. How much of the
 > charge that leaves you paying depends on how far the run had got — the
 > settlement is server-side and happens once the workflow reaches its final
-> state, not when the command returns, and **this CLI never sees your Buzz
-> ledger**, so it reports no figure. Settle it against your
-> [transaction history](https://civitai.com/user/transactions).
+> state, not when the command returns, and **this CLI never sees your account
+> Buzz ledger**, so `cancel` itself reports no figure. Once the workflow reaches
+> its final state, `civitai workflows get <id>` shows the transactions the
+> server recorded for it — see [Reading a workflow's Buzz
+> transactions](#reading-a-workflows-buzz-transactions). Otherwise settle it
+> against your [transaction history](https://civitai.com/user/transactions).
 >
 > (This is also why `--timeout` and Ctrl-C deliberately do **not** cancel: they
 > stop the wait, not the job.)
@@ -2032,6 +2049,44 @@ read and the cancel a workflow can reach a final status on its own; that is
 harmless, since cancelling a finished workflow is a server-side no-op.
 
 <sub>Until civitai/cli#341, `civitai workflows cancel not-a-real-workflow-zzz --yes` printed *"Cancelled workflow not-a-real-workflow-zzz"* and exited `0` — while `civitai workflows get` on the same id correctly reported a 404.</sub>
+
+### Reading a workflow's Buzz transactions
+
+`orchestrator.getWorkflow` often returns the orchestrator's own money record for
+that one workflow. When it does, `civitai workflows get <id>` prints it — and so
+does `civitai generate` when a run it waited on ends `failed`, `expired` or
+`canceled`:
+
+```
+Buzz transactions for this workflow (2 recorded)
+  debit   8
+  credit  8
+  net     0
+```
+
+**These are entries the server returned, not a rule the CLI is asserting.** The
+block reports what is recorded against *this* workflow id and nothing more —
+`net` is simply `debit` minus `credit` over the rows above it. It is **not**
+your account balance (`civitai buzz` reports that), it is **not** your account
+transaction history, and it does not tell you what a failure or a cancel does in
+general. Where the payload carries no record, the CLI says so and points you at
+your [transaction history](https://civitai.com/user/transactions) instead — an
+absent record is *"nothing to report"*, never *"no money moved"*.
+
+A transaction `type` this build does not recognise makes the net **unreportable**
+rather than dropping the entry out of the arithmetic:
+
+```
+Buzz transactions for this workflow (3 recorded)
+  debit  12  (2 entries)
+  hold   3
+  net    (not computed)
+```
+
+`--json` is unaffected: it has always passed the raw payload through, including
+the `transactions` object with every field this CLI does not model.
+
+<sub>Until civitai/cli#346, `civitai workflows get` on a failed run printed *"this CLI cannot see your Buzz ledger … settle it against your Buzz transaction history"* while holding `{"type":"debit","amount":8}` and `{"type":"credit","amount":8}` from that very run — and `civitai workflows list` was already rendering the same settlement as `COST 0`.</sub>
 
 ### Exit codes specific to `generate`
 

--- a/claudedocs/decisions/28-no-claims-about-unobservable-spend.md
+++ b/claudedocs/decisions/28-no-claims-about-unobservable-spend.md
@@ -70,6 +70,71 @@ the guard**: the golden is the guard, for the reason (b) itself gives.
 
 The traced chain also lives at the code, in `runWorkflowsCancel`'s comment.
 
+## 🔴 "THE CLI CANNOT OBSERVE THE LEDGER" IS TRUE OF THE ACCOUNT AND FALSE PER WORKFLOW — civitai/cli#346
+
+**Read this before printing `buzzLedgerUnknownNote` on a surface that holds a
+workflow.** The rule below is unchanged; what changed is one premise it was
+applied through, and the fix is a SUBTRACTION — the CLI stops disclaiming
+knowledge it is holding. It asserts no refund rule, and #307's re-pricing
+account still stands as the RULE nobody may promise an amount for.
+
+**What was found.** A blind credentialed dogfood run (2026-08-10, run 3 — the
+first to reach `civitai generate`) read a failed workflow back with
+`civitai workflows get` and was told *"this CLI cannot see your Buzz ledger …
+settle it against your Buzz transaction history (/user/transactions)"* — while
+the payload the command had already parsed contained
+
+```json
+"transactions": {"list": [{"type":"debit","amount":8,…},
+                          {"type":"credit","amount":8,…}]}
+```
+
+and `civitai workflows list` was rendering the same settlement as `COST 0` for
+that run. **The one view that disclaimed the knowledge was the one view that
+discarded it**, and it sent the user to a website for numbers on their screen.
+
+**The distinction that keeps this inside the rule.** *Reporting a ledger the
+server handed you is the opposite of claiming an unobservable one.* Two
+different objects were being conflated:
+
+- the **account-wide Buzz ledger** — still unreadable from here; `civitai buzz`
+  is a balance, not a history. `buzzLedgerUnknownNote` is about THIS, is
+  unchanged, and still renders wherever no per-workflow record is in hand.
+- the **orchestrator's per-workflow transaction record** — on the
+  `orchestrator.getWorkflow` payload, itemised, and now rendered.
+
+**What was built.** `genapi.Workflow.Settlement()` decodes the measured
+`{"list":[…]}` envelope into per-type totals plus `Debits`/`Credits`/`Net`;
+`cmd.reportWorkflowSettlement` prints it. Both fail CLOSED: an absent, null,
+empty or unrecognised record reads as *nothing to report* — **never** as *no
+money moved* — and a transaction `type` this build cannot place on either side
+of the subtraction withholds the NET rather than silently dropping the entry out
+of the arithmetic. Direction is corroborated, not assumed: debit − credit for the
+run above equals the `COST 0` the server's own list rendered.
+
+**The guards, in the same three shapes.** (1) `workflowSettlementPrintedNote` is
+one constant — the sentence that REPLACES `buzzLedgerUnknownNote` — asserted to
+point at the record and to decide nothing; (2) its call sites are an asserted
+bidirectional ledger (`TestSettlementPrintedNoteLedger`, 3 sites); (3) every new
+rendering is golden-pinned in `TestGoldenSpendCopy`. The
+`buzzLedgerUnknownNote` ledger is UNCHANGED at 3/1/3 — each site now selects
+between the two sentences rather than gaining or losing a reference.
+
+🔴 **AND THE PHRASE LIST LOST A THIRD TIME, IN THIS PR, AS PREDICTED BELOW.**
+A control case *"the transactions the server recorded are printed above and
+nothing is refunded"* was ACCEPTED by the new constant's guard: both required
+clauses present, and `refundDirectionalClaims` bans `"not refunded"` but not
+`"nothing is refunded"` — the identical hole (b) records. The list was NOT
+extended; the case was removed and the append mutation is left to the golden,
+which killed it. Measured: appending `". Nothing is refunded."`, `"A cancelled
+run always nets to zero."` and `", so any credit there has been refunded"` to
+the three new surfaces each reddened exactly one golden **and no other test**.
+
+**Residual, unchanged and now wider.** A surface that prints its own fate copy
+without touching either constant is still invisible to all six guards. So is a
+`transactions` envelope in some shape other than `{"list":[…]}`: it reads as
+unobservable, i.e. the pre-#346 behaviour, which is the fail-closed direction.
+
 ---
 
 28. **The CLI must not make CLAIMS about a spend it cannot observe.** Same shape

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -1326,12 +1326,36 @@ func waitAndCollect(ctx context.Context, cmd *cobra.Command, deps generateDeps, 
 		// ledger, so it cannot confirm any figure it might quote. It therefore
 		// states the outcome and names the command that can answer the money
 		// question. See AGENTS.md item 28.
+		//
+		// 🔴 #346 ADDED THE ONE CASE WHERE IT DOES NOT HAVE TO SAY THAT. The
+		// workflow this poll just read back carries the orchestrator's own
+		// per-workflow transactions; where it does, they are printed and the
+		// disclaimer is replaced by a pointer at them. This is a SUBTRACTION —
+		// the CLI stops disclaiming knowledge it is holding — and it asserts no
+		// refund rule either way: an absent record still prints the note, because
+		// "no entries returned" is not evidence that no money moved.
+		//
+		// Both go to STDERR, never stdout: this branch returns an error, and with
+		// --json a caller's stdout must stay machine-clean.
+		fate := buzzLedgerUnknownNote
+		if reportWorkflowSettlement(errw, errw, wf) {
+			fate = workflowSettlementPrintedNote
+		}
 		return fmt.Errorf("the generation finished with status %q and produced no usable result; %s. Inspect the run with `civitai workflows get %s` (%s)",
-			safeTerm(wf.Status), buzzLedgerUnknownNote, safeTerm(workflowID), noFailureReasonNote)
+			safeTerm(wf.Status), fate, safeTerm(workflowID), noFailureReasonNote)
 	}
 
 	kept, excluded := genapi.PartitionOutputs(wf)
-	reportExcludedOutputs(errw, excluded)
+	// The settlement is printed here only when there is an exclusion note to
+	// qualify — that note is the one place this path speaks to the fate of the
+	// charge. A run that delivered everything it was charged for gets no new
+	// block; #346 is about a disclaimer contradicting the payload, not about
+	// adding a money screen to the happy path.
+	settled := false
+	if len(excluded) > 0 {
+		settled = reportWorkflowSettlement(errw, errw, wf)
+	}
+	reportExcludedOutputs(errw, excluded, settled)
 	requested := 0
 	if o.quantitySet {
 		requested = o.quantity

--- a/internal/cmd/generate_golden_copy_test.go
+++ b/internal/cmd/generate_golden_copy_test.go
@@ -219,12 +219,65 @@ func TestGoldenSpendCopy(t *testing.T) {
 		})
 	}
 
-	// --- the excluded-outputs note ------------------------------------------
+	// --- the excluded-outputs note, BOTH modes ------------------------------
+	//
+	// 🔴 #346 gave this surface a second rendering, and an unpinned second
+	// rendering is exactly the hole this file's header describes: a sentence
+	// could be added to the settled branch while the pinned unsettled branch
+	// stayed byte-identical.
 	t.Run("excluded_outputs_note", func(t *testing.T) {
 		blocked := "minor"
 		var b bytes.Buffer
-		reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}})
+		reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}}, false)
 		assertGolden(t, "excluded_outputs_note", b.String())
+	})
+	t.Run("excluded_outputs_note_settled", func(t *testing.T) {
+		blocked := "minor"
+		var b bytes.Buffer
+		reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}}, true)
+		assertGolden(t, "excluded_outputs_note_settled", b.String())
+	})
+
+	// --- the per-workflow settlement block (#346) ---------------------------
+	//
+	// It is the surface that REPLACES the disclaimer, so it is money copy by
+	// definition: whatever it says is what a user reads instead of "this CLI
+	// cannot see your Buzz ledger". Three renderings, because they are three
+	// different sentences and a mutation only has to survive in one of them.
+	for _, c := range []struct{ name, payload string }{
+		// The #346 payload itself: one debit, one matching credit, net 0.
+		{"settlement_debit_credit", wfWithTransactions},
+		// A type this build cannot place, where the NET is withheld. Its
+		// "not computed" sentence is the one a future edit is most likely to
+		// replace with a guess.
+		{"settlement_unclassified_type", wfWithUnclassifiedTransaction},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			var wf genapi.Workflow
+			if err := json.Unmarshal([]byte(c.payload), &wf); err != nil {
+				t.Fatalf("fixture: %v", err)
+			}
+			if !reportWorkflowSettlement(&out, &errb, &wf) {
+				t.Fatal("CONTROL failure: the fixture rendered no settlement, so there is no copy to pin")
+			}
+			assertGolden(t, c.name, out.String()+"\n"+errb.String())
+		})
+	}
+
+	// --- the terminal-status error when the poll reply DID itemise the run ---
+	t.Run("terminal_status_failed_settled", func(t *testing.T) {
+		clock := newFakeClock()
+		calls := 0
+		var s genSeams
+		s.poll = clock.cfg()
+		s.getWorkflow = scriptedWorkflows(&calls, wfWithTransactions)
+		c, _, _ := genCmd("")
+		err := runGenerate(c, s.deps(t), waitOpts(t.TempDir()))
+		if err == nil {
+			t.Fatal("a failed workflow must not report success")
+		}
+		assertGolden(t, "terminal_status_failed_settled", err.Error())
 	})
 
 	// --- the succeeded-but-empty error --------------------------------------

--- a/internal/cmd/generate_output.go
+++ b/internal/cmd/generate_output.go
@@ -166,7 +166,12 @@ func planOutputTarget(tmpl, outDir, workflowID string, n int, rawURL string) (st
 // them out silently: the visible symptom of doing so is "the command said it
 // worked and I got two files instead of the four I paid for", with nothing on
 // screen explaining the gap.
-func reportExcludedOutputs(errw io.Writer, excluded []genapi.Output) {
+//
+// `settled` reports that the caller has ALREADY printed this workflow's own
+// transaction record immediately above (see reportWorkflowSettlement). It comes
+// in as the return value of that print rather than being re-derived here, so the
+// "printed above" pointer cannot claim a block that was never rendered.
+func reportExcludedOutputs(errw io.Writer, excluded []genapi.Output, settled bool) {
 	if len(excluded) == 0 {
 		return
 	}
@@ -187,9 +192,23 @@ func reportExcludedOutputs(errw io.Writer, excluded []genapi.Output) {
 	// the Buzz ledger and cannot tell the two exclusion kinds apart from the
 	// payload, so it must not settle the refund question in either direction.
 	// See AGENTS.md item 28 and #278.
-	fmt.Fprintln(errw, st.Dim(
-		"These were part of the workflow you were charged for. Whether any of that charge comes back depends on why each output was excluded and is decided server-side; "+
-			buzzLedgerUnknownNote+"."))
+	//
+	// 🔴 #346 SPLIT THIS SENTENCE IN TWO, AND THE SPLIT IS A SUBTRACTION. When the
+	// caller has just printed the workflow's own debits and credits, telling the
+	// user that this CLI cannot see the ledger and pointing them at
+	// /user/transactions is false in context — the workflow-level record is on
+	// screen. The replacement still answers nothing: it states what this CLI does
+	// not do (map a charge onto individual outputs — a claim about this program,
+	// which is checkable) and points at the entries. It does NOT say the server
+	// has no per-output record; that would be a claim about a payload this build
+	// has only seen one shape of. Where no settlement was printed, the original
+	// sentence is unchanged.
+	fate := "Whether any of that charge comes back depends on why each output was excluded and is decided server-side; " +
+		buzzLedgerUnknownNote + "."
+	if settled {
+		fate = "This CLI does not map a charge onto individual outputs; " + workflowSettlementPrintedNote + "."
+	}
+	fmt.Fprintln(errw, st.Dim("These were part of the workflow you were charged for. "+fate))
 }
 
 // reportOutputCountMismatch warns when fewer deliverable outputs came back than

--- a/internal/cmd/generate_output_test.go
+++ b/internal/cmd/generate_output_test.go
@@ -493,7 +493,7 @@ func TestReportExcludedOutputs_DoesNotSettleTheRefund(t *testing.T) {
 	blocked := "minor"
 	id := "out_1"
 	var b bytes.Buffer
-	reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: id, BlockedReason: &blocked}}})
+	reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: id, BlockedReason: &blocked}}}, false)
 	got := b.String()
 
 	if got == "" {
@@ -511,6 +511,44 @@ func TestReportExcludedOutputs_DoesNotSettleTheRefund(t *testing.T) {
 	for _, banned := range refundDirectionalClaims {
 		if strings.Contains(lower, banned) {
 			t.Errorf("the exclusion note decides the refund question with %q.\n%s", banned, got)
+		}
+	}
+}
+
+// The SETTLED variant of the same surface (#346). When the caller has already
+// printed this workflow's own transaction record, the note must stop disclaiming
+// a ledger that is on screen — and must still decide nothing.
+//
+// 🔴 The two modes are asserted as a PAIR, in one place, because the hazard is
+// symmetric: the unsettled branch losing the disclaimer is #278 returning, and
+// the settled branch keeping it is #346 returning.
+func TestReportExcludedOutputs_SettledPointsAtTheRecordAndStillDecidesNothing(t *testing.T) {
+	blocked := "minor"
+	var b bytes.Buffer
+	reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}}, true)
+	got := b.String()
+
+	if got == "" {
+		t.Fatal("CONTROL failure: reportExcludedOutputs printed nothing in settled mode")
+	}
+	if strings.Contains(got, buzzLedgerUnknownNote) {
+		t.Errorf("#346: the note still disclaims a ledger whose per-workflow entries the caller just printed:\n%s", got)
+	}
+	if strings.Contains(got, "/user/transactions") {
+		t.Errorf("#346: the account-wide history pointer is still on a per-workflow surface:\n%s", got)
+	}
+	if !strings.Contains(got, workflowSettlementPrintedNote) {
+		t.Errorf("the settled note does not render the shared pointer constant verbatim, so it has grown its own wording "+
+			"for the money question — the exact drift #278's consolidation exists to prevent:\n%s", got)
+	}
+	// The charge half survives here too.
+	if !strings.Contains(got, "charged") {
+		t.Errorf("the settled note no longer says the workflow was charged:\n%s", got)
+	}
+	lower := strings.ToLower(got)
+	for _, banned := range refundDirectionalClaims {
+		if strings.Contains(lower, banned) {
+			t.Errorf("the settled exclusion note decides the refund question with %q.\n%s", banned, got)
 		}
 	}
 }

--- a/internal/cmd/generate_refund_copy_test.go
+++ b/internal/cmd/generate_refund_copy_test.go
@@ -168,7 +168,10 @@ func TestBuzzLedgerNote_IsRenderedOnEverySpendOutcomeSurface(t *testing.T) {
 	t.Run("excluded_outputs_note", func(t *testing.T) {
 		blocked := "minor"
 		var b bytes.Buffer
-		reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}})
+		// settled=false: this guard is about the surface that has NO per-workflow
+		// record to point at, which is the one the constant exists for. The
+		// settled counterpart is asserted in generate_output_test.go.
+		reportExcludedOutputs(&b, []genapi.Output{{Blob: genapi.Blob{ID: "out_1", BlockedReason: &blocked}}}, false)
 		if b.Len() == 0 {
 			t.Fatal("CONTROL failure: reportExcludedOutputs printed nothing")
 		}

--- a/internal/cmd/testdata/golden/excluded_outputs_note_settled.txt
+++ b/internal/cmd/testdata/golden/excluded_outputs_note_settled.txt
@@ -1,0 +1,1 @@
+⚠ 1 output(s) will NOT be saved — they are not deliverable results: - out_1: not available (the job finished without producing a usable file) These were part of the workflow you were charged for. This CLI does not map a charge onto individual outputs; the transactions the server recorded for this workflow are printed above.

--- a/internal/cmd/testdata/golden/settlement_debit_credit.txt
+++ b/internal/cmd/testdata/golden/settlement_debit_credit.txt
@@ -1,0 +1,1 @@
+Buzz transactions for this workflow (2 recorded) debit 8 credit 8 net 0 net is debit minus credit over the entries above, for this workflow only — it is not your account balance, which `civitai buzz` reports.

--- a/internal/cmd/testdata/golden/settlement_unclassified_type.txt
+++ b/internal/cmd/testdata/golden/settlement_unclassified_type.txt
@@ -1,0 +1,1 @@
+Buzz transactions for this workflow (3 recorded) debit 12 (2 entries) hold 3 net (not computed) net is not computed: this build does not know which way "hold" moves Buzz, so the entries above are listed without a total.

--- a/internal/cmd/testdata/golden/terminal_status_failed_settled.txt
+++ b/internal/cmd/testdata/golden/terminal_status_failed_settled.txt
@@ -1,0 +1,1 @@
+the generation finished with status "failed" and produced no usable result; the transactions the server recorded for this workflow are printed above. Inspect the run with `civitai workflows get wf_123` (the orchestrator often supplies no failure reason, so it may not say why)

--- a/internal/cmd/workflow_settlement.go
+++ b/internal/cmd/workflow_settlement.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/civitai/cli/internal/genapi"
+	"github.com/civitai/cli/internal/ui"
+)
+
+// workflowSettlementPrintedNote is what a surface says INSTEAD of
+// buzzLedgerUnknownNote once it has printed the workflow's own transactions
+// (#346).
+//
+// 🔴 IT IS A POINTER AT FACTS, NOT A RULE. buzzLedgerUnknownNote exists because
+// the CLI cannot answer "what became of this charge" and must not pretend to;
+// #346 showed that on a workflow the server DOES itemise, printing that sentence
+// sent the user to a website for a number that was in the payload the command
+// had just parsed. So where the numbers are on screen, this replaces it — and it
+// still asserts nothing: it names where the entries are, and the entries are the
+// server's own.
+//
+// It deliberately does NOT re-point at /user/transactions. That pointer answers
+// the ACCOUNT-WIDE question, which this block does not touch, and repeating it
+// here is exactly the conflation #346 reported.
+//
+// It is a shared constant for the same reason buzzLedgerUnknownNote is: two
+// hand-written variants drift, and the drift is invisible until someone reads
+// both screens. Its call sites are an asserted ledger — see
+// TestSettlementPrintedNoteLedger.
+const workflowSettlementPrintedNote = "the transactions the server recorded for this workflow are printed above"
+
+// reportWorkflowSettlement prints the orchestrator's own transaction record for
+// ONE workflow, and reports whether it printed anything.
+//
+// 🔴 THE RETURN VALUE IS LOAD-BEARING. workflowSettlementPrintedNote says the
+// entries are "printed above", so a caller may only use it when this function
+// actually printed them. Returning the fact — rather than each caller re-deciding
+// whether a settlement exists — is what keeps that sentence true by construction
+// instead of by two predicates agreeing.
+//
+// rows go to `out` (they are DATA, the same class as the status and the output
+// list) and the one line explaining the arithmetic goes to `errw`, per this
+// repo's stream convention. A caller whose stdout must stay machine-clean passes
+// errw for both.
+//
+// 🔴 It reports, it does not conclude. Every number is a sum of entries the
+// server returned for this workflow id; nothing here generalises to what a
+// failure or a cancel does, and nothing here is the account-wide Buzz ledger.
+func reportWorkflowSettlement(out, errw io.Writer, wf *genapi.Workflow) bool {
+	s, ok := wf.Settlement()
+	if !ok {
+		return false
+	}
+	entries := 0
+	for _, t := range s.Totals {
+		entries += t.Count
+	}
+
+	fmt.Fprintf(out, "\n%s\n", ui.For(out).Bold(fmt.Sprintf("Buzz transactions for this workflow (%d recorded)", entries)))
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, t := range s.Totals {
+		// The type string is server-origin text, like every other field this
+		// package prints, so it goes through safeTerm.
+		// The third cell is omitted rather than emitted empty: a tab-terminated
+		// empty cell pads to the column width, leaving trailing spaces on every
+		// row of the commonest rendering.
+		if t.Count > 1 {
+			fmt.Fprintf(tw, "  %s\t%s\t(%d entries)\n", safeTerm(dashIfEmpty(t.Type)), buzzAmount(t.Amount), t.Count)
+			continue
+		}
+		fmt.Fprintf(tw, "  %s\t%s\n", safeTerm(dashIfEmpty(t.Type)), buzzAmount(t.Amount))
+	}
+	if s.NetKnown {
+		fmt.Fprintf(tw, "  net\t%s\n", buzzAmount(s.Net))
+	} else {
+		fmt.Fprintf(tw, "  net\t(not computed)\n")
+	}
+	_ = tw.Flush()
+
+	st := ui.For(errw)
+	if s.NetKnown {
+		fmt.Fprintln(errw, st.Dim(
+			"net is debit minus credit over the entries above, for this workflow only — it is not your account balance, which `civitai buzz` reports."))
+	} else {
+		fmt.Fprintln(errw, st.Dim(fmt.Sprintf(
+			"net is not computed: this build does not know which way %s moves Buzz, so the entries above are listed without a total.",
+			safeTerm(quotedList(s.Unclassified)))))
+	}
+	return true
+}
+
+// quotedList renders a type list as `"a", "b"` for the not-computed line.
+func quotedList(items []string) string {
+	out := ""
+	for i, s := range items {
+		if i > 0 {
+			out += ", "
+		}
+		out += fmt.Sprintf("%q", s)
+	}
+	return out
+}

--- a/internal/cmd/workflow_settlement_regression_test.go
+++ b/internal/cmd/workflow_settlement_regression_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/genapi"
+)
+
+// #346 — THE ONE VIEW THAT DISCLAIMED THE KNOWLEDGE WAS THE ONE VIEW THAT
+// DISCARDED IT.
+//
+// A blind credentialed dogfood run read a failed workflow back with
+// `civitai workflows get` and was told *"this CLI cannot see your Buzz ledger …
+// settle it against your Buzz transaction history (/user/transactions)"* — while
+// the payload the command had just parsed itemised the run:
+//
+//	"transactions":{"list":[{"type":"debit","amount":8,…},
+//	                        {"type":"credit","amount":8,…}]}
+//
+// `civitai workflows list` had been rendering that same settlement as `COST 0`
+// all along. The command sent the user to a website for a number on their screen.
+//
+// 🔴 EVERY ASSERTION BELOW IS ABOUT BEHAVIOUR THIS PACKAGE ALREADY EXPOSED —
+// runWorkflowsGet, runGenerate, the shared constant — and NOT about any symbol
+// #346 introduced. That is deliberate: this file compiles against the
+// pre-change tree, so it can be watched to FAIL there. A regression test that
+// only compiles after the fix proves the fix exists, not that it fixed anything.
+//
+// It asserts NO refund rule, in either direction. What it pins is that a
+// disclaimer of knowledge is not printed alongside the knowledge, and that the
+// disclaimer SURVIVES wherever the payload really is silent.
+
+// wfWithTransactions is the #346 payload: a failed run with one non-deliverable
+// output (so the excluded-output note, which carried the disclaimer, fires) and
+// the orchestrator's own debit/credit pair.
+const wfWithTransactions = `{
+  "id":"wf_346","status":"failed","createdAt":"2026-08-10T09:00:00Z","completedAt":"2026-08-10T09:00:20Z",
+  "transactions":{"list":[
+    {"type":"debit","amount":8,"accountType":"user","createdAt":"2026-08-10T09:00:00Z"},
+    {"type":"credit","amount":8,"accountType":"user","createdAt":"2026-08-10T09:00:19Z"}]},
+  "steps":[{"$type":"textToImage","name":"s","status":"failed",
+    "output":{"images":[{"id":"gone","type":"image","available":false}]}}]}`
+
+// wfWithoutTransactions is the SAME workflow with the record absent — the case
+// the disclaimer is actually for.
+const wfWithoutTransactions = `{
+  "id":"wf_346b","status":"failed","createdAt":"2026-08-10T09:00:00Z","completedAt":"2026-08-10T09:00:20Z",
+  "steps":[{"$type":"textToImage","name":"s","status":"failed",
+    "output":{"images":[{"id":"gone","type":"image","available":false}]}}]}`
+
+// TestWorkflowsGet_RendersTheTransactionsItParsed is #346 itself.
+func TestWorkflowsGet_RendersTheTransactionsItParsed(t *testing.T) {
+	c, out, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfWithTransactions, nil), workflowsGetOpts{}, "wf_346"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	stdout, stderr := out.String(), errb.String()
+	both := stdout + stderr
+
+	// POSITIVE CONTROL. If the excluded-output report stopped rendering, the
+	// disclaimer assertion below would pass for the wrong reason — the surface
+	// that carried it would simply be gone.
+	if !strings.Contains(stderr, "will NOT be saved") {
+		t.Fatalf("CONTROL failure: the excluded-output report did not render, so the disclaimer assertion below is "+
+			"vacuous.\nstderr:\n%s", stderr)
+	}
+
+	// The record itself: both entries and the arithmetic over them.
+	for _, want := range []string{"debit", "credit", "net"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("#346: `workflows get` did not render the %q the payload contains.\nstdout:\n%s", want, stdout)
+		}
+	}
+	// The amounts, so a heading with no numbers under it cannot pass.
+	if !strings.Contains(stdout, "8") {
+		t.Errorf("#346: the transaction amounts are missing.\nstdout:\n%s", stdout)
+	}
+
+	// THE DEFECT: the disclaimer must not be printed beside the data.
+	if strings.Contains(both, buzzLedgerUnknownNote) {
+		t.Errorf("#346: `workflows get` printed %q for a workflow whose own transactions it had already parsed. "+
+			"That sentence sends the user to a website for numbers that are on their screen.\nstdout:\n%s\nstderr:\n%s",
+			buzzLedgerUnknownNote, stdout, stderr)
+	}
+	// …and neither may the pointer on its own: /user/transactions answers the
+	// ACCOUNT-WIDE question, which is not the one this view was asked.
+	if strings.Contains(both, "/user/transactions") {
+		t.Errorf("#346: the account-wide transaction-history pointer is still on the per-workflow view.\n"+
+			"stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	// The half that is NOT in doubt must survive: the workflow was charged.
+	if !strings.Contains(stderr, "charged") {
+		t.Errorf("the excluded-output note no longer says the workflow was charged; that half was never in doubt.\n%s", stderr)
+	}
+}
+
+// The COUNTERPART, and the reason this is not a deletion: a payload that really
+// carries no transaction record still gets the disclaimer. Without this, "remove
+// the sentence everywhere" would pass the test above.
+func TestWorkflowsGet_KeepsTheDisclaimerWhenThePayloadIsSilent(t *testing.T) {
+	c, out, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfWithoutTransactions, nil), workflowsGetOpts{}, "wf_346b"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	stdout, stderr := out.String(), errb.String()
+	if !strings.Contains(stderr, "will NOT be saved") {
+		t.Fatalf("CONTROL failure: the excluded-output report did not render.\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, buzzLedgerUnknownNote) {
+		t.Errorf("a workflow with NO transaction record must keep the ledger disclaimer — an absent record is not "+
+			"evidence that no money moved.\nstderr:\n%s", stderr)
+	}
+	// And no settlement block may be invented for it.
+	if strings.Contains(stdout, "Buzz transactions") {
+		t.Errorf("a settlement block was rendered for a payload that carries none:\n%s", stdout)
+	}
+}
+
+// The same defect on the money-spending path: `generate` polls the workflow back
+// and its terminal-status error carried the same disclaimer.
+func TestGenerate_TerminalStatusRendersTheTransactionsItPolled(t *testing.T) {
+	withStdinTTY(t, false)
+	clock := newFakeClock()
+	calls := 0
+	var s genSeams
+	s.poll = clock.cfg()
+	s.getWorkflow = scriptedWorkflows(&calls, wfWithTransactions)
+
+	c, out, errb := genCmd("")
+	err := runGenerate(c, s.deps(t), waitOpts(t.TempDir()))
+	if err == nil {
+		t.Fatal("a failed workflow must not report success")
+	}
+	stderr := errb.String()
+	if strings.Contains(err.Error(), buzzLedgerUnknownNote) {
+		t.Errorf("#346: the terminal-status error disclaims a ledger the poll reply itemises.\n  got: %v", err)
+	}
+	if strings.Contains(err.Error(), "/user/transactions") {
+		t.Errorf("#346: the terminal-status error still points at the account-wide history.\n  got: %v", err)
+	}
+	for _, want := range []string{"debit", "credit", "net"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("#346: `generate` did not render the %q from the workflow it polled.\nstderr:\n%s", want, stderr)
+		}
+	}
+	// 🔴 STDOUT MUST STAY CLEAN. This branch returns an error and `--json` puts a
+	// machine payload on stdout; a money block written there would corrupt it.
+	if out.Len() != 0 {
+		t.Errorf("the settlement block leaked onto stdout on the failure path: %q", out.String())
+	}
+}
+
+// The counterpart on the generate path.
+func TestGenerate_TerminalStatusKeepsTheDisclaimerWhenSilent(t *testing.T) {
+	withStdinTTY(t, false)
+	for _, st := range []string{genapi.StatusFailed, genapi.StatusExpired, genapi.StatusCanceled} {
+		t.Run(st, func(t *testing.T) {
+			clock := newFakeClock()
+			calls := 0
+			var s genSeams
+			s.poll = clock.cfg()
+			s.getWorkflow = scriptedWorkflows(&calls, wfJSON(st))
+			c, _, _ := genCmd("")
+			err := runGenerate(c, s.deps(t), waitOpts(t.TempDir()))
+			if err == nil {
+				t.Fatalf("%s must not report success", st)
+			}
+			if !strings.Contains(err.Error(), buzzLedgerUnknownNote) {
+				t.Errorf("%s: a poll reply with no transaction record must keep the disclaimer.\n  got: %v", st, err)
+			}
+		})
+	}
+}

--- a/internal/cmd/workflow_settlement_test.go
+++ b/internal/cmd/workflow_settlement_test.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/genapi"
+)
+
+// wfWithUnclassifiedTransaction carries a type this build cannot place on either
+// side of the subtraction, which is the fail-closed branch.
+const wfWithUnclassifiedTransaction = `{
+  "id":"wf_346c","status":"failed","createdAt":"2026-08-10T09:00:00Z",
+  "transactions":{"list":[
+    {"type":"debit","amount":8},{"type":"debit","amount":4},{"type":"hold","amount":3}]},
+  "steps":[]}`
+
+func settlementOf(t *testing.T, payload string) (stdout, stderr string, printed bool) {
+	t.Helper()
+	var wf genapi.Workflow
+	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
+		t.Fatalf("fixture does not decode: %v", err)
+	}
+	var out, errb bytes.Buffer
+	printed = reportWorkflowSettlement(&out, &errb, &wf)
+	return out.String(), errb.String(), printed
+}
+
+// The block reports the entries and the arithmetic over them, and nothing else.
+func TestReportWorkflowSettlement_ReportsTheEntries(t *testing.T) {
+	stdout, stderr, printed := settlementOf(t, wfWithTransactions)
+	if !printed {
+		t.Fatal("the #346 payload must render a settlement")
+	}
+	for _, want := range []string{"debit", "credit", "net", "8"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the block is missing %q:\n%s", want, stdout)
+		}
+	}
+	// net 0 is the arithmetic `workflows list` renders as COST 0 for the same run.
+	if !strings.Contains(normaliseCopy(stdout), "net 0") {
+		t.Errorf("net is not reported as 0 for a matched debit/credit pair:\n%s", stdout)
+	}
+	// 🔴 The block itself must not answer the refund question in either
+	// direction. It is a record; the rule stays server-side (AGENTS.md item 28).
+	lower := strings.ToLower(stdout + stderr)
+	for _, banned := range refundDirectionalClaims {
+		if strings.Contains(lower, banned) {
+			t.Errorf("the settlement block decides the refund question with %q:\n%s\n%s", banned, stdout, stderr)
+		}
+	}
+	// And it must not re-point at the account-wide history: that is the
+	// conflation #346 reported.
+	if strings.Contains(stdout+stderr, "/user/transactions") {
+		t.Errorf("the per-workflow block points at the account-wide history:\n%s\n%s", stdout, stderr)
+	}
+	// It must scope itself against the account balance, or "net 0" reads as a
+	// balance rather than as this run's arithmetic.
+	if !strings.Contains(stderr, "civitai buzz") {
+		t.Errorf("nothing distinguishes this workflow's net from the account balance:\n%s", stderr)
+	}
+}
+
+// FAIL CLOSED: an unclassifiable type withholds the net rather than quietly
+// dropping the entry out of the subtraction.
+func TestReportWorkflowSettlement_UnclassifiedTypeWithholdsTheNet(t *testing.T) {
+	stdout, stderr, printed := settlementOf(t, wfWithUnclassifiedTransaction)
+	if !printed {
+		t.Fatal("an unclassifiable type must still render the entries")
+	}
+	if !strings.Contains(stdout, "not computed") {
+		t.Errorf("the net was reported despite an unplaceable type:\n%s", stdout)
+	}
+	// The withheld figure must not appear anywhere: 8+4-0 = 12 would be the
+	// number a silent drop produces.
+	if strings.Contains(normaliseCopy(stdout), "net 12") {
+		t.Errorf("the unclassified entry was dropped out of the arithmetic and a net was printed anyway:\n%s", stdout)
+	}
+	// The entry is still REPORTED, under the server's own name.
+	if !strings.Contains(stdout, "hold") {
+		t.Errorf("the unclassified entry was hidden rather than reported:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, `"hold"`) {
+		t.Errorf("the explanation does not name the type it could not place:\n%s", stderr)
+	}
+	// The multi-entry type reports how many entries it folded together.
+	if !strings.Contains(normaliseCopy(stdout), "(2 entries)") {
+		t.Errorf("two debits were summed into one row without saying so:\n%s", stdout)
+	}
+}
+
+// Nothing is printed, and nothing is claimed, when the payload carries no
+// record. 🔴 The return value is what every caller's "printed above" pointer
+// depends on, so a false positive here would make that sentence a lie.
+func TestReportWorkflowSettlement_SilentWhenUnobservable(t *testing.T) {
+	stdout, stderr, printed := settlementOf(t, wfWithoutTransactions)
+	if printed {
+		t.Error("a payload with no transaction record must report that it printed nothing")
+	}
+	if stdout != "" || stderr != "" {
+		t.Errorf("something was printed for a payload with no record:\nstdout: %q\nstderr: %q", stdout, stderr)
+	}
+}
+
+// A server-origin type string is terminal-escaped like every other field this
+// package prints.
+func TestReportWorkflowSettlement_SanitisesTheServerType(t *testing.T) {
+	stdout, _, printed := settlementOf(t, `{"id":"w","status":"failed","transactions":{"list":[
+	  {"type":"deb\u001b[31mit","amount":1}]}}`)
+	if !printed {
+		t.Fatal("CONTROL failure: the fixture rendered nothing, so the escape assertion is vacuous")
+	}
+	if strings.Contains(stdout, "\x1b[31m") {
+		t.Errorf("a raw control sequence from the server reached the terminal:\n%q", stdout)
+	}
+}
+
+// GUARD A, for #346's constant — the same shape as
+// TestBuzzLedgerNote_AssertsNonObservabilityAndNoDirection.
+//
+// workflowSettlementPrintedNote is what a user reads INSTEAD of "this CLI cannot
+// see your Buzz ledger". The whole basis for dropping that disclaimer is that
+// the entries are on screen, so this constant must do two things and no more:
+// point at them, and decide nothing.
+func TestSettlementPrintedNote_PointsAtTheRecordAndDecidesNothing(t *testing.T) {
+	if !strings.Contains(workflowSettlementPrintedNote, "printed above") {
+		t.Errorf("the note no longer says the entries are printed above. That clause is the whole licence for omitting "+
+			"buzzLedgerUnknownNote — without it the CLI has simply stopped answering.\n  got: %s", workflowSettlementPrintedNote)
+	}
+	if !strings.Contains(workflowSettlementPrintedNote, "the server recorded") {
+		t.Errorf("the note no longer attributes the entries to the SERVER. They are the orchestrator's record, not this "+
+			"CLI's conclusion, and the attribution is what keeps it a report.\n  got: %s", workflowSettlementPrintedNote)
+	}
+	// It is per-workflow, and must not be mistaken for the account ledger.
+	if strings.Contains(workflowSettlementPrintedNote, "/user/transactions") {
+		t.Errorf("the per-workflow note points at the account-wide history — the conflation #346 reported.\n  got: %s",
+			workflowSettlementPrintedNote)
+	}
+	lower := strings.ToLower(workflowSettlementPrintedNote)
+	for _, banned := range refundDirectionalClaims {
+		if strings.Contains(lower, banned) {
+			t.Errorf("the note decides the refund question with %q. Reporting a record is allowed; stating the rule is "+
+				"not (AGENTS.md item 28).\n  got: %s", banned, workflowSettlementPrintedNote)
+		}
+	}
+}
+
+// GUARD A' — the POSITIVE CONTROL. The predicate above must reject sentences
+// that assert a direction or that stop pointing at the record, and accept the
+// real constant. Without this, a ban list that has stopped matching passes.
+//
+// 🔴 WHAT THIS CONTROL CANNOT DO, MEASURED WHILE WRITING IT. The first version
+// of the table below carried the case *"the transactions the server recorded are
+// printed above and nothing is refunded"* — and the predicate ACCEPTED it: both
+// required clauses are present, and `refundDirectionalClaims` bans
+// `"not refunded"` but not `"nothing is refunded"`. That is not a bug in this
+// test, it is item 28's finding reproduced a third time: a sentence that keeps
+// every required clause and APPENDS a claim is not detectable from text, and no
+// length of phrase list changes that (the item's own "DO NOT REACH FOR A THIRD
+// PHRASE LIST"). The offending case was removed rather than the list extended.
+//
+// The APPEND mutation is caught by TestGoldenSpendCopy instead, which compares
+// the whole normalised rendering of every surface this constant lands on. That
+// is the guard; this one only proves the enumerated wordings still bite.
+func TestSettlementPrintedNote_GuardCanStillFire(t *testing.T) {
+	rejects := func(s string) bool {
+		if !strings.Contains(s, "printed above") || !strings.Contains(s, "the server recorded") {
+			return true
+		}
+		lower := strings.ToLower(s)
+		for _, banned := range refundDirectionalClaims {
+			if strings.Contains(lower, banned) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range []struct{ name, text string }{
+		{"a direction bolted onto the pointer",
+			"the transactions the server recorded for this workflow are printed above, so it was refunded"},
+		{"the paraphrase that beat the first guard",
+			"your Buzz returns to your balance automatically; confirm with `civitai buzz`"},
+		{"a pointer that names no record", "check the numbers above"},
+		{"an enumerated wording appended to the real constant",
+			workflowSettlementPrintedNote + "; the rest will be refunded"},
+	} {
+		if !rejects(c.text) {
+			t.Errorf("CONTROL failure: the guard accepts %s:\n  %s", c.name, c.text)
+		}
+	}
+	if rejects(workflowSettlementPrintedNote) {
+		t.Fatalf("CONTROL failure: the guard rejects the constant it is written to accept:\n  %s", workflowSettlementPrintedNote)
+	}
+}
+
+// GUARD C — the asserted call-site ledger, the same idiom as
+// TestBuzzLedgerNoteIsTheOnlyRefundWording.
+//
+// It fails in BOTH directions. A file that GAINED a reference is a new surface
+// speaking about the fate of a charge; a file that LOST one has started wording
+// the money question itself. #346's constant needs this for exactly the reason
+// #278's did: the goldens cover the surfaces we know about and are structurally
+// blind to a new one.
+func TestSettlementPrintedNoteLedger(t *testing.T) {
+	want := map[string]int{
+		"workflow_settlement.go": 1, // the const declaration
+		"generate_output.go":     1, // the settled excluded-outputs note
+		"generate.go":            1, // the settled terminal-status error
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
+	}
+	got := map[string]int{}
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, rerr := os.ReadFile(filepath.Clean(name))
+		if rerr != nil {
+			t.Fatalf("CONTROL failure: read %s: %v", name, rerr)
+		}
+		scanned++
+		// Comment lines are excluded for the same reason the #278 ledger excludes
+		// them: what is pinned is where the constant is RENDERED.
+		n := 0
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			n += strings.Count(line, "workflowSettlementPrintedNote")
+		}
+		if n > 0 {
+			got[name] = n
+		}
+	}
+	if scanned < 10 {
+		t.Fatalf("CONTROL failure, not a finding: scanned only %d non-test .go files in internal/cmd", scanned)
+	}
+	if len(got) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: the identifier appears in 0 of %d scanned files — it was renamed or the "+
+			"scan is broken. Do not read this as 'no sites'.", scanned)
+	}
+	if fmt.Sprint(sortedPairs(got)) != fmt.Sprint(sortedPairs(want)) {
+		t.Fatalf("the workflowSettlementPrintedNote call-site ledger changed.\n  got:  %v\n  want: %v\n\n"+
+			"🔴 A file that GAINED a reference is a new surface that stops disclaiming the ledger — pin its rendering in "+
+			"TestGoldenSpendCopy in the same change, or the sentence beside it is unreviewed. A file that LOST one has grown "+
+			"its own wording for the money question (AGENTS.md item 28).",
+			sortedPairs(got), sortedPairs(want))
+	}
+}

--- a/internal/cmd/workflows.go
+++ b/internal/cmd/workflows.go
@@ -150,6 +150,20 @@ func printWorkflow(out, errw io.Writer, wf *genapi.Workflow) {
 	// the ONLY surviving evidence that a different checkpoint was billed.
 	reportModelSubstitutions(errw, wf.Substitutions(), substitutionOnRead)
 
+	// 🔴 #346: THIS VIEW HELD THE ANSWER AND PRINTED THE DISCLAIMER. The payload
+	// this command has already parsed itemises the workflow's own debits and
+	// credits, and the excluded-output note below used to answer "what became of
+	// the charge" with "this CLI cannot see your Buzz ledger … settle it against
+	// /user/transactions" — sending the user to a website for numbers that were
+	// on their screen. `civitai workflows list` had been rendering the same
+	// settlement as its COST column all along.
+	//
+	// The block prints for ANY status, terminal or not, because it is a RECORD of
+	// what the server has entered so far and not a claim that the run is over —
+	// unlike the excluded-output report below, which is gated on IsTerminalStatus
+	// precisely because it does make a claim about a job that ran (#280).
+	settled := reportWorkflowSettlement(out, errw, wf)
+
 	kept, excluded := genapi.PartitionOutputs(wf)
 	fmt.Fprintf(out, "\n%s\n", ui.For(out).Bold(fmt.Sprintf("Outputs (%d deliverable, %d excluded)", len(kept), len(excluded))))
 	if len(kept) == 0 && len(excluded) == 0 {
@@ -194,7 +208,7 @@ func printWorkflow(out, errw io.Writer, wf *genapi.Workflow) {
 			"This workflow has not finished. Re-run this command to check again — it is a read and spends nothing."))
 		return
 	}
-	reportExcludedOutputs(errw, excluded)
+	reportExcludedOutputs(errw, excluded, settled)
 	if len(kept) > 0 {
 		fmt.Fprintln(errw, ui.For(errw).Dim(
 			"Output URLs are presigned and expire — fetch them promptly, or re-run this command for fresh links."))

--- a/internal/cmd/workflows_test.go
+++ b/internal/cmd/workflows_test.go
@@ -205,7 +205,13 @@ func excludedOutputReport(t *testing.T, payload string) string {
 		t.Fatalf("fixture is blind to #280: it carries no excluded output, so the charge claim is unreachable")
 	}
 	var b bytes.Buffer
-	reportExcludedOutputs(&b, excluded)
+	// Both #280 fixtures carry no `transactions` record, so the surface they
+	// render is the unsettled one. Deriving the block with settled=false keeps
+	// these assertions matching what runWorkflowsGet prints for them; a fixture
+	// that GAINED a record would make this derivation stop matching the real
+	// stderr, which fails LOUD ("must still get the excluded-output report")
+	// rather than passing silently.
+	reportExcludedOutputs(&b, excluded, false)
 	block := b.String()
 	if strings.TrimSpace(block) == "" {
 		t.Fatalf("positive control failed: reportExcludedOutputs printed nothing for %d excluded output(s)", len(excluded))

--- a/internal/genapi/settlement.go
+++ b/internal/genapi/settlement.go
@@ -1,0 +1,133 @@
+package genapi
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// The two transaction types this build knows the DIRECTION of.
+//
+// 🔴 They are the only two ever OBSERVED on the wire, and the direction is
+// corroborated rather than assumed: a failed workflow read back on 2026-08-10
+// carried `{"type":"debit","amount":8}` and `{"type":"credit","amount":8}`, and
+// the SAME workflow rendered `COST 0` in `civitai workflows list` — i.e. the
+// server's own cost for that run equals debit minus credit. Anything else is
+// left UNCLASSIFIED on purpose; see Settlement.NetKnown.
+const (
+	TransactionDebit  = "debit"
+	TransactionCredit = "credit"
+)
+
+// WorkflowTransaction is one entry of the orchestrator's per-workflow money
+// record.
+//
+// Only the two fields the CLI reports are modelled. The shape is
+// orchestrator-owned, so the type string is echoed VERBATIM and never relabelled
+// (the same rule Workflow.Transactions' own comment states).
+type WorkflowTransaction struct {
+	Type   string  `json:"type"`
+	Amount float64 `json:"amount"`
+}
+
+// TransactionTotal is every entry of one type, summed.
+type TransactionTotal struct {
+	// Type is the server's own string, untouched.
+	Type string
+	// Amount is the sum of that type's entries.
+	Amount float64
+	// Count is how many entries were summed into Amount.
+	Count int
+}
+
+// Settlement is what the orchestrator recorded against ONE workflow.
+//
+// 🔴 IT IS A RECORD, NOT A RULE. Every field here is arithmetic over entries the
+// server returned for this workflow id. It says nothing about whether a failure
+// or a cancel is refunded in general, and nothing about the account-wide Buzz
+// ledger, which this CLI still cannot read. That distinction is the whole of
+// AGENTS.md item 28: reporting a ledger you were handed is the opposite of
+// claiming an unobservable one.
+type Settlement struct {
+	// Totals is one entry per distinct type, in the order the types were first
+	// seen in the payload — the server's order, not one this package invents.
+	Totals []TransactionTotal
+	// Debits and Credits are the sums of the two classified types.
+	Debits  float64
+	Credits float64
+	// Net is Debits - Credits. 🔴 Read it ONLY when NetKnown is true.
+	Net float64
+	// NetKnown is false when the payload carried at least one type this build
+	// cannot place on either side of the subtraction. It FAILS CLOSED: an
+	// unrecognised type makes the net unreportable rather than silently dropping
+	// the entry out of the arithmetic, which would print a confident wrong
+	// number for a run the user paid for.
+	NetKnown bool
+	// Unclassified lists those types, verbatim and de-duplicated, so a caller can
+	// name what it could not place instead of saying only "unknown".
+	Unclassified []string
+}
+
+// Settlement decodes the workflow's `transactions` record into a reportable
+// summary.
+//
+// The second return is false — meaning "nothing to report", NOT "nothing
+// happened" — when the field is absent, null, not the observed
+// `{"list":[…]}` envelope, or carries an empty list. A caller must keep whatever
+// it says when the settlement is unobservable; an absent record is not evidence
+// that no money moved.
+//
+// 🔴 ONLY the measured envelope is accepted. `orchestrator.getWorkflow` returned
+// `"transactions":{"list":[…]}`; a bare array or some other wrapper is NOT
+// speculatively supported, because guessing a shape here would turn a parse this
+// package got wrong into a money figure on a user's screen. An unrecognised
+// shape reads as unobservable, which is the pre-existing behaviour.
+func (w *Workflow) Settlement() (*Settlement, bool) {
+	if w == nil {
+		return nil, false
+	}
+	return parseSettlement(w.Transactions)
+}
+
+func parseSettlement(raw json.RawMessage) (*Settlement, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var env struct {
+		List []WorkflowTransaction `json:"list"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, false
+	}
+	if len(env.List) == 0 {
+		return nil, false
+	}
+
+	s := &Settlement{NetKnown: true}
+	at := map[string]int{}
+	seenUnclassified := map[string]bool{}
+	for _, t := range env.List {
+		label := strings.TrimSpace(t.Type)
+		key := strings.ToLower(label)
+		if i, ok := at[key]; ok {
+			s.Totals[i].Amount += t.Amount
+			s.Totals[i].Count++
+		} else {
+			at[key] = len(s.Totals)
+			s.Totals = append(s.Totals, TransactionTotal{Type: label, Amount: t.Amount, Count: 1})
+		}
+		switch key {
+		case TransactionDebit:
+			s.Debits += t.Amount
+		case TransactionCredit:
+			s.Credits += t.Amount
+		default:
+			s.NetKnown = false
+			if !seenUnclassified[key] {
+				seenUnclassified[key] = true
+				s.Unclassified = append(s.Unclassified, label)
+			}
+		}
+	}
+	s.Net = s.Debits - s.Credits
+	return s, true
+}

--- a/internal/genapi/settlement_test.go
+++ b/internal/genapi/settlement_test.go
@@ -1,0 +1,183 @@
+package genapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// wfWith wraps a `transactions` value in a minimal workflow so the tests below
+// drive the SAME decode path production does — json.Unmarshal into Workflow,
+// then Settlement() — rather than handing parseSettlement a pre-built
+// RawMessage. A test that skips the outer decode cannot see a wrong struct tag.
+func wfWith(transactions string) *Workflow {
+	body := `{"id":"wf_1","status":"failed"`
+	if transactions != "" {
+		body += `,"transactions":` + transactions
+	}
+	body += `}`
+	var w Workflow
+	if err := json.Unmarshal([]byte(body), &w); err != nil {
+		panic(err)
+	}
+	return &w
+}
+
+// The #346 payload, verbatim in shape: a debit and a matching credit.
+func TestSettlement_DebitAndCredit(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":"debit","amount":8},{"type":"credit","amount":8}]}`).Settlement()
+	if !ok {
+		t.Fatal("the observed payload must decode to a settlement")
+	}
+	if s.Debits != 8 || s.Credits != 8 {
+		t.Errorf("debits/credits = %v/%v, want 8/8", s.Debits, s.Credits)
+	}
+	if !s.NetKnown || s.Net != 0 {
+		t.Errorf("net = %v (known %v), want 0/true — this is the run `workflows list` renders as COST 0", s.Net, s.NetKnown)
+	}
+	// Order is the SERVER's, first-seen: the CLI must not re-sort a record it
+	// does not own.
+	if len(s.Totals) != 2 || s.Totals[0].Type != "debit" || s.Totals[1].Type != "credit" {
+		t.Errorf("totals = %+v, want debit then credit in payload order", s.Totals)
+	}
+	if s.Totals[0].Count != 1 || s.Totals[1].Count != 1 {
+		t.Errorf("entry counts = %d/%d, want 1/1", s.Totals[0].Count, s.Totals[1].Count)
+	}
+	if len(s.Unclassified) != 0 {
+		t.Errorf("unclassified = %v, want none", s.Unclassified)
+	}
+}
+
+// A charge that stands: one debit, no credit.
+func TestSettlement_DebitOnly(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":"debit","amount":12}]}`).Settlement()
+	if !ok {
+		t.Fatal("a single debit is still a settlement")
+	}
+	if !s.NetKnown || s.Net != 12 {
+		t.Errorf("net = %v (known %v), want 12/true", s.Net, s.NetKnown)
+	}
+}
+
+// Repeated entries of one type SUM, and the count survives so a renderer can say
+// how many were folded together.
+func TestSettlement_RepeatedTypesSum(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":"debit","amount":8},{"type":"debit","amount":4},{"type":"credit","amount":3}]}`).Settlement()
+	if !ok {
+		t.Fatal("want a settlement")
+	}
+	if s.Debits != 12 || s.Credits != 3 || s.Net != 9 {
+		t.Errorf("debits/credits/net = %v/%v/%v, want 12/3/9", s.Debits, s.Credits, s.Net)
+	}
+	if len(s.Totals) != 2 {
+		t.Fatalf("totals = %+v, want one row per TYPE", s.Totals)
+	}
+	if s.Totals[0].Count != 2 || s.Totals[0].Amount != 12 {
+		t.Errorf("the debit row = %+v, want amount 12 over 2 entries", s.Totals[0])
+	}
+}
+
+// 🔴 FAIL CLOSED. A type this build cannot place on either side of the
+// subtraction must make the NET unreportable — not silently drop out of it. The
+// alternative prints a confident wrong number for a run the user paid for.
+func TestSettlement_UnknownTypeMakesTheNetUnknown(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":"debit","amount":8},{"type":"hold","amount":3}]}`).Settlement()
+	if !ok {
+		t.Fatal("an unknown type must still report the entries it saw")
+	}
+	if s.NetKnown {
+		t.Errorf("net was reported known despite the unclassified type %v — the arithmetic silently dropped an entry", s.Unclassified)
+	}
+	if len(s.Unclassified) != 1 || s.Unclassified[0] != "hold" {
+		t.Errorf("unclassified = %v, want [hold] verbatim", s.Unclassified)
+	}
+	// The entry itself is still REPORTED, verbatim and unrelabelled — it is the
+	// arithmetic that is withheld, not the fact.
+	if len(s.Totals) != 2 || s.Totals[1].Type != "hold" || s.Totals[1].Amount != 3 {
+		t.Errorf("totals = %+v, want the unclassified entry reported as the server named it", s.Totals)
+	}
+	// The classified half is still summed, so a renderer can show it.
+	if s.Debits != 8 {
+		t.Errorf("debits = %v, want 8", s.Debits)
+	}
+}
+
+// A blank type is unclassifiable in exactly the same way — it must not fall
+// through into either side.
+func TestSettlement_BlankTypeIsUnclassified(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":"","amount":5}]}`).Settlement()
+	if !ok {
+		t.Fatal("want a settlement")
+	}
+	if s.NetKnown || s.Debits != 0 || s.Credits != 0 {
+		t.Errorf("a blank type was classified: net known %v, debits %v, credits %v", s.NetKnown, s.Debits, s.Credits)
+	}
+}
+
+// Case and surrounding space do not change what a type IS.
+func TestSettlement_TypeMatchIsCaseAndSpaceInsensitive(t *testing.T) {
+	s, ok := wfWith(`{"list":[{"type":" Debit ","amount":8},{"type":"CREDIT","amount":2}]}`).Settlement()
+	if !ok {
+		t.Fatal("want a settlement")
+	}
+	if !s.NetKnown || s.Net != 6 {
+		t.Errorf("net = %v (known %v), want 6/true", s.Net, s.NetKnown)
+	}
+	// The LABEL keeps the server's own casing — trimmed, never rewritten.
+	if s.Totals[0].Type != "Debit" {
+		t.Errorf("label = %q, want the server's own %q", s.Totals[0].Type, "Debit")
+	}
+}
+
+// Every shape that means "nothing to report". 🔴 It means exactly that, and NOT
+// "no money moved" — every caller keeps its existing wording in this case.
+func TestSettlement_UnobservableShapes(t *testing.T) {
+	for _, c := range []struct{ name, body string }{
+		{"absent", ""},
+		{"null", `null`},
+		{"empty object", `{}`},
+		{"empty list", `{"list":[]}`},
+		{"null list", `{"list":null}`},
+		{"a bare array, which was never observed on this route", `[{"type":"debit","amount":8}]`},
+		{"a scalar", `7`},
+		{"a string", `"none"`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s, ok := wfWith(c.body).Settlement()
+			if ok || s != nil {
+				t.Errorf("%s must read as unobservable, got %+v", c.name, s)
+			}
+		})
+	}
+}
+
+// A nil workflow is unobservable rather than a panic: this is called from a
+// render path that already tolerates a partially-populated read.
+func TestSettlement_NilWorkflow(t *testing.T) {
+	var w *Workflow
+	if s, ok := w.Settlement(); ok || s != nil {
+		t.Errorf("a nil workflow must report nothing, got %+v", s)
+	}
+}
+
+// POSITIVE CONTROL for the whole file. The table above asserts a string of
+// zeroes; without a case that MUST decode, a Settlement() wired to
+// `return nil, false` would pass every one of them.
+func TestSettlement_ControlTheDecoderCanReturnTrue(t *testing.T) {
+	if _, ok := wfWith(`{"list":[{"type":"debit","amount":1}]}`).Settlement(); !ok {
+		t.Fatal("CONTROL failure: the decoder never returns a settlement, so the unobservable cases above prove nothing")
+	}
+}
+
+// The raw `transactions` bytes must survive on the struct untouched, because
+// `--json` hands the whole payload to a script and this package promises not to
+// relabel an orchestrator-owned shape.
+func TestSettlement_RawTransactionsAreNotConsumed(t *testing.T) {
+	w := wfWith(`{"list":[{"type":"debit","amount":8,"externalTransactionId":"xyz"}]}`)
+	if !strings.Contains(string(w.Transactions), "externalTransactionId") {
+		t.Errorf("a field the struct does not model was lost from the raw record: %s", w.Transactions)
+	}
+	if _, ok := w.Settlement(); !ok {
+		t.Fatal("an entry carrying unmodelled fields must still decode")
+	}
+}


### PR DESCRIPTION
Fixes #346.

## The defect

`civitai workflows get` on a failed run printed:

> Whether any of that charge comes back … is decided server-side; **this CLI cannot see your Buzz ledger** — `civitai buzz` reports a balance, not a history, so settle it against your Buzz transaction history (/user/transactions).

…while the payload it had just parsed contained `"transactions":{"list":[{"type":"debit","amount":8,…},{"type":"credit","amount":8,…}]}`, and `civitai workflows list` was already rendering that same settlement as `COST 0`. **The one view that disclaimed the knowledge was the one view that discarded it**, and it sent the user to a website for numbers on their screen.

## The fix — a SUBTRACTION, not a new claim

🔴 **No refund rule is asserted anywhere in this PR.** What is printed is entries the server returned for one workflow id. Reporting a ledger you were handed is the opposite of claiming an unobservable one — that distinction is the whole issue, and AGENTS.md item 28 is unchanged. What changed is a premise it was applied through: *"the CLI cannot observe the ledger"* is true of the **account** and false **per workflow**.

`civitai workflows get <id>` (always) and `civitai generate` (terminal-status + excluded-output paths only) now print:

```
Buzz transactions for this workflow (2 recorded)
  debit   8
  credit  8
  net     0
net is debit minus credit over the entries above, for this workflow only — it is not your account balance, which `civitai buzz` reports.
```

and the sentence beside it changes from the disclaimer to `the transactions the server recorded for this workflow are printed above`.

**Where no record is in the payload, the disclaimer renders exactly as before** — `nothing to report` is never `no money moved`.

### Both layers fail closed

- `genapi.Workflow.Settlement()` accepts **only** the measured `{"list":[…]}` envelope. Absent, `null`, empty, a bare array, a scalar → unobservable, i.e. pre-#346 behaviour. A bare array is *not* speculatively supported: guessing a shape here would turn a bad parse into a money figure on a user's screen.
- A transaction `type` this build cannot place on either side of the subtraction **withholds the NET** rather than dropping the entry out of the arithmetic:

```
Buzz transactions for this workflow (3 recorded)
  debit  12  (2 entries)
  hold   3
  net    (not computed)
net is not computed: this build does not know which way "hold" moves Buzz, so the entries above are listed without a total.
```

Direction is corroborated, not assumed: `debit − credit` for the #346 run equals the `COST 0` the server's own list route rendered for it.

`--json` is untouched — it was always a raw passthrough and already carried `transactions`.

## Guards — item 28's three shapes, reproduced

1. **One constant.** `workflowSettlementPrintedNote` is the single sentence that replaces `buzzLedgerUnknownNote`; asserted to point at the record, attribute it to the server, and decide nothing.
2. **An asserted bidirectional call-site ledger** (`TestSettlementPrintedNoteLedger`, 3 sites), failing on growth *and* shrinkage.
3. **Golden pinning** of all three new renderings.

The `buzzLedgerUnknownNote` ledger is **unchanged at 3/1/3** — each site now selects between two sentences rather than gaining or losing a reference.

### 🔴 NO EXISTING GOLDEN MOVED

Every pre-existing pinned fixture carries no `transactions` record, so all take the unchanged branch. `generate_help_long.txt` in particular is **untouched**. Four goldens are **added**:

| golden | why it exists |
|---|---|
| `settlement_debit_credit` | the #346 rendering itself |
| `settlement_unclassified_type` | the withheld-net sentence, the one most likely to be replaced with a guess |
| `excluded_outputs_note_settled` | this surface gained a *second* rendering; an unpinned one is the hole the golden header warns about |
| `terminal_status_failed_settled` | `generate`'s error when the poll reply did itemise the run |

### 🔴 The phrase list lost a THIRD time, in this PR, exactly as item 28 predicted

A control case *"the transactions the server recorded are printed above **and nothing is refunded**"* was **ACCEPTED** by the new constant's guard: both required clauses present, and `refundDirectionalClaims` bans `"not refunded"` but not `"nothing is refunded"` — the identical hole item 28(b) records. **The list was not extended** (item 28: *"DO NOT REACH FOR A THIRD PHRASE LIST"*). The case was removed and the append mutation left to the golden, which kills it.

## Verification

**Red at base, green at HEAD.** The regression file is written entirely against symbols that already existed on `origin/main` (`runWorkflowsGet`, `runGenerate`, `buzzLedgerUnknownNote`) precisely so it *compiles* there and can be watched to fail. Measured against `3156b80`:

| test | `origin/main` | HEAD |
|---|---|---|
| `TestWorkflowsGet_RendersTheTransactionsItParsed` | **FAIL** (printed the disclaimer verbatim) | PASS |
| `TestGenerate_TerminalStatusRendersTheTransactionsItPolled` | **FAIL** | PASS |
| `TestWorkflowsGet_KeepsTheDisclaimerWhenThePayloadIsSilent` | PASS (invariant guard) | PASS |
| `TestGenerate_TerminalStatusKeepsTheDisclaimerWhenSilent` ×3 | PASS (invariant guard) | PASS |

**Mutation matrix** — each mutant applied, run, reverted:

| mutant | killed by | note |
|---|---|---|
| append `". Nothing is refunded."` to the settled exclusion note | `TestGoldenSpendCopy/excluded_outputs_note_settled`, **1 failing test** | no phrase-list test fired — the golden is the only guard |
| append `"A cancelled run always nets to zero."` to the settlement note | `TestGoldenSpendCopy/settlement_debit_credit` | " |
| append `", so any credit there has been refunded"` to the terminal error | `TestGoldenSpendCopy/terminal_status_failed_settled` | " |
| drop `NetKnown = false` (fail-closed removed) | 4 tests, incl. the explicit `net 12` silent-drop assertion | |
| `Settlement()` always unobservable | **17** tests incl. both #346 regressions | proves reachability |
| hardcode `settled := true` in `printWorkflow` | the invariant guard + the pre-existing #280 test | pins the seam between "printed" and "pointed at" |

**Gates, counted from output rather than exit codes:**

- `go test ./... -v`: **RUN 3433 / PASS 3429 / FAIL 0 / SKIP 4**, 19 packages ok, 0 `build failed`, 0 `panic: test timed out`. (Baseline `origin/main`: RUN 3344 / PASS 3337 / FAIL 0.)
- `make ci`: 19/19 packages ok, 0 FAIL.
- `make ci-shallow` (depth-1 clone, which CI uses): `ok=19/19 failing-tests=0 failing-packages=0 timeouts=0`.
- `make lint` equivalent — golangci-lint **v2.12.2**, the CI-pinned version, under `nix-shell -p golangci-lint`: **`0 issues.`** Positive control for that zero: a *compiling* defect (an unexported function never called, in the new file) produced **`1 issues: * unused: 1`** naming `internal/cmd/workflow_settlement.go`. Reverted; re-ran; back to `0 issues.`
- `gofmt -s -l .`: clean.

🔴 **No live probe was run. Nothing in this PR spent Buzz** — every test is `httptest` or a JSON fixture, and the fixture is the shape from the issue report.

## Docs, moved in lockstep

- **README**: new `### Reading a workflow's Buzz transactions`; the `generate` ledger callout is re-scoped into *account ledger* vs *this workflow's transactions*; the `workflows get` command-table row and the `cancel` callout updated. The callout's stale *"the rule … is not readable from the civitai monorepo"* (already superseded by #307) is corrected while it was being edited.
- **AGENTS.md** item 28's trigger gains *"rendering a workflow's OWN transactions"*; the body is untouched.
- **`claudedocs/decisions/28-…md`** gains a supersession header above the byte-pinned `---` rule (the same place #307's lives), recording the finding, the account-vs-workflow distinction, the guards, the third phrase-list loss and the residuals.

## Unverified / residual

- The `{"list":[…]}` envelope is the **only** shape ever observed on `orchestrator.getWorkflow`; another shape reads as unobservable (the fail-closed direction), not as a parse error.
- `debit`/`credit` are the only two types observed. Direction is corroborated against `workflows list`' `COST 0`, not read from the orchestrator source.
- `workflows cancel` deliberately gains nothing: its read happens *before* the mutation, so the record it could show is pre-settlement. Its post-cancel note already points at `workflows get`, which now shows the entries once the workflow settles.
- Item 28's standing residual is unchanged and now slightly wider: a **new** file printing its own fate copy without touching either constant is invisible to all six guards until it lands on a golden surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
