### PR TITLE
docs(readme): three published-contract claims a reader could not reproduce (#360, #361, #364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1778,26 +1778,43 @@ default checkpoint, runs the job, and bills you for **what actually ran**. Until
 recently the reply was indistinguishable from success — a nonexistent version id
 came back `200 OK` at the default price.
 
-The server now reports each swap, and `civitai generate` surfaces it:
+The server now reports each swap, and `civitai generate` surfaces it. A version
+id that is perfectly real but belongs to a *different* model family is the
+easiest way to see it — here an SD 1.5 checkpoint sent to a Flux ecosystem:
 
 ```console
-$ civitai generate "a cat" --checkpoint 999999999 --dry-run
-⚠ The server will NOT use the checkpoint you asked for. It has substituted a
-  different model, and this estimate prices the SUBSTITUTE. Nothing has
-  been submitted or charged yet.
-    requested version 999999999 -> will run version 2436219  (reason: unrecognized)
-      the server does not offer that version in this model family at all …
+$ civitai generate "a cat" --ecosystem Flux1Kontext --checkpoint 128713 --dry-run
+⚠ The server will NOT use the checkpoint you asked for. It has substituted a different model, and this estimate prices the SUBSTITUTE. Nothing has been submitted or charged yet.
+    requested version 128713 -> will run version 1892509  (reason: unrecognized)
+      the server does not offer that version in this model family at all — it may be a community checkpoint that was never offered for generation, or a version retired since this command was written. Check it with `civitai model-versions get <id>` and pin a version that is still offered
+To refuse a run like this instead of being told about it, pass --fail-on-substitution.
 ```
 
 The checkpoint line in the summary you approve is annotated too, so the model
 that will *not* run is never the last one you read before saying yes:
 
 ```console
-Checkpoint:   DreamShaper — 8 (Checkpoint, id 128713)  [SUPERSEDED — the server will run version 2436219 instead; see the warning above]
+Checkpoint:       DreamShaper — 8 (Checkpoint, id 128713)  [SUPERSEDED — the server will run version 1892509 instead; see the warning above]
 ```
 
 Your own id stays on the line: the CLI marks it, it never quietly substitutes
 the applied one.
+
+Two things about that transcript, so you can tell a *reproduction* from a
+*mismatch*:
+
+- **The applied id is the server's current answer, not a constant.** `1892509`
+  is whatever that family's default was when this was run; yours will differ,
+  and so will the price. What reproduces is the *shape* — a warning naming both
+  ids and a `reason`, and a `[SUPERSEDED …]` note on the checkpoint line.
+- **A version id that does not exist at all will NOT get you here.** `generate`
+  resolves every `--checkpoint` against the public model-version API before it
+  prices anything, so `--checkpoint 999999999` fails locally with
+  `--checkpoint 999999999: not found (404): Model not found` and exit `4` — no
+  estimate, no submit, nothing charged. That is the [deliberate live
+  lookup](#-a-checkpoint-does-not-carry-its-ecosystem) doing its job: it is the
+  *nonexistent* id it closes off, and it cannot tell you whether an id that does
+  exist belongs to the family you are generating with.
 
 It is reported **on the estimate** (`--dry-run`, and before the confirmation
 prompt on a real run — while you can still back out), **again after the submit**
@@ -2270,11 +2287,12 @@ release and prints a one-line notice; `--no-update-check` (or
 
 ## Global flags
 
-These are accepted by **every** command:
+Four of these are accepted by **every** command. `-v` / `--version` is the
+exception — it is **root-only**:
 
 | Flag | What it does |
 | --- | --- |
-| `-v`, `--version` | Print the version and exit. (`civitai version` prints version + commit + build date.) |
+| `-v`, `--version` | **On the root command only.** `civitai --version` prints the version and exits; on a subcommand it is not a flag at all — `civitai app validate --version` fails with `unknown flag: --version` and exits `2`. From a script, use `civitai version` (version + commit + build date), which works from anywhere. |
 | `-h`, `--help` | Help for any command. `civitai --help` also prints the [exit-code](#exit-codes) contract. |
 | `--no-color` | Disable all colour and styling. Also via `NO_COLOR` or `CIVITAI_NO_COLOR`. |
 | `--color` | Force colour **even when stdout is not a TTY**. Also via `CLICOLOR_FORCE` or `CIVITAI_COLOR`. |
@@ -2399,7 +2417,10 @@ fi
 string this CLI really prints, so searching this page for a few words of your
 error should land you on the right row. (A test asserts that each of these
 strings still exists in the source, so the index cannot quietly go stale the way
-a hand-written list does.)
+a hand-written list does — and for the rows most easily confused with one
+another, a second test runs the command the row names and checks it really
+prints that string, because "the string exists somewhere" was green while a row
+credited it to the wrong command.)
 
 ### Credentials and access
 
@@ -2427,7 +2448,8 @@ a hand-written list does.)
 
 | You saw | What it means | Where to read more |
 | --- | --- | --- |
-| `is this an App project?` | There is no `block.manifest.json` at the path you named. The path itself was fine — which is why this exits `1` and not `2`. | [Validate fidelity](#validate-fidelity) |
+| `… not found at project root …` | **`civitai app validate`** (and `app submit`, which validates first) found no `block.manifest.json` in the directory you named — the full line is `block.manifest.json not found at project root <dir>`. The path itself was fine — which is why this exits `1` and not `2`. | [Validate fidelity](#validate-fidelity) |
+| `is this an App project?` | A **different** message with the same cause, from a different command: `civitai app listing …`, which has to work out *which* app you mean from the working directory. `app validate` and `app submit` never print it — they report the row above. Run `app listing` from the app directory, or name the app with `--slug` / `--dir`. | [Listing media requirements](#listing-media-requirements) |
 | `no such directory — pass the path to an App project root` | The path does not exist. This is a **usage** error: exit `2`, and `--json` prints nothing at all. | [Exit codes](#exit-codes) |
 | `is not a directory — pass the App project ROOT` | You pointed at a file — often the manifest itself. Pass the directory holding it. Exit `2`. | [Exit codes](#exit-codes) |
 | `it did NOT check that the file is loaded` | The `BLOCK_READY` advisory on its **weak** tier: it could not resolve what your `index.html` loads, so it only checked whether *some* file mentions the message. The lines that follow name what it could not follow. | [The host handshake](#the-host-handshake-block_ready) |

--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,20 @@ $ civitai app listing add-screenshot ./assets/screenshot-1.png --caption "Grid v
 `assets/` is scaffolded by every template, with a README of the requirements and
 **no placeholder images** — the files above are ones you supply.
 
+**Every `app listing` subcommand has to work out *which* app you mean, and it
+does that from the working directory** — it reads `blockId` out of the
+`block.manifest.json` next to you. Run from somewhere else and there is no
+manifest to read, so it stops before it builds a request:
+
+```text
+$ cd /tmp && civitai app listing status
+Error: could not resolve the app — run this from your app directory (with block.manifest.json) or pass --slug: no block.manifest.json found in . — is this an App project? run `civitai app init` to create one
+```
+
+Two flags name the app instead: **`--slug <blockId>`** skips the manifest
+entirely, and **`--dir <path>`** points at the app directory from wherever you
+are. Both work on every `listing` subcommand.
+
 Details worth knowing before you start:
 
 - **Source images** are png/jpeg/webp and are size-checked **locally before any
@@ -2448,8 +2462,8 @@ credited it to the wrong command.)
 
 | You saw | What it means | Where to read more |
 | --- | --- | --- |
-| `… not found at project root …` | **`civitai app validate`** (and `app submit`, which validates first) found no `block.manifest.json` in the directory you named — the full line is `block.manifest.json not found at project root <dir>`. The path itself was fine — which is why this exits `1` and not `2`. | [Validate fidelity](#validate-fidelity) |
-| `is this an App project?` | A **different** message with the same cause, from a different command: `civitai app listing …`, which has to work out *which* app you mean from the working directory. `app validate` and `app submit` never print it — they report the row above. Run `app listing` from the app directory, or name the app with `--slug` / `--dir`. | [Listing media requirements](#listing-media-requirements) |
+| `… not found at project root …` | **`civitai app validate`** found no `block.manifest.json` in the directory you named — the finding reads `block.manifest.json not found at project root <dir>`, which the terminal wraps onto a second line for a long path (`--json` carries it as one `message` string). `app submit` prints it too, because it validates first. `app submit --skip-validate` never prints it, because it waives the validation that produces it — that run fails on the row below instead. The path itself was fine, which is why this exits `1` and not `2`. | [Exit code 1](#exit-code-1) |
+| `is this an App project?` | The same cause, reported by a command that did not validate first: `civitai app listing …`, which has to work out *which* app you mean from the working directory, and `app submit --skip-validate`, which waived the check that produces the row above. `app validate` and a plain `app submit` never print it, because validation reports the row above first. Run `app listing` from the app directory, or name the app with `--slug` / `--dir`. | [After you submit](#after-you-submit-review--approve--deploy) |
 | `no such directory — pass the path to an App project root` | The path does not exist. This is a **usage** error: exit `2`, and `--json` prints nothing at all. | [Exit codes](#exit-codes) |
 | `is not a directory — pass the App project ROOT` | You pointed at a file — often the manifest itself. Pass the directory holding it. Exit `2`. | [Exit codes](#exit-codes) |
 | `it did NOT check that the file is loaded` | The `BLOCK_READY` advisory on its **weak** tier: it could not resolve what your `index.html` loads, so it only checked whether *some* file mentions the message. The lines that follow name what it could not follow. | [The host handshake](#the-host-handshake-block_ready) |

--- a/internal/cmd/generate_substitution_test.go
+++ b/internal/cmd/generate_substitution_test.go
@@ -805,9 +805,21 @@ func TestREADME_DryRunTranscriptMatchesRealOutput(t *testing.T) {
 	readme := string(raw)
 
 	// The exact fixture the README's transcript uses.
+	//
+	// The ids changed with #360: the transcript used to invoke
+	// `--checkpoint 999999999`, an id that does NOT exist — and `generate`
+	// resolves every --checkpoint against the public model-version API before it
+	// prices anything, so that command 404s locally (exit 4) and never reaches
+	// the estimate this block claims to show. The documented invocation is now a
+	// REAL version id in the wrong model family, which is what actually
+	// substitutes; these constants are its measured requested/applied pair.
+	const (
+		readmeRequestedVersion = 128713
+		readmeAppliedVersion   = 1892509
+	)
 	var buf bytes.Buffer
 	reportModelSubstitutions(&buf, []genapi.ModelSubstitution{
-		{Requested: 999999999, Applied: 2436219, Reason: genapi.SubstitutionUnrecognized},
+		{Requested: readmeRequestedVersion, Applied: readmeAppliedVersion, Reason: genapi.SubstitutionUnrecognized},
 	}, substitutionAtEstimate)
 
 	// The id line is the one that rotted: it carries the ids, the tense and the
@@ -832,9 +844,23 @@ func TestREADME_DryRunTranscriptMatchesRealOutput(t *testing.T) {
 
 	// 🔴 And the stale form must be GONE, not merely joined by the correct one.
 	// A README that shows both would still be teaching the wrong thing.
-	if strings.Contains(readme, "-> ran version 2436219") {
-		t.Errorf("README still shows the pre-tense-fix estimate line (`-> ran version 2436219`), " +
-			"which contradicts the lead above it saying nothing has been charged yet")
+	staleTense := fmt.Sprintf("-> ran version %d", readmeAppliedVersion)
+	if strings.Contains(readme, staleTense) {
+		t.Errorf("README still shows the pre-tense-fix estimate line (`%s`), "+
+			"which contradicts the lead above it saying nothing has been charged yet", staleTense)
+	}
+
+	// 🔴 And the invocation ABOVE the transcript must be one that can reach it.
+	// #360's defect was not the rendered line — that half was already pinned by
+	// the assertion above and was green — it was the `$ civitai generate …`
+	// command, which 404'd on a nonexistent id long before anything was priced.
+	// A block whose output is byte-perfect under a command that cannot produce it
+	// is exactly as misleading as a stale line, and nothing could see it.
+	if strings.Contains(readme, "--checkpoint 999999999 --dry-run") {
+		t.Errorf("the README substitution transcript is introduced by " +
+			"`--checkpoint 999999999 --dry-run`. That id does not exist, so " +
+			"ResolveModelVersion refuses it with `not found (404)` and exit 4 before the " +
+			"estimate is priced — the block below it can never be produced by the command above it (#360).")
 	}
 }
 

--- a/internal/cmd/generate_substitution_test.go
+++ b/internal/cmd/generate_substitution_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -839,15 +840,22 @@ func TestREADME_DryRunTranscriptMatchesRealOutput(t *testing.T) {
 	if !strings.Contains(readme, idLine) {
 		t.Errorf("README's --dry-run transcript does not match real output.\n"+
 			"  renderer emits: %q\n"+
-			"  README does not contain that line — update the transcript in README.md", idLine)
+			"  no line in README.md is that line.\n"+
+			"  The RENDERER is the authority here: move the README transcript onto this line "+
+			"(and if the ids changed, move readmeRequestedVersion/readmeAppliedVersion with it).", idLine)
 	}
 
 	// 🔴 And the stale form must be GONE, not merely joined by the correct one.
 	// A README that shows both would still be teaching the wrong thing.
-	staleTense := fmt.Sprintf("-> ran version %d", readmeAppliedVersion)
-	if strings.Contains(readme, staleTense) {
+	//
+	// Matched on the SHAPE, not on today's applied id: binding this to
+	// readmeAppliedVersion silently dropped cover for the historical stale text
+	// (`-> ran version 2436219`), which is the string this assertion was written
+	// for. Any id in the past tense is the defect.
+	staleTenseRe := regexp.MustCompile(`->\s*ran version \d+`)
+	if m := staleTenseRe.FindString(readme); m != "" {
 		t.Errorf("README still shows the pre-tense-fix estimate line (`%s`), "+
-			"which contradicts the lead above it saying nothing has been charged yet", staleTense)
+			"which contradicts the lead above it saying nothing has been charged yet", m)
 	}
 
 	// 🔴 And the invocation ABOVE the transcript must be one that can reach it.
@@ -856,12 +864,79 @@ func TestREADME_DryRunTranscriptMatchesRealOutput(t *testing.T) {
 	// command, which 404'd on a nonexistent id long before anything was priced.
 	// A block whose output is byte-perfect under a command that cannot produce it
 	// is exactly as misleading as a stale line, and nothing could see it.
-	if strings.Contains(readme, "--checkpoint 999999999 --dry-run") {
-		t.Errorf("the README substitution transcript is introduced by " +
-			"`--checkpoint 999999999 --dry-run`. That id does not exist, so " +
-			"ResolveModelVersion refuses it with `not found (404)` and exit 4 before the " +
-			"estimate is priced — the block below it can never be produced by the command above it (#360).")
+	//
+	// 🔴 STRUCTURAL, not spelled. The first repair was
+	// `strings.Contains(readme, "--checkpoint 999999999 --dry-run")` — a search
+	// of the WHOLE FILE for one literal, unanchored to the transcript. Measured:
+	// `--checkpoint 999999998` in the fence passed, the same flags reordered
+	// passed, and a CORRECT README whose caveat bullet happened to spell the
+	// banned literal FAILED, naming the wrong location. So: find the fence the
+	// real id line lives in, read the `$ civitai generate …` line that introduces
+	// it, and require ITS --checkpoint to be the id the block is rendered from.
+	inv := readmeTranscriptInvocation(readme, idLine)
+	if inv == "" {
+		t.Fatalf("the README block containing %q has no `$ civitai generate …` line above it — "+
+			"a transcript with no invocation cannot be checked for reachability at all (#360)", idLine)
 	}
+	got, ok := invocationCheckpoint(inv)
+	switch {
+	case !ok:
+		t.Errorf("the invocation introducing the substitution transcript passes no --checkpoint:\n  %s\n"+
+			"The block below it shows a checkpoint substitution, so it cannot be produced by that command (#360).", inv)
+	case got != readmeRequestedVersion:
+		t.Errorf("the invocation introducing the substitution transcript asks for --checkpoint %d, "+
+			"but the block below it is the rendering of a substitution REQUESTED for %d:\n  %s\n"+
+			"The output shown cannot be produced by the command shown. (#360 was this exactly, with "+
+			"999999999 — an id that does not exist, so ResolveModelVersion refuses it with "+
+			"`not found (404)` and exit 4 before anything is priced.)", got, readmeRequestedVersion, inv)
+	}
+	if !strings.Contains(inv, "--dry-run") {
+		t.Errorf("the substitution transcript is rendered at the ESTIMATE phase "+
+			"(substitutionAtEstimate), but its invocation is not a --dry-run:\n  %s", inv)
+	}
+}
+
+// readmeTranscriptInvocation returns the `$ civitai generate …` line that
+// introduces the fenced block containing idLine, or "" if the walk leaves the
+// fence without finding one. Anchoring to the fence is the point: a literal
+// searched for across the whole file answers a question about the page, not
+// about the transcript.
+func readmeTranscriptInvocation(readme, idLine string) string {
+	lines := strings.Split(readme, "\n")
+	target := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, idLine) {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		return ""
+	}
+	for i := target - 1; i >= 0; i-- {
+		ln := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(ln, "```") {
+			return "" // walked out of the fence with no invocation in it
+		}
+		if strings.HasPrefix(ln, "$ civitai generate") {
+			return ln
+		}
+	}
+	return ""
+}
+
+var invocationCheckpointRe = regexp.MustCompile(`--checkpoint[=\s]+(\d+)`)
+
+func invocationCheckpoint(invocation string) (int, bool) {
+	m := invocationCheckpointRe.FindStringSubmatch(invocation)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // --- the flag hint ------------------------------------------------------------

--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // The README's Troubleshooting section is a SYMPTOM INDEX: its first column is a
@@ -204,8 +206,19 @@ func TestREADMETroubleshootingSymptomsExistInTheSource(t *testing.T) {
 // So this is a RELATIONSHIP guard, not a component one: for a curated set of
 // rows it drives the REAL command through NewRootCmd and asserts the row's
 // fragment is in what that command actually emitted — plus, where two rows are
-// confusable, that the OTHER command does not emit it. A row can only pass by
-// being about the command it claims.
+// confusable, that the OTHER command does not emit it.
+//
+// 🔴 AND IT READS THE ROW'S OWN PROSE, WHICH THE FIRST VERSION DID NOT. That
+// version examined `row[0]` (the fragment) and `row[2]` (the link), never
+// `row[1]` — the cell that says WHICH COMMAND PRINTS IT. So `emittedBy` /
+// `notEmittedBy` were Go-side labels decoupled from the sentence a reader
+// actually reads, and the #361 defect could be re-typed verbatim under a green
+// suite: rewriting the cell to "Printed by `civitai app validate` … `app
+// listing` never prints it" left every assertion passing. The red/green matrix
+// that shipped with it reddened on the LINK cell, so attribution was never the
+// discriminator. `attributionProseCheck` below is the repair: the cell's
+// command mentions are parsed out and must AGREE with the measured ledger, in
+// both directions and with nothing unmeasured left over.
 //
 // It is deliberately a ledger of a few rows rather than every row: proving
 // reachability means driving each command into its failure mode, and several of
@@ -216,9 +229,17 @@ func TestREADMETroubleshootingSymptomsExistInTheSource(t *testing.T) {
 // a user gets. `args` is a function so a row can point the command at a scratch
 // directory the harness makes.
 type attributionRun struct {
-	name string
-	args func(emptyProject, scratch string) []string
-	env  map[string]string
+	// readmeName is the EXACT inline-code text the row's cause cell must use to
+	// name this invocation, after normalisation (a leading `civitai ` and a
+	// trailing `…` are stripped). It is matched by EQUALITY, never substring:
+	// `app submit` and `app submit --skip-validate` are DIFFERENT claims — the
+	// first prints `not found at project root` and the second prints `is this an
+	// App project?` — and a substring match would let either satisfy the other's
+	// row, which is the shadowing that hid #361's sibling defect (F1).
+	readmeName string
+	name       string
+	args       func(emptyProject, scratch string) []string
+	env        map[string]string
 }
 
 // symptomAttribution is one Troubleshooting row and the commands it belongs to.
@@ -240,62 +261,103 @@ type symptomAttribution struct {
 }
 
 func symptomAttributions() []symptomAttribution {
-	appValidate := func(name string) attributionRun {
+	appValidate := func() attributionRun {
 		return attributionRun{
-			name: name,
-			args: func(empty, _ string) []string { return []string{"app", "validate", empty} },
+			readmeName: "app validate",
+			name:       "app validate",
+			args:       func(empty, _ string) []string { return []string{"app", "validate", empty} },
+		}
+	}
+	// `app submit` on a manifest-less directory, with and without the flag that
+	// waives validation. THE TWO PRINT DIFFERENT MESSAGES, and the pair is the
+	// whole of F1: the shipped rows said "`app validate` and `app submit` never
+	// print [`is this an App project?`]", which is true only for the default
+	// argv. `--skip-validate` is documented on this same page, and `app submit`'s
+	// own validation failure hands the reader the falsifier in one hop ("fix
+	// before submitting, or pass --skip-validate").
+	appSubmit := func(skipValidate bool) attributionRun {
+		name := "app submit"
+		if skipValidate {
+			name = "app submit --skip-validate"
+		}
+		return attributionRun{
+			readmeName: name,
+			// --package-only never contacts the server. Without --skip-validate
+			// the run never gets that far anyway (validation fails first); WITH
+			// it, packaging is reached and manifest.Load is what fails.
+			name: name + " --package-only",
+			args: func(empty, scratch string) []string {
+				a := []string{"app", "submit", empty}
+				if skipValidate {
+					a = append(a, "--skip-validate")
+				}
+				return append(a, "--package-only", "--out", filepath.Join(scratch, "b.zip"))
+			},
 		}
 	}
 	return []symptomAttribution{
 		{
 			fragment: "not found at project root",
-			anchor:   "#validate-fidelity",
+			// NOT #validate-fidelity: that section is about how faithfully the
+			// LOCAL mirror reproduces the server's approve-time validator, and
+			// never mentions a missing manifest, a project root, or what to do
+			// about one. Exit code 1 states this exact case in so many words —
+			// "a real directory with no block.manifest.json at its root — you
+			// pointed at a real place, so the invocation was right and the
+			// project is wrong" — which is what the row's last sentence is
+			// about. The anchor assertion below is tautological on its own (the
+			// ledger constant IS the expected value), so the choice is argued
+			// here rather than pinned there.
+			anchor: "#exit-code-1",
 			emittedBy: []attributionRun{
-				appValidate("app validate"),
-				{
-					// --package-only never contacts the server, and this row
-					// never gets that far anyway: validation fails first. It is
-					// here because the README row claims `app submit` validates
-					// first, and an unmeasured claim in the index is the thing
-					// this file exists to stop.
-					name: "app submit --package-only",
-					args: func(empty, scratch string) []string {
-						return []string{"app", "submit", empty, "--package-only", "--out", filepath.Join(scratch, "b.zip")}
-					},
-				},
+				appValidate(),
+				appSubmit(false),
+			},
+			notEmittedBy: []attributionRun{
+				appSubmit(true),
 			},
 			why: "the manifest-missing verdict is the most likely error in the whole tool, and until #361 " +
 				"the index did not contain it in any form",
 		},
 		{
 			fragment: "is this an App project?",
-			anchor:   "#listing-media-requirements",
+			// NOT #listing-media-requirements: that section is image formats,
+			// byte caps and aspect ratios, and says nothing about how `app
+			// listing` decides WHICH app you mean. "After you submit" is where
+			// the `app listing` flow is walked through, and now carries the
+			// working-directory resolution and the --slug/--dir remedy this row
+			// tells the reader to use.
+			anchor: "#after-you-submit-review--approve--deploy",
 			emittedBy: []attributionRun{
 				{
 					// The slug resolve fails on the manifest before any request
 					// is built, so the token only has to be non-empty to get
 					// past the credential gate.
-					name: "app listing status",
+					readmeName: "app listing",
+					name:       "app listing status",
 					args: func(empty, _ string) []string {
 						return []string{"app", "listing", "status", "--dir", empty}
 					},
 					env: map[string]string{"CIVITAI_TOKEN": "not-a-real-token"},
 				},
+				appSubmit(true),
 			},
 			notEmittedBy: []attributionRun{
-				appValidate("app validate"),
+				appValidate(),
 				{
 					// `app submit` DOES call manifest.Load — but only after
 					// validation has passed, so a missing manifest never reaches
-					// it. Listing the caller is not the same as measuring the
-					// message, and this row is the difference: the first draft of
-					// this fix credited `app submit`, `app dev-token` and
-					// `app dev-tunnel` from a grep of manifest.Load callers, and
-					// none of the three prints it for a missing manifest.
-					name: "app submit --package-only",
-					args: func(empty, scratch string) []string {
-						return []string{"app", "submit", empty, "--package-only", "--out", filepath.Join(scratch, "b.zip")}
-					},
+					// it UNLESS --skip-validate waives the validation. Listing
+					// the caller is not the same as measuring the message, and
+					// this row is the difference: the first draft of this fix
+					// credited `app submit`, `app dev-token` and `app dev-tunnel`
+					// from a grep of manifest.Load callers. dev-token and
+					// dev-tunnel discard the load error and still print nothing;
+					// `app submit` prints it on exactly one argv, which is why it
+					// now appears on BOTH rows under two different readmeNames.
+					readmeName: "app submit",
+					name:       appSubmit(false).name,
+					args:       appSubmit(false).args,
 				},
 			},
 			why: "#361 itself: the row credited this string to `app validate`, which has never printed it, " +
@@ -333,10 +395,15 @@ func runAttribution(t *testing.T, r attributionRun, empty, scratch string) strin
 // regression coverage: `app validate` did not print the string before the fix
 // either. It is here so a future "helpfully" shared manifest loader cannot make
 // the old row retroactively true.
+//
+// The `attributes` subtest is the one that reads `row[1]`. Without it every
+// assertion here is about a cell a reader never reads for attribution, and the
+// #361 defect can be re-typed into the prose under a green suite.
 func TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand(t *testing.T) {
 	md := readREADME(t)
 	section := readmeTroubleshootingSection(t)
 	ledger := symptomAttributions()
+	paths := knownCommandPaths(t)
 
 	// Positive control on the ledger itself: an empty (or accidentally emptied)
 	// ledger passes every assertion below while checking nothing.
@@ -346,15 +413,26 @@ func TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand(t *testing.T
 
 	for _, a := range ledger {
 		t.Run(a.fragment, func(t *testing.T) {
-			row, ok := troubleshootingRowFor(section, a.fragment)
-			if !ok {
+			row, n := troubleshootingRowFor(section, a.fragment)
+			if n == 0 {
 				t.Fatalf("the Troubleshooting index has no row whose first column quotes %q.\n"+
 					"Why it matters: %s.\n"+
 					"A reader searching this page for the error in front of them finds nothing.", a.fragment, a.why)
 			}
+			if n > 1 {
+				// Two rows quoting the same fragment means this test picked one
+				// of them and said nothing about the other — and a reader
+				// searching the page has the same problem.
+				t.Fatalf("%d Troubleshooting rows quote %q in their first column. "+
+					"This guard can only speak about one of them, so the others would drift unwatched: "+
+					"merge them, or make each fragment name exactly one row.", n, a.fragment)
+			}
 			if len(row) < 3 {
 				t.Fatalf("row for %q has %d cells, want 3: %v", a.fragment, len(row), row)
 			}
+			t.Run("attributes it to the ledger's commands", func(t *testing.T) {
+				attributionProseCheck(t, a, row[1], paths)
+			})
 			if !strings.Contains(row[2], "("+a.anchor+")") {
 				t.Errorf("the row for %q links to %q, but must point at %s.\n"+
 					"Why it matters: %s.\n"+
@@ -402,10 +480,15 @@ func TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand(t *testing.T
 	}
 }
 
-// troubleshootingRowFor returns the cells of the first Troubleshooting row whose
-// FIRST column quotes fragment. Matching on the first column only is the point:
-// a fragment mentioned in another row's prose must not satisfy the lookup.
-func troubleshootingRowFor(section, fragment string) ([]string, bool) {
+// troubleshootingRowFor returns the cells of the Troubleshooting row whose FIRST
+// column quotes fragment, plus HOW MANY rows matched. Matching on the first
+// column only is the point: a fragment mentioned in another row's prose must not
+// satisfy the lookup. Returning the count matters too — the first version
+// returned the first match, so a later row whose first cell is a superset of an
+// earlier one's would silently shadow the row this ledger means.
+func troubleshootingRowFor(section, fragment string) ([]string, int) {
+	var first []string
+	var n int
 	for _, line := range strings.Split(section, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
@@ -419,20 +502,238 @@ func troubleshootingRowFor(section, fragment string) ([]string, bool) {
 			continue
 		}
 		if strings.Contains(cells[0], fragment) && strings.Contains(cells[0], "`") {
-			return cells, true
+			n++
+			if first == nil {
+				first = cells
+			}
 		}
 	}
-	return nil, false
+	return first, n
+}
+
+// ----------------------------------------------------------------------------
+// Reading the attribution out of the row's own prose
+// ----------------------------------------------------------------------------
+
+// inlineCodeSpanRe captures the text inside a markdown inline-code span.
+var inlineCodeSpanRe = regexp.MustCompile("`([^`]+)`")
+
+// attributionNegations is the CLOSED set of phrases that make a clause a
+// NEGATIVE attribution ("X never prints it"). It is deliberately about PRINTING
+// and nothing else: a clause may legitimately say a command "did not validate
+// first" or "does not exist", and neither is a claim about the message.
+var attributionNegations = []string{
+	"never print",
+	"does not print",
+	"do not print",
+	"did not print",
+	"will not print",
+	"cannot print",
+	"prints neither",
+}
+
+// commandMention is one command a cause cell names, and whether the clause
+// naming it was a negation.
+type commandMention struct {
+	name    string
+	negated bool
+}
+
+// splitAttributionClauses cuts a cause cell into clauses at sentence ends,
+// semicolons and spaced em-dashes — never inside an inline-code span, so a
+// documented message containing ". " cannot be torn in half. A COMMA is
+// deliberately not a separator: "`app validate` and a plain `app submit` never
+// print it, because …" is ONE claim about two commands.
+func splitAttributionClauses(cell string) []string {
+	var clauses []string
+	var cur []rune
+	inCode := false
+	rs := []rune(cell)
+	flush := func() {
+		if s := strings.TrimSpace(string(cur)); s != "" {
+			clauses = append(clauses, s)
+		}
+		cur = cur[:0]
+	}
+	for i := 0; i < len(rs); i++ {
+		r := rs[i]
+		if r == '`' {
+			inCode = !inCode
+			cur = append(cur, r)
+			continue
+		}
+		if !inCode {
+			isBreak := (r == '.' || r == ';') && i+1 < len(rs) && rs[i+1] == ' '
+			isDash := r == '—' && i > 0 && rs[i-1] == ' ' && i+1 < len(rs) && rs[i+1] == ' '
+			if isBreak || isDash {
+				flush()
+				i++
+				continue
+			}
+		}
+		cur = append(cur, r)
+	}
+	flush()
+	return clauses
+}
+
+// normalizeCommandSpan renders an inline-code span the way a readmeName is
+// written: no `civitai ` prefix, no trailing ellipsis, single-spaced.
+func normalizeCommandSpan(span string) string {
+	s := strings.Join(strings.Fields(span), " ")
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(s, "…"), "..."))
+	return strings.TrimSpace(strings.TrimPrefix(s, "civitai "))
+}
+
+// knownCommandPaths is every command path in the REAL Cobra tree, minus the root
+// name — "app", "app validate", "app listing status", "generate", … Derived from
+// the tree rather than a hand-list so a renamed command cannot leave this
+// recogniser quietly matching nothing.
+func knownCommandPaths(t *testing.T) map[string]bool {
+	t.Helper()
+	root := NewRootCmd()
+	prefix := root.Name() + " "
+	out := map[string]bool{}
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			out[strings.TrimPrefix(sub.CommandPath(), prefix)] = true
+			walk(sub)
+		}
+	}
+	walk(root)
+	// Positive control on the walk: a tree read as empty would make every span
+	// below "not a command", and the completeness check would pass vacuously.
+	if len(out) < 20 {
+		t.Fatalf("the Cobra walk found %d command paths — it is not reading the real tree, so "+
+			"no verdict below would be about the README", len(out))
+	}
+	return out
+}
+
+// namesAKnownCommand reports whether a normalised span STARTS with a real
+// command path, so `app submit --skip-validate` counts as naming a command while
+// `--json` and `block.manifest.json not found …` do not.
+func namesAKnownCommand(name string, paths map[string]bool) bool {
+	words := strings.Fields(name)
+	for n := len(words); n > 0; n-- {
+		if paths[strings.Join(words[:n], " ")] {
+			return true
+		}
+	}
+	return false
+}
+
+// commandMentionsIn parses a cause cell into the commands it names and the
+// polarity of the clause naming each.
+func commandMentionsIn(cell string, paths map[string]bool) []commandMention {
+	var out []commandMention
+	for _, clause := range splitAttributionClauses(cell) {
+		lower := strings.ToLower(clause)
+		negated := false
+		for _, p := range attributionNegations {
+			if strings.Contains(lower, p) {
+				negated = true
+				break
+			}
+		}
+		for _, m := range inlineCodeSpanRe.FindAllStringSubmatch(clause, -1) {
+			name := normalizeCommandSpan(m[1])
+			if name == "" || !namesAKnownCommand(name, paths) {
+				continue
+			}
+			out = append(out, commandMention{name: name, negated: negated})
+		}
+	}
+	return out
+}
+
+// attributionProseCheck is the F2 repair: the row's CAUSE cell — the sentence a
+// reader actually reads to learn which command printed their error — must agree
+// with the measured ledger, in both directions and with nothing left over.
+//
+//   - every emittedBy command is named in a POSITIVE clause and in no negative one
+//   - every notEmittedBy command is named in a NEGATIVE clause and in no positive one
+//   - every command the cell names at all is in the ledger, so the row cannot
+//     carry an attribution nothing measured
+//
+// Matching is by EQUALITY on the normalised span, so `app submit` never stands
+// in for `app submit --skip-validate`.
+func attributionProseCheck(t *testing.T, a symptomAttribution, cell string, paths map[string]bool) {
+	t.Helper()
+	mentions := commandMentionsIn(cell, paths)
+	// Positive control on the parser: a cell it reads as naming no command would
+	// satisfy every "must not appear positively" clause below for free.
+	if len(mentions) == 0 {
+		t.Fatalf("the cause cell for %q names no command this parser can see, so nothing below is a "+
+			"fact about the README.\ncell: %s", a.fragment, cell)
+	}
+	pos := map[string]bool{}
+	neg := map[string]bool{}
+	for _, m := range mentions {
+		if m.negated {
+			neg[m.name] = true
+		} else {
+			pos[m.name] = true
+		}
+	}
+	for _, r := range a.emittedBy {
+		if !pos[r.readmeName] {
+			t.Errorf("the row for %q is MEASURED to be printed by `%s`, but its cause cell never says so.\n"+
+				"Why it matters: %s.\n"+
+				"The cell is what a reader reads to find their command; a ledger that agrees with itself "+
+				"and not with the prose is #361 with the labels moved into Go.\ncell: %s",
+				a.fragment, r.readmeName, a.why, cell)
+		}
+		if neg[r.readmeName] {
+			t.Errorf("the row for %q says `%s` does NOT print it, but running that command printed it.\n"+
+				"Why it matters: %s.\ncell: %s", a.fragment, r.readmeName, a.why, cell)
+		}
+	}
+	for _, r := range a.notEmittedBy {
+		if !neg[r.readmeName] {
+			t.Errorf("the row for %q is measured NOT to be printed by `%s`, but its cause cell does not "+
+				"say so in a negated clause (it must, in one of %v).\n"+
+				"Why it matters: %s.\ncell: %s",
+				a.fragment, r.readmeName, attributionNegations, a.why, cell)
+		}
+		if pos[r.readmeName] {
+			t.Errorf("the row for %q credits `%s` with printing it, and running that command did not.\n"+
+				"Why it matters: %s.\n"+
+				"This is the #361 defect exactly: a row about a command that never emits the string.\ncell: %s",
+				a.fragment, r.readmeName, a.why, cell)
+		}
+	}
+	ledgered := map[string]bool{}
+	for _, r := range a.emittedBy {
+		ledgered[r.readmeName] = true
+	}
+	for _, r := range a.notEmittedBy {
+		ledgered[r.readmeName] = true
+	}
+	for _, m := range mentions {
+		if !ledgered[m.name] {
+			t.Errorf("the cause cell for %q names `%s`, which this ledger never runs.\n"+
+				"An unmeasured attribution in the index is exactly what #361 was. Either add a measured "+
+				"run for `%s` to symptomAttributions(), or stop naming it here.\ncell: %s",
+				a.fragment, m.name, m.name, cell)
+		}
+	}
 }
 
 // readmeHasAnchor reports whether a GitHub-style `#anchor` resolves to a heading
-// in md. The slug rules mirror GitHub's: lowercase, drop everything that is not
-// alphanumeric/space/hyphen, spaces to hyphens — which is why a 🔴 heading's
-// anchor carries a leading hyphen.
+// in md. Lines inside fenced code blocks are skipped: a shell comment or a
+// Markdown sample beginning with `#` is not a heading, and counting one would
+// let a dead link pass.
 func readmeHasAnchor(md, anchor string) bool {
 	want := strings.TrimPrefix(anchor, "#")
+	inFence := false
 	for _, line := range strings.Split(md, "\n") {
-		if !strings.HasPrefix(line, "#") {
+		if t := strings.TrimSpace(line); strings.HasPrefix(t, "```") || strings.HasPrefix(t, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || !strings.HasPrefix(line, "#") {
 			continue
 		}
 		text := strings.TrimSpace(strings.TrimLeft(line, "#"))
@@ -443,17 +744,105 @@ func readmeHasAnchor(md, anchor string) bool {
 	return false
 }
 
+// githubAnchorSlug mirrors GitHub's heading-slug rules: lowercase, drop
+// everything that is not alphanumeric/space/hyphen/UNDERSCORE, spaces to
+// hyphens — which is why a 🔴 heading's anchor carries a leading hyphen.
+//
+// 🔴 The underscore is not cosmetic and it was wrong here. Dropping it turned
+// "The host handshake (`BLOCK_READY`)" into `the-host-handshake-blockready`, so
+// readmeHasAnchor reported `#the-host-handshake-block_ready` — a link that
+// exists and works, and is used five times on the page — as a dead anchor. A
+// guard that fails on correct input is one somebody deletes.
 func githubAnchorSlug(heading string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(heading) {
 		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
 			b.WriteRune(r)
 		case r == ' ':
 			b.WriteRune('-')
 		}
 	}
 	return b.String()
+}
+
+// TestAttributionProseParser validates the INSTRUMENT before its verdict above
+// is read. A parser that saw no command, or that let `app submit` stand in for
+// `app submit --skip-validate`, would make attributionProseCheck report a
+// confident pass about a cell it never understood.
+//
+// The second case is the mutation the F2 audit demonstrated, verbatim: the #361
+// defect re-typed into the prose while the link cell stayed correct.
+func TestAttributionProseParser(t *testing.T) {
+	paths := knownCommandPaths(t)
+	got := func(cell string) map[string]bool {
+		m := map[string]bool{}
+		for _, x := range commandMentionsIn(cell, paths) {
+			m[x.name] = x.negated
+		}
+		return m
+	}
+
+	t.Run("positive and negative clauses are told apart", func(t *testing.T) {
+		m := got("Printed by `civitai app listing …`. `app validate` never prints it — it reports the row above.")
+		if neg, ok := m["app listing"]; !ok || neg {
+			t.Errorf("`app listing` must be read as a POSITIVE mention; got %v", m)
+		}
+		if neg, ok := m["app validate"]; !ok || !neg {
+			t.Errorf("`app validate` must be read as a NEGATIVE mention; got %v", m)
+		}
+	})
+
+	t.Run("a flagged invocation does not stand in for the bare command", func(t *testing.T) {
+		m := got("Printed by `app submit --skip-validate`, which waived validation.")
+		if _, ok := m["app submit"]; ok {
+			t.Errorf("`app submit --skip-validate` must NOT register as a mention of `app submit` — "+
+				"they print different messages, and conflating them is F1; got %v", m)
+		}
+		if neg, ok := m["app submit --skip-validate"]; !ok || neg {
+			t.Errorf("the flagged form must register positively under its own name; got %v", m)
+		}
+	})
+
+	t.Run("non-command code spans are ignored", func(t *testing.T) {
+		m := got("The full line is `block.manifest.json not found at project root <dir>`; `--json` carries it as one `message` string.")
+		if len(m) != 0 {
+			t.Errorf("no command is named in that cell, but the parser found %v", m)
+		}
+	})
+
+	t.Run("a negation about something other than printing is not a negation", func(t *testing.T) {
+		m := got("Reported by `app listing`, which did not validate first.")
+		if neg, ok := m["app listing"]; !ok || neg {
+			t.Errorf("`did not validate` is not a claim about printing; got %v", m)
+		}
+	})
+}
+
+// TestGithubAnchorSlugKeepsUnderscores is the F4 regression guard.
+//
+// Measured red before the fix: githubAnchorSlug dropped `_`, so the anchor for
+// the `BLOCK_READY` heading came back `the-host-handshake-blockready` and
+// readmeHasAnchor called a live, five-times-used link dead. Both of the ledger
+// rows most likely to be added next (the two `BLOCK_READY` advisory rows) point
+// at that heading.
+func TestGithubAnchorSlugKeepsUnderscores(t *testing.T) {
+	if got, want := githubAnchorSlug("The host handshake (`BLOCK_READY`)"), "the-host-handshake-block_ready"; got != want {
+		t.Errorf("githubAnchorSlug = %q, want %q — GitHub preserves underscores", got, want)
+	}
+	md := readREADME(t)
+	if !readmeHasAnchor(md, "#the-host-handshake-block_ready") {
+		t.Error("readmeHasAnchor cannot see `#the-host-handshake-block_ready`, a heading README.md really has " +
+			"and links to five times")
+	}
+	// Negative control: the searcher must be able to report a miss at all.
+	if readmeHasAnchor(md, "#there-is-no-such-heading-in-this-readme") {
+		t.Error("readmeHasAnchor found a heading that does not exist — it cannot report a miss")
+	}
+	// And a `#` line inside a fenced block is not a heading.
+	if readmeHasAnchor("```sh\n# not a heading\n```\n", "#-not-a-heading") {
+		t.Error("readmeHasAnchor counted a shell comment inside a code fence as a heading")
+	}
 }
 
 // TestREADMETroubleshootingCoversTheRefusalsAuthorsActuallyHit pins the FLOOR of

--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -184,6 +184,278 @@ func TestREADMETroubleshootingSymptomsExistInTheSource(t *testing.T) {
 	}
 }
 
+// ----------------------------------------------------------------------------
+// Attribution — issue #361
+// ----------------------------------------------------------------------------
+//
+// 🔴 THE GUARD ABOVE ASKS "DOES THIS STRING EXIST?", WHICH IS NOT THE QUESTION A
+// READER OF THE INDEX IS ASKING. They are holding an error from ONE command and
+// want the row for THAT command.
+//
+// Measured drift (#361): the row for `is this an App project?` said it came from
+// `civitai app validate` and linked to Validate fidelity. `app validate` has
+// never printed it — it produces its own finding, `block.manifest.json not found
+// at project root <dir>`, which the index did not carry at all. The string is
+// real (`internal/manifest`, reached by `app submit` / `app listing` /
+// `app dev-token` / `app dev-tunnel`), so the existence guard stayed green the
+// whole time, and the one message a new author is most likely to hit was the one
+// the index could not resolve.
+//
+// So this is a RELATIONSHIP guard, not a component one: for a curated set of
+// rows it drives the REAL command through NewRootCmd and asserts the row's
+// fragment is in what that command actually emitted — plus, where two rows are
+// confusable, that the OTHER command does not emit it. A row can only pass by
+// being about the command it claims.
+//
+// It is deliberately a ledger of a few rows rather than every row: proving
+// reachability means driving each command into its failure mode, and several of
+// them need a live server. Ledger membership is the claim "these rows are worth
+// the run", and the confusable pair from #361 is why the ledger exists.
+
+// attributionRun is one real invocation, driven through the same NewRootCmd path
+// a user gets. `args` is a function so a row can point the command at a scratch
+// directory the harness makes.
+type attributionRun struct {
+	name string
+	args func(emptyProject, scratch string) []string
+	env  map[string]string
+}
+
+// symptomAttribution is one Troubleshooting row and the commands it belongs to.
+type symptomAttribution struct {
+	// fragment is the row's first column, verbatim after the extractor's
+	// backtick/ellipsis trim — i.e. exactly what documentedSymptoms returns.
+	fragment string
+	// anchor must appear in the row's "Where to read more" cell, and must be a
+	// heading that exists. A right string under a wrong link is still a row that
+	// sends the reader somewhere that does not explain their error.
+	anchor string
+	// emittedBy must each really print fragment.
+	emittedBy []attributionRun
+	// notEmittedBy must each really NOT print it. This is the half that names
+	// the defect: `app validate` printing `is this an App project?` is precisely
+	// the world the old row described.
+	notEmittedBy []attributionRun
+	why          string
+}
+
+func symptomAttributions() []symptomAttribution {
+	appValidate := func(name string) attributionRun {
+		return attributionRun{
+			name: name,
+			args: func(empty, _ string) []string { return []string{"app", "validate", empty} },
+		}
+	}
+	return []symptomAttribution{
+		{
+			fragment: "not found at project root",
+			anchor:   "#validate-fidelity",
+			emittedBy: []attributionRun{
+				appValidate("app validate"),
+				{
+					// --package-only never contacts the server, and this row
+					// never gets that far anyway: validation fails first. It is
+					// here because the README row claims `app submit` validates
+					// first, and an unmeasured claim in the index is the thing
+					// this file exists to stop.
+					name: "app submit --package-only",
+					args: func(empty, scratch string) []string {
+						return []string{"app", "submit", empty, "--package-only", "--out", filepath.Join(scratch, "b.zip")}
+					},
+				},
+			},
+			why: "the manifest-missing verdict is the most likely error in the whole tool, and until #361 " +
+				"the index did not contain it in any form",
+		},
+		{
+			fragment: "is this an App project?",
+			anchor:   "#listing-media-requirements",
+			emittedBy: []attributionRun{
+				{
+					// The slug resolve fails on the manifest before any request
+					// is built, so the token only has to be non-empty to get
+					// past the credential gate.
+					name: "app listing status",
+					args: func(empty, _ string) []string {
+						return []string{"app", "listing", "status", "--dir", empty}
+					},
+					env: map[string]string{"CIVITAI_TOKEN": "not-a-real-token"},
+				},
+			},
+			notEmittedBy: []attributionRun{
+				appValidate("app validate"),
+				{
+					// `app submit` DOES call manifest.Load — but only after
+					// validation has passed, so a missing manifest never reaches
+					// it. Listing the caller is not the same as measuring the
+					// message, and this row is the difference: the first draft of
+					// this fix credited `app submit`, `app dev-token` and
+					// `app dev-tunnel` from a grep of manifest.Load callers, and
+					// none of the three prints it for a missing manifest.
+					name: "app submit --package-only",
+					args: func(empty, scratch string) []string {
+						return []string{"app", "submit", empty, "--package-only", "--out", filepath.Join(scratch, "b.zip")}
+					},
+				},
+			},
+			why: "#361 itself: the row credited this string to `app validate`, which has never printed it, " +
+				"and sent the reader to a section that does not explain it",
+		},
+	}
+}
+
+// runAttribution executes one invocation and returns everything the user would
+// see: stdout, stderr, and the error text `main` prints as `Error: …`.
+func runAttribution(t *testing.T, r attributionRun, empty, scratch string) string {
+	t.Helper()
+	// Never let a README guard reach the network for a version check.
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+	for k, v := range r.env {
+		t.Setenv(k, v)
+	}
+	stdout, stderr, err := run(t, r.args(empty, scratch)...)
+	var b strings.Builder
+	b.WriteString(stdout)
+	b.WriteString(stderr)
+	if err != nil {
+		b.WriteString(err.Error())
+	}
+	return b.String()
+}
+
+// TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand is the #361
+// guard: existence -> attribution.
+//
+// Red/green matrix, measured: with README.md at `origin/main` and this file at
+// HEAD, both ledger rows fail — the first because no row quotes the string at
+// all, the second because its link cell says `#validate-fidelity`. Both pass
+// with the README fix. The `notEmittedBy` half is an INVARIANT guard rather than
+// regression coverage: `app validate` did not print the string before the fix
+// either. It is here so a future "helpfully" shared manifest loader cannot make
+// the old row retroactively true.
+func TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand(t *testing.T) {
+	md := readREADME(t)
+	section := readmeTroubleshootingSection(t)
+	ledger := symptomAttributions()
+
+	// Positive control on the ledger itself: an empty (or accidentally emptied)
+	// ledger passes every assertion below while checking nothing.
+	if len(ledger) < 2 {
+		t.Fatalf("the attribution ledger holds %d rows — it must at least cover the confusable pair from #361", len(ledger))
+	}
+
+	for _, a := range ledger {
+		t.Run(a.fragment, func(t *testing.T) {
+			row, ok := troubleshootingRowFor(section, a.fragment)
+			if !ok {
+				t.Fatalf("the Troubleshooting index has no row whose first column quotes %q.\n"+
+					"Why it matters: %s.\n"+
+					"A reader searching this page for the error in front of them finds nothing.", a.fragment, a.why)
+			}
+			if len(row) < 3 {
+				t.Fatalf("row for %q has %d cells, want 3: %v", a.fragment, len(row), row)
+			}
+			if !strings.Contains(row[2], "("+a.anchor+")") {
+				t.Errorf("the row for %q links to %q, but must point at %s.\n"+
+					"Why it matters: %s.\n"+
+					"A row whose string is right and whose link is wrong still lands the reader on a "+
+					"section that does not explain their error — which is the #361 defect exactly.",
+					a.fragment, strings.TrimSpace(row[2]), a.anchor, a.why)
+			}
+			// The link has to go somewhere. GitHub renders a dead anchor as a
+			// silent no-op, so this cannot be left to review.
+			if !readmeHasAnchor(md, a.anchor) {
+				t.Errorf("the row for %q points at %s, which is not a heading in README.md", a.fragment, a.anchor)
+			}
+
+			for _, r := range a.emittedBy {
+				t.Run("emitted by "+r.name, func(t *testing.T) {
+					out := runAttribution(t, r, t.TempDir(), t.TempDir())
+					// Positive control on the runner: a command that printed
+					// nothing would satisfy notEmittedBy below unconditionally.
+					if strings.TrimSpace(out) == "" {
+						t.Fatalf("`civitai %s` emitted nothing at all — this harness is not observing the command",
+							strings.Join(r.args("<dir>", "<scratch>"), " "))
+					}
+					if !strings.Contains(out, a.fragment) {
+						t.Errorf("README credits %q to `%s`, but that command did not print it.\n"+
+							"Why it matters: %s.\nWhat it printed:\n%s", a.fragment, r.name, a.why, out)
+					}
+				})
+			}
+			for _, r := range a.notEmittedBy {
+				t.Run("not emitted by "+r.name, func(t *testing.T) {
+					out := runAttribution(t, r, t.TempDir(), t.TempDir())
+					if strings.TrimSpace(out) == "" {
+						t.Fatalf("`civitai %s` emitted nothing at all — the absence below would be a fact "+
+							"about the harness, not about the command",
+							strings.Join(r.args("<dir>", "<scratch>"), " "))
+					}
+					if strings.Contains(out, a.fragment) {
+						t.Errorf("`%s` prints %q, which the README attributes elsewhere.\n"+
+							"Either the row is now wrong or this ledger is: %s\nWhat it printed:\n%s",
+							r.name, a.fragment, a.why, out)
+					}
+				})
+			}
+		})
+	}
+}
+
+// troubleshootingRowFor returns the cells of the first Troubleshooting row whose
+// FIRST column quotes fragment. Matching on the first column only is the point:
+// a fragment mentioned in another row's prose must not satisfy the lookup.
+func troubleshootingRowFor(section, fragment string) ([]string, bool) {
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") || !strings.HasSuffix(line, "|") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		for i := range cells {
+			cells[i] = strings.TrimSpace(cells[i])
+		}
+		if len(cells) == 0 {
+			continue
+		}
+		if strings.Contains(cells[0], fragment) && strings.Contains(cells[0], "`") {
+			return cells, true
+		}
+	}
+	return nil, false
+}
+
+// readmeHasAnchor reports whether a GitHub-style `#anchor` resolves to a heading
+// in md. The slug rules mirror GitHub's: lowercase, drop everything that is not
+// alphanumeric/space/hyphen, spaces to hyphens — which is why a 🔴 heading's
+// anchor carries a leading hyphen.
+func readmeHasAnchor(md, anchor string) bool {
+	want := strings.TrimPrefix(anchor, "#")
+	for _, line := range strings.Split(md, "\n") {
+		if !strings.HasPrefix(line, "#") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimLeft(line, "#"))
+		if githubAnchorSlug(text) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func githubAnchorSlug(heading string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(heading) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
 // TestREADMETroubleshootingCoversTheRefusalsAuthorsActuallyHit pins the FLOOR of
 // what the section must cover, independently of the guard above.
 //

--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -840,8 +840,14 @@ func TestGithubAnchorSlugKeepsUnderscores(t *testing.T) {
 		t.Error("readmeHasAnchor found a heading that does not exist — it cannot report a miss")
 	}
 	// And a `#` line inside a fenced block is not a heading.
-	if readmeHasAnchor("```sh\n# not a heading\n```\n", "#-not-a-heading") {
-		t.Error("readmeHasAnchor counted a shell comment inside a code fence as a heading")
+	const fenced = "## Real Heading\n\n```sh\n# not a heading\n```\n"
+	if !readmeHasAnchor(fenced, "#real-heading") {
+		t.Error("POSITIVE CONTROL FAILED: readmeHasAnchor cannot see a heading outside a fence, " +
+			"so the negative below would be a fact about the walk")
+	}
+	if readmeHasAnchor(fenced, "#not-a-heading") {
+		t.Error("readmeHasAnchor counted a shell comment inside a code fence as a heading — " +
+			"README.md really contains such lines (`# …` inside ```sh blocks), so a dead anchor could pass")
 	}
 }
 


### PR DESCRIPTION
Closes #360, closes #361, closes #364.

Three README claims a reader could act on and get a different answer than the
page promises. Two of the three had a guard aimed at them that was green the
whole time; part of the deliverable is closing those holes.

## Re-verification first — all three still reproduced on current `main`

The issues were filed against a binary from `3156b80`. `main` is now `9c7baed`
(eight commits later) and `cebfa45` (#356) rewrote the `--checkpoint` guidance
next door, so every symptom was re-measured against `./bin/civitai` built from
`9c7baed` (`v0.1.92-18-g9c7baed`) before a line was written. **None was already
fixed.**

**#360, symptom 1** — the documented `--dry-run` block:

```
$ ./bin/civitai generate "a cat" --checkpoint 999999999 --dry-run
Error: --checkpoint 999999999: not found (404): Model not found
rc=4
```

**#360, symptom 2** — the documented `[SUPERSEDED …]` block:

```
$ ./bin/civitai generate "a cat" --checkpoint 128713 --dry-run
Workflow:         txt2img
Checkpoint:       DreamShaper — 8 (Checkpoint, id 128713)
Resources ready:  true
…  total  8
rc=0
```

No warning, no `[SUPERSEDED …]`, no substitution.

**#361**:

```
$ ./bin/civitai app validate <emptydir>
✗ 1 validation error(s) in <emptydir>:
  - block.manifest.json not found at project root <emptydir>
Error: validation failed
rc=1
```

`is this an App project?` is nowhere in that output; `block.manifest.json not
found at project root` was nowhere in the index.

**#364**:

```
$ ./bin/civitai app validate --version
Error: unknown flag: --version
rc=2
$ ./bin/civitai models search --version
Error: unknown flag: --version
rc=2
```

Every `generate` invocation on this PR was `--dry-run` only. Nothing was
submitted and nothing was charged.

## #360 — an invocation that actually substitutes

The section's job is to make a substitution recognisable *before* a spend, and
it demonstrated it with a command that 404s locally. Searching for one that
reproduces today found this, run twice with the same shape:

```
$ ./bin/civitai generate "a cat" --ecosystem Flux1Kontext --checkpoint 128713 --dry-run
⚠ The server will NOT use the checkpoint you asked for. It has substituted a different model, …
    requested version 128713 -> will run version 1892509  (reason: unrecognized)
      the server does not offer that version in this model family at all — …
To refuse a run like this instead of being told about it, pass --fail-on-substitution.
…
Checkpoint:       DreamShaper — 8 (Checkpoint, id 128713)  [SUPERSEDED — the server will run version 1892509 instead; see the warning above]
```

A real version id in the *wrong model family* is what substitutes; a
*nonexistent* one is refused by `ResolveModelVersion` before anything is priced.
Both console blocks are now that output verbatim, with two caveats added so a
reader can tell a reproduction from a mismatch: the applied id is server state
and will differ, and `--checkpoint 999999999` is now documented as the local
`404`/exit-4 it really is.

**AGENTS item 13 was read before touching this.** Nothing was added to the
generation path — no check, table, enum or default. The change is documentation
of the live lookup (`ResolveModelVersion`) that item 13 already sanctions.

## #361 — existence → attribution, and the hole that hid it

The index gains a row for the message `app validate` really prints, and the
`is this an App project?` row is repointed at `app listing`, which is what
emits it.

**The existing guard could not see any of this.** It asserts each row's
fragment exists *somewhere* in non-test source; `is this an App project?` does
exist (in `internal/manifest`), so the row's attribution and its link were both
wrong under a green test.

`TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand` is the
strengthening: for a curated ledger it drives the **real** command through
`NewRootCmd`, and asserts (a) a row exists whose first column quotes the
fragment, (b) the row's link cell names the right anchor **and** that anchor is
a heading that exists, (c) the command really printed the fragment, and (d) for
the confusable pair, that the *other* command did not.

### Red → green matrix

| tree | result |
| --- | --- |
| `README.md` at `origin/main`, test at HEAD | **RED** — 2 failures |
| both at HEAD | **GREEN** — 8 leaf subtests |

The red output, verbatim:

```
--- FAIL: …/not_found_at_project_root
    the Troubleshooting index has no row whose first column quotes "not found at project root".
--- FAIL: …/is_this_an_App_project?
    the row for "is this an App project?" links to "[Validate fidelity](#validate-fidelity)",
    but must point at #listing-media-requirements.
```

### Mutation matrix — each arm broken on purpose and watched fail with THIS guard's message

| mutation | new guard | old existence guard |
| --- | --- | --- |
| `validate.go` finding gains `— is this an App project?` (i.e. the old row made retroactively true) | **RED** at `not_emitted_by_app_validate` | PASS — structurally blind |
| `resolveListingSlug` drops the `%w` cause | **RED** at `emitted_by_app_listing_status` | PASS |
| `validate.go` message reworded to `absent from project root` | **RED** at both `emitted_by` arms | RED (also) |
| `README.md` swapped to `origin/main` | **RED** at both rows | PASS |

The `notEmittedBy` half is labelled in the code as an **invariant guard**, not
regression coverage: `app validate` did not print that string before this PR
either. Row 1 of the mutation table is why it is there.

### A second attribution error, caught by writing the test

The first draft of the row credited the string to `app submit`, `app dev-token`
and `app dev-tunnel` as well — taken from #361's own list of `manifest.Load`
callers. **None of the three prints it for a missing manifest**: `app submit`
validates first and reports the other message, and dev-token/dev-tunnel discard
the load error. Listing a caller is not measuring a message. `app submit
--package-only` is now a `notEmittedBy` row so that stays measured.

## #364 — docs, not code, and why

`--version` is Cobra's, derived from a command's `Version` field. Making the
sentence true in code means either setting `Version` on every subcommand — so
every subcommand's help grows a `--version` flag, and `civitai app validate
--version` prints a version instead of validating — or hand-rolling a
persistent flag with the same effect. That is a behaviour change to a published
contract in order to satisfy a sentence, and `civitai version` (version +
commit + build date) already answers the scripted case from anywhere. So the
sentence moves: the table now says four of the five are global and `--version`
is root-only, with the exact failure a caller gets.

## Gates — counted, not read off an exit code

```
go test ./... -count=1 -v
=== RUN   3468
--- PASS  3464
--- FAIL  0
--- SKIP  4
ok        19 packages   FAIL 0   ("no test files" 1)
grep -c 'panic: test timed out' -> 0
```

`make ci` — green (tidy + vet + test + build).
`gofmt -s -l .` — 0 files, against 353 `.go` files in the tree (positive control
on the walk).
`make lint` via `nix-shell -p golangci-lint` — **v2.12.2**, which matches the
version pinned in `.github/workflows/ci.yml`. **0 issues.** Instrument validated
with a negative control: an unused variable added to the new test file made it
report `declared and not used: x (typecheck)`, and removing it returned it to 0.

`make ci-shallow` was **not** run — this change touches no test that reads git
history (README + two `_test.go` files).

## Overlap note

A parallel PR is fixing #365, which includes four unrelated README nits. This PR
touches four README regions: the silent-model-substitution section, the Global
flags table, the Troubleshooting intro sentence, and the "Validating and
submitting" table. If #365 touches any of those, the overlap should be resolved
between the two PRs rather than by either one unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
