### PR TITLE
fix(app)!: `withdraw` deleted the store listing silently, on the repair path three docs promised carried it forward (#350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires. The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
 | `civitai app status [blockId] [--id <pubreq>] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). See [Submission status](#submission-status). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
-| `civitai app withdraw [pubreq-id] [--id <pubreq>]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. Idempotent; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
+| `civitai app withdraw [pubreq-id] [--id <pubreq>] [--yes]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. **Also deletes a first-version app's store listing — icon, cover and every captioned screenshot**, so it asks first and needs `--yes` in a script. Idempotent for the submission only; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--out-name <template>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
 | `civitai workflows list [--limit <n>] [--cursor <c>] [--tag <t>] [--json]` | **List the generation workflows you have submitted**, newest first — status, when, cost, and `deliverable/total` outputs. Cursor-paged: the next cursor is printed on stdout when more results exist. Reading spends nothing. See [Generate](#listing-and-cancelling-workflows). |
 | `civitai workflows get <workflow-id> [--json]` | **Look up one generation workflow** — status, steps, outputs, and the Buzz transactions the server recorded for it. This is how you re-attach after `--no-wait`, a `--timeout` expiry or a Ctrl-C. Outputs that are blocked, unavailable or hidden are listed **with the reason** rather than omitted. Output URLs are presigned and expire; re-run for fresh links. Reading spends nothing. See [Generate](#waiting-downloading-and-re-attaching) and [Reading a workflow's Buzz transactions](#reading-a-workflows-buzz-transactions). |
@@ -1210,7 +1210,9 @@ guide.
 listing **cannot go live without an icon AND a cover**. `civitai app submit`
 mints your listing as a **draft** and prints this reminder inline — which is the
 moment to act on it, because the media is settable **while the app is in review**
-and carries forward when a moderator approves it. Attach it without the browser:
+and will carry forward on APPROVAL only — withdrawing the submission, or a
+moderator rejecting it, deletes the listing and everything on it. Attach it
+without the browser:
 
 ```text
 $ civitai app listing status                        # what's attached vs. required
@@ -1281,14 +1283,29 @@ first to free the slug, then resubmit:
 
 ```text
 $ civitai app status                          # find the pubreq_ id
-$ civitai app withdraw pubreq_01HZX           # frees the slug
-$ civitai app submit                          # resubmit the new bundle
+$ civitai app withdraw pubreq_01HZX           # frees the slug — and DELETES the store listing
+$ civitai app submit                          # resubmit the new bundle (listing starts EMPTY)
+$ civitai app listing set-icon ./assets/icon.png    # re-attach the media
 ```
 
+> **⚠ Withdrawing a first-version submission deletes that app's store listing**
+> — its icon, its cover and **every screenshot with its caption**. That is
+> server-side and the CLI cannot opt out of it: the withdraw route takes the
+> publish-request id and nothing else. Resubmitting mints an **empty** listing;
+> the media does not come back, and neither do the captions. The same discard
+> happens when a moderator **rejects** a first-version submission. A withdraw on
+> an app whose listing is already **approved** (a subsequent version) leaves the
+> live listing alone.
+>
+> Because that is irreversible, `civitai app withdraw` **asks first** on a
+> terminal, and **refuses** in a non-interactive shell unless you pass `--yes`.
+
 `civitai app withdraw <pubreq-id>` (or `--id <pubreq>`) withdraws **your own**
-pending publish request. It is **idempotent** (an already-withdrawn request still
-returns success) and only a **`pending`** request can be withdrawn — an already
-approved/rejected one cannot.
+pending publish request. It is **idempotent with respect to the submission**
+(an already-withdrawn request still returns success) and only a **`pending`**
+request can be withdrawn — an already approved/rejected one cannot. The
+idempotency does **not** extend to the listing: the first withdraw deletes it,
+and a second call does not bring it back.
 
 ### Listing media requirements
 
@@ -2470,6 +2487,7 @@ credited it to the wrong command.)
 | `nothing index.html loads reaches it` | The **strong** tier: the emitter is in your project but nothing the browser loads reaches it — an orphan file. Copying `civitai-host.js` in is only half the fix; it has to be referenced too. | [The host handshake](#the-host-handshake-block_ready) |
 | `no lockfile is committed` / `is not a lockfile` | The platform build installs **strictly** from the committed lockfile, so a missing one — or a zero-byte one created with `touch` — fails the build server-side. A lockfile is generated by the package manager, never hand-written. | [Validate fidelity](#validate-fidelity) |
 | `refusing to submit without --yes` | A submit that would really upload asked for confirmation and found no TTY. Pass `--yes` in CI, or `--package-only` to just write the .zip. | [Command reference](#command-reference) |
+| `refusing to withdraw without --yes` | A withdraw asked for confirmation and found no TTY. It gates because withdrawing a **first-version** submission deletes that app's store listing — icon, cover and every captioned screenshot. Pass `--yes` once you have accepted that; nothing was withdrawn and no request was sent. 🔴 **BREAKING:** this refusal is new — a scripted `civitai app withdraw <id>` that used to exit `0` now exits `1` until you add `--yes`. | [After you submit](#after-you-submit-review--approve--deploy) |
 
 ### Generating
 

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -87,10 +87,10 @@ that goes back to moderator review (the live listing is untouched until the
 revision is approved); pass --changelog to describe the change.
 
 The app is resolved from block.manifest.json in the current directory (or pass
---slug). Your store listing is created as a DRAFT when you run
-` + "`civitai app submit`" + `, so you can set its media WHILE your app is pending review
-— the media you attach carries forward when a moderator approves it. Set it
-early to clear the publish floor before you go live.
+--slug). ` + "`civitai app submit`" + ` mints your listing as a DRAFT, so its media is
+settable while pending review. It will
+` + strings.Join(wrapRunes(withdrawListingCaveat+".", 78), "\n") + `
+Do not hand-caption a set you may withdraw.
 
 Source files are checked locally BEFORE any upload — ` + listingImageFormats + `, at most
 ` + humanBytes(maxIconBytes) + ` for an icon, ` + humanBytes(maxCoverBytes) + ` for a cover, ` + humanBytes(maxScreenshotBytes) + ` for a screenshot.

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -247,10 +247,21 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 // store listing won't publish without an icon + cover, with the exact commands
 // to add them. Kept static (no server call) so it works even pre-first-listing.
 // This submit MINTED the store listing as a draft, so the media is settable NOW —
-// no need to wait for approval (it carries forward when the app is approved).
+// no need to wait for approval.
+//
+// 🔴 THE "CARRIES FORWARD" LINE CARRIES ITS CAVEAT (#350). This was one of the
+// three surfaces that promised the media survives, unqualified, and it is the
+// worst of them: it is printed at the exact moment the author decides to spend
+// an afternoon on artwork, and it was reprinted verbatim over an emptied listing
+// after a withdraw→resubmit. See withdrawListingCaveat.
 func printListingFloorHeadsUp(out io.Writer) {
 	fmt.Fprintln(out, "\nStore listing: your listing needs an icon AND a cover before it can publish.")
-	fmt.Fprintln(out, "You can add them NOW, while the app is in review — they carry forward on approval:")
+	// Wrapped at 78 so the caveat does not arrive as one 130-column line that a
+	// standard terminal breaks mid-clause; the rest of this block is already
+	// under 80.
+	for _, line := range wrapRunes("You can add them NOW, while the app is in review — they "+withdrawListingCaveat+":", 78) {
+		fmt.Fprintln(out, line)
+	}
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-icon <file>"))
 	fmt.Fprintf(out, "  %s\n", ui.Code("civitai app listing set-cover <file>"))
 	fmt.Fprintf(out, "  %s   # what's attached vs. required\n", ui.Code("civitai app listing status"))

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,6 +15,51 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// withdrawDiscardsListing is the ONE sentence naming what a withdraw destroys,
+// stated once so `--help`, the confirmation prompt and the line printed after
+// the withdraw lands cannot drift apart. Three separate copies of a weaker claim
+// are how issue #350 happened.
+//
+// 🔴 IT IS SERVER-SIDE AND THE CLI CANNOT OPT OUT — do not "fix" this by
+// changing the request. Traced in `civitai/civitai`, not assumed:
+//
+//   - `POST /api/v1/blocks/withdraw` (src/pages/api/v1/blocks/withdraw.ts) takes
+//     a body schema with EXACTLY ONE field, `publishRequestId` (:78-83). There is
+//     no flag to preserve the listing, and the tRPC spelling
+//     (`blocks.withdrawPublishRequest`) shares the same single-field schema and
+//     the same service call, so neither route can avoid it.
+//   - `withdrawRequest` calls `deleteOnsiteDraftListingForSlug`
+//     (src/server/services/blocks/publish-request.service.ts:1543 → :1454-1459)
+//     immediately after the status flip, as a deliberate application-level
+//     `deleteMany` — NOT a Prisma cascade. `AppBlockPublishRequest` has no
+//     relation to `AppListing` at all; the two are joined by the slug string.
+//
+// WHAT SURVIVES, STATED SO THE COPY DOES NOT OVERCLAIM. The `deleteMany`
+// predicate is `{slug, kind:'onsite', appBlockId: null, status:'draft'}`, so it
+// can only ever remove the PRE-APPROVAL DRAFT listing that `app submit` minted
+// for a FIRST version. A subsequent-version withdraw on an app that is already
+// approved matches nothing and leaves the live listing untouched. The screenshot
+// rows cascade away with it; the underlying Image rows are `onDelete: SetNull`,
+// so the uploaded images are detached rather than hard-deleted — but the
+// listing's icon/cover slots and every screenshot CAPTION are gone, and a
+// resubmit mints an empty draft rather than reusing anything.
+const withdrawDiscardsListing = "withdrawing a FIRST-VERSION submission also DELETES that app's store listing server-side — " +
+	"its icon, its cover and every screenshot with its caption. Resubmitting mints an EMPTY listing; the media does not come back"
+
+// withdrawListingCaveat is the qualification that MUST accompany every place
+// this CLI tells an author their listing media "carries forward".
+//
+// 🔴 IT IS ONE CONSTANT BECAUSE THREE COPIES OF THE UNQUALIFIED CLAIM IS
+// LITERALLY THE BUG (#350). The README quickstart, `app listing --help` and
+// `app submit`'s success output each said the media carries forward, each was
+// true across approval and false across withdraw, and nothing distinguished the
+// two for the reader — so the CLI reprinted the promise over a listing it had
+// just helped destroy. A fourth surface that repeats the claim must repeat this
+// with it; TestCarriesForwardClaimsAreQualifiedEverywhere is the ledger, and it
+// covers the README too (which cannot import a Go constant, so the guard is what
+// keeps the prose and the help in step).
+const withdrawListingCaveat = "carry forward on APPROVAL only — withdrawing the submission, or a moderator rejecting it, deletes the listing and everything on it"
+
 func newAppWithdrawCmd() *cobra.Command {
 	var idFlag string
 	var assumeYes bool
@@ -23,6 +70,16 @@ func newAppWithdrawCmd() *cobra.Command {
 		Long: `Withdraw your own pending App submission so you can resubmit a new bundle
 for the same slug.
 
+🔴 THIS IS NOT A FREE REPAIR — IT DESTROYS YOUR STORE LISTING. ` + withdrawDiscardsListing + `.
+That is server-side and this command cannot opt out of it: the withdraw route
+takes the publish-request id and nothing else. So attach your listing media
+AFTER the submission you intend to keep, not before a withdraw — and if a
+listing already has media you care about, copy the captions somewhere first.
+
+The same discard happens when a MODERATOR REJECTS a first-version submission.
+What "carries forward" is APPROVAL: media survives a moderator approving the
+app, and does not survive the app leaving review any other way.
+
 Calls the token-authenticated, self-scoped withdraw route
 (POST /api/v1/blocks/withdraw) with your stored credential — you can only ever
 withdraw your OWN submissions. Both a personal API key and an OAuth login
@@ -31,15 +88,19 @@ withdraw your OWN submissions. Both a personal API key and an OAuth login
 
 Only a submission still in the 'pending' review state can be withdrawn; an
 already-approved/rejected (or already-withdrawn) request cannot. Withdrawing is
-idempotent — withdrawing an already-withdrawn request still succeeds.
+idempotent WITH RESPECT TO THE SUBMISSION ONLY — withdrawing an already-withdrawn
+request still succeeds, but the listing the FIRST withdraw deleted is already
+gone and a second call does not restore it.
 
 Pass the publish-request id as a positional argument or via --id (find it with
 "civitai app status").
 
-Withdraw is non-interactive (it never prompts); --yes/-y is accepted as a no-op
-for symmetry with "civitai app submit" so the same scripted flag works on both.`,
-		Example: `  civitai app withdraw pubreq_01H        # withdraw by publish-request id
-  civitai app withdraw --id pubreq_01H   # same, via the flag`,
+CONFIRMATION: because that deletion is irreversible, an interactive run asks
+first. Pass --yes/-y to skip the prompt in a script; a non-interactive shell
+without --yes REFUSES rather than deleting a listing silently.`,
+		Example: `  civitai app withdraw pubreq_01H        # withdraw by publish-request id (asks first)
+  civitai app withdraw --id pubreq_01H   # same, via the flag
+  civitai app withdraw pubreq_01H --yes  # skip the prompt (scripts/CI)`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
@@ -65,19 +126,90 @@ for symmetry with "civitai app submit" so the same scripted flag works on both.`
 				return asUsageError(fmt.Errorf("a publish-request id is required — pass it as an argument or with --id (find it via `civitai app status`)"))
 			}
 
+			// 🔴 The gate runs BEFORE the client is even constructed, so a refusal
+			// cannot have issued a request. "Nothing was destroyed" is then
+			// structural rather than a claim — TestAppWithdrawNonTTYRefusalIssuesNoRequest
+			// asserts the server saw zero hits.
+			if err := confirmWithdraw(cmd, id, assumeYes); err != nil {
+				return err
+			}
+
 			client := appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), "")
 			ctx := context.Background()
 
 			if err := client.WithdrawRequest(ctx, id); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), ui.Success(fmt.Sprintf("Withdrew %s", id)))
+			out, errw := cmd.OutOrStdout(), cmd.ErrOrStderr()
+			fmt.Fprintln(out, ui.Success(fmt.Sprintf("Withdrew %s", id)))
+			// 🔴 Repeated at the point of use, not just in --help: a `--yes` run
+			// never saw the prompt, and the line printed after the thing happened is
+			// the one place the author is guaranteed to read. Issue #350 was found by
+			// a user whose only signal was a bare "Withdrew …" and rc=0.
+			fmt.Fprintln(errw, ui.For(errw).Warn("Its store listing went with it if this was a first-version submission — icon, cover and every screenshot."))
+			fmt.Fprintln(errw, ui.For(errw).Dim("Check with `civitai app listing status`; after you resubmit, re-attach the media with `civitai app listing set-icon` / `set-cover` / `add-screenshot`."))
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&idFlag, "id", "", "the publish-request id to withdraw (pubreq_...)")
-	// Accepted for symmetry with `app submit`; withdraw is non-interactive so this
-	// is a documented no-op (nothing to skip).
-	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "accepted for symmetry with 'app submit' (withdraw is non-interactive; no-op)")
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the confirmation and withdraw (required in a non-interactive shell)")
 	return cmd
+}
+
+// confirmWithdraw gates the withdraw mutation, mirroring confirmSubmit,
+// confirmGenerate and confirmCancel.
+//
+// Withdraw was the one destructive App command that did NOT gate (issue #350).
+// It reads as the routine repair path — `--help` called it idempotent and the
+// README documents withdraw → fix → resubmit — while the server-side listing
+// delete it triggers is irreversible and, at the time it fires, has been
+// contradicted by three separate places in this CLI promising the media carries
+// forward. A user withdrew to fix a version number and silently lost a
+// hand-captioned screenshot set, four seconds after `listing status` said it was
+// there.
+//
+//   - --yes/-y              → proceed without prompting.
+//   - non-TTY without --yes → REFUSE (never hang, never destroy silently).
+//   - interactive TTY       → say what is lost, prompt, proceed only on "y".
+//
+// Everything it prints goes to STDERR so stdout stays machine-clean.
+//
+// 🔴 The prompt DEFAULTS TO NO: the switch enumerates the ACCEPTING answers and
+// everything else — including a bare Enter — aborts. Rewriting it to enumerate
+// the refusing answers instead would turn `[y/N]` into `[Y/n]` and delete a
+// listing on a stray keystroke.
+//
+// 🔴 IT DOES NOT LOOK THE LISTING UP FIRST, and that is deliberate. Naming the
+// exact media count would need three more reads (submission → slug, slug →
+// listing, listing → assets), each a new failure mode on a path whose whole job
+// is to be reachable when something is already wrong, and it would put a copy of
+// the server's `appBlockId: null, status:'draft'` predicate in the CLI to decide
+// whether to warn at all. The residual, accepted: the prompt says WHAT is
+// destroyed and under WHICH condition, but not how many screenshots you have.
+func confirmWithdraw(cmd *cobra.Command, publishRequestID string, assumeYes bool) error {
+	if assumeYes {
+		return nil
+	}
+	if !stdinIsTTY() {
+		return fmt.Errorf("refusing to withdraw without --yes in a non-interactive shell — %s. "+
+			"Pass --yes to confirm, or `civitai app listing status` to see what %s would take with it",
+			withdrawDiscardsListing, safeTerm(publishRequestID))
+	}
+
+	errw := cmd.ErrOrStderr()
+	st := ui.For(errw)
+	fmt.Fprintf(errw, "About to withdraw %s.\n", safeTerm(publishRequestID))
+	fmt.Fprintln(errw, st.Warn("This is not just a resubmit: "+withdrawDiscardsListing+"."))
+	fmt.Fprintln(errw, st.Dim("The media only survives a moderator APPROVING the app — not a withdraw, and not a rejection."))
+	fmt.Fprintln(errw, st.Dim("Copy any captions you want to keep before answering; `civitai app listing status` prints them."))
+	fmt.Fprint(errw, "Withdraw it? [y/N]: ")
+
+	r := bufio.NewReader(cmd.InOrStdin())
+	line, _ := r.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return errors.New("withdraw aborted")
+	}
 }

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -70,7 +70,9 @@ func newAppWithdrawCmd() *cobra.Command {
 		Long: `Withdraw your own pending App submission so you can resubmit a new bundle
 for the same slug.
 
-🔴 THIS IS NOT A FREE REPAIR — IT DESTROYS YOUR STORE LISTING. ` + withdrawDiscardsListing + `.
+🔴 THIS IS NOT A FREE REPAIR —
+` + strings.Join(wrapRunes(withdrawDiscardsListing+".", 78), "\n") + `
+
 That is server-side and this command cannot opt out of it: the withdraw route
 takes the publish-request id and nothing else. So attach your listing media
 AFTER the submission you intend to keep, not before a withdraw — and if a

--- a/internal/cmd/app_withdraw_confirm_test.go
+++ b/internal/cmd/app_withdraw_confirm_test.go
@@ -1,0 +1,469 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// Coverage for issue #350: `civitai app withdraw` destroyed the app's entire
+// store listing — icon, cover and every captioned screenshot — with no warning,
+// no prompt and rc=0.
+//
+// 🔴 WHO DELETES, TRACED IN `civitai/civitai` RATHER THAN GUESSED, because the
+// answer decided the fix. The CLI does NOT issue the destructive call: the
+// withdraw route's body schema has exactly one field, `publishRequestId`
+// (src/pages/api/v1/blocks/withdraw.ts:78-83), and the tRPC spelling shares it.
+// The delete is `withdrawRequest` → `deleteOnsiteDraftListingForSlug`
+// (src/server/services/blocks/publish-request.service.ts:1543 → :1454-1459), a
+// deliberate application-level `deleteMany`, NOT a Prisma cascade —
+// `AppBlockPublishRequest` has no relation to `AppListing` at all. So the CLI
+// cannot avoid the destruction, and the whole fix is: stop being surprising.
+//
+// 🔴 NOT ONE OF THESE TESTS PERFORMS A REAL WITHDRAWAL. Every case runs against
+// httptest. A real withdraw destroys a listing and permanently consumes a
+// blockId, so the seam that must never be exercised for real is exactly the one
+// several of these tests assert was NEVER CALLED — which is why they count
+// requests against a local server instead of asserting on output alone.
+
+// countingWithdrawServer returns an httptest server for the withdraw route plus
+// the counter of requests it received.
+//
+// The counter is the point. "Nothing was destroyed" is the claim every refusal
+// path in this file makes, and an assertion on the error message cannot
+// establish it: a command that printed a refusal AND fired the request would
+// pass that assertion perfectly. Counting hits makes the claim structural.
+func countingWithdrawServer(t *testing.T, status int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"message":"not found"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// runWithdrawStdin drives the real root command with stdin wired to `stdin`,
+// capturing stdout and stderr separately (the confirmation writes to stderr).
+func runWithdrawStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	root := NewRootCmd()
+	var out, errb bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(args)
+	// 🔴 Execute FIRST, then read the buffers. Go evaluates return operands left
+	// to right, so `return out.String(), errb.String(), root.Execute()` captures
+	// both buffers BEFORE the command has written anything — two empty strings
+	// and a correct error, which reads exactly like a command that printed
+	// nothing. Cost an assertion round here; keep it explicit.
+	err := root.Execute()
+	return out.String(), errb.String(), err
+}
+
+// withdrawEnv points the CLI at srv with a token configured.
+func withdrawEnv(t *testing.T, baseURL string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-1")
+	t.Setenv("CIVITAI_BASE_URL", baseURL)
+}
+
+// --- confirmWithdraw unit tests (the safety logic in isolation) ---
+
+// --yes proceeds regardless of TTY, and prints NOTHING — a scripted run that
+// emitted a prompt into its own stderr would be a new surprise of its own.
+func TestConfirmWithdraw_YesBypassesPrompt(t *testing.T) {
+	withStdinTTY(t, false)
+	c, out := newConfirmCmd("")
+	if err := confirmWithdraw(c, "pubreq_01H", true); err != nil {
+		t.Fatalf("--yes should proceed: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("--yes must not prompt, got %q", out.String())
+	}
+}
+
+// A non-interactive shell without --yes REFUSES. The message has to carry the
+// thing the user did not know, so it is asserted against the constant the help
+// and the prompt share rather than a hand-typed paraphrase.
+func TestConfirmWithdraw_NonTTYRefuses(t *testing.T) {
+	withStdinTTY(t, false)
+	c, out := newConfirmCmd("")
+	err := confirmWithdraw(c, "pubreq_01H", false)
+	if err == nil {
+		t.Fatal("a non-TTY withdraw without --yes must refuse")
+	}
+	if !strings.Contains(err.Error(), "refusing to withdraw without --yes") {
+		t.Errorf("refusal should be recognisable: %v", err)
+	}
+	if !strings.Contains(err.Error(), withdrawDiscardsListing) {
+		t.Errorf("refusal must say WHAT is destroyed (the shared constant), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pubreq_01H") {
+		t.Errorf("refusal should name the target: %v", err)
+	}
+	if out.String() != "" {
+		t.Errorf("a refusal must not also print a prompt: %q", out.String())
+	}
+}
+
+// 🔴 The prompt DEFAULTS TO NO. Every answer that is not an explicit yes aborts,
+// including a bare Enter — the case a user hits by reflex. If this ever
+// enumerated the REFUSING answers instead, `[y/N]` would silently become
+// `[Y/n]` and a stray keystroke would delete a listing.
+func TestConfirmWithdraw_TTYDeclineAborts(t *testing.T) {
+	for _, answer := range []string{"", "\n", "n\n", "N\n", "no\n", "  \n", "nope\n", "yes please\n", "q\n"} {
+		t.Run(strings.TrimSpace(answer)+"|", func(t *testing.T) {
+			withStdinTTY(t, true)
+			c, out := newConfirmCmd(answer)
+			err := confirmWithdraw(c, "pubreq_01H", false)
+			if err == nil {
+				t.Fatalf("answer %q must abort", answer)
+			}
+			if !strings.Contains(err.Error(), "withdraw aborted") {
+				t.Errorf("answer %q: want an abort error, got %v", answer, err)
+			}
+			// The prompt must have named the loss before asking.
+			if !strings.Contains(out.String(), "Withdraw it? [y/N]:") {
+				t.Errorf("prompt missing or re-defaulted: %q", out.String())
+			}
+		})
+	}
+}
+
+func TestConfirmWithdraw_TTYAcceptProceeds(t *testing.T) {
+	for _, answer := range []string{"y\n", "Y\n", "yes\n", "YES\n", "  y  \n"} {
+		t.Run(strings.TrimSpace(answer), func(t *testing.T) {
+			withStdinTTY(t, true)
+			c, out := newConfirmCmd(answer)
+			if err := confirmWithdraw(c, "pubreq_01H", false); err != nil {
+				t.Fatalf("answer %q should proceed: %v", answer, err)
+			}
+			if !strings.Contains(out.String(), withdrawDiscardsListing) {
+				t.Errorf("the prompt must state what is destroyed BEFORE asking: %q", out.String())
+			}
+		})
+	}
+}
+
+// The confirmation goes to STDERR, so stdout stays machine-clean.
+func TestConfirmWithdraw_PromptGoesToStderr(t *testing.T) {
+	withStdinTTY(t, true)
+	root := NewRootCmd()
+	var out, errb bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetIn(strings.NewReader("n\n"))
+	if err := confirmWithdraw(root, "pubreq_01H", false); err == nil {
+		t.Fatal("expected the decline to abort")
+	}
+	if out.String() != "" {
+		t.Errorf("the prompt must not touch stdout, got %q", out.String())
+	}
+	if !strings.Contains(errb.String(), "Withdraw it? [y/N]:") {
+		t.Errorf("the prompt belongs on stderr, got %q", errb.String())
+	}
+}
+
+// --- end-to-end: what the refusal did to the network ---
+
+// 🔴 THE CENTRAL GUARANTEE. A non-interactive `app withdraw <id>` without --yes
+// refuses AND issues ZERO requests, so "nothing was destroyed" is a fact about
+// the wire rather than a claim about the copy.
+func TestAppWithdrawNonTTYRefusalIssuesNoRequest(t *testing.T) {
+	withStdinTTY(t, false)
+	srv, hits := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "withdraw", "pubreq_01H")
+	if err == nil {
+		t.Fatal("a scripted withdraw without --yes must refuse")
+	}
+	if n := hits.Load(); n != 0 {
+		t.Fatalf("the refusal issued %d request(s) — it must issue NONE, or the refusal "+
+			"is printed over a listing that has already been deleted", n)
+	}
+	if !strings.Contains(err.Error(), "refusing to withdraw without --yes") {
+		t.Errorf("refusal message: %v", err)
+	}
+	if strings.Contains(out, "Withdrew") {
+		t.Errorf("a refusal must never print the success line: %q", out)
+	}
+}
+
+// The refusal exits 1 (generic), NOT 2/3/4/5/6.
+//
+// Per AGENTS.md item 7 the exit code is decided by errors.Is against the
+// classification sentinels and by NOTHING in the message, so this asserts the
+// error is untagged — which is precisely what routes it to exitGeneric in
+// cmd/civitai/main.go's default branch. Asserting the wording instead would say
+// nothing at all about the exit code.
+func TestAppWithdrawRefusalCarriesNoClassificationSentinel(t *testing.T) {
+	withStdinTTY(t, false)
+	srv, _ := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "withdraw", "pubreq_01H")
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	for _, s := range []struct {
+		name string
+		err  error
+	}{
+		{"ErrUsage", ErrUsage},
+		{"civitai.ErrBadRequest", civitai.ErrBadRequest},
+		{"civitai.ErrUnauthorized", civitai.ErrUnauthorized},
+		{"civitai.ErrNotFound", civitai.ErrNotFound},
+		{"civitai.ErrRateLimited", civitai.ErrRateLimited},
+		{"civitai.ErrNetwork", civitai.ErrNetwork},
+	} {
+		if errors.Is(err, s.err) {
+			t.Errorf("the withdraw refusal is tagged %s, so it exits with that kind's code "+
+				"instead of the generic 1 the README publishes for it", s.name)
+		}
+	}
+}
+
+// An interactive DECLINE issues no request either.
+func TestAppWithdrawInteractiveDeclineIssuesNoRequest(t *testing.T) {
+	withStdinTTY(t, true)
+	srv, hits := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	out, errb, err := runWithdrawStdin(t, "n\n", "app", "withdraw", "pubreq_01H")
+	if err == nil {
+		t.Fatal("answering n must abort")
+	}
+	if n := hits.Load(); n != 0 {
+		t.Fatalf("declining issued %d request(s) — it must issue NONE", n)
+	}
+	if !strings.Contains(errb, "Withdraw it? [y/N]:") {
+		t.Errorf("expected the prompt on stderr, got %q", errb)
+	}
+	if strings.Contains(out, "Withdrew") {
+		t.Errorf("a declined withdraw must not print the success line: %q", out)
+	}
+}
+
+// An interactive ACCEPT proceeds — exactly one request, and the success line.
+func TestAppWithdrawInteractiveAcceptIssuesTheRequest(t *testing.T) {
+	withStdinTTY(t, true)
+	srv, hits := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	out, errb, err := runWithdrawStdin(t, "y\n", "app", "withdraw", "pubreq_01H")
+	if err != nil {
+		t.Fatalf("answering y should withdraw: %v", err)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("a confirmed withdraw issued %d request(s), want exactly 1", n)
+	}
+	// 🔴 The prompt must actually have been SHOWN. Without this the test passes
+	// against pre-#350 code, which ignored stdin entirely and withdrew — a green
+	// that would have certified the bug.
+	if !strings.Contains(errb, "Withdraw it? [y/N]:") {
+		t.Errorf("the withdraw proceeded without ever asking: %q", errb)
+	}
+	if !strings.Contains(out, "Withdrew") {
+		t.Errorf("expected the success line, got %q", out)
+	}
+}
+
+// CONTROL — a legitimate confirmed withdraw still succeeds, over --yes rather
+// than the prompt. If this ever goes red the gate has broken the command it was
+// added to protect.
+func TestAppWithdrawWithYesStillSucceeds(t *testing.T) {
+	withStdinTTY(t, false)
+	srv, hits := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "withdraw", "pubreq_01H", "--yes")
+	if err != nil {
+		t.Fatalf("app withdraw --yes: %v", err)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("--yes issued %d request(s), want exactly 1", n)
+	}
+	if !strings.Contains(out, "Withdrew") {
+		t.Errorf("expected the success line, got %q", out)
+	}
+}
+
+// CONTROL — a withdraw of an id the server does not know still 404s, and still
+// classifies as ErrNotFound (exit 4). #341 fixed exactly this class for
+// `workflows cancel`; the gate added here must not regress it, and must not
+// swallow the 404 behind a confirmation.
+func TestAppWithdrawUnknownIDStill404s(t *testing.T) {
+	withStdinTTY(t, false)
+	srv, hits := countingWithdrawServer(t, http.StatusNotFound)
+	withdrawEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "withdraw", "pubreq_nope", "--yes")
+	if err == nil {
+		t.Fatal("an unknown publish-request id must still fail")
+	}
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("the 404 control issued %d request(s), want 1 — the confirmation must not "+
+			"have replaced the server's own answer", n)
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("an unknown id must stay classified ErrNotFound (exit 4), got %v", err)
+	}
+}
+
+// The line printed AFTER a successful withdraw names the loss, because a --yes
+// run never saw the prompt. Issue #350's reporter's only signal was a bare
+// "Withdrew …" and rc=0.
+func TestAppWithdrawSuccessWarnsAboutTheListing(t *testing.T) {
+	withStdinTTY(t, false)
+	srv, _ := countingWithdrawServer(t, http.StatusOK)
+	withdrawEnv(t, srv.URL)
+
+	out, errb, err := run(t, "app", "withdraw", "pubreq_01H", "--yes")
+	if err != nil {
+		t.Fatalf("app withdraw --yes: %v", err)
+	}
+	for _, want := range []string{"store listing", "icon", "cover", "screenshot"} {
+		if !strings.Contains(strings.ToLower(errb), want) {
+			t.Errorf("the post-withdraw note must name %q, got %q", want, errb)
+		}
+	}
+	if !strings.Contains(errb, "civitai app listing status") {
+		t.Errorf("the note must name the next command to run, got %q", errb)
+	}
+	// The note is advisory: it belongs on stderr so `civitai app withdraw … >out`
+	// keeps the same stdout it always had.
+	if strings.Contains(out, "store listing") {
+		t.Errorf("the advisory note must not be on stdout: %q", out)
+	}
+}
+
+// --- the docs half of #350 ---
+
+// TestWithdrawHelpRetractsTheFreeRepairFraming pins the help-text corrections
+// #350 asked for, using only LITERAL strings.
+//
+// The literals are deliberate: this test compiles against pre-#350 code, so it
+// can be watched to FAIL there. Its sibling below asserts the same body against
+// the shared constant, which is stronger coupling but cannot exist at base — see
+// that test's note.
+func TestWithdrawHelpRetractsTheFreeRepairFraming(t *testing.T) {
+	out, _, err := run(t, "app", "withdraw", "--help")
+	if err != nil {
+		t.Fatalf("app withdraw --help: %v", err)
+	}
+	for _, want := range []string{
+		// The idempotency sentence is true of the submission and false of the
+		// listing; `--help` used to say it flatly.
+		"idempotent WITH RESPECT TO THE SUBMISSION ONLY",
+		// A rejection discards the draft too (publish-request.service.ts:4969),
+		// which the issue did not know and an author needs to.
+		"MODERATOR REJECTS",
+		// The gate itself has to be discoverable from --help, or a script author
+		// meets it for the first time as a CI failure.
+		"CONFIRMATION:",
+		"REFUSES rather than deleting a listing silently",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`app withdraw --help` no longer says %q:\n%s", want, out)
+		}
+	}
+	// The retracted claims: withdraw is NOT non-interactive any more, and --yes
+	// is NOT a no-op. Leaving either sentence in place would document the exact
+	// behaviour the fix removed — and both were in the help #350 quoted.
+	for _, gone := range []string{"never prompts", "no-op", "non-interactive (it"} {
+		if strings.Contains(out, gone) {
+			t.Errorf("`app withdraw --help` still describes the pre-#350 behaviour %q:\n%s", gone, out)
+		}
+	}
+}
+
+// TestWithdrawHelpQuotesTheDestructionConstant couples `--help` to the SAME
+// sentence the prompt and the refusal use, so a reword moves all three or fails.
+//
+// It cannot be run against pre-#350 code: the constant does not exist there, so
+// the package does not compile. That is a statement about the test, not evidence
+// about the fix — the behavioural red-at-base claims live in the tests above.
+func TestWithdrawHelpQuotesTheDestructionConstant(t *testing.T) {
+	out, _, err := run(t, "app", "withdraw", "--help")
+	if err != nil {
+		t.Fatalf("app withdraw --help: %v", err)
+	}
+	if !strings.Contains(out, withdrawDiscardsListing) {
+		t.Errorf("`app withdraw --help` no longer quotes withdrawDiscardsListing verbatim, so the "+
+			"help, the prompt and the refusal can now disagree about what is destroyed:\n%s", out)
+	}
+}
+
+// TestCarriesForwardClaimsAreQualifiedEverywhere is the SEAM guard for the docs
+// half of #350.
+//
+// The defect was not in any one surface: three separately-correct sentences —
+// the README quickstart, `app listing --help`, and `app submit`'s success
+// output — each said the listing media "carries forward", each was true across
+// APPROVAL and false across withdraw, and nothing distinguished the two for the
+// reader. Fixing one and leaving two is the failure mode this forbids, so the
+// assertion is over the SET of surfaces, not over any member of it.
+//
+// The two Go surfaces are checked against the shared constant, so a reword moves
+// them together. The README cannot import a Go constant, so it is checked
+// against the constant's TEXT with whitespace normalised — that lets prose wrap
+// however it likes while still failing if the claim itself drifts.
+func TestCarriesForwardClaimsAreQualifiedEverywhere(t *testing.T) {
+	norm := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+	caveat := norm(withdrawListingCaveat)
+
+	var submitHeadsUp bytes.Buffer
+	printListingFloorHeadsUp(&submitHeadsUp)
+
+	listingHelp, _, err := run(t, "app", "listing", "--help")
+	if err != nil {
+		t.Fatalf("app listing --help: %v", err)
+	}
+
+	surfaces := []struct{ name, body string }{
+		{"`app submit` success output (printListingFloorHeadsUp)", submitHeadsUp.String()},
+		{"`app listing --help`", listingHelp},
+		{"README.md", readREADME(t)},
+	}
+	for _, s := range surfaces {
+		if !strings.Contains(norm(s.body), caveat) {
+			t.Errorf("%s promises the media carries forward without the #350 qualification.\n"+
+				"It must contain (whitespace-insensitively):\n  %s\n"+
+				"Fixing one surface and leaving the others is what made this a data-loss bug: "+
+				"the CLI reprinted the unqualified promise over a listing it had just deleted.", s.name, caveat)
+		}
+	}
+
+	// POSITIVE CONTROL. Every assertion above is a `Contains`, and a Contains
+	// suite passes identically whether the extractor works or reads an empty
+	// string. Prove each surface is really loaded and non-trivial first.
+	for _, s := range surfaces {
+		if len(s.body) < 200 {
+			t.Fatalf("%s produced only %d bytes — the guard above is asserting over nothing",
+				s.name, len(s.body))
+		}
+	}
+
+	// NEGATIVE CONTROL on the matcher itself: it must be able to MISS. A
+	// substring check that somehow matched everything would make the whole test
+	// vacuous.
+	if strings.Contains(norm(submitHeadsUp.String()), caveat+" and pigs fly") {
+		t.Error("the caveat matcher cannot report a miss, so its hits prove nothing")
+	}
+}

--- a/internal/cmd/app_withdraw_confirm_test.go
+++ b/internal/cmd/app_withdraw_confirm_test.go
@@ -399,14 +399,26 @@ func TestWithdrawHelpRetractsTheFreeRepairFraming(t *testing.T) {
 // It cannot be run against pre-#350 code: the constant does not exist there, so
 // the package does not compile. That is a statement about the test, not evidence
 // about the fix — the behavioural red-at-base claims live in the tests above.
+//
+// Whitespace is normalised on both sides. The help hard-wraps the constant at 78
+// columns (cobra does not wrap `Long`, so an unwrapped 190-column paragraph would
+// break mid-clause in a standard terminal) while the refusal emits it as one
+// line. Pinning the bytes would therefore pin the LINE BREAKS, and this guard
+// exists to pin the CLAIM.
 func TestWithdrawHelpQuotesTheDestructionConstant(t *testing.T) {
+	norm := func(s string) string { return strings.Join(strings.Fields(s), " ") }
 	out, _, err := run(t, "app", "withdraw", "--help")
 	if err != nil {
 		t.Fatalf("app withdraw --help: %v", err)
 	}
-	if !strings.Contains(out, withdrawDiscardsListing) {
-		t.Errorf("`app withdraw --help` no longer quotes withdrawDiscardsListing verbatim, so the "+
+	if !strings.Contains(norm(out), norm(withdrawDiscardsListing)) {
+		t.Errorf("`app withdraw --help` no longer states withdrawDiscardsListing, so the "+
 			"help, the prompt and the refusal can now disagree about what is destroyed:\n%s", out)
+	}
+	// NEGATIVE CONTROL: whitespace normalisation must not have turned the check
+	// into one that matches anything.
+	if strings.Contains(norm(out), norm(withdrawDiscardsListing)+" and pigs fly") {
+		t.Error("the normalised matcher cannot report a miss, so its hit proves nothing")
 	}
 }
 

--- a/internal/cmd/app_withdraw_test.go
+++ b/internal/cmd/app_withdraw_test.go
@@ -47,7 +47,7 @@ func TestAppWithdrawSuccess(t *testing.T) {
 	t.Setenv("CIVITAI_TOKEN", "tok-1")
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 
-	out, _, err := run(t, "app", "withdraw", "pubreq_01H")
+	out, _, err := run(t, "app", "withdraw", "pubreq_01H", "--yes")
 	if err != nil {
 		t.Fatalf("app withdraw: %v", err)
 	}
@@ -68,9 +68,14 @@ func TestAppWithdrawSuccess(t *testing.T) {
 	}
 }
 
-// TestAppWithdrawYesFlagAccepted proves `withdraw <id> --yes` is accepted (no
-// "unknown flag") for symmetry with `app submit`. Withdraw is non-interactive, so
-// --yes is a no-op that must still parse and complete the withdraw cleanly.
+// TestAppWithdrawYesFlagAccepted proves both spellings of the flag are accepted
+// (no "unknown flag") and complete the withdraw cleanly.
+//
+// 🔴 --yes IS NO LONGER A NO-OP (#350). It used to be one — withdraw never
+// prompted, and the flag existed only so the same scripted invocation worked on
+// `app submit` and `app withdraw`. It is now the real bypass for a confirmation
+// gate, which is why every test in this file that expects the withdraw to LAND
+// has to pass it. See app_withdraw_confirm_test.go for the gate's own matrix.
 func TestAppWithdrawYesFlagAccepted(t *testing.T) {
 	var rec withdrawRec
 	srv := withdrawServer(t, map[string]any{"ok": true}, http.StatusOK, &rec)
@@ -105,7 +110,7 @@ func TestAppWithdrawByIDFlag(t *testing.T) {
 	t.Setenv("CIVITAI_TOKEN", "tok")
 	t.Setenv("CIVITAI_BASE_URL", srv.URL)
 
-	if _, _, err := run(t, "app", "withdraw", "--id", "pubreq_flag"); err != nil {
+	if _, _, err := run(t, "app", "withdraw", "--id", "pubreq_flag", "--yes"); err != nil {
 		t.Fatalf("app withdraw --id: %v", err)
 	}
 	if rec.publishRequestID != "pubreq_flag" {
@@ -153,6 +158,11 @@ func TestAppWithdrawArgAndFlagErrors(t *testing.T) {
 	}
 }
 
+// Deliberately WITHOUT --yes: the token check runs before the #350 confirmation
+// gate, so this also pins that ordering. A run with no credential must say so
+// rather than prompting the author to approve a destruction it could never have
+// performed — the assertion below is on the token message, so a gate that jumped
+// the queue would turn this red.
 func TestAppWithdrawMissingTokenErrors(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("CIVITAI_TOKEN", "")
@@ -185,7 +195,7 @@ func TestAppWithdrawErrorMapping(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 		t.Setenv("CIVITAI_TOKEN", "tok")
 		t.Setenv("CIVITAI_BASE_URL", srv.URL)
-		_, _, err := run(t, "app", "withdraw", "pubreq_01H")
+		_, _, err := run(t, "app", "withdraw", "pubreq_01H", "--yes")
 		srv.Close()
 		if err == nil {
 			t.Fatalf("status %d: expected error", tc.status)

--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -872,6 +872,9 @@ func TestREADMETroubleshootingCoversTheRefusalsAuthorsActuallyHit(t *testing.T) 
 	}{
 		{"refusing to submit without --yes",
 			"the CI-blocking refusal; a scripted `app submit` cannot get past it and the README never mentioned it"},
+		{"refusing to withdraw without --yes",
+			"the #350 gate, and the only refusal in this index that BROKE a working script — a scripted " +
+				"`app withdraw` used to exit 0, so an author who never reads --help meets it as a CI failure"},
 		{"cannot derive a slug from",
 			"the blockId refusal — it stops `app create` dead, and the identity it guards can never be renamed"},
 		{"no such directory — pass the path to an App project root",


### PR DESCRIPTION
Fixes #350.

## Who deletes — traced, not assumed

The CLI does **not** issue the destructive call, and **cannot avoid it**:

- `POST /api/v1/blocks/withdraw` (`civitai/civitai` → `src/pages/api/v1/blocks/withdraw.ts:78-83`) validates a body schema with **exactly one field**, `publishRequestId`. There is no parameter that preserves the listing, and the tRPC spelling `blocks.withdrawPublishRequest` (`src/server/routers/blocks.router.ts:1277-1281`) shares the same single-field schema and the same service call.
- `withdrawRequest` calls `deleteOnsiteDraftListingForSlug` at `src/server/services/blocks/publish-request.service.ts:1543`, defined at `:1454-1459`:
  ```ts
  await dbWrite.appListing.deleteMany({
    where: { slug: opts.slug, kind: 'onsite', appBlockId: null, status: 'draft' },
  });
  ```
  A deliberate application-level `deleteMany` — **not** a Prisma cascade. `AppBlockPublishRequest` (`prisma/schema.prisma:2381`) has **no relation to `AppListing` at all**; they are joined by the slug string.
- `AppListingScreenshot.appListing` is `onDelete: Cascade`, so screenshots go with it. The `Image` rows are `onDelete: SetNull` — detached, not hard-deleted — but the icon/cover slots and **every screenshot caption** are gone.
- The `404` the reporter saw is a genuinely missing row, not a visibility filter (`offsite-listing.service.ts:1600-1625` has no publish-request-state predicate).
- **`rejectRequest` does the same** (`publish-request.service.ts:4969`). The issue did not know this; the docs now say it.

**Scope correction the fix does not overclaim past:** the `appBlockId: null, status:'draft'` predicate means only a **first-version pre-approval draft** is destroyed. A withdraw on an already-approved app leaves the live listing alone.

So the CLI cannot avoid the destruction. The whole fix is: **stop being surprising.**

## The fix

**1. A confirmation gate, matching the house pattern** (`confirmSubmit` / `confirmGenerate` / `confirmCancel`):

- `--yes/-y` → proceed.
- Interactive TTY → say what is lost, prompt `[y/N]` **defaulting to no**, proceed only on an explicit yes.
- Non-interactive without `--yes` → **REFUSE**.

The gate runs **before the client is constructed**, so a refusal issues **zero requests** — "nothing was destroyed" is structural, and is asserted as a request count rather than as copy.

**2. A warning after a successful withdraw**, because a `--yes` run never saw the prompt. The reporter's only signal was a bare `Withdrew …` and `rc=0`.

**3. The three "carries forward" claims are now ONE constant plus a cross-surface ledger test.** Three copies of the unqualified claim is what made this data loss rather than a surprise — the CLI reprinted the promise over a listing it had just helped destroy. Corrected in the README quickstart, `app listing --help`, and `app submit`'s success output, and extended to cover rejection.

**4. `app withdraw --help`** stops framing withdraw→resubmit as a free repair and qualifies the idempotency sentence — idempotent **with respect to the submission only**.

**Deliberately not done:** looking the listing up to name the media count. It would need three more reads (submission → slug → listing → assets), each a new failure mode on a path whose job is to work when something is already wrong, and it would put a copy of the server's draft predicate in the CLI. The residual is stated in `confirmWithdraw`'s comment: the prompt says *what* is destroyed and under *which* condition, but not how many screenshots you have.

## 🔴 BREAKING

A non-interactive `civitai app withdraw <id>` **without `--yes` now refuses and exits `1`**, where it previously withdrew and exited `0`. Scripts and CI must add `--yes`. The refusal issues no request, so nothing is withdrawn and nothing is destroyed. `--yes` is also no longer the documented no-op it used to be.

Per `claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md`, the refusal carries **no classification sentinel**, which is what routes it to the generic `1` — pinned by `errors.Is` against all six kinds, not by message text. The README's troubleshooting index carries the symptom row and the BREAKING note.

## Test coverage

🔴 **No live probe. Zero real withdrawals.** Every case runs through `httptest` + `t.TempDir()`.

### Red-at-base matrix (measured against `origin/main`, production files only)

| Test | at `origin/main` | at HEAD |
| --- | --- | --- |
| `TestAppWithdrawNonTTYRefusalIssuesNoRequest` | **FAIL** | PASS |
| `TestAppWithdrawRefusalCarriesNoClassificationSentinel` | **FAIL** | PASS |
| `TestAppWithdrawInteractiveDeclineIssuesNoRequest` | **FAIL** | PASS |
| `TestAppWithdrawInteractiveAcceptIssuesTheRequest` | **FAIL** | PASS |
| `TestAppWithdrawSuccessWarnsAboutTheListing` | **FAIL** | PASS |
| `TestWithdrawHelpRetractsTheFreeRepairFraming` | **FAIL** | PASS |
| `TestREADMETroubleshootingCoversTheRefusalsAuthorsActuallyHit` | **FAIL** | PASS |
| `TestAppWithdrawWithYesStillSucceeds` | PASS | PASS |
| `TestAppWithdrawUnknownIDStill404s` | PASS | PASS |

The last two **pass at base and are labelled CONTROLS, not regression coverage** — they exist to prove the gate did not break the command it protects, and did not regress the unknown-id `404`→exit-4 behaviour #341 just fixed for `workflows cancel`.

**Stated plainly:** the seven `TestConfirmWithdraw_*` unit tests and the two constant-coupled ledger tests reference symbols that do not exist at base, so the package does not compile there. **Non-compilation is not evidence**, which is why every behavioural claim above is carried by a test built from literal strings that does compile at base.

### Mutation matrix — 12 mutants, 12 killed, 0 survivors

Each verified to die on **its own** assertion (re-run one test at a time; `go test -v` emits failure lines *before* the `--- FAIL:` header, so a naive parse mis-attributes them).

| Mutant | Killed by | On which error |
| --- | --- | --- |
| M1 `--yes` bypass deleted | `TestAppWithdrawWithYesStillSucceeds` (+7) | the non-TTY refusal now fires on a `--yes` run |
| M2 non-TTY refusal disabled (`if false`) | `TestAppWithdrawNonTTYRefusalIssuesNoRequest` | `refusal message: withdraw aborted` — the guard's own string is gone |
| M3 TTY test inverted | 7 tests incl. `TestConfirmWithdraw_TTYAcceptProceeds` | refusal fires on a terminal |
| M4 prompt defaults to YES | `TestConfirmWithdraw_TTYDeclineAborts` | `answer "" must abort` (7/10 subtests) |
| M5 gate moved AFTER the mutation | `TestAppWithdrawNonTTYRefusalIssuesNoRequest` | `the refusal issued 1 request(s) — it must issue NONE` |
| M6 post-success warning neutered | `TestAppWithdrawSuccessWarnsAboutTheListing` | `the post-withdraw note must name "store listing"` |
| M7 refusal drops WHAT is destroyed | `TestConfirmWithdraw_NonTTYRefuses` | `refusal must say WHAT is destroyed` |
| M8 `--help` drops the destruction sentence | `TestWithdrawHelpQuotesTheDestructionConstant` | help/prompt/refusal can now disagree |
| M9 `--help` restores the idempotency overclaim | `TestWithdrawHelpRetractsTheFreeRepairFraming` | the false sentence is back |
| M10 `app submit` drops the caveat | `TestCarriesForwardClaimsAreQualifiedEverywhere` | names that surface |
| M11 `app listing --help` drops the caveat | same | names that surface |
| M12 README drops the caveat | same | names that surface |

**Reachability**, not just breakability:

- The `assumeYes` arm executes — M1 shows removing it reddens a previously-green non-TTY `--yes` path, which is only green because that arm short-circuits ahead of the TTY check.
- The non-TTY arm executes with **no earlier check pre-empting it** — M2 (`if false`) falls through to the prompt and produces `withdraw aborted`, a *different* error, proving the arm was the one running.
- Both switch arms execute — accept (`case "y"`) via `TTYAcceptProceeds`, default via M4 flipping 7 subtests.
- The gate genuinely precedes the request — M5.

The seam-ledger and normalised-matcher tests each carry a **positive control** (surfaces are non-trivially loaded) and a **negative control** (the matcher can still miss).

## Gates — counted from output, never from an exit code

- `make ci`: **19** packages `ok`, `--- FAIL` = **0**, `^FAIL` = **0**, `build failed` = **0**, `panic: test timed out` = **0**.
- `make lint` (golangci-lint **v2.12.2** under `nix-shell -p golangci-lint`, matching the CI pin): **0 issues**.
- **Lint positive control**, with a *compiling* defect (a compile error would only prove the compiler works): inserting an unused unexported func with an ineffectual assignment — `go build` clean — produced **2 issues** (`ineffassign: 1`, `unused: 1`) and `make: *** Error 1`. Removed; back to **0**. So the pair is **2 on the control, 0 under test**.

## Not verified

The server-side behaviour is established by **reading `civitai/civitai`**, not by executing a withdraw — deliberately, since a real withdraw destroys a listing and permanently consumes a blockId. The claims about what the server deletes carry file:line citations above and in `withdrawDiscardsListing`'s comment, and every CLI-side behaviour is exercised hermetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
