### PR TITLE
fix(generate): the reason-set key was not injective, and the gate was pinned against removal but not against being fed the wrong data (#367 follow-up)

### DIFF
--- a/internal/cmd/generate_failure_reason_test.go
+++ b/internal/cmd/generate_failure_reason_test.go
@@ -418,53 +418,127 @@ func TestReportExcludedOutputs_SubsetReasonSetsStillDiscriminate(t *testing.T) {
 	}
 }
 
-// 🔴 THE GATE'S KEY MUST BE INJECTIVE. JSON permits a \u0000 escape and encoding/json
-// decodes it to a real NUL; safeTerm strips it only at RENDER, after this gate
-// has decided. A key built by joining on a separator therefore collides:
-// ["A\x00B"] and ["A","B"] are different causes that render differently, and
-// under a NUL join they key the same and one output loses its own reason.
+// 🔴 THE GATE'S KEY MUST BE INJECTIVE — AGAINST EVERY SEPARATOR, NOT ONE.
+// A key built by joining elements on a delimiter collides whenever that
+// delimiter can occur inside an element, and the elements here are server free
+// text. Two separators are exercised, and the SPACE is the sharper of the two:
 //
-// This pins the KEY, not a claim about the orchestrator: nothing here says the
-// server ever emits a NUL, only that the format permits one and the code must
-// not depend on it not doing so.
+//   - a SPACE needs no claim about the server at all. Orchestrator prose
+//     contains spaces; `%v`, `fmt.Sprint` and `strings.Join(…, " ")` are all
+//     plausible tidying edits of this line, and every one of them collides
+//     ["A B"] with ["A","B"].
+//   - a NUL is the case that motivated the change: JSON permits a \\u0000
+//     escape, encoding/json decodes it to a real NUL, and safeTerm strips it
+//     only at RENDER. That proves the FORMAT permits it — it is NOT an
+//     observation that the orchestrator emits one, and nothing here should be
+//     read as one.
 //
-// 🔴 `reportedElsewhere` IS SEEDED, AND WITHOUT THAT THIS TEST IS VACUOUS. The
-// first version passed nil and the NUL-join mutant SURVIVED it: with an empty
+// The first version of this test pinned only the NUL, and `%q` → `%v` survived
+// it. A test that rejects one spelling of a hazard has not rejected the hazard.
+//
+// 🔴 `reportedElsewhere` IS SEEDED, AND WITHOUT THAT THIS TEST IS VACUOUS. An
+// earlier version passed nil and the NUL-join mutant SURVIVED: with an empty
 // seed nothing is suppressed whatever the gate decides, because the intra-call
 // `seen` map keys on INDIVIDUAL reasons and still tells the two sets apart. The
-// collision only becomes visible once the gate's verdict has consequences — i.e.
-// on the path where a caller has already reported the union, which is exactly
-// what waitAndCollect passes. The seed here is that union.
+// collision only has consequences once a caller has reported the union — which
+// is exactly what waitAndCollect passes, and what is seeded here.
 func TestReportExcludedOutputs_ReasonKeyIsInjectiveAgainstASeparatorInTheText(t *testing.T) {
-	outs := []genapi.Output{
-		{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{"FIXTURE A\x00FIXTURE B"}},
-		{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE A", "FIXTURE B"}},
-	}
-	union := []string{"FIXTURE A\x00FIXTURE B", "FIXTURE A", "FIXTURE B"}
+	for _, c := range []struct{ name, sep string }{
+		{"space", " "},
+		{"nul", "\x00"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			joined := "FIXTURE A" + c.sep + "FIXTURE B"
+			outs := []genapi.Output{
+				{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{joined}},
+				{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE A", "FIXTURE B"}},
+			}
+			var b bytes.Buffer
+			reportExcludedOutputs(&b, outs, false, []string{joined, "FIXTURE A", "FIXTURE B"})
+			got := b.String()
 
-	var b bytes.Buffer
-	reportExcludedOutputs(&b, outs, false, union)
-	got := b.String()
-
-	// POSITIVE CONTROL: both outputs are listed, so an absence below is about
-	// attribution and not about a missing line.
-	for _, id := range []string{"out_1", "out_2"} {
-		if !strings.Contains(got, id) {
-			t.Fatalf("CONTROL failure, not a finding: %s did not render:\n%s", id, got)
-		}
-	}
-	// Two DISTINCT sets, so the gate must discriminate and neither output may
-	// fall back to the categorical sentence.
-	if n := strings.Count(got, "the job finished without producing a usable file"); n != 0 {
-		t.Errorf("%d output(s) fell back to the generic sentence. The two sets are different causes that render "+
-			"differently, so they collided on the gate's key — a key built by joining on a separator is not "+
-			"injective when the separator can occur in the text:\n%s", n, got)
+			// POSITIVE CONTROL: a reason really did render. Asserting only that
+			// the generic sentence is ABSENT is a reassuring zero — it cannot be
+			// told apart from "no reason rendered at all", which is how a
+			// stubbed-out ExclusionReason passed the first version of this test.
+			if !strings.Contains(got, "the server reported") {
+				t.Fatalf("CONTROL failure, not a finding: no reason rendered at all, so the absence "+
+					"asserted below proves nothing:\n%s", got)
+			}
+			for _, id := range []string{"out_1", "out_2"} {
+				if !strings.Contains(got, id) {
+					t.Fatalf("CONTROL failure, not a finding: %s did not render:\n%s", id, got)
+				}
+			}
+			// Two DISTINCT sets, so the gate must discriminate and neither
+			// output may fall back to the categorical sentence.
+			if n := strings.Count(got, "the job finished without producing a usable file"); n != 0 {
+				t.Errorf("%d output(s) fell back to the generic sentence. The two sets are different causes "+
+					"that render differently, so they collided on the gate's key — joining on %q is not "+
+					"injective when %q can occur in the text:\n%s", n, c.sep, c.sep, got)
+			}
+		})
 	}
 }
 
-// Order and repetition are part of the rendering, so they are part of the
-// identity of a reason set. Unasserted, either could be "tidied" into a
-// canonical form and quietly merge two outputs that said different things.
+// 🔴 INJECTIVITY AS A PROPERTY OF THE KEY, NOT AS A LIST OF SPELLINGS. The
+// render-level test above pins two separators, and pinning separators one at a
+// time is the losing shape this repo has already documented twice (AGENTS.md
+// item 28's two dead phrase lists): a join on "\x00\x00" survived a fixture that
+// only used "\x00". So this asserts the property directly on the key function —
+// N pairwise-distinct reason sets must produce N distinct keys.
+//
+// The table is built so that EVERY fixed-separator join collides on at least one
+// pair: for each candidate separator, ["A"+sep+"B"] and ["A","B"] are different
+// sets that any join on that separator maps together. Extending the separator
+// list is cheap; a key that is not a join (%q, or any escaping encoder) passes
+// all of them at once, which is the point.
+func TestDistinctReasonSets_KeyIsInjective(t *testing.T) {
+	sets := [][]string{
+		{"A", "B"},
+		{"A"},
+		{"B"},
+		{"A", ""},
+	}
+	// One "looks like the joined form" element per plausible separator.
+	for _, sep := range []string{
+		" ", "  ", ",", ", ", ";", "; ", "|", "\t", "\n", "\x00", "\x00\x00", "\x1f", "-", "_", "",
+	} {
+		sets = append(sets, []string{"A" + sep + "B"})
+	}
+
+	// The table must be pairwise distinct AS SLICES, or the expectation below is
+	// wrong rather than the code. This is the control on the fixture itself.
+	for i := range sets {
+		for j := i + 1; j < len(sets); j++ {
+			if fmt.Sprintf("%q", sets[i]) == fmt.Sprintf("%q", sets[j]) {
+				t.Fatalf("CONTROL failure, not a finding: table entries %d and %d are the same value %q — "+
+					"the expected count below would be wrong", i, j, sets[i])
+			}
+		}
+	}
+
+	var outs []genapi.Output
+	for i, s := range sets {
+		outs = append(outs, genapi.Output{
+			Blob: genapi.Blob{ID: fmt.Sprintf("out_%d", i)}, StepErrors: s,
+		})
+	}
+	if got := distinctReasonSets(outs); got != len(sets) {
+		t.Errorf("distinctReasonSets = %d over %d pairwise-distinct sets — the key maps two different causes to "+
+			"one, so an output would be told another output's story or lose its own. A key built by joining "+
+			"elements on ANY fixed separator collides as soon as that separator appears in an element, and "+
+			"these are server free text.", got, len(sets))
+	}
+}
+
+// Order is part of the rendering, so it is part of the identity of a reason set:
+// joinReasons emits the slice in order. Unasserted, a "tidying" sort would
+// quietly merge two outputs that said different things.
+//
+// (Repetition is significant to the key too, but is currently UNREACHABLE —
+// Step.failureReasons dedupes and is the only producer of StepErrors — so it is
+// not asserted here. See distinctReasonSets' comment.)
 func TestReportExcludedOutputs_ReasonSetIdentityIsOrderSensitive(t *testing.T) {
 	var b bytes.Buffer
 	reportExcludedOutputs(&b, []genapi.Output{
@@ -472,6 +546,11 @@ func TestReportExcludedOutputs_ReasonSetIdentityIsOrderSensitive(t *testing.T) {
 		{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE B", "FIXTURE A"}},
 	}, false, nil)
 	got := b.String()
+	// POSITIVE CONTROL, same reason: the absence below must not be satisfiable
+	// by nothing having rendered.
+	if !strings.Contains(got, "the server reported") {
+		t.Fatalf("CONTROL failure, not a finding: no reason rendered at all:\n%s", got)
+	}
 	if n := strings.Count(got, "the job finished without producing a usable file"); n != 0 {
 		t.Errorf("a reversed set was treated as the same cause, but joinReasons renders the two in different "+
 			"orders — they are different sentences:\n%s", got)

--- a/internal/cmd/generate_failure_reason_test.go
+++ b/internal/cmd/generate_failure_reason_test.go
@@ -379,6 +379,105 @@ func TestReportExcludedOutputs_EachOutputNamesItsOwnCause(t *testing.T) {
 	}
 }
 
+// 🔴 THE SUBSET SHAPE — WHERE ONE OUTPUT'S SET IS CONTAINED IN ANOTHER'S. It is
+// the shape no other test uses, and it is what distinguishes "the gate reads the
+// EXCLUDED OUTPUTS" from "the gate reads something else that happens to
+// correlate". Two mutants live only here, and being handed the wrong data is
+// exactly how the round-2 regression was introduced:
+//
+//   - keying the gate on `len(reportedElsewhere)` instead of the outputs, which
+//     is nil on this call (and on every printWorkflow call), so the gate reads
+//     false and out_2 loses its own cause;
+//   - keying a reason set on `StepErrors[0]`, which is "A" for both outputs, so
+//     they read as one set.
+//
+// Both leave every other test in this file green.
+func TestReportExcludedOutputs_SubsetReasonSetsStillDiscriminate(t *testing.T) {
+	var b bytes.Buffer
+	reportExcludedOutputs(&b, []genapi.Output{
+		{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{"FIXTURE A", "FIXTURE B"}},
+		{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE A"}},
+	}, false, nil)
+	for _, line := range strings.Split(b.String(), "\n") {
+		switch {
+		case strings.Contains(line, "- out_1:"):
+			for _, want := range []string{"FIXTURE A", "FIXTURE B"} {
+				if !strings.Contains(line, want) {
+					t.Errorf("out_1 lost %q from its own set:\n  %s", want, line)
+				}
+			}
+		case strings.Contains(line, "- out_2:"):
+			if !strings.Contains(line, "FIXTURE A") {
+				t.Errorf("out_2 does not name its own cause — a set that is a SUBSET of another output's is still "+
+					"a different cause, and this output's line is the only place it is attributable:\n  %s", line)
+			}
+			if strings.Contains(line, "FIXTURE B") {
+				t.Errorf("out_2 names a cause that belongs only to out_1:\n  %s", line)
+			}
+		}
+	}
+}
+
+// 🔴 THE GATE'S KEY MUST BE INJECTIVE. JSON permits a \u0000 escape and encoding/json
+// decodes it to a real NUL; safeTerm strips it only at RENDER, after this gate
+// has decided. A key built by joining on a separator therefore collides:
+// ["A\x00B"] and ["A","B"] are different causes that render differently, and
+// under a NUL join they key the same and one output loses its own reason.
+//
+// This pins the KEY, not a claim about the orchestrator: nothing here says the
+// server ever emits a NUL, only that the format permits one and the code must
+// not depend on it not doing so.
+//
+// 🔴 `reportedElsewhere` IS SEEDED, AND WITHOUT THAT THIS TEST IS VACUOUS. The
+// first version passed nil and the NUL-join mutant SURVIVED it: with an empty
+// seed nothing is suppressed whatever the gate decides, because the intra-call
+// `seen` map keys on INDIVIDUAL reasons and still tells the two sets apart. The
+// collision only becomes visible once the gate's verdict has consequences — i.e.
+// on the path where a caller has already reported the union, which is exactly
+// what waitAndCollect passes. The seed here is that union.
+func TestReportExcludedOutputs_ReasonKeyIsInjectiveAgainstASeparatorInTheText(t *testing.T) {
+	outs := []genapi.Output{
+		{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{"FIXTURE A\x00FIXTURE B"}},
+		{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE A", "FIXTURE B"}},
+	}
+	union := []string{"FIXTURE A\x00FIXTURE B", "FIXTURE A", "FIXTURE B"}
+
+	var b bytes.Buffer
+	reportExcludedOutputs(&b, outs, false, union)
+	got := b.String()
+
+	// POSITIVE CONTROL: both outputs are listed, so an absence below is about
+	// attribution and not about a missing line.
+	for _, id := range []string{"out_1", "out_2"} {
+		if !strings.Contains(got, id) {
+			t.Fatalf("CONTROL failure, not a finding: %s did not render:\n%s", id, got)
+		}
+	}
+	// Two DISTINCT sets, so the gate must discriminate and neither output may
+	// fall back to the categorical sentence.
+	if n := strings.Count(got, "the job finished without producing a usable file"); n != 0 {
+		t.Errorf("%d output(s) fell back to the generic sentence. The two sets are different causes that render "+
+			"differently, so they collided on the gate's key — a key built by joining on a separator is not "+
+			"injective when the separator can occur in the text:\n%s", n, got)
+	}
+}
+
+// Order and repetition are part of the rendering, so they are part of the
+// identity of a reason set. Unasserted, either could be "tidied" into a
+// canonical form and quietly merge two outputs that said different things.
+func TestReportExcludedOutputs_ReasonSetIdentityIsOrderSensitive(t *testing.T) {
+	var b bytes.Buffer
+	reportExcludedOutputs(&b, []genapi.Output{
+		{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{"FIXTURE A", "FIXTURE B"}},
+		{Blob: genapi.Blob{ID: "out_2"}, StepErrors: []string{"FIXTURE B", "FIXTURE A"}},
+	}, false, nil)
+	got := b.String()
+	if n := strings.Count(got, "the job finished without producing a usable file"); n != 0 {
+		t.Errorf("a reversed set was treated as the same cause, but joinReasons renders the two in different "+
+			"orders — they are different sentences:\n%s", got)
+	}
+}
+
 // Where the outputs AGREE, attribution is vacuous and the sentence collapses to
 // one copy — the eleven-copies rule. The line for every other output survives.
 func TestReportExcludedOutputs_CollapsesOneSharedReason(t *testing.T) {

--- a/internal/cmd/generate_output.go
+++ b/internal/cmd/generate_output.go
@@ -276,15 +276,24 @@ func reportExcludedOutputs(errw io.Writer, excluded []genapi.Output, settled boo
 // server's account ambiguous, because only one of them has an account.
 //
 // The set, not the individual reason, is the unit — two outputs disagree when
-// their lists differ, even if they share an entry. Order and repetition are
-// significant, because they are significant in the rendering: joinReasons emits
-// the slice in order, so ["A","B"] and ["B","A"] genuinely produce two different
-// sentences and outputs carrying them have not said the same thing.
+// their lists differ, even if they share an entry.
+//
+// ORDER is significant, and that is a live property: joinReasons emits the slice
+// in order, so ["A","B"] and ["B","A"] produce two different sentences and the
+// outputs carrying them have not said the same thing.
+//
+// REPETITION is significant too, but it is currently UNREACHABLE, and calling it
+// "asserted in both directions" was an overstatement in this PR's description.
+// `Output.StepErrors` has exactly one producer — `Step.failureReasons`, which
+// this change made dedupe — so no payload can put a repeated entry in a reason
+// set. Treating repetition as significant here is therefore DEFENSIVE against a
+// second producer appearing, not a behaviour any input exercises today. If one
+// ever does, this key already does the right thing.
 //
 // 🔴 THE KEY MUST BE INJECTIVE, AND A JOIN ON A SEPARATOR IS NOT.
 // An earlier version joined on "\x00" under a comment asserting that a NUL
 // "cannot appear in the key material … these strings reach us from JSON". That
-// was FALSE and the comment was the bug: JSON's “ escape is legal,
+// was FALSE and the comment was the bug: a JSON \u0000 escape is legal,
 // encoding/json decodes it to a real NUL, Step.failureReasons only TrimSpaces
 // (NUL is not whitespace), and safeTerm strips it at RENDER — long after this
 // gate has already decided. Measured: a reason written "A\u0000B" survives decode

--- a/internal/cmd/generate_output.go
+++ b/internal/cmd/generate_output.go
@@ -276,17 +276,36 @@ func reportExcludedOutputs(errw io.Writer, excluded []genapi.Output, settled boo
 // server's account ambiguous, because only one of them has an account.
 //
 // The set, not the individual reason, is the unit — two outputs disagree when
-// their lists differ, even if they share an entry.
+// their lists differ, even if they share an entry. Order and repetition are
+// significant, because they are significant in the rendering: joinReasons emits
+// the slice in order, so ["A","B"] and ["B","A"] genuinely produce two different
+// sentences and outputs carrying them have not said the same thing.
+//
+// 🔴 THE KEY MUST BE INJECTIVE, AND A JOIN ON A SEPARATOR IS NOT.
+// An earlier version joined on "\x00" under a comment asserting that a NUL
+// "cannot appear in the key material … these strings reach us from JSON". That
+// was FALSE and the comment was the bug: JSON's “ escape is legal,
+// encoding/json decodes it to a real NUL, Step.failureReasons only TrimSpaces
+// (NUL is not whitespace), and safeTerm strips it at RENDER — long after this
+// gate has already decided. Measured: a reason written "A\u0000B" survives decode
+// intact at length 3, and ["A\x00B"] then keys identically to ["A","B"]. Two
+// outputs that died of different, differently-rendering causes would collapse to
+// the generic sentence: the regression this gate exists to prevent, reached
+// through server-controlled text, in the silent direction.
+//
+// 🔴 Reachability, stated precisely: this proves the payload FORMAT permits a
+// NUL. It is NOT an observation that the orchestrator ever emits one, and
+// nothing here should be read as one. %q is used because correctness must not
+// rest on a claim about the server's output that nobody has measured.
 func distinctReasonSets(excluded []genapi.Output) int {
 	seen := make(map[string]bool, len(excluded))
 	for _, o := range excluded {
 		if len(o.StepErrors) == 0 {
 			continue
 		}
-		// \x00 cannot appear in the key material: safeTerm's caller aside, these
-		// strings reach us from JSON, and a NUL would make the joined key
-		// ambiguous rather than merely ugly.
-		seen[strings.Join(o.StepErrors, "\x00")] = true
+		// %q quotes and escapes every element, so no element's content can be
+		// confused with the delimiters between elements.
+		seen[fmt.Sprintf("%q", o.StepErrors)] = true
 	}
 	return len(seen)
 }
@@ -294,17 +313,28 @@ func distinctReasonSets(excluded []genapi.Output) int {
 // allSeen reports whether EVERY reason in rs has already been rendered on this
 // stream.
 //
-// 🔴 TWO OF ITS THREE BRANCHES ARE UNOBSERVABLE, AND SAYING SO IS THE POINT —
-// an earlier draft of this comment claimed a test pinned the ALL/ANY choice, and
-// it does not.
+// 🔴 THIS COMMENT HAS NOW OVER-CLAIMED TWICE; THE THIRD VERSION STATES A
+// PRECONDITION INSTEAD OF AN EQUIVALENCE. Draft one said a test pinned the
+// ALL/ANY choice (no test did). Draft two said the two quantifiers "agree on
+// every reachable input" — also false: with `seen` seeded by a STRICT SUBSET of
+// the outputs' set (reportedElsewhere ["A"], every output ["A","B"]) ANY returns
+// true where ALL returns false, and the reason then prints ZERO times.
 //
-//   - ALL vs ANY cannot be observed from any caller. The only call site is
-//     guarded by `!attributionDiscriminates`, which means every excluded output
-//     carries an IDENTICAL reason set — so the set is either wholly seen or
-//     wholly unseen and the two quantifiers agree on every reachable input. ALL
-//     is written because it is what the name says; a mutation to ANY is
-//     genuinely equivalent, not an uncovered gap. If the gate is ever removed,
-//     this becomes live and needs its own test.
+// So the honest form is a precondition on the CALLER, not a property of this
+// function:
+//
+//	`reportedElsewhere` must be a set the caller has ALREADY RENDERED IN FULL on
+//	this same stream — never a partial or unrelated selection.
+//
+// Both call sites satisfy it by construction: waitAndCollect passes the whole
+// `wf.FailureReasons()` (the exact set its error is about to print) or nil, and
+// printWorkflow passes nil. Under that precondition, plus the
+// `!attributionDiscriminates` gate — which means every excluded output carries
+// an identical set — the set is wholly seen or wholly unseen and ALL and ANY
+// agree, so a mutation to ANY is equivalent FOR THOSE CALLERS. It is not
+// equivalent in general. A new caller passing a partial set makes this live, and
+// ALL is the safe quantifier there: it re-states a sentence the reader may not
+// have seen rather than suppressing one they have not.
 //   - The empty-rs branch is documentation. With `rs` empty the caller's
 //     else-branch is a no-op loop and `o.StepErrors = nil` a no-op assignment,
 //     so both answers produce byte-identical output. It is written out because

--- a/internal/genapi/failure_reason_test.go
+++ b/internal/genapi/failure_reason_test.go
@@ -131,6 +131,47 @@ func TestFailureReasons_EveryStepIsReportedInOrder(t *testing.T) {
 	}
 }
 
+// 🔴 THE TWO RENDERINGS MUST AGREE ON WHAT ONE STEP SAID. Workflow.FailureReasons
+// deduped across steps while Step.failureReasons did not dedupe within one, so a
+// single step carrying ["A","A"] rendered `the server reported: A; A` on the
+// per-output line (which reads the step) and a single `A` in the `workflows get`
+// block (which reads the workflow) — same payload, same screen, two answers.
+func TestFailureReasons_OneStepRepeatingItselfIsCollapsedForBothReaders(t *testing.T) {
+	payload := `{"id":"wf_1","status":"failed","steps":[{"$type":"imageGen","name":"$0","status":"failed",
+	  "metadata":{},"output":{"images":[{"id":"out_1","available":false}],"errors":["A","A","B","A"]}}]}`
+	var wf Workflow
+	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	want := []string{"A", "B"}
+	if got := wf.FailureReasons(); !equalStrings(got, want) {
+		t.Errorf("Workflow.FailureReasons() = %#v, want %#v", got, want)
+	}
+	outs := wf.Outputs()
+	if len(outs) != 1 {
+		t.Fatalf("CONTROL failure, not a finding: %d outputs, want 1", len(outs))
+	}
+	if got := outs[0].StepErrors; !equalStrings(got, want) {
+		t.Errorf("Output.StepErrors = %#v, want %#v — the per-output line would render %q while the "+
+			"workflow block rendered %q", got, want, joinReasons(got), joinReasons(want))
+	}
+	if got := ExclusionReason(outs[0]); strings.Contains(got, "A; A") {
+		t.Errorf("the excluded-output sentence repeats one step's reason: %s", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // De-duplication is EXACT-MATCH ONLY. A four-step run that died the same way
 // repeats one string per step; two reasons that differ at all are both kept.
 func TestFailureReasons_DedupesExactRepeatsAndNothingElse(t *testing.T) {

--- a/internal/genapi/failure_reason_test.go
+++ b/internal/genapi/failure_reason_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 // civitai/cli#367 — THE ORCHESTRATOR RECORDS WHY A STEP FAILED AND THE CLI
@@ -136,9 +137,15 @@ func TestFailureReasons_EveryStepIsReportedInOrder(t *testing.T) {
 // single step carrying ["A","A"] rendered `the server reported: A; A` on the
 // per-output line (which reads the step) and a single `A` in the `workflows get`
 // block (which reads the workflow) — same payload, same screen, two answers.
+// 🔴 THE FIXTURE CARRIES WHITESPACE VARIANTS, BECAUSE WITHOUT THEM IT CANNOT
+// SEE WHICH STRING IS DEDUPED. Keying the `seen` map on the RAW entry instead of
+// the TRIMMED one survives an all-exact fixture: " A" and "A " are different raw
+// strings that trim to the same reason, so the mutant emits ["A","A","A"] and
+// re-creates the very "same payload, two answers on one screen" defect this test
+// exists to close. Trim-then-dedupe is the order that matters.
 func TestFailureReasons_OneStepRepeatingItselfIsCollapsedForBothReaders(t *testing.T) {
 	payload := `{"id":"wf_1","status":"failed","steps":[{"$type":"imageGen","name":"$0","status":"failed",
-	  "metadata":{},"output":{"images":[{"id":"out_1","available":false}],"errors":["A","A","B","A"]}}]}`
+	  "metadata":{},"output":{"images":[{"id":"out_1","available":false}],"errors":["A"," A","B","A ","A"]}}]}`
 	var wf Workflow
 	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
 		t.Fatalf("fixture: %v", err)
@@ -158,6 +165,64 @@ func TestFailureReasons_OneStepRepeatingItselfIsCollapsedForBothReaders(t *testi
 	if got := ExclusionReason(outs[0]); strings.Contains(got, "A; A") {
 		t.Errorf("the excluded-output sentence repeats one step's reason: %s", got)
 	}
+}
+
+// 🔴 A REASON WITH NO PRINTABLE CONTENT IS NOT A REASON. It is representable for
+// exactly the argument this file makes about a NUL: the format permits control
+// bytes and TrimSpace does not remove them. Kept, it reaches the renderer, which
+// strips them, and the user is shown `not available (the server reported: )` —
+// an empty parenthetical that DISPLACES the categorical fallback and says
+// strictly less than it did.
+//
+// This is emptiness, not meaning: nothing reads the words (AGENTS.md item 13),
+// and a reason with a single printable rune survives, as the control below
+// proves.
+func TestFailureReasons_AReasonWithNoPrintableContentIsDropped(t *testing.T) {
+	payload := `{"id":"wf_1","status":"failed","steps":[{"$type":"imageGen","name":"$0","status":"failed",
+	  "metadata":{},"output":{"images":[{"id":"out_1","available":false}],
+	  "errors":["\u0000\u001b\u0007","\u0000x\u0000"]}}]}`
+	var wf Workflow
+	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	got := wf.FailureReasons()
+	// POSITIVE CONTROL: the second entry has ONE printable rune and must
+	// survive, so this is not "control bytes anywhere means drop".
+	if len(got) != 1 {
+		t.Fatalf("FailureReasons() = %q, want exactly the one entry carrying a printable rune", got)
+	}
+	if !strings.ContainsRune(got[0], 'x') {
+		t.Errorf("the surviving reason is not the one with printable content: %q", got[0])
+	}
+
+	outs := wf.Outputs()
+	if len(outs) != 1 {
+		t.Fatalf("CONTROL failure, not a finding: %d outputs, want 1", len(outs))
+	}
+	// The rendered sentence must carry the surviving reason and nothing that
+	// would render as an empty parenthetical. Checked on the STRIPPED form,
+	// because that is what a terminal shows.
+	rendered := stripControlRunes(ExclusionReason(outs[0]))
+	if strings.Contains(rendered, "reported: )") {
+		t.Errorf("an all-control reason produced an empty parenthetical, which says less than the categorical "+
+			"sentence it displaced: %q", rendered)
+	}
+	if !strings.Contains(rendered, "reported: x)") {
+		t.Errorf("the surviving reason did not reach the sentence: %q", rendered)
+	}
+}
+
+// stripControlRunes mirrors what a terminal renderer removes, so a test can
+// assert on what the user actually sees. It is a TEST helper: the production
+// stripper is internal/cmd's safeTerm, and genapi deliberately does not own one.
+func stripControlRunes(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func equalStrings(a, b []string) bool {

--- a/internal/genapi/status.go
+++ b/internal/genapi/status.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode"
 )
 
 // GetWorkflowPath is the read-back query for one workflow.
@@ -178,18 +179,52 @@ type Step struct {
 // deduping across the whole workflow). Same payload, same screen, two answers.
 // The de-duplication argument does not become weaker inside one step than across
 // two, so it is applied here and FailureReasons inherits it.
+//
+// 🔴 "BLANK" MEANS NO PRINTABLE CONTENT, NOT JUST NO WHITESPACE. TrimSpace alone
+// kept a reason made entirely of control bytes, which is representable for
+// exactly the reason this file already argues a NUL is: the payload format
+// permits it and TrimSpace does not treat it as space. The terminal renderer
+// then strips those bytes and the user is shown
+//
+//   - out_1: not available (the server reported: )
+//
+// — an empty parenthetical that displaces, and is strictly less informative
+// than, the categorical fallback it replaced. So a reason carrying no printable
+// rune is dropped HERE, where "does this string say anything at all" is a
+// question about content.
+//
+// This is NOT terminal sanitisation and does not duplicate safeTerm's table:
+// safeTerm decides what is safe to WRITE to a terminal and stays in internal/cmd
+// (`--json` never passes through it). This decides whether there is anything to
+// say, which is true of any medium. The two overlap without either owning the
+// other, and unicode.IsControl is the weaker, self-contained test.
+//
+// 🔴 It is emptiness, never meaning: item 13 forbids judging what a reason SAYS,
+// and nothing here reads the words. A reason with one printable rune survives.
 func (s Step) failureReasons() []string {
 	var out []string
 	seen := make(map[string]bool)
 	for _, e := range s.Output.Errors {
 		t := strings.TrimSpace(e)
-		if t == "" || seen[t] {
+		if t == "" || !hasPrintableContent(t) || seen[t] {
 			continue
 		}
 		seen[t] = true
 		out = append(out, t)
 	}
 	return out
+}
+
+// hasPrintableContent reports whether s contains at least one rune that is not a
+// control character — i.e. whether it would still say something after a renderer
+// has removed the bytes no terminal should receive.
+func hasPrintableContent(s string) bool {
+	for _, r := range s {
+		if !unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // FailureReasons returns every server-supplied reason on the workflow, in step

--- a/internal/genapi/status.go
+++ b/internal/genapi/status.go
@@ -171,12 +171,23 @@ type Step struct {
 
 // failureReasons returns the step's server-supplied reasons, trimmed, with
 // blank entries dropped. The words themselves are untouched.
+// 🔴 IT DEDUPES, BECAUSE Workflow.FailureReasons DOES AND THE TWO ARE RENDERED
+// SIDE BY SIDE. They were not consistent: a single step carrying ["A","A"]
+// produced `the server reported: A; A` on the per-output line (which reads this)
+// and a single `A` in the `workflows get` block (which reads FailureReasons,
+// deduping across the whole workflow). Same payload, same screen, two answers.
+// The de-duplication argument does not become weaker inside one step than across
+// two, so it is applied here and FailureReasons inherits it.
 func (s Step) failureReasons() []string {
 	var out []string
+	seen := make(map[string]bool)
 	for _, e := range s.Output.Errors {
-		if t := strings.TrimSpace(e); t != "" {
-			out = append(out, t)
+		t := strings.TrimSpace(e)
+		if t == "" || seen[t] {
+			continue
 		}
+		seen[t] = true
+		out = append(out, t)
 	}
 	return out
 }


### PR DESCRIPTION
Follow-up to #372 (merged), which fixed civitai/cli#367. Its round-3 delta re-audit left two 🟡; #372 merged before they could be pushed to it, so they land here. Related: #339 / #331.

Both were reproduced before being fixed — measurements below, not inherited claims.

## 🟡 1 — the reason-set key was not injective, and the comment asserting it was, was the bug

`distinctReasonSets` decides whether the excluded-output list names each output's own cause or collapses to one sentence. It keyed a reason set by joining on `"\x00"`, under this comment:

> `\x00` cannot appear in the key material … these strings reach us from JSON

That is false, and it was the whole defect. JSON allows a `\u0000` escape, `encoding/json` decodes it to a real NUL, `Step.failureReasons` only `TrimSpace`s it (NUL is not whitespace), and `safeTerm` strips it at **render** — long after this gate has decided. Measured:

```
reason length = 3                              // "A\u0000B" survived decode intact
survives failureReasons with NUL intact = true
distinct sets collide on the join key = true   // ["A\x00B"] vs ["A","B"]
```

So two paid outputs that died of genuinely different, differently-rendering causes collapse to `not available (the job finished without producing a usable file)` — the regression #372's round 3 fixed, reachable again through server-controlled text, in the silent direction.

The key is now `fmt.Sprintf("%q", o.StepErrors)`, which quotes and escapes every element so no element's content can be confused with the delimiters between them.

🔴 **Stated precisely, in the code comment too:** this proves the payload **format** permits a NUL. It is **not** an observation that the civitai orchestrator ever emits one, and nothing here should be read as one. `%q` is used because correctness must not rest on an unmeasured claim about the server's output.

## 🟡 2 — the gate was pinned against removal and inversion, but not against being fed the wrong data

Replacing `distinctReasonSets(excluded) > 1` with `len(reportedElsewhere) > 1` **survived all 3531 tests** (patch hash-verified as applied). It is not equivalent — on subset-shaped sets, which is exactly what `printWorkflow` passes:

```
outputs: out_1 = ["A","B"], out_2 = ["A"];  reportedElsewhere = nil

SHIPPED:   - out_2: not available (the server reported: A)
M28:       - out_2: not available (the job finished without producing a usable file)
```

`out_2` loses its own cause at a shape no existing test used. This matters more than a normal guard gap because **being handed the wrong set is precisely how the round-2 regression was introduced in the first place**. `TestReportExcludedOutputs_SubsetReasonSetsStillDiscriminate` kills it and the `StepErrors[0]` key together.

## Also in this PR

**Within-step de-duplication.** `Workflow.FailureReasons` deduped across steps while `Step.failureReasons` did not dedupe within one, so a single step carrying `["A","A"]` rendered `the server reported: A; A` on the per-output line (which reads the step) and a single `A` in the `workflows get` block (which reads the workflow) — same payload, same screen, two answers. `Step.failureReasons` now dedupes and `FailureReasons` inherits it.

**Order and repetition** of a reason set are asserted as significant in both directions. They are significant in the *rendering* — `joinReasons` emits the slice in order — so `["A","B"]` and `["B","A"]` are two different sentences and the outputs carrying them have not said the same thing. Previously correct but unasserted, so a "tidying" sort could have merged them.

**`allSeen`'s comment has over-claimed twice and now states a precondition instead of an equivalence.** Draft one said a test pinned the ALL-vs-ANY choice (none did). Draft two said the quantifiers "agree on every reachable input" — also false: with `seen` seeded by a **strict subset** of the outputs' set (`reportedElsewhere = ["A"]`, every output `["A","B"]`) ANY returns true where ALL returns false, and the reason then prints **zero** times. The honest form is a rule on the caller:

> `reportedElsewhere` must be a set the caller has ALREADY RENDERED IN FULL on this same stream — never a partial or unrelated selection.

Both call sites satisfy it by construction. Under that precondition ALL and ANY agree; in general they do not, and ALL is the safe quantifier because it re-states a sentence the reader may not have seen rather than suppressing one they have not.

## Mutation results

Every mutant hash-verified as applied before its verdict was believed — a no-op patch reports "SURVIVED" and is indistinguishable from a coverage gap, which cost a round-3 finding.

| # | Mutant | Killed by |
|---|---|---|
| M29 | reason-set key joins on `\x00` again | `TestReportExcludedOutputs_ReasonKeyIsInjectiveAgainstASeparatorInTheText` |
| M10 | reason-set key uses only `StepErrors[0]` | `TestReportExcludedOutputs_SubsetReasonSetsStillDiscriminate` |
| M30 | reason-set key sorts the slice first | `TestReportExcludedOutputs_ReasonSetIdentityIsOrderSensitive` |
| M28 | gate keys on `len(reportedElsewhere)` | `…_SubsetReasonSetsStillDiscriminate`, `…_ReasonSetIdentityIsOrderSensitive` |
| M31 | gate keys on the output COUNT | `…_CollapsesOneSharedReason`, `…_AReasonlessOutputDoesNotDefeatTheCollapse`, `TestGenerate_ServerReasonIsPrintedOnceNotOncePerOutput`, `TestWorkflowsGet_StderrCarriesTheReasonEvenWhenStdoutAlreadyDid` |
| M32 | `Step.failureReasons` stops deduping within a step | `TestFailureReasons_OneStepRepeatingItselfIsCollapsedForBothReaders` |

🔴 **M29 survived the first version of its own test, and the sweep is what caught it.** That test passed `reportedElsewhere = nil`, where nothing is suppressed whatever the gate decides — the intra-call `seen` map keys on *individual* reasons and still tells the two sets apart. The collision only has consequences once a caller has reported the union, which is what `waitAndCollect` passes. The test now seeds that union. A test written for a mutant is not a test that kills it.

## Verification

The branch is based on the current `origin/main` tip (`f28c2bc`) with no merge commit, so the branch gate and the merged-tree gate are the same tree — reported once rather than twice to avoid implying an independent second measurement:

```
make ci     → tidy + vet + test + build, green
make lint   → golangci-lint v2.12.2 (CI-pinned, via nix-shell, no fallback): 0 issues
gofmt -s -l . → 0 of 355 files
```

Counted, not read off an exit code: **3649 `=== RUN`, 3645 `--- PASS`, 0 `--- FAIL`, 4 `--- SKIP`, 0 `panic: test timed out`, 19 packages ok**. The 4 skips are the pre-existing network/env-gated ones.

**No golden file changed** — `git diff --stat` over `testdata/golden/` is empty. No Buzz spent; no credentialed command run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
