### PR TITLE
docs(claude): the README-lockstep rule was scoped to two item numbers, and README is not one place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@
 - `AGENTS.md` is the single source of truth for **agent guidance**; keep curated
   guidance there, not here.
 - The split: `AGENTS.md` holds **decisions and rationale**; `README.md` is the
-  **published user contract** (exit codes, `--json` shapes, the command
-  reference) that items 24 and 26 must move in lockstep with — a behaviour change
-  touching either is incomplete until both are updated.
+  **published user contract** — exit codes, `--json` shapes, the command
+  reference. **Any** behaviour change is incomplete until `README.md` moves with
+  it; this is not scoped to the AGENTS items that happen to cite it today.
+- 🔴 **"README" is not one place.** The command's own section, the exit-code
+  table and the Troubleshooting index each state the contract and each goes stale
+  ALONE — #371 shipped having updated two of the three (#378). Grep the whole
+  file for every surface that names the behaviour you changed, and note that some
+  of that prose is generated (`internal/cmd/exitcodes_doc.go`) or frozen verbatim
+  by a provenanced fixture, so it cannot be corrected in place.


### PR DESCRIPTION
Two defects in one bullet, both measured this session.

1. The lockstep rule was written as applying to "items 24 and 26". Three PRs
   merged today (#368, #370, #371) each required a README move and NONE was
   about item 24 or 26 — #371's was adjacent to item 7. A general rule tied to
   two item numbers under-describes its own scope, against RULES.md's "read
   every rule at its WIDEST reading". AGENTS.md also warns items are append-only
   and that renumbering breaks pointers, so hard-coding two of them here is
   fragile on top of being wrong.

   The relative clause ("...that items 24 and 26 must move in lockstep with")
   was also ambiguous about whether "either"/"both" meant the two items or the
   two files.

2. "README" is not one place, and nothing said so. #371 updated the exit-code
   bullet and the Troubleshooting index but not the command's own section —
   two of three, filed as #378. Verified still live at 36cd097:
   README.md:1619 states the app-metrics behaviour the other two surfaces
   were corrected for.

The new bullet also records that some of that prose cannot be corrected in
place: the exit-code section is generated from internal/cmd/exitcodes_doc.go
(TestREADMEExitCodeSectionsAreGenerated) and part of it is frozen verbatim
against a git-provenanced fixture (TestEveryPreSplitClauseSurvives,
testdata/exitcodes_base_table.md). Both verified present at 36cd097. That is
why #371 had to add a correction beside the frozen text rather than rewrite it,
and the next person to hit it should not have to rediscover the mechanism.

Gate: go test ./... -count=1 -> 19 ok packages, 0 FAIL, 0 timeout panics.
No Go file changed, so golangci-lint is unaffected and was not run.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)