### PR TITLE
test(app): the newest-first submission assumption was unpinned at both call sites, and README moved in two of three places (#371 follow-up) (#378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,9 +1617,10 @@ civitai app view my-cool-app --json
 App Blocks. The slug is resolved to its `appBlockId` through your own
 submissions, so analytics exist only once a version has been **approved** — an
 app still in review reports that instead of an empty dashboard. Like `app pull`,
-the message names the latest submission's own state and the next step for it:
-where it is in review, or — for a **rejected** or **withdrawn** submission — that
-nothing is in review and a new `civitai app submit` is what moves it.
+the message names the next step **for** the latest submission's own state: where
+it is in review, or — for a **rejected** or **withdrawn** submission — that
+nothing is in review and a new `civitai app submit` is what moves it. (Unlike
+`app pull`, it does not print the submission's version and status themselves.)
 
 ```text
 $ civitai app metrics gen-matrix --from 2026-05-01 --to 2026-08-03

--- a/README.md
+++ b/README.md
@@ -1620,7 +1620,8 @@ app still in review reports that instead of an empty dashboard. Like `app pull`,
 the message names the next step **for** the latest submission's own state: where
 it is in review, or — for a **rejected** or **withdrawn** submission — that
 nothing is in review and a new `civitai app submit` is what moves it. (Unlike
-`app pull`, it does not print the submission's version and status themselves.)
+`app pull`, it does not print the `(latest submission: <version> <status>)` pair
+— a **pending** app is told where to look, without its version being named.)
 
 ```text
 $ civitai app metrics gen-matrix --from 2026-05-01 --to 2026-08-03

--- a/README.md
+++ b/README.md
@@ -1616,7 +1616,10 @@ civitai app view my-cool-app --json
 `civitai app metrics <slug>` shows the owner-only analytics for one of **your**
 App Blocks. The slug is resolved to its `appBlockId` through your own
 submissions, so analytics exist only once a version has been **approved** — an
-app still in review reports that instead of an empty dashboard.
+app still in review reports that instead of an empty dashboard. Like `app pull`,
+the message names the latest submission's own state and the next step for it:
+where it is in review, or — for a **rejected** or **withdrawn** submission — that
+nothing is in review and a new `civitai app submit` is what moves it.
 
 ```text
 $ civitai app metrics gen-matrix --from 2026-05-01 --to 2026-08-03

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -241,6 +241,15 @@ func resolveAppBlockID(ctx context.Context, list func(context.Context, string) (
 		}
 	}
 	// Newest first, so subs[0] is the state whose next step to name.
+	//
+	// 🔴 subs[0], NEVER subs[len(subs)-1] — and it was unpinned here and in
+	// explainMissingApp alike until #378: mutating BOTH to the last row left the
+	// whole suite green (3653 RUN, 0 FAIL), because every fixture had one row,
+	// where the two ends are the same row. This command prints no "latest
+	// submission" parenthetical, so reading the wrong end is invisible — the
+	// oldest row's advice simply reads as the truth. Pinned by
+	// TestAppMetricsAdviceNamesTheNewestSubmission and the call-site ledger in
+	// app_newest_submission_test.go.
 	return "", fmt.Errorf("app %q has no approved App Block yet — analytics only exist once a submitted version is approved; %s",
 		slug, pullReviewAdvice(slug, subs[0].Status))
 }

--- a/internal/cmd/app_metrics_test.go
+++ b/internal/cmd/app_metrics_test.go
@@ -694,18 +694,39 @@ func TestAppMetricsNoApprovedBlockYet(t *testing.T) {
 	}
 }
 
-// notApprovedSubmissionsBody is a one-row, never-approved submissions list
-// (appBlockId null) carrying an explicit review state. submissionsBody hard-codes
+// notApprovedSubmissionsBody is a never-approved submissions list (appBlockId
+// null) whose NEWEST row carries status. submissionsBody hard-codes
 // `"status":"approved"`, which is exactly the row that CANNOT exercise the
 // state-dependent advice — with a null appBlockId it is also incoherent — so the
 // terminal-state guards need their own fixture.
-func notApprovedSubmissionsBody(slug, status string) string {
-	b, _ := json.Marshal(map[string]any{"submissions": []any{
-		map[string]any{
-			"id": "pubreq_1", "blockId": slug, "version": "0.2.0", "status": status,
+//
+// 🔴 IT IS TWO ROWS, AND THE SECOND ONE IS THE WHOLE POINT (issue #378). It used
+// to be one row, where `subs[0]` and `subs[len(subs)-1]` are the SAME row — so
+// every guard built on it, including the cross-command seam guard below, was
+// structurally unable to see which end of the list the advice came from.
+// Mutating both call sites to the last row left the entire suite green. The
+// older row's state is chosen to land in a DIFFERENT pullReviewAdvice branch, so
+// reading the wrong end produces a different sentence rather than the same one.
+func notApprovedSubmissionsBody(t *testing.T, slug, status string) string {
+	t.Helper()
+	older := "rejected"
+	if pullReviewAdvice(slug, older) == pullReviewAdvice(slug, status) {
+		older = "withdrawn"
+	}
+	if pullReviewAdvice(slug, older) == pullReviewAdvice(slug, status) {
+		t.Fatalf("no decoy state produces advice different from %q — this fixture cannot "+
+			"distinguish the newest row from the oldest", status)
+	}
+	row := func(id, version, st string) map[string]any {
+		return map[string]any{
+			"id": id, "blockId": slug, "version": version, "status": st,
 			"submittedAt": "2026-06-20T08:00:00.000Z", "updatedAt": "2026-06-20T08:00:00.000Z",
 			"createdAt": "2026-06-20T08:00:00.000Z", "appBlockId": nil,
-		},
+		}
+	}
+	b, _ := json.Marshal(map[string]any{"submissions": []any{
+		row("pubreq_2", "0.2.0", status), // newest — the state under test
+		row("pubreq_1", "0.1.0", older),  // older — must not be the one answered
 	}})
 	return string(b)
 }
@@ -734,7 +755,7 @@ func TestAppMetricsTerminalSubmissionIsNotDescribedAsInReview(t *testing.T) {
 		t.Run(tc.status, func(t *testing.T) {
 			var rec metricsRec
 			srv := metricsServer(t,
-				notApprovedSubmissionsBody("stuck-app", tc.status), http.StatusOK,
+				notApprovedSubmissionsBody(t, "stuck-app", tc.status), http.StatusOK,
 				trpcEnvelope(verifiedAnalyticsPayload), http.StatusOK, &rec)
 			defer srv.Close()
 			setupMetricsEnv(t, srv.URL)
@@ -783,12 +804,20 @@ func TestAppMetricsTerminalSubmissionIsNotDescribedAsInReview(t *testing.T) {
 // state, the sentence `app metrics` prints and the sentence `app pull` prints
 // must be the same sentence. It reddens when either call site re-opens its own
 // copy, in either direction.
+//
+// 🔴 IT SHIPPED WITH A ONE-ROW BODY, WHICH IT CANNOT BE (issue #378). Agreement
+// between two commands says nothing about WHICH ROW they agree on: a one-row
+// fixture makes `subs[0]` and `subs[len(subs)-1]` the same row, so mutating both
+// sites to the last row kept this guard — and the whole suite — green while both
+// answered the wrong submission. notApprovedSubmissionsBody now carries a second,
+// differently-stated row; the per-site "which row" property is
+// TestAppPullAdviceNamesTheNewestSubmission and its `app metrics` twin.
 func TestPullAndMetricsGiveTheSameNextStepForTheSameState(t *testing.T) {
 	for _, status := range []string{"rejected", "withdrawn", "pending"} {
 		t.Run(status, func(t *testing.T) {
 			// The advice is per-app-name, so both runs must use one slug.
 			const slug = "shared-app"
-			body := notApprovedSubmissionsBody(slug, status)
+			body := notApprovedSubmissionsBody(t, slug, status)
 
 			var rec metricsRec
 			msrv := metricsServer(t, body, http.StatusOK, trpcEnvelope(verifiedAnalyticsPayload), http.StatusOK, &rec)

--- a/internal/cmd/app_newest_submission_test.go
+++ b/internal/cmd/app_newest_submission_test.go
@@ -188,12 +188,15 @@ func TestAppMetricsAdviceNamesTheNewestSubmission(t *testing.T) {
 			if rec.trpcReached {
 				t.Error("a null appBlockId must not reach the analytics query")
 			}
-			// 🔴 WHAT THE README MAY CLAIM ABOUT THIS MESSAGE. `app metrics`
-			// prints NO `(latest submission: …)` — so for a PENDING app it names
-			// no state at all, and prose saying it "names the latest submission's
-			// state" is false for the commonest case. The section says "the next
-			// step FOR the latest submission's own state" instead; this is the
-			// measurement that wording rests on.
+			// 🔴 WHAT THE README MAY CLAIM ABOUT THIS MESSAGE, AND NO MORE.
+			// `app metrics` prints NO `(latest submission: …)` pair — so for a
+			// PENDING app it names no state at all, and prose saying it "names
+			// the latest submission's state" is false for the commonest case.
+			// The section says "the next step FOR the latest submission's own
+			// state" instead, and its parenthetical is scoped to THIS pair,
+			// because the status word itself IS printed (uppercased) in the
+			// rejected and withdrawn branches. Widening that sentence past what
+			// this assertion measures is how it went wrong the first time.
 			if m := latestParenthetical.FindString(msg); m != "" {
 				t.Errorf("`app metrics` printed %q — if it now reports the state itself, the README "+
 					"`App metrics` section says it does not, and moves with this", m)
@@ -324,10 +327,26 @@ func TestPullReviewAdviceCallScannerIsCalibrated(t *testing.T) {
 	}
 }
 
-// testFuncBody returns the source of the top-level func named name, from its
-// declaration to the next top-level `func`, or "" when it is not declared.
-// Bodies are compared, not just names, so a ledger entry cannot be satisfied by
-// an unrelated test that merely exists.
+// testFuncBody returns the source of the top-level func named name — from its
+// declaration to its own closing brace — or "" when it is not declared. Bodies
+// are compared, not just names, so a ledger entry cannot be satisfied by an
+// unrelated test that merely exists.
+//
+// 🔴 IT ENDS AT THE CLOSING BRACE, NOT AT THE NEXT `func`, AND THE DIFFERENCE
+// WAS A LIVE HOLE. Ending at the next top-level func swallowed everything
+// between them — for TestAppMetricsAdviceNamesTheNewestSubmission that was 6013
+// bytes reaching past `var newestFirstAdviceSites`, i.e. THE LEDGER'S OWN
+// `exercises` LITERALS. So the metrics test's "body" contained the string
+// `run(t, "app", "pull"` (the ledger data, not the test), and repointing
+// app_pull.go's entry at the metrics test stayed green: a stale re-bind, exactly
+// what this binding exists to catch. Every future `exercises` value would have
+// landed in that same swallowed literal, so the guard weakened as the ledger
+// grew. Measured before the fix: pull body 3062 bytes / metrics body 6013.
+//
+// Truncating on a column-0 `}` assumes gofmt (nested braces are indented), which
+// `make ci` enforces. A raw string literal holding a line that is exactly `}`
+// would end the body early — that direction is SAFE: the fragment goes missing
+// and the ledger fails loudly, rather than matching something it should not see.
 func testFuncBody(src, name string) string {
 	decl := "\nfunc " + name + "("
 	i := strings.Index("\n"+src, decl)
@@ -335,8 +354,18 @@ func testFuncBody(src, name string) string {
 		return ""
 	}
 	body := ("\n" + src)[i+1:]
+	// Upper bound, and REDUNDANT under gofmt — stated rather than sold as a
+	// second guard. gofmt always ends a file with a newline, so the column-0
+	// brace below always matches first. Measured: deleting this line alone
+	// leaves the suite green (an equivalent mutant on gofmt'd input); deleting
+	// BOTH truncations goes red on the calibration battery. It is kept only as a
+	// bound for input with no column-0 closing brace at all.
 	if j := strings.Index(body[1:], "\nfunc "); j >= 0 {
 		body = body[:j+1]
+	}
+	// The real end: this func's own closing brace, at column 0.
+	if j := strings.Index(body, "\n}\n"); j >= 0 {
+		body = body[:j+2]
 	}
 	return body
 }
@@ -365,6 +394,42 @@ func TestTestFuncBodyIsCalibrated(t *testing.T) {
 	// A prefix must not match a longer name (TestAlphaExtra != TestAlpha).
 	if got := testFuncBody("func TestAlphaExtra(t *testing.T) {}\n", "TestAlpha"); got != "" {
 		t.Errorf("a name prefix must not bind, got %q", got)
+	}
+
+	// 🔴 THE CASE THAT HID THE REAL BUG: a func followed by a top-level
+	// declaration that is NOT a func. The battery above is func→func only, so an
+	// extractor ending at "the next func" passed every case here while swallowing
+	// `var newestFirstAdviceSites` in the real file — and that var holds the very
+	// `exercises` literals the binding searches for, making it self-satisfying.
+	for _, decl := range []struct{ name, src string }{
+		{"var", "var newestFirstAdviceSites = map[string]newestFirstSite{\n\t\"x\": {exercises: `run(t, \"app\", \"metrics\"`},\n}\n"},
+		{"type", "type other struct {\n\tf string // run(t, \"app\", \"metrics\"\n}\n"},
+		{"const", "const other = `run(t, \"app\", \"metrics\"`\n"},
+	} {
+		t.Run("stops before a top-level "+decl.name, func(t *testing.T) {
+			src := "package cmd\n\nfunc TestOnly(t *testing.T) {\n\trun(t, \"app\", \"pull\")\n}\n\n" + decl.src
+			body := testFuncBody(src, "TestOnly")
+			if !strings.Contains(body, `run(t, "app", "pull")`) {
+				t.Fatalf("the extractor lost TestOnly's own body: %q", body)
+			}
+			if strings.Contains(body, `run(t, "app", "metrics"`) {
+				t.Errorf("the extractor ran past TestOnly's closing brace into the following %s, "+
+					"so a ledger literal declared there would satisfy the binding it is supposed to check: %q", decl.name, body)
+			}
+		})
+	}
+
+	// The LAST func in a file has no following declaration to stop at — it must
+	// still extract, or the binding silently depends on file order.
+	last := testFuncBody("package cmd\n\nfunc TestLast(t *testing.T) {\n\trun(t, \"app\", \"pull\")\n}\n", "TestLast")
+	if !strings.Contains(last, `run(t, "app", "pull")`) {
+		t.Errorf("the last func in a file must still extract, got %q", last)
+	}
+
+	// Nested braces are indented under gofmt, so they must not end the body.
+	nested := testFuncBody("package cmd\n\nfunc TestNested(t *testing.T) {\n\tif x {\n\t\ty()\n\t}\n\trun(t, \"app\", \"pull\")\n}\n", "TestNested")
+	if !strings.Contains(nested, `run(t, "app", "pull")`) {
+		t.Errorf("an indented closing brace must not end the body, got %q", nested)
 	}
 }
 
@@ -436,8 +501,17 @@ func TestNewestFirstAdviceCallSitesAreLedgered(t *testing.T) {
 		// swapped ledger actively misdirects — its shrink-direction message
 		// names the wrong test to delete.
 		if !strings.Contains(body, site.exercises) {
-			t.Errorf("internal/cmd/%s is ledgered as pinned by %s, whose body never runs %s — "+
-				"the ledger is bound to the wrong test, so its failure messages name the wrong coverage",
+			// The message states the REQUIREMENT, not a diagnosis. Two very
+			// different things reach here: a stale re-bind (the hazard), and a
+			// legitimate refactor that moved the argv into a helper (not a
+			// hazard at all). Asserting "bound to the wrong test" is false in
+			// the second case and sends the reader hunting for a mistake nobody
+			// made, so name what the guard needs instead of guessing why.
+			t.Errorf("internal/cmd/%s is ledgered as pinned by %s, but that test's body does not contain %s.\n"+
+				"This binding requires the argv fragment LITERALLY in the pinning test's own body, so the "+
+				"ledger cannot be satisfied by an unrelated test that merely exists. Either the entry now names "+
+				"the wrong test (re-point it), or the invocation moved into a helper (inline it in the test, or "+
+				"update this entry's `exercises` to a fragment that is still literally there).",
 				name, site.pinnedBy, site.exercises)
 		}
 	}

--- a/internal/cmd/app_newest_submission_test.go
+++ b/internal/cmd/app_newest_submission_test.go
@@ -1,0 +1,354 @@
+package cmd
+
+// THE NEWEST-FIRST ASSUMPTION, PINNED — issue #378.
+//
+// `app pull` (explainMissingApp) and `app metrics` (resolveAppBlockID) reach the
+// same precondition — submissions exist for the slug, none carries an
+// appBlockId — and both answer it by reading ONE row out of a list the server
+// returns newest-first, then handing that row's status to pullReviewAdvice.
+//
+// 🔴 THAT ROW CHOICE WAS UNPINNED AT BOTH SITES, AND NOT BECAUSE NOBODY TESTED
+// IT. Every fixture the two commands' own tests used had a SINGLE row, where
+// `subs[0]` and `subs[len(subs)-1]` are the same row — so mutating both call
+// sites to the last row left the entire suite green (measured on this branch's
+// parent: 3653 RUN, 0 FAIL, 0 SKIP-of-these). The seam guard added for the
+// shared predicate (TestPullAndMetricsGiveTheSameNextStepForTheSameState) used
+// the same one-row body, so it agreed with itself about the wrong row: both
+// sites move together, so a shared-predicate check stays green while both are
+// wrong. That is the isolation-seam shape — every fixture was scoped to one
+// surface, and the surface none of them loaded was "a list with a history".
+//
+// Under that mutant `app pull` prints a self-contradictory sentence, because the
+// parenthetical and the advice come from opposite ends of the list:
+//
+//	(latest submission: 0.1.1 pending); that submission was WITHDRAWN, so
+//	nothing is in review
+//
+// So the guards here are (a) behavioural, per call site, over a MULTI-ROW list
+// whose ends disagree, asserting the advice matches the NEWEST row, plus for
+// `app pull` the relationship the mutant breaks — the state named in the
+// parenthetical and the state the advice describes are the same state — and
+// (b) a LEDGER of the call sites that consume the ordering, which fails when
+// that set grows or shrinks, because a structural count is the only thing that
+// notices a THIRD caller arriving with no behavioural case of its own.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// twoRowNotApprovedBody is a never-approved (appBlockId null) submissions list
+// whose ENDS DISAGREE: the newest row carries newest, the oldest carries oldest.
+// One row is what made the mutation invisible, so a fixture here is only useful
+// if first != last AND the two produce different advice.
+func twoRowNotApprovedBody(t *testing.T, slug, newest, oldest string) string {
+	t.Helper()
+	if pullReviewAdvice(slug, newest) == pullReviewAdvice(slug, oldest) {
+		t.Fatalf("statuses %q and %q produce the SAME advice, so this fixture cannot tell "+
+			"the newest row from the oldest — pick states in different pullReviewAdvice branches", newest, oldest)
+	}
+	return `{"submissions":[
+		{"id":"p2","blockId":"` + slug + `","appBlockId":null,"version":"0.1.1","status":"` + newest + `"},
+		{"id":"p1","blockId":"` + slug + `","appBlockId":null,"version":"0.1.0","status":"` + oldest + `"}
+	]}`
+}
+
+// latestParenthetical extracts the `(latest submission: <version> <status>)`
+// `app pull` prints, so the assertion below can compare the state the CLI
+// REPORTED against the state its advice DESCRIBES rather than against a literal
+// the test also chose.
+var latestParenthetical = regexp.MustCompile(`\(latest submission: ([^)]*)\)`)
+
+func newestFirstCases() []struct {
+	name           string
+	newest, oldest string
+} {
+	return []struct {
+		name           string
+		newest, oldest string
+	}{
+		// The issue's prescribed shape: a resubmission still in review over a
+		// withdrawn predecessor. The mutant answers "that submission was
+		// WITHDRAWN, so nothing is in review" for an app that IS in review.
+		{"newest pending over an older withdrawn", "pending", "withdrawn"},
+		// The mirror, so "always say check-where-it-is-in-review" cannot pass:
+		// the newest row is terminal and the older one is not.
+		{"newest withdrawn over an older pending", "withdrawn", "pending"},
+		{"newest rejected over an older pending", "rejected", "pending"},
+		// Two terminal states that are not the same terminal state.
+		{"newest rejected over an older withdrawn", "rejected", "withdrawn"},
+	}
+}
+
+// TestAppPullAdviceNamesTheNewestSubmission is call site 1 of the ledger:
+// explainMissingApp (internal/cmd/app_pull.go).
+func TestAppPullAdviceNamesTheNewestSubmission(t *testing.T) {
+	const slug = "my-block"
+	for _, tc := range newestFirstCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := pullDisambiguationServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), 0)
+			defer srv.Close()
+			pullEnv(t, srv)
+
+			_, _, err := run(t, "app", "pull", "--app", slug)
+			if err == nil {
+				t.Fatal("expected an error when nothing is approved yet")
+			}
+			msg := err.Error()
+
+			// REACHABILITY, asserted before anything else is read out of msg: an
+			// earlier check bailing out (the lookup declining, a row with an
+			// appBlockId, the len==0 branch) would leave the server's own
+			// message here, and every assertion below would then be about a
+			// sentence the disambiguation never wrote.
+			if !strings.Contains(msg, "no approved version yet") {
+				t.Fatalf("the disambiguation did not run — nothing below is about the newest row; got: %s", msg)
+			}
+
+			// THE REPORTED STATE: the parenthetical must name the newest row.
+			m := latestParenthetical.FindStringSubmatch(msg)
+			if m == nil {
+				t.Fatalf("no `(latest submission: …)` to compare the advice against; got: %s", msg)
+			}
+			reported := strings.Fields(m[1])
+			if len(reported) != 2 {
+				t.Fatalf("the parenthetical is not `<version> <status>`: %q", m[1])
+			}
+			if reported[0] != "0.1.1" || reported[1] != tc.newest {
+				t.Errorf("`latest submission:` names %q, not the newest row (0.1.1 %s)", m[1], tc.newest)
+			}
+
+			// THE RELATIONSHIP the mutant breaks: whatever state the CLI just
+			// reported, the advice must be the advice FOR THAT STATE. Derived
+			// from the parenthetical, not from tc, so a message that is
+			// internally consistent about the wrong row still fails the check
+			// above rather than passing both by accident.
+			if want := pullReviewAdvice(slug, reported[1]); !strings.Contains(msg, want) {
+				t.Errorf("the message reports %q and then gives the advice for a different state.\nwant substring: %s\ngot: %s",
+					m[1], want, msg)
+			}
+			// And explicitly not the OLDEST row's advice — the mutant's output.
+			if other := pullReviewAdvice(slug, tc.oldest); strings.Contains(msg, other) {
+				t.Errorf("the advice is the OLDEST row's (%s), not the newest's (%s) — subs[0] became subs[len(subs)-1].\ngot: %s",
+					tc.oldest, tc.newest, msg)
+			}
+
+			// AGENTS.md item 7: this message replaces a not-found error and its
+			// exit code (4) is pinned by the sentinel, never by the text.
+			if !errors.Is(err, civitai.ErrNotFound) {
+				t.Errorf("want the not-found classification (exit 4), got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// TestAppMetricsAdviceNamesTheNewestSubmission is call site 2 of the ledger:
+// resolveAppBlockID (internal/cmd/app_metrics.go).
+//
+// `app metrics` prints no `(latest submission: …)` parenthetical, so the
+// self-contradiction is INVISIBLE here — the wrong advice simply reads as the
+// truth about a state the user is never shown. That is why this site needs its
+// own case rather than riding on `app pull`'s.
+func TestAppMetricsAdviceNamesTheNewestSubmission(t *testing.T) {
+	const slug = "stuck-app"
+	for _, tc := range newestFirstCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec metricsRec
+			srv := metricsServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), 0,
+				trpcEnvelope(verifiedAnalyticsPayload), 0, &rec)
+			defer srv.Close()
+			setupMetricsEnv(t, srv.URL)
+
+			_, _, err := run(t, "app", "metrics", slug)
+			if err == nil {
+				t.Fatal("expected an error when every submission has a null appBlockId")
+			}
+			msg := err.Error()
+			// REACHABILITY: the resolver's own precondition, not a transport or
+			// envelope failure that would carry no advice at all.
+			if !strings.Contains(msg, "no approved App Block yet") {
+				t.Fatalf("the resolver did not reach the not-approved branch; got: %s", msg)
+			}
+			if rec.trpcReached {
+				t.Error("a null appBlockId must not reach the analytics query")
+			}
+
+			if want := pullReviewAdvice(slug, tc.newest); !strings.Contains(msg, want) {
+				t.Errorf("the advice is not the NEWEST row's.\nwant substring: %s\ngot: %s", want, msg)
+			}
+			if other := pullReviewAdvice(slug, tc.oldest); strings.Contains(msg, other) {
+				t.Errorf("the advice is the OLDEST row's (%s), not the newest's (%s) — subs[0] became subs[len(subs)-1].\ngot: %s",
+					tc.oldest, tc.newest, msg)
+			}
+
+			// AGENTS.md item 7, the other direction: `app metrics` publishes this
+			// state as exit 1 (the app EXISTS, its analytics do not), so it must
+			// not have acquired `app pull`'s not-found classification.
+			if errors.Is(err, civitai.ErrNotFound) {
+				t.Errorf("a never-approved app still EXISTS — exit 4 promises it does not; got %T: %v", err, err)
+			}
+			if errors.Is(err, ErrUsage) {
+				t.Errorf("this is not a mistake about the invocation (exit 2); got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+// newestFirstAdviceSites is the LEDGER: every non-test file that turns a
+// newest-first submissions list into the "nothing is approved yet" next step,
+// mapped to the behavioural test that proves it reads the NEWEST row.
+//
+// It is asserted in BOTH directions on purpose. A shrunk set means a call site
+// lost its coverage; a GROWN set is the case a behavioural test cannot see at
+// all — a third command open-coding the same row pick, arriving green because
+// no fixture of its own ever had two rows. That is exactly how this defect got
+// in: `app metrics` was the second caller, and it inherited the untested
+// assumption along with the sentence.
+var newestFirstAdviceSites = map[string]string{
+	"app_pull.go":    "TestAppPullAdviceNamesTheNewestSubmission",
+	"app_metrics.go": "TestAppMetricsAdviceNamesTheNewestSubmission",
+}
+
+// countPullReviewAdviceCalls counts CALL sites of pullReviewAdvice in one Go
+// source, ignoring its own declaration and anything after a `//`.
+func countPullReviewAdviceCalls(src string) int {
+	n := 0
+	for _, line := range strings.Split(src, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		if strings.Contains(line, "func pullReviewAdvice(") {
+			continue
+		}
+		n += strings.Count(line, "pullReviewAdvice(")
+	}
+	return n
+}
+
+// TestPullReviewAdviceCallScannerIsCalibrated validates the INSTRUMENT the
+// ledger below reads its verdict from, in both directions — a scanner that can
+// never count and one that counts everything are indistinguishable from a green
+// ledger otherwise.
+func TestPullReviewAdviceCallScannerIsCalibrated(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want int
+	}{
+		// Positive control: it can observe a call at all.
+		{"a call", "x := pullReviewAdvice(app, subs[0].Status)\n", 1},
+		{"two calls on separate lines", "a := pullReviewAdvice(s, x)\nb := pullReviewAdvice(s, y)\n", 2},
+		// Negative controls: it must reject the things that are not call sites.
+		{"the declaration itself", "func pullReviewAdvice(app, status string) string {\n", 0},
+		{"a comment mentioning the call", "// both call pullReviewAdvice(slug, subs[0].Status) here\n", 0},
+		{"a trailing comment beside code", "y := 1 // pullReviewAdvice(a, b)\n", 0},
+		{"an unrelated file", "package cmd\n\nfunc other() {}\n", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countPullReviewAdviceCalls(tc.src); got != tc.want {
+				t.Errorf("countPullReviewAdviceCalls(%q) = %d, want %d", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewestFirstAdviceCallSitesAreLedgered fails when the set of call sites
+// grows or shrinks, and when a ledgered site names a behavioural test that is
+// not in the package.
+func TestNewestFirstAdviceCallSitesAreLedgered(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+
+	found := map[string]int{}
+	var tests strings.Builder
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			tests.Write(b)
+			continue
+		}
+		scanned++
+		if n := countPullReviewAdviceCalls(string(b)); n > 0 {
+			found[name] = n
+		}
+	}
+	// Positive control on the walk: a mis-set working directory, or a filter
+	// that matched nothing, would otherwise report an empty set as "no drift".
+	if scanned < 10 {
+		t.Fatalf("only %d non-test .go files scanned in internal/cmd — the walk is wrong, so an empty result means nothing", scanned)
+	}
+	if len(found) == 0 {
+		t.Fatal("the scan found NO pullReviewAdvice call sites at all — the ledger is wired to nothing")
+	}
+
+	for name := range found {
+		if _, ok := newestFirstAdviceSites[name]; !ok {
+			t.Errorf("internal/cmd/%s calls pullReviewAdvice and is NOT in newestFirstAdviceSites.\n"+
+				"It selects one row out of a newest-first list, which is the assumption issue #378 found "+
+				"unpinned at BOTH existing sites. Add it to the ledger together with a behavioural case "+
+				"over a multi-row fixture whose ends disagree (see twoRowNotApprovedBody).", name)
+		}
+	}
+	for name, pinnedBy := range newestFirstAdviceSites {
+		if _, ok := found[name]; !ok {
+			t.Errorf("newestFirstAdviceSites names internal/cmd/%s, which no longer calls pullReviewAdvice. "+
+				"If the call moved, move the ledger entry with it; if it went away, drop the entry and %s.",
+				name, pinnedBy)
+			continue
+		}
+		if !strings.Contains(tests.String(), "func "+pinnedBy+"(") {
+			t.Errorf("internal/cmd/%s is ledgered as pinned by %s, which is not a test in this package — "+
+				"the ledger names coverage that does not exist", name, pinnedBy)
+		}
+	}
+}
+
+// TestREADMEAppMetricsSectionNamesTheTerminalStates is the OTHER half of #378:
+// "README" is not one place. The `app metrics` behaviour reached the exit-code
+// bullet and the errors table but not the command's own section, which still
+// described the whole state as "an app still in review" — the narrow reading the
+// shared advice exists to correct, and the one a reader of that section gets.
+//
+// It asserts the load-bearing nouns rather than a sentence, so a rewrite that
+// keeps the meaning keeps this green.
+func TestREADMEAppMetricsSectionNamesTheTerminalStates(t *testing.T) {
+	section := readmeSectionSlice(t, readREADME(t), "\n## App metrics\n")
+	// Positive control on the extractor before reading anything out of it.
+	if len(section) < 400 {
+		t.Fatalf("the `App metrics` section is only %d bytes — the extractor is reading the wrong block:\n%s", len(section), section)
+	}
+	for _, want := range []string{"rejected", "withdrawn", "civitai app submit"} {
+		if !strings.Contains(section, want) {
+			t.Errorf("the README `App metrics` section does not name %q.\n"+
+				"`app metrics` gives a rejected or withdrawn app a NEW-SUBMISSION next step, not a review to wait for; "+
+				"the exit-code bullet and the errors table both say so and this section is the third surface (#378).", want)
+		}
+	}
+	// The parallel `app pull` section is where this wording came from — if it
+	// loses it, the two sections have drifted again in the other direction.
+	pull := readmeSectionSlice(t, readREADME(t), "\n## Pull your app's repository (`app pull`)\n")
+	if len(pull) < 400 {
+		t.Fatalf("the `app pull` section is only %d bytes — the extractor is reading the wrong block:\n%s", len(pull), pull)
+	}
+	for _, want := range []string{"rejected", "withdrawn"} {
+		if !strings.Contains(pull, want) {
+			t.Errorf("the README `app pull` section no longer names %q — the two sections describe ONE shared next step", want)
+		}
+	}
+}

--- a/internal/cmd/app_newest_submission_test.go
+++ b/internal/cmd/app_newest_submission_test.go
@@ -343,10 +343,32 @@ func TestPullReviewAdviceCallScannerIsCalibrated(t *testing.T) {
 // landed in that same swallowed literal, so the guard weakened as the ledger
 // grew. Measured before the fix: pull body 3062 bytes / metrics body 6013.
 //
-// Truncating on a column-0 `}` assumes gofmt (nested braces are indented), which
-// `make ci` enforces. A raw string literal holding a line that is exactly `}`
-// would end the body early — that direction is SAFE: the fragment goes missing
-// and the ledger fails loudly, rather than matching something it should not see.
+// Truncating on a column-0 `}` assumes gofmt, which nests braces under indent.
+// 🔴 THAT IS NOT ENFORCED BY `make ci` — it runs `tidy vet test build` and no
+// formatter. The gofmt gate is CI's `build-test` job (`gofmt -s -l .`) and
+// `make lint` (golangci-lint `formatters: gofmt`). AGENTS.md carries a 🔴 about
+// exactly this misattribution and #287 removed the same false claim from
+// AGENTS.md itself; naming the wrong enforcer here would just re-introduce it.
+//
+// Two shapes defeat the column-0 brace, in OPPOSITE directions, and only one of
+// them is safe:
+//
+//   - A raw string literal holding a line that is exactly `}` ends the body
+//     EARLY. Measured: the func's own argv drops out, so the ledger fails loudly.
+//     Safe — it cannot match something it should not see.
+//   - `} // trailing comment` on the closing brace over-includes SILENTLY, which
+//     is the NEW-1 direction, and it is gofmt-clean, so no gate catches it.
+//     Measured on this file: the metrics body grows 2727 → 5260 bytes, running
+//     through the `newestFirstSite` type declaration but stopping BEFORE
+//     `var newestFirstAdviceSites` — so the binding still holds today and the
+//     re-bind mutant still fails.
+//
+// 🔴 But it holds on the DECLARATION ORDER between these tests and the ledger
+// var, and nothing pins that order. Moving `var newestFirstAdviceSites` above
+// the pinning tests, or adding a trailing comment plus a reorder, is what would
+// reopen NEW-1. If you reorder this file, re-run the re-bind mutant (repoint one
+// entry's pinnedBy at the other's test, keep its `exercises`) and confirm it
+// still reddens.
 func testFuncBody(src, name string) string {
 	decl := "\nfunc " + name + "("
 	i := strings.Index("\n"+src, decl)

--- a/internal/cmd/app_newest_submission_test.go
+++ b/internal/cmd/app_newest_submission_test.go
@@ -28,12 +28,17 @@ package cmd
 // whose ends disagree, asserting the advice matches the NEWEST row, plus for
 // `app pull` the relationship the mutant breaks — the state named in the
 // parenthetical and the state the advice describes are the same state — and
-// (b) a LEDGER of the call sites that consume the ordering, which fails when
-// that set grows or shrinks, because a structural count is the only thing that
-// notices a THIRD caller arriving with no behavioural case of its own.
+// (b) a LEDGER of the files that CALL pullReviewAdvice, which fails when that
+// set grows or shrinks, because a structural count is the only thing that
+// notices a third CALLER OF THAT HELPER arriving with no behavioural case of its
+// own. Its scope is the helper's callers and NOT every site that reads one row
+// from a newest-first list — three such sites exist today that it cannot see,
+// enumerated on newestFirstAdviceSites. Read that before treating a green run
+// here as "the row-pick assumption is covered".
 
 import (
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -53,9 +58,14 @@ func twoRowNotApprovedBody(t *testing.T, slug, newest, oldest string) string {
 		t.Fatalf("statuses %q and %q produce the SAME advice, so this fixture cannot tell "+
 			"the newest row from the oldest — pick states in different pullReviewAdvice branches", newest, oldest)
 	}
+	// Every field that could identify a row differs between the two — id,
+	// version, status AND submittedAt. Identical timestamps would leave the rows
+	// indistinguishable on the one axis that separates "trusts the server's
+	// order" from "sorts client-side", so a future client-side sort could not be
+	// told from the current behaviour.
 	return `{"submissions":[
-		{"id":"p2","blockId":"` + slug + `","appBlockId":null,"version":"0.1.1","status":"` + newest + `"},
-		{"id":"p1","blockId":"` + slug + `","appBlockId":null,"version":"0.1.0","status":"` + oldest + `"}
+		{"id":"p2","blockId":"` + slug + `","appBlockId":null,"version":"0.1.1","status":"` + newest + `","submittedAt":"2026-06-21T08:00:00.000Z"},
+		{"id":"p1","blockId":"` + slug + `","appBlockId":null,"version":"0.1.0","status":"` + oldest + `","submittedAt":"2026-06-20T08:00:00.000Z"}
 	]}`
 }
 
@@ -92,7 +102,7 @@ func TestAppPullAdviceNamesTheNewestSubmission(t *testing.T) {
 	const slug = "my-block"
 	for _, tc := range newestFirstCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := pullDisambiguationServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), 0)
+			srv := pullDisambiguationServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), http.StatusOK)
 			defer srv.Close()
 			pullEnv(t, srv)
 
@@ -160,8 +170,8 @@ func TestAppMetricsAdviceNamesTheNewestSubmission(t *testing.T) {
 	for _, tc := range newestFirstCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			var rec metricsRec
-			srv := metricsServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), 0,
-				trpcEnvelope(verifiedAnalyticsPayload), 0, &rec)
+			srv := metricsServer(t, twoRowNotApprovedBody(t, slug, tc.newest, tc.oldest), http.StatusOK,
+				trpcEnvelope(verifiedAnalyticsPayload), http.StatusOK, &rec)
 			defer srv.Close()
 			setupMetricsEnv(t, srv.URL)
 
@@ -177,6 +187,16 @@ func TestAppMetricsAdviceNamesTheNewestSubmission(t *testing.T) {
 			}
 			if rec.trpcReached {
 				t.Error("a null appBlockId must not reach the analytics query")
+			}
+			// 🔴 WHAT THE README MAY CLAIM ABOUT THIS MESSAGE. `app metrics`
+			// prints NO `(latest submission: …)` — so for a PENDING app it names
+			// no state at all, and prose saying it "names the latest submission's
+			// state" is false for the commonest case. The section says "the next
+			// step FOR the latest submission's own state" instead; this is the
+			// measurement that wording rests on.
+			if m := latestParenthetical.FindString(msg); m != "" {
+				t.Errorf("`app metrics` printed %q — if it now reports the state itself, the README "+
+					"`App metrics` section says it does not, and moves with this", m)
 			}
 
 			if want := pullReviewAdvice(slug, tc.newest); !strings.Contains(msg, want) {
@@ -200,23 +220,69 @@ func TestAppMetricsAdviceNamesTheNewestSubmission(t *testing.T) {
 	}
 }
 
-// newestFirstAdviceSites is the LEDGER: every non-test file that turns a
-// newest-first submissions list into the "nothing is approved yet" next step,
-// mapped to the behavioural test that proves it reads the NEWEST row.
+// newestFirstAdviceSites is the LEDGER of every non-test file that CALLS
+// pullReviewAdvice, mapped to the behavioural test proving that call reads the
+// NEWEST row, plus the argv fragment that test must actually drive.
 //
-// It is asserted in BOTH directions on purpose. A shrunk set means a call site
-// lost its coverage; a GROWN set is the case a behavioural test cannot see at
-// all — a third command open-coding the same row pick, arriving green because
-// no fixture of its own ever had two rows. That is exactly how this defect got
-// in: `app metrics` was the second caller, and it inherited the untested
-// assumption along with the sentence.
-var newestFirstAdviceSites = map[string]string{
-	"app_pull.go":    "TestAppPullAdviceNamesTheNewestSubmission",
-	"app_metrics.go": "TestAppMetricsAdviceNamesTheNewestSubmission",
+// 🔴 ITS SCOPE IS "CALLERS OF pullReviewAdvice", NOT "READS ONE ROW OUT OF A
+// NEWEST-FIRST LIST", AND THE DIFFERENCE IS NOT HYPOTHETICAL. The scanner is
+// keyed on the helper's name, so it sees a new caller of THAT helper and nothing
+// else. An earlier version of this comment claimed it catches "a third command
+// open-coding the same row pick"; it does not, and three sites read one row from
+// a newest-first list today that it cannot see — each of which survives reversal
+// with the whole suite green:
+//
+//   - internal/cmd/apps.go, ownedSubmission — returns the first slug-matching
+//     row and prints its Status/DeployState verbatim; its fixture
+//     (ownedSubmissionBody) is ONE row, which is this PR's defect under a
+//     different name. Filed as its own issue rather than fixed here.
+//   - internal/cmd/app_metrics.go, the first-non-null appBlockId pick five lines
+//     above the call this ledger covers. TestAppMetricsPicksNewestNonNullAppBlockID
+//     says "newest" in its name but has one non-null row, so it is vacuous for
+//     the property it names.
+//   - internal/appapi/appblocks.go, the "newest-first, so the first match is
+//     latest" scan — outside this package, so outside the walk entirely.
+//
+// Widening the scanner to the row-pick SHAPE was rejected: any pattern over
+// `subs[0]` is spelled rather than structural (it turns on a variable name) and
+// would be a new unvalidated claim. So the ledger states the narrow thing it can
+// actually check, and the residual is enumerated here rather than implied away.
+//
+// Within that scope it is asserted in BOTH directions: a shrunk set means a call
+// site lost its coverage, a grown one means a new caller arrived with no
+// behavioural case of its own — which is how `app metrics` inherited the
+// untested assumption along with the sentence.
+type newestFirstSite struct {
+	// pinnedBy is the behavioural test that proves this file reads subs[0].
+	pinnedBy string
+	// exercises is a fragment of that test's OWN BODY, naming the command this
+	// file implements. Without it the binding is satisfied by any test in the
+	// package, so swapping two pinnedBy values stayed green — and the
+	// shrink-direction message then tells a maintainer to delete the wrong test.
+	exercises string
+}
+
+var newestFirstAdviceSites = map[string]newestFirstSite{
+	"app_pull.go": {
+		pinnedBy:  "TestAppPullAdviceNamesTheNewestSubmission",
+		exercises: `run(t, "app", "pull"`,
+	},
+	"app_metrics.go": {
+		pinnedBy:  "TestAppMetricsAdviceNamesTheNewestSubmission",
+		exercises: `run(t, "app", "metrics"`,
+	},
 }
 
 // countPullReviewAdviceCalls counts CALL sites of pullReviewAdvice in one Go
 // source, ignoring its own declaration and anything after a `//`.
+//
+// Its two known blind spots both fail SILENT-GREEN, so they are stated rather
+// than implied: it strips from the first `//` regardless of string context (a
+// call written after a `//` inside a string literal is invisible), and it counts
+// the identifier followed by `(`, so a call reached through a function value
+// (`f := pullReviewAdvice; f(app, s)`) is not counted. Neither shape exists in
+// this package today; if one appears, the ledger under-reports rather than
+// erroring, which is why the walk below also asserts a floor.
 func countPullReviewAdviceCalls(src string) int {
 	n := 0
 	for _, line := range strings.Split(src, "\n") {
@@ -258,9 +324,53 @@ func TestPullReviewAdviceCallScannerIsCalibrated(t *testing.T) {
 	}
 }
 
+// testFuncBody returns the source of the top-level func named name, from its
+// declaration to the next top-level `func`, or "" when it is not declared.
+// Bodies are compared, not just names, so a ledger entry cannot be satisfied by
+// an unrelated test that merely exists.
+func testFuncBody(src, name string) string {
+	decl := "\nfunc " + name + "("
+	i := strings.Index("\n"+src, decl)
+	if i < 0 {
+		return ""
+	}
+	body := ("\n" + src)[i+1:]
+	if j := strings.Index(body[1:], "\nfunc "); j >= 0 {
+		body = body[:j+1]
+	}
+	return body
+}
+
+// TestTestFuncBodyIsCalibrated is the instrument control for the binding below:
+// an extractor that returned "" for everything would make every `exercises`
+// check fail loudly, but one that returned the WHOLE FILE would make every one
+// of them pass — the silent-green direction, and the one that matters.
+func TestTestFuncBodyIsCalibrated(t *testing.T) {
+	const src = "package cmd\n\n" +
+		"func TestAlpha(t *testing.T) {\n\trun(t, \"app\", \"pull\")\n}\n\n" +
+		"func TestBeta(t *testing.T) {\n\trun(t, \"app\", \"metrics\")\n}\n"
+
+	alpha := testFuncBody(src, "TestAlpha")
+	if !strings.Contains(alpha, `run(t, "app", "pull")`) {
+		t.Errorf("the extractor lost TestAlpha's own body: %q", alpha)
+	}
+	// THE POINT: it must STOP at the next func, or the binding is satisfied by
+	// any test anywhere in the file.
+	if strings.Contains(alpha, `run(t, "app", "metrics")`) {
+		t.Errorf("the extractor ran past the end of TestAlpha into TestBeta: %q", alpha)
+	}
+	if got := testFuncBody(src, "TestGamma"); got != "" {
+		t.Errorf("a func that is not declared must extract to \"\", got %q", got)
+	}
+	// A prefix must not match a longer name (TestAlphaExtra != TestAlpha).
+	if got := testFuncBody("func TestAlphaExtra(t *testing.T) {}\n", "TestAlpha"); got != "" {
+		t.Errorf("a name prefix must not bind, got %q", got)
+	}
+}
+
 // TestNewestFirstAdviceCallSitesAreLedgered fails when the set of call sites
-// grows or shrinks, and when a ledgered site names a behavioural test that is
-// not in the package.
+// grows or shrinks, and when a ledgered site's pinning test is missing or does
+// not actually drive that site's command.
 func TestNewestFirstAdviceCallSitesAreLedgered(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -290,8 +400,11 @@ func TestNewestFirstAdviceCallSitesAreLedgered(t *testing.T) {
 	}
 	// Positive control on the walk: a mis-set working directory, or a filter
 	// that matched nothing, would otherwise report an empty set as "no drift".
-	if scanned < 10 {
-		t.Fatalf("only %d non-test .go files scanned in internal/cmd — the walk is wrong, so an empty result means nothing", scanned)
+	// The floor is near the real count (55 non-test files at the time of
+	// writing), because a floor far below it passes a PARTIAL walk — which is
+	// the same silent green with extra steps.
+	if scanned < 40 {
+		t.Fatalf("only %d non-test .go files scanned in internal/cmd — the walk is wrong or partial, so an empty result means nothing", scanned)
 	}
 	if len(found) == 0 {
 		t.Fatal("the scan found NO pullReviewAdvice call sites at all — the ledger is wired to nothing")
@@ -305,16 +418,27 @@ func TestNewestFirstAdviceCallSitesAreLedgered(t *testing.T) {
 				"over a multi-row fixture whose ends disagree (see twoRowNotApprovedBody).", name)
 		}
 	}
-	for name, pinnedBy := range newestFirstAdviceSites {
+	for name, site := range newestFirstAdviceSites {
 		if _, ok := found[name]; !ok {
 			t.Errorf("newestFirstAdviceSites names internal/cmd/%s, which no longer calls pullReviewAdvice. "+
 				"If the call moved, move the ledger entry with it; if it went away, drop the entry and %s.",
-				name, pinnedBy)
+				name, site.pinnedBy)
 			continue
 		}
-		if !strings.Contains(tests.String(), "func "+pinnedBy+"(") {
+		body := testFuncBody(tests.String(), site.pinnedBy)
+		if body == "" {
 			t.Errorf("internal/cmd/%s is ledgered as pinned by %s, which is not a test in this package — "+
-				"the ledger names coverage that does not exist", name, pinnedBy)
+				"the ledger names coverage that does not exist", name, site.pinnedBy)
+			continue
+		}
+		// THE BINDING, not merely the name: the pinning test must drive THIS
+		// file's command. Existence alone left the two entries swappable, and a
+		// swapped ledger actively misdirects — its shrink-direction message
+		// names the wrong test to delete.
+		if !strings.Contains(body, site.exercises) {
+			t.Errorf("internal/cmd/%s is ledgered as pinned by %s, whose body never runs %s — "+
+				"the ledger is bound to the wrong test, so its failure messages name the wrong coverage",
+				name, site.pinnedBy, site.exercises)
 		}
 	}
 }

--- a/internal/cmd/app_pull.go
+++ b/internal/cmd/app_pull.go
@@ -193,6 +193,17 @@ func explainMissingApp(ctx context.Context, list submissionLister, app string, o
 		}
 	}
 	// Newest first (ListSubmissions), so subs[0] is the state to report.
+	//
+	// 🔴 BOTH READS BELOW MUST NAME THE SAME ROW, AND NOTHING NOTICED WHEN THEY
+	// DID NOT (#378). The parenthetical and the advice are two reads of one list;
+	// pointing the advice at subs[len(subs)-1] here (and at the twin in
+	// resolveAppBlockID) left the entire suite green while this sentence
+	// contradicted itself out loud — "(latest submission: 0.1.1 pending); that
+	// submission was WITHDRAWN, so nothing is in review". Every fixture had one
+	// row, where the two ends coincide. Pinned by
+	// TestAppPullAdviceNamesTheNewestSubmission, which derives the expected
+	// advice FROM the parenthetical, and by the call-site ledger in
+	// app_newest_submission_test.go.
 	latest := ""
 	if state := strings.TrimSpace(strings.TrimSpace(subs[0].Version) + " " + strings.TrimSpace(subs[0].Status)); state != "" {
 		latest = " (latest submission: " + state + ")"

--- a/internal/cmd/exitcodes_claims_test.go
+++ b/internal/cmd/exitcodes_claims_test.go
@@ -66,9 +66,13 @@ func exitCodeContractClaims() []contractClaim {
 			pinnedBy: "TestAppMetricsNoApprovedBlockYet (negative) + TestAppMetricsUnknownSlugIsActionableNotFound (positive control)",
 		},
 		{
-			code:    1,
-			name:    "the not-ready 1 is not always \"wait for approval\"",
-			phrases: []string{"**rejected** or **withdrawn**", "nothing is in review", "civitai app submit"},
+			code: 1,
+			name: "the not-ready 1 is not always \"wait for approval\"",
+			// Bare nouns, no markdown emphasis: `**rejected**` would redden on a
+			// meaning-preserving reword to `*rejected*`, and this file's own header
+			// says a row is the load-bearing NOUNS, not incidental wording. The
+			// bare word is a substring of the emphasised one either way.
+			phrases: []string{"rejected", "withdrawn", "nothing is in review", "civitai app submit"},
 			why: "the row above frames the whole state as \"still in review\", which was measured on the only " +
 				"state anyone exercised (pending) and is false for the two the CLI can also be handed. " +
 				"`app metrics` printed \"check where it is in review\" for a REJECTED app — a review that is " +

--- a/internal/cmd/exitcodes_claims_test.go
+++ b/internal/cmd/exitcodes_claims_test.go
@@ -58,8 +58,27 @@ func exitCodeContractClaims() []contractClaim {
 			phrases: []string{"exists but is not ready", "app metrics", "still in review", "app status"},
 			why: "4 promises the resource does not exist. For an app awaiting approval the slug is RIGHT " +
 				"and the app IS there — only its analytics are not — so collapsing the two onto 4 destroys " +
-				"the only actionable distinction: fix your slug versus wait for approval",
+				"the only actionable distinction: fix your slug versus wait for approval. " +
+				"🔴 THIS ROW IS THE 1-vs-4 SPLIT ONLY, NOT THE WHOLE OF WHAT 1 PROMISES HERE: its phrases " +
+				"say \"still in review\", which is the PENDING case, and code 1 also covers a rejected or " +
+				"withdrawn latest submission, where there is no review to wait for. The row below carries " +
+				"that half (issue #378)",
 			pinnedBy: "TestAppMetricsNoApprovedBlockYet (negative) + TestAppMetricsUnknownSlugIsActionableNotFound (positive control)",
+		},
+		{
+			code:    1,
+			name:    "the not-ready 1 is not always \"wait for approval\"",
+			phrases: []string{"**rejected** or **withdrawn**", "nothing is in review", "civitai app submit"},
+			why: "the row above frames the whole state as \"still in review\", which was measured on the only " +
+				"state anyone exercised (pending) and is false for the two the CLI can also be handed. " +
+				"`app metrics` printed \"check where it is in review\" for a REJECTED app — a review that is " +
+				"not happening — until pullReviewAdvice became shared with `app pull`, so what exit 1 " +
+				"promises for this state is a next step chosen FROM the latest submission's own state, not a " +
+				"blanket instruction to wait. Ledgered separately because the sentence above is verbatim " +
+				"pre-split text that TestEveryPreSplitClauseSurvives forbids rewriting in place",
+			pinnedBy: "TestAppMetricsTerminalSubmissionIsNotDescribedAsInReview + " +
+				"TestAppMetricsAdviceNamesTheNewestSubmission (which row) + " +
+				"TestPullAndMetricsGiveTheSameNextStepForTheSameState (the seam)",
 		},
 		{
 			code:    2,


### PR DESCRIPTION
Closes #378. Follow-up to #371 (`7f780fb`). **No behaviour change** — the code was already correct; what was missing is the coverage that would notice if it stopped being, and one doc sentence.

## Half 1 — the newest-first assumption, unpinned at both call sites

`app pull` (`explainMissingApp`) and `app metrics` (`resolveAppBlockID`) both answer "nothing is approved yet" by reading **one row** out of a newest-first submissions list and handing its status to the shared `pullReviewAdvice`. *Which* row was untested at both sites, because every fixture had a **single row** — where `subs[0]` and `subs[len(subs)-1]` are the same row.

The cross-command seam guard could not see it either: agreement between two commands says nothing about *which row* they agree on, and it used the same one-row body. Both sites move together, so a shared-predicate check stays green while both are wrong.

### What I verified (measured, this branch, `go test -v` with `=== RUN` / `--- FAIL` counted from the output — not an exit code)

I re-ran the mutation myself rather than trusting the issue's number.

| tree | mutation | result |
|---|---|---|
| `origin/main` (`e433b91`) | none | 3653 RUN, 0 FAIL |
| `origin/main` | **both** sites → `subs[len(subs)-1].Status` | **3653 RUN, 0 FAIL — survives** |
| HEAD | none | 3673 RUN, 0 FAIL (`make ci` + `make ci-shallow` green) |
| HEAD | `app_metrics.go` **only** | **12 FAIL** — incl. all 4 subtests of `TestAppMetricsAdviceNamesTheNewestSubmission`; `TestAppPullAdviceNames…` stays green (correct scoping) |
| HEAD | `app_pull.go` **only** | **9 FAIL** — incl. all 4 subtests of `TestAppPullAdviceNamesTheNewestSubmission`; `TestAppMetricsAdviceNames…` stays green |
| HEAD | **both** sites | **17 FAIL** |

The issue's "1782 tests" did not reproduce as a number (I measure 3653 for `./...`), but its *claim* did, exactly: **the both-site mutant is fully green on `origin/main`.**

Each new guard fails with **its own** error, not a neighbour's — the pull one reproduces the self-contradiction verbatim:

```
app_newest_submission_test.go:133: the message reports "0.1.1 pending" and then gives the advice for a different state.
  got: … approved (latest submission: 0.1.1 pending); that submission was WITHDRAWN, so nothing is in review …
```

Reachability is asserted **before** anything else is read out of the message (`no approved version yet` / `no approved App Block yet`), so an earlier check bailing out fails loudly instead of passing the row assertions vacuously — and the failures above are the row assertions firing, not the reachability `Fatalf`.

### What is in it

- `notApprovedSubmissionsBody` now emits **two** rows, the older one deliberately in a *different* `pullReviewAdvice` branch (it `t.Fatalf`s if no decoy state discriminates). That alone makes the existing seam guard and the terminal-state guards able to see which end they read.
- Per-site behavioural cases over a 4-case table whose ends disagree in both directions. The `app pull` one derives the expected advice **from the printed parenthetical**, so it pins the *relationship* the mutant breaks rather than a literal the test also chose; `app metrics` prints no parenthetical, so the wrong advice is invisible there and it gets its own case rather than riding along.
- A **ledger** of the call sites that consume the ordering, red when the set **grows** (a third caller with no behavioural case — how `app metrics` inherited this in the first place) or **shrinks**. Its source scanner is calibrated in both directions (`TestPullReviewAdviceCallScannerIsCalibrated`: a call → 1, the declaration → 0, a comment mentioning the call → 0), and the walk asserts a minimum file count so a mis-set cwd cannot report "no drift".
- AGENTS.md item 7 is honoured, both directions: `errors.Is` on the sentinels, and the two sites' *different* codes (pull 4, metrics 1) are asserted separately.

### Mutation-tested the new guards themselves (each red with **its own** message)

- third unledgered call site added to `app_status.go` → ledger red ("calls pullReviewAdvice and is NOT in newestFirstAdviceSites")
- ledger entry repointed at a non-caller → red in the shrink direction too
- ledger `pinnedBy` renamed to a test that does not exist → red
- README sentence reverted to the pre-#378 text → `TestREADMEAppMetricsSectionNamesTheTerminalStates` red
- the code-1 terminal-states bullet dropped from `exitcodes_doc.go` → the new claims row red

## Half 2 — the third README surface

`README.md:1619`, the **`app metrics` command's own section**, still said only *"an app still in review reports that instead of an empty dashboard"*. #371 moved the exit-code bullet (`:2536`) and the errors table (`:2627`); the command section is the third surface and did not move. It now mirrors the parallel `app pull` section's wording, and `TestREADMEAppMetricsSectionNamesTheTerminalStates` pins **both** sections on the load-bearing nouns (so a rewording that keeps the meaning stays green).

**README lines touched: 1616–1623 only** (one paragraph in `## App metrics`). ~~flagged for merge against #373~~ — **corrected**: #373's PR is #387 and it touches **zero** README lines. The open PRs touching README are #385 (@1201) and #386 (@2601); neither overlaps this hunk. No known conflict.

## The 🟢 from the issue

`exitcodes_claims_test.go`'s code-1 row framed the whole state as "still in review" / "wait for approval". Added a **second** row for what exit 1 also promises (a next step chosen from the latest submission's own state), rather than rewriting the first — the first row's phrase is verbatim pre-split text that `TestEveryPreSplitClauseSurvives` forbids rewriting in place, which the issue's context section flagged. The old row's `why` now says which half it is.

## Gate

- `make ci` green (full clone) **and** `make ci-shallow` green (depth-1, 19/19 ok, 0 timeouts) — both tiers, since this touches a file near the git-provenanced fixture.
- `make lint` equivalent: `golangci-lint v2.12.2` (the version `.github/workflows/ci.yml` pins) → **0 issues**, and I ran a **negative control** — a deliberate `undefined: fmt` in the new file made it report 1 issue — so the zero is a zero the instrument can move off.

## What I believe but did **not** verify

- That the server really returns submissions newest-first. This PR pins the CLI to `subs[0]` and pins that `subs[0]` is what both messages describe; the *ordering* itself is the server's contract (`internal/appapi/appblocks.go` documents it) and no test here exercises a live server. If the server ever stops ordering that way, every guard in this PR stays green and both messages become wrong together — that is the residual, and it is not closeable client-side.
- That no path outside `internal/cmd` consumes the ordering. The ledger scans that package only; it fails loudly (not silently) if `pullReviewAdvice` moves out of it.

## Found, not fixed

- `TestAppPullNotApprovedSaysSoInsteadOfDenyingTheApp` already used a two-row body (newest `pending` / oldest `withdrawn`) and still missed this: it asserts `"0.1.1 pending"` and `"civitai app status my-block"` are present, and the *withdrawn* advice also contains that second string, so the mutant satisfied both. Left as-is — its own subject is the #359 regression — but it is a worked example of a fixture having the right shape and the wrong assertions.

---

## Post-audit revision (commit `448f1cb`)

A blind adversarial audit returned **no 🔴, "safe to merge"** — every published number reproduced, both tiers green, lint instrument-validated independently. It raised three 🟡 findings **in the claims, not the code**, all now fixed. The full battery was re-run afterwards, not reasoned about.

**1. The ledger's comment claimed a scope the ledger does not have.** It said a grown set catches "a third command open-coding the same row pick". It does not — the scanner is keyed on `pullReviewAdvice(` callers. Three sites read one row from a newest-first list today that it cannot see, and **all survive reversal fully green**: `apps.go`'s `ownedSubmission` (one-row fixture, `Status`/`DeployState` printed verbatim — this PR's defect under another name), `app_metrics.go`'s first-non-null `appBlockId` pick *five lines above* the call pinned here (`TestAppMetricsPicksNewestNonNullAppBlockID` says "newest" but has one non-null row, so it is vacuous for the property it names), and `appapi/appblocks.go:609`.

**I took the narrow option**: widening the scanner to the row-pick *shape* would turn on a variable name — spelled, not structural, and a new unvalidated claim. The comment now states the narrow scope and **enumerates all three residuals**, and the two in-package ones are filed as **#390** rather than vanishing into a comment edit.

**2. The README sentence overclaimed — and my own test comment said so.** It read "the message names the latest submission's own state", but for the **pending** case `app metrics` names no state at all; only rejected/withdrawn do. Now uses the errors-table wording at `README.md:2630` ("the next step **for** the latest submission's own state") plus an explicit "(Unlike `app pull`, it does not print the submission's version and status themselves.)" The behavioural test now **asserts that absence** (`app metrics` emits no `(latest submission: …)`), so the prose rests on a measurement rather than on my recollection.

**3. `pinnedBy` survived a stale re-bind.** It only checked the named test existed *somewhere in the package*, so **swapping the two entries was fully green** — and the shrink-direction message then tells a maintainer to delete the **wrong** test. Entries are now `{pinnedBy, exercises}`, where `exercises` is an argv fragment the pinning test's **own body** must contain, extracted by `testFuncBody` — calibrated against the silent-green failure mode (an extractor returning the whole file makes every binding pass), not just the loud one.

Nits also taken: fixture rows pairwise distinct on `submittedAt`; literal `0` → `http.StatusOK`; walk floor 10 → 40 against 55 real files (a partial walk of 12 used to pass); the scanner's two silent-green blind spots documented; markdown emphasis dropped from the new claims row's phrases (`**rejected**` would have reddened on a reword to `*rejected*`, contrary to that file's own stated principle).

### Re-run battery — 10 mutants, each red with **its own** error

| # | mutant | result |
|---|---|---|
| M1 | `app_metrics.go` call site | 12 FAIL — "the advice is not the NEWEST row's" |
| M2 | `app_pull.go` call site | 9 FAIL — "reports \"0.1.1 pending\" and then gives the advice for a different state" |
| M3 | both | 17 FAIL |
| M4 | ledger grows (3rd call site) | "calls pullReviewAdvice and is NOT in newestFirstAdviceSites" |
| M5 | ledger shrinks (repointed) | "… which no longer calls pullReviewAdvice" |
| M6 | `pinnedBy` → deleted test | "… is not a test in this package" |
| **M7** | **`pinnedBy` values SWAPPED** | red, but with **one** error only — see the correction below |
| **M8** | **`testFuncBody` returns whole file** | **"the extractor ran past the end of TestAlpha into TestBeta"** |
| M9 | README reverted | section "does not name \"rejected\"" |
| M10 | code-1 bullet dropped | "exit code 1 no longer publishes \"rejected\"" |

Suite after the fixes: **3674 RUN, 0 FAIL**. `make ci` green; `ci-shallow` re-run **after** committing (it reads committed state only, so the pre-commit run did not see these fixes) — 19/19 ok, 0 timeouts; golangci-lint v2.12.2 → 0 issues.

### Still not verified, after the audit

The server's newest-first ordering itself — unchanged from above, and now the explicit subject of the last section of **#390**: every guard in this PR would stay green if that contract changed, because nothing client-side sorts.

---

## Second revision — the delta audit found finding 3 only HALF fixed (commit `d929b16`)

The delta re-audit closed findings 1 and 2 and independently re-derived the ledger enumeration as complete, but caught the `exercises` binding **self-satisfying for one entry**. My M7 row above overstated what the mechanism delivered; it is corrected in place.

**🟡 NEW-1 — `testFuncBody` swallowed the ledger's own declaration.** It ended a body at the **next top-level `func`**, not at the func's closing brace. `TestAppMetricsAdviceNamesTheNewestSubmission` ends well before the next `func`, so its "body" ran on through `var newestFirstAdviceSites` — **the declaration holding both `exercises` literals**. Its body therefore contained `run(t, "app", "pull"` (the ledger's own data, not the test), and the binding was satisfied by the thing it was checking.

Reproduced before fixing, with my own probe:

```
TestAppPullAdviceNames…     body=3062 bytes  pull=true   metrics=false  swallowedLedgerDecl=false
TestAppMetricsAdviceNames…  body=6013 bytes  pull=true   metrics=true   swallowedLedgerDecl=true
```

**Operational consequence, verified myself:** repointing `app_pull.go`'s entry at the metrics test while keeping its `exercises` left the ledger test **green**. That is the stale re-bind this binding exists to close. After the fix it dies with the intended message:

```
internal/cmd/app_pull.go is ledgered as pinned by TestAppMetricsAdviceNamesTheNewestSubmission,
but that test's body does not contain run(t, "app", "pull".
```

After the fix: bodies are 2643 / 2727 bytes, neither containing the other's fragment nor the ledger declaration.

**Corrected M7 row.** M7 (the *full* swap) was red before this fix, but with **exactly one** error — `app_metrics.go`'s — which is precisely why the surviving half was invisible. It now fails with **both** errors. The claim "the swap is caught" was true; "the binding is closed" was not, and only the second one mattered.

**Why it was structural, not incidental:** every future `exercises` value would land in that same swallowed literal, so the guard weakened as the ledger grew. `TestTestFuncBodyIsCalibrated` could not see it — its battery was `func`→`func` only. It now covers a target func followed by a top-level **`var`**, **`type`** and **`const`** (the gap that hid this), plus last-func-in-file and indented-nested-brace cases.

**🟢 NEW-2** — the parenthetical said the command "does not print the submission's version and status themselves". The *version* is never printed, but the *status* is named, uppercased, in the rejected/withdrawn branches. Now scoped to what the test measures: the `(latest submission: <version> <status>)` pair.

**🟢 NEW-3** — the binding's failure message asserted "the ledger is bound to the wrong test", which is **false** for a legitimate refactor that moved the argv into a helper. It now states the requirement and names both ways to satisfy it.

### Re-run battery for this revision

| # | mutant | result |
|---|---|---|
| M1–M3 | the three call-site mutants | unchanged: 12 / 9 / 17 FAIL |
| M4–M6 | ledger grow / shrink / missing test | unchanged, each with its own message |
| **M7** | full `pinnedBy` swap | now **two** errors, one per entry (was one) |
| **M11** | **half re-bind — one entry repointed** | **now red** (was green — the finding) |
| **M12** | extractor reverted to next-func truncation | **3 calibration subtests red** (`var`/`type`/`const`) |
| M13 | extractor truncates nothing | 3 subtests red |
| M9a | README `App metrics` sentence removed | red on all three nouns |

Suite: **3677 RUN, 0 FAIL**. `make ci` green; `ci-shallow` re-run after committing — 19/19; golangci-lint v2.12.2 → 0 issues.

### 🔴 A correction to my own previous report

The **M9 row in the revision above was a vacuous green.** After I reworded the README for NEW-2, the M9 mutation's anchor no longer matched, so its `assert` raised and the mutation **never applied** — and the summary grep I was reading the results through did not show the traceback, so it reported `FAIL=0` as if the guard had been exercised. I caught it only by grepping the raw log for `AssertionError`. Re-run with a corrected anchor (M9a above), it is properly red. **Nothing was wrong with the guard; the instrument reporting on it was broken, in the reassuring direction.** Worth stating because it is the same class this PR exists to fix.

### Residual I am not claiming closed

The *wording* of the new README parenthetical is unguarded. Reverting only that clause to the NEW-2 overclaim leaves the suite **green** (measured, M9b) — the section guard greps `rejected`/`withdrawn`/`civitai app submit`, and the behavioural test pins the absence of the pair, but no test reads that sentence. So NEW-2 is fixed, not fenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
