### PR TITLE
fix(test): the attribution guard reddened on three classes of correct README prose, and four claims outran their evidence (#373)

### DIFF
--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
+	"unicode"
 
 	"github.com/spf13/cobra"
 )
@@ -228,18 +231,19 @@ func TestREADMETroubleshootingSymptomsExistInTheSource(t *testing.T) {
 // attributionRun is one real invocation, driven through the same NewRootCmd path
 // a user gets. `args` is a function so a row can point the command at a scratch
 // directory the harness makes.
+//
+// 🔴 There is deliberately no `readmeName` field any more, and #373 is why. It
+// held the EXACT inline-code text the cause cell had to use, matched by string
+// EQUALITY on the normalised span — which reddened on three classes of CORRECT
+// prose, including this ledger's OWN measured argv (`app listing status --dir
+// <path>` is what the harness runs, and the cell was not allowed to say so
+// because the field said `app listing`). A prose span is now matched against
+// the run's REAL argv instead; see resolveSpan for the rule and for how F1's
+// `app submit` / `app submit --skip-validate` distinction survives the change.
 type attributionRun struct {
-	// readmeName is the EXACT inline-code text the row's cause cell must use to
-	// name this invocation, after normalisation (a leading `civitai ` and a
-	// trailing `…` are stripped). It is matched by EQUALITY, never substring:
-	// `app submit` and `app submit --skip-validate` are DIFFERENT claims — the
-	// first prints `not found at project root` and the second prints `is this an
-	// App project?` — and a substring match would let either satisfy the other's
-	// row, which is the shadowing that hid #361's sibling defect (F1).
-	readmeName string
-	name       string
-	args       func(emptyProject, scratch string) []string
-	env        map[string]string
+	name string
+	args func(emptyProject, scratch string) []string
+	env  map[string]string
 }
 
 // symptomAttribution is one Troubleshooting row and the commands it belongs to.
@@ -263,9 +267,8 @@ type symptomAttribution struct {
 func symptomAttributions() []symptomAttribution {
 	appValidate := func() attributionRun {
 		return attributionRun{
-			readmeName: "app validate",
-			name:       "app validate",
-			args:       func(empty, _ string) []string { return []string{"app", "validate", empty} },
+			name: "app validate",
+			args: func(empty, _ string) []string { return []string{"app", "validate", empty} },
 		}
 	}
 	// `app submit` on a manifest-less directory, with and without the flag that
@@ -281,7 +284,6 @@ func symptomAttributions() []symptomAttribution {
 			name = "app submit --skip-validate"
 		}
 		return attributionRun{
-			readmeName: name,
 			// --package-only never contacts the server. Without --skip-validate
 			// the run never gets that far anyway (validation fails first); WITH
 			// it, packaging is reached and manifest.Load is what fails.
@@ -324,17 +326,29 @@ func symptomAttributions() []symptomAttribution {
 			// NOT #listing-media-requirements: that section is image formats,
 			// byte caps and aspect ratios, and says nothing about how `app
 			// listing` decides WHICH app you mean. "After you submit" is where
-			// the `app listing` flow is walked through, and now carries the
+			// the `app listing` flow is walked through, and it states both the
 			// working-directory resolution and the --slug/--dir remedy this row
-			// tells the reader to use.
+			// sends the reader to use.
+			//
+			// 🔴 It did not GAIN that remedy with this row, and #373 corrects
+			// the claim that it did (#368's F5: the section "now documents …
+			// the --slug/--dir remedy"). Measured: `--slug <blockId>` and
+			// `--dir` were already documented in this same section BEFORE that
+			// change — README@fc03d33:1255, a bullet still shipping today at
+			// README:1306, about twenty lines below the block #368 added, which
+			// now says it a second time. What #368 really added is the worked
+			// failure above it: the transcript of `app listing status` run from
+			// the wrong directory. So the anchor is the right choice for a
+			// weaker reason than the one that was recorded — the section
+			// explained the remedy all along, and the row could have pointed
+			// here from the start.
 			anchor: "#after-you-submit-review--approve--deploy",
 			emittedBy: []attributionRun{
 				{
 					// The slug resolve fails on the manifest before any request
 					// is built, so the token only has to be non-empty to get
 					// past the credential gate.
-					readmeName: "app listing",
-					name:       "app listing status",
+					name: "app listing status",
 					args: func(empty, _ string) []string {
 						return []string{"app", "listing", "status", "--dir", empty}
 					},
@@ -344,21 +358,21 @@ func symptomAttributions() []symptomAttribution {
 			},
 			notEmittedBy: []attributionRun{
 				appValidate(),
-				{
-					// `app submit` DOES call manifest.Load — but only after
-					// validation has passed, so a missing manifest never reaches
-					// it UNLESS --skip-validate waives the validation. Listing
-					// the caller is not the same as measuring the message, and
-					// this row is the difference: the first draft of this fix
-					// credited `app submit`, `app dev-token` and `app dev-tunnel`
-					// from a grep of manifest.Load callers. dev-token and
-					// dev-tunnel discard the load error and still print nothing;
-					// `app submit` prints it on exactly one argv, which is why it
-					// now appears on BOTH rows under two different readmeNames.
-					readmeName: "app submit",
-					name:       appSubmit(false).name,
-					args:       appSubmit(false).args,
-				},
+				// `app submit` DOES call manifest.Load — but only after
+				// validation has passed, so a missing manifest never reaches it
+				// UNLESS --skip-validate waives the validation. Listing the
+				// caller is not the same as measuring the message, and this row
+				// is the difference: the first draft of this fix credited `app
+				// submit`, `app dev-token` and `app dev-tunnel` from a grep of
+				// manifest.Load callers. dev-token and dev-tunnel discard the
+				// load error and still print nothing; `app submit` prints it on
+				// exactly one argv, which is why the SAME constructor appears on
+				// both rows — row 1 as an emitter, here as a non-emitter.
+				//
+				// It is a call, not a field-by-field copy of one: #373 found the
+				// copy byte-equivalent today and a drift seam on the exact
+				// identity this guard resolves prose spans against.
+				appSubmit(false),
 			},
 			why: "#361 itself: the row credited this string to `app validate`, which has never printed it, " +
 				"and sent the reader to a section that does not explain it",
@@ -388,13 +402,18 @@ func runAttribution(t *testing.T, r attributionRun, empty, scratch string) strin
 // TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand is the #361
 // guard: existence -> attribution.
 //
-// Red/green matrix, measured: with README.md at `origin/main` and this file at
-// HEAD, both ledger rows fail — the first because no row quotes the string at
-// all, the second because its link cell says `#validate-fidelity`. Both pass
-// with the README fix. The `notEmittedBy` half is an INVARIANT guard rather than
-// regression coverage: `app validate` did not print the string before the fix
-// either. It is here so a future "helpfully" shared manifest loader cannot make
-// the old row retroactively true.
+// Red/green matrix, re-measured for #373 against a PINNED ref rather than
+// `origin/main` — which is what this said, and which has since moved past the
+// fix, so the sentence had stopped describing anything. With README.md at
+// `9c7baed` (the commit before #361 was repaired) and this file at HEAD, both
+// ledger rows fail: row 1 because no row quotes the string at all, row 2 on TWO
+// counts — its cause cell names no invocation the parser can see, and its link
+// cell says `#validate-fidelity`. Both pass with the README at HEAD.
+//
+// The `notEmittedBy` half is an INVARIANT guard rather than regression coverage:
+// `app validate` did not print the string before the fix either. It is here so a
+// future "helpfully" shared manifest loader cannot make the old row
+// retroactively true.
 //
 // The `attributes` subtest is the one that reads `row[1]`. Without it every
 // assertion here is about a cell a reader never reads for attribution, and the
@@ -515,27 +534,272 @@ func troubleshootingRowFor(section, fragment string) ([]string, int) {
 // Reading the attribution out of the row's own prose
 // ----------------------------------------------------------------------------
 
-// inlineCodeSpanRe captures the text inside a markdown inline-code span.
-var inlineCodeSpanRe = regexp.MustCompile("`([^`]+)`")
+// The cause cell is English prose, and this parser has to answer two questions
+// about it: WHICH measured invocation each inline-code span names, and WHETHER
+// the sentence says that invocation prints the message or says it does not.
+//
+// 🔴 #373 — the first version answered both with flat string matching, and all
+// three of those decisions reddened on CORRECT prose:
+//
+//  1. A span had to EQUAL a hand-written `readmeName`. So `app listing status
+//     --dir <path>` — the ledger's OWN measured argv — was reported as "a
+//     command this ledger never runs", because the field said `app listing`.
+//     So was a bare `app` used as an English noun ("your `app` directory"):
+//     19 of the tree's command paths are single words, several of them ordinary
+//     nouns.
+//  2. A clause was negative iff it contained one of seven literal phrases, all
+//     of them `…print`. `do not emit it` was therefore a POSITIVE attribution;
+//     `do not print it` passed.
+//  3. That polarity coloured the whole clause, so "`app validate` never prints
+//     it, but `app listing` does" made both negative.
+//
+// This matters more than the friction: the file's own F4 note says a guard that
+// fails on correct input is one somebody deletes, and the two cause cells this
+// runs on are the highest-traffic prose on that page.
+//
+// The repair is structural on all three counts. A span is resolved against the
+// run's REAL argv (resolveSpan) rather than against a name somebody typed twice.
+// Negation is a property of a PREDICATE — a printing verb with a negator on it —
+// and each mention takes the polarity of the NEAREST predicate, so one negation
+// no longer colours a sentence that changes direction. A contrastive conjunction
+// ends a predicate's scope, which is what "…, but X does" means in English.
+//
+// What remains is vocabulary: two closed word sets, matched with English
+// inflection rather than as whole phrases, so rewording around the same verb
+// needs no new entry.
+//
+// 🔴 The direction it fails in is NOT uniform, and an earlier draft of this
+// comment claimed it was. A denial phrased with a verb this file does not list
+// leaves the mention at its DEFAULT polarity, which is POSITIVE — measured:
+//
+//	`app listing` does not output it.   -> read as a POSITIVE attribution
+//	`app listing` never produces it.    -> read as a POSITIVE attribution
+//
+// So for a NON-emitter an unlisted denial goes red (the required negative
+// never appears), but for an EMITTER it goes GREEN — appended to the shipped
+// row-2 cell, both sentences above yield ZERO problems while `never prints it`
+// yields one. That is a live false negative, not a regression: the seven-phrase
+// predecessor behaved identically. It is the honest boundary of the guard —
+// it catches a wrong attribution, not every wrong SENTENCE — and the fix for a
+// missed phrasing is a word in printVerbStems, never a special case.
+//
+// 🔴 The same boundary has a DISTANCE half, and it fails the other way. A
+// negator reaches its verb across at most three tokens, so a denial that pushes
+// them further apart reads POSITIVE — and for a NON-emitter that reddens
+// correct prose. All four of these are natural English and all four are read as
+// attributions today:
+//
+//	`app validate` does not, as of today, print it.
+//	`app validate` does not, on this path, ever print it.
+//	`app validate` will not, under any circumstances, print it.
+//	`app validate` never actually goes on to print it.
+//
+// Widening the window is not free: it is bounded from the other side by
+// sentences where the negator belongs to a different word ("finds there is no
+// manifest, so it prints this"), and both boundaries now carry a fixture. Three
+// is where those two natural readings stop colliding, not a number with a
+// theory behind it. Pre-existing since the first cut of #373; the remedy in
+// prose is to put the negator next to its verb.
+//
+// ONE rule here is deliberately not pinned: the SPACE requirement on the `.`/`;`
+// clause split, which exists so a filename or a version number in unfenced prose
+// ("block.manifest.json", "v1.2.3") cannot cut a clause in half. No such text is
+// in either cell today and every fixture that would create one is contrived, so
+// it survives mutation on purpose.
+//
+// 🔴 The nearest-predicate TIE-BREAK used to be on that list, with the reason
+// "both readings are arbitrary and no natural sentence distinguishes them". That
+// was false, and the #387 delta audit built the counterexample — a rephrase of
+// the shipped cell's own sentence, with a predicate two tokens away on each
+// side:
+//
+//	Not printed by `app validate`, which reports the row above.
+//
+// The earlier predicate is the negated one, so keeping it on a tie is the
+// correct English reading. Flipping to `<=` hands the tie to `reports` and the
+// guard announces "credits `app validate` with printing it" about CORRECT
+// prose — the exact false-positive class this file exists to remove. It is a
+// load-bearing claim, and it is now pinned by a fixture.
+//
+// Rejected alternative: require the cause cell to carry its attribution in a
+// fixed machine-readable syntax. That is fully deterministic and needs no
+// vocabulary at all — and it would dictate the wording of the sentence the
+// reader reads, which is the thing this row exists to get right. The guard is
+// here to follow the prose, not to author it.
 
-// attributionNegations is the CLOSED set of phrases that make a clause a
-// NEGATIVE attribution ("X never prints it"). It is deliberately about PRINTING
-// and nothing else: a clause may legitimately say a command "did not validate
-// first" or "does not exist", and neither is a claim about the message.
-var attributionNegations = []string{
-	"never print",
-	"does not print",
-	"do not print",
-	"did not print",
-	"will not print",
-	"cannot print",
-	"prints neither",
+// printVerbStems are the verbs a cause cell uses to say a command PRODUCES the
+// message. Matched with regular English inflection (-s/-es/-ed/-d/-ing) plus the
+// irregulars below, so "prints", "printed", "emits" and "reported" all count
+// without being enumerated.
+var printVerbStems = []string{"print", "emit", "report", "say", "show", "surface", "display"}
+
+// printVerbIrregulars are the inflections the suffix rule does not generate.
+var printVerbIrregulars = map[string]bool{"said": true, "shown": true}
+
+// attributionNegators flip a printing predicate. This is the closed English
+// negator set, NOT a list of printing phrasings: these words negate whatever
+// verb they attach to, and the parser only ever consults them next to a verb
+// from printVerbStems. That is what keeps "which did not validate first" — a
+// real sentence in the shipped README — from reading as a claim about printing.
+var attributionNegators = map[string]bool{
+	"not": true, "never": true, "no": true, "neither": true, "nor": true,
+	"nothing": true, "cannot": true, "can't": true, "won't": true,
+	"doesn't": true, "don't": true, "didn't": true, "isn't": true, "aren't": true,
+	"without": true,
 }
 
-// commandMention is one command a cause cell names, and whether the clause
-// naming it was a negation.
+// contrastConjunctions end the scope of a preceding predicate: in "X never
+// prints it, but Y does", the negation stops at "but". Only unambiguously
+// contrastive words are listed — "while" and "yet" have common non-contrastive
+// readings ("while waiting", "no approved version yet") and would cut a clause
+// in half for the wrong reason.
+var contrastConjunctions = map[string]bool{
+	"but": true, "whereas": true, "although": true, "though": true,
+}
+
+// proseToken is one word or one inline-code span of a clause, kept in order so
+// that "the nearest predicate" is a distance a machine can compute.
+type proseToken struct {
+	code bool   // an inline-code span — a candidate command mention
+	text string // code: the span's contents; word: lowercased, punctuation stripped
+}
+
+// tokenizeClause splits a clause into words and inline-code spans.
+func tokenizeClause(clause string) []proseToken {
+	var out []proseToken
+	rs := []rune(clause)
+	for i := 0; i < len(rs); i++ {
+		switch {
+		case rs[i] == '`':
+			j := i + 1
+			for j < len(rs) && rs[j] != '`' {
+				j++
+			}
+			out = append(out, proseToken{code: true, text: string(rs[i+1 : j])})
+			i = j
+		case unicode.IsSpace(rs[i]):
+			// separator
+		default:
+			j := i
+			for j < len(rs) && !unicode.IsSpace(rs[j]) && rs[j] != '`' {
+				j++
+			}
+			w := strings.ToLower(strings.Trim(string(rs[i:j]), `.,;:()*_—"'`))
+			if w != "" {
+				out = append(out, proseToken{text: w})
+			}
+			i = j - 1
+		}
+	}
+	return out
+}
+
+// isPrintVerb reports whether a word claims the message was PRODUCED.
+func isPrintVerb(w string) bool {
+	if printVerbIrregulars[w] {
+		return true
+	}
+	for _, stem := range printVerbStems {
+		switch w {
+		case stem, stem + "s", stem + "es", stem + "ed", stem + "d", stem + "ing":
+			return true
+		}
+	}
+	return false
+}
+
+// spanPolarity is one inline-code span of a clause with the polarity the
+// sentence gives it.
+type spanPolarity struct {
+	span    string
+	negated bool
+}
+
+// attributionSpansIn assigns a polarity to every inline-code span in one clause.
+// The clause is first cut at contrastive conjunctions, because a predicate
+// governs only its own side of a contrast.
+func attributionSpansIn(clause string) []spanPolarity {
+	tokens := tokenizeClause(clause)
+	var out []spanPolarity
+	start := 0
+	for i := 0; i <= len(tokens); i++ {
+		if i == len(tokens) || (!tokens[i].code && contrastConjunctions[tokens[i].text]) {
+			out = append(out, segmentSpanPolarities(tokens[start:i])...)
+			start = i + 1
+		}
+	}
+	return out
+}
+
+// segmentSpanPolarities is the polarity rule itself, over one contrast-free
+// segment.
+//
+// The default is POSITIVE, because a cause cell often attributes with no
+// printing verb at all — "**`civitai app validate`** found no
+// `block.manifest.json` in the directory you named" is the shipped row 1 — and
+// because negation is the marked case in English. A span is negative when a
+// negator sits immediately in front of it ("but not `app listing`"), and
+// otherwise when the NEAREST printing predicate in the segment is negated. The
+// nearest-predicate rule is what stops a single negation from colouring spans
+// that a later predicate speaks for.
+func segmentSpanPolarities(tokens []proseToken) []spanPolarity {
+	type predicate struct {
+		at      int
+		negated bool
+	}
+	var preds []predicate
+	for i, tk := range tokens {
+		if tk.code || !isPrintVerb(tk.text) {
+			continue
+		}
+		neg := false
+		for j := i - 1; j >= 0 && j >= i-3; j-- {
+			if !tokens[j].code && attributionNegators[tokens[j].text] {
+				neg = true
+				break
+			}
+		}
+		// "prints neither X nor Y" puts the negator AFTER the verb.
+		if i+1 < len(tokens) && !tokens[i+1].code && attributionNegators[tokens[i+1].text] {
+			neg = true
+		}
+		preds = append(preds, predicate{at: i, negated: neg})
+	}
+	var out []spanPolarity
+	for i, tk := range tokens {
+		if !tk.code {
+			continue
+		}
+		negated := false
+		switch {
+		case i > 0 && !tokens[i-1].code && attributionNegators[tokens[i-1].text]:
+			negated = true
+		case len(preds) > 0:
+			best := preds[0]
+			for _, p := range preds[1:] {
+				if absInt(p.at-i) < absInt(best.at-i) {
+					best = p
+				}
+			}
+			negated = best.negated
+		}
+		out = append(out, spanPolarity{span: tk.text, negated: negated})
+	}
+	return out
+}
+
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// commandMention is one invocation a cause cell names, which measured run it
+// resolves to, and whether the sentence naming it was a negation.
 type commandMention struct {
-	name    string
+	span    string
+	run     int // index into the row's runs, or spanUnmeasured / spanAmbiguous
 	negated bool
 }
 
@@ -544,6 +808,12 @@ type commandMention struct {
 // documented message containing ". " cannot be torn in half. A COMMA is
 // deliberately not a separator: "`app validate` and a plain `app submit` never
 // print it, because …" is ONE claim about two commands.
+//
+// That rationale had no case behind it until #373 — adding ',' here left the
+// whole suite green. TestAttributionProseParser now carries a fixture ("`app
+// validate`, a plain `app submit` and `app listing` never print it") whose
+// leading command falls into a predicate-less segment, and so flips to POSITIVE,
+// the moment a comma separates.
 func splitAttributionClauses(cell string) []string {
 	var clauses []string
 	var cur []rune
@@ -577,8 +847,8 @@ func splitAttributionClauses(cell string) []string {
 	return clauses
 }
 
-// normalizeCommandSpan renders an inline-code span the way a readmeName is
-// written: no `civitai ` prefix, no trailing ellipsis, single-spaced.
+// normalizeCommandSpan renders an inline-code span the way an argv is written:
+// no `civitai ` prefix, no trailing ellipsis, single-spaced.
 func normalizeCommandSpan(span string) string {
 	s := strings.Join(strings.Fields(span), " ")
 	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(s, "…"), "..."))
@@ -589,6 +859,20 @@ func normalizeCommandSpan(span string) string {
 // name — "app", "app validate", "app listing status", "generate", … Derived from
 // the tree rather than a hand-list so a renamed command cannot leave this
 // recogniser quietly matching nothing.
+//
+// The VALUE says whether the path is a FAMILY — a parent that has subcommands.
+// That distinction is load-bearing since #373: a family is not an invocation, so
+// the `app` in "your `app` directory" is English rather than an attribution.
+//
+// Why HasSubCommands is the right test, and the scope of the claim: `root.go`
+// gives every parent that has subcommands AND no action of its own a RunE that
+// prints help (or rejects an unknown subcommand). It cannot be read back off the
+// built tree — after that injection every node reports Runnable() — so the
+// claim was measured instead, on the two families these cause cells name:
+// `civitai app` and `civitai app listing` each print their help and exit 0.
+// A future parent that also did work of its own would be misread as a family;
+// that fails CLOSED for the run underneath it, which is still matched by its own
+// path and flags.
 func knownCommandPaths(t *testing.T) map[string]bool {
 	t.Helper()
 	root := NewRootCmd()
@@ -597,7 +881,7 @@ func knownCommandPaths(t *testing.T) map[string]bool {
 	var walk func(c *cobra.Command)
 	walk = func(c *cobra.Command) {
 		for _, sub := range c.Commands() {
-			out[strings.TrimPrefix(sub.CommandPath(), prefix)] = true
+			out[strings.TrimPrefix(sub.CommandPath(), prefix)] = sub.HasSubCommands()
 			walk(sub)
 		}
 	}
@@ -608,41 +892,211 @@ func knownCommandPaths(t *testing.T) map[string]bool {
 		t.Fatalf("the Cobra walk found %d command paths — it is not reading the real tree, so "+
 			"no verdict below would be about the README", len(out))
 	}
+	// Positive control on the family flag itself. `app` and `app listing` are
+	// both parents; a walk that recorded none would leave the family rule in
+	// resolveSpan switched off rather than satisfied, and nothing else here
+	// would notice.
+	families := 0
+	for _, isFamily := range out {
+		if isFamily {
+			families++
+		}
+	}
+	if families < 2 {
+		t.Fatalf("the Cobra walk found %d parent commands — `app` and `app listing` are both parents, "+
+			"so anything below 2 means HasSubCommands is not being read", families)
+	}
 	return out
 }
 
-// namesAKnownCommand reports whether a normalised span STARTS with a real
-// command path, so `app submit --skip-validate` counts as naming a command while
-// `--json` and `block.manifest.json not found …` do not.
-func namesAKnownCommand(name string, paths map[string]bool) bool {
-	words := strings.Fields(name)
-	for n := len(words); n > 0; n-- {
-		if paths[strings.Join(words[:n], " ")] {
-			return true
+// commandPathIn returns the longest leading run of WORDS in fields that is a
+// real command path. A flag ends the search, so `app submit --skip-validate`
+// names `app submit`, while `--json` and `block.manifest.json not found …` name
+// nothing.
+func commandPathIn(fields []string, paths map[string]bool) (string, bool) {
+	var found string
+	var ok bool
+	for n := 1; n <= len(fields); n++ {
+		if strings.HasPrefix(fields[n-1], "-") {
+			break
+		}
+		p := strings.Join(fields[:n], " ")
+		if _, exists := paths[p]; exists {
+			found, ok = p, true
 		}
 	}
-	return false
+	return found, ok
 }
 
-// commandMentionsIn parses a cause cell into the commands it names and the
-// polarity of the clause naming each.
-func commandMentionsIn(cell string, paths map[string]bool) []commandMention {
-	var out []commandMention
-	for _, clause := range splitAttributionClauses(cell) {
-		lower := strings.ToLower(clause)
-		negated := false
-		for _, p := range attributionNegations {
-			if strings.Contains(lower, p) {
-				negated = true
-				break
+// argvFlags is the set of flag names in an argv or a prose span, with any
+// `=value` cut off.
+func argvFlags(fields []string) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range fields {
+		if !strings.HasPrefix(f, "-") {
+			continue
+		}
+		if i := strings.Index(f, "="); i > 0 {
+			f = f[:i]
+		}
+		out[f] = true
+	}
+	return out
+}
+
+// ledgerRun is one measured invocation of a row, plus the argv shape a prose
+// span has to match to be read as naming it. Both are derived from `args` — the
+// argv IS the measurement, so it is what the prose is held against.
+type ledgerRun struct {
+	run   attributionRun
+	emits bool
+	argv  []string
+	path  string
+	flags map[string]bool
+}
+
+// rowRuns flattens a row's ledger into its emitting and non-emitting runs.
+func rowRuns(a symptomAttribution, paths map[string]bool) []ledgerRun {
+	var out []ledgerRun
+	add := func(r attributionRun, emits bool) {
+		argv := r.args("<dir>", "<scratch>")
+		path, _ := commandPathIn(argv, paths)
+		out = append(out, ledgerRun{run: r, emits: emits, argv: argv, path: path, flags: argvFlags(argv)})
+	}
+	for _, r := range a.emittedBy {
+		add(r, true)
+	}
+	for _, r := range a.notEmittedBy {
+		add(r, false)
+	}
+	return out
+}
+
+// Outcomes of resolveSpan that are not an index into the row's runs.
+const (
+	spanUnmeasured = -1
+	spanAmbiguous  = -2
+)
+
+// resolveSpan maps one normalised inline-code span onto the row's measured runs:
+//
+//	(i, true)               — the span names runs[i]
+//	(spanUnmeasured, true)  — it names a command this ledger never runs
+//	(spanAmbiguous, true)   — it names several measured runs and picks none
+//	(0, false)              — it is not an invocation at all
+//
+// The rules, in order:
+//
+//   - No command path in front (`--json`, `block.manifest.json not found …`):
+//     not an invocation.
+//   - A FAMILY with no flags (`app`, `app listing`) is not an invocation either
+//     — running it prints help. Its reading depends on how many of the row's
+//     runs it spans, and the three cases are NOT interchangeable:
+//     EXACTLY ONE, it is shorthand for that run; SEVERAL, it identifies none of
+//     them and is not read at all ("your `app` directory", and equally "`app`
+//     prints it"); NONE, it is an attribution to something the row never ran and
+//     is reported as unmeasured. 🔴 An earlier draft of this comment said a
+//     family spanning "none or several" went unchecked, and for one commit the
+//     code agreed with it — that was the measured regression the #387 audit
+//     caught, and this sentence is the one that outlived the fix by 30 lines.
+//     The residual is only the SEVERAL case. Every leaf mention is checked, and
+//     #361 was a leaf.
+//   - Otherwise the span is an invocation claim, matched against each run whose
+//     path it names or prefixes, keeping the runs whose flags are a superset of
+//     the span's. Ties are broken on the row's DISTINGUISHING flags — those
+//     present on one candidate and absent on another. `--skip-validate` is one,
+//     so `app submit` cannot resolve to the --skip-validate run and F1's
+//     distinction survives the move off string equality; `--package-only` and
+//     `--out` are on both submit runs, so declining to name them is not a claim
+//     about anything and the bare `app submit` still lands on the run it means.
+func resolveSpan(span string, runs []ledgerRun, paths map[string]bool) (int, bool) {
+	fields := strings.Fields(span)
+	path, ok := commandPathIn(fields, paths)
+	if !ok {
+		return 0, false
+	}
+	flags := argvFlags(fields)
+	var candidates []int
+	for i, r := range runs {
+		if r.path == path || strings.HasPrefix(r.path, path+" ") {
+			candidates = append(candidates, i)
+		}
+	}
+	if isFamily := paths[path]; isFamily && len(flags) == 0 {
+		switch {
+		case len(candidates) == 1:
+			// Unambiguous shorthand for the one run underneath it.
+			return candidates[0], true
+		case len(candidates) == 0:
+			// 🔴 NOT the same situation as several, and lumping the two together
+			// was a measured REGRESSION in the first cut of this fix (#387
+			// audit). A family the row measures NOTHING under is an attribution
+			// to a command nobody ran — the #361 shape — and crediting row 1's
+			// `not found at project root` to `app listing` is the single most
+			// plausible authoring error on that page. The pre-#373 guard caught
+			// it; the exemption written for `app` silently un-attributed all
+			// eleven families.
+			return spanUnmeasured, true
+		default:
+			// Several: the span picks none of them, so it is not an attribution
+			// to any measured invocation. This is the `app` in "your `app`
+			// directory" — and equally "`app` prints it", which identifies no
+			// invocation either.
+			return 0, false
+		}
+	}
+	distinguishing := map[string]bool{}
+	for _, i := range candidates {
+		for f := range runs[i].flags {
+			for _, j := range candidates {
+				if !runs[j].flags[f] {
+					distinguishing[f] = true
+				}
 			}
 		}
-		for _, m := range inlineCodeSpanRe.FindAllStringSubmatch(clause, -1) {
-			name := normalizeCommandSpan(m[1])
-			if name == "" || !namesAKnownCommand(name, paths) {
+	}
+	var matches []int
+	for _, i := range candidates {
+		match := true
+		for f := range flags {
+			if !runs[i].flags[f] {
+				match = false
+			}
+		}
+		for f := range distinguishing {
+			if flags[f] != runs[i].flags[f] {
+				match = false
+			}
+		}
+		if match {
+			matches = append(matches, i)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], true
+	case 0:
+		return spanUnmeasured, true
+	default:
+		return spanAmbiguous, true
+	}
+}
+
+// commandMentionsIn parses a cause cell into the invocations it names and the
+// polarity the sentence gives each.
+func commandMentionsIn(cell string, paths map[string]bool, runs []ledgerRun) []commandMention {
+	var out []commandMention
+	for _, clause := range splitAttributionClauses(cell) {
+		for _, sp := range attributionSpansIn(clause) {
+			name := normalizeCommandSpan(sp.span)
+			if name == "" {
 				continue
 			}
-			out = append(out, commandMention{name: name, negated: negated})
+			idx, ok := resolveSpan(name, runs, paths)
+			if !ok {
+				continue
+			}
+			out = append(out, commandMention{span: name, run: idx, negated: sp.negated})
 		}
 	}
 	return out
@@ -657,68 +1111,147 @@ func commandMentionsIn(cell string, paths map[string]bool) []commandMention {
 //   - every command the cell names at all is in the ledger, so the row cannot
 //     carry an attribution nothing measured
 //
-// Matching is by EQUALITY on the normalised span, so `app submit` never stands
-// in for `app submit --skip-validate`.
+// Matching is against the run's measured ARGV (resolveSpan), so `app submit`
+// never stands in for `app submit --skip-validate` and the ledger's own argv is
+// something the cell is allowed to write out in full.
+//
+// 🔴 Two exemptions make those three lines narrower than they read, and both
+// are measured rather than inferred. (a) A bare FAMILY name that spans SEVERAL
+// of the row's runs identifies no invocation, so it is not read at all —
+// "`app` prints it" is unchecked, though `app` naming nothing the row measures
+// is caught (resolveSpan). (b) A denial phrased with a verb outside
+// printVerbStems reads as POSITIVE, so an EMITTER wrongly denied in such a
+// sentence passes; see the vocabulary note above for the two measured cases.
+// Neither is a licence to widen: they are where the guard stops, written down
+// so nobody reads a green here as more than it is.
 func attributionProseCheck(t *testing.T, a symptomAttribution, cell string, paths map[string]bool) {
 	t.Helper()
-	mentions := commandMentionsIn(cell, paths)
-	// Positive control on the parser: a cell it reads as naming no command would
-	// satisfy every "must not appear positively" clause below for free.
+	for _, p := range attributionProseProblems(a, cell, paths) {
+		t.Error(p)
+	}
+}
+
+// attributionProseProblems returns everything wrong with a cause cell, as
+// messages.
+//
+// It is a function of the cell rather than a bundle of t.Errorf calls so that
+// BOTH controls can be exercised directly: a cell that must be clean is asserted
+// to produce ZERO problems, and a cell carrying a real mis-attribution is
+// asserted to produce a specific NON-ZERO count. A checker wired to nothing
+// returns zero for both, and only the pair tells them apart.
+func attributionProseProblems(a symptomAttribution, cell string, paths map[string]bool) []string {
+	runs := rowRuns(a, paths)
+	mentions := commandMentionsIn(cell, paths, runs)
+	// Positive control on the parser: a cell it reads as naming no invocation
+	// would satisfy every "must not appear positively" check below for free.
 	if len(mentions) == 0 {
-		t.Fatalf("the cause cell for %q names no command this parser can see, so nothing below is a "+
-			"fact about the README.\ncell: %s", a.fragment, cell)
+		return []string{fmt.Sprintf("the cause cell for %q names no invocation this parser can see, so "+
+			"nothing else here is a fact about the README.\ncell: %s", a.fragment, cell)}
 	}
-	pos := map[string]bool{}
-	neg := map[string]bool{}
+	pos := map[int]bool{}
+	neg := map[int]bool{}
 	for _, m := range mentions {
+		if m.run < 0 {
+			continue
+		}
 		if m.negated {
-			neg[m.name] = true
+			neg[m.run] = true
 		} else {
-			pos[m.name] = true
+			pos[m.run] = true
 		}
 	}
-	for _, r := range a.emittedBy {
-		if !pos[r.readmeName] {
-			t.Errorf("the row for %q is MEASURED to be printed by `%s`, but its cause cell never says so.\n"+
-				"Why it matters: %s.\n"+
-				"The cell is what a reader reads to find their command; a ledger that agrees with itself "+
-				"and not with the prose is #361 with the labels moved into Go.\ncell: %s",
-				a.fragment, r.readmeName, a.why, cell)
+	var probs []string
+	for i, lr := range runs {
+		argv := "civitai " + strings.Join(lr.argv, " ")
+		if lr.emits {
+			if !pos[i] {
+				probs = append(probs, fmt.Sprintf("the row for %q is MEASURED to be printed by `%s`, but no "+
+					"code span in its cause cell resolves to that invocation (measured argv: %s).\n"+
+					"Why it matters: %s.\n"+
+					"The cell is what a reader reads to find their command; a ledger that agrees with itself "+
+					"and not with the prose is #361 with the labels moved into Go.\ncell: %s",
+					a.fragment, lr.run.name, argv, a.why, cell))
+			}
+			if neg[i] {
+				probs = append(probs, fmt.Sprintf("the row for %q says `%s` does NOT print it, but running that "+
+					"command printed it (measured argv: %s).\nWhy it matters: %s.\ncell: %s",
+					a.fragment, lr.run.name, argv, a.why, cell))
+			}
+			continue
 		}
-		if neg[r.readmeName] {
-			t.Errorf("the row for %q says `%s` does NOT print it, but running that command printed it.\n"+
-				"Why it matters: %s.\ncell: %s", a.fragment, r.readmeName, a.why, cell)
+		if !neg[i] {
+			probs = append(probs, fmt.Sprintf("the row for %q is measured NOT to be printed by `%s`, but its "+
+				"cause cell does not say so: no span resolving to that invocation (measured argv: %s) sits "+
+				"near a NEGATED printing verb — `never prints`, `does not emit`, `will not report`, and so "+
+				"on, from %v negated by %v.\nWhy it matters: %s.\ncell: %s",
+				a.fragment, lr.run.name, argv, printVerbStems, sortedKeys(attributionNegators), a.why, cell))
 		}
-	}
-	for _, r := range a.notEmittedBy {
-		if !neg[r.readmeName] {
-			t.Errorf("the row for %q is measured NOT to be printed by `%s`, but its cause cell does not "+
-				"say so in a negated clause (it must, in one of %v).\n"+
-				"Why it matters: %s.\ncell: %s",
-				a.fragment, r.readmeName, attributionNegations, a.why, cell)
-		}
-		if pos[r.readmeName] {
-			t.Errorf("the row for %q credits `%s` with printing it, and running that command did not.\n"+
-				"Why it matters: %s.\n"+
+		if pos[i] {
+			probs = append(probs, fmt.Sprintf("the row for %q credits `%s` with printing it, and running that "+
+				"command did not (measured argv: %s).\nWhy it matters: %s.\n"+
 				"This is the #361 defect exactly: a row about a command that never emits the string.\ncell: %s",
-				a.fragment, r.readmeName, a.why, cell)
+				a.fragment, lr.run.name, argv, a.why, cell))
 		}
-	}
-	ledgered := map[string]bool{}
-	for _, r := range a.emittedBy {
-		ledgered[r.readmeName] = true
-	}
-	for _, r := range a.notEmittedBy {
-		ledgered[r.readmeName] = true
 	}
 	for _, m := range mentions {
-		if !ledgered[m.name] {
-			t.Errorf("the cause cell for %q names `%s`, which this ledger never runs.\n"+
+		switch m.run {
+		case spanUnmeasured:
+			// 🔴 "never runs" is the wrong diagnosis when the row DOES run that
+			// command path and the span merely fails to say WHICH invocation —
+			// a bare `app submit` against a row measuring two flagged submits
+			// reported "which this ledger never runs" for a command run twice.
+			// A guard that cries wolf is bad; one that cries wolf with a
+			// misleading message is worse, so the message names the argvs it is
+			// actually choosing between.
+			if near := ledgerArgvsUnder(m.span, runs, paths); len(near) > 0 {
+				probs = append(probs, fmt.Sprintf("the cause cell for %q names `%s`, which does not identify any "+
+					"invocation this ledger measures. Under that command path it runs:\n  %s\n"+
+					"Name the flag that picks one of them out, or add a measured run to "+
+					"symptomAttributions().\ncell: %s",
+					a.fragment, m.span, strings.Join(near, "\n  "), cell))
+				continue
+			}
+			probs = append(probs, fmt.Sprintf("the cause cell for %q names `%s`, which this ledger never runs.\n"+
 				"An unmeasured attribution in the index is exactly what #361 was. Either add a measured "+
 				"run for `%s` to symptomAttributions(), or stop naming it here.\ncell: %s",
-				a.fragment, m.name, m.name, cell)
+				a.fragment, m.span, m.span, cell))
+		case spanAmbiguous:
+			probs = append(probs, fmt.Sprintf("the cause cell for %q names `%s`, which matches more than one of "+
+				"this row's measured invocations, so it attributes the message to none of them.\n"+
+				"Name the flag that tells them apart.\ncell: %s", a.fragment, m.span, cell))
 		}
 	}
+	return probs
+}
+
+// ledgerArgvsUnder returns the measured argvs whose command path the span names
+// or prefixes — i.e. the invocations an unresolved span was choosing between.
+// Empty when the row genuinely never runs that command, which is the case the
+// "never runs" wording is for.
+func ledgerArgvsUnder(span string, runs []ledgerRun, paths map[string]bool) []string {
+	path, ok := commandPathIn(strings.Fields(span), paths)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, r := range runs {
+		if r.path == path || strings.HasPrefix(r.path, path+" ") {
+			out = append(out, "civitai "+strings.Join(r.argv, " "))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedKeys renders a set deterministically, so a failure message does not
+// shuffle between runs.
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // readmeHasAnchor reports whether a GitHub-style `#anchor` resolves to a heading
@@ -751,8 +1284,11 @@ func readmeHasAnchor(md, anchor string) bool {
 // 🔴 The underscore is not cosmetic and it was wrong here. Dropping it turned
 // "The host handshake (`BLOCK_READY`)" into `the-host-handshake-blockready`, so
 // readmeHasAnchor reported `#the-host-handshake-block_ready` — a link that
-// exists and works, and is used five times on the page — as a dead anchor. A
-// guard that fails on correct input is one somebody deletes.
+// exists and works, and that several places on the page use — as a dead anchor.
+// A guard that fails on correct input is one somebody deletes.
+//
+// How many places is COUNTED by the test below rather than written down here.
+// #373: this comment said "five times" and the measured number is FOUR.
 func githubAnchorSlug(heading string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(heading) {
@@ -775,22 +1311,47 @@ func githubAnchorSlug(heading string) string {
 // defect re-typed into the prose while the link cell stayed correct.
 func TestAttributionProseParser(t *testing.T) {
 	paths := knownCommandPaths(t)
-	got := func(cell string) map[string]bool {
-		m := map[string]bool{}
-		for _, x := range commandMentionsIn(cell, paths) {
-			m[x.name] = x.negated
+	// Resolution is per-ROW, so the parser is exercised against a real row's
+	// measured runs. This one covers all four invocations the two rows share.
+	row := symptomAttributions()[1]
+	runs := rowRuns(row, paths)
+	if len(runs) != 4 {
+		t.Fatalf("the `is this an App project?` row measures %d invocations, want 4 — the fixtures below "+
+			"name specific ones, so a changed ledger must move them too", len(runs))
+	}
+	resolved := func(i int) string {
+		switch i {
+		case spanUnmeasured:
+			return "<not in this ledger>"
+		case spanAmbiguous:
+			return "<ambiguous>"
+		default:
+			return runs[i].run.name
+		}
+	}
+	// got maps each span the parser saw to "<polarity><the run it resolved to>".
+	got := func(cell string) map[string]string {
+		m := map[string]string{}
+		for _, x := range commandMentionsIn(cell, paths, runs) {
+			pol := "+"
+			if x.negated {
+				pol = "-"
+			}
+			m[x.span] = pol + resolved(x.run)
 		}
 		return m
+	}
+	want := func(t *testing.T, m map[string]string, span, expect string) {
+		t.Helper()
+		if m[span] != expect {
+			t.Errorf("span `%s` read as %q, want %q; whole parse: %v", span, m[span], expect, m)
+		}
 	}
 
 	t.Run("positive and negative clauses are told apart", func(t *testing.T) {
 		m := got("Printed by `civitai app listing …`. `app validate` never prints it — it reports the row above.")
-		if neg, ok := m["app listing"]; !ok || neg {
-			t.Errorf("`app listing` must be read as a POSITIVE mention; got %v", m)
-		}
-		if neg, ok := m["app validate"]; !ok || !neg {
-			t.Errorf("`app validate` must be read as a NEGATIVE mention; got %v", m)
-		}
+		want(t, m, "app listing", "+app listing status")
+		want(t, m, "app validate", "-app validate")
 	})
 
 	t.Run("a flagged invocation does not stand in for the bare command", func(t *testing.T) {
@@ -799,9 +1360,184 @@ func TestAttributionProseParser(t *testing.T) {
 			t.Errorf("`app submit --skip-validate` must NOT register as a mention of `app submit` — "+
 				"they print different messages, and conflating them is F1; got %v", m)
 		}
-		if neg, ok := m["app submit --skip-validate"]; !ok || neg {
-			t.Errorf("the flagged form must register positively under its own name; got %v", m)
+		want(t, m, "app submit --skip-validate", "+app submit --skip-validate --package-only")
+	})
+
+	t.Run("the bare command resolves to the run without the distinguishing flag", func(t *testing.T) {
+		// The other half of the same rule: `--package-only` and `--out` are on
+		// BOTH submit runs, so a cell that names neither is still unambiguous.
+		m := got("`app submit` prints it, because it validates first.")
+		want(t, m, "app submit", "+app submit --package-only")
+	})
+
+	t.Run("the ledger's own measured argv is something the cell may write out", func(t *testing.T) {
+		// #373 class 1: this exact span was reported as "a command this ledger
+		// never runs", while being the argv the harness executes.
+		m := got("Run `app listing status --dir <path>` from anywhere.")
+		want(t, m, "app listing status --dir <path>", "+app listing status")
+	})
+
+	t.Run("a family name spanning several measured runs is English, not an attribution", func(t *testing.T) {
+		// #373 class 1: `app` is a parent — `civitai app` prints help — and it
+		// prefixes every run this row measures, so it identifies none of them.
+		m := got("Run `app listing` from your `app` directory.")
+		if _, ok := m["app"]; ok {
+			t.Errorf("a bare `app` used as an English noun must not register as a command mention; got %v", m)
 		}
+		want(t, m, "app listing", "+app listing status")
+	})
+
+	t.Run("a family the row measures NOTHING under is an unmeasured attribution", func(t *testing.T) {
+		// 🔴 The #387 audit's finding, and a measured REGRESSION in the first
+		// cut of #373: the exemption written for "your `app` directory" also
+		// swallowed families the row runs nothing under, which is the #361
+		// shape. Crediting row 1's `not found at project root` to `app listing`
+		// is the single most plausible authoring error on that page; it was
+		// caught before #373, silently not caught after, and is caught again.
+		row1 := rowRuns(symptomAttributions()[0], paths)
+		if idx, ok := resolveSpan("app listing", row1, paths); !ok || idx != spanUnmeasured {
+			t.Errorf("row 1 credits `app listing`: resolveSpan = (%d, %v), want (%d, true) — row 1 measures "+
+				"nothing under `app listing`, so naming it is an attribution nobody ran", idx, ok, spanUnmeasured)
+		}
+		// And a family with no relationship to the App path at all.
+		if idx, ok := resolveSpan("workflows", runs, paths); !ok || idx != spanUnmeasured {
+			t.Errorf("row 2 credits `workflows`: resolveSpan = (%d, %v), want (%d, true)", idx, ok, spanUnmeasured)
+		}
+		// The exemption that remains: `app` spans ALL FOUR of row 2's runs, so
+		// it identifies none of them and stays English.
+		if _, ok := resolveSpan("app", runs, paths); ok {
+			t.Error("a bare `app`, which prefixes every run this row measures, must still be exempt")
+		}
+	})
+
+	t.Run("a family carrying a flag is an invocation claim, not a family reference", func(t *testing.T) {
+		// The `len(flags) == 0` half of the family rule. `--slug` is real and
+		// documented on this page, but no run in this ledger passes it, so the
+		// span names an argv nobody measured rather than the `--dir` run.
+		if idx, ok := resolveSpan("app listing --slug <blockId>", runs, paths); !ok || idx != spanUnmeasured {
+			t.Errorf("resolveSpan(`app listing --slug <blockId>`) = (%d, %v), want (%d, true) — a flag the "+
+				"ledger never passed cannot ride in on the family exemption", idx, ok, spanUnmeasured)
+		}
+	})
+
+	t.Run("an unresolved span under a measured path says so, instead of `never runs`", func(t *testing.T) {
+		// A cry-wolf with a MISLEADING message is worse than a cry-wolf. Two
+		// runs sharing no flags: a bare `app submit` picks neither, and the old
+		// wording called a command the row runs twice one it "never runs".
+		synth := symptomAttribution{
+			fragment: "synthetic row, for the message only",
+			emittedBy: []attributionRun{
+				{name: "app submit --package-only", args: func(e, _ string) []string {
+					return []string{"app", "submit", e, "--package-only"}
+				}},
+				{name: "app submit --skip-validate", args: func(e, _ string) []string {
+					return []string{"app", "submit", e, "--skip-validate"}
+				}},
+			},
+		}
+		joined := strings.Join(attributionProseProblems(synth, "Printed by `app submit`.", paths), "\n")
+		if strings.Contains(joined, "never runs") {
+			t.Errorf("`app submit` is run twice by this row; the message must not say the ledger never "+
+				"runs it.\n%s", joined)
+		}
+		for _, want := range []string{"does not identify any invocation", "--package-only", "--skip-validate"} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("the message must name %q so the author can see what to disambiguate.\n%s", want, joined)
+			}
+		}
+	})
+
+	t.Run("negation is a property of the verb, not of a listed phrase", func(t *testing.T) {
+		// #373 class 2: `do not print` passed and `do not emit` did not.
+		for _, cell := range []string{
+			"`app validate` does not print it.",
+			"`app validate` do not emit it.",
+			"`app validate` will not report it.",
+			"`app validate` never surfaces it.",
+			"`app validate` cannot display it.",
+			"`app validate` prints neither it nor the row above.",
+			// Each of the next four pins one word or rule that an independently
+			// built mutation sweep found unpinned (#387 audit finding 4).
+			"`app validate` will print no such line.",     // the negator "no", after the verb
+			"`app validate` exits without printing it.",   // the negator "without"
+			"`app validate` has never shown it.",          // an irregular inflection
+			"`app validate` never said it.",               // the other irregular
+			"`app validate` **never** prints it.",         // emphasis marks must not hide the negator
+			"`app validate` does not, in fact, print it.", // the negator three tokens ahead of the verb
+		} {
+			if m := got(cell); m["app validate"] != "-app validate" {
+				t.Errorf("cell %q must read as a NEGATIVE attribution; got %v", cell, m)
+			}
+		}
+	})
+
+	t.Run("a negator further from the verb than the window does not reach it", func(t *testing.T) {
+		// The other boundary of the same rule, and the reason it is a window at
+		// all: "no" here negates the MANIFEST, not the printing. Without an
+		// upper bound this reads as a denial and the row's real emitter goes
+		// red — the false-positive class #373 exists to remove.
+		m := got("`app listing` finds there is no manifest, so it prints this.")
+		want(t, m, "app listing", "+app listing status")
+	})
+
+	t.Run("an em-dash starts a new clause, so a predicate does not reach across it", func(t *testing.T) {
+		// splitAttributionClauses states this and #387 found it unfixtured —
+		// the same "rationale with no case behind it" defect fixed for the
+		// comma. Merged into one clause, `app listing` binds to the NEGATED
+		// `prints` one token away instead of the `show` in its own sentence.
+		m := got("`app validate` never prints — `app listing` does show it.")
+		want(t, m, "app validate", "-app validate")
+		want(t, m, "app listing", "+app listing status")
+	})
+
+	t.Run("a negator directly in front of a command negates it with no verb of its own", func(t *testing.T) {
+		// English elides the second verb phrase. The contrast segment here has
+		// no predicate at all, so without this rule it would default to POSITIVE
+		// and credit a command the row measures as silent — a mutant that
+		// survived until this case existed.
+		m := got("`app listing status` prints it, but not `app validate`.")
+		want(t, m, "app listing status", "+app listing status")
+		want(t, m, "app validate", "-app validate")
+	})
+
+	t.Run("a later predicate speaks for the commands nearer to it", func(t *testing.T) {
+		// One clause, two predicates of opposite polarity and no contrast word
+		// to cut it. Binding every mention to the FIRST predicate — which is
+		// what "the clause is positive or negative" amounts to — makes `app
+		// validate` positive here, and that mutant survived the rest of this
+		// table until this case was added.
+		m := got("Reported by `app listing`, and `app validate` never prints it.")
+		want(t, m, "app listing", "+app listing status")
+		want(t, m, "app validate", "-app validate")
+	})
+
+	t.Run("on a tie the EARLIER predicate keeps the mention", func(t *testing.T) {
+		// A rephrase of the shipped cell's own sentence, with a predicate two
+		// tokens away on either side: `printed` (negated by the leading `Not`)
+		// before, `reports` after. English reads this as a denial. Handing the
+		// tie to the later predicate instead makes the guard report "credits
+		// `app validate` with printing it" about correct prose — measured, 3
+		// problems becomes 5 — so this is a claim, not an implementation detail.
+		m := got("Not printed by `app validate`, which reports the row above.")
+		want(t, m, "app validate", "-app validate")
+	})
+
+	t.Run("a contrast conjunction ends the negation's scope", func(t *testing.T) {
+		// #373 class 3: one negation coloured the whole clause.
+		m := got("`app validate` never prints it, but `app listing` does.")
+		want(t, m, "app validate", "-app validate")
+		want(t, m, "app listing", "+app listing status")
+	})
+
+	t.Run("a comma does not separate a shared subject list", func(t *testing.T) {
+		// This is the rationale splitAttributionClauses states and #373 found
+		// unpinned: adding ',' as a separator left the suite green. It cannot
+		// now — comma-splitting puts `app validate` in a segment with no
+		// predicate, which defaults to POSITIVE.
+		m := got("`app validate`, a plain `app submit` and `app listing` never print it.")
+		want(t, m, "app validate", "-app validate")
+		want(t, m, "app submit", "-app submit --package-only")
+		want(t, m, "app listing", "-app listing status")
 	})
 
 	t.Run("non-command code spans are ignored", func(t *testing.T) {
@@ -813,8 +1549,194 @@ func TestAttributionProseParser(t *testing.T) {
 
 	t.Run("a negation about something other than printing is not a negation", func(t *testing.T) {
 		m := got("Reported by `app listing`, which did not validate first.")
-		if neg, ok := m["app listing"]; !ok || neg {
-			t.Errorf("`did not validate` is not a claim about printing; got %v", m)
+		want(t, m, "app listing", "+app listing status")
+	})
+
+	t.Run("a span matching several measured runs is reported, not guessed", func(t *testing.T) {
+		// Reachable as soon as a row measures one command twice with the same
+		// flags and a different operand — a plausible next ledger entry, and
+		// nothing in today's ledger does it, so without this fixture the branch
+		// is unreachable and deleting it is invisible.
+		twice := symptomAttribution{
+			fragment: "synthetic row, for the ambiguity branch only",
+			emittedBy: []attributionRun{
+				{name: "app validate <project>", args: func(empty, _ string) []string {
+					return []string{"app", "validate", empty}
+				}},
+				{name: "app validate <scratch>", args: func(_, scratch string) []string {
+					return []string{"app", "validate", scratch}
+				}},
+			},
+		}
+		runsTwice := rowRuns(twice, paths)
+		if idx, ok := resolveSpan("app validate", runsTwice, paths); !ok || idx != spanAmbiguous {
+			t.Errorf("resolveSpan(`app validate`) = (%d, %v), want (%d, true): a span matching two measured "+
+				"runs attributes the message to neither of them", idx, ok, spanAmbiguous)
+		}
+		probs := attributionProseProblems(twice, "Printed by `app validate`.", paths)
+		if len(probs) == 0 || !strings.Contains(strings.Join(probs, "\n"), "matches more than one") {
+			t.Errorf("an ambiguous mention must be REPORTED rather than silently resolved; got %v", probs)
+		}
+	})
+
+	t.Run("a command outside the ledger is still reported", func(t *testing.T) {
+		// The leftover rule survives the move off equality: a leaf command this
+		// row never measured is an unmeasured attribution, which is #361.
+		m := got("`generate` prints it too.")
+		want(t, m, "generate", "+<not in this ledger>")
+	})
+}
+
+// TestAttributionProseCheckAcceptsCorrectProseAndRejectsMisattribution is the
+// #373 regression guard, run as a PAIR.
+//
+// The defect it pins is a FALSE POSITIVE: three classes of correct prose that
+// reddened the row. So the regression test is the correct prose — but a checker
+// that returns "no problems" for everything would pass that half perfectly,
+// which is why the same table carries mis-attributed cells and asserts a
+// non-zero count with the right message. Neither half means anything alone.
+//
+// Every fixture is built by editing the cell the README really ships, and each
+// edit asserts it matched something first: a fixture built by a replacement that
+// silently did nothing is the shipped cell again, and would report a clean pass
+// about a case it never constructed.
+func TestAttributionProseCheckAcceptsCorrectProseAndRejectsMisattribution(t *testing.T) {
+	paths := knownCommandPaths(t)
+	row := symptomAttributions()[1]
+	section := readmeTroubleshootingSection(t)
+	cells, n := troubleshootingRowFor(section, row.fragment)
+	if n != 1 || len(cells) < 3 {
+		t.Fatalf("expected exactly one Troubleshooting row quoting %q with 3 cells, got n=%d cells=%v",
+			row.fragment, n, cells)
+	}
+	shipped := cells[1]
+
+	// edit applies old/new pairs to the shipped cell, asserting each one matched.
+	edit := func(t *testing.T, oldNew ...string) string {
+		t.Helper()
+		out := shipped
+		for i := 0; i+1 < len(oldNew); i += 2 {
+			if !strings.Contains(out, oldNew[i]) {
+				t.Fatalf("the shipped cause cell no longer contains %q, so this fixture would be the "+
+					"shipped cell unchanged and would prove nothing.\ncell: %s", oldNew[i], out)
+			}
+			out = strings.Replace(out, oldNew[i], oldNew[i+1], 1)
+		}
+		return out
+	}
+
+	t.Run("correct prose", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			cell          func(t *testing.T) string
+			whyItReddened string
+		}{
+			{"the cell the README ships", func(*testing.T) string { return shipped },
+				"the baseline: if this is not clean, nothing below is about #373"},
+			{"class 1a — the ledger's own measured argv", func(t *testing.T) string {
+				return edit(t, "Run `app listing` from the app directory",
+					"Run `app listing status --dir <path>` from anywhere")
+			}, "`app listing status --dir <path>` is what the harness runs, and the guard called it unmeasured"},
+			{"class 1b — a bare `app` as an English noun", func(t *testing.T) string {
+				return edit(t, "from the app directory", "from your `app` directory")
+			}, "`app` is one of 19 single-word command paths, and several are ordinary nouns"},
+			{"class 2 — a negation outside the seven listed phrases", func(t *testing.T) string {
+				return edit(t, "never print it", "do not emit it")
+			}, "only `…print` phrasings counted, so `do not emit it` read as a POSITIVE attribution"},
+			{"class 3 — two polarities in one comma-joined clause", func(t *testing.T) string {
+				return edit(t, "never print it, because validation reports the row above first.",
+					"never print it, but `app listing` does.")
+			}, "one negation coloured the whole clause, so `app listing` came out negated"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				cell := tc.cell(t)
+				probs := attributionProseProblems(row, cell, paths)
+				if len(probs) != 0 {
+					t.Errorf("this cause cell is CORRECT and the guard reported %d problem(s).\n"+
+						"Why this case exists: %s.\n"+
+						"A guard that fails on correct input is one somebody deletes — that is the stake, "+
+						"not the friction.\ncell: %s\nproblems:\n%s",
+						len(probs), tc.whyItReddened, cell, strings.Join(probs, "\n"))
+				}
+			})
+		}
+	})
+
+	// The other control. Without it, "0 problems" above is indistinguishable
+	// from a checker wired to nothing.
+	t.Run("misattribution", func(t *testing.T) {
+		cases := []struct {
+			name, mustSay string
+			cell          func(t *testing.T) string
+		}{
+			{"#361 re-typed: a non-emitter credited with printing it", "credits `app validate`",
+				func(t *testing.T) string {
+					return edit(t, "`app validate` and a plain `app submit` never print it",
+						"`app validate` and a plain `app submit` print it")
+				}},
+			{"F1 re-typed: the bare command standing in for the flagged one", "`app submit --package-only`",
+				func(t *testing.T) string {
+					return edit(t, "and `app submit --skip-validate`, which waived", "and `app submit`, which waived")
+				}},
+			// A cell that contradicts itself: clause 1 still credits `app
+			// listing`, so the "is MEASURED to be printed by" arm stays quiet
+			// and only the emitter-must-not-be-denied arm can catch this one.
+			{"an emitter the cell also denies", "does NOT print it, but running that command printed it",
+				func(t *testing.T) string {
+					return edit(t, "Run `app listing` from the app directory",
+						"`app listing` never prints it. Run it from the app directory")
+				}},
+			// Not the same defect as crediting a non-emitter: here the cell says
+			// nothing at all about the two commands a reader is most likely to
+			// have just run. Every other row of this table also trips the
+			// "credits X" arm, so without this one the "must be named in a
+			// NEGATED clause" arm could be deleted and the suite stays green —
+			// measured.
+			{"a non-emitter the cell simply never mentions", "is measured NOT to be printed by",
+				func(t *testing.T) string {
+					return edit(t, "`app validate` and a plain `app submit` never print it, "+
+						"because validation reports the row above first. ", "")
+				}},
+			// End-to-end cover for the #387 audit's finding: the family
+			// exemption must not swallow a family the row runs nothing under.
+			{"a family the row measures nothing under", "which this ledger never runs",
+				func(t *testing.T) string {
+					return edit(t, "Run `app listing`", "`workflows` prints it too. Run `app listing`")
+				}},
+			{"an attribution nothing measured", "which this ledger never runs",
+				func(t *testing.T) string {
+					return edit(t, "Run `app listing`", "`generate` prints it too. Run `app listing`")
+				}},
+			// Both mentions have to go: the guard reads the WHOLE cell, so the
+			// remedy sentence at the end still credits `app listing` on its own.
+			// Deleting only the first one is not a defect and does not redden —
+			// measured while writing this table.
+			{"an emitter the cell never names", "MEASURED to be printed by",
+				func(t *testing.T) string {
+					return edit(t,
+						"`civitai app listing …`", "the listing commands",
+						"Run `app listing` from the app directory", "Run it from the app directory")
+				}},
+			{"a cell that names no invocation at all", "names no invocation",
+				func(*testing.T) string { return "The same cause, reported by a command that did not validate first." }},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				cell := tc.cell(t)
+				probs := attributionProseProblems(row, cell, paths)
+				if len(probs) == 0 {
+					t.Fatalf("POSITIVE CONTROL FAILED: this cause cell is WRONG and the guard reported "+
+						"nothing. A zero from this checker is only meaningful once this number can "+
+						"move.\ncell: %s", cell)
+				}
+				if !strings.Contains(strings.Join(probs, "\n"), tc.mustSay) {
+					t.Errorf("the guard went red, but for the wrong reason — no problem mentions %q, so a "+
+						"green elsewhere could be green for an unrelated reason.\nproblems:\n%s",
+						tc.mustSay, strings.Join(probs, "\n"))
+				}
+				t.Logf("positive control: %d problem(s), first is:\n%s", len(probs), probs[0])
+			})
 		}
 	})
 }
@@ -823,17 +1745,32 @@ func TestAttributionProseParser(t *testing.T) {
 //
 // Measured red before the fix: githubAnchorSlug dropped `_`, so the anchor for
 // the `BLOCK_READY` heading came back `the-host-handshake-blockready` and
-// readmeHasAnchor called a live, five-times-used link dead. Both of the ledger
-// rows most likely to be added next (the two `BLOCK_READY` advisory rows) point
-// at that heading.
+// readmeHasAnchor called a live link dead. Both of the ledger rows most likely
+// to be added next (the two `BLOCK_READY` advisory rows) point at that heading.
+//
+// 🔴 The link COUNT is measured here, not asserted from memory. #373: the
+// comment above githubAnchorSlug, the failure message below, and commit
+// ae58a47's own F4 paragraph all said the anchor was "used five times"; there
+// are FOUR links to it — the table of contents, one prose link in the
+// dev-tunnel walkthrough, and the two Troubleshooting rows. The commit message
+// cannot be rewritten, so this is the correction of record. Counting it means
+// the number in the failure a maintainer reads is whatever is true that day.
 func TestGithubAnchorSlugKeepsUnderscores(t *testing.T) {
-	if got, want := githubAnchorSlug("The host handshake (`BLOCK_READY`)"), "the-host-handshake-block_ready"; got != want {
+	const anchor = "#the-host-handshake-block_ready"
+	if got, want := githubAnchorSlug("The host handshake (`BLOCK_READY`)"), strings.TrimPrefix(anchor, "#"); got != want {
 		t.Errorf("githubAnchorSlug = %q, want %q — GitHub preserves underscores", got, want)
 	}
 	md := readREADME(t)
-	if !readmeHasAnchor(md, "#the-host-handshake-block_ready") {
-		t.Error("readmeHasAnchor cannot see `#the-host-handshake-block_ready`, a heading README.md really has " +
-			"and links to five times")
+	// Positive control on the count: an anchor nothing links to would make the
+	// assertion below a fact about a string rather than about a live link.
+	links := strings.Count(md, "]("+anchor+")")
+	if links == 0 {
+		t.Fatalf("no link in README.md targets %s, so whether readmeHasAnchor can resolve it says "+
+			"nothing about any reader's click", anchor)
+	}
+	if !readmeHasAnchor(md, anchor) {
+		t.Errorf("readmeHasAnchor cannot see `%s`, a heading README.md really has and links to %d times",
+			anchor, links)
 	}
 	// Negative control: the searcher must be able to report a miss at all.
 	if readmeHasAnchor(md, "#there-is-no-such-heading-in-this-readme") {


### PR DESCRIPTION
Closes #373 (the 🟡 item and both "inaccurate claims"; the 🟢 items I did not take are listed at the bottom).

One file changed, `internal/cmd/readme_troubleshooting_test.go`. **No README line was touched** — the shipped cause cells pass the repaired guard unchanged, which is the point.

> **Updated after a blind adversarial audit**, which found a **measured regression in this PR's own fix** plus a false claim in its own comment. Both are corrected here; the audit's findings and my independent re-verification of each are in the last section. Counted numbers below are the corrected ones.

## The defect: a guard that reddens on correct prose is a guard somebody deletes

`attributionProseCheck` reads the Troubleshooting row's *cause cell* — the sentence a reader reads to find which command printed their error — and holds it against a ledger of real invocations. It went RED on prose that is right.

### I verified: all three classes reproduce against the pre-fix guard

Driven through the real `attributionProseCheck` with the pre-fix code, on variants of the shipped `is this an App project?` cell:

```
--- FAIL: TestI373Repro/class_1a:_the_ledger's_own_measured_argv
    the cause cell for "is this an App project?" names `app listing status --dir <path>`,
    which this ledger never runs.
--- FAIL: TestI373Repro/class_1b:_bare_`app`_as_an_English_noun
    the cause cell for "is this an App project?" names `app`, which this ledger never runs.
--- FAIL: TestI373Repro/class_2:_a_negation_outside_the_7-phrase_set
    ... is measured NOT to be printed by `app validate`, but its cause cell does not say
    so in a negated clause (it must, in one of [never print does not print ...])
    ... credits `app validate` with printing it, and running that command did not.
    (×2, same pair for `app submit`)
--- FAIL: TestI373Repro/class_3:_two_polarities_in_one_comma-joined_clause
    ... says `app listing` does NOT print it, but running that command printed it.
```

`app listing status --dir <path>` is the argv **this ledger's own harness executes**. That was the sharpest one.

### The fix is structural, not an allowlist

| class | old rule | new rule |
| --- | --- | --- |
| 1 | span must EQUAL a hand-written `readmeName` | span resolves against the run's **real argv** — command path (prefix-compatible) + flags, ties broken on the row's **distinguishing** flags |
| 1 | any single word in the tree is a command | a **family** (parent with subcommands) spanning **one** of the row's runs is shorthand for it, spanning **several** is exempt, spanning **none** is reported as unmeasured |
| 2 | seven literal `…print` phrases | negation is a property of a **predicate** — printing verb + negator — over two closed word sets with English inflection |
| 3 | one negation colours the whole clause | each mention takes the polarity of the **nearest** predicate; a contrastive conjunction ends a predicate's scope |

`readmeName` is deleted. F1's distinction is preserved by the distinguishing-flag rule: `--skip-validate` is on one submit run and not the other, so it discriminates; `--package-only`/`--out` are on both, so declining to name them is not a claim.

### Where the guard stops — stated, not implied

Two exemptions make it narrower than it reads, both **measured**, both written into the code:

- **A bare family spanning SEVERAL of a row's runs is not read at all.** `your \`app\` directory` is why; the cost is that `\`app\` prints it` is also unchecked. A family the row runs **nothing** under *is* caught — that distinction is the audit finding below.
- **An unlisted denial verb leaves the mention POSITIVE, not unattributed.** So a non-emitter denied with an unlisted verb goes red, but an **emitter** denied that way goes **green**. Measured on the shipped cell: `` `app listing` does not output it. `` → 0 problems, `` `app listing` never produces it. `` → 0 problems, `` `app listing` never prints it. `` → 1 problem. Not a regression (the seven-phrase predecessor behaved identically), but an earlier draft of my own comment claimed the opposite failure direction.
- **A negator reaches its verb across at most three tokens**, so a denial that separates them further reads POSITIVE — and for a non-emitter that *reddens correct prose*. Measured: `does not, as of today, print it`, `does not, on this path, ever print it`, `will not, under any circumstances, print it` and `never actually goes on to print it` all parse `+app validate`. Widening is not free: the window is bounded from the other side by `finds there is no manifest, so it prints this`, and **both boundaries now carry a fixture**. Three is where those two natural readings stop colliding, not a number with a theory behind it.

Reading English prose needs *some* lexicon. The deterministic alternative I rejected, recorded in the code: require the cause cell to carry its attribution in a fixed machine-readable syntax — no vocabulary at all, but it would dictate the wording of the sentence the reader reads.

## Red/green matrix

| tree | result |
| --- | --- |
| guard at `origin/main` (e433b91), the 4 correct-prose variants | **RED** — 4/4 subtests fail |
| guard at HEAD, same 4 variants | **GREEN** |
| README at pinned `9c7baed` (pre-#361), guard at HEAD | **RED** — both ledger rows, row 2 on two counts |
| README + guard at HEAD | **GREEN** |

## The pair, never the zero alone

`attributionProseProblems` is a function returning problems, so both controls are exercised directly.

- **Under test (must be 0):** **5** correct-prose cells — the shipped cell plus classes 1a, 1b, 2, 3 → **0 problems each**.
- **Positive control (must move):** **8** mis-attributed cells → **4, 2, 1, 2, 1, 1, 1, 1** problems, each asserted to contain the *specific* message for the arm it breaks.

## Mutation matrix

**Round 1 (18 mutants, deletion-shaped)** — every arm of the check and the parser deleted or inverted in turn; all killed, **4 of them only after a fixture was added** (first-predicate binding, negator-immediately-before, emitter-must-not-be-denied, non-emitter-must-be-negated). The ambiguity branch was **unreachable** in today's ledger; it is now reached by a synthetic row.

**Round 2 (12 mutants, value-shaped)** — built after the audit pointed out that round 1 only ever deleted whole rules. 10 killed at the time, 2 deliberate survivors — one of which did not survive scrutiny:

| mutant | result |
| --- | --- |
| negator window `i-3` → `i-2` | killed by `does not, in fact, print it` |
| negator window `i-3` → `i-4` | killed by `finds there is no manifest, so it prints this` |
| family `len(flags)==0` guard dropped | killed by `app listing --slug <blockId>` |
| negators lose `"no"` / lose `"without"` | killed |
| `printVerbIrregulars` emptied | killed by `has never shown it` / `never said it` |
| em-dash clause split deleted | killed (new fixture) |
| tokenizer `*` strip removed | killed by `**never** prints it` |
| family: `none` lumped back in with `several` | killed by 3 tests |
| under-specified-span message branch deleted | killed |
| nearest-predicate tie-break `<` → `<=` | **now killed** — see round 3 |
| `.`/`;` split's space requirement dropped | **survives on purpose** |

**Round 3 (3 mutants)** — after the delta audit falsified one of those two reasons. The tie-break is now **pinned and killed by its own fixture**; the `.`/`;` space requirement still survives on purpose, re-verified; and the family fix re-verified as still killed by 3 tests.

**Totals: 33 mutants, 32 killed, 1 conscious survivor** — the `.`/`;` space requirement, which guards filenames and version numbers in unfenced prose, of which these cells contain none, and every fixture that would create one is contrived.

## Four claims corrected to the scope actually measured

1. **`#the-host-handshake-block_ready` is linked FOUR times, not five** (README:56 TOC, :979 prose, :2606, :2607). The count is now **counted by the test**.
2. **The same "five times" is in commit `ae58a47`'s F4 paragraph** — immutable, so the comment carries the correction of record.
3. **The `#after-you-submit` rationale said the section "now carries" the `--slug`/`--dir` remedy.** It documented both *before* #368: `README@fc03d33:1255`, still shipping at `README:1306`, ~20 lines below the block #368 added. The anchor is right for a **weaker** reason than recorded.
4. **The red/green matrix said "README.md at `origin/main`"** — a moving ref that has since passed the fix. Re-measured against pinned `9c7baed`.

Three 🟢 items came along: the hand-copied `appSubmit(false)` entry is a **call** again; the comma-exclusion **and** em-dash rationales in `splitAttributionClauses` now have fixtures (both were stated design reasons with no case behind them); and an unresolved span under a path the row *does* run no longer says "which this ledger never runs" — it names the argvs it was choosing between.

## Audit round 1 — findings and my independent re-verification

The audit returned no 🔴 and "merge after fixing 🟡 #1". I re-derived each finding myself rather than taking it:

1. **🔴-priority (graded 🟡) — the family exemption was a measured regression, and the audit was right.** My own probe on the real ledger: row 1 credited to `` `app listing` `` → **1 problem at e433b91, 0 at my first commit**; row 2 credited to `` `workflows` `` → same; leaf control `app dev-tunnel` → 1 → 1. I then ran the pre-fix guard directly and it caught **all four** probe cases. Fixed by splitting `none` from `several` — `none` returns `spanUnmeasured`. Re-measured after the fix: both false negatives → 1 problem with the correct message, leaf control unchanged, `your \`app\` directory` still 0. Pinned by a parser test **and** an end-to-end misattribution cell.
2. **🟡 — the stated failure direction was false in one direction.** Verified: out-of-vocabulary denials parse as `POSITIVE`, and on the full shipped cell both yield **0 problems** while the in-vocabulary control yields 1. Comment rewritten with the measured cases; the unqualified invariant list above `attributionProseCheck` now carries both exemptions.
3. **🟡 — counted results in this body did not match the code.** Correct: **8** mis-attributed cells at **4/2/1/2/1/1/1/1** (the audit measured 7 at 4/2/1/2/1/1/1 for the committed state; I have since added the family cell), and round 1 was **18** mutants, not 15. Both corrected above. On a PR titled *"four claims outran their evidence"* that was the right thing to be caught on.
4. **🟡 — mutation coverage was deletion-shaped.** Accepted; round 2 above is the response, with the two conscious survivors named in code.
5. **🟡 — the fixtures couple to eight exact substrings of the shipped cell.** True and disclosed here rather than redesigned: changing `never print it` → `do not print it`, a copy-edit the repaired *semantic* guard accepts as correct prose, produces **4 fixture-layer Fatals**. The message is actionable and points at the fixture, and building fixtures from real prose is what stops them drifting from the page — but a maintainer's first experience of it looks like the defect this PR fixes, so it is stated, not hidden.

**Nit taken:** `spanUnmeasured`'s "which this ledger never runs" was misleading for an under-specified span — on a row measuring `app submit` twice, a bare `` `app submit` `` was told the ledger never runs it. It now names the candidate argvs.

## Audit round 2 (delta) — two more claims of mine that were false

No 🔴; both remaining items were **comments**, not behaviour, and both were mine.

1. **🟡 `resolveSpan`'s doc comment still documented the regression I had removed.** Verified byte-identical to the pre-fix version: it still said a family spanning "**none or several**" of a row's runs goes unchecked, while the inline comment 30 lines below called that same lumping "a measured REGRESSION". A comment claiming a guard is absent when it exists is exactly what licenses deleting it. Rewritten to state all three cases separately — **one** run is shorthand, **several** is exempt, **none** is reported — and to say which sentence outlived the fix.
2. **🟡 My reason for leaving the tie-break unpinned was false, and I verified the counterexample myself.** I claimed "no natural sentence distinguishes them". The audit's rephrase of the shipped cell's own sentence does:

   ```
   Not printed by `app validate`, which reports the row above.
   ```

   `printed` (negated by the leading `Not`) is two tokens before the mention, `reports` two tokens after — a genuine tie. **My measurement:** at `d000219` it parses `-app validate` with **3 problems**; with `<` → `<=` it parses **`+app validate`** with **5**, i.e. the guard announces *"credits `app validate` with printing it"* about correct prose — the exact false-positive class this PR removes. It is now pinned by a fixture, and mutating `<` → `<=` fails **that fixture by name**. The stated reason is replaced with the counterexample.
3. **🟢 The window's new upper bound asserted a boundary without disclosing what falls outside it.** Verified: `does not, as of today, print it`, `does not, on this path, ever print it`, `will not, under any circumstances, print it` and `never actually goes on to print it` all parse **POSITIVE**, which for a non-emitter reddens correct prose. Added to the residual block above, together with why widening is not free — the other boundary fixture would break.

The other conscious survivor (`.`/`;` space requirement) was confirmed accurate and is left as-is.

## Gates — counted from output, not read off an exit code

```
go test ./... -count=1 -v
RUN=3685  PASS=3681  FAIL=0  SKIP=4
grep -c 'panic: test timed out' -> 0
```

`make ci` — green. `gofmt -s -l .` — **0 files** against **365** `.go` files found. `make lint` via `nix-shell -p golangci-lint` — **v2.12.2**, matching the CI pin — **0 issues**; instrument validated by an unplanned negative control (the first run reported a genuine `unused` leftover from this change and returned to 0 once removed).

**`make ci-shallow` — run on the committed change**, after audit round 1 noted I had skipped that tier: `ok=19/19 failing-tests=0 failing-packages=0 timeouts=0 go-test-rc=0`. Re-run after amending, since that target reads committed state only. Both tiers read, not one.

No `civitai generate` invocation was made, dry-run or otherwise; nothing was submitted and nothing was charged.

## What I verified vs what I believe

**I verified:** the three false-positive classes redden the pre-fix guard and pass the fixed one; the shipped README cells stay green with no README edit; the family regression, in both directions, against both guards; the tie-break counterexample flipping polarity under `<=` (3 problems → 5); all 33 mutants across three rounds, with the 1 remaining survivor intentional; the control pair and its exact counts; the BLOCK_READY link count of 4; the `fc03d33:1255` / `README:1306` provenance; `civitai app` and `civitai app listing` print help and exit 0; both test tiers.

**I believe, and did not prove:** that the two closed word sets cover the phrasings a future author will reach for. They cover every phrasing in the shipped cells and every one measured so far, and the fix for a missed one is a word in `printVerbStems` — but the emitter-side false negative above is proof that "unlisted verb" is not uniformly safe, and I am not claiming it is.

## Not fixed here

- **The fence-anchoring test gap** (`generate_substitution_test.go:904-915`) — real, two lines, in a file parallel PRs may be editing.
- **The 2×2 ledger symmetry is unasserted.** Note the issue's phrasing is exact in one direction only: row 1's `emittedBy` *is* row 2's `notEmittedBy`, but row 1's `notEmittedBy` is a strict **subset** of row 2's `emittedBy`. An assertion written from that wording would be false.
- **`validate.validateDir`'s TOCTOU** — recorded in #373 as not-a-defect; unchanged.

## Overlap note

**Zero README lines touched**, so there is nothing to reconcile with the parallel README work in **PR #384** (issue #378). Sibling PRs in flight: **#384, #385, #386** — an earlier version of this note named those by *issue* number, which was wrong. Files touched here: `internal/cmd/readme_troubleshooting_test.go` only. None of `internal/appapi/listing*.go`, `internal/cmd/app_metrics.go`, `internal/cmd/app_pull.go` or `internal/scaffold/templates/page-money/` was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
