### PR TITLE
fix(ui): server text could put invisible and order-reversing runes on the terminal (#393)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,10 +144,13 @@ These go beyond the global defaults because this repo's release pipeline
   money-spending surface whose wire shape is not a public contract. Read
   items 12–17, 19, 21 and 22 before touching it.
 - `internal/saferune` — the ONE rule about which runes SERVER-supplied text may
-  put in front of a user: C0/C1, all of `unicode.Cf` (zero-width, the bidi
-  overrides) and six blank-but-graphic runes. `cmd`'s `safeTerm` and `genapi`'s
-  `hasPrintableContent` both call it; #393 was two tables that disagreed. Its
-  doc comment states what is deliberately KEPT and what the strip costs.
+  put in front of a user: `Cc` plus Unicode's `Default_Ignorable_Code_Point`,
+  less U+FE0F, plus two blank-but-graphic runes. It is NOT applied to what the
+  USER typed. `cmd`'s `safeTerm` and `genapi`'s `hasPrintableContent` both call
+  it; #393 was two tables that disagreed, and its first fix drew the class on a
+  category instead of the property and was wrong in both directions. Read its
+  doc comment before changing the class: it states the derivation, the one
+  exception, what is deliberately KEPT and the nine scripts the strip costs.
 - **Module root** (`package cli`, `main.go` + `schema.go`) exists *only* to
   `go:embed` the vendored `schema/` and `examples/`. It is not the executable.
 - `npm/` — the `@civitai/cli` wrapper (postinstall downloads the matching raw

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,9 @@ These go beyond the global defaults because this repo's release pipeline
 - `internal/saferune` — the ONE rule about which runes SERVER-supplied text may
   put in front of a user: `Cc` plus Unicode's `Default_Ignorable_Code_Point`,
   less U+FE0F, plus two blank-but-graphic runes. It is NOT applied to what the
-  USER typed. `cmd`'s `safeTerm` and `genapi`'s `hasPrintableContent` both call
+  USER typed on the command line — two documented exceptions, `--input` file
+  content and `download`'s mixed-origin target path.
+  `cmd`'s `safeTerm` and `genapi`'s `hasPrintableContent` both call
   it; #393 was two tables that disagreed, and its first fix drew the class on a
   category instead of the property and was wrong in both directions. Read its
   doc comment before changing the class: it states the derivation, the one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,11 @@ These go beyond the global defaults because this repo's release pipeline
   `pkg/civitai` (that is the public read/download SDK) because generation is a
   money-spending surface whose wire shape is not a public contract. Read
   items 12–17, 19, 21 and 22 before touching it.
+- `internal/saferune` — the ONE rule about which runes SERVER-supplied text may
+  put in front of a user: C0/C1, all of `unicode.Cf` (zero-width, the bidi
+  overrides) and six blank-but-graphic runes. `cmd`'s `safeTerm` and `genapi`'s
+  `hasPrintableContent` both call it; #393 was two tables that disagreed. Its
+  doc comment states what is deliberately KEPT and what the strip costs.
 - **Module root** (`package cli`, `main.go` + `schema.go`) exists *only* to
   `go:embed` the vendored `schema/` and `examples/`. It is not the executable.
 - `npm/` — the `@civitai/cli` wrapper (postinstall downloads the matching raw

--- a/README.md
+++ b/README.md
@@ -2361,10 +2361,12 @@ Five things it is not:
   character Unicode marks **default-ignorable** — the zero-width spaces and
   joiners, the bidi overrides that reverse the order a line is *displayed* in,
   the variation selectors (except the one that keeps an emoji looking like an
-  emoji) — and two runes that paint nothing while claiming to be a symbol.
-  Letters, punctuation, accents, CJK, emoji and right-to-left *script* survive,
-  as do the format characters Unicode says must be drawn (Arabic end-of-ayah,
-  the Syriac abbreviation mark, ruby annotation marks).
+  emoji) — plus two runes that paint nothing while Unicode files them as a
+  symbol and a mark, and four Hangul *fillers* that paint nothing while Unicode
+  files them as letters. Punctuation, accents, CJK, emoji, ordinary letters and
+  right-to-left *script* survive, as do the format characters Unicode says must
+  be drawn (Arabic end-of-ayah, the Syriac abbreviation mark, ruby annotation
+  marks).
   🔴 **Every removed character is invisible on its own, but some of them change
   how their NEIGHBOURS are drawn**, so this is not free: an emoji built from a
   zero-width joiner renders as its components, a subdivision flag falls back to
@@ -2373,10 +2375,18 @@ Five things it is not:
   `ണ്`, a different letter), Devanagari, Bengali, Tamil, Kannada, Sinhala and
   Mongolian. **`--json` is not filtered at all** — it is a raw passthrough, so a
   script sees exactly what the server sent.
-- **It is not applied to anything YOU typed.** This filter is for server text
-  only. Your prompt, your flag values and the ids you pass are echoed back
-  exactly as typed — most importantly on the confirmation screen before a spend,
-  which has to show what will really be sent.
+- **It is not applied to the prompt you typed.** The filter is for text the
+  server sent. Your prompt, your negative prompt, `--aspect-ratio`,
+  `--ecosystem`, the paths you pass to `--image` / `--input`, and the ids you
+  give `workflows cancel` / `app withdraw` are all echoed back exactly as typed
+  — most importantly on the confirmation screen before a spend, which has to
+  show what will really be sent. **Two deliberate exceptions**, both outside
+  that screen: a value read out of an `--input` *file* is filtered like server
+  text (a graph file can come from anywhere), and `civitai download` filters the
+  path it reports even when you set it with `--out`, because the same variable
+  usually holds a filename the **server** chose — so an `--out` path containing
+  an invisible character is reported without it while the file is written to the
+  path you gave.
 - **It is not always there.** Some failures record nothing. In that case the
   error says so instead: *"the orchestrator often supplies no failure reason, so
   it may not say why"*. That is a measured case, not a gap in the CLI, and there
@@ -2695,7 +2705,7 @@ credited it to the wrong command.)
 | `interrupted while waiting` | **The generation is still running and has already been charged.** Ctrl-C stopped the wait, not the job. Re-attach with `civitai workflows get <id>`. | [Waiting, downloading, and re-attaching](#waiting-downloading-and-re-attaching) |
 | `model substituted` | The server ran a **different checkpoint** than you asked for and billed for what ran. Warned by default; `--fail-on-substitution` turns it into a refusal on the estimate, before any spend. | [Silent model substitution](#-silent-model-substitution) |
 | `The server reported: …` | The orchestrator recorded an account of what happened, and what follows is the server's own words. The CLI does not interpret them and does not know whether the failure is retryable; the only thing it changes is that invisible and direction-reversing characters are removed before the text reaches your terminal (`--json` is unfiltered). Printed on the `generate` error and by `civitai workflows get`. | [What the server says went wrong](#what-the-server-says-went-wrong) |
-| `An indented line under a row is what the server recorded` | The same record, on `civitai workflows list`: the indented lines beneath a workflow's row are the server's own words for that workflow, wrapped but never abbreviated (invisible characters are removed, as above; nothing else is). The indent is not decoration — it keeps server text out of the column a real row starts in, so a message cannot pose as a workflow of yours. It holds for the line breaks the CLI makes: the CLI wraps to a fixed 79 columns and never asks how wide your terminal is, so in a **narrower** terminal — or with wide (CJK) characters — your terminal re-wraps and the overflow can still reach column zero. | [What the server says went wrong](#what-the-server-says-went-wrong) |
+| `An indented line under a row is what the server recorded` | The same record, on `civitai workflows list`: the indented lines beneath a workflow's row are the server's own words for that workflow, wrapped but never abbreviated (the invisible characters above are removed, and wrapping collapses runs of whitespace and breaks a token longer than the line — no words are dropped). The indent is not decoration — it keeps server text out of the column a real row starts in, so a message cannot pose as a workflow of yours. It holds for the line breaks the CLI makes: the CLI wraps to a fixed 79 columns and never asks how wide your terminal is, so in a **narrower** terminal — or with wide (CJK) characters — your terminal re-wraps and the overflow can still reach column zero. | [What the server says went wrong](#what-the-server-says-went-wrong) |
 | `the orchestrator often supplies no failure reason, so it may not say why` | The same failure with **no** account recorded — a real, measured case, not a CLI limitation. Neither `civitai workflows get <id>` nor `civitai workflows list` will say why either. | [What the server says went wrong](#what-the-server-says-went-wrong) |
 
 ### Everything else

--- a/README.md
+++ b/README.md
@@ -2350,24 +2350,33 @@ The server reported:
   - Could not generate images with the given prompts and images. Please try again with different inputs.
 ```
 
-Four things it is not:
+Five things it is not:
 
 - **It is not this CLI's opinion.** The text is the server's. Nothing here
   classifies it, matches on its wording, or maps it to a list of known messages
   — so a message the platform adds tomorrow arrives intact rather than being
   swallowed by a stale table.
 - **It is not quite byte-for-byte, on the terminal.** Before printing any
-  server-supplied text, the CLI removes the characters a terminal cannot show
-  honestly: escape and control bytes, every Unicode *format* character
-  (zero-width spaces and joiners, and the bidi overrides that reverse the order
-  a line is **displayed** in), and the handful of runes that render as blank
-  while claiming to be letters. Words, punctuation, accents, CJK, emoji and
-  right-to-left *script* are untouched — only characters with no visible glyph
-  are dropped. Two knock-on effects worth knowing: an emoji built from a
-  zero-width joiner (a family, a subdivision flag) renders as its components,
-  and Persian/Arabic text that relies on a zero-width non-joiner renders joined.
-  **`--json` is not filtered at all** — it is a raw passthrough, so a script
-  sees exactly what the server sent.
+  server-supplied text, the CLI removes escape and control bytes plus every
+  character Unicode marks **default-ignorable** — the zero-width spaces and
+  joiners, the bidi overrides that reverse the order a line is *displayed* in,
+  the variation selectors (except the one that keeps an emoji looking like an
+  emoji) — and two runes that paint nothing while claiming to be a symbol.
+  Letters, punctuation, accents, CJK, emoji and right-to-left *script* survive,
+  as do the format characters Unicode says must be drawn (Arabic end-of-ayah,
+  the Syriac abbreviation mark, ruby annotation marks).
+  🔴 **Every removed character is invisible on its own, but some of them change
+  how their NEIGHBOURS are drawn**, so this is not free: an emoji built from a
+  zero-width joiner renders as its components, a subdivision flag falls back to
+  🏴, and text that uses the join controls to make a distinction loses it —
+  Persian/Arabic (`می‌روم` renders joined), Malayalam (the chillu `ണ്‍` becomes
+  `ണ്`, a different letter), Devanagari, Bengali, Tamil, Kannada, Sinhala and
+  Mongolian. **`--json` is not filtered at all** — it is a raw passthrough, so a
+  script sees exactly what the server sent.
+- **It is not applied to anything YOU typed.** This filter is for server text
+  only. Your prompt, your flag values and the ids you pass are echoed back
+  exactly as typed — most importantly on the confirmation screen before a spend,
+  which has to show what will really be sent.
 - **It is not always there.** Some failures record nothing. In that case the
   error says so instead: *"the orchestrator often supplies no failure reason, so
   it may not say why"*. That is a measured case, not a gap in the CLI, and there
@@ -2395,7 +2404,8 @@ cannot vouch for — one carrying a URL, a path, a stack frame, an infra name, o
 running past 300 characters or one line — with a generic *"… reported a system
 error"*. `workflows get` applies none of that, so where the two disagree the raw
 one can be the more informative. **When a failure is worth chasing, read both.**
-The CLI reproduces neither transform; it prints what each endpoint sent.
+The CLI reproduces neither transform; it prints what each endpoint sent, less the
+invisible characters described above.
 
 <sub>Until civitai/cli#367 this was discarded at parse time — the field existed on the wire and the CLI had no place to put it — so every failure printed the same generic sentence no matter what caused it, and `civitai workflows get` answered a failed run with a status and nothing else. `civitai workflows list` kept discarding it until civitai/cli#382, at a different wire path.</sub>
 

--- a/README.md
+++ b/README.md
@@ -2350,12 +2350,24 @@ The server reported:
   - Could not generate images with the given prompts and images. Please try again with different inputs.
 ```
 
-Three things it is not:
+Four things it is not:
 
-- **It is not this CLI's opinion.** The text is the server's, passed through
-  unchanged. Nothing here classifies it, matches on its wording, or maps it to a
-  list of known messages — so a message the platform adds tomorrow arrives
-  intact rather than being swallowed by a stale table.
+- **It is not this CLI's opinion.** The text is the server's. Nothing here
+  classifies it, matches on its wording, or maps it to a list of known messages
+  — so a message the platform adds tomorrow arrives intact rather than being
+  swallowed by a stale table.
+- **It is not quite byte-for-byte, on the terminal.** Before printing any
+  server-supplied text, the CLI removes the characters a terminal cannot show
+  honestly: escape and control bytes, every Unicode *format* character
+  (zero-width spaces and joiners, and the bidi overrides that reverse the order
+  a line is **displayed** in), and the handful of runes that render as blank
+  while claiming to be letters. Words, punctuation, accents, CJK, emoji and
+  right-to-left *script* are untouched — only characters with no visible glyph
+  are dropped. Two knock-on effects worth knowing: an emoji built from a
+  zero-width joiner (a family, a subdivision flag) renders as its components,
+  and Persian/Arabic text that relies on a zero-width non-joiner renders joined.
+  **`--json` is not filtered at all** — it is a raw passthrough, so a script
+  sees exactly what the server sent.
 - **It is not always there.** Some failures record nothing. In that case the
   error says so instead: *"the orchestrator often supplies no failure reason, so
   it may not say why"*. That is a measured case, not a gap in the CLI, and there
@@ -2672,8 +2684,8 @@ credited it to the wrong command.)
 | `--image requires --ecosystem` | Without an ecosystem the server never promotes the job to image-to-image: your images are silently dropped and you are billed for a plain text-to-image run. Hence a refusal rather than a warning. | [Image-to-image](#image-to-image---image-and---ecosystem) |
 | `interrupted while waiting` | **The generation is still running and has already been charged.** Ctrl-C stopped the wait, not the job. Re-attach with `civitai workflows get <id>`. | [Waiting, downloading, and re-attaching](#waiting-downloading-and-re-attaching) |
 | `model substituted` | The server ran a **different checkpoint** than you asked for and billed for what ran. Warned by default; `--fail-on-substitution` turns it into a refusal on the estimate, before any spend. | [Silent model substitution](#-silent-model-substitution) |
-| `The server reported: …` | The orchestrator recorded an account of what happened, and what follows is the server's own words, passed through unchanged. The CLI does not interpret them and does not know whether the failure is retryable. Printed on the `generate` error and by `civitai workflows get`. | [What the server says went wrong](#what-the-server-says-went-wrong) |
-| `An indented line under a row is what the server recorded` | The same record, on `civitai workflows list`: the indented lines beneath a workflow's row are the server's own words for that workflow, wrapped but never shortened. The indent is not decoration — it keeps server text out of the column a real row starts in, so a message cannot pose as a workflow of yours. It holds for the line breaks the CLI makes: the CLI wraps to a fixed 79 columns and never asks how wide your terminal is, so in a **narrower** terminal — or with wide (CJK) characters — your terminal re-wraps and the overflow can still reach column zero. | [What the server says went wrong](#what-the-server-says-went-wrong) |
+| `The server reported: …` | The orchestrator recorded an account of what happened, and what follows is the server's own words. The CLI does not interpret them and does not know whether the failure is retryable; the only thing it changes is that invisible and direction-reversing characters are removed before the text reaches your terminal (`--json` is unfiltered). Printed on the `generate` error and by `civitai workflows get`. | [What the server says went wrong](#what-the-server-says-went-wrong) |
+| `An indented line under a row is what the server recorded` | The same record, on `civitai workflows list`: the indented lines beneath a workflow's row are the server's own words for that workflow, wrapped but never abbreviated (invisible characters are removed, as above; nothing else is). The indent is not decoration — it keeps server text out of the column a real row starts in, so a message cannot pose as a workflow of yours. It holds for the line breaks the CLI makes: the CLI wraps to a fixed 79 columns and never asks how wide your terminal is, so in a **narrower** terminal — or with wide (CJK) characters — your terminal re-wraps and the overflow can still reach column zero. | [What the server says went wrong](#what-the-server-says-went-wrong) |
 | `the orchestrator often supplies no failure reason, so it may not say why` | The same failure with **no** account recorded — a real, measured case, not a CLI limitation. Neither `civitai workflows get <id>` nor `civitai workflows list` will say why either. | [What the server says went wrong](#what-the-server-says-went-wrong) |
 
 ### Everything else

--- a/internal/cmd/app_withdraw.go
+++ b/internal/cmd/app_withdraw.go
@@ -188,6 +188,8 @@ without --yes REFUSES rather than deleting a listing silently.`,
 // the server's `appBlockId: null, status:'draft'` predicate in the CLI to decide
 // whether to warn at all. The residual, accepted: the prompt says WHAT is
 // destroyed and under WHICH condition, but not how many screenshots you have.
+// The id is the user's own positional argument and is echoed exactly, not
+// sanitised — same rule as confirmCancel (civitai/cli#393).
 func confirmWithdraw(cmd *cobra.Command, publishRequestID string, assumeYes bool) error {
 	if assumeYes {
 		return nil
@@ -195,12 +197,12 @@ func confirmWithdraw(cmd *cobra.Command, publishRequestID string, assumeYes bool
 	if !stdinIsTTY() {
 		return fmt.Errorf("refusing to withdraw without --yes in a non-interactive shell — %s. "+
 			"Pass --yes to confirm, or `civitai app listing status` to see what %s would take with it",
-			withdrawDiscardsListing, safeTerm(publishRequestID))
+			withdrawDiscardsListing, publishRequestID)
 	}
 
 	errw := cmd.ErrOrStderr()
 	st := ui.For(errw)
-	fmt.Fprintf(errw, "About to withdraw %s.\n", safeTerm(publishRequestID))
+	fmt.Fprintf(errw, "About to withdraw %s.\n", publishRequestID)
 	fmt.Fprintln(errw, st.Warn("This is not just a resubmit: "+withdrawDiscardsListing+"."))
 	fmt.Fprintln(errw, st.Dim("The media only survives a moderator APPROVING the app — not a withdraw, and not a rejection."))
 	fmt.Fprintln(errw, st.Dim("Copy any captions you want to keep before answering; `civitai app listing status` prints them."))

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -722,6 +722,18 @@ func checkTargetCollisions(files []civitai.ModelVersionFile, o *downloadOpts) er
 // pass a relative or absolute path). A basename that degenerates to ".", "/", or
 // ".." (empty or all-slashes server name) is unusable and errors rather than
 // writing to a junk path.
+// 🔴 THE RETURNED PATH IS MIXED-ORIGIN, WHICH IS WHY ITS PRINT SITES SANITISE
+// IT EVEN THOUGH #393 SAYS USER INPUT IS ECHOED EXACTLY. With `--out` it is the
+// user's own bytes, verbatim; without it, it is built from
+// `filepath.Base(f.Name)` — the SERVER's file name, which safeTerm's own
+// docstring names as a forgery vector. One value, two origins, and the callers
+// cannot tell them apart, so the safe treatment wins: printing it raw would let
+// a hostile uploader forge the `Saved … (SHA256 verified)` line for a
+// papercut's worth of fidelity. The cost, stated rather than hidden: an `--out`
+// path containing an invisible rune is echoed without it, so a user copying
+// that line gets a path that does not exist. Separating the two would mean
+// threading the origin out of here; it is not worth it on this path, and the
+// README says what the CLI actually does.
 func targetPath(f civitai.ModelVersionFile, o *downloadOpts) (string, string, error) {
 	if o.out != "" {
 		return o.out, "", nil

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -1022,10 +1022,17 @@ func buildGenerateGraph(ctx context.Context, deps generateDeps, o generateOpts) 
 	// only those cannot be matched back to the files on disk — which is the whole
 	// point of showing them before a spend.
 	// resolveImages preserves order, so imgs[i] is o.images[i].
+	//
+	// 🔴 TWO ORIGINS ON ONE LINE, AND ONLY ONE OF THEM IS SANITISED. `o.images[i]`
+	// is what the USER typed on the command line and is echoed exactly — this
+	// line's whole purpose is to let them match the blob back to the file they
+	// named, which a rewritten path defeats. `img.URL` came back from the SERVER
+	// (an opaque blob URL after upload) and goes through safeTerm. Collapsing the
+	// two into one treatment is the mistake civitai/cli#393's first cut made.
 	for i, img := range imgs {
 		src := ""
 		if i < len(o.images) {
-			src = safeTerm(o.images[i]) + " "
+			src = o.images[i] + " "
 		}
 		out.images = append(out.images, fmt.Sprintf("%s(%dx%d) → %s", src, img.Width, img.Height, safeTerm(img.URL)))
 	}
@@ -1663,7 +1670,8 @@ func workflowLines(built *resolvedGraph) (label, note string) {
 // never showed it.
 func printImageDisclosure(errw io.Writer, o generateOpts, built *resolvedGraph) {
 	if o.ecosystem != "" {
-		fmt.Fprintf(errw, "  Ecosystem:  %s\n", safeTerm(o.ecosystem))
+		// User-typed flag value, echoed exactly — see confirmGenerate.
+		fmt.Fprintf(errw, "  Ecosystem:  %s\n", o.ecosystem)
 	}
 	for _, img := range built.images {
 		fmt.Fprintf(errw, "  Image:      %s\n", img)
@@ -1694,16 +1702,23 @@ func confirmGenerate(cmd *cobra.Command, o generateOpts, built *resolvedGraph, c
 	if note != "" {
 		fmt.Fprintln(errw, st.Dim(note))
 	}
+	// 🔴 NOTHING ON THIS SCREEN THAT THE USER TYPED IS SANITISED, AND THAT IS THE
+	// POINT OF THE SCREEN. It is the last thing shown before an irreversible
+	// spend, so it has to show what will actually be SENT. #393's first cut ran
+	// the prompt through safeTerm and a typed Persian prompt (`می‌روم`, held apart
+	// by a ZWNJ) rendered joined while the graph on the wire carried the original
+	// — the approval screen stopped describing the job it was approving.
+	// TestApprovalScreenEchoesTypedInput_AndStripsServerText pins it.
 	if built.inputPath != "" {
 		// With --input the CLI has deliberately not interpreted the graph, so it
 		// names the file rather than echoing fields it did not parse. Printing a
 		// partial summary would imply the CLI had checked the rest.
-		fmt.Fprintf(errw, "  Graph:      %s (sent as-is; this CLI did not interpret it)\n", safeTerm(built.inputPath))
+		fmt.Fprintf(errw, "  Graph:      %s (sent as-is; this CLI did not interpret it)\n", built.inputPath)
 	} else {
-		fmt.Fprintf(errw, "  Prompt:     %s\n", safeTerm(o.prompt))
+		fmt.Fprintf(errw, "  Prompt:     %s\n", o.prompt)
 	}
 	if o.negativePrompt != "" {
-		fmt.Fprintf(errw, "  Negative:   %s\n", safeTerm(o.negativePrompt))
+		fmt.Fprintf(errw, "  Negative:   %s\n", o.negativePrompt)
 	}
 	if o.quantitySet {
 		fmt.Fprintf(errw, "  Quantity:   %d\n", o.quantity)
@@ -1777,7 +1792,8 @@ func printGenerateQuote(out, errw io.Writer, built *resolvedGraph, o generateOpt
 		fmt.Fprintf(tw, "\t%s\n", note)
 	}
 	if built.inputPath != "" {
-		fmt.Fprintf(tw, "Graph:\t%s (sent as-is)\n", safeTerm(built.inputPath))
+		// User-typed path, echoed exactly — see confirmGenerate.
+		fmt.Fprintf(tw, "Graph:\t%s (sent as-is)\n", built.inputPath)
 	} else {
 		// NOT safeTerm(o.prompt) — see the disclosure above. The interactive
 		// confirmation in confirmGenerate DOES echo the real prompt and must keep
@@ -1797,7 +1813,7 @@ func printGenerateQuote(out, errw io.Writer, built *resolvedGraph, o generateOpt
 		fmt.Fprintf(tw, "Quantity:\t%d\n", o.quantity)
 	}
 	if o.aspectRatio != "" {
-		fmt.Fprintf(tw, "Aspect ratio:\t%s\n", safeTerm(o.aspectRatio))
+		fmt.Fprintf(tw, "Aspect ratio:\t%s\n", o.aspectRatio)
 	}
 	if built.checkpoint != "" {
 		fmt.Fprintf(tw, "Checkpoint:\t%s%s\n", built.checkpoint, built.checkpointNote)

--- a/internal/cmd/generate.go
+++ b/internal/cmd/generate.go
@@ -1708,7 +1708,8 @@ func confirmGenerate(cmd *cobra.Command, o generateOpts, built *resolvedGraph, c
 	// the prompt through safeTerm and a typed Persian prompt (`می‌روم`, held apart
 	// by a ZWNJ) rendered joined while the graph on the wire carried the original
 	// — the approval screen stopped describing the job it was approving.
-	// TestApprovalScreenEchoesTypedInput_AndStripsServerText pins it.
+	// TestSameBytesTypedAndReceived_AreEchoedAndStripped pins it, and
+	// TestSafeTermIsNeverAppliedToUserTypedInput pins the call sites.
 	if built.inputPath != "" {
 		// With --input the CLI has deliberately not interpreted the graph, so it
 		// names the file rather than echoing fields it did not parse. Printing a

--- a/internal/cmd/safeterm.go
+++ b/internal/cmd/safeterm.go
@@ -56,10 +56,16 @@ func safeTerm(s string) string {
 // cannot see it. Indenting is what makes a continuation line unable to occupy
 // column zero, and therefore unable to impersonate a line the CLI itself wrote.
 //
-// It deliberately does NOT collapse the newlines: the reason is passed through
-// verbatim (AGENTS.md item 13), so the fix is where the text SITS, not what it
-// says. A trailing newline is left alone rather than padded into a line of
-// whitespace.
+// It deliberately does NOT collapse the newlines: nothing here reads, matches
+// or rewrites the reason's WORDS (AGENTS.md item 13), so the fix is where the
+// text SITS, not what it says. A trailing newline is left alone rather than
+// padded into a line of whitespace.
+//
+// "Verbatim" is no longer the precise word for what reaches this function, and
+// it used to say so: since civitai/cli#393 the string has already lost its
+// invisible and direction-reversing runes to safeTerm. That is a change to the
+// BYTES, made without reading them; item 13's rule is about interpretation, and
+// it still holds.
 func indentContinuation(s, pad string) string {
 	if !strings.Contains(s, "\n") {
 		return s

--- a/internal/cmd/safeterm.go
+++ b/internal/cmd/safeterm.go
@@ -1,39 +1,41 @@
 package cmd
 
-import "strings"
+import (
+	"strings"
 
-// safeTerm strips terminal control characters from a SERVER-ORIGIN string before
-// it is printed to the user's terminal, so a malicious uploader cannot inject
-// ANSI/OSC escape sequences through model/version names, usernames, tags,
-// creators, base-model labels, descriptions, download/image URLs, article
-// titles/authors, trained words, or file names.
+	"github.com/civitai/cli/internal/saferune"
+)
+
+// safeTerm strips the runes a SERVER-ORIGIN string may not put on the user's
+// terminal, before it is printed, so a malicious uploader cannot inject
+// ANSI/OSC escape sequences — or invisible and direction-altering characters —
+// through model/version names, usernames, tags, creators, base-model labels,
+// descriptions, download/image URLs, article titles/authors, trained words,
+// file names, or an orchestrator failure reason.
 //
 // Without this, a hostile field can perform terminal OUTPUT FORGERY: cursor
 // moves + line-clears (\x1b[1A\x1b[2K) to overwrite the CLI's own "SHA256
 // verified" line or hide a warning, an OSC-52 clipboard-set (\x1b]52;c;...\x07),
 // or a window-title spoof.
 //
-// Removed: every C0 control byte (0x00–0x1F) and DEL (0x7F) EXCEPT newline and
-// tab (legitimate layout), plus the C1 control range (U+0080–U+009F) — the 8-bit
-// forms of the CSI/OSC escape introducers (0x9B = CSI, 0x9D = OSC, …). Ordinary
-// printable and multibyte UTF-8 text passes through byte-for-byte.
+// 🔴 IT IS THE ONE GATE, AND WHAT IT REMOVES IS DEFINED ONE LAYER DOWN.
+// `internal/saferune` owns the class — every C0 control and DEL except newline
+// and tab, the C1 range (the 8-bit CSI/OSC introducers), all of `unicode.Cf`
+// (zero-width spaces and joiners, the bidi overrides/embeddings/isolates that
+// reverse the DISPLAYED order of a line) and the handful of runes that render
+// as blank while Unicode calls them a letter or a symbol. Read that package's
+// doc comment before changing what is stripped: it states what is deliberately
+// KEPT (combining marks, right-to-left script, private-use, whitespace
+// separators) and the cost the strip knowingly accepts. Do not add a second
+// table here — civitai/cli#393 was two tables that disagreed.
+//
+// Ordinary printable and multibyte UTF-8 text passes through byte-for-byte.
 //
 // Only the HUMAN (table/detail) renderers call this. `--json` output is emitted
 // RAW: control characters are already \uXXXX-escaped in spec-compliant JSON, so a
 // pipe is safe and sanitizing would corrupt machine-readable bytes.
 func safeTerm(s string) string {
-	if !strings.ContainsFunc(s, isStrippedControl) {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, ch := range s {
-		if isStrippedControl(ch) {
-			continue
-		}
-		b.WriteRune(ch)
-	}
-	return b.String()
+	return saferune.Strip(s)
 }
 
 // indentContinuation prefixes every line of s AFTER the first with pad, so a
@@ -93,10 +95,11 @@ func indentContinuation(s, pad string) string {
 // and nothing here can prevent it. The residual is stated in the README too.
 //
 // A second, narrower case of the same gap: the budget counts RUNES, and a rune
-// is not a display cell. 38 East Asian wide runes occupy 76 columns, so a line
-// this function considers 38 wide is 76 wide on screen. Fixing that needs a
-// character-width table (a new dependency, or a hand-rolled one) and is filed
-// separately rather than smuggled in here.
+// is not a display cell. Measured at listReasonWrapWidth: 75 CJK runes occupy
+// 150 columns, so a line this function considers inside a 75-wide budget is
+// twice that on screen. Fixing it needs a character-width table (a new direct
+// dependency, or a hand-rolled one) and is civitai/cli#397 — filed separately
+// rather than smuggled in here.
 //
 // It reuses wrapTokens (validate_print.go), the CLI's one greedy line filler, so
 // the wrapped surfaces cannot disagree about how a line is broken.
@@ -133,10 +136,19 @@ func wrapServerText(s string, width int) string {
 // "silently overflowing into a column an attacker can forge a row in, versus a
 // visibly broken token". Demonstrated, not hypothesised: a single token of
 // U+2800 BRAILLE PATTERN BLANK padding around row-shaped text renders as a
-// spaced table row, is ONE token to strings.Fields, is above U+009F so safeTerm
-// keeps it, and passes the server's own `isLikelySafeMessage` (under 300 chars,
-// single line, matches no unsafe pattern) — so it arrives verbatim, produced a
-// 266-rune emitted line, and the terminal placed its tail at column zero.
+// spaced table row, is ONE token to strings.Fields, and passes the server's own
+// `isLikelySafeMessage` (under 300 chars, single line, matches no unsafe
+// pattern) — so it arrived verbatim, produced a 266-rune emitted line, and the
+// terminal placed its tail at column zero.
+//
+// 🔴 THAT PARTICULAR PAYLOAD NO LONGER REACHES HERE, AND THIS IS STILL LOAD
+// BEARING. civitai/cli#393 added U+2800 (and every other invisible rune) to
+// what safeTerm strips, so the demonstration above now arrives as
+// `wf_forgedsucceeded` — one visibly-joined token, not a row. What it
+// demonstrated is unchanged: an over-long single token, which a 200-character
+// URL, an id or an unspaced foreign-script sentence produces without any
+// invisible rune at all. Deleting this because its original fixture was closed
+// upstream would reopen the overflow for every one of those.
 //
 // It is applied HERE and not in wrapTokens on purpose. wrapTokens is shared with
 // printFinding, where findingTokens deliberately keeps a quoted span whole so
@@ -161,15 +173,7 @@ func hardSplitOverlong(tokens []string, width int) []string {
 	return out
 }
 
-// isStrippedControl reports whether r is a terminal control character safeTerm
-// removes: any C0 control or DEL (other than newline and tab), or any C1 control
-// (U+0080–U+009F).
-func isStrippedControl(r rune) bool {
-	if r == '\n' || r == '\t' {
-		return false
-	}
-	if r < 0x20 || r == 0x7f {
-		return true
-	}
-	return r >= 0x80 && r <= 0x9f
-}
+// (isStrippedControl lived here. It WAS safeTerm's table; it is now
+// saferune.Stripped, so that internal/genapi can ask the same question and get
+// the same answer — civitai/cli#393 was two spellings of one rule that
+// disagreed.)

--- a/internal/cmd/safeterm.go
+++ b/internal/cmd/safeterm.go
@@ -18,16 +18,21 @@ import (
 // verified" line or hide a warning, an OSC-52 clipboard-set (\x1b]52;c;...\x07),
 // or a window-title spoof.
 //
-// 🔴 IT IS THE ONE GATE, AND WHAT IT REMOVES IS DEFINED ONE LAYER DOWN.
-// `internal/saferune` owns the class — every C0 control and DEL except newline
-// and tab, the C1 range (the 8-bit CSI/OSC introducers), all of `unicode.Cf`
-// (zero-width spaces and joiners, the bidi overrides/embeddings/isolates that
-// reverse the DISPLAYED order of a line) and the handful of runes that render
-// as blank while Unicode calls them a letter or a symbol. Read that package's
-// doc comment before changing what is stripped: it states what is deliberately
-// KEPT (combining marks, right-to-left script, private-use, whitespace
-// separators) and the cost the strip knowingly accepts. Do not add a second
-// table here — civitai/cli#393 was two tables that disagreed.
+// 🔴 IT IS THE ONE GATE, AND WHAT IT REMOVES IS DEFINED ONE LAYER DOWN — READ
+// IT THERE, NOT HERE. `internal/saferune` owns the class: `Cc` (every C0
+// control and DEL except newline and tab, plus the C1 range — the 8-bit CSI/OSC
+// introducers), Unicode's `Default_Ignorable_Code_Point` property, one
+// documented exception, and two runes the property cannot reach.
+//
+// This paragraph deliberately does NOT restate the membership rule, and the
+// version that did is why: it said "all of `unicode.Cf` … and the handful of
+// runes that render as blank", was written when the class WAS `Cf`, and stayed
+// behind when the class moved to the property — so it ended up false in both
+// directions (32 `Cf` runes are kept; most of what is stripped is not `Cf`)
+// while its own last sentence forbade keeping a second table. A summary of a
+// rule is a copy of it. The rule, the derivation, what is deliberately KEPT and
+// what the strip costs are all in saferune's package doc; read that before
+// changing anything about what is stripped, and add nothing here.
 //
 // Ordinary printable and multibyte UTF-8 text passes through byte-for-byte.
 //

--- a/internal/cmd/safeterm_invisible_test.go
+++ b/internal/cmd/safeterm_invisible_test.go
@@ -47,7 +47,7 @@ func invisibleOrBidiRunes(s string) []string {
 const (
 	zwspReason = "FIXTURE alpha\u200b\u200b\u200bbeta"
 	rloReason  = "FIXTURE gamma\u202edelta\u202c"
-	blankOnly  = "\u200b⠀\u202e"
+	blankOnly  = "\u200b\u2800\u202e"
 )
 
 // wfWithReason builds a terminal-status workflow whose single step carries the
@@ -62,13 +62,20 @@ const (
 // battery. Only a payload whose bytes really are invisible can tell "not
 // filtered" from "nothing there to filter".
 //
-// Nothing in the fixtures needs escaping: none of them contains a quote or a
-// backslash, and an invisible rune is ordinary JSON string content.
+// `encoding/json` is what does the quoting, and it is the right tool for
+// exactly this reason: it escapes only what JSON cannot carry literally — the
+// C0 controls, a quote, a backslash — and leaves every rune in the invisible
+// class as RAW BYTES, which is the property the guard needs. `%q` would have
+// escaped those too, which is the trap above.
 func wfWithReason(reason string) string {
+	q, err := json.Marshal(reason)
+	if err != nil {
+		panic(err)
+	}
 	return `{"id":"wf_123","status":"failed","createdAt":"2026-08-05T12:00:00Z","steps":[
 	  {"$type":"imageGen","name":"$0","status":"failed","metadata":{},
 	   "output":{"images":[{"id":"out_1","type":"image","available":false}],
-	   "errors":["` + reason + `"]}}]}`
+	   "errors":[` + string(q) + `]}}]}`
 }
 
 // --- the gate itself ----------------------------------------------------------
@@ -82,7 +89,7 @@ func TestSafeTerm_StripsTheInvisibleAndBidiClass(t *testing.T) {
 		{"byte order mark", "a\ufeffb", "ab"},
 		{"right-to-left override", "a\u202eb", "ab"},
 		{"left-to-right isolate", "a\u2066b\u2069", "ab"},
-		{"braille pattern blank", "a⠀b", "ab"},
+		{"braille pattern blank", "a\u2800b", "ab"},
 		{"hangul filler", "a\u3164b", "ab"},
 		{"still keeps C0 behaviour", "a\x1b[2Kb", "a[2Kb"},
 		{"still keeps newline and tab", "a\tb\nc", "a\tb\nc"},

--- a/internal/cmd/safeterm_invisible_test.go
+++ b/internal/cmd/safeterm_invisible_test.go
@@ -1,0 +1,346 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/civitai/cli/internal/genapi"
+)
+
+// civitai/cli#393 — THE INVISIBLE AND BIDI CLASS, ASSERTED WHERE A USER WOULD
+// SEE IT.
+//
+// internal/saferune's tests pin the CLASS against a full-Unicode sweep. These
+// pin that the class actually reaches the SCREEN — that safeTerm still gates
+// every human surface, that `--json` still does not go through it, and that a
+// reason which renders as nothing no longer prints an empty parenthetical.
+// "Verified in isolation" is the vacuous green this repo keeps rediscovering:
+// saferune could be perfect and a surface could have stopped calling it.
+//
+// 🔴 THE PREDICATE BELOW IS DELIBERATELY NOT saferune.Stripped. A guard that
+// asks the implementation what it strips is satisfied by an implementation that
+// strips nothing. `unicode.Cf` is the standard library's own answer, and U+2800
+// is the measured counterexample from #382, so this is an independently-built
+// check that can disagree with the code under test.
+func invisibleOrBidiRunes(s string) []string {
+	var out []string
+	for _, r := range s {
+		if unicode.Is(unicode.Cf, r) || r == 0x2800 {
+			out = append(out, fmt.Sprintf("U+%04X", r))
+		}
+	}
+	return out
+}
+
+// The fixtures. Each names a different half of the hazard so a failure message
+// says which one arrived:
+//
+//   - zwspReason is INVISIBLE: U+200B is not unicode.IsSpace, so strings.Fields
+//     sees one token and the padding reads as column alignment it is not.
+//   - rloReason REORDERS: U+202E makes the terminal display the rest of the
+//     line right-to-left, so what the user reads is not what the bytes say.
+const (
+	zwspReason = "FIXTURE alpha\u200b\u200b\u200bbeta"
+	rloReason  = "FIXTURE gamma\u202edelta\u202c"
+	blankOnly  = "\u200b⠀\u202e"
+)
+
+// wfWithReason builds a terminal-status workflow whose single step carries the
+// reason as RAW UTF-8 bytes.
+//
+// 🔴 RAW, NOT `%q`, AND THAT IS THE DIFFERENCE BETWEEN A GUARD AND A DECORATION.
+// The first version wrote the reason with `%q`, which spells every invisible
+// rune as a JSON \uXXXX escape — seven ASCII bytes. `encoding/json` decodes
+// them to the same runes, so every human-surface assertion passed either way…
+// and the `--json` guard became VACUOUS: a mutant routing the raw payload
+// through safeTerm found no invisible byte to remove and survived the whole
+// battery. Only a payload whose bytes really are invisible can tell "not
+// filtered" from "nothing there to filter".
+//
+// Nothing in the fixtures needs escaping: none of them contains a quote or a
+// backslash, and an invisible rune is ordinary JSON string content.
+func wfWithReason(reason string) string {
+	return `{"id":"wf_123","status":"failed","createdAt":"2026-08-05T12:00:00Z","steps":[
+	  {"$type":"imageGen","name":"$0","status":"failed","metadata":{},
+	   "output":{"images":[{"id":"out_1","type":"image","available":false}],
+	   "errors":["` + reason + `"]}}]}`
+}
+
+// --- the gate itself ----------------------------------------------------------
+
+func TestSafeTerm_StripsTheInvisibleAndBidiClass(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"zero width space", "a\u200bb", "ab"},
+		{"zero width joiner", "a\u200db", "ab"},
+		{"word joiner", "a\u2060b", "ab"},
+		{"soft hyphen", "a\u00adb", "ab"},
+		{"byte order mark", "a\ufeffb", "ab"},
+		{"right-to-left override", "a\u202eb", "ab"},
+		{"left-to-right isolate", "a\u2066b\u2069", "ab"},
+		{"braille pattern blank", "a⠀b", "ab"},
+		{"hangul filler", "a\u3164b", "ab"},
+		{"still keeps C0 behaviour", "a\x1b[2Kb", "a[2Kb"},
+		{"still keeps newline and tab", "a\tb\nc", "a\tb\nc"},
+		{"leaves right-to-left SCRIPT alone", "שלום", "שלום"},
+		{"leaves CJK and emoji alone", "日本語 🚀", "日本語 🚀"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeTerm(tc.in); got != tc.want {
+				t.Errorf("safeTerm(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- every surface that prints server free text -------------------------------
+
+// 🔴 FOUR SURFACES, BECAUSE A GUARD ON ONE OF THEM IS A GUARD ON ONE OF THEM.
+// #367's first round mutation-tested a single site and two others survived
+// dropping safeTerm entirely. Each case here drives a different renderer, and
+// each carries a positive control so a green cannot come from nothing being
+// printed.
+func TestServerTextSurfaces_EmitNoInvisibleOrBidiRune(t *testing.T) {
+	for _, reason := range []string{zwspReason, rloReason} {
+		t.Run("workflows get reason block", func(t *testing.T) {
+			c, out, _ := genCmd("")
+			if err := runWorkflowsGet(c, wfGetDeps(wfWithReason(reason), nil),
+				workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+				t.Fatalf("workflows get: %v", err)
+			}
+			assertNoInvisibleRunes(t, "the `workflows get` reason block", out.String())
+		})
+
+		t.Run("excluded-output line", func(t *testing.T) {
+			var b bytes.Buffer
+			reportExcludedOutputs(&b, []genapi.Output{
+				{Blob: genapi.Blob{ID: "out_1"}, StepErrors: []string{reason}},
+			}, false, nil)
+			assertNoInvisibleRunes(t, "the excluded-output line", b.String())
+		})
+
+		t.Run("workflows list reason lines", func(t *testing.T) {
+			stdout, _ := renderList(t, listPage(listRow("wf_bad", "failed",
+				`["`+reason+`"]`)))
+			assertNoInvisibleRunes(t, "`workflows list` stdout", stdout)
+		})
+
+		t.Run("the generate dead-end error", func(t *testing.T) {
+			msg := runToTerminal(t, wfWithReason(reason)).Error()
+			assertNoInvisibleRunes(t, "the `generate` error", msg)
+		})
+	}
+}
+
+// assertNoInvisibleRunes is the paired predicate: the class is gone AND the
+// words arrived, so a green cannot come from the whole string being dropped.
+func assertNoInvisibleRunes(t *testing.T, surface, got string) {
+	t.Helper()
+	if bad := invisibleOrBidiRunes(got); len(bad) > 0 {
+		t.Errorf("%s put %s on the terminal. An invisible rune is a separator no wrapper splits on; a bidi "+
+			"control changes the order the line is DISPLAYED in — what the user reads is then not what the "+
+			"bytes say (civitai/cli#393):\n%q", surface, strings.Join(bad, ", "), got)
+	}
+	for _, want := range []string{"FIXTURE"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("CONTROL failure, not a finding: %s never rendered the reason, so the check above is "+
+				"vacuous: %q", surface, got)
+		}
+	}
+}
+
+// --- `--json` is a raw passthrough and must NOT be filtered --------------------
+
+// 🔴 THE PAIR, NOT THE ABSENCE. Asserting only that the human path strips the
+// runes says nothing about `--json`; asserting only that `--json` keeps them
+// says nothing about the human path. Both branches run over ONE payload, so the
+// test cannot be satisfied by a build in which neither branch does anything.
+//
+// internal/ui/CONVENTION.md rule 1: machine-readable output emits zero styling
+// and is not sanitised — control characters are already \uXXXX-escaped by
+// spec-compliant JSON, and filtering would corrupt bytes a script is parsing.
+//
+// 🔴 THE ASSERTION IS ON THE DECODED VALUE, NOT ON THE BYTES, AND THAT IS THE
+// ONLY HONEST SPELLING. A JSON \u200b escape and a raw U+200B are the SAME JSON
+// string, so `strings.ContainsRune` over the emitted bytes answers a question
+// about which spelling the SERVER chose, not about what the CLI passed on — the
+// first version of this test failed for exactly that reason. What a script sees
+// is the decoded value, so that is what is checked, and the whole payload is
+// compared field-by-field below.
+func TestWorkflowsGetJSON_KeepsWhatTheHumanPathStrips(t *testing.T) {
+	payload := wfWithReason(zwspReason + rloReason)
+
+	c, jsonOut, _ := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(payload, nil), workflowsGetOpts{jsonOut: true}, "wf_123"); err != nil {
+		t.Fatalf("workflows get --json: %v", err)
+	}
+	got := jsonOut.String()
+	if !strings.Contains(got, "FIXTURE alpha") {
+		t.Fatalf("CONTROL failure, not a finding: `--json` emitted no payload at all:\n%s", got)
+	}
+	// `workflows get --json` is a raw passthrough of the server's PAYLOAD — it
+	// re-indents, so the claim is semantic and not byte-for-byte: every field,
+	// including ones the CLI does not model, decodes to exactly what arrived.
+	var gotDoc, wantDoc any
+	if err := json.Unmarshal([]byte(got), &gotDoc); err != nil {
+		t.Fatalf("CONTROL failure, not a finding: `--json` emitted invalid JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(payload), &wantDoc); err != nil {
+		t.Fatalf("fixture is not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotDoc, wantDoc) {
+		t.Errorf("`workflows get --json` altered the server payload:\n got: %s\nwant: %s", got, payload)
+	}
+	assertJSONReasonKeepsTheClass(t, "workflows get --json", got)
+
+	// The other half of the pair, same payload through the human renderer.
+	c2, human, _ := genCmd("")
+	if err := runWorkflowsGet(c2, wfGetDeps(payload, nil),
+		workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	assertNoInvisibleRunes(t, "the `workflows get` reason block", human.String())
+}
+
+// The same pair for `workflows list`, whose `--json` path is a different
+// function reading a different wire shape (and which re-marshals, so only the
+// decoded value is a contract there).
+func TestWorkflowsListJSON_KeepsWhatTheHumanPathStrips(t *testing.T) {
+	payload := listPage(listRow("wf_bad", "failed", `["`+zwspReason+`"]`))
+
+	c, out, _ := genCmd("")
+	if err := runWorkflowsList(c, wfListDeps(payload, nil, nil, nil), workflowsListOpts{jsonOut: true}); err != nil {
+		t.Fatalf("workflows list --json: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "FIXTURE alpha") {
+		t.Fatalf("CONTROL failure, not a finding: `--json` emitted no payload at all:\n%s", got)
+	}
+	assertJSONReasonKeepsTheClass(t, "workflows list --json", got)
+
+	human, _ := renderList(t, payload)
+	assertNoInvisibleRunes(t, "`workflows list` stdout", human)
+}
+
+// assertJSONReasonKeepsTheClass decodes the emitted JSON and asserts every
+// reason string still carries the runes the human path removes. It walks the
+// decoded tree rather than naming a path, so it works for both wire shapes.
+func assertJSONReasonKeepsTheClass(t *testing.T, surface, emitted string) {
+	t.Helper()
+	var doc any
+	if err := json.Unmarshal([]byte(emitted), &doc); err != nil {
+		t.Fatalf("CONTROL failure, not a finding: %s emitted invalid JSON (%v):\n%s", surface, err, emitted)
+	}
+	var found []string
+	var walk func(any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case string:
+			if strings.Contains(t, "FIXTURE") {
+				found = append(found, t)
+			}
+		case []any:
+			for _, e := range t {
+				walk(e)
+			}
+		case map[string]any:
+			for _, e := range t {
+				walk(e)
+			}
+		}
+	}
+	walk(doc)
+	if len(found) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: %s carried no reason string at all, so the checks below are "+
+			"vacuous:\n%s", surface, emitted)
+	}
+	for _, s := range found {
+		if !strings.ContainsRune(s, 0x200b) {
+			t.Errorf("%s: the decoded reason lost U+200B. `--json` is a raw passthrough — a script must see "+
+				"what the server sent, and sanitising it would corrupt machine-readable output "+
+				"(internal/ui/CONVENTION.md rule 1): %q", surface, s)
+		}
+	}
+}
+
+// --- the empty parenthetical (the internal/genapi half) -----------------------
+
+// 🔴 END-TO-END FOR THE OTHER HALF OF #393. `hasPrintableContent` used
+// unicode.IsControl, which is Cc-only, so a reason made entirely of invisible
+// runes counted as CONTENT: the heading printed with nothing under it, and on
+// the excluded-output line it displaced the categorical fallback with
+// `(the server reported: )`.
+//
+// Both directions are asserted. The positive control is a reason that differs
+// from the fixture by ONE visible rune — without it, "no heading" is equally
+// satisfied by a renderer that has stopped printing reasons at all.
+func TestWorkflowsGet_AReasonThatRendersAsNothingIsNotAReason(t *testing.T) {
+	c, out, _ := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfWithReason(blankOnly), nil),
+		workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "wf_123") {
+		t.Fatalf("CONTROL failure, not a finding: the workflow did not render at all:\n%s", got)
+	}
+	if strings.Contains(got, "The server reported:") {
+		t.Errorf("a reason made only of invisible runes printed a heading with nothing under it:\n%q", got)
+	}
+
+	// POSITIVE CONTROL: one visible rune more, and the heading is back.
+	c2, out2, _ := genCmd("")
+	if err := runWorkflowsGet(c2, wfGetDeps(wfWithReason(blankOnly+"x"), nil),
+		workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	if !strings.Contains(out2.String(), "The server reported:") {
+		t.Errorf("CONTROL failure, not a finding: a reason carrying a visible rune printed no heading either, "+
+			"so the absence above is not about emptiness:\n%q", out2.String())
+	}
+}
+
+// The same rule on the excluded-output line, where the empty parenthetical
+// DISPLACED a sentence that said more.
+//
+// 🔴 IT IS DRIVEN THROUGH THE PAYLOAD, NOT BY HAND-SETTING StepErrors. The drop
+// happens in genapi.dedupeReasons, so an Output built directly in a test with
+// `StepErrors: []string{blankOnly}` is a state the wire cannot produce — and a
+// direct call therefore tests the renderer against an impossible input and
+// fails for a reason nobody has. This goes through the command, which is where
+// the seam between the two packages actually is.
+func TestWorkflowsGet_AnInvisibleReasonFallsBackToTheCategoricalSentence(t *testing.T) {
+	c, _, errb := genCmd("")
+	if err := runWorkflowsGet(c, wfGetDeps(wfWithReason(blankOnly), nil),
+		workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	got := errb.String()
+	if !strings.Contains(got, "out_1") {
+		t.Fatalf("CONTROL failure, not a finding: the excluded output did not render:\n%s", got)
+	}
+	if strings.Contains(got, "reported: )") {
+		t.Errorf("an all-invisible reason produced an empty parenthetical, which says strictly less than the "+
+			"categorical sentence it displaced:\n%q", got)
+	}
+	if !strings.Contains(got, "the job finished without producing a usable file") {
+		t.Errorf("the categorical fallback did not take over from the empty reason:\n%q", got)
+	}
+
+	// POSITIVE CONTROL: the same fixture plus one visible rune still reports the
+	// server's account, so the fallback above is about emptiness and not about
+	// reasons having stopped reaching this line.
+	c2, _, errb2 := genCmd("")
+	if err := runWorkflowsGet(c2, wfGetDeps(wfWithReason(blankOnly+"FIXTURE x"), nil),
+		workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+		t.Fatalf("workflows get: %v", err)
+	}
+	if !strings.Contains(errb2.String(), "FIXTURE x") {
+		t.Errorf("CONTROL failure, not a finding: a reason with a visible rune did not reach the "+
+			"excluded-output line either:\n%q", errb2.String())
+	}
+}

--- a/internal/cmd/safeterm_userinput_test.go
+++ b/internal/cmd/safeterm_userinput_test.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// civitai/cli#393 — THE CLI DOES NOT SANITISE WHAT THE USER TYPED, AND THE
+// APPROVAL SCREEN IS WHY.
+//
+// The first cut of #393 applied safeTerm to `o.prompt`. Measured live through
+// the real interactive `confirmGenerate`: a typed Persian prompt `می\u200cروم روی
+// اسب` — held apart by a ZWNJ — rendered as `میروم روی اسب`, joined, while the
+// graph on the wire carried the original. So the last screen before an
+// irreversible spend stopped showing what would be sent, on the CLI's only
+// money path. `printGenerateQuote`'s own comment already said that screen
+// "DOES echo the real prompt and must keep doing so".
+//
+// Two guards, because neither alone is enough:
+//
+//  1. TestSafeTermIsNeverAppliedToUserTypedInput is STRUCTURAL — it reads this
+//     package's own source and fails if any call site routes a user-typed
+//     option field through safeTerm again. It cannot see whether the value is
+//     actually printed.
+//  2. TestSameBytesTypedAndReceived_AreEchoedAndStripped is BEHAVIOURAL — it
+//     drives the real approval screen and the real server-text renderer with
+//     the SAME bytes and asserts the two opposite outcomes. It cannot see a new
+//     call site that is never exercised.
+
+// userTypedArgs are the argument expressions that unambiguously hold what the
+// user typed on the command line. Bare identifiers (`id`, `workflowID`) are
+// deliberately NOT listed: the same name holds a server-returned id at other
+// call sites, so a name-based rule there would report the wrong answer with
+// confidence. Those sites are covered by review and by the behavioural test.
+var userTypedArgs = map[string]string{
+	"o.prompt":          "the typed prompt — the screen must show what will be SENT",
+	"o.negativePrompt":  "the typed negative prompt, same reason",
+	"o.aspectRatio":     "a typed flag value",
+	"o.ecosystem":       "a typed flag value",
+	"o.images[i]":       "the path the user typed, printed so they can match it to the blob",
+	"built.inputPath":   "the path the user typed to --input",
+	"o.inputPath":       "the same value before it is resolved",
+	"o.checkpoint":      "a typed flag value",
+	"o.negativePrompts": "reserved: any future typed field",
+}
+
+// minSafeTermCallsScanned is the POSITIVE CONTROL. A parser that has stopped
+// finding calls — a moved package, a renamed helper, the wrong directory —
+// scans nothing, finds no violation and reports a serene pass. There are 150
+// calls today.
+const minSafeTermCallsScanned = 100
+
+func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
+	// parser.ParseFile over an explicit file list rather than parser.ParseDir,
+	// which Go 1.25 deprecated. The list is the package's own non-test sources;
+	// a read that returns none of them trips the control below.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	scanned, files := 0, 0
+	var bad []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, perr)
+		}
+		files++
+		ast.Inspect(file, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			id, ok := ce.Fun.(*ast.Ident)
+			if !ok || id.Name != "safeTerm" || len(ce.Args) != 1 {
+				return true
+			}
+			scanned++
+			arg := renderExpr(ce.Args[0])
+			if why, forbidden := userTypedArgs[arg]; forbidden {
+				bad = append(bad, fmt.Sprintf("%s: safeTerm(%s) — %s", fset.Position(ce.Lparen), arg, why))
+			}
+			return true
+		})
+	}
+	if files < 20 {
+		t.Fatalf("CONTROL failure, not a finding: only %d source file(s) parsed in this package", files)
+	}
+
+	if scanned < minSafeTermCallsScanned {
+		t.Fatalf("CONTROL failure, not a finding: only %d safeTerm call(s) found, want >= %d. The scan is "+
+			"broken, and a clean result from it means nothing.", scanned, minSafeTermCallsScanned)
+	}
+	if len(bad) > 0 {
+		t.Errorf("%d call site(s) sanitise input the USER typed:\n  %s\n\n"+
+			"safeTerm is for SERVER-supplied text. Rewriting the user's own bytes makes the pre-spend approval "+
+			"screen stop describing the job it is approving — civitai/cli#393. See internal/saferune's package doc.",
+			len(bad), strings.Join(bad, "\n  "))
+	}
+	t.Logf("scanned %d safeTerm call site(s); %d forbidden argument shapes are pinned", scanned, len(userTypedArgs))
+}
+
+// renderExpr prints the small set of expression shapes safeTerm arguments take.
+// Anything else renders as a form that cannot collide with a pinned name, so an
+// unrecognised shape is never silently treated as safe-by-default.
+func renderExpr(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return renderExpr(v.X) + "." + v.Sel.Name
+	case *ast.IndexExpr:
+		return renderExpr(v.X) + "[" + renderExpr(v.Index) + "]"
+	case *ast.StarExpr:
+		return "*" + renderExpr(v.X)
+	case *ast.CallExpr:
+		var args []string
+		for _, a := range v.Args {
+			args = append(args, renderExpr(a))
+		}
+		return renderExpr(v.Fun) + "(" + strings.Join(args, ", ") + ")"
+	default:
+		return "<expr>"
+	}
+}
+
+// 🔴 THE SAME BYTES, TWO ORIGINS, TWO OPPOSITE OUTCOMES — WHICH IS THE WHOLE
+// RULE IN ONE ASSERTION. Typed by the user, the string is echoed exactly.
+// Received from the server, the same string loses the class. A test that only
+// checked one direction is satisfiable by a build that sanitises everything
+// (the bug) or nothing (the other bug).
+//
+// The corpus spans the class rather than listing the three runes from the
+// issue: a C0 escape, the zero-width and bidi Cf runes, the blank-but-graphic
+// residue, the `Mn` rune the category cut missed, a non-emoji variation
+// selector, and — as the control on the class itself — the emoji presentation
+// selector and a must-be-drawn mark, which survive BOTH paths.
+func TestSameBytesTypedAndReceived_AreEchoedAndStripped(t *testing.T) {
+	for _, probe := range []struct {
+		name    string
+		rune_   string
+		survive bool // true when the rune is not in the class at all
+	}{
+		// One rune per probe, so "stripped to the surrounding words" is the same
+		// assertion for every row.
+		{"C0 escape", "\x1b", false},
+		{"zero width space", "\u200b", false},
+		{"right-to-left override", "\u202e", false},
+		{"braille pattern blank", "\u2800", false},
+		{"combining grapheme joiner", "͏", false},
+		{"zero width non-joiner", "\u200c", false},
+		{"text presentation selector", "︎", false},
+		{"emoji presentation selector", "️", true},
+		{"arabic end of ayah", "\u06dd", true},
+		{"ordinary CJK", "日", true},
+	} {
+		t.Run(probe.name, func(t *testing.T) {
+			typed := "FIXTURE alpha" + probe.rune_ + "beta"
+
+			// --- typed by the user: echoed byte-for-byte ---------------------
+			withStdinTTY(t, true)
+			c, _, errb := genCmd("n\n")
+			o := generateOpts{prompt: typed}
+			if err := confirmGenerate(c, o, &resolvedGraph{}, 100, 1000, true); err == nil {
+				t.Fatal("CONTROL failure, not a finding: answering 'n' did not refuse, so this is not the " +
+					"interactive approval screen")
+			}
+			screen := errb.String()
+			if !strings.Contains(screen, "Generate? [y/N]") {
+				t.Fatalf("CONTROL failure, not a finding: the approval screen did not render:\n%q", screen)
+			}
+			if !strings.Contains(screen, typed) {
+				t.Errorf("the approval screen did not echo the typed prompt byte-for-byte.\n want: %q\n"+
+					" got:  %q\n\nThis screen is the last thing shown before an irreversible spend, so it has "+
+					"to show what will actually be sent (civitai/cli#393).", typed, screen)
+			}
+
+			// --- received from the server: the class is removed ---------------
+			c2, out, _ := genCmd("")
+			if err := runWorkflowsGet(c2, wfGetDeps(wfWithReason(typed), nil),
+				workflowsGetOpts{baseURL: "https://civitai.com"}, "wf_123"); err != nil {
+				t.Fatalf("workflows get: %v", err)
+			}
+			rendered := out.String()
+			if !strings.Contains(rendered, "FIXTURE alpha") {
+				t.Fatalf("CONTROL failure, not a finding: the reason never rendered:\n%q", rendered)
+			}
+			switch {
+			case probe.survive:
+				if !strings.Contains(rendered, typed) {
+					t.Errorf("the server reason lost %s, which is NOT in the class — it must survive both "+
+						"paths:\n %q", probe.name, rendered)
+				}
+			default:
+				if strings.Contains(rendered, typed) {
+					t.Errorf("the server reason kept %s. Typed by the user it is echoed; sent by the server it "+
+						"must be removed — that asymmetry is the rule:\n %q", probe.name, rendered)
+				}
+				if !strings.Contains(rendered, "FIXTURE alphabeta") {
+					t.Errorf("the server reason was not stripped to the surrounding words:\n %q", rendered)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/safeterm_userinput_test.go
+++ b/internal/cmd/safeterm_userinput_test.go
@@ -49,6 +49,40 @@ var userTypedArgs = map[string]string{
 	"o.negativePrompts": "reserved: any future typed field",
 }
 
+// 🔴 bareIdentArgs IS THE OTHER HALF OF THE GUARD, AND IT EXISTS BECAUSE THE
+// FIRST HALF WAS BLIND TO A NAMING CONVENTION.
+//
+// userTypedArgs above pins argument SHAPES (`o.prompt`, `built.inputPath`). A
+// delta audit found that `safeTerm(target)` in `download.go` carries the user's
+// own `--out` path — `targetPath` returns `o.out` verbatim — and no assertion
+// could see it, because the argument is spelled as a bare local. A guard that
+// only understands one naming convention is the reason that survived.
+//
+// So every bare-identifier argument must be classified HERE. The ledger does
+// not decide whether sanitising is right; it makes the decision impossible to
+// skip. A new bare identifier fails this test until someone writes down where
+// its bytes come from, which is the thinking that was missing for `target`.
+//
+// It fails in both directions: an unclassified name (the set grew) and a
+// classified name that no longer appears (the set shrank, so the note is stale
+// and the next reader would trust it).
+var bareIdentArgs = map[string]string{
+	"workflowID": "SERVER: the id from the submit reply / poll, not the one the user typed",
+	"target":     "MIXED: --out verbatim, else filepath.Base(SERVER file name). Sanitised for the server half — see targetPath",
+	"w":          "SERVER-derived: a download warning, or an image-metadata weight",
+	"status":     "SERVER: a workflow status string",
+	"r":          "SERVER: an orchestrator failure reason",
+	"note":       "SERVER-derived: a routing note built from the server's file name",
+	"k":          "SERVER cost-map key, and (generate_input.go) a key out of the user's own --input file",
+	"workflow":   "the workflow value out of the user's --input FILE — the documented file-content exception",
+	"t":          "SERVER: a trained word",
+	"sha":        "SERVER: a published hash",
+	"reason":     "SERVER: an orchestrator failure reason",
+	"name":       "SERVER: a published file name",
+	"h":          "SERVER: a hash out of image metadata",
+	"baseModel":  "SERVER: a base-model label",
+}
+
 // minSafeTermCallsScanned is the POSITIVE CONTROL. A parser that has stopped
 // finding calls — a moved package, a renamed helper, the wrong directory —
 // scans nothing, finds no violation and reports a serene pass. There are 150
@@ -65,7 +99,8 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 	}
 	fset := token.NewFileSet()
 	scanned, files := 0, 0
-	var bad []string
+	var bad, unclassified []string
+	seenBare := map[string]bool{}
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -90,6 +125,12 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 			if why, forbidden := userTypedArgs[arg]; forbidden {
 				bad = append(bad, fmt.Sprintf("%s: safeTerm(%s) — %s", fset.Position(ce.Lparen), arg, why))
 			}
+			if _, bare := ce.Args[0].(*ast.Ident); bare {
+				if _, known := bareIdentArgs[arg]; !known {
+					unclassified = append(unclassified, fmt.Sprintf("%s: safeTerm(%s)", fset.Position(ce.Lparen), arg))
+				}
+				seenBare[arg] = true
+			}
 			return true
 		})
 	}
@@ -107,7 +148,20 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 			"screen stop describing the job it is approving — civitai/cli#393. See internal/saferune's package doc.",
 			len(bad), strings.Join(bad, "\n  "))
 	}
-	t.Logf("scanned %d safeTerm call site(s); %d forbidden argument shapes are pinned", scanned, len(userTypedArgs))
+	if len(unclassified) > 0 {
+		t.Errorf("%d safeTerm call site(s) pass a bare local whose ORIGIN is not written down:\n  %s\n\n"+
+			"Add it to bareIdentArgs saying where its bytes come from. A bare name hides the answer — "+
+			"`safeTerm(target)` carries the user's own --out path and no guard could see it until this "+
+			"ledger existed.", len(unclassified), strings.Join(unclassified, "\n  "))
+	}
+	for name := range bareIdentArgs {
+		if !seenBare[name] {
+			t.Errorf("bareIdentArgs classifies %q, which is no longer passed to safeTerm anywhere. A stale "+
+				"note reads as coverage; delete it or fix the name.", name)
+		}
+	}
+	t.Logf("scanned %d safeTerm call site(s) across %d file(s); %d forbidden shapes and %d bare-identifier "+
+		"origins are pinned", scanned, files, len(userTypedArgs), len(bareIdentArgs))
 }
 
 // renderExpr prints the small set of expression shapes safeTerm arguments take.

--- a/internal/cmd/workflows_cancel.go
+++ b/internal/cmd/workflows_cancel.go
@@ -142,6 +142,12 @@ must never be what stops you halting a job that is spending your Buzz.`,
 // everything else — including a bare Enter — cancels. Rewriting it to enumerate
 // the refusing answers instead would turn `[y/N]` into `[Y/n]` and destroy a
 // paid-for job on a stray keystroke.
+// 🔴 THE ID IS NOT SANITISED, DELIBERATELY (civitai/cli#393). `workflowID` is
+// the positional argument the USER typed; this prompt exists so they can see
+// that it is the run they meant, which a rewritten id defeats. safeTerm is for
+// SERVER-supplied text — see internal/saferune's package doc for the rule and
+// for the residual it accepts (a hostile id pasted from elsewhere is echoed as
+// typed).
 func confirmCancel(cmd *cobra.Command, workflowID string, assumeYes bool) error {
 	if assumeYes {
 		return nil
@@ -149,12 +155,12 @@ func confirmCancel(cmd *cobra.Command, workflowID string, assumeYes bool) error 
 	if !stdinIsTTY() {
 		return fmt.Errorf("refusing to cancel without --yes in a non-interactive shell — cancelling %s is irreversible: it throws away whatever the run has not produced yet, and you are still billed for what it did produce. "+
 			"Pass --yes to confirm, or `civitai workflows get %s` to see what it has produced first",
-			safeTerm(workflowID), safeTerm(workflowID))
+			workflowID, workflowID)
 	}
 
 	errw := cmd.ErrOrStderr()
 	st := ui.For(errw)
-	fmt.Fprintf(errw, "About to cancel workflow %s.\n", safeTerm(workflowID))
+	fmt.Fprintf(errw, "About to cancel workflow %s.\n", workflowID)
 	fmt.Fprintln(errw, st.Warn("You are billed for what this run has already delivered; the server re-prices the rest."))
 	fmt.Fprintln(errw, st.Dim("What the ledger ends up doing is decided server-side — "+buzzLedgerUnknownNote+"."))
 	fmt.Fprintln(errw, st.Dim("Outputs it has not produced yet are lost. It cannot be un-cancelled."))
@@ -224,7 +230,7 @@ func requireWorkflowExists(ctx context.Context, get getWorkflowFn, id string) er
 		// Not reachable from the command tree — newWorkflowsCancelCmd wires both
 		// seams — but a nil seam that SKIPPED the check would silently restore the
 		// #341 behaviour for whoever forgot to wire it, so it is loud instead.
-		return fmt.Errorf("internal error: `workflows cancel` was built without its read seam, so it cannot tell whether %s exists — refusing to cancel", safeTerm(id))
+		return fmt.Errorf("internal error: `workflows cancel` was built without its read seam, so it cannot tell whether %s exists — refusing to cancel", id)
 	}
 	if _, _, err := get(ctx, id); err != nil {
 		if !errors.Is(err, civitai.ErrNotFound) {
@@ -232,7 +238,7 @@ func requireWorkflowExists(ctx context.Context, get getWorkflowFn, id string) er
 		}
 		return civitai.Tag(civitai.ErrNotFound, fmt.Errorf(
 			"no such workflow %s — nothing was cancelled: the server does not know that id. Check it with `civitai workflows list`",
-			safeTerm(id)))
+			id))
 	}
 	return nil
 }
@@ -304,13 +310,13 @@ func runWorkflowsCancel(cmd *cobra.Command, deps workflowsCancelDeps, o workflow
 		return writeRawJSON(cmd.OutOrStdout(), raw)
 	}
 	out, errw := cmd.OutOrStdout(), cmd.ErrOrStderr()
-	fmt.Fprintf(out, "Cancelled workflow %s\n", safeTerm(id))
+	fmt.Fprintf(out, "Cancelled workflow %s\n", id)
 	// 🔴 Repeated at the point of use, not just in --help: the one place a user
 	// is guaranteed to read is the line printed after the thing happened.
 	fmt.Fprintln(errw, ui.For(errw).Warn(
 		"You are billed for what it already delivered; the server re-prices the rest once the workflow settles."))
 	fmt.Fprintln(errw, ui.For(errw).Dim("What the ledger ends up doing is decided server-side — "+buzzLedgerUnknownNote+"."))
 	fmt.Fprintln(errw, ui.For(errw).Dim(fmt.Sprintf(
-		"Check what it produced before stopping with `civitai workflows get %s`.", safeTerm(id))))
+		"Check what it produced before stopping with `civitai workflows get %s`.", id)))
 	return nil
 }

--- a/internal/genapi/failure_reason_test.go
+++ b/internal/genapi/failure_reason_test.go
@@ -6,7 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"unicode"
+
+	"github.com/civitai/cli/internal/saferune"
 )
 
 // civitai/cli#367 — THE ORCHESTRATOR RECORDS WHY A STEP FAILED AND THE CLI
@@ -212,18 +213,54 @@ func TestFailureReasons_AReasonWithNoPrintableContentIsDropped(t *testing.T) {
 	}
 }
 
-// stripControlRunes mirrors what a terminal renderer removes, so a test can
-// assert on what the user actually sees. It is a TEST helper: the production
-// stripper is internal/cmd's safeTerm, and genapi deliberately does not own one.
-func stripControlRunes(s string) string {
-	var b strings.Builder
-	for _, r := range s {
-		if !unicode.IsControl(r) {
-			b.WriteRune(r)
-		}
+// 🔴 THE SAME RULE FOR RUNES `unicode.IsControl` CANNOT SEE — civitai/cli#393.
+// The test above uses NUL and ESC, which are Cc, so it passed both before and
+// after the fix and is structurally blind to the class that motivated it. These
+// three reasons carry no Cc byte at all: a zero-width space, a braille blank
+// and a right-to-left override, each of which renders as nothing (or as a
+// reordering) and each of which the old predicate counted as content.
+//
+// The mixed entry is the positive control and it is deliberately last in the
+// array: a fix that dropped everything, or that stopped at the first entry,
+// fails here rather than passing for the wrong reason.
+func TestFailureReasons_AReasonOfOnlyInvisibleRunesIsDropped(t *testing.T) {
+	payload := `{"id":"wf_1","status":"failed","steps":[{"$type":"imageGen","name":"$0","status":"failed",
+	  "metadata":{},"output":{"images":[{"id":"out_1","available":false}],
+	  "errors":["\u200b\u200b","⠀⠀⠀","\u202e\u202c","\u200bFIXTURE x\u202e"]}}]}`
+	var wf Workflow
+	if err := json.Unmarshal([]byte(payload), &wf); err != nil {
+		t.Fatalf("fixture: %v", err)
 	}
-	return b.String()
+	got := wf.FailureReasons()
+	if len(got) != 1 {
+		t.Fatalf("FailureReasons() = %q, want exactly the one entry that renders as something", got)
+	}
+	if !strings.Contains(got[0], "FIXTURE x") {
+		t.Errorf("the surviving reason is not the one with visible content: %q", got[0])
+	}
+
+	outs := wf.Outputs()
+	if len(outs) != 1 {
+		t.Fatalf("CONTROL failure, not a finding: %d outputs, want 1", len(outs))
+	}
+	rendered := stripControlRunes(ExclusionReason(outs[0]))
+	if strings.Contains(rendered, "reported: )") {
+		t.Errorf("an all-invisible reason produced an empty parenthetical: %q", rendered)
+	}
+	if !strings.Contains(rendered, "reported: FIXTURE x)") {
+		t.Errorf("the surviving reason did not reach the sentence: %q", rendered)
+	}
 }
+
+// stripControlRunes is what a terminal renderer removes, so a test can assert
+// on what the user actually sees.
+//
+// 🔴 IT DELEGATES, AND IT USED TO MIRROR. Its own copy of the rule was
+// `!unicode.IsControl` — which is Cc-only, so this helper's idea of "what the
+// user sees" kept U+200B and the test could not see the empty parenthetical
+// civitai/cli#393 is about. A test helper that re-implements the thing under
+// test is a third table, and it drifted exactly like the second one did.
+func stripControlRunes(s string) string { return saferune.Strip(s) }
 
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {

--- a/internal/genapi/status.go
+++ b/internal/genapi/status.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"unicode"
+
+	"github.com/civitai/cli/internal/saferune"
 )
 
 // GetWorkflowPath is the read-back query for one workflow.
@@ -193,14 +194,18 @@ type Step struct {
 // rune is dropped HERE, where "does this string say anything at all" is a
 // question about content.
 //
-// This is NOT terminal sanitisation and does not duplicate safeTerm's table:
-// safeTerm decides what is safe to WRITE to a terminal and stays in internal/cmd
-// (`--json` never passes through it). This decides whether there is anything to
-// say, which is true of any medium. The two overlap without either owning the
-// other, and unicode.IsControl is the weaker, self-contained test.
+// This is NOT terminal sanitisation: safeTerm decides what is safe to WRITE to
+// a terminal and stays in internal/cmd (`--json` never passes through either of
+// them). This decides whether there is anything to say, which is true of any
+// medium. 🔴 BUT THE TWO MUST AGREE ABOUT WHICH RUNES RENDER AS NOTHING, AND
+// FOR ONE RELEASE THEY DID NOT — that is civitai/cli#393. This side used
+// `unicode.IsControl`, which is Cc-only, so a reason made entirely of U+200B
+// ZERO WIDTH SPACE counted as content, displaced the categorical fallback and
+// rendered as the empty parenthetical above anyway. Both sides now ask
+// `internal/saferune`, which is why it is a package and not a function.
 //
 // 🔴 It is emptiness, never meaning: item 13 forbids judging what a reason SAYS,
-// and nothing here reads the words. A reason with one printable rune survives.
+// and nothing here reads the words. A reason with one visible rune survives.
 func (s Step) failureReasons() []string { return dedupeReasons(s.Output.Errors) }
 
 // dedupeReasons is THE rule for turning a server-supplied `errors` array into
@@ -240,17 +245,15 @@ func dedupeReasons(raw []string) []string {
 	return out
 }
 
-// hasPrintableContent reports whether s contains at least one rune that is not a
-// control character — i.e. whether it would still say something after a renderer
-// has removed the bytes no terminal should receive.
-func hasPrintableContent(s string) bool {
-	for _, r := range s {
-		if !unicode.IsControl(r) {
-			return true
-		}
-	}
-	return false
-}
+// hasPrintableContent reports whether s would still say something once a
+// renderer has removed the runes no terminal should receive — i.e. whether what
+// survives is more than whitespace.
+//
+// It delegates rather than deciding, and the delegation IS the fix for
+// civitai/cli#393: the answer has to be the complement of what safeTerm strips,
+// and any local re-statement of that here is a second table that will drift
+// from the first. See internal/saferune.
+func hasPrintableContent(s string) bool { return saferune.HasVisibleContent(s) }
 
 // FailureReasons returns every server-supplied reason on the workflow, in step
 // order.

--- a/internal/saferune/saferune.go
+++ b/internal/saferune/saferune.go
@@ -1,0 +1,180 @@
+// Package saferune owns the ONE rule this CLI has about which runes a
+// SERVER-SUPPLIED string may put in front of a user, and nothing else.
+//
+// 🔴 IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE TWO PACKAGES ASK THE SAME
+// QUESTION AND MUST NOT ANSWER IT DIFFERENTLY. `internal/cmd`'s safeTerm asks
+// "may this rune reach the terminal"; `internal/genapi`'s hasPrintableContent
+// asks "would this string still say anything once a renderer has removed the
+// runes it removes". The second question is the first one's complement, and
+// before civitai/cli#393 they were answered by two tables that disagreed:
+// safeTerm stripped C0/C1 while hasPrintableContent used unicode.IsControl,
+// which is Cc-only, so a reason made entirely of U+200B counted as content,
+// displaced the categorical fallback, and rendered as `(the server reported: )`
+// — an empty parenthetical. `internal/genapi` cannot import `internal/cmd`
+// (the import runs the other way), so the shared answer lives below them both.
+//
+// # THE CLASS, AND WHY EACH PART OF IT IS IN
+//
+//   - unicode.Cc — every C0 control, DEL and C1, except newline and tab. This
+//     is what safeTerm always removed: the ANSI/OSC introducers a hostile field
+//     uses for terminal OUTPUT FORGERY (cursor-up + line-clear to overwrite the
+//     CLI's own "SHA256 verified" line, an OSC-52 clipboard set, a window-title
+//     spoof). The range test below IS unicode.Cc, exactly and by measurement —
+//     TestCcFastPathIsExactlyTheCategory pins the equivalence.
+//
+//   - unicode.Cf — all 170 format characters. They are what #393 is about, and
+//     Go already agrees they are not text: `unicode.IsPrint` and
+//     `unicode.IsGraphic` are BOTH false for every one of them. Two hazards
+//     live here. INVISIBILITY: U+200B ZERO WIDTH SPACE and friends are not
+//     unicode.IsSpace, so `strings.Fields` does not split on them — text that
+//     looks like several columns to a reader is ONE token to every wrapper in
+//     this CLI, which is how a reason becomes a forged table row. REORDERING:
+//     U+202A–U+202E and U+2066–U+2069 (the bidi embeddings, overrides and
+//     isolates) change the order in which a terminal DISPLAYS a line, so what
+//     the user reads is not what the bytes say. No other guard addressed that.
+//
+//   - blankButGraphic — the residue, six runes that render as nothing while
+//     Unicode classifies them as a letter, a symbol or a mark. No category
+//     captures "has no glyph", and Go ships no Default_Ignorable table, so this
+//     is the one hand-written list in the package. It is not a denylist of
+//     hazards seen in the wild: it is the complete set that a sweep of every
+//     assigned code point flags, cross-checked against the Unicode NAMES in
+//     `golang.org/x/text/unicode/runenames` — see saferune_test.go, which
+//     re-derives it from those names on every run and fails if Unicode grows a
+//     seventh.
+//
+// # WHAT IS DELIBERATELY NOT STRIPPED, AND WHAT THAT COSTS
+//
+//   - Mn/Mc/Me COMBINING MARKS. `é` written as `e` + U+0301 must survive, and
+//     so must VARIATION SELECTOR-16 (U+FE0F, category Mn) — which is why an
+//     emoji keeps its emoji presentation through this filter.
+//
+//   - RIGHT-TO-LEFT SCRIPT. Arabic and Hebrew LETTERS are Lo and are ordinary
+//     content; only the bidi CONTROLS are Cf. Conflating the two would mangle
+//     real text, and a guard that cannot tell them apart is not a guard.
+//
+//   - Zl/Zp (U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR) and Zs. They
+//     are unicode.IsSpace, so `strings.Fields` already splits on them and the
+//     token hazard above cannot arise; stripping them would silently JOIN two
+//     words. Residual, stated rather than rediscovered: a terminal that
+//     implemented U+2028 as a line break would put its tail at column zero,
+//     where indentContinuation cannot see it because there is no `\n`. No
+//     terminal is known to do that, and it has not been measured here.
+//
+//   - Cn (unassigned) and Co (private use). Both are non-graphic to Go, so a
+//     `!unicode.IsGraphic` rule would have swept them up — and that rule was
+//     rejected for it. Cn is "unassigned IN GO'S TABLE", so stripping it
+//     deletes any character newer than the toolchain's Unicode version,
+//     silently, from legitimate text. Co renders as a vendor glyph or tofu:
+//     visible, and neither invisible nor reordering.
+//
+// 🔴 THE ACCEPTED COST, WHICH IS REAL AND IS NOT A BUG REPORT. Stripping the
+// whole of Cf takes U+200D ZERO WIDTH JOINER and U+200C ZERO WIDTH NON-JOINER
+// with it. So a multi-person emoji ZWJ sequence degrades into its components
+// (👨‍👩‍👧 renders as three people, not one family), a subdivision flag degrades to
+// 🏴 (its tag characters are Cf), and — the sharpest one — Persian and Arabic
+// text that uses ZWNJ to keep a prefix from joining renders JOINED. That is a
+// content change to legitimate text, and it is the price of having no
+// carve-outs: every exemption is a rune with exactly the property the class
+// exists to remove (invisible, not a space, so an invisible separator), and a
+// class with a hole in it is a class an attacker aims at. The maintainer chose
+// STRIP over escaping for civitai/cli#393; escaping would keep the bytes at the
+// cost of every surface having to render an escape.
+package saferune
+
+import (
+	"strings"
+	"unicode"
+)
+
+// blankButGraphic is the hand-written residue described above: runes that
+// occupy no visible glyph while Unicode calls them a letter (Lo), a symbol (So)
+// or a mark (Mn), so no category test finds them.
+//
+// U+2800 is the MEASURED counterexample from civitai/cli#382 — a single token of
+// it padded around row-shaped text rendered as a spaced table row, was one token
+// to strings.Fields, was above U+009F so safeTerm kept it, and passed the
+// server's own `isLikelySafeMessage`. The Hangul fillers are the same trick with
+// a different code point (U+3164 is the classic "invisible username"), which is
+// the whole reason this is derived from a property rather than from the three
+// runes the issue happened to name.
+//
+// Keep it sorted; the test that re-derives it from Unicode names reports the
+// difference as a set, not as a diff.
+var blankButGraphic = [...]rune{
+	0x115F,  // HANGUL CHOSEONG FILLER
+	0x1160,  // HANGUL JUNGSEONG FILLER
+	0x2800,  // BRAILLE PATTERN BLANK
+	0x3164,  // HANGUL FILLER
+	0xFFA0,  // HALFWIDTH HANGUL FILLER
+	0x16FE4, // KHITAN SMALL SCRIPT FILLER
+}
+
+// Stripped reports whether r must be removed from server-supplied text before a
+// human renderer prints it.
+//
+// Newline and tab are kept: they are legitimate layout, and the guards against
+// what a server can do WITH them live in internal/cmd (indentContinuation stops
+// a `\n` from starting a line at column zero; wrapServerText stops a long line
+// from being broken by the terminal at column zero). Stripping them here would
+// silently repeal a promise those two make about paragraph structure.
+func Stripped(r rune) bool {
+	if r == '\n' || r == '\t' {
+		return false
+	}
+	// unicode.Cc, spelled as a range test: the whole category is C0, DEL and
+	// C1, so this is an exact restatement and not an approximation of it.
+	if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+		return true
+	}
+	// Everything below U+00A0 that is left is printable ASCII.
+	if r < 0xa0 {
+		return false
+	}
+	for _, b := range blankButGraphic {
+		if r == b {
+			return true
+		}
+	}
+	return unicode.Is(unicode.Cf, r)
+}
+
+// Strip removes every Stripped rune from s. It only ever removes: what survives
+// is a subsequence of the input, in the input's order, byte-for-byte.
+func Strip(s string) string {
+	if !strings.ContainsFunc(s, Stripped) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, ch := range s {
+		if Stripped(ch) {
+			continue
+		}
+		b.WriteRune(ch)
+	}
+	return b.String()
+}
+
+// HasVisibleContent reports whether s would still show a reader anything: at
+// least one rune that survives Strip and is not whitespace.
+//
+// 🔴 IT IS THE COMPLEMENT OF Strip AND MUST STAY THAT WAY. The two are used by
+// different packages for different questions, and the seam between them is
+// where civitai/cli#393 lived: whatever Strip removes, this must not count as
+// content, or a string that renders as nothing is treated as something and
+// displaces a fallback that said more. TestHasVisibleContentAgreesWithStrip
+// pins the relationship over every rune rather than over a fixture.
+//
+// The whitespace clause is the second half of the same idea and is not new
+// behaviour for the caller: `strings.TrimSpace` already emptied an all-space
+// string before this was reached. What it adds is the mixed case — `"⠀ ⠀"`
+// trims to itself, because U+2800 is not a space, and renders as three blanks.
+func HasVisibleContent(s string) bool {
+	for _, r := range s {
+		if !Stripped(r) && !unicode.IsSpace(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/saferune/saferune.go
+++ b/internal/saferune/saferune.go
@@ -1,85 +1,111 @@
 // Package saferune owns the ONE rule this CLI has about which runes a
 // SERVER-SUPPLIED string may put in front of a user, and nothing else.
 //
+// 🔴 SERVER-SUPPLIED. NOT "EVERY STRING THE CLI PRINTS". The CLI does not
+// sanitise what the USER typed — a prompt, a flag value, a path, a workflow id
+// the user passed on the command line is echoed back byte-for-byte, because the
+// screen that precedes an irreversible spend has to show what will actually be
+// sent. The first cut of civitai/cli#393 got this wrong: `safeTerm` was applied
+// to `o.prompt`, so a typed Persian prompt (`می‌روم`, held apart by a ZWNJ)
+// rendered joined on the approval screen while the graph on the wire carried
+// the original. The screen stopped showing the job. Call sites are audited in
+// both directions and pinned by TestApprovalScreenEchoesTypedInput_AndStripsServerText.
+//
 // 🔴 IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE TWO PACKAGES ASK THE SAME
 // QUESTION AND MUST NOT ANSWER IT DIFFERENTLY. `internal/cmd`'s safeTerm asks
 // "may this rune reach the terminal"; `internal/genapi`'s hasPrintableContent
 // asks "would this string still say anything once a renderer has removed the
-// runes it removes". The second question is the first one's complement, and
-// before civitai/cli#393 they were answered by two tables that disagreed:
-// safeTerm stripped C0/C1 while hasPrintableContent used unicode.IsControl,
-// which is Cc-only, so a reason made entirely of U+200B counted as content,
-// displaced the categorical fallback, and rendered as `(the server reported: )`
-// — an empty parenthetical. `internal/genapi` cannot import `internal/cmd`
-// (the import runs the other way), so the shared answer lives below them both.
+// runes it removes". The second is the first one's complement, and before #393
+// they were answered by two tables that disagreed: safeTerm stripped C0/C1
+// while hasPrintableContent used unicode.IsControl, which is Cc-only, so a
+// reason made entirely of U+200B counted as content and rendered as
+// `(the server reported: )` — an empty parenthetical. `internal/genapi` cannot
+// import `internal/cmd` (the import runs the other way), so the shared answer
+// lives below them both.
 //
-// # THE CLASS, AND WHY EACH PART OF IT IS IN
+// # THE CLASS
 //
-//   - unicode.Cc — every C0 control, DEL and C1, except newline and tab. This
-//     is what safeTerm always removed: the ANSI/OSC introducers a hostile field
-//     uses for terminal OUTPUT FORGERY (cursor-up + line-clear to overwrite the
-//     CLI's own "SHA256 verified" line, an OSC-52 clipboard set, a window-title
-//     spoof). The range test below IS unicode.Cc, exactly and by measurement —
-//     TestCcFastPathIsExactlyTheCategory pins the equivalence.
+//	Cc, minus \n and \t
+//	+ Default_Ignorable_Code_Point
+//	- U+FE0F VARIATION SELECTOR-16          (the one deliberate exception)
+//	+ blankButGraphic                       (2 runes the property cannot reach)
 //
-//   - unicode.Cf — all 170 format characters. They are what #393 is about, and
-//     Go already agrees they are not text: `unicode.IsPrint` and
-//     `unicode.IsGraphic` are BOTH false for every one of them. Two hazards
-//     live here. INVISIBILITY: U+200B ZERO WIDTH SPACE and friends are not
-//     unicode.IsSpace, so `strings.Fields` does not split on them — text that
-//     looks like several columns to a reader is ONE token to every wrapper in
-//     this CLI, which is how a reason becomes a forged table row. REORDERING:
-//     U+202A–U+202E and U+2066–U+2069 (the bidi embeddings, overrides and
-//     isolates) change the order in which a terminal DISPLAYS a line, so what
-//     the user reads is not what the bytes say. No other guard addressed that.
+// 🔴 IT IS DRAWN ON A UNICODE PROPERTY, AND THE FIRST CUT DREW IT ON A GENERAL
+// CATEGORY INSTEAD — WRONG IN BOTH DIRECTIONS AT ONCE. That cut used
+// `unicode.Cf`, while the argument for it was written as a property
+// ("invisible, and not a space"). Category and property are not the same set:
 //
-//   - blankButGraphic — the residue, six runes that render as nothing while
-//     Unicode classifies them as a letter, a symbol or a mark. No category
-//     captures "has no glyph", and Go ships no Default_Ignorable table, so this
-//     is the one hand-written list in the package. It is not a denylist of
-//     hazards seen in the wild: it is the complete set that a sweep of every
-//     assigned code point flags, cross-checked against the Unicode NAMES in
-//     `golang.org/x/text/unicode/runenames` — see saferune_test.go, which
-//     re-derives it from those names on every run and fails if Unicode grows a
-//     seventh.
+//   - UNDER-INCLUSIVE, and the #393 symptom still reproduced through the gap.
+//     U+034F COMBINING GRAPHEME JOINER is invisible and is `Mn`, so it was
+//     KEPT: a failure reason of three CGJs rendered a `The server reported:`
+//     heading with an invisible line under it, and `(the server reported: )` on
+//     the excluded-output line — the exact defect #393 exists to close, in a
+//     rune the fix did not cover. The same held for the 260 variation
+//     selectors, U+17B4/17B5 and U+180B–U+180F.
 //
-// # WHAT IS DELIBERATELY NOT STRIPPED, AND WHAT THAT COSTS
+//   - OVER-INCLUSIVE, and it deleted text Unicode requires be RENDERED. All 13
+//     Prepended_Concatenation_Mark runes are `Cf` and all 13 are drawn: U+06DD
+//     ARABIC END OF AYAH is the rosette around a Quranic verse number, U+070F
+//     is the Syriac abbreviation mark. So were the 3 interlinear-annotation
+//     (ruby) marks and the 16 Egyptian hieroglyph quadrat controls — 32 runes
+//     in total, removed from text that needs them.
 //
-//   - Mn/Mc/Me COMBINING MARKS. `é` written as `e` + U+0301 must survive, and
-//     so must VARIATION SELECTOR-16 (U+FE0F, category Mn) — which is why an
-//     emoji keeps its emoji presentation through this filter.
+// Default_Ignorable_Code_Point is the Unicode property that means exactly
+// "invisible; ignore in rendering", and its derivation already makes both
+// corrections: it ADDS Other_Default_Ignorable_Code_Point (which carries
+// U+034F, the Hangul fillers, U+17B4/17B5) and Variation_Selector, and it
+// SUBTRACTS the three sets above. See defaultIgnorable for the derivation,
+// quoted from UAX #44 and re-derived from Go's own tables rather than
+// hand-listed.
 //
-//   - RIGHT-TO-LEFT SCRIPT. Arabic and Hebrew LETTERS are Lo and are ordinary
-//     content; only the bidi CONTROLS are Cf. Conflating the two would mangle
-//     real text, and a guard that cannot tell them apart is not a guard.
+// # THE ONE EXCEPTION, AND WHY IT IS ONE RATHER THAN NONE
 //
-//   - Zl/Zp (U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR) and Zs. They
-//     are unicode.IsSpace, so `strings.Fields` already splits on them and the
-//     token hazard above cannot arise; stripping them would silently JOIN two
-//     words. Residual, stated rather than rediscovered: a terminal that
-//     implemented U+2028 as a line break would put its tail at column zero,
-//     where indentContinuation cannot see it because there is no `\n`. No
-//     terminal is known to do that, and it has not been measured here.
+// U+FE0F VARIATION SELECTOR-16 is Default_Ignorable and is KEPT. It is
+// load-bearing: it is what makes an emoji render as an emoji rather than as
+// monochrome text, so stripping it changes what the user sees of a legitimate
+// message. Every other variation selector (VS1–15, VS17–256, the Mongolian
+// free variation selectors) is stripped.
 //
-//   - Cn (unassigned) and Co (private use). Both are non-graphic to Go, so a
-//     `!unicode.IsGraphic` rule would have swept them up — and that rule was
-//     rejected for it. Cn is "unassigned IN GO'S TABLE", so stripping it
-//     deletes any character newer than the toolchain's Unicode version,
-//     silently, from legitimate text. Co renders as a vendor glyph or tofu:
-//     visible, and neither invisible nor reordering.
+// 🔴 AN EARLIER VERSION OF THIS COMMENT ARGUED THERE COULD BE NO EXCEPTIONS —
+// "a class with a hole in it is a class an attacker aims at" — and that
+// argument was FALSE ON ITS OWN TERMS, because the class it defended had 263
+// holes in it: every named rune with exactly the stated property that happened
+// to be `Mn` rather than `Cf` was kept, unremarked. The rule is therefore not
+// "no exceptions"; it is: the class is a PROPERTY, exceptions are explicit,
+// enumerated and pinned, and there is currently exactly one. VS16 is defensible
+// where a ZWJ carve-out would not be — VS16 changes how an adjacent glyph is
+// drawn and cannot act as an invisible separator, while U+200D can and does.
 //
-// 🔴 THE ACCEPTED COST, WHICH IS REAL AND IS NOT A BUG REPORT. Stripping the
-// whole of Cf takes U+200D ZERO WIDTH JOINER and U+200C ZERO WIDTH NON-JOINER
-// with it. So a multi-person emoji ZWJ sequence degrades into its components
-// (👨‍👩‍👧 renders as three people, not one family), a subdivision flag degrades to
-// 🏴 (its tag characters are Cf), and — the sharpest one — Persian and Arabic
-// text that uses ZWNJ to keep a prefix from joining renders JOINED. That is a
-// content change to legitimate text, and it is the price of having no
-// carve-outs: every exemption is a rune with exactly the property the class
-// exists to remove (invisible, not a space, so an invisible separator), and a
-// class with a hole in it is a class an attacker aims at. The maintainer chose
-// STRIP over escaping for civitai/cli#393; escaping would keep the bytes at the
-// cost of every surface having to render an escape.
+// # WHAT IS DELIBERATELY NOT STRIPPED
+//
+//   - COMBINING MARKS that are not Default_Ignorable. `e`+U+0301 must survive.
+//   - RIGHT-TO-LEFT SCRIPT. Arabic and Hebrew letters are `Lo`, ordinary
+//     content; only the bidi CONTROLS are in the class. A filter that cannot
+//     tell them apart mangles real messages.
+//   - Zl/Zp/Zs (U+2028, U+2029, NBSP, ideographic space). They are
+//     `unicode.IsSpace` — which is also why the DI derivation subtracts them —
+//     so `strings.Fields` already splits on them and the unsplittable-token
+//     hazard cannot arise; stripping would silently JOIN two words. Residual,
+//     stated rather than rediscovered: a terminal that implemented U+2028 as a
+//     line break would put its tail at column zero, where indentContinuation
+//     cannot see it because there is no `\n`. Not measured; no terminal is
+//     known to do it.
+//   - Co (private use): renders as a vendor glyph or tofu. Visible, and neither
+//     invisible nor reordering. Cn (unassigned) is likewise out of the class
+//     EXCEPT where Unicode has explicitly reserved it as default-ignorable
+//     (U+2065, U+FFF0–U+FFF8, U+E01F0–U+E0FFF); a blanket `!IsGraphic` rule was
+//     rejected because it would delete any character newer than the toolchain's
+//     Unicode tables from legitimate text.
+//
+// 🔴 THE ACCEPTED COST, WHICH IS REAL. The class contains U+200D ZERO WIDTH
+// JOINER and U+200C ZERO WIDTH NON-JOINER, so text that depends on them renders
+// differently: emoji ZWJ sequences break into their components, and at least
+// nine scripts lose orthographic distinctions — Malayalam chillu (`ണ്‍` becomes
+// `ണ്`, a DIFFERENT letter), Devanagari half-forms and conjuncts, Bengali,
+// Tamil, Kannada, Sinhala repaya, Persian/Arabic ZWNJ, and Mongolian (both the
+// vowel separator and the free variation selectors). The measured sheet is
+// TestStripDocumentedDegradations. The maintainer chose STRIP over escaping for
+// #393; this is what that costs, and it is written down rather than discovered.
 package saferune
 
 import (
@@ -87,31 +113,77 @@ import (
 	"unicode"
 )
 
-// blankButGraphic is the hand-written residue described above: runes that
-// occupy no visible glyph while Unicode calls them a letter (Lo), a symbol (So)
-// or a mark (Mn), so no category test finds them.
+// emojiPresentationSelector is U+FE0F, the single documented exception to the
+// class. See the package doc.
+const emojiPresentationSelector = 0xFE0F
+
+// blankButGraphic is what the property cannot reach: runes that occupy a cell
+// and paint nothing, which Unicode classifies as a symbol or a mark and does
+// NOT mark default-ignorable.
 //
-// U+2800 is the MEASURED counterexample from civitai/cli#382 — a single token of
-// it padded around row-shaped text rendered as a spaced table row, was one token
-// to strings.Fields, was above U+009F so safeTerm kept it, and passed the
-// server's own `isLikelySafeMessage`. The Hangul fillers are the same trick with
-// a different code point (U+3164 is the classic "invisible username"), which is
-// the whole reason this is derived from a property rather than from the three
-// runes the issue happened to name.
+// U+2800 is the MEASURED counterexample from civitai/cli#382 — a single token
+// of it padded around row-shaped text rendered as a spaced table row, was one
+// token to strings.Fields, and passed the server's own `isLikelySafeMessage`.
 //
-// Keep it sorted; the test that re-derives it from Unicode names reports the
-// difference as a set, not as a diff.
+// It was six entries before the class moved to Default_Ignorable_Code_Point;
+// the four Hangul fillers are Other_Default_Ignorable_Code_Point and are now
+// covered by the property itself. What remains is re-derived from Unicode NAMES
+// on every test run by TestBlankButGraphicIsExactlyTheResidue, which fails both
+// when the list grows a guess and when Unicode grows a third.
 var blankButGraphic = [...]rune{
-	0x115F,  // HANGUL CHOSEONG FILLER
-	0x1160,  // HANGUL JUNGSEONG FILLER
 	0x2800,  // BRAILLE PATTERN BLANK
-	0x3164,  // HANGUL FILLER
-	0xFFA0,  // HALFWIDTH HANGUL FILLER
 	0x16FE4, // KHITAN SMALL SCRIPT FILLER
 }
 
-// Stripped reports whether r must be removed from server-supplied text before a
-// human renderer prints it.
+// defaultIgnorable reports the Unicode Default_Ignorable_Code_Point property.
+//
+// 🔴 IT IS THE UAX #44 DERIVATION, RE-DERIVED FROM GO'S TABLES RATHER THAN
+// HAND-LISTED, because a hand-listed copy is a snapshot that stops being true
+// the next time the toolchain's Unicode version moves. DerivedCoreProperties'
+// own derivation reads:
+//
+//	Default_Ignorable_Code_Point =
+//	    Other_Default_Ignorable_Code_Point
+//	  + Cf (Format characters)
+//	  + Variation_Selector
+//	  - White_Space
+//	  - FFF9..FFFB   (Interlinear annotation format characters)
+//	  - 13430..1343F (Egyptian hieroglyph format characters)
+//	  - Prepended_Concatenation_Mark (Exceptional format characters that should be visible)
+//
+// Go ships every one of those as a range table except the two literal ranges,
+// which the UCD itself states as literals. Three of the four subtractions are
+// the entire over-inclusion fix: they are what keeps ARABIC END OF AYAH (13
+// runes), the ruby marks (3) and the hieroglyph quadrat controls (16) out of
+// the class.
+//
+// The White_Space subtraction is CURRENTLY A NO-OP — measured: the intersection
+// is empty, because U+180E stopped being White_Space in Unicode 6.3 and no
+// other format character is whitespace. It is kept because this is a quoted
+// derivation rather than a minimised one, and it is labelled here rather than
+// counted as coverage: no mutation test can kill a mutant that deletes it.
+// TestDerivationSubtractionsAreLiveExceptWhiteSpace pins the emptiness, so the
+// day it becomes live somebody is told.
+func defaultIgnorable(r rune) bool {
+	if unicode.Is(unicode.White_Space, r) {
+		return false
+	}
+	if unicode.Is(unicode.Prepended_Concatenation_Mark, r) {
+		return false
+	}
+	if r >= 0xFFF9 && r <= 0xFFFB {
+		return false
+	}
+	if r >= 0x13430 && r <= 0x1343F {
+		return false
+	}
+	return unicode.Is(unicode.Other_Default_Ignorable_Code_Point, r) ||
+		unicode.Is(unicode.Cf, r) ||
+		unicode.Is(unicode.Variation_Selector, r)
+}
+
+// Stripped reports whether r must be removed from SERVER-SUPPLIED text before a
+// human renderer prints it. It is not asked about text the user typed.
 //
 // Newline and tab are kept: they are legitimate layout, and the guards against
 // what a server can do WITH them live in internal/cmd (indentContinuation stops
@@ -131,12 +203,18 @@ func Stripped(r rune) bool {
 	if r < 0xa0 {
 		return false
 	}
+	if r == emojiPresentationSelector {
+		return false
+	}
+	if defaultIgnorable(r) {
+		return true
+	}
 	for _, b := range blankButGraphic {
 		if r == b {
 			return true
 		}
 	}
-	return unicode.Is(unicode.Cf, r)
+	return false
 }
 
 // Strip removes every Stripped rune from s. It only ever removes: what survives
@@ -164,7 +242,7 @@ func Strip(s string) string {
 // where civitai/cli#393 lived: whatever Strip removes, this must not count as
 // content, or a string that renders as nothing is treated as something and
 // displaces a fallback that said more. TestHasVisibleContentAgreesWithStrip
-// pins the relationship over every rune rather than over a fixture.
+// pins the relationship over every code point rather than over a fixture.
 //
 // The whitespace clause is the second half of the same idea and is not new
 // behaviour for the caller: `strings.TrimSpace` already emptied an all-space

--- a/internal/saferune/saferune.go
+++ b/internal/saferune/saferune.go
@@ -2,14 +2,23 @@
 // SERVER-SUPPLIED string may put in front of a user, and nothing else.
 //
 // 🔴 SERVER-SUPPLIED. NOT "EVERY STRING THE CLI PRINTS". The CLI does not
-// sanitise what the USER typed — a prompt, a flag value, a path, a workflow id
-// the user passed on the command line is echoed back byte-for-byte, because the
-// screen that precedes an irreversible spend has to show what will actually be
-// sent. The first cut of civitai/cli#393 got this wrong: `safeTerm` was applied
+// sanitise what the USER typed on the command line — a prompt, a flag value, a
+// path, a workflow id is echoed back byte-for-byte, because the screen that
+// precedes an irreversible spend has to show what will actually be sent.
+//
+// Two documented exceptions, both away from that screen, both stated here
+// because "server text only" is the tempting over-claim: a value read out of an
+// `--input` FILE is filtered (a graph file can be downloaded or generated, so
+// it is not "what the user typed"), and `download`'s target path is filtered
+// because the same variable holds `--out` verbatim in one branch and a
+// SERVER-chosen file name in the others — see targetPath's comment for the
+// trade and the papercut it accepts. The first cut of civitai/cli#393 got this wrong: `safeTerm` was applied
 // to `o.prompt`, so a typed Persian prompt (`می‌روم`, held apart by a ZWNJ)
 // rendered joined on the approval screen while the graph on the wire carried
 // the original. The screen stopped showing the job. Call sites are audited in
-// both directions and pinned by TestApprovalScreenEchoesTypedInput_AndStripsServerText.
+// both directions and pinned by internal/cmd's TestSafeTermIsNeverAppliedToUserTypedInput
+// (structural, over every call site) and TestSameBytesTypedAndReceived_AreEchoedAndStripped
+// (behavioural, the same bytes typed and received).
 //
 // 🔴 IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE TWO PACKAGES ASK THE SAME
 // QUESTION AND MUST NOT ANSWER IT DIFFERENTLY. `internal/cmd`'s safeTerm asks

--- a/internal/saferune/saferune_test.go
+++ b/internal/saferune/saferune_test.go
@@ -1,0 +1,419 @@
+package saferune
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+
+	"golang.org/x/text/unicode/runenames"
+)
+
+// civitai/cli#393 — WHAT THIS FILE PINS IS A PROPERTY, NOT THREE CODE POINTS.
+//
+// The issue named U+2800, U+200B and U+202E because those are the three that
+// were measured. A test asserting those three are stripped passes while the
+// hazard sits in a fourth rune nobody enumerated, which is the SPELLED guard
+// this repo keeps relearning to avoid — see AGENTS.md item 28's two dead phrase
+// lists, and TestDistinctReasonSets_KeyIsInjective for the shape that worked.
+//
+// So the guards below sweep EVERY code point and compare Stripped against an
+// oracle built from a DIFFERENT data source than the implementation:
+//
+//   - the implementation reasons in Unicode CATEGORIES (Cc, Cf) plus a
+//     six-rune residue;
+//   - the oracle reasons in Unicode NAMES, read out of
+//     `golang.org/x/text/unicode/runenames` (a test-only import of a module
+//     this repo already requires for `x/text/message`).
+//
+// A rune whose published NAME says it is zero-width, invisible, a filler or a
+// bidi control, and which is not whitespace, must be stripped. That catches the
+// fourth rune: if a future Unicode revision adds one, it arrives with a name and
+// this fails, naming it.
+//
+// The opposite direction — "can it redden on correct input?" — is
+// TestStripKeepsLegitimateText and TestStripDocumentedDegradations: ordinary
+// CJK, emoji, accented Latin and right-to-left SCRIPT must all survive
+// byte-for-byte, and the two places where legitimate text is knowingly changed
+// are asserted as intended rather than left to be discovered.
+//
+// Every invisible rune below is written as a `\u` escape on purpose: a literal
+// one is invisible in the source too, and staticcheck's ST1018 rejects it.
+
+// suspectNameRe is the oracle. Every alternative is anchored and spelled out,
+// because a loose pattern reddens on visible runes whose name merely contains a
+// suspicious word — `DUPLOYAN AFFIX ATTACHED LEFT-TO-RIGHT SECANT` is a drawn
+// glyph, not a bidi control, and an unanchored `LEFT-TO-RIGHT` matched it.
+var suspectNameRe = regexp.MustCompile(`^(?:` +
+	`ZERO WIDTH .*|` +
+	`INVISIBLE .*|` +
+	`BRAILLE PATTERN BLANK|` +
+	`SOFT HYPHEN|` +
+	`WORD JOINER|` +
+	`MONGOLIAN VOWEL SEPARATOR|` +
+	`ARABIC LETTER MARK|` +
+	`FIRST STRONG ISOLATE|` +
+	`POP DIRECTIONAL (?:FORMATTING|ISOLATE)|` +
+	`(?:LEFT-TO-RIGHT|RIGHT-TO-LEFT) (?:MARK|EMBEDDING|OVERRIDE|ISOLATE)|` +
+	`.*FILLER|` +
+	`INTERLINEAR ANNOTATION .*|` +
+	`TAG .*` +
+	`)$`)
+
+// oracleFlags reports whether the Unicode NAME of r says it is invisible or
+// reorders text.
+//
+// Two refinements, both of which cost something and are stated rather than
+// hidden:
+//
+//   - unicode.IsSpace is excluded. U+2028 LINE SEPARATOR and U+2029 PARAGRAPH
+//     SEPARATOR match the name patterns and are deliberately NOT stripped (see
+//     the package doc): they are whitespace, so every wrapper in this CLI
+//     already splits on them and the "one unsplittable token" hazard cannot
+//     arise there.
+//
+//   - unicode.IsPunct is excluded. `.*FILLER` also matches five drawn
+//     punctuation marks — DEVANAGARI GAP FILLER, NEWA GAP FILLER, DIVES AKURU
+//     GAP FILLER, KAWI PUNCTUATION SPACE FILLER and MANICHAEAN PUNCTUATION LINE
+//     FILLER — which have glyphs. Punctuation is visible by construction, so it
+//     is not part of the class.
+func oracleFlags(r rune) bool {
+	name := runenames.Name(r)
+	if name == "" || strings.HasPrefix(name, "<") {
+		return false // unnamed, unassigned, or a `<control>` placeholder
+	}
+	return suspectNameRe.MatchString(name) && !unicode.IsSpace(r) && !unicode.IsPunct(r)
+}
+
+// legacyStripped is the predicate that SHIPPED before #393 — safeTerm's
+// C0/DEL/C1 table, spelled exactly as it stood. It is kept as the NEGATIVE
+// CONTROL: the sweep reports how many runes it misses, so a green run here is a
+// claim about a test that has been watched to go red rather than about a test
+// nobody has ever seen fail.
+func legacyStripped(r rune) bool {
+	if r == '\n' || r == '\t' {
+		return false
+	}
+	if r < 0x20 || r == 0x7f {
+		return true
+	}
+	return r >= 0x80 && r <= 0x9f
+}
+
+// oracleSet is the flagged set, computed once — the sweep is 1.1M name lookups.
+var oracleSet = sync.OnceValue(func() []rune {
+	var out []rune
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if oracleFlags(r) {
+			out = append(out, r)
+		}
+	}
+	return out
+})
+
+// minOracleFlagged is the POSITIVE CONTROL on the oracle itself. A regex that
+// has stopped matching — a renamed x/text API, a wrong table, a typo in an
+// alternative — flags nothing, sweeps an empty set, finds no violations and
+// reports a serene pass. Measured today: 126. A floor of 100 leaves room for
+// Unicode to retire a few without letting an instrument wired to nothing
+// through.
+const minOracleFlagged = 100
+
+func TestStripsEveryInvisibleOrReorderingRune(t *testing.T) {
+	flagged := oracleSet()
+	if len(flagged) < minOracleFlagged {
+		t.Fatalf("CONTROL failure, not a finding: the name oracle flagged %d rune(s), want >= %d. "+
+			"The oracle is broken, and every assertion below would pass by checking nothing.",
+			len(flagged), minOracleFlagged)
+	}
+
+	// NEGATIVE CONTROL, and it is the red half of the matrix: the predicate that
+	// shipped before #393 must FAIL this sweep. If it passes, the sweep cannot
+	// tell the fix from the bug it replaced.
+	missedByLegacy := 0
+	for _, r := range flagged {
+		if !legacyStripped(r) {
+			missedByLegacy++
+		}
+	}
+	if missedByLegacy == 0 {
+		t.Fatalf("CONTROL failure, not a finding: the pre-#393 predicate strips every rune this sweep flags, "+
+			"so the sweep cannot tell the fix from the bug it replaced (%d flagged)", len(flagged))
+	}
+	t.Logf("oracle flagged %d rune(s); the pre-#393 predicate missed %d of them", len(flagged), missedByLegacy)
+
+	var leaked []string
+	for _, r := range flagged {
+		if !Stripped(r) {
+			leaked = append(leaked, fmt.Sprintf("U+%04X %s", r, runenames.Name(r)))
+		}
+	}
+	if len(leaked) > 0 {
+		t.Errorf("%d rune(s) whose Unicode NAME says they are invisible or reorder text survive Stripped:\n  %s\n\n"+
+			"Any one of them is an invisible separator `strings.Fields` will not split on, or a control that "+
+			"changes what the terminal DISPLAYS. Add the class, not the code point.",
+			len(leaked), strings.Join(leaked, "\n  "))
+	}
+}
+
+// The other direction of the same ledger: blankButGraphic must be EXACTLY the
+// residue the categories do not reach. It fails when Unicode grows a seventh
+// such rune (a name arrives that no category test catches) and equally when a
+// rune is listed there that the oracle does not recognise — a hand-written list
+// nobody re-derives is how a denylist starts.
+func TestBlankButGraphicIsExactlyTheResidue(t *testing.T) {
+	want := map[rune]bool{}
+	for _, r := range oracleSet() {
+		if !unicode.Is(unicode.Cc, r) && !unicode.Is(unicode.Cf, r) {
+			want[r] = true
+		}
+	}
+	if len(want) == 0 {
+		t.Fatal("CONTROL failure, not a finding: the oracle flagged nothing outside Cc/Cf, so this ledger " +
+			"compares an empty set with an empty set and proves nothing")
+	}
+
+	have := map[rune]bool{}
+	for _, r := range blankButGraphic {
+		have[r] = true
+	}
+	for r := range want {
+		if !have[r] {
+			t.Errorf("U+%04X %s renders as nothing and is neither Cc nor Cf, so no category test reaches it — "+
+				"add it to blankButGraphic", r, runenames.Name(r))
+		}
+	}
+	for r := range have {
+		if !want[r] {
+			t.Errorf("blankButGraphic lists U+%04X %q, which the name oracle does not recognise as invisible. "+
+				"Either the oracle is too narrow or this entry is a guess; a list nobody can re-derive is a denylist.",
+				r, runenames.Name(r))
+		}
+	}
+}
+
+// The C0/DEL/C1 range test in Stripped claims to BE unicode.Cc. If that stops
+// being true the package doc is wrong, and the doc is what a reader trusts
+// instead of re-deriving it.
+func TestCcRangeTestIsExactlyTheCategory(t *testing.T) {
+	n := 0
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		inRange := r < 0x20 || (r >= 0x7f && r <= 0x9f)
+		if inRange {
+			n++
+		}
+		if inRange != unicode.Is(unicode.Cc, r) {
+			t.Fatalf("U+%04X: the range test says %v, unicode.Cc says %v", r, inRange, unicode.Is(unicode.Cc, r))
+		}
+	}
+	if n != 65 {
+		t.Errorf("the range covers %d code points, want 65 (0x00-0x1F, 0x7F-0x9F)", n)
+	}
+}
+
+// 🔴 CAN IT REDDEN ON CORRECT INPUT? Everything here is legitimate content and
+// must survive byte-for-byte. RIGHT-TO-LEFT SCRIPT is the case that matters
+// most: Arabic and Hebrew letters are ordinary text, only the bidi CONTROLS are
+// not, and a filter that cannot tell them apart mangles real messages.
+func TestStripKeepsLegitimateText(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"ascii", "dreamshaper-8 failed: try again"},
+		{"newline and tab", "a\tb\nc"},
+		{"precomposed accents", "café — Résumé"},
+		{"decomposed accents (combining marks)", "café — Résumé"},
+		{"CJK", "日本語のモデルが見つかりません"},
+		{"Korean", "한국어 텍스트"},
+		{"Cyrillic and Greek", "Привет — Ελληνικά"},
+		{"Arabic script", "لم يتم العثور على النموذج"},
+		{"Hebrew script", "הדגם לא נמצא"},
+		{"emoji", "🚀 done"},
+		{"emoji with a variation selector", "✌\ufe0f"},
+		{"skin-tone modifier", "\U0001F44D\U0001F3FD"},
+		{"box drawing and braille that is not blank", "┌──┐ ± × ÷ ≈ ⠿"},
+		{"NBSP and ideographic space", "a\u00a0b\u3000c"},
+		{"line and paragraph separators", "a\u2028b\u2029c"},
+		{"private use", "a\uf8ffb"},
+		{"replacement character", "a�b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Strip(tc.in); got != tc.in {
+				t.Errorf("Strip mangled legitimate text:\n  in:  %q\n  got: %q", tc.in, got)
+			}
+			if !HasVisibleContent(tc.in) {
+				t.Errorf("HasVisibleContent says %q says nothing", tc.in)
+			}
+		})
+	}
+}
+
+// The RTL pair, asserted as a pair because that is the distinction: the SCRIPT
+// survives, the OVERRIDE does not, and the words on either side of the override
+// are still there.
+func TestStripRemovesTheBidiControlAndKeepsTheScript(t *testing.T) {
+	const arabic = "النموذج"
+	in := "prompt \u202e" + arabic + "\u202c rejected"
+	got := Strip(in)
+	if strings.ContainsRune(got, 0x202e) || strings.ContainsRune(got, 0x202c) {
+		t.Errorf("a bidi control survived: %q", got)
+	}
+	// POSITIVE CONTROL: nothing else was dropped, so the absence above is not
+	// the whole string having been eaten.
+	for _, want := range []string{"prompt ", arabic, " rejected"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Strip dropped %q along with the control: %q", want, got)
+		}
+	}
+	if want := "prompt " + arabic + " rejected"; got != want {
+		t.Errorf("Strip = %q, want %q — exactly the text with the two controls removed", got, want)
+	}
+}
+
+// 🔴 THE ACCEPTED COST, PINNED SO IT CANNOT CHANGE SILENTLY IN EITHER
+// DIRECTION. Stripping the whole of Cf takes ZWJ and ZWNJ with it. These are
+// the cases where legitimate text renders differently afterwards, and they are
+// asserted as INTENDED — if someone carves an exemption for U+200D, this fails
+// and points at the package doc's argument for why a class with a hole in it is
+// not a class.
+func TestStripDocumentedDegradations(t *testing.T) {
+	t.Run("an emoji ZWJ sequence degrades into its components", func(t *testing.T) {
+		family := "\U0001F468\u200d\U0001F469\u200d\U0001F467"
+		want := "\U0001F468\U0001F469\U0001F467"
+		if got := Strip(family); got != want {
+			t.Errorf("Strip(family emoji) = %q, want %q", got, want)
+		}
+	})
+	t.Run("a subdivision flag degrades to the black flag", func(t *testing.T) {
+		// The black flag plus the tag characters spelling "gbsct" and CANCEL
+		// TAG. Every tag character is Cf.
+		scotland := "\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F"
+		if got := Strip(scotland); got != "\U0001F3F4" {
+			t.Errorf("Strip(Scotland flag) = %q, want the bare black flag", got)
+		}
+	})
+	t.Run("Persian text loses its ZWNJ and renders joined", func(t *testing.T) {
+		// می\u200cروم — "I go", whose prefix is held apart by a ZWNJ.
+		withZWNJ := "می\u200cروم"
+		joined := "میروم"
+		if got := Strip(withZWNJ); got != joined {
+			t.Errorf("Strip = %q, want %q", got, joined)
+		}
+	})
+}
+
+// Strip only ever REMOVES: no rune is added, replaced or reordered, and running
+// it twice changes nothing. Without this a "helpful" future edit could replace
+// the class with U+FFFD or with a visible escape and every other test here would
+// still pass.
+func TestStripOnlyRemovesAndIsIdempotent(t *testing.T) {
+	corpus := []string{
+		"", "plain", "a\u200bb", "⠀⠀wf_forged⠀⠀succeeded",
+		"\u202emirror", "café 日本語 🚀", "a\x1b[2Kb", "\u200b", "\t\n",
+		"می\u200cر", "mixed \u00ad soft \u2060 hyphen",
+		"\u3164\u115f\u1160\uffa0\U00016FE4",
+	}
+	for _, in := range corpus {
+		got := Strip(in)
+		if !isSubsequence(got, in) {
+			t.Errorf("Strip(%q) = %q, which is not a subsequence of the input — it added or reordered runes", in, got)
+		}
+		if again := Strip(got); again != got {
+			t.Errorf("Strip is not idempotent: %q -> %q -> %q", in, got, again)
+		}
+		for _, r := range got {
+			if Stripped(r) {
+				t.Errorf("Strip(%q) left U+%04X, which Stripped rejects", in, r)
+			}
+		}
+	}
+}
+
+func isSubsequence(sub, of string) bool {
+	i := 0
+	subr := []rune(sub)
+	for _, r := range of {
+		if i < len(subr) && subr[i] == r {
+			i++
+		}
+	}
+	return i == len(subr)
+}
+
+// 🔴 THE SEAM, WHICH IS WHERE #393 ACTUALLY LIVED. internal/cmd decides what a
+// terminal may receive and internal/genapi decides whether a string still says
+// anything; they were two tables and they disagreed. This asserts the
+// RELATIONSHIP over every code point rather than over a fixture: a string says
+// something exactly when what survives Strip is not all whitespace.
+//
+// It carries its own negative control — `unicode.IsControl`, the predicate
+// genapi used — so the number of code points on which the old answer was wrong
+// is reported rather than assumed.
+func TestHasVisibleContentAgreesWithStrip(t *testing.T) {
+	legacyWrong := 0
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if r >= 0xD800 && r <= 0xDFFF {
+			continue // surrogates cannot appear in a Go string as themselves
+		}
+		s := string(r)
+		want := strings.TrimSpace(Strip(s)) != ""
+		if got := HasVisibleContent(s); got != want {
+			t.Fatalf("U+%04X %s: HasVisibleContent = %v but what survives Strip is %q. A string that renders "+
+				"as nothing must not count as content — that is the empty parenthetical in civitai/cli#393.",
+				r, runenames.Name(r), got, Strip(s))
+		}
+		if (!unicode.IsControl(r)) != want {
+			legacyWrong++
+		}
+	}
+	if legacyWrong == 0 {
+		t.Fatal("CONTROL failure, not a finding: unicode.IsControl gives the same answer as the fix on every " +
+			"code point, so this test cannot tell them apart")
+	}
+	t.Logf("unicode.IsControl (the pre-#393 predicate) disagrees with the rendered result on %d code point(s)", legacyWrong)
+
+	// Multi-rune strings, including the shapes TrimSpace alone cannot reach.
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"x", true},
+		{" x ", true},
+		{"   ", false},
+		{"\u200b", false},
+		{"\u200b\u200b\u200b", false},
+		{"⠀", false},
+		{"⠀ ⠀", false}, // TrimSpace leaves this intact: U+2800 is not a space
+		{"\u202e\u202c", false},
+		{"\u200bx", true},
+		{"\u00a0", false},
+		{"\u3000x\u3000", true},
+		{"\uf8ff", true}, // private use is not part of the class and is kept
+	} {
+		if got := HasVisibleContent(tc.in); got != tc.want {
+			t.Errorf("HasVisibleContent(%q) = %v, want %v (survives Strip as %q)", tc.in, got, tc.want, Strip(tc.in))
+		}
+	}
+}
+
+// The measured vector from civitai/cli#382, restated as what #393 changes about
+// it: U+2800-padded text READS as a table row and is ONE token to strings.Fields.
+// After the strip it is neither.
+func TestBlankPaddedRowShapedTextIsNoLongerRowShaped(t *testing.T) {
+	forged := strings.Repeat("⠀", 8) + "wf_forged" + strings.Repeat("⠀", 2) + "succeeded"
+
+	// CONTROL: before the strip it really is one token that looks like a row.
+	if n := len(strings.Fields(forged)); n != 1 {
+		t.Fatalf("CONTROL failure, not a finding: the fixture is %d token(s), not the single unsplittable one the "+
+			"hazard needs", n)
+	}
+	got := Strip(forged)
+	if strings.ContainsRune(got, 0x2800) {
+		t.Errorf("the padding survived: %q", got)
+	}
+	if got != "wf_forgedsucceeded" {
+		t.Errorf("Strip = %q, want the two words with the invisible padding gone — visibly one word, which is "+
+			"the point: it can no longer pose as two aligned columns", got)
+	}
+}

--- a/internal/saferune/saferune_test.go
+++ b/internal/saferune/saferune_test.go
@@ -11,88 +11,114 @@ import (
 	"golang.org/x/text/unicode/runenames"
 )
 
-// civitai/cli#393 — WHAT THIS FILE PINS IS A PROPERTY, NOT THREE CODE POINTS.
+// civitai/cli#393 — WHAT THIS FILE PINS IS A PROPERTY, NOT A LIST OF CODE
+// POINTS.
 //
 // The issue named U+2800, U+200B and U+202E because those are the three that
 // were measured. A test asserting those three are stripped passes while the
-// hazard sits in a fourth rune nobody enumerated, which is the SPELLED guard
-// this repo keeps relearning to avoid — see AGENTS.md item 28's two dead phrase
-// lists, and TestDistinctReasonSets_KeyIsInjective for the shape that worked.
+// hazard sits in a fourth rune nobody enumerated — which is exactly what
+// happened to the first cut of this package: it drew the class on the general
+// category `Cf`, and U+034F COMBINING GRAPHEME JOINER (invisible, `Mn`)
+// reproduced the whole #393 symptom straight through it.
 //
 // So the guards below sweep EVERY code point and compare Stripped against an
 // oracle built from a DIFFERENT data source than the implementation:
 //
-//   - the implementation reasons in Unicode CATEGORIES (Cc, Cf) plus a
-//     six-rune residue;
+//   - the implementation reasons in Unicode PROPERTIES — Cc, and the UAX #44
+//     derivation of Default_Ignorable_Code_Point — plus a two-rune residue;
 //   - the oracle reasons in Unicode NAMES, read out of
 //     `golang.org/x/text/unicode/runenames` (a test-only import of a module
 //     this repo already requires for `x/text/message`).
 //
-// A rune whose published NAME says it is zero-width, invisible, a filler or a
-// bidi control, and which is not whitespace, must be stripped. That catches the
-// fourth rune: if a future Unicode revision adds one, it arrives with a name and
-// this fails, naming it.
+// Both directions are asserted, because the category cut was wrong in both:
+// TestStripsEveryInvisibleOrReorderingRune is under-inclusion (a rune whose
+// published name says it is invisible must be stripped) and
+// TestClassKeepsEveryRuneUnicodeSaysMustBeDrawn is over-inclusion (the 32 runes
+// Unicode's own derivation carves OUT must survive).
 //
-// The opposite direction — "can it redden on correct input?" — is
-// TestStripKeepsLegitimateText and TestStripDocumentedDegradations: ordinary
-// CJK, emoji, accented Latin and right-to-left SCRIPT must all survive
-// byte-for-byte, and the two places where legitimate text is knowingly changed
-// are asserted as intended rather than left to be discovered.
-//
-// Every invisible rune below is written as a `\u` escape on purpose: a literal
-// one is invisible in the source too, and staticcheck's ST1018 rejects it.
+// Every rune of the class is written as a `\u` escape in this file, U+2800
+// included. The reason that applies to all of them is that a literal is
+// invisible in the SOURCE too, so a reader cannot see what a fixture contains
+// or that it contains anything. staticcheck's ST1018 enforces a strict subset
+// of the same habit — it rejects a literal FORMAT character only, so it would
+// not have flagged U+034F, a variation selector (both `Mn`) or U+2800 (`So`),
+// and a green lint says nothing about those.
 
 // suspectNameRe is the oracle. Every alternative is anchored and spelled out,
 // because a loose pattern reddens on visible runes whose name merely contains a
 // suspicious word — `DUPLOYAN AFFIX ATTACHED LEFT-TO-RIGHT SECANT` is a drawn
 // glyph, not a bidi control, and an unanchored `LEFT-TO-RIGHT` matched it.
+//
+// 🔴 `COMBINING GRAPHEME JOINER` AND `VARIATION SELECTOR` ARE HERE BECAUSE THE
+// AUDIT FOUND THEM MISSING. The previous pattern anchored `WORD JOINER` only,
+// so the oracle could not see U+034F — and an oracle blind to the same runes as
+// the implementation is not an oracle, it is a second copy. When adding to the
+// class, add the name pattern too, or the sweep silently stops covering it.
 var suspectNameRe = regexp.MustCompile(`^(?:` +
 	`ZERO WIDTH .*|` +
 	`INVISIBLE .*|` +
 	`BRAILLE PATTERN BLANK|` +
 	`SOFT HYPHEN|` +
-	`WORD JOINER|` +
-	`MONGOLIAN VOWEL SEPARATOR|` +
+	`(?:WORD|COMBINING GRAPHEME) JOINER|` +
+	`MONGOLIAN (?:VOWEL SEPARATOR|FREE VARIATION SELECTOR .*)|` +
+	`VARIATION SELECTOR(?:-[0-9]+)?|` +
 	`ARABIC LETTER MARK|` +
 	`FIRST STRONG ISOLATE|` +
 	`POP DIRECTIONAL (?:FORMATTING|ISOLATE)|` +
 	`(?:LEFT-TO-RIGHT|RIGHT-TO-LEFT) (?:MARK|EMBEDDING|OVERRIDE|ISOLATE)|` +
+	`KHMER VOWEL INHERENT .*|` +
 	`.*FILLER|` +
 	`INTERLINEAR ANNOTATION .*|` +
 	`TAG .*` +
 	`)$`)
 
+// mustBeDrawn is the set Unicode's own Default_Ignorable derivation SUBTRACTS —
+// runes that are `Cf` and are nevertheless rendered. It is expressed as the
+// property and the two literal ranges the UCD states, not as 32 hand-copied
+// code points, so it tracks the toolchain's Unicode version.
+func mustBeDrawn(r rune) bool {
+	return unicode.Is(unicode.Prepended_Concatenation_Mark, r) ||
+		(r >= 0xFFF9 && r <= 0xFFFB) || // interlinear annotation (ruby) marks
+		(r >= 0x13430 && r <= 0x1343F) // Egyptian hieroglyph quadrat controls
+}
+
 // oracleFlags reports whether the Unicode NAME of r says it is invisible or
-// reorders text.
+// reorders text, after the policy carve-outs.
 //
-// Two refinements, both of which cost something and are stated rather than
-// hidden:
+// Each exclusion costs something and is stated rather than hidden:
 //
-//   - unicode.IsSpace is excluded. U+2028 LINE SEPARATOR and U+2029 PARAGRAPH
-//     SEPARATOR match the name patterns and are deliberately NOT stripped (see
-//     the package doc): they are whitespace, so every wrapper in this CLI
-//     already splits on them and the "one unsplittable token" hazard cannot
-//     arise there.
-//
-//   - unicode.IsPunct is excluded. `.*FILLER` also matches five drawn
-//     punctuation marks — DEVANAGARI GAP FILLER, NEWA GAP FILLER, DIVES AKURU
-//     GAP FILLER, KAWI PUNCTUATION SPACE FILLER and MANICHAEAN PUNCTUATION LINE
-//     FILLER — which have glyphs. Punctuation is visible by construction, so it
-//     is not part of the class.
+//   - unicode.IsSpace. U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR
+//     match the name patterns and are deliberately NOT stripped (see the
+//     package doc): they are whitespace, so every wrapper already splits on
+//     them. Unicode's own derivation subtracts them for the same reason.
+//   - unicode.IsPunct. `.*FILLER` also matches five DRAWN punctuation marks —
+//     DEVANAGARI GAP FILLER, NEWA GAP FILLER, DIVES AKURU GAP FILLER, KAWI
+//     PUNCTUATION SPACE FILLER, MANICHAEAN PUNCTUATION LINE FILLER.
+//   - mustBeDrawn, for the same reason Unicode subtracts it.
+//   - U+FE0F, the single documented exception, pinned on its own below.
 func oracleFlags(r rune) bool {
 	name := runenames.Name(r)
 	if name == "" || strings.HasPrefix(name, "<") {
 		return false // unnamed, unassigned, or a `<control>` placeholder
 	}
-	return suspectNameRe.MatchString(name) && !unicode.IsSpace(r) && !unicode.IsPunct(r)
+	if !suspectNameRe.MatchString(name) {
+		return false
+	}
+	if unicode.IsSpace(r) || unicode.IsPunct(r) || mustBeDrawn(r) {
+		return false
+	}
+	return r != emojiPresentationSelector
 }
 
-// legacyStripped is the predicate that SHIPPED before #393 — safeTerm's
-// C0/DEL/C1 table, spelled exactly as it stood. It is kept as the NEGATIVE
-// CONTROL: the sweep reports how many runes it misses, so a green run here is a
+// The two predicates that SHIPPED, kept as NEGATIVE CONTROLS. Every sweep
+// reports how many runes each of them gets wrong, so a green run here is a
 // claim about a test that has been watched to go red rather than about a test
 // nobody has ever seen fail.
-func legacyStripped(r rune) bool {
+//
+//   - legacyCcOnly is safeTerm's original C0/DEL/C1 table.
+//   - firstCutCfOnly is the #393 fix as first written: category `Cf`, wrong in
+//     both directions.
+func legacyCcOnly(r rune) bool {
 	if r == '\n' || r == '\t' {
 		return false
 	}
@@ -100,6 +126,17 @@ func legacyStripped(r rune) bool {
 		return true
 	}
 	return r >= 0x80 && r <= 0x9f
+}
+
+func firstCutCfOnly(r rune) bool {
+	if legacyCcOnly(r) {
+		return true
+	}
+	switch r {
+	case 0x115F, 0x1160, 0x2800, 0x3164, 0xFFA0, 0x16FE4:
+		return true
+	}
+	return unicode.Is(unicode.Cf, r)
 }
 
 // oracleSet is the flagged set, computed once — the sweep is 1.1M name lookups.
@@ -116,10 +153,10 @@ var oracleSet = sync.OnceValue(func() []rune {
 // minOracleFlagged is the POSITIVE CONTROL on the oracle itself. A regex that
 // has stopped matching — a renamed x/text API, a wrong table, a typo in an
 // alternative — flags nothing, sweeps an empty set, finds no violations and
-// reports a serene pass. Measured today: 126. A floor of 100 leaves room for
-// Unicode to retire a few without letting an instrument wired to nothing
-// through.
-const minOracleFlagged = 100
+// reports a serene pass. Measured today: 385 (126 before the class moved off
+// `Cf`). A floor of 300 leaves room for Unicode to retire some without letting
+// an instrument wired to nothing through.
+const minOracleFlagged = 300
 
 func TestStripsEveryInvisibleOrReorderingRune(t *testing.T) {
 	flagged := oracleSet()
@@ -129,20 +166,30 @@ func TestStripsEveryInvisibleOrReorderingRune(t *testing.T) {
 			len(flagged), minOracleFlagged)
 	}
 
-	// NEGATIVE CONTROL, and it is the red half of the matrix: the predicate that
-	// shipped before #393 must FAIL this sweep. If it passes, the sweep cannot
-	// tell the fix from the bug it replaced.
-	missedByLegacy := 0
+	// NEGATIVE CONTROLS, and they are the red half of the matrix. BOTH shipped
+	// predicates must fail this sweep — including the `Cf` cut, which is what
+	// makes this test a guard on the class MOVING rather than on the class
+	// existing.
+	missedByLegacy, missedByFirstCut := 0, 0
 	for _, r := range flagged {
-		if !legacyStripped(r) {
+		if !legacyCcOnly(r) {
 			missedByLegacy++
 		}
+		if !firstCutCfOnly(r) {
+			missedByFirstCut++
+		}
 	}
-	if missedByLegacy == 0 {
-		t.Fatalf("CONTROL failure, not a finding: the pre-#393 predicate strips every rune this sweep flags, "+
-			"so the sweep cannot tell the fix from the bug it replaced (%d flagged)", len(flagged))
+	for _, c := range []struct {
+		name string
+		n    int
+	}{{"the pre-#393 Cc-only predicate", missedByLegacy}, {"the first-cut Cf-only predicate", missedByFirstCut}} {
+		if c.n == 0 {
+			t.Fatalf("CONTROL failure, not a finding: %s strips every rune this sweep flags, so the sweep "+
+				"cannot tell the current class from it (%d flagged)", c.name, len(flagged))
+		}
 	}
-	t.Logf("oracle flagged %d rune(s); the pre-#393 predicate missed %d of them", len(flagged), missedByLegacy)
+	t.Logf("oracle flagged %d rune(s); Cc-only missed %d, the Cf-only first cut missed %d",
+		len(flagged), missedByLegacy, missedByFirstCut)
 
 	var leaked []string
 	for _, r := range flagged {
@@ -158,21 +205,166 @@ func TestStripsEveryInvisibleOrReorderingRune(t *testing.T) {
 	}
 }
 
-// The other direction of the same ledger: blankButGraphic must be EXACTLY the
-// residue the categories do not reach. It fails when Unicode grows a seventh
-// such rune (a name arrives that no category test catches) and equally when a
-// rune is listed there that the oracle does not recognise — a hand-written list
-// nobody re-derives is how a denylist starts.
+// 🔴 THE OVER-INCLUSION DIRECTION, WHICH THE `Cf` CUT FAILED SILENTLY. Thirteen
+// Prepended_Concatenation_Marks, three interlinear-annotation marks and sixteen
+// Egyptian quadrat controls are `Cf` AND are drawn — U+06DD ARABIC END OF AYAH
+// is the rosette around a Quranic verse number. Stripping them deletes text
+// Unicode requires be rendered, and no assertion in the first cut could see it
+// because every test asked "is the invisible thing gone?".
+func TestClassKeepsEveryRuneUnicodeSaysMustBeDrawn(t *testing.T) {
+	var must []rune
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if mustBeDrawn(r) {
+			must = append(must, r)
+		}
+	}
+	if len(must) != 32 {
+		t.Fatalf("CONTROL failure, not a finding: the must-be-drawn set has %d rune(s), want 32 "+
+			"(13 Prepended_Concatenation_Mark + 3 interlinear + 16 Egyptian quadrat). The set is "+
+			"mis-derived, so the assertions below prove nothing.", len(must))
+	}
+
+	// NEGATIVE CONTROL: the first cut stripped ALL of them. Without this the
+	// test below cannot distinguish the fix from a predicate that never
+	// stripped anything in this range.
+	strippedByFirstCut := 0
+	for _, r := range must {
+		if firstCutCfOnly(r) {
+			strippedByFirstCut++
+		}
+	}
+	if strippedByFirstCut != len(must) {
+		t.Fatalf("CONTROL failure, not a finding: the Cf-only first cut stripped %d of %d must-be-drawn runes, "+
+			"want all of them — this test is not measuring the correction it claims to", strippedByFirstCut, len(must))
+	}
+	t.Logf("must-be-drawn: %d rune(s); the Cf-only first cut deleted all %d", len(must), strippedByFirstCut)
+
+	for _, r := range must {
+		if Stripped(r) {
+			t.Errorf("U+%04X %s is stripped. Unicode's Default_Ignorable derivation subtracts it precisely "+
+				"because it is a FORMAT character that is DRAWN; removing it deletes a mark the script needs.",
+				r, runenames.Name(r))
+		}
+	}
+}
+
+// 🔴 ONE OF THE DERIVATION'S FOUR SUBTRACTIONS IS CURRENTLY A NO-OP, AND
+// SAYING SO IS THE POINT OF THIS TEST.
+//
+// The mutation battery for this change deleted each subtraction in turn. Three
+// of them (Prepended_Concatenation_Mark: 13 runes, interlinear: 3, Egyptian
+// quadrat: 16) turn a test red. Deleting the White_Space subtraction changes
+// NOTHING — the intersection is empty with this toolchain's Unicode tables,
+// because U+180E MONGOLIAN VOWEL SEPARATOR stopped being White_Space in Unicode
+// 6.3 and no other format character is whitespace.
+//
+// So that clause is an UNREACHABLE guard: no behavioural test can kill a mutant
+// that removes it, and counting it as covered would be a false claim. It stays
+// because the derivation is quoted from UAX #44 and a faithful copy is worth
+// more than a minimal one — if a future Unicode version puts a format character
+// back into White_Space, the clause is what stops the CLI deleting a space. This
+// test pins the emptiness so that the day it stops being empty, someone is told
+// the clause has become live and owes a behavioural case.
+func TestDerivationSubtractionsAreLiveExceptWhiteSpace(t *testing.T) {
+	base := func(r rune) bool {
+		return unicode.Is(unicode.Other_Default_Ignorable_Code_Point, r) ||
+			unicode.Is(unicode.Cf, r) ||
+			unicode.Is(unicode.Variation_Selector, r)
+	}
+	ws, pcm, interlinear, egyptian := 0, 0, 0, 0
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if !base(r) {
+			continue
+		}
+		if unicode.Is(unicode.White_Space, r) {
+			ws++
+		}
+		if unicode.Is(unicode.Prepended_Concatenation_Mark, r) {
+			pcm++
+		}
+		if r >= 0xFFF9 && r <= 0xFFFB {
+			interlinear++
+		}
+		if r >= 0x13430 && r <= 0x1343F {
+			egyptian++
+		}
+	}
+	if ws != 0 {
+		t.Errorf("the White_Space subtraction now removes %d rune(s) from the class, so it has become "+
+			"REACHABLE. It was documented as a no-op that no mutation test could kill; that is no longer "+
+			"true and it needs a behavioural case of its own.", ws)
+	}
+	for _, c := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"Prepended_Concatenation_Mark", pcm, 13},
+		{"interlinear annotation", interlinear, 3},
+		{"Egyptian hieroglyph quadrat", egyptian, 16},
+	} {
+		if c.got != c.want {
+			t.Errorf("the %s subtraction covers %d rune(s), want %d — the number moved, so the "+
+				"must-be-drawn ledger is measuring a different set than the one it was written against",
+				c.name, c.got, c.want)
+		}
+	}
+	t.Logf("subtractions: White_Space %d (empty: unreachable by construction), PCM %d, interlinear %d, Egyptian %d",
+		ws, pcm, interlinear, egyptian)
+}
+
+// 🔴 ONE EXCEPTION, AND EXACTLY ONE. U+FE0F is what makes an emoji render as an
+// emoji; it is Default_Ignorable and is kept anyway. Every other variation
+// selector is stripped. Asserted in both directions so the exception cannot
+// quietly grow a second member, and so it cannot quietly disappear either.
+func TestEmojiPresentationSelectorIsTheOnlyException(t *testing.T) {
+	if Stripped(emojiPresentationSelector) {
+		t.Errorf("U+FE0F VARIATION SELECTOR-16 is stripped. It is load-bearing: without it an emoji renders " +
+			"as monochrome text, which changes what the user sees of a legitimate message.")
+	}
+	kept, strippedN := []string{}, 0
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		if !unicode.Is(unicode.Variation_Selector, r) {
+			continue
+		}
+		if Stripped(r) {
+			strippedN++
+			continue
+		}
+		if r != emojiPresentationSelector {
+			kept = append(kept, fmt.Sprintf("U+%04X %s", r, runenames.Name(r)))
+		}
+	}
+	if len(kept) > 0 {
+		t.Errorf("the exception has grown to %d more variation selector(s):\n  %s\nThe package doc says there "+
+			"is exactly one; a second undocumented one is how a class becomes a denylist.",
+			len(kept), strings.Join(kept, "\n  "))
+	}
+	if strippedN < 200 {
+		t.Fatalf("CONTROL failure, not a finding: only %d variation selector(s) are stripped, so the "+
+			"exception above is not being measured against a populated set", strippedN)
+	}
+	t.Logf("variation selectors: %d stripped, 1 kept (U+FE0F)", strippedN)
+}
+
+// The other direction of the residue ledger: blankButGraphic must be EXACTLY
+// what the property cannot reach. It fails when Unicode grows a third such rune
+// and equally when a rune is listed there that the oracle does not recognise —
+// a hand-written list nobody re-derives is how a denylist starts.
+//
+// It shrank from six to two when the class moved to Default_Ignorable: the four
+// Hangul fillers are Other_Default_Ignorable_Code_Point, so the property now
+// covers them and the ledger says so rather than leaving them duplicated.
 func TestBlankButGraphicIsExactlyTheResidue(t *testing.T) {
 	want := map[rune]bool{}
 	for _, r := range oracleSet() {
-		if !unicode.Is(unicode.Cc, r) && !unicode.Is(unicode.Cf, r) {
+		if !unicode.Is(unicode.Cc, r) && !defaultIgnorable(r) {
 			want[r] = true
 		}
 	}
 	if len(want) == 0 {
-		t.Fatal("CONTROL failure, not a finding: the oracle flagged nothing outside Cc/Cf, so this ledger " +
-			"compares an empty set with an empty set and proves nothing")
+		t.Fatal("CONTROL failure, not a finding: the oracle flagged nothing outside Cc/Default_Ignorable, so " +
+			"this ledger compares an empty set with an empty set and proves nothing")
 	}
 
 	have := map[rune]bool{}
@@ -181,8 +373,8 @@ func TestBlankButGraphicIsExactlyTheResidue(t *testing.T) {
 	}
 	for r := range want {
 		if !have[r] {
-			t.Errorf("U+%04X %s renders as nothing and is neither Cc nor Cf, so no category test reaches it — "+
-				"add it to blankButGraphic", r, runenames.Name(r))
+			t.Errorf("U+%04X %s renders as nothing, is not Cc and is not Default_Ignorable, so no property "+
+				"test reaches it — add it to blankButGraphic", r, runenames.Name(r))
 		}
 	}
 	for r := range have {
@@ -214,9 +406,10 @@ func TestCcRangeTestIsExactlyTheCategory(t *testing.T) {
 }
 
 // 🔴 CAN IT REDDEN ON CORRECT INPUT? Everything here is legitimate content and
-// must survive byte-for-byte. RIGHT-TO-LEFT SCRIPT is the case that matters
-// most: Arabic and Hebrew letters are ordinary text, only the bidi CONTROLS are
-// not, and a filter that cannot tell them apart mangles real messages.
+// must survive byte-for-byte. Two groups matter most: RIGHT-TO-LEFT SCRIPT
+// (Arabic and Hebrew letters are ordinary text; only the bidi CONTROLS are not)
+// and the runes Unicode's derivation carves out, which the previous class
+// deleted.
 func TestStripKeepsLegitimateText(t *testing.T) {
 	for _, tc := range []struct{ name, in string }{
 		{"ascii", "dreamshaper-8 failed: try again"},
@@ -229,13 +422,20 @@ func TestStripKeepsLegitimateText(t *testing.T) {
 		{"Arabic script", "لم يتم العثور على النموذج"},
 		{"Hebrew script", "הדגם לא נמצא"},
 		{"emoji", "🚀 done"},
-		{"emoji with a variation selector", "✌\ufe0f"},
+		{"emoji with the presentation selector", "✌️"},
 		{"skin-tone modifier", "\U0001F44D\U0001F3FD"},
 		{"box drawing and braille that is not blank", "┌──┐ ± × ÷ ≈ ⠿"},
-		{"NBSP and ideographic space", "a\u00a0b\u3000c"},
-		{"line and paragraph separators", "a\u2028b\u2029c"},
-		{"private use", "a\uf8ffb"},
+		{"NBSP and ideographic space", "a b　c"},
+		{"line and paragraph separators", "a b c"},
+		{"private use", "ab"},
 		{"replacement character", "a�b"},
+		// The carve-outs, each a rune the Cf-only class deleted.
+		{"Arabic end of ayah", "القرآن\u06dd١"},
+		{"Arabic number sign", "\u0600١٢"},
+		{"Syriac abbreviation mark", "ܐ\u070fܒ"},
+		{"Kaithi number sign", "\U000110bd\U00011066"},
+		{"interlinear annotation (ruby)", "\ufff9漢\ufffa kan \ufffb"},
+		{"Egyptian hieroglyph quadrat controls", "\U00013000\U00013430\U00013001"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := Strip(tc.in); got != tc.in {
@@ -270,48 +470,90 @@ func TestStripRemovesTheBidiControlAndKeepsTheScript(t *testing.T) {
 	}
 }
 
-// 🔴 THE ACCEPTED COST, PINNED SO IT CANNOT CHANGE SILENTLY IN EITHER
-// DIRECTION. Stripping the whole of Cf takes ZWJ and ZWNJ with it. These are
-// the cases where legitimate text renders differently afterwards, and they are
-// asserted as INTENDED — if someone carves an exemption for U+200D, this fails
-// and points at the package doc's argument for why a class with a hole in it is
-// not a class.
+// 🔴 THE DEGRADATION SHEET: WHAT LEGITIMATE TEXT LOSES, MEASURED AND PINNED SO
+// IT CANNOT CHANGE SILENTLY IN EITHER DIRECTION.
+//
+// The class contains the join controls, so every script that uses them to make
+// an orthographic distinction loses that distinction. The first version of this
+// sheet listed two cases (emoji, Persian) and the audit measured eight more.
+// Each expectation is written as the surviving SEQUENCE, spelled out — never as
+// `Strip(in)` — so it cannot be derived from the implementation it tests.
+//
+// Malayalam is the sharpest: the chillu is a different LETTER, not a different
+// shape of the same one.
 func TestStripDocumentedDegradations(t *testing.T) {
-	t.Run("an emoji ZWJ sequence degrades into its components", func(t *testing.T) {
-		family := "\U0001F468\u200d\U0001F469\u200d\U0001F467"
-		want := "\U0001F468\U0001F469\U0001F467"
-		if got := Strip(family); got != want {
-			t.Errorf("Strip(family emoji) = %q, want %q", got, want)
-		}
-	})
-	t.Run("a subdivision flag degrades to the black flag", func(t *testing.T) {
-		// The black flag plus the tag characters spelling "gbsct" and CANCEL
-		// TAG. Every tag character is Cf.
-		scotland := "\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F"
-		if got := Strip(scotland); got != "\U0001F3F4" {
-			t.Errorf("Strip(Scotland flag) = %q, want the bare black flag", got)
-		}
-	})
-	t.Run("Persian text loses its ZWNJ and renders joined", func(t *testing.T) {
-		// می\u200cروم — "I go", whose prefix is held apart by a ZWNJ.
-		withZWNJ := "می\u200cروم"
-		joined := "میروم"
-		if got := Strip(withZWNJ); got != joined {
-			t.Errorf("Strip = %q, want %q", got, joined)
-		}
-	})
+	for _, tc := range []struct{ name, in, want, note string }{
+		{
+			"emoji ZWJ sequence", "\U0001F468\u200d\U0001F469\u200d\U0001F467",
+			"\U0001F468\U0001F469\U0001F467", "one family becomes three people",
+		},
+		{
+			"subdivision flag",
+			"\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F",
+			"\U0001F3F4", "the tag characters are Cf; the flag falls back to black",
+		},
+		{
+			"emoji TEXT presentation selector", "✈︎", "✈",
+			"VS15 is stripped, so a deliberately-monochrome glyph may render as emoji",
+		},
+		{
+			"Persian ZWNJ", "می\u200cروم", "میروم", "the prefix joins the stem",
+		},
+		{
+			"Malayalam chillu", "ണ്\u200d", "ണ്",
+			"chillu-N becomes NA + virama — a DIFFERENT letter, not a variant shape",
+		},
+		{
+			"Devanagari half-form", "क्\u200dष", "क्ष",
+			"the explicit half-form request is lost; the renderer picks its own conjunct",
+		},
+		{
+			"Devanagari forced conjunct-break", "क्\u200cष", "क्ष",
+			"the explicit NON-joining request is lost, which is the opposite change",
+		},
+		{
+			"Bengali conjunct", "ক্\u200dষ", "ক্ষ", "same mechanism as Devanagari",
+		},
+		{
+			"Tamil non-joining", "க்\u200cஷ", "க்ஷ", "same mechanism",
+		},
+		{
+			"Kannada half-form", "ಕ್\u200d", "ಕ್", "same mechanism",
+		},
+		{
+			"Sinhala repaya", "ර්\u200dය", "ර්ය", "the repaya form is lost",
+		},
+		{
+			"Mongolian vowel separator", "ᠮᠣᠩ\u180eᠭᠣᠯ", "ᠮᠣᠩᠭᠣᠯ", "U+180E is Cf",
+		},
+		{
+			"Mongolian free variation selector", "ᠨ᠋", "ᠨ",
+			"FVS1 is Variation_Selector, newly in the class — it selects a letter's shape",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// CONTROL: the fixture really does carry something to lose.
+			if tc.in == tc.want {
+				t.Fatalf("CONTROL failure, not a finding: fixture and expectation are identical, so this row "+
+					"asserts nothing (%s)", tc.note)
+			}
+			if got := Strip(tc.in); got != tc.want {
+				t.Errorf("Strip(%q) = %q, want %q\n  %s", tc.in, got, tc.want, tc.note)
+			}
+		})
+	}
 }
 
 // Strip only ever REMOVES: no rune is added, replaced or reordered, and running
 // it twice changes nothing. Without this a "helpful" future edit could replace
-// the class with U+FFFD or with a visible escape and every other test here would
-// still pass.
+// the class with U+FFFD or with a visible escape and every other test here
+// would still pass.
 func TestStripOnlyRemovesAndIsIdempotent(t *testing.T) {
 	corpus := []string{
-		"", "plain", "a\u200bb", "⠀⠀wf_forged⠀⠀succeeded",
+		"", "plain", "a\u200bb", "\u2800\u2800wf_forged\u2800\u2800succeeded",
 		"\u202emirror", "café 日本語 🚀", "a\x1b[2Kb", "\u200b", "\t\n",
 		"می\u200cر", "mixed \u00ad soft \u2060 hyphen",
-		"\u3164\u115f\u1160\uffa0\U00016FE4",
+		"\u3164\u115f\u1160\uffa0\U00016FE4", "a͏b", "ا\u06dd١",
 	}
 	for _, in := range corpus {
 		got := Strip(in)
@@ -383,13 +625,16 @@ func TestHasVisibleContentAgreesWithStrip(t *testing.T) {
 		{"   ", false},
 		{"\u200b", false},
 		{"\u200b\u200b\u200b", false},
-		{"⠀", false},
-		{"⠀ ⠀", false}, // TrimSpace leaves this intact: U+2800 is not a space
+		{"\u2800", false},
+		{"\u2800 \u2800", false}, // TrimSpace leaves this: U+2800 is not a space
 		{"\u202e\u202c", false},
+		{"͏͏͏", false}, // the rune the Cf-only class kept
 		{"\u200bx", true},
-		{"\u00a0", false},
-		{"\u3000x\u3000", true},
-		{"\uf8ff", true}, // private use is not part of the class and is kept
+		{" ", false},
+		{"　x　", true},
+		{"", true},      // private use is not in the class and is kept
+		{"\u06dd", true}, // must-be-drawn: a rune, therefore content
+		{"️", true},      // the documented exception
 	} {
 		if got := HasVisibleContent(tc.in); got != tc.want {
 			t.Errorf("HasVisibleContent(%q) = %v, want %v (survives Strip as %q)", tc.in, got, tc.want, Strip(tc.in))
@@ -401,7 +646,7 @@ func TestHasVisibleContentAgreesWithStrip(t *testing.T) {
 // it: U+2800-padded text READS as a table row and is ONE token to strings.Fields.
 // After the strip it is neither.
 func TestBlankPaddedRowShapedTextIsNoLongerRowShaped(t *testing.T) {
-	forged := strings.Repeat("⠀", 8) + "wf_forged" + strings.Repeat("⠀", 2) + "succeeded"
+	forged := strings.Repeat("\u2800", 8) + "wf_forged" + strings.Repeat("\u2800", 2) + "succeeded"
 
 	// CONTROL: before the strip it really is one token that looks like a row.
 	if n := len(strings.Fields(forged)); n != 1 {


### PR DESCRIPTION
Closes #393 (the invisible/bidi half — the display-width half is **#397**).

Two commits: the original fix, then the three 🔴 from an adversarial audit. This body describes the **current** state; where the first cut was wrong it says so, because the corrections are the interesting part.

## 1. The strip is for SERVER text. It is not applied to what the user typed.

The first cut ran `safeTerm` over `o.prompt`. Measured through the real interactive `confirmGenerate`: a typed Persian prompt `می‌روم` (held apart by a ZWNJ) rendered **joined** on the pre-spend approval screen while the graph on the wire carried the original — the last screen before an irreversible spend stopped describing the job it was approving. `printGenerateQuote`'s own comment already said that screen *"DOES echo the real prompt and must keep doing so"*.

Removed from **15** call sites, audited by AST rather than by eye:

| where | argument |
|---|---|
| `confirmGenerate` (the approval screen) | `o.prompt`, `o.negativePrompt`, `built.inputPath` |
| `printGenerateQuote` (`--dry-run`) | `built.inputPath`, `o.aspectRatio` |
| `printImageDisclosure` | `o.ecosystem` |
| `buildGenerateGraph` image labels | `o.images[i]` |
| `workflows cancel` (3 sites), `requireWorkflowExists` (2), `runWorkflowsCancel` (2) | the typed workflow id |
| `app withdraw` (2 sites) | the typed publish-request id |

**Kept** on the same line as one of those: `safeTerm(img.URL)` in `buildGenerateGraph` — that URL came back from the server after upload. The audit's list had six sites; my own pass found `o.ecosystem` and the second `built.inputPath` additionally, and found that `img.URL` is server-supplied and must stay. Call sites went 166 → **150**.

**Judgement call, stated rather than buried:** `--input` FILE CONTENT (`generate_input.go`'s `workflow` value and graph keys) still goes through `safeTerm`. It is not "what the user typed" — a graph file can be downloaded or generated — and neither line is on the spend-fidelity path (the CLI names the file, never echoes its fields).

## 2+3. The class was a CATEGORY where the argument said PROPERTY — wrong in both directions

| direction | what it did | measured |
|---|---|---|
| **under**-inclusive | `U+034F` COMBINING GRAPHEME JOINER is invisible and `Mn`, so it was kept | a reason of three CGJs rendered `The server reported:` with an invisible line under it, and `(the server reported: )` on stderr — the exact #393 symptom, straight through the fix |
| **over**-inclusive | deleted 32 runes Unicode requires be **drawn** | 13 `Prepended_Concatenation_Mark` (incl. `U+06DD` ARABIC END OF AYAH, the rosette around a Quranic verse number; `U+070F` Syriac abbreviation mark), 3 ruby marks, 16 Egyptian quadrat controls |

**The class is now:** `Cc` (minus `\n`/`\t`) + `Default_Ignorable_Code_Point` − `U+FE0F` + 2 blank-but-graphic runes. **4,238 code points.**

`Default_Ignorable_Code_Point` is *derived*, not hand-listed — the UAX #44 formula over Go's own range tables (`Other_Default_Ignorable_Code_Point ∪ Cf ∪ Variation_Selector`, minus `White_Space`, minus `Prepended_Concatenation_Mark`, minus the two literal ranges the UCD itself states). Its subtractions *are* the over-inclusion fix, and `Other_Default_Ignorable_Code_Point` is what brings in `U+034F`, the Hangul fillers and `U+17B4/17B5`. The blank-but-graphic list shrank 6 → **2** (`U+2800`, `U+16FE4`) because the property now covers the Hangul fillers itself.

**One exception, and exactly one: `U+FE0F` is kept.** It is load-bearing for emoji presentation and cannot act as an invisible separator, unlike `U+200D`. The first cut's *"a class with a hole in it is a class an attacker aims at"* is **retracted in the code**: it was false on its own terms, because the category it defended silently kept 263 runes with exactly the stated property. The rule is now "property + enumerated exceptions", currently one, pinned in both directions.

### Re-measured degradation sheet: nine scripts, not two

Emoji ZWJ sequences, subdivision flags, VS15 text presentation, **Persian/Arabic** ZWNJ, **Malayalam chillu `ണ്‍` → `ണ്` (a different letter)**, Devanagari half-forms *and* forced conjunct-breaks, Bengali, Tamil, Kannada, Sinhala repaya, Mongolian vowel separator, Mongolian free variation selectors. Each is a row in `TestStripDocumentedDegradations` with the surviving sequence spelled out — never `Strip(in)` — so no expectation is derived from the implementation.

## Guards

Two independently-built oracles plus two new guards for the user-input rule:

- **Name oracle** (`x/text/unicode/runenames`) — implementation reasons in properties, oracle in names. **385** runes flagged (was 126; the `WORD JOINER`-only pattern could not see `U+034F`, which is how an oracle becomes a second copy of the code).
- **Must-be-drawn ledger** — the over-inclusion direction, which the first cut had no assertion capable of seeing.
- **`TestSafeTermIsNeverAppliedToUserTypedInput`** — structural: walks every `safeTerm` call site by AST, fails on a forbidden argument shape.
- **`TestSameBytesTypedAndReceived_AreEchoedAndStripped`** — behavioural: the *same bytes* typed into the approval screen and received as a server reason, asserted to be echoed and stripped respectively. Ten probes spanning the class, including two controls (`U+FE0F`, `U+06DD`) that must survive **both** paths.

### Red/green matrix — 18 mutants, 17 killed, 1 declared unreachable

Each applied to a clean tree; the killing test is the intended one.

| # | mutation | killed by |
|---|---|---|
| M1 | drop `Default_Ignorable` entirely | saferune sweep + seam, 4 cmd surfaces, genapi |
| M2 | revert to `Cf` only (the audited first cut) | `TestStripsEvery…`, `TestEmojiPresentation…` |
| M3–M5 | drop the PCM / interlinear / Egyptian subtraction | `TestClassKeepsEveryRuneUnicodeSaysMustBeDrawn` + the matching `TestStripKeepsLegitimateText` row + `TestSameBytesTyped…/arabic_end_of_ayah` |
| M6 | drop the `White_Space` subtraction | **SURVIVED — and it is unreachable, not uncovered.** Measured: `White_Space ∩ (Other_DI ∪ Cf ∪ VS)` is **empty** (U+180E left `White_Space` in Unicode 6.3). No behavioural test can kill it. The clause stays because the derivation is quoted rather than minimised; it is now *labelled* in the code and `TestDerivationSubtractionsAreLiveExceptWhiteSpace` pins the emptiness so the day it becomes live somebody is told. |
| M7 | strip `U+FE0F` too | `TestEmojiPresentation…`, `TestSameBytesTyped…` |
| M8 | widen the exception to every variation selector | `TestStripsEvery…`, `TestEmojiPresentation…` |
| M9/M10 | remove `U+2800` / add a visible rune to the residue | `TestBlankButGraphicIsExactlyTheResidue` (both directions) |
| M11 | `HasVisibleContent` back to `unicode.IsControl` | seam + genapi + 2 cmd surfaces |
| M12 | `Strip` replaces instead of removes | `TestStripOnlyRemoves…`, the degradation sheet |
| M13 | `safeTerm` stops calling `saferune` | `TestSafeTerm`, `TestServerTextSurfaces…`, `TestSameBytesTyped…` |
| M14 | drop `safeTerm` at ONE surface | that surface's subtest only |
| M15 | route `--json` through `safeTerm` | `TestWorkflowsGetJSON…` |
| M16–M18 | re-sanitise the typed prompt / `--input` path / image path | `TestSafeTermIsNeverAppliedToUserTypedInput` **and** `TestSameBytesTyped…` (M16) |

In-test negative controls, printed on every run: oracle **385** flagged, Cc-only misses **385**, the Cf-only first cut misses **262**; the Cf-only cut deletes **all 32** must-be-drawn runes; **259** variation selectors stripped, 1 kept; `unicode.IsControl` disagrees with the rendered result on **4,194** code points. Each of those is `t.Fatal`-guarded at zero, so the test cannot pass by measuring nothing.

### Control pairs

- **Lint instrument** (this is a **negative** control — the audit was right about the vocabulary): inserted one literal `U+200B` into a string literal in the new test file → `saferune_test.go:415:13: ST1018 … (staticcheck)`, `1 issues`; restored → `0 issues`.
- **`--json` pair**: one payload, both branches — decoded `--json` still carries the class *and* the whole payload compares `DeepEqual` to what the server sent; the human render of the same payload carries none of it. The fixture builds the reason with `encoding/json`, which escapes only what JSON cannot carry (so a C0 probe is legal) and leaves the invisible class as **raw bytes** — the property that made M15 killable.
- **Typed/received pair**: same bytes, opposite outcomes, ten probes.
- **`TestStripKeepsLegitimateText`**: 23 cases, byte-for-byte — including the six carve-out rows the first class deleted.

## Round 3: the delta audit's 🔴 — `--out`, and which option I took

**Option (b): kept the sanitisation, narrowed the sentence — plus the guard extension from (a).** Reasoning, since the coordinator asked for it explicitly:

`targetPath` returns `o.out` **verbatim** when `--out` is set, and `filepath.Join(dir, filepath.Base(f.Name))` — a **server-chosen** file name — in every other branch. One variable, two origins, and the four print sites cannot tell them apart. Unsanitising it would hand a hostile uploader the `Saved … (SHA256 verified)` line, which is the exact forgery `safeTerm`'s own docstring names ("file names"), in exchange for a papercut. Splitting the two means threading provenance out of `targetPath` — a signature change on a download path that #399 has just documented as largely untested, in the last round, for a cosmetic gain. So the strip stays and the README now says what the CLI does, in three places (`targetPath`'s comment, `saferune`'s package doc, the README bullet), including the papercut it accepts: an `--out` path containing an invisible character is *reported* without it while the file is written to the path you gave.

**The guard gap is fixed regardless, and it is the more valuable half.** The AST guard understood only `o.`-prefixed shapes, so `safeTerm(target)` was structurally invisible to it. Every **bare-identifier** argument (14 names, 31 calls) is now classified in a ledger recording where its bytes come from. It fails when the set **grows** (an unclassified name) and when it **shrinks** (a stale note), and both directions are mutation-certified:

| # | mutation | result |
|---|---|---|
| M19 | remove `"target"` from the ledger | **KILLED** — "5 call site(s) pass a bare local whose ORIGIN is not written down" |
| M20 | add a name that is never passed | **KILLED** — "classifies `ghostName`, which is no longer passed to safeTerm anywhere" |

The ledger does not decide whether a strip is right; it makes the question impossible to skip, which is the thinking that was missing for `target`.

### The five 🟡/🟢, all text

- **`safeterm.go`'s class summary** described the pre-rework `Cf` class — false in both directions after the class moved — while its own last sentence forbade keeping a second table. The summary **was** the second table; it is now a pointer with that failure recorded as the reason.
- **Two citations to a test that never existed** (`saferune.go`, `generate.go`) → the two real guards.
- **"nothing else is"** → wrapping also collapses whitespace runs and hard-splits an over-long token.
- **"This filter is for server text only"** → over-claimed; `--input` file content and `download`'s target path are named as the two exceptions, in the README, `saferune`'s doc and `AGENTS.md`.
- **"Letters … survive"** → false for the four Hangul fillers (`Lo`); the clause the rewrite dropped is restored. **U+16FE4 is a mark, not a symbol.**

The 18-mutant battery was re-run after the guard change: **17 killed, M6 unchanged as the declared-unreachable one.**

## `--json`

Untouched. The audit re-derived this independently by call-graph reachability (7 JSON-emitting functions can reach `safeTerm`; every one branches to `writeRawJSON` and **returns** first). **Correcting my own earlier claim:** I reported "149 calls in 64 functions" — that was a *line* count, so 17 calls sharing a line were never individually inspected. AST enumeration gave **166 in 63** before this change and **150 in 56** after, and two enclosing functions do also call `writeRawJSON` (`runWorkflowsCancel`, `waitAndCollect`) — now one, since `runWorkflowsCancel` no longer sanitises. The conclusion held; the evidence I quoted for it did not.

## Docs

`README.md` in six places (a third audit round found two more: the *"nothing else is"* clause and the over-broad *"server text only"* framing — see round 3). The bullet I added in the first cut was **false in the reassuring direction** — *"only characters with no visible glyph are dropped"* and *"right-to-left script untouched"* — and is rewritten against what the class actually does, with the nine scripts named and a new bullet stating that nothing the user types is filtered. Also corrected: `README.md:2398`'s *"it prints what each endpoint sent"*, structurally identical to the bullet 30 lines above and missed the first time. `AGENTS.md`'s Layout bullet now describes the property, the exception and the cost (**+388** bytes, not the +308 I reported; 25,964 of 28,758).

**Left alone, and the audit agreed:** `README.md:899`'s `cost.factors … verbatim` — its subject is the `--json` map.

## Filed, not fixed here

**#399** — `safeTerm` is unpinned at most of its call sites: the auditor deleted it at 25 sampled sites and **20 left the suite green**. Measured identical on `27cd5de`, so it is pre-existing and not this PR's to fix.

## Gate

`make ci` green (20/20) · `golangci-lint 2.12.2` (the CI pin) **0 issues**, negative control re-run at the final tree (1 × ST1018 on a planted literal, 0 restored) · `./scripts/ci-shallow.sh` **after** each commit: `ok=20/20 failing-tests=0 timeouts=0`.

## What I believe rather than verified

- No terminal implements `U+2028`/`U+2029` as a line break — the reason they stay out of the class. Not measured.
- The class is complete *for named runes*: an invisible rune that is neither `Default_Ignorable` nor named as such would pass both the implementation and the oracle. `U+2800` and `U+16FE4` are the two known such runes; I cannot prove there is no third.
- The degradation sheet is what the *strip* does to those scripts. I asserted the resulting code-point sequences; I did not render them in a terminal to confirm what a shaping engine draws.
- `U+16FE4` is in the residue because the name oracle flags it, not because I watched a terminal render it blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
