### PR TITLE
docs(agents): the shallow tier reads committed state, so a dirty-tree run reports green about the previous commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,12 @@ follows is specific to this repo's toolchain.
   - Fix: require every check to hold a **terminal** conclusion
     (`SUCCESS|FAILURE|CANCELLED|TIMED_OUT|NEUTRAL|SKIPPED`) and assert a
     minimum expected check count.
+- 🔴 **`./scripts/ci-shallow.sh` reads COMMITTED state only** — it clones the
+  branch at its tip, so running it on a dirty tree measures the **previous**
+  commit and reports green about code you did not write. Its result is a claim
+  about `HEAD`, never about the working tree: commit first, and confirm the SHA
+  it cloned is the one you meant. This bit three separate agents in one session,
+  each time in the reassuring direction.
 
 ## Git rules
 


### PR DESCRIPTION
One bullet added to **Shell & CI gotchas** — the section for tools that produce a clean exit and reassuring output while doing nothing.

## The trap

`./scripts/ci-shallow.sh` clones the branch **at its committed tip**. Run it on a dirty tree and it measures the *parent* commit and reports green — about code that was never tested. Its result is a claim about `HEAD`, never about the working tree.

## Why it earns a line here rather than a global rule

It is repo-specific (this script, this two-tier setup), and it was measured **three separate times in one session**, each in the reassuring direction:

- an agent ran it after applying review fixes, got `19/19 ok`, and only later realised it had tested the **pre-fix** commit; it committed and re-ran to get a real result
- two other agents hit the same shape on different PRs

None of these produced a red. That is the point — the failure mode is a green that means nothing, which is what the surrounding bullets are all about.

## Remedy

Same shape as the section's other entries: read what the tool actually did rather than its exit code. Commit first, then confirm the SHA it cloned is the one you meant.

## Ceiling

`AGENTS.md` is 26,524 bytes against the 28,758 ceiling (2,234 to spare). Guard tests pass: **18 RUN / 18 PASS / 0 FAIL** across `TestAgentsMDStaysUnderItsCeiling`, `TestAgentsSizeGuardCanStillFire`, `TestAgentsItemCrossReferencesResolve`, `TestAgentsItemRefRegexMatchesTheSpellingsInUse`, `TestLayoutSectionLedgersEveryInternalPackage`, and the layout-ledger parser suites.

No trigger-index item was added or renumbered; this is a prose bullet in an existing section.
