### PR TITLE
docs(listing): the assumption #400's fix rested on is measured now, and it holds

### DIFF
--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -89,6 +89,16 @@ type ListingScreenshot struct {
 // to render `status` + the trailing floor line). For an APPROVED parent the
 // server resolves the media from the in-flight shadow revision (an idempotent
 // begin), so the assets reflect the pending revision, not the live listing.
+//
+// 🔴 THAT SHADOW IS SEEDED FROM THE LIVE LISTING, NOT EMPTY — measured
+// 2026-08-12 against an approved listing whose shadow this very read had just
+// opened: it reported the live icon and cover ids, not two empty slots. The CLI
+// depends on it. `reportStagedBelowFloor` (#400) decides whether the publish
+// floor is met by reading THIS view, so an empty-seeded shadow would make every
+// live listing look below-floor and would route a genuine rejection down the
+// "this is only the floor" path. The same read also reported
+// `hasPendingRevision: false` while that shadow existed, so the flag means
+// SUBMITTED, not "a shadow exists".
 type ListingEditView struct {
 	ParentID           string  `json:"parentId"`
 	Slug               string  `json:"slug"`

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -291,6 +291,13 @@ func printListingStatus(w io.Writer, slug string, ref *appapi.ListingRef, view *
 			fmt.Fprintf(w, "  Add one:  %s\n", ui.Code("civitai app listing set-cover <file>"))
 		}
 	}
+	// `hasPendingRevision` means SUBMITTED, not "a shadow exists" — measured
+	// 2026-08-12 on an approved listing carrying an open shadow
+	// (`shadowId: apl_01KZVG3M…`, media attached, never submitted): the server
+	// still reported `hasPendingRevision: false`. That matters because #400's
+	// below-floor path deliberately LEAVES such a shadow open, and if the flag
+	// tracked existence instead this line would tell the author a moderator was
+	// reviewing something that had not been sent. It does not.
 	if view.HasPendingRevision {
 		fmt.Fprintln(w, "\nA revision is currently under moderator review.")
 	} else if ref.Status == "approved" {
@@ -738,20 +745,28 @@ func reportStagedBelowFloor(ctx context.Context, out io.Writer, client *appapi.C
 // INGESTED counts, because the server is free to answer with either and both
 // name an image this command put there. A pre-existing image matches neither.
 //
-// 🔴 THE RESIDUAL IS STATED BECAUSE IT DECIDES WHETHER THIS FIX APPLIES AT ALL,
-// and it is unmeasured. If the platform stores a re-encoded DERIVATIVE under a
-// NEW image id — this repo already documents that it re-encodes icons from
-// decoded pixels (#295 / #344, see app_listing_reencode_test.go) — while
-// echoing back the id it was GIVEN, then the re-read reports an id this CLI has
-// never seen and cannot recognise. The check then fails CLOSED: the user gets
-// the same submit error they get today, so this is a fix that did not apply,
-// never a new false report. Widening it to "the slot is non-empty" would trade
-// that for the opposite failure — a listing being re-branded already HAS an
-// icon, so presence alone would certify the image the author is REPLACING.
-// The measurement that settles it is one credentialed run against a live
-// listing: compare `setIcon`'s echoed `iconId` with what
-// `getMyListingForEdit` then reports in the slot. Until someone runs it, do not
-// restate this comment as if the derivative case were handled.
+// 🔴 THE ONE ASSUMPTION THIS RESTS ON IS NOW MEASURED, and it holds. The worry
+// was that the platform might store a re-encoded DERIVATIVE under a NEW image
+// id — this repo documents that it re-encodes icons from decoded pixels
+// (#295 / #344, see app_listing_reencode_test.go) — while echoing back the id
+// it was GIVEN. The re-read would then report an id this CLI has never seen,
+// the check would fail CLOSED, and the whole #400 fix would silently not apply.
+//
+// Measured 2026-08-12 against the live platform, one `set-icon` on an approved
+// listing (`sensei`), reading the wire: `ingestAssetFromDataUri` minted image
+// 139517683, `setIcon` echoed `iconId` 139517683, and `getMyListingForEdit`
+// then reported 139517683 in the slot. ALL THREE AGREE — the Image row is
+// created at INGEST and the slot references that same row; the re-encode is a
+// URL TRANSFORM (`…/width=320/…` in the asset URL), not a second row. So the
+// echo and the ingested id are the same value in practice, and accepting either
+// is belt-and-braces rather than the load-bearing part.
+//
+// What is still NOT proven is that they must always agree — one listing, one
+// kind, one day. Hence both candidates stay. If this ever regresses the failure
+// is the safe one: the user gets the submit error they got before #400, never a
+// false success. Widening to "the slot is non-empty" would trade that for the
+// opposite failure — a listing being re-branded already HAS an icon, so
+// presence alone would certify the image the author is REPLACING.
 func attachLanded(view *appapi.ListingEditView, kind mediaKind, imageID int, res *appapi.AttachResult) bool {
 	switch kind {
 	case kindIcon:


### PR DESCRIPTION
Follow-up to #403. **Comments only** — `git diff` carries no non-comment line, and no behaviour changes.

#403 shipped a check that proves an attached asset landed **by image id**, and stated plainly that the thing deciding whether it works in production was unmeasured:

> If the platform stores a re-encoded **derivative** under a **new** image id […] while echoing back the id it was **given**, then the re-read reports an id this CLI has never seen and cannot recognise. The check then fails CLOSED […] Until someone runs it, do not restate this comment as if the derivative case were handled.

Ran it.

## The measurement

One `set-icon` against a live approved listing (`sensei`), reading the wire through a local logging proxy that forwarded everything to civitai.com **except `submitListingRevision`**, which it answered locally with the below-floor 400 — so no revision was ever sent to a moderator and the live listing was untouched. (3 submit attempts, 3 refused locally, 0 forwarded.)

| step | image id |
| --- | --- |
| `ingestAssetFromDataUri` minted | `139517683` |
| `setIcon` echoed as `iconId` | `139517683` |
| `getMyListingForEdit` then reported in the slot | **`139517683`** |

All three agree. The `Image` row is created at **ingest** and the slot references that same row; the re-encode is a **URL transform** (`…/width=320/…` in the asset URL), not a second row. **So #403 does fix #400 in production**, and accepting either candidate id is belt-and-braces rather than the load-bearing part.

Both candidates stay. One listing, one kind, one day does not prove they must always agree — and if it ever regresses, the failure is the safe one: the author gets the submit error they got before #400, never a false success.

## Two more things the same run settled

Recorded where the code depends on them rather than in a doc nobody opens:

- **`hasPendingRevision` means SUBMITTED, not "a shadow exists".** Measured `false` on a listing carrying an open, media-bearing, never-submitted shadow (`apl_01KZVG3M…`). #400's below-floor path deliberately leaves exactly that shadow open, so had the flag tracked existence, `app listing status` would tell the author a moderator was reviewing something that was never sent. It doesn't.
- **The shadow is seeded from the live listing, not empty.** It reported the live icon and cover ids on a read that had *just* opened it. `reportStagedBelowFloor` reads that view to decide whether the publish floor is met, so an empty-seeded shadow would make every live listing look below-floor and route a genuine rejection down the "this is only the floor" path.

## Incidentally confirmed end-to-end

The run exited **2**, and the fix correctly *declined* to swallow the 400 — `sensei`'s floor is met, so the floor cannot be the reason. That is the live-server confirmation of both the exit-code correction and the floor-met guard, which until now existed only as a stub test.

## Known residue on `sensei`

Its shadow revision now holds a re-uploaded icon (`139517683`, 320×320 JPEG — the largest derivative I could fetch) rather than the original (`139463748`). Nothing is live and nothing is queued: the revision was never submitted, `hasPendingRevision` is `false`, and the public listing still serves the original. It only matters if that shadow is later submitted; setting the icon from the original artwork clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
