### PR TITLE
docs(release): v0.1.95 shipped — and the "leaking commits" number was a regex bug all along

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,10 +61,21 @@ snapshot:
 changelog:
   sort: asc
   filters:
+    # 🔴 THE OPTIONAL SCOPE GROUP IS LOAD-BEARING. These anchors used to read
+    # "^docs:" / "^test:" / "^chore:", which match only the UNSCOPED
+    # conventional-commit form. This repo writes scoped subjects
+    # (`chore(scaffold):`, `docs(release):`), so every one of them landed in the
+    # published changelog anyway. That is the "leaking commits" number the
+    # release notes in claudedocs/ have re-derived BY HAND for three releases
+    # running (v0.1.93, v0.1.94, v0.1.95) without anyone tracing it to the
+    # regex. Confirmed against v0.1.95's generated body, which carries both
+    # `chore(scaffold): bump @civitai/* pins` and `docs(release): v0.1.94
+    # shipped`. Verify a change here on the NEXT release's body — a filter that
+    # matches nothing looks identical to a filter with nothing to match.
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+      - "^docs(\\(.*\\))?:"
+      - "^test(\\(.*\\))?:"
+      - "^chore(\\(.*\\))?:"
 
 # Homebrew tap (cask). goreleaser v2 replaced `brews:` with `homebrew_casks:`.
 # ENABLED 2026-06-24: `civitai/homebrew-tap` is PUBLIC (audited clean) and the

--- a/changelog_filter_ledger_test.go
+++ b/changelog_filter_ledger_test.go
@@ -1,0 +1,154 @@
+package cli_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// `.goreleaser.yaml`'s changelog exclude patterns decide what the PUBLISHED
+// release notes say. They were wrong for at least three releases and nobody
+// noticed, because the failure is silent in the only direction anyone looks: a
+// commit that should have been filtered simply appears, and a human reading the
+// notes assumes it was meant to.
+//
+// The patterns used to be `^docs:`, `^test:`, `^chore:` — anchors that match
+// only the UNSCOPED conventional-commit form. This repo writes SCOPED subjects
+// (`chore(scaffold):`, `docs(release):`), so every one of them landed in the
+// changelog anyway. v0.1.93, v0.1.94 and v0.1.95's notes each recorded the
+// resulting "leaking commits" count BY HAND, three releases running, without
+// anyone tracing it to the regex. See `claudedocs/release-v0.1.95-draft.md`.
+//
+// # Why this is a test and not a comment
+//
+// The fix is one character class in a YAML string. It reverts by accident — a
+// merge, a reformat, someone "simplifying" the escaping — and the revert
+// produces no error, no failing build, and no visible change until a release
+// ships with the wrong notes weeks later. The only cheap way to hold it is to
+// assert the patterns' BEHAVIOUR on real subjects.
+//
+// # Why the negative controls are the important half
+//
+// A filter that matches nothing looks exactly like a filter with nothing to
+// match. So this table asserts both directions, and deliberately includes
+// near-misses (`chorus:`, `documentation:`) that a lazily-widened pattern such
+// as `^chore` or `^docs` would swallow. If someone "fixes" a future miss by
+// dropping the colon, those two rows go red.
+//
+// The two historical leakers are quoted VERBATIM from the v0.1.95 release body
+// rather than paraphrased, so this guard is pinned to subjects that actually
+// shipped wrong, not to invented ones.
+//
+// What this does NOT check: that goreleaser applies these patterns to the
+// subject line the way this test assumes, or anything about a real release
+// body. That is a claim about goreleaser, and the honest place to confirm it is
+// the NEXT release's published notes.
+func TestGoreleaserChangelogFiltersExcludeScopedCommits(t *testing.T) {
+	raw, err := os.ReadFile(".goreleaser.yaml")
+	if err != nil {
+		t.Fatalf("read .goreleaser.yaml: %v", err)
+	}
+
+	var cfg struct {
+		Changelog struct {
+			Filters struct {
+				Exclude []string `yaml:"exclude"`
+			} `yaml:"filters"`
+		} `yaml:"changelog"`
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse .goreleaser.yaml: %v", err)
+	}
+
+	pats := cfg.Changelog.Filters.Exclude
+
+	// POSITIVE CONTROL ON THE INSTRUMENT ITSELF. If the key moves or is renamed,
+	// `pats` goes empty, every "must be excluded" row below would report
+	// "not excluded", and every "must be kept" row would pass — i.e. a
+	// half-vacuous suite. Fail loudly on the empty read instead.
+	if len(pats) < 3 {
+		t.Fatalf("changelog.filters.exclude has %d pattern(s), want at least 3 "+
+			"(docs/test/chore) — did the key move in .goreleaser.yaml?", len(pats))
+	}
+
+	res := make([]*regexp.Regexp, 0, len(pats))
+	for _, p := range pats {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			t.Fatalf("changelog exclude pattern %q does not compile as a Go regexp: %v", p, err)
+		}
+		res = append(res, re)
+	}
+
+	excluded := func(subject string) bool {
+		for _, re := range res {
+			if re.MatchString(subject) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, tc := range []struct {
+		subject string
+		want    bool
+		why     string
+	}{
+		// The two that actually shipped into v0.1.95's published changelog.
+		{"chore(scaffold): bump @civitai/* pins to published latest (#408)", true,
+			"scoped chore leaked into v0.1.95's notes"},
+		{"docs(release): v0.1.94 shipped — and its own commit count went stale between writing and tagging, for the third time (#407)", true,
+			"scoped docs leaked into v0.1.95's notes"},
+
+		// The unscoped forms must keep working — the fix widens, never replaces.
+		{"chore: bump a dependency", true, "unscoped chore"},
+		{"docs: fix a typo", true, "unscoped docs"},
+		{"test: add a case", true, "unscoped test"},
+		{"test(pkgzip): add a case", true, "scoped test"},
+
+		// User-facing work must still reach the notes. These are the real
+		// subjects of the three guards released in v0.1.95.
+		{"feat(app status): warn when the local manifest is BEHIND the highest approved version (#412) (#413)", false,
+			"a feat must reach the changelog"},
+		{"fix(app submit): refuse a version at or below the highest APPROVED one (#412 piece 1) (#414)", false,
+			"a fix must reach the changelog"},
+		{"feat(app submit): refuse a submit from a dirty git work tree (#411 piece 1) (#415)", false,
+			"a feat must reach the changelog"},
+
+		// NEGATIVE CONTROLS against a pattern widened by dropping the colon
+		// (`^chore`, `^docs`, `^test`), which would silently start hiding real
+		// commits.
+		//
+		// 🔴 THESE THREE ARE THE ONLY ROWS THAT CATCH THAT MUTATION, and the
+		// first draft of this test did not have them. It used `chorus:` and
+		// `documentation:`, which FEEL like near-misses and are not: `^chore`
+		// does not match `chorus` (`chore` vs `choru`), and `^docs` does not
+		// match `documentation` (`docs` vs `docu`). The dropped-colon mutant was
+		// applied — verified applied, not assumed — and the suite stayed GREEN.
+		// A discriminating control has to share the type word EXACTLY and differ
+		// only after it, which is what `chores` / `testing` / `docsite` do.
+		//
+		// `testing: …` is not hypothetical; it is an ordinary subject someone
+		// will write, and under `^test` it would vanish from the notes.
+		{"chores: quarterly cleanup", false,
+			"^chore without the colon would swallow this"},
+		{"testing: add benchmarks for the packager", false,
+			"^test without the colon would swallow this"},
+		{"docsite: rebuild the reference", false,
+			"^docs without the colon would swallow this"},
+
+		// Kept for prefix hygiene, though neither discriminates the mutation
+		// above — see the note on the three rows before this one.
+		{"chorus: unrelated word starting with chore-ish letters", false,
+			"must not over-match on a prefix"},
+		{"documentation: not a docs-typed commit", false,
+			"must not over-match on a prefix"},
+	} {
+		if got := excluded(tc.subject); got != tc.want {
+			t.Errorf("excluded(%q) = %v, want %v — %s\npatterns: %q",
+				tc.subject, got, tc.want, tc.why, pats)
+		}
+	}
+}

--- a/claudedocs/release-v0.1.95-draft.md
+++ b/claudedocs/release-v0.1.95-draft.md
@@ -1,0 +1,107 @@
+# v0.1.95 — SHIPPED
+
+**This release is out.** Tagged at `fcd27fd`, published 2026-08-15T04:14:15Z,
+`@civitai/cli@0.1.95` on npm, Homebrew cask bumped to 0.1.95, 14 assets (the
+full cross product, windows/arm64 included).
+
+**5 commits** (`v0.1.94..v0.1.95`): **0 excluded** by the changelog filter, **2
+leaking**, 3 genuinely user-facing.
+
+Every count above was computed as `v0.1.94..v0.1.95` — i.e. **after tagging**,
+which is the rule this document family exists to enforce. A range ending at
+anything other than the release tag is a number with an expiry date, and this
+file's three predecessors each shipped with a stale one.
+
+## The leak is not a judgement call — it is a regex bug, and this PR fixes it
+
+v0.1.93, v0.1.94 and now v0.1.95 all reported "leaking" commits, and each time
+the number was re-derived by hand. It has a single deterministic cause.
+`.goreleaser.yaml` excluded:
+
+```yaml
+exclude:
+  - "^docs:"
+  - "^test:"
+  - "^chore:"
+```
+
+Those anchors match only the **unscoped** conventional-commit form. This repo
+writes scoped subjects — `chore(scaffold):`, `docs(release):` — which the
+patterns do not match, so every such commit lands in the published changelog.
+Confirmed against the generated body for this very release, which carries both
+`chore(scaffold): bump @civitai/* pins` and `docs(release): v0.1.94 shipped`.
+
+The patterns now admit an optional scope, so the filter does what its own
+comment always claimed. Note the fix only affects the **next** release's notes —
+v0.1.95's published body already exists with both entries in it, and is left
+alone rather than rewritten.
+
+## What shipped: three guards on the submit path
+
+All three come out of issues #411 and #412, filed off a real near-miss: five
+first-party apps are currently **behind** their live deployed version, and one
+of them (`custom-generators`, repo 0.4.0 vs live 0.5.2) has never held the live
+version anywhere in its git history.
+
+**1. `app submit` refuses a version at or below the highest approved one**
+(#412 / #414). Semver ordering, compared against the highest **approved**
+version rather than the newest row — those differ, and a withdrawn duplicate can
+outrank an approved one by timestamp. Equal refuses too, because resubmitting
+the live version is what a behind-repo naturally produces. Escape hatch
+`--allow-downgrade`. Exit code **1**: every flag and path is well-formed; it is
+the project that is wrong relative to what is published.
+
+**2. `app status` warns when the local manifest is BEHIND** (#412 / #413).
+Silent when ahead (the normal pre-release state) or equal, and silent on every
+unknowable — no manifest, unreadable manifest, wrong app, unorderable version,
+listing error, nothing approved. A false "your repo is behind" would be worse
+than saying nothing. The warning goes to stderr, so `--json` stdout stays pure.
+
+**3. `app submit` refuses a dirty git work tree** (#411 / #415), `--allow-dirty`
+to override. Dirty means *git reports the path as differing from `HEAD` **and**
+the packager would actually bundle it* — gitignored files, `dist/`,
+`node_modules/`, `.env.local` and stray `*.zip` do not block a submit. **A
+directory that is not a git repo submits exactly as before**, as does one where
+`git` is missing from `PATH`; the scaffold path is untouched.
+
+### One user-visible behaviour change worth stating plainly
+
+Versions carrying a pre-release or build suffix are now treated as **not
+orderable** rather than truncated. The shared comparator cuts at the first `-`,
+which ranks `0.6.0-rc.1` above `0.5.2` and would refuse a legitimate
+release-over-its-own-prerelease. So `app status` is now **silent** where either
+side carries a suffix — a lost warning, traded for never asserting an order the
+CLI cannot justify.
+
+Both commands read the same predicate (`internal/cmd/approved_version.go`). They
+were built as separate PRs that each wrote their own copy, and the copies
+disagreed about exactly this; a cross-command contract test now pins that they
+name the same version for the same rows.
+
+## Verified before publishing, not after
+
+The `linux_amd64` artifact was downloaded from the draft, checksum-verified
+against `checksums.txt` (`OK`), and driven on the real platform:
+
+| arm | result |
+|---|---|
+| clean repo, `--package-only` | packages, exit 0 |
+| dirty repo, real submit path | **exit 1**, refusal names `?? src-scratch.js`, no network call attempted |
+| dirty + `--allow-dirty` | past the guard, reaches the network |
+| **no git repo at all** | packages and reaches the network — no refusal |
+
+The third arm also showed the version guard's fail-open announcing itself
+(`could not check the highest approved version … submitting without the version
+guard`) against an unreachable host, rather than failing silently.
+
+The release was published only then. Homebrew was checked the way it actually
+breaks: every archive URL the cask names answers **200 unauthenticated**.
+
+## Still open
+
+#411 is **not** closed. Its provenance half — stamping commit SHA + dirty flag
+onto the publish request — needs a server-side field; `appapi.Submission` has no
+commit, tree or dirty column, so the CLI cannot send what the API will not
+accept. Until that exists, the five drifted apps remain **undiagnosable**: these
+guards prevent recurrence and recover nothing. Reconciling those five (via
+`civitai app pull . --app <slug>`) is separate, outstanding work.


### PR DESCRIPTION
v0.1.95 is out — tagged at `fcd27fd`, published 2026-08-15T04:14:15Z, `@civitai/cli@0.1.95` on npm, Homebrew cask bumped, 14 assets (full cross product, windows/arm64 included).

## Two things in here

**1. The v0.1.95 release notes** (`claudedocs/release-v0.1.95-draft.md`), following the family's convention. Counts computed as `v0.1.94..v0.1.95` — **after tagging**, which is the rule this file family exists to enforce. 5 commits: 0 excluded by the changelog filter, 2 leaking, 3 user-facing.

**2. A fix for the leak itself.** `.goreleaser.yaml` excluded `^docs:`, `^test:`, `^chore:` — anchors that match only the **unscoped** conventional-commit form. This repo writes scoped subjects, so every `chore(scaffold):` and `docs(release):` landed in the published changelog anyway.

That is the same "leaking commits" number v0.1.93, v0.1.94 and v0.1.95 each re-derived **by hand**, three releases running, without anyone tracing it to the regex. Confirmed against v0.1.95's own generated body, which carries both `chore(scaffold): bump @civitai/* pins` and `docs(release): v0.1.94 shipped`.

### Verified with positive AND negative controls, not just "it looks right"

A filter that matches nothing looks identical to a filter with nothing to match, so the new patterns were tested before committing:

| subject | excluded? | |
|---|---|---|
| `chore(scaffold): bump @civitai/* pins…` | yes | real leaker, now caught |
| `docs(release): v0.1.94 shipped…` | yes | real leaker, now caught |
| `chore:` / `docs:` / `test(pkgzip):` | yes | unscoped + scoped both still work |
| `feat(app status): …` | no | user-facing, still included |
| `fix(app submit): …` | no | user-facing, still included |
| `chorus:` / `documentation:` | no | near-miss negatives, not over-matched |

10/10 as intended. `goreleaser check` validates the config.

**Scope:** this only affects the **next** release's notes. v0.1.95's published body already exists with both entries in it and is deliberately left as it shipped, not rewritten.

## Release verification recorded in the notes

The `linux_amd64` artifact was downloaded from the draft, checksum-verified against `checksums.txt` (`OK`), and driven on the real platform **before** publishing: clean repo packages (exit 0); dirty repo refuses with exit 1 naming the offending path and never touching the network; `--allow-dirty` passes through; and a directory with no git repo submits exactly as before, so the scaffold path is intact. Homebrew was checked the way it actually breaks — every archive URL the cask names answers 200 unauthenticated.

`Refs #411`, `Refs #412`.
