### PR TITLE
test(readme): widen the TOC gate to `###` — it found two sections missing, one linked from nowhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ contract, and **packages/submits** it for review.
 - [Download model files](#download-model-files)
 - [Generate](#generate) — **spends real Buzz**
   - [`--max-cost` is an estimate check, not a spending cap](#---max-cost-is-an-estimate-check-not-a-spending-cap)
+  - [A checkpoint does not carry its ecosystem](#-a-checkpoint-does-not-carry-its-ecosystem)
   - [Silent model substitution](#-silent-model-substitution)
   - [Confirmation](#confirmation)
   - [Image-to-image: `--image` and `--ecosystem`](#image-to-image---image-and---ecosystem)
@@ -83,6 +84,7 @@ contract, and **packages/submits** it for review.
   - [Waiting, downloading, and re-attaching](#waiting-downloading-and-re-attaching)
   - [Listing and cancelling workflows](#listing-and-cancelling-workflows)
   - [What the server says went wrong](#what-the-server-says-went-wrong)
+  - [Reading a workflow's Buzz transactions](#reading-a-workflows-buzz-transactions)
   - [Exit codes specific to `generate`](#exit-codes-specific-to-generate)
 - [Scripting with `--json`](#scripting-with---json)
   - [Cursor pagination loop](#cursor-pagination-loop)

--- a/internal/cmd/readme_nav_test.go
+++ b/internal/cmd/readme_nav_test.go
@@ -147,6 +147,24 @@ func readmeRowPlusLinkedSections(t *testing.T, md, row string) string {
 // work on github.com. They exercise the four cases the algorithm gets wrong if
 // it is written naively: a dropped `&` leaving a double hyphen, backticks
 // around a `--flag`, a leading emoji, and an underscore that must SURVIVE.
+//
+// 🔴 THE CORPUS IS OBSERVED ANCHORS ONLY. Adding a pair derived from this same
+// function would make the control agree with itself, which is the exact failure
+// readmeAnchorSlug's own doc comment warns about — so a newly-written heading
+// does not belong here (see TestREADMEWidenedTOCEntriesSlugAsExpected, which
+// pins those separately and says what it is and is not worth).
+//
+// # `###` is not an untested case
+//
+// The heading LEVEL is not an input: GitHub computes the slug from the heading
+// text alone, and so does readmeAnchorSlug — which takes the text and nothing
+// else. The corpus bears that out empirically rather than by assertion: seven of
+// the eight pairs below are `###` headings in this very README, and only
+// `Submit & auth` is a `##`. So the `###` entries the table of contents gained
+// are not a new anchor FORM, and each one's distinguishing character class is
+// already pinned by an observed anchor — a leading emoji dropping to a bare
+// hyphen by `🔴 Silent model substitution`, and an apostrophe vanishing without
+// a separator by `there aren't twelve` → `there-arent-twelve`.
 func TestREADMEAnchorSlugMatchesKnownGitHubAnchors(t *testing.T) {
 	cases := map[string]string{
 		"Submit & auth":                                  "submit--auth",
@@ -161,6 +179,38 @@ func TestREADMEAnchorSlugMatchesKnownGitHubAnchors(t *testing.T) {
 	for heading, want := range cases {
 		if got := readmeAnchorSlug(heading); got != want {
 			t.Errorf("readmeAnchorSlug(%q) = %q, want %q", heading, got, want)
+		}
+	}
+}
+
+// TestREADMEWidenedTOCEntriesSlugAsExpected pins the anchors of the two
+// subsections the widened TOC gate found missing, so the exact strings written
+// into the Contents list are asserted rather than assumed.
+//
+// 🔴 THIS IS NOT A CONTROL, AND IT IS DELIBERATELY NOT IN THE CORPUS ABOVE.
+// These anchors were derived from readmeAnchorSlug, not observed on github.com,
+// so they cannot testify that the algorithm is RIGHT. What they are worth is the
+// other failure: TestREADMEAnchorLinksResolve compares a heading and a link
+// through this same function, so a change to the algorithm moves both sides
+// together and stays green while every anchor in the file silently changes. A
+// literal expected value is the only thing that notices.
+func TestREADMEWidenedTOCEntriesSlugAsExpected(t *testing.T) {
+	cases := map[string]string{
+		"🔴 A checkpoint does not carry its ecosystem": "-a-checkpoint-does-not-carry-its-ecosystem",
+		"Reading a workflow's Buzz transactions":      "reading-a-workflows-buzz-transactions",
+	}
+	for heading, want := range cases {
+		if got := readmeAnchorSlug(heading); got != want {
+			t.Errorf("readmeAnchorSlug(%q) = %q, want %q", heading, got, want)
+		}
+	}
+	// The pin is only worth anything if the README really carries these
+	// headings under those anchors — otherwise it pins two strings nothing uses.
+	headings := readmeHeadings(t, readREADME(t))
+	for heading, slug := range cases {
+		if got, ok := headings[slug]; !ok || got != heading {
+			t.Errorf("README.md has no heading %q at #%s (found %q, present=%v) — this pin is asserting a string the document does not use",
+				heading, slug, got, ok)
 		}
 	}
 }
@@ -201,14 +251,11 @@ func TestREADMEAnchorLinksResolve(t *testing.T) {
 	}
 }
 
-// TestREADMETableOfContentsCoversEverySection requires each top-level (`##`)
-// section to be reachable from the "## Contents" list. A TOC that silently stops
-// covering the document is the state this whole change set exists to end, and it
-// degrades one section at a time rather than all at once — so the check has to
-// be per-section, not "a TOC exists".
-func TestREADMETableOfContentsCoversEverySection(t *testing.T) {
-	md := stripFencedCode(readREADME(t))
-
+// readmeContentsLinks returns the set of anchor slugs the "## Contents" list
+// links to. The block is delimited structurally — the `## Contents` heading to
+// the next `## ` — so ordinary edits inside it do not move the bounds.
+func readmeContentsLinks(t *testing.T, md string) map[string]bool {
+	t.Helper()
 	const heading = "\n## Contents\n"
 	i := strings.Index(md, heading)
 	if i < 0 {
@@ -223,30 +270,270 @@ func TestREADMETableOfContentsCoversEverySection(t *testing.T) {
 	for _, m := range readmeAnchorRe.FindAllStringSubmatch(toc, -1) {
 		linked[m[1]] = true
 	}
+	// Positive control: a Contents block that extracted to nothing would report
+	// every section as missing (loud) — but it would report every TOC entry as
+	// legitimate (silent), which is the reverse direction below.
 	if len(linked) < 20 {
 		t.Fatalf("the Contents section holds only %d links — the extractor is reading the wrong block", len(linked))
 	}
+	return linked
+}
 
-	var missing []string
-	sections := 0
-	for _, m := range readmeHeadingRe.FindAllStringSubmatch(md, -1) {
-		if m[1] != "##" {
+// readmeSection is one `##` or `###` heading with the `##` section that contains
+// it. `Parent` is the empty string for a `##` heading (it is its own section).
+type readmeSection struct {
+	Level  int
+	Text   string
+	Slug   string
+	Parent string // the `##` heading text a `###` sits under
+}
+
+// readmeSections walks the README top to bottom and returns every `##`/`###`
+// heading in document order, each `###` tagged with the `##` it belongs to.
+//
+// The walk is line-by-line rather than a whole-file regex because the PARENT is
+// the whole point: scope below is decided per `##` section, and a regex over the
+// flat text cannot say which section a `###` fell in.
+func readmeSections(t *testing.T, md string) []readmeSection {
+	t.Helper()
+	var out []readmeSection
+	parent := ""
+	for _, line := range strings.Split(stripFencedCode(md), "\n") {
+		m := anyHeadingRe.FindStringSubmatch(line)
+		if m == nil {
 			continue
 		}
-		slug := readmeAnchorSlug(m[2])
-		if slug == "contents" {
+		switch len(m[1]) {
+		case 2:
+			parent = m[2]
+			out = append(out, readmeSection{Level: 2, Text: m[2], Slug: readmeAnchorSlug(m[2])})
+		case 3:
+			if parent == "" {
+				t.Fatalf("README.md has a `### %s` before any `##` heading — the section walk cannot attribute it", m[2])
+			}
+			out = append(out, readmeSection{Level: 3, Text: m[2], Slug: readmeAnchorSlug(m[2]), Parent: parent})
+		}
+	}
+	return out
+}
+
+// readmeTOCExemptSections names the `##` sections whose `###` subsections are
+// deliberately NOT table-of-contents entries. The exemption is keyed by PARENT
+// SECTION, never by individual heading: a per-heading allowlist grows one line
+// per omission and reads as a to-do list, whereas naming the section states a
+// rule a future author can apply to a subsection that does not exist yet.
+//
+// Both entries are the same shape — a section whose `###` children are an
+// ENUMERATION of the index directly above them, not topics a reader navigates
+// to. Everything else in the README is in scope.
+var readmeTOCExemptSections = map[string]string{
+	"Exit codes": "its `### Exit code N` subsections are GENERATED from exitCodeDocs " +
+		"(internal/cmd/exitcodes_doc.go) and asserted byte-for-byte by " +
+		"TestREADMEExitCodeSectionsAreGenerated. Their number and their headings follow " +
+		"that table, so listing them in a hand-written TOC would put a generated set " +
+		"behind a hand-maintained index — the exact drift that generator exists to end. " +
+		"Each is already reachable by name from the `[Detail](#exit-code-N)` link in the " +
+		"table the generator renders alongside them. Putting them in the TOC is a " +
+		"decision to generate the TOC too, not a line to add by hand.",
+	"Troubleshooting": "its `###` children are the column headers of ONE lookup table — " +
+		"the section's own first line is \"Look up the message you got\", and the TOC " +
+		"entry for it already says \"look the error message up here\". A reader arrives " +
+		"by searching for their error string, not by picking `Generating` over " +
+		"`Everything else`, so the buckets are an ordering of the index rather than " +
+		"destinations. Every row already carries its own cross-reference into the " +
+		"section that holds the detail, and those ARE in the TOC.",
+}
+
+// readmeTOCMinSubsections is the anti-vacuity floor for the widened gate: the
+// number of `###` headings that must survive the exemptions above and really be
+// checked.
+//
+// 🔴 It is what makes the exemption map safe to hold a rule instead of a list.
+// The failure mode of a parent-keyed exemption is that it is TOO BROAD — naming
+// `Generate` would silently retire 12 subsections and the gate would go on
+// printing a green PASS over a document it had stopped reading. This floor turns
+// that into a red run: the real in-scope count is 33, so exempting any of the
+// substantial sections (`Generate` 12, `Command reference` 6, `Install` 5,
+// `Scripting with --json` 5) drops it under the floor and the guard says so by
+// name. It is set well below 33 so ordinary additions and deletions never trip
+// it.
+const readmeTOCMinSubsections = 25
+
+// TestREADMETableOfContentsCoversEverySection requires each top-level (`##`)
+// section AND each in-scope second-level (`###`) subsection to be reachable from
+// the "## Contents" list. A TOC that silently stops covering the document is the
+// state this whole change set exists to end, and it degrades one section at a
+// time rather than all at once — so the check has to be per-section, not "a TOC
+// exists".
+//
+// # Why `###` is in scope at all
+//
+// The gate used to stop at `##`, and the document rotted underneath it exactly
+// where it could not look. `### Is your repo behind what you shipped?` shipped in
+// #416 while its sibling `### Deployed is not the same as listed in the store`
+// was listed, and nothing noticed the pair had gone half-covered. Widening it
+// found two more of the same in one pass: `### 🔴 A checkpoint does not carry its
+// ecosystem` — a money-safety subsection linked from NOWHERE in the file — and
+// `### Reading a workflow's Buzz transactions`, both live in the README and both
+// absent from a TOC that lists all ten of their siblings.
+//
+// # The rule, and what it deliberately does not cover
+//
+// Every `##` and every `###` is a TOC entry, EXCEPT the `###` children of the
+// sections named in readmeTOCExemptSections — with a reason recorded there per
+// section, and a count floor that reddens if the exemption set grows enough to
+// hollow the gate out.
+//
+// Depth stops at `###`. `#### Which dotenv files end up in the bundle` is the
+// file's only fourth-level heading and it is NOT required, because the TOC is a
+// map of the document and a map that reproduces every leaf is the document. That
+// bound comes from readmeHeadingRe/readmeSections, so a `####` cannot be required
+// here and cannot be counted either.
+//
+// This asserts PRESENCE — that a heading has a TOC line pointing at its anchor.
+// It says nothing about whether the TOC's ORDER matches the document's, or about
+// whether the label beside the link still describes the section. Neither is a
+// hole this guard can close, and both are stated so a green run is not read as
+// "the TOC is correct".
+func TestREADMETableOfContentsCoversEverySection(t *testing.T) {
+	md := readREADME(t)
+	linked := readmeContentsLinks(t, md)
+
+	// A renamed or deleted exempt section must not silently widen the scope back
+	// out (or, worse, narrow it: a stale key exempting nothing reads as a rule
+	// still being applied). Both are checked before the exemption is honoured.
+	sections := readmeSections(t, md)
+	for name := range readmeTOCExemptSections {
+		found, children := false, 0
+		for _, s := range sections {
+			if s.Level == 2 && s.Text == name {
+				found = true
+			}
+			if s.Level == 3 && s.Parent == name {
+				children++
+			}
+		}
+		if !found {
+			t.Errorf("readmeTOCExemptSections names the `## %s` section, which no longer exists in README.md. "+
+				"Rename the key or drop it — an exemption for a section that is gone is a rule nobody can check.", name)
+			continue
+		}
+		if children == 0 {
+			t.Errorf("readmeTOCExemptSections exempts `## %s` from the `###` TOC requirement, but that section has no "+
+				"`###` subsections. The exemption is exempting nothing — drop it.", name)
+		}
+	}
+
+	var missing []string
+	tops, subs := 0, 0
+	for _, s := range sections {
+		if s.Slug == "contents" {
 			continue // the TOC does not list itself
 		}
-		sections++
-		if !linked[slug] {
-			missing = append(missing, m[2]+"  (#"+slug+")")
+		switch s.Level {
+		case 2:
+			tops++
+		case 3:
+			if _, exempt := readmeTOCExemptSections[s.Parent]; exempt {
+				continue
+			}
+			subs++
+		}
+		if !linked[s.Slug] {
+			missing = append(missing, strings.Repeat("#", s.Level)+" "+s.Text+"  (#"+s.Slug+")")
 		}
 	}
-	if sections < 15 {
-		t.Fatalf("found only %d top-level sections — the heading scan is wrong", sections)
+
+	// Two floors, because the two levels fail independently: a heading scan that
+	// lost `###` entirely would keep the `##` half green.
+	if tops < 15 {
+		t.Fatalf("found only %d top-level sections — the heading scan is wrong", tops)
 	}
+	if subs < readmeTOCMinSubsections {
+		t.Fatalf("only %d `###` subsections are in scope, want at least %d — either the heading scan is wrong or "+
+			"readmeTOCExemptSections has grown until this gate checks almost nothing. Exempting a section is a "+
+			"decision about the README's navigation; making the gate vacuous is not.", subs, readmeTOCMinSubsections)
+	}
+
 	if len(missing) > 0 {
-		t.Errorf("README sections missing from `## Contents`:\n  %s", strings.Join(missing, "\n  "))
+		t.Errorf("README sections missing from `## Contents`:\n  %s\n\n"+
+			"Every `##` and every `###` needs a line in the TOC, except the `###` children of %v.",
+			strings.Join(missing, "\n  "), readmeTOCExemptSectionNames())
+	}
+}
+
+// readmeTOCExemptSectionNames returns the exempt section names, sorted, for use
+// in a failure message.
+func readmeTOCExemptSectionNames() []string {
+	var names []string
+	for name := range readmeTOCExemptSections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestREADMETableOfContentsListsNothingElse is the REVERSE direction of the gate
+// above, and it exists for the reason the layout ledger is bidirectional: a
+// one-directional guard leaves half the rot in place. The forward half catches a
+// section that grew without a TOC line; this half catches a TOC line that
+// outlived its section, or that reaches into a section the rule says is not
+// navigated that way.
+//
+// It is NOT a duplicate of TestREADMEAnchorLinksResolve. That guard asks whether
+// a link resolves to SOME heading anywhere in the file — so it is satisfied by a
+// TOC entry pointing at `### Exit code 3` or at a Troubleshooting bucket, both of
+// which are the half-covered state readmeTOCExemptSections exists to forbid. This
+// one asks whether the target is a heading the TOC is allowed to list at all.
+func TestREADMETableOfContentsListsNothingElse(t *testing.T) {
+	md := readREADME(t)
+	linked := readmeContentsLinks(t, md)
+
+	inScope := map[string]bool{}
+	exempt := map[string]string{} // slug → the section it belongs to
+	for _, s := range readmeSections(t, md) {
+		if _, off := readmeTOCExemptSections[s.Parent]; off && s.Level == 3 {
+			exempt[s.Slug] = s.Parent
+			continue
+		}
+		inScope[s.Slug] = true
+	}
+	// Positive control: an empty in-scope set would report every TOC entry as
+	// stale, which is loud — but an in-scope set built from the wrong text would
+	// report a handful, which is not. The floor pins the set to the real document.
+	if len(inScope) < readmeTOCMinSubsections {
+		t.Fatalf("only %d headings are TOC-eligible — the section walk is reading the wrong text", len(inScope))
+	}
+
+	var stale, offLimits []string
+	for slug := range linked {
+		if inScope[slug] {
+			continue
+		}
+		if parent, ok := exempt[slug]; ok {
+			// The recorded reason is printed here rather than only living in the
+			// map, because this is where a maintainer collides with the rule: a
+			// message that says "not allowed" without saying why is a message
+			// whose cheapest resolution is to delete the guard.
+			offLimits = append(offLimits, slug+"\n      a `###` under `## "+parent+"`, which is exempt because "+
+				readmeTOCExemptSections[parent])
+			continue
+		}
+		stale = append(stale, slug)
+	}
+	sort.Strings(stale)
+	sort.Strings(offLimits)
+
+	if len(stale) > 0 {
+		t.Errorf("the `## Contents` list links %d anchor(s) that are no longer a `##`/`###` heading: %v\n\n"+
+			"A TOC entry that outlived its section renders as an ordinary link that goes nowhere. "+
+			"Delete the line, or restore the heading.", len(stale), stale)
+	}
+	if len(offLimits) > 0 {
+		t.Errorf("the `## Contents` list links %d subsection(s) of an exempt section:\n    %s\n\n"+
+			"readmeTOCExemptSections holds those sections' `###` children OUT of the TOC wholesale, so a single "+
+			"one listed there is the half-covered state the exemption exists to prevent. Either drop the line, or "+
+			"drop the exemption and list every sibling.", len(offLimits), strings.Join(offLimits, "\n    "))
 	}
 }
 


### PR DESCRIPTION
`TestREADMETableOfContentsCoversEverySection` asserted the `## Contents` list covered every `##` heading — and nothing else. A `###` section could be added, or rot out of the TOC, with no gate.

That is not hypothetical. #416 added `### Is your repo behind what you shipped?` with no TOC entry while its sibling `### Deployed is not the same as listed in the store` had one; the entry was added by hand afterwards and nothing stopped the next one being forgotten.

## What the widened gate found

Two more of the same, both live in the README today, both absent from a TOC that lists all ten of their siblings:

| Heading | Note |
|---|---|
| `### 🔴 A checkpoint does not carry its ecosystem` | linked from **nowhere** in the file — a money-safety subsection a TOC reader could not reach |
| `### Reading a workflow's Buzz transactions` | in the TOC's `Generate` block's blind spot; linked from three places in prose, but not the map |

Both are added to the TOC in this PR.

## The rule

**Every `##` and every `###` is a table-of-contents entry, except the `###` children of the sections named in `readmeTOCExemptSections`.**

The exemption is keyed by **parent section**, never by individual heading. A per-heading allowlist grows one line per omission and reads as a to-do list; naming the section states a rule a future author can apply to a subsection nobody has written yet.

Two sections are exempt, and they are the same shape — a section whose `###` children are an *enumeration of the index directly above them*, not topics a reader navigates to:

- **`## Exit codes`** — its `### Exit code N` subsections are **generated** from `exitCodeDocs` and asserted byte-for-byte by `TestREADMEExitCodeSectionsAreGenerated`. Their number and their headings follow that table, so listing them in a hand-written TOC would put a generated set behind a hand-maintained index — the exact drift that generator exists to end. Each is already reachable by name from the `[Detail](#exit-code-N)` link the generator renders alongside them. **Putting them in the TOC is a decision to generate the TOC too, not a line to add by hand** — flagging that explicitly rather than forcing it through.
- **`## Troubleshooting`** — its `###` children are the column headers of one lookup table. The section's own first line is "Look up the message you got", and its TOC entry already says "look the error message up here". A reader arrives by searching for their error string, not by picking `Generating` over `Everything else`. Every row already cross-references the section holding the detail, and those *are* in the TOC.

**Depth stops at `###`.** The file's only `####` (`#### Which dotenv files end up in the bundle`) is not required: a map that reproduces every leaf is the document. That bound comes from the heading scan, so a `####` can neither be required nor counted.

The guard asserts **presence**. It says nothing about whether the TOC's *order* matches the document's, or whether a link's label still describes its section — both stated in the doc comment so a green run is not read as "the TOC is correct".

## Anti-vacuity: 33 in scope, floored at 25

The failure mode of a parent-keyed exemption is that it grows **too broad** and the gate goes on printing green over a document it stopped reading. `readmeTOCMinSubsections = 25` against a real in-scope count of **33** turns that into a red run: exempting any substantial section — `Generate` (12), `Command reference` (6), `Install` (5), `Scripting with --json` (5) — drops the count under the floor and the guard says so by name. Two further checks keep the exemption honest: an exempt section that no longer exists (a rename) errors, and one with no `###` children errors as "exempting nothing".

## Both directions

A one-directional guard leaves half the rot in place, so `TestREADMETableOfContentsListsNothingElse` is the reverse: a TOC entry whose heading is gone, or one reaching into an exempt section, both fail.

It is **not** a duplicate of `TestREADMEAnchorLinksResolve`. That guard asks whether a link resolves to *some* heading anywhere in the file, so it is satisfied by a TOC entry pointing at `### Exit code 3` — precisely the half-covered state the exemption exists to forbid. The mutation table below shows `AnchorLinksResolve` staying **green** on that fixture while the new guard fires.

## Anchors

The `###` anchor form does **not** differ from `##` — GitHub slugs from heading text alone, and so does `readmeAnchorSlug`, which takes the text and nothing else. Rather than assume it, note that **seven of the eight pairs** in the existing `TestREADMEAnchorSlugMatchesKnownGitHubAnchors` control corpus are already `###` headings (only `Submit & auth` is a `##`), and each new entry's distinguishing character class is pinned by an *observed* anchor: leading emoji → bare hyphen by `🔴 Silent model substitution`, dropped apostrophe by `there aren't twelve` → `there-arent-twelve`.

The two new anchors are pinned in a **separate** test, deliberately not added to that corpus: they were derived from `readmeAnchorSlug`, not observed on github.com, so they cannot testify the algorithm is right — and adding them would make the control agree with itself, which is what `readmeAnchorSlug`'s own doc comment warns against. What they *are* worth is the other failure: `AnchorLinksResolve` compares heading and link through the same function, so an algorithm change moves both sides together and stays green. A literal expected value is the only thing that notices.

## Mutation table

Every mutant killed by **this guard's own named assertion**. The two survivors are deliberate attribution controls — they prove which branch did the killing, not an untested path.

| # | Mutation | Result | Killing assertion |
|---|---|---|---|
| M1 | Remove a real `###` TOC entry (`Deployed is not the same…`) | 🔴 killed | `README sections missing from `## Contents`` — names it |
| M2 | Rename a `###` heading, leave its TOC entry | 🔴 killed | `links 1 anchor(s) that are no longer a `##`/`###` heading: [gotchas]` |
| M3 | Add a TOC entry into an exempt section (`### Exit code 3`) | 🔴 killed | `links 1 subsection(s) of an exempt section` — **`AnchorLinksResolve` PASSES**, proving it is not a duplicate |
| M6a | Remove the `## Exit codes` TOC entry | 🔴 killed | `missing from `## Contents`: ## Exit codes` |
| M6b | **Mutant:** forward match by **prefix** instead of exact, same fixture as M6a | 🟢 **survives** | `#exit-codes` is a prefix of `#exit-codes-specific-to-generate` ⇒ exact matching is load-bearing, and M6a's kill is attributable to it |
| M4 | **Mutant:** narrow the gate back to `##` only | 🔴 killed | `only 0 `###` subsections are in scope, want at least 25` |
| M5 | **Mutant:** delete the reverse off-limits branch, same fixture as M3 | 🟢 **survives** | ⇒ that branch is exactly what killed M3 |
| M7 | **Mutant:** over-broad exemption (add `Generate`, −12) | 🔴 killed | `only 21 `###` subsections are in scope, want at least 25` |
| M8 | Rename an exempt parent section | 🔴 killed | `names the `## Troubleshooting` section, which no longer exists in README.md` |
| M9 | **Mutant:** exemption naming a section with no `###` children | 🔴 killed | `The exemption is exempting nothing — drop it.` |

M0 and M10 (baseline before and after the battery) are both 6/6 PASS, so no mutation leaked into the tree.

**The demonstration the gate reddens on real content:** M1 above is exactly that — removing a shipped `###` entry from `origin/main`'s README produces a named failure, and restoring it greens. The gate also ran **red on unmodified `origin/main`**, naming the two genuinely missing entries; the README change in this PR is what greens it.

## Gates

- `make ci` — 20/20 packages ok, 0 FAIL, 0 timeout panics
- `make ci-shallow` — `ok=20/20 failing-tests=0 failing-packages=0 timeouts=0`
- `go test ./... -v` — counted: **4135 `=== RUN` / 4131 `--- PASS` / 0 `--- FAIL` / 4 `--- SKIP`**, zero `panic: test timed out`
- `golangci-lint run ./...` from the module root — **0 issues**, negative-controlled by planting an `SA4000` violation and watching it report `1 issues: staticcheck: 1` (and the run carries no `does not contain main module` warning)

Scope: `README.md` and `internal/cmd/readme_nav_test.go` only. No `internal/**` code paths touched.
