### PR TITLE
fix(pkgzip): exclude `.git` when it is a FILE, not only a directory (#409)

### DIFF
--- a/internal/pkgzip/excluded_path_test.go
+++ b/internal/pkgzip/excluded_path_test.go
@@ -156,7 +156,20 @@ func TestIsExcludedPathAgreesWithBuild(t *testing.T) {
 		".env.local",
 		".envrc",
 		"nested/.env.development.local",
+		// 🔴 #409: a linked worktree's / submodule's `.git` is a regular FILE.
+		// It is here because the two sides used to AGREE about it — and agree
+		// that it ships. Both now drop it, and a fix applied to only one side
+		// (an inline check in Build's walk instead of in the shared
+		// isExcludedFile) makes this test red, which is what makes the fix
+		// observable through the seam rather than only through Build.
+		".git",
+		"sub/.git",
 	}
+	// The names that merely START with ".git" stay in the fixture as content:
+	// both sides must keep shipping them, and a prefix match would make Build
+	// and the predicate agree on a WRONG answer, which only the exact-name
+	// assertions in git_metadata_file_test.go can catch.
+	files = append(files, ".gitignore", ".gitattributes", "src/.gitkeep")
 	for _, f := range files {
 		writeFile(t, dir, f, "x")
 	}

--- a/internal/pkgzip/git_metadata_file_test.go
+++ b/internal/pkgzip/git_metadata_file_test.go
@@ -1,0 +1,332 @@
+package pkgzip
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TESTS FOR ISSUE #409: `.git` is a FILE in a linked worktree and in a
+// submodule, and the exclusion used to be keyed on the entry's TYPE rather than
+// its NAME.
+//
+// 🔴 THE DEFECT WAS NOT "we forgot .git" — `.git` was on excludedDirs from the
+// start. It was that the name was consulted ONLY inside `if d.IsDir()`, so the
+// rule held for the shape the author of it had in mind (a clone) and silently
+// did not hold for the two shapes that are equally normal (a linked worktree,
+// a submodule). In those, `.git` is a regular file holding `gitdir: <abspath>`;
+// it passed the directory gate (not a directory) and the file gate
+// (isExcludedFile only knew *.zip and .env*) and was packaged.
+//
+// What that cost: Forgejo rejects a bundle containing `.git` with
+// "path contains a malformed path component [path: .git]" — a 400 that names
+// neither the CLI, the bundle, nor the author's checkout, so `app submit` was a
+// hard stop with no route to the cause. And the file's CONTENT is an absolute
+// path on the author's machine, which the packager should not be assembling
+// into an upload whatever the server does with it.
+//
+// The fixtures below build REAL worktrees and REAL submodules rather than
+// hand-writing a `.git` file, because the claim under test is about what git
+// actually produces. Each one asserts its own precondition (that `.git` really
+// came out a regular file) — a fixture that silently produced a directory would
+// exercise the path that always worked and pass for the wrong reason.
+
+// gitEnv isolates every git invocation here from the machine's own config.
+func gitEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("GIT_AUTHOR_NAME", "cli-test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "cli-test@example.invalid")
+	t.Setenv("GIT_COMMITTER_NAME", "cli-test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "cli-test@example.invalid")
+}
+
+// runGit runs a git subcommand in dir and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	c := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	var out, errb bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &errb
+	if err := c.Run(); err != nil {
+		t.Fatalf("git -C %s %s: %v\n%s", dir, strings.Join(args, " "), err, errb.String())
+	}
+	return strings.TrimRight(out.String(), "\r\n")
+}
+
+// tempRepo creates a real git repository in a fresh temp dir — NEVER inside the
+// CLI's own checkout — carrying a minimal packageable app.
+func tempRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH — the real-repo fixtures cannot be built")
+	}
+	gitEnv(t)
+	// EvalSymlinks: on macOS t.TempDir() lives under a symlink and git answers
+	// with the resolved path, which makes the fixture's own paths disagree.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	runGit(t, root, "init", "-q", "-b", "fixture-main")
+	writeFile(t, root, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, root, "package.json", "{}")
+	writeFile(t, root, "src/App.tsx", "export default 1")
+	// Negative control, carried by every fixture: names that merely START with
+	// ".git" are bundle content and must survive whatever the fix does.
+	writeFile(t, root, ".gitignore", "node_modules\n")
+	writeFile(t, root, ".gitattributes", "* text=auto\n")
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "fixture")
+	return root
+}
+
+// requireGitIsAFile is the fixture's own precondition. Without it a fixture that
+// produced a `.git` DIRECTORY would exercise the branch that never broke, and
+// the test would pass while saying nothing about #409.
+func requireGitIsAFile(t *testing.T, dir string) {
+	t.Helper()
+	info, err := os.Lstat(filepath.Join(dir, ".git"))
+	if err != nil {
+		t.Fatalf("fixture has no .git at %s: %v — nothing to exclude, so this test is vacuous", dir, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("fixture's .git is %v, not a regular file — this fixture exercises the DIRECTORY "+
+			"branch, which never had the bug; #409 is unobserved by it", info.Mode())
+	}
+	b, err := os.ReadFile(filepath.Join(dir, ".git"))
+	if err != nil {
+		t.Fatalf("read fixture .git: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "gitdir:") {
+		t.Fatalf("fixture's .git does not hold a gitdir: pointer (%q) — not the shape #409 is about", string(b))
+	}
+}
+
+// TestBuildExcludesGitFileInLinkedWorktree is the issue's own reproduction:
+// package from a linked worktree, where `.git` is a file.
+func TestBuildExcludesGitFileInLinkedWorktree(t *testing.T) {
+	root := tempRepo(t)
+	wt := filepath.Join(filepath.Dir(root), "linked-worktree")
+	runGit(t, root, "worktree", "add", "-q", "--detach", wt, "HEAD")
+	t.Cleanup(func() { _ = exec.Command("git", "-C", root, "worktree", "remove", "--force", wt).Run() })
+
+	requireGitIsAFile(t, wt)
+
+	res, err := Build(wt)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	got := namesInZip(t, res.Zip)
+	sort.Strings(got)
+
+	for _, f := range got {
+		if f == ".git" || strings.HasPrefix(f, ".git/") {
+			t.Errorf("the bundle carries %q from a linked worktree (#409). Forgejo rejects the push with "+
+				"\"path contains a malformed path component [path: .git]\", and the file's body is an "+
+				"absolute path on the author's machine. Full bundle: %v", f, got)
+		}
+	}
+
+	// The bundle must still be the app. Asserted as an exact set so a fix that
+	// over-matches (dropping .gitignore / .gitattributes) is a FAILURE here, not
+	// a silently smaller upload.
+	want := []string{".gitattributes", ".gitignore", "block.manifest.json", "package.json", "src/App.tsx"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("worktree bundle = %v, want %v", got, want)
+	}
+
+	// The count comparison the issue used as its tell: same commit, same files.
+	clone := res.Files
+	cloneRes, err := Build(root)
+	if err != nil {
+		t.Fatalf("Build(clone): %v", err)
+	}
+	if len(clone) != len(cloneRes.Files) {
+		t.Errorf("worktree packaged %d file(s), clone packaged %d — the same commit must package identically "+
+			"whatever the shape of the checkout (worktree=%v clone=%v)",
+			len(clone), len(cloneRes.Files), clone, cloneRes.Files)
+	}
+}
+
+// TestBuildExcludesGitFileInSubmodule covers the other shape, and it puts the
+// `.git` file BELOW the root — the exclusion has to hold at any depth, not only
+// at the directory being packaged.
+func TestBuildExcludesGitFileInSubmodule(t *testing.T) {
+	parent := tempRepo(t)
+
+	child, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	runGit(t, child, "init", "-q", "-b", "fixture-main")
+	writeFile(t, child, "lib.ts", "export const x = 1")
+	runGit(t, child, "add", "-A")
+	runGit(t, child, "commit", "-q", "-m", "child")
+
+	// git >= 2.38 refuses file:// submodules unless told otherwise.
+	runGit(t, parent, "-c", "protocol.file.allow=always", "submodule", "add", "-q", child, "sub")
+	runGit(t, parent, "commit", "-q", "-m", "add submodule")
+
+	requireGitIsAFile(t, filepath.Join(parent, "sub"))
+
+	res, err := Build(parent)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	got := namesInZip(t, res.Zip)
+	sort.Strings(got)
+
+	for _, f := range got {
+		if f == "sub/.git" || strings.Contains(f, "/.git/") || strings.HasSuffix(f, "/.git") {
+			t.Errorf("the bundle carries %q from a submodule (#409): a `.git` file below the root. "+
+				"Full bundle: %v", f, got)
+		}
+	}
+
+	// NEGATIVE CONTROLS, and the reason this fix must be an EXACT-NAME match
+	// rather than a prefix: `.gitmodules` is what tells the platform the
+	// submodule exists, and `.gitignore` / `.gitattributes` are ordinary project
+	// files. Dropping any of them would be a silent content loss.
+	want := []string{
+		".gitattributes", ".gitignore", ".gitmodules",
+		"block.manifest.json", "package.json", "src/App.tsx", "sub/lib.ts",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("submodule bundle = %v, want %v", got, want)
+	}
+}
+
+// TestBuildExcludesVCSMetadataFilesAtAnyDepth is the same claim without a git
+// binary: the exclusion is by NAME at every depth, for a file exactly as for a
+// directory, and it stops at the exact name.
+func TestBuildExcludesVCSMetadataFilesAtAnyDepth(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "block.manifest.json", `{"blockId":"x"}`)
+	writeFile(t, dir, "src/App.tsx", "export default 1")
+
+	// VCS metadata as a FILE — the #409 shape — at the root and nested.
+	writeFile(t, dir, ".git", "gitdir: /home/someone/secret-layout/.git/worktrees/wt\n")
+	writeFile(t, dir, "sub/.git", "gitdir: ../.git/modules/sub\n")
+	writeFile(t, dir, "a/b/c/.git", "gitdir: /elsewhere\n")
+	writeFile(t, dir, ".hg", "x")
+	writeFile(t, dir, "vendor/.svn", "x")
+	// VCS metadata as a DIRECTORY — the shape that always worked. Kept so a fix
+	// cannot pass by moving the rule from one branch to the other.
+	writeFile(t, dir, "nested/.git/HEAD", "ref: refs/heads/main")
+
+	// NEGATIVE CONTROLS: real project files whose names merely begin with
+	// ".git". A prefix match instead of an exact one silently deletes these.
+	kept := []string{".gitignore", ".gitattributes", ".gitmodules", "src/.gitkeep", ".github/workflows/ci.yml"}
+	for _, k := range kept {
+		writeFile(t, dir, k, "x")
+	}
+
+	res, err := Build(dir)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	got := namesInZip(t, res.Zip)
+	sort.Strings(got)
+
+	for _, f := range got {
+		base := f
+		if i := strings.LastIndex(f, "/"); i >= 0 {
+			base = f[i+1:]
+		}
+		switch base {
+		case ".git", ".hg", ".svn":
+			t.Errorf("VCS metadata %q was packaged — the exclusion is keyed on the name, at any depth, "+
+				"for a file as for a directory. Full bundle: %v", f, got)
+		}
+	}
+
+	want := []string{
+		".gitattributes", ".github/workflows/ci.yml", ".gitignore", ".gitmodules",
+		"block.manifest.json", "src/.gitkeep", "src/App.tsx",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("bundle = %v, want %v (a difference here is either leaked VCS metadata or a "+
+			"legitimately-named project file silently dropped)", got, want)
+	}
+}
+
+// TestVCSNamesExcludedForEitherType pins the predicates the DIRTY-TREE GUARD
+// calls (#411, internal/cmd/app_submit_dirty_guard.go). They are the same rule
+// as Build's, reproduced for a caller that holds a path instead of a walk — so
+// a change to Build that does not move these leaves the guard disagreeing with
+// the bundle, which is a false refusal in one direction and a fail-open in the
+// other.
+func TestVCSNamesExcludedForEitherType(t *testing.T) {
+	for _, n := range []string{".git", ".hg", ".svn"} {
+		if !IsExcludedFile(n) {
+			t.Errorf("IsExcludedFile(%q) = false — a worktree/submodule %s is a regular FILE, and the "+
+				"packager would upload it", n, n)
+		}
+		if !IsExcludedPath(n) {
+			t.Errorf("IsExcludedPath(%q) = false", n)
+		}
+		if !IsExcludedPath("sub/" + n) {
+			t.Errorf("IsExcludedPath(%q) = false — the rule must hold at any depth", "sub/"+n)
+		}
+		if !IsExcludedEntry(n, 0) {
+			t.Errorf("IsExcludedEntry(%q, regular) = false", n)
+		}
+		if !IsExcludedEntry(n, fs.ModeDir) {
+			t.Errorf("IsExcludedEntry(%q, dir) = false — the directory case must not regress", n)
+		}
+	}
+	// NEGATIVE CONTROLS on both predicates.
+	for _, n := range []string{".gitignore", ".gitattributes", ".gitmodules", ".gitkeep", "git", "gitdir", ".githooks"} {
+		if IsExcludedFile(n) {
+			t.Errorf("IsExcludedFile(%q) = true — an exact-name rule must not swallow it", n)
+		}
+		if IsExcludedPath(n) {
+			t.Errorf("IsExcludedPath(%q) = true", n)
+		}
+		if IsExcludedEntry("src/"+n, 0) {
+			t.Errorf("IsExcludedEntry(%q, regular) = true", "src/"+n)
+		}
+	}
+	// A DIRECTORY named .github is bundle content too (the prefix mutant's other
+	// victim).
+	if IsExcludedEntry(".github", fs.ModeDir) {
+		t.Error("IsExcludedEntry(\".github\", dir) = true — .github/ is project content")
+	}
+}
+
+// TestVCSMetadataNamesAreASubsetOfExcludedDirs is the LEDGER between the two
+// maps. vcsMetadataNames names the entries whose exclusion is type-independent;
+// every one of them must also be in excludedDirs, or the directory case quietly
+// depends on which map a future edit touched.
+func TestVCSMetadataNamesAreASubsetOfExcludedDirs(t *testing.T) {
+	if len(vcsMetadataNames) == 0 {
+		t.Fatal("CONTROL failure: vcsMetadataNames is empty, so this ledger checks nothing")
+	}
+	for n := range vcsMetadataNames {
+		if _, ok := excludedDirs[n]; !ok {
+			t.Errorf("%q is in vcsMetadataNames but not excludedDirs — a DIRECTORY by that name would "+
+				"still be walked into, so the two halves of the rule disagree", n)
+		}
+		if !isExcludedFile(n) {
+			t.Errorf("🔴 SEAM: %q is in vcsMetadataNames but isExcludedFile(%q) = false. The map is the "+
+				"declaration; isExcludedFile is what ships.", n, n)
+		}
+	}
+	// And the reverse must NOT hold: excludedDirs is deliberately wider, and
+	// promoting all of it to a file rule would drop bundle content (a shell
+	// script named `build`, a data file named `out`).
+	if _, promoted := vcsMetadataNames["dist"]; promoted {
+		t.Error("`dist` must not be type-independent — a plain FILE named dist is bundle content")
+	}
+	if isExcludedFile("build") || isExcludedFile("dist") || isExcludedFile("out") || isExcludedFile("node_modules") {
+		t.Error("a regular file named after a build/dependency DIRECTORY is bundle content; only VCS " +
+			"metadata names are excluded regardless of type")
+	}
+}

--- a/internal/pkgzip/pkgzip.go
+++ b/internal/pkgzip/pkgzip.go
@@ -5,8 +5,12 @@
 // Two kinds of exclusion are applied:
 //
 //   - Directory names (excludedDirs): VCS metadata, dependency installs, build
-//     output, tooling caches — see that var.
-//   - File names (isExcludedFile): build artifacts (*.zip) and EVERY file whose
+//     output, tooling caches — see that var. The VCS names among them
+//     (vcsMetadataNames) are excluded whether the entry is a directory or a
+//     regular file, because in a linked worktree or a submodule `.git` is a
+//     FILE — see that var for the incident.
+//   - File names (isExcludedFile): VCS metadata that is a regular file
+//     (a worktree's / submodule's `.git`), build artifacts (*.zip) and EVERY file whose
 //     BASE NAME starts with ".env" — dotted or not, so `.envrc` (direnv, which
 //     routinely holds exported credentials) goes too — except a three-name
 //     allow-list. The scaffolded page-money template points a real,
@@ -77,6 +81,47 @@ var excludedDirs = map[string]struct{}{
 	".turbo":        {},
 }
 
+// vcsMetadataNames are the excludedDirs entries whose exclusion is INDEPENDENT
+// OF FILE TYPE: they are dropped whether the entry is a directory or a regular
+// file, at any depth.
+//
+// 🔴 THE RULE USED TO BE KEYED ON TYPE, AND THAT IS ISSUE #409. `.git` was on
+// excludedDirs from the beginning, but the map was consulted only inside Build's
+// `if d.IsDir()` branch — so the exclusion held for the shape its author had in
+// mind (a clone) and silently did not hold for two shapes that are just as
+// ordinary. In a LINKED WORKTREE and in a SUBMODULE, `.git` is a regular file
+// holding `gitdir: <absolute path>`; it passed the directory gate (not a
+// directory) and the file gate (isExcludedFile knew only *.zip and .env*), and
+// was packaged. `app submit` from a worktree then died on a server error that
+// named nothing the author could act on — Forgejo 422, "path contains a
+// malformed path component [path: .git]" — while the same commit submitted from
+// a clone succeeded. The tell was the file count: 62 from the worktree, 61 from
+// the clone.
+//
+// 🔴 EXACT NAMES, NOT A PREFIX. `.gitignore`, `.gitattributes`, `.gitmodules`,
+// `.gitkeep` and a `.github/` directory are all project content that belongs in
+// the bundle; a prefix match on ".git" would delete every one of them from a
+// submission with no error anywhere. (Contrast the dotenv rule below, which IS a
+// prefix — there the failure mode of being too narrow is a leaked credential, so
+// it is aimed the other way on purpose.)
+//
+// 🔴 ONLY VCS METADATA IS PROMOTED, NOT ALL OF excludedDirs. The issue suggested
+// having isExcludedFile reject any name in excludedDirs; that would also drop a
+// regular file named `build`, `dist`, `out` or `coverage` — a build script
+// without an extension is a real thing, and dropping one is a silent content
+// loss with no server-side error to catch it. A regular file named exactly
+// `.git`, `.hg` or `.svn`, by contrast, is never author content: it is VCS
+// plumbing in every case, and the server rejects it outright.
+//
+// Every name here MUST also be in excludedDirs — the directory half of the rule
+// still runs through that map, and TestVCSMetadataNamesAreASubsetOfExcludedDirs
+// pins the two together.
+var vcsMetadataNames = map[string]struct{}{
+	".git": {},
+	".hg":  {},
+	".svn": {},
+}
+
 // excludedFilePatterns is the human-readable list of file-level exclusions, for
 // CLI messaging. The authoritative matcher is isExcludedFile — keep the two in
 // sync. These are matched on the file's BASE NAME anywhere in the tree.
@@ -131,10 +176,17 @@ var keptEnvFiles = map[string]struct{}{
 }
 
 // isExcludedFile reports whether a regular file (by base name) must be left out
-// of the package. The rule is deliberately CONSERVATIVE toward "never upload a
-// secret": every base name starting with ".env" is dropped UNLESS it is one of
-// the three names on the keptEnvFiles allow-list. Build-time config for the
-// server must come from the manifest / build recipe, not an uploaded dotenv.
+// of the package. Three rules, in order:
+//
+//   - VCS metadata by EXACT name (vcsMetadataNames): a linked worktree's or a
+//     submodule's `.git` is a regular file, and issue #409 is what happens when
+//     only the directory shape is excluded. See that var.
+//   - Build artifacts (*.zip).
+//   - Dotenv. That rule is deliberately CONSERVATIVE toward "never upload a
+//     secret": every base name starting with ".env" is dropped UNLESS it is one
+//     of the three names on the keptEnvFiles allow-list. Build-time config for
+//     the server must come from the manifest / build recipe, not an uploaded
+//     dotenv.
 //
 // 🔴 THE PREFIX IS ".env", NOT ".env." — UNDOTTED NAMES ARE EXCLUDED TOO. The
 // match was `name == ".env" || HasPrefix(name, ".env.")` until the README
@@ -154,6 +206,12 @@ var keptEnvFiles = map[string]struct{}{
 // contents, so "kept" is a statement about WHERE the file goes, never a claim
 // that it holds no secret — see the 🔴 note on keptEnvFiles.
 func isExcludedFile(name string) bool {
+	// VCS metadata that is a regular FILE, not a directory: a linked worktree's
+	// or a submodule's `.git` (issue #409). Matched on the EXACT name, so
+	// `.gitignore` / `.gitattributes` / `.gitmodules` still ship.
+	if _, vcs := vcsMetadataNames[name]; vcs {
+		return true
+	}
 	// Build artifacts.
 	if strings.HasSuffix(name, ".zip") {
 		return true
@@ -323,7 +381,10 @@ func IsExcluded(name string) bool {
 //     truncates the walk — everything under it is out.
 //   - the final component, when it is a FILE, is excluded by isExcludedFile.
 //     Build applies the directory rule only to directories, so a plain file
-//     named `dist` is bundle content, and so it is here.
+//     named `dist` is bundle content, and so it is here. The exception is
+//     vcsMetadataNames (`.git`/`.hg`/`.svn`), which isExcludedFile drops too —
+//     in a linked worktree or a submodule `.git` IS a regular file (#409), so
+//     for those three names the answer is the same either way.
 //
 // A trailing "/" marks the path as a DIRECTORY — git's porcelain spelling for an
 // untracked directory (`?? dist/`) — so the final component takes the directory


### PR DESCRIPTION
Closes #409.

## What was wrong

The exclusion was keyed on the entry's **type**, not its **name**. `.git` was on `excludedDirs` from the start, but that map was consulted only inside `Build`'s `if d.IsDir()` branch. In a **linked worktree** and in a **submodule**, `.git` is a regular file holding `gitdir: <absolute path>` — it passed the directory gate (not a directory) and the file gate (`isExcludedFile` knew only `*.zip` and `.env*`), and got packaged.

The author saw a Forgejo 422 that named neither the CLI, the bundle, nor the shape of their checkout, while the same commit submitted from a clone succeeded.

## Reproduced against the built binary, before and after

Real `git worktree add`, real `civitai app submit --package-only`:

| binary | clone | worktree | worktree bundle |
|---|---|---|---|
| `origin/main` @ `e816594` | `Packaged 5 file(s)` | `Packaged 6 file(s)` | `.git` `.gitattributes` `.gitignore` `block.manifest.json` `index.html` `src/App.tsx` |
| this branch | `Packaged 5 file(s)` | `Packaged 5 file(s)` | `.gitattributes` `.gitignore` `block.manifest.json` `index.html` `src/App.tsx` |

The 6-vs-5 tell is the issue's own (62 vs 61 there). The packaged `.git` body was `gitdir: /tmp/i409-repro-tkkaGc/app/.git/worktrees/wt` — the developer's local filesystem layout, assembled into an upload.

## The change

`isExcludedFile` now drops the VCS metadata names — `.git`, `.hg`, `.svn` — by **exact name, at any depth**, so the rule holds whichever shape the entry has. New `vcsMetadataNames` var carries the rationale.

Two decisions worth reviewing:

- **Exact name, not a prefix.** `.gitignore`, `.gitattributes`, `.gitmodules`, `.gitkeep` and a `.github/` directory are project content. A prefix match would delete every one of them from a submission with no error anywhere — the opposite failure mode from the dotenv rule below it, which *is* a prefix on purpose because there being-too-narrow means a leaked credential.
- **Only VCS metadata is promoted, not all of `excludedDirs`** (the issue suggested the latter). That would also drop a regular file named `build`, `dist`, `out` or `coverage` — an extensionless build script is a real thing, and dropping one is silent content loss with no server-side rejection to catch it. A file named exactly `.git`/`.hg`/`.svn` is never author content.

## The shared-predicate seam (#411)

`IsExcludedPath` / `IsExcludedEntry` are what the `app submit` dirty-tree guard asks "would the packager bundle this?", so this change moves two behaviours. Both now answer the same as `Build`, and `TestIsExcludedPathAgreesWithBuild` carries `.git` + `sub/.git` in its fixture (plus `.gitignore` / `.gitattributes` / `src/.gitkeep` as content), so a fix applied to only one side goes red — that mutant is in the table below.

Checked live against both binaries, on a throwaway repo, with the guard actually reachable (a token configured, base URL at a closed port — `--package-only` skips the guard entirely, so an earlier probe through it was wired to nothing):

| arm | `origin/main` | this branch |
|---|---|---|
| uncommitted bundle file (positive control) | REFUSED | REFUSED |
| clean tree (negative control) | passed to network | passed to network |
| untracked `dist/` | passed to network | passed to network |
| untracked `.gitignore` | REFUSED | REFUSED |
| untracked `.gitfile-probe` | REFUSED | REFUSED |

Identical in every arm. `git status` never reports `.git` itself, so in practice the guard is never asked about it — the value here is that the two predicates cannot drift.

## Tests

Real `git worktree add` and real `git submodule add` fixtures, each asserting its own precondition (that `.git` really came out a regular file holding a `gitdir:` pointer) — a fixture that quietly produced a directory would exercise the branch that never broke and pass for the wrong reason. Plus a git-free any-depth fixture and predicate-level assertions. Fixtures are built in temp dirs only.

**Red at base / green at HEAD** (`internal/pkgzip`, counted from `--- PASS` / `--- FAIL`, not an exit code):

| | `=== RUN` | `--- PASS` | `--- FAIL` | `--- SKIP` |
|---|---|---|---|---|
| the 4 new bug tests at `origin/main` `e816594` | 4 | 0 | **4** | 0 |
| whole package at HEAD | 28 | 28 | 0 | 0 |

**Mutants** — all six killed, none by a compile error, each with a distinct killing assertion:

| mutant | killed by | on |
|---|---|---|
| revert the fix | 5 tests | `the bundle carries ".git" from a linked worktree (#409)` |
| prefix match instead of exact name | 5 tests, incl. `TestIsExcludedFileRule` | `IsExcludedFile(".gitignore") = true — an exact-name rule must not swallow it`; bundle loses `.gitignore` `.gitattributes` `.gitmodules` `src/.gitkeep` |
| root only, not any depth | 4 tests (worktree test correctly still passes) | `VCS metadata "a/b/c/.git" was packaged — the exclusion is keyed on the name, at any depth` |
| drop the DIRECTORY half (`.git` out of `excludedDirs`) | 9 tests | `%q is in vcsMetadataNames but not excludedDirs — a DIRECTORY by that name would still be walked into` |
| fix `Build`'s walk inline, not the shared predicate | 3 tests | `Build and IsExcludedPath disagree about this tree` (the seam guard) |
| promote only `.git`, leave `.hg`/`.svn` | 2 tests | `VCS metadata ".hg" was packaged` |

## Neighbouring exclusions — measured, and one is NOT fixed here

Run against the fixed binary, planting each name as the *other* filesystem type:

- **`node_modules`, `dist`, `build`, `out`, `coverage`, `.next`, `.venv`, `venv`, `.turbo` as regular FILES → all shipped.** Same *shape* as #409, deliberately not the same *defect*: none of them is ever VCS plumbing, an extensionless `build` script is plausible author content, and the server does not reject them. Left directory-only, and `TestVCSMetadataNamesAreASubsetOfExcludedDirs` now pins that on purpose.
- 🔴 **`.env.local/`, `.env.d/` and `artifact.zip/` as DIRECTORIES → their contents shipped**, including a planted `.env.d/db.env` containing `API_SECRET=leak`. This is the **mirror** of #409 — a name-keyed rule that fires for only one filesystem type — and for the dotenv half it carries the same credential-leak hazard the rule was written to prevent. **It is not fixed in this PR**, deliberately: it is a separate behaviour change with its own blast radius (a `.environment/` directory would start being dropped whole), and the dotenv rule is ledger-bound to a README section that documents it in terms of files. Worth its own issue rather than a rider on this one.

## Not done

The issue's second suggestion — a local fast-fail in `app validate` / `app submit` saying "`.git` is a file here, you are in a worktree" — is deliberately not implemented. With the packager fixed there is nothing to warn about: submitting from a worktree now produces a bundle byte-identical to the clone's, so a hard stop would refuse a workflow that works.

## Gates

`make ci` (20/20 packages ok, 0 failures), `make ci-shallow` (`ok=20/20 failing-tests=0 failing-packages=0 timeouts=0`), full-repo `golangci-lint run ./...` → `0 issues`. The linter was validated against a negative control first (a planted unused func → `rc=1`, `1 issues`, naming the file) so the clean verdict is a fact about the code rather than about the invocation. No `panic: test timed out` in any run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
