### PR TITLE
refactor(appapi): one slug predicate, not four — and the three that were exact were silently wrong

### DIFF
--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -629,7 +629,20 @@ func latestMatchingSubmission(subs []Submission, slug, version string) *Submissi
 	var anyMatch *Submission
 	for i := range subs {
 		s := &subs[i]
-		if s.BlockID != slug || s.Version != version {
+		// 🔴 THE SLUG COMPARE IS SHARED (SameSlug, slug.go); THE VERSION COMPARE
+		// IS DELIBERATELY STILL EXACT. They are not the same question. The slug
+		// is the app's identity and has one canonical spelling per the manifest
+		// schema, so folding case and padding can only rejoin a mis-spelling to
+		// the app it names. A version is an ORDERED value whose spelling this
+		// function does not own: "0.2.0", " 0.2.0 " and "v0.2.0" are the same
+		// release, but deciding that is comparableVersion's job in
+		// internal/cmd/approved_version.go, which encodes a policy (a
+		// pre-release is NOT ORDERABLE) that a fold-and-trim compare would
+		// quietly contradict. Widening it here would also widen what a timed-out
+		// submit may report as "the row that landed", which is the id a user
+		// hands to `civitai app withdraw`. Out of scope for the slug
+		// consolidation, and named so it does not read as an oversight.
+		if !SameSlug(s.BlockID, slug) || s.Version != version {
 			continue
 		}
 		switch strings.ToLower(s.Status) {

--- a/internal/appapi/slug.go
+++ b/internal/appapi/slug.go
@@ -1,0 +1,90 @@
+package appapi
+
+import "strings"
+
+// THE SLUG-COMPARISON PREDICATE — ONE COPY, FOUR CALLERS.
+//
+// "Is this submissions-route row the app I am talking about?" was answered four
+// different ways in this binary, and the four disagreed:
+//
+//	site                                          compare
+//	internal/cmd/approved_version.go   (#412)     EqualFold + TrimSpace
+//	internal/cmd/apps.go     ownedSubmission      ==
+//	internal/appapi/appblocks.go latestMatching   !=
+//	internal/cmd/app_status.go warnLocalVersionDrift  !=
+//
+// The normalising one was written LAST (#414) and deliberately, after an audit
+// showed that an exact match makes the #412 version guard a SILENT no-op on a
+// cased or padded blockId: a non-matching slug lands in the "no approved rows"
+// branch, which proceeds without a word because that is also what a genuine
+// first submit looks like. The other three never got the same treatment, so the
+// binary held one site that had reasoned about the hazard and three that had
+// not — the usual shape, wrong at N-1 sites in the same direction.
+//
+// This file is the consolidation. It lives in appapi and not in internal/cmd
+// because appapi owns Submission.BlockID — the field on one side of all four
+// comparisons — and because appapi cannot import internal/cmd, while every cmd
+// caller already imports appapi. The predicate is a statement about THIS
+// route's contract, so it belongs next to the client that speaks it.
+//
+// The ledger that keeps the count at four is TestBlockIDComparisonsUseSameSlug
+// in internal/cmd/slug_predicate_ledger_test.go: it scans both packages for a
+// blockId compared with == or != against anything but the empty string, and
+// fails on a fifth site the day it is written.
+
+// SameSlug reports whether two spellings name the same App Block slug.
+//
+// 🔴 IT NORMALISES, AND THAT IS DEFENCE IN DEPTH AGAINST AN UNDOCUMENTED SERVER
+// CHANGE, NOT A LIVE HAZARD. This claim is carried over verbatim from #414's
+// delta audit and must not be upgraded while being moved. The route as it
+// stands today cannot hand back a mis-cased blockId:
+// civitai:src/pages/api/v1/blocks/submissions.ts filters with
+// `where.slug = blockId` (an exact Prisma match) and echoes `blockId: row.slug`
+// from the same non-nullable column, so every row it returns matches the value
+// asked for byte-for-byte. In the mis-casing scenario the server returns ZERO
+// rows, not mis-cased ones.
+//
+// What the normalisation buys is the asymmetry: status and deployState were
+// already compared case- and whitespace-insensitively while the slug was
+// compared byte-for-byte, and the slug is the field whose mismatch is SILENT.
+// If that server contract ever changed, the #412 feature would switch off on
+// exactly the app it exists to protect, with no output to notice. The check is
+// two string compares; keeping it is cheap insurance, and claiming it closes a
+// hazard that exists today is not true.
+//
+// 🔴 ONE CALLER'S ARGUMENT IS STRONGER THAN THAT, AND IT IS NOT THE SERVER'S.
+// warnLocalVersionDrift compares a LOCAL block.manifest.json's blockId against
+// a row's, and manifest.Load is a bare json.Unmarshal — it does not validate
+// against schema/app-block.manifest.schema.json. So on that one side an
+// unnormalised value is reachable by hand-editing a file, without any server
+// contract having to change. That is a shorter path to a mis-spelling than the
+// three row-vs-request sites have; it is still not a demonstrated live break,
+// because a manifest spelled that way fails `civitai app submit`'s own
+// validation. See the comment at that call site.
+//
+// 🔴 WHY THIS CANNOT MERGE TWO DIFFERENT APPS, which is the question a widening
+// predicate has to answer. A valid slug matches
+// `^[a-z][a-z0-9-]*[a-z0-9]$` — the pattern in
+// schema/app-block.manifest.schema.json, which the server's own validator
+// (civitai:src/server/services/block-manifest-validator.service.ts) shares. It
+// admits no uppercase and no whitespace, so EqualFold+TrimSpace is the IDENTITY
+// MAP on the set of valid slugs: it can only ever join a mis-spelling to the
+// one valid slug it is a mis-spelling OF. What it newly admits is therefore
+// exactly the intended set — invalid spellings of the same app — and never a
+// second app.
+//
+// 🔴 EMPTY IS NEVER A MATCH, INCLUDING EMPTY-AGAINST-EMPTY. The `==` this
+// replaces answered TRUE for two empty strings, so a row with no blockId
+// matched a request with no slug and read as "yes, that is your app". No slug
+// names an app; nothing downstream of any of the four call sites wants that
+// answer, and app_status.go already carried a hand-written `m.BlockID == ""`
+// guard for precisely this. It is folded in here so the four sites cannot
+// disagree about it either. TrimSpace runs first, so an all-whitespace blockId
+// is empty for this purpose too — which the hand-written guard did not catch.
+func SameSlug(a, b string) bool {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	return strings.EqualFold(a, b)
+}

--- a/internal/appapi/slug_test.go
+++ b/internal/appapi/slug_test.go
@@ -1,0 +1,188 @@
+package appapi
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// THE SHARED SLUG PREDICATE, AND THE ONE appapi-SIDE SITE THAT NOW CALLS IT.
+//
+// Before the consolidation, three of the four blockId comparisons in this binary
+// were `==`/`!=` and the whole suite was green over a cased or padded blockId at
+// every one of them — 4 sites, 0 fixtures. These cases are the fixtures that
+// were missing: each drives ONE site with a spelling only the shared predicate
+// accepts, so each is red on the exact compare it replaced.
+//
+// 🔴 THE NEGATIVE CONTROLS ARE NOT DECORATION. A predicate that widened too far
+// would pass every positive case here and be catastrophically wrong: it decides
+// whether a submission row is YOUR app. So every positive case below is paired
+// with the same four rejects — an unrelated slug, a slug this one is a PREFIX
+// of, a slug this one is a SUFFIX-EXTENSION of, and the empty string.
+
+// slugRejects are the spellings that must NEVER match "my-block". They are
+// chosen so a plausible over-wide implementation fails at least one:
+// substring/prefix matching fails on "my-block-2" and "my", a Contains fails on
+// both, and an implementation that treats empty as a wildcard fails on "".
+var slugRejects = []struct{ name, spelling, breaks string }{
+	{"unrelated app", "gen-matrix", "a different app entirely"},
+	{"extension of the slug", "my-block-2", "prefix matching would accept a DIFFERENT registered app"},
+	{"prefix of the slug", "my", "suffix/Contains matching would accept a shorter unrelated slug"},
+	{"empty", "", "no slug names an app; empty must never be a wildcard"},
+}
+
+// TestSameSlugAcceptsOnlyRespellingsOfTheSameSlug pins the predicate itself:
+// what it admits over `==`, and what it still refuses.
+func TestSameSlugAcceptsOnlyRespellingsOfTheSameSlug(t *testing.T) {
+	const canonical = "my-block"
+
+	// (a) What normalising ADMITS that `==` rejected — and only this. Every
+	// entry is an invalid spelling per schema/app-block.manifest.schema.json's
+	// `^[a-z][a-z0-9-]*[a-z0-9]$`, which is why joining it to the canonical slug
+	// cannot collide with a second real app.
+	for _, respelling := range []string{
+		"My-Block", "MY-BLOCK", "my-Block",
+		" my-block", "my-block ", "  my-block  ",
+		"\tmy-block\n", " My-Block ",
+	} {
+		if !SameSlug(respelling, canonical) {
+			t.Errorf("SameSlug(%q, %q) = false, want true — a cased or padded blockId names the SAME app, "+
+				"and rejecting it is the silent failure this predicate exists to remove", respelling, canonical)
+		}
+		// Symmetric: the callers pass the row on either side depending on the
+		// site (row-vs-request at three of them, manifest-vs-row at the fourth).
+		if !SameSlug(canonical, respelling) {
+			t.Errorf("SameSlug(%q, %q) = false, want true — the predicate must not depend on argument order, "+
+				"because its four callers do not agree on which side is which", canonical, respelling)
+		}
+	}
+
+	// (b) The negative controls, in both argument orders.
+	for _, r := range slugRejects {
+		if SameSlug(r.spelling, canonical) {
+			t.Errorf("SameSlug(%q, %q) = true, want false — %s", r.spelling, canonical, r.breaks)
+		}
+		if SameSlug(canonical, r.spelling) {
+			t.Errorf("SameSlug(%q, %q) = true, want false — %s", canonical, r.spelling, r.breaks)
+		}
+	}
+
+	// (c) EMPTY AGAINST EMPTY, the one case where this is stricter than the `==`
+	// it replaces. `"" == ""` was TRUE at three sites, so a row carrying no
+	// blockId matched a request carrying no slug and read as "yes, that is your
+	// app". All-whitespace is the same case after TrimSpace, and the
+	// hand-written `m.BlockID == ""` guard in app_status.go did not catch it.
+	for _, pair := range [][2]string{{"", ""}, {" ", ""}, {"", "\t"}, {"   ", "  "}} {
+		if SameSlug(pair[0], pair[1]) {
+			t.Errorf("SameSlug(%q, %q) = true, want false — an empty slug names no app, so answering "+
+				"'these are the same app' is a false claim the callers act on", pair[0], pair[1])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 3: internal/appapi/appblocks.go — latestMatchingSubmission
+// ---------------------------------------------------------------------------
+
+// recoverRowSlug is recoverRow (submit_recover_newest_test.go) with the blockId
+// under the caller's control, which that helper hard-codes.
+func recoverRowSlug(id, blockID, version, status, submittedAt string) Submission {
+	return Submission{
+		ID:          id,
+		BlockID:     blockID,
+		Version:     version,
+		Status:      status,
+		SubmittedAt: submittedAt,
+	}
+}
+
+// TestLatestMatchingSubmissionMatchesARespelledBlockID is site 3's red-at-base
+// case. `s.BlockID != slug` dropped the only matching row, so recoverTimedOutSubmit
+// found nothing and SubmitVersion reported the submit as timed out — telling an
+// author their upload may not have landed while the row proving it landed was in
+// the response being scanned.
+func TestLatestMatchingSubmissionMatchesARespelledBlockID(t *testing.T) {
+	for _, spelling := range []string{"My-Block", " my-block ", "MY-BLOCK", "\tmy-block"} {
+		t.Run(spelling, func(t *testing.T) {
+			subs := []Submission{
+				recoverRowSlug("pubreq_ours", spelling, "0.2.0", "pending", "2026-07-29T10:00:00Z"),
+			}
+			got := latestMatchingSubmission(subs, "my-block", "0.2.0")
+			if got == nil {
+				t.Fatalf("latestMatchingSubmission found no match for a row whose blockId is %q — "+
+					"that is the same app, and dropping it makes a landed submit report as timed out", spelling)
+			}
+			if got.ID != "pubreq_ours" {
+				t.Errorf("matched %q, want pubreq_ours", got.ID)
+			}
+		})
+	}
+}
+
+// TestLatestMatchingSubmissionStillRejectsOtherSlugs is the negative half, and
+// the guard against a fix that widened too far. It also pins that the VERSION
+// compare stayed EXACT — a deliberate decision recorded at the call site, and
+// the thing a blanket "normalise everything" change would have broken silently.
+func TestLatestMatchingSubmissionStillRejectsOtherSlugs(t *testing.T) {
+	for _, r := range slugRejects {
+		t.Run("slug/"+r.name, func(t *testing.T) {
+			subs := []Submission{
+				recoverRowSlug("pubreq_theirs", r.spelling, "0.2.0", "pending", "2026-07-29T10:00:00Z"),
+			}
+			if got := latestMatchingSubmission(subs, "my-block", "0.2.0"); got != nil {
+				t.Errorf("a row for blockId %q matched a request for %q (%s) — reporting it would name a "+
+					"DIFFERENT app's publishRequestId as this submit's result", r.spelling, "my-block", r.breaks)
+			}
+		})
+	}
+
+	// 🔴 THE VERSION COMPARE IS STILL EXACT. If a future change reached for
+	// SameSlug on the version too — the obvious "make it consistent" move — this
+	// fails. The version's ordering policy lives in comparableVersion
+	// (internal/cmd/approved_version.go) and declares a pre-release NOT
+	// ORDERABLE; a fold-and-trim compare here would contradict that quietly.
+	for _, v := range []string{" 0.2.0", "0.2.0 ", "V0.2.0", "v0.2.0", "0.2.0-rc.1"} {
+		t.Run("version/"+v, func(t *testing.T) {
+			subs := []Submission{
+				recoverRowSlug("pubreq_other_version", "my-block", v, "pending", "2026-07-29T10:00:00Z"),
+			}
+			if got := latestMatchingSubmission(subs, "my-block", "0.2.0"); got != nil {
+				t.Errorf("a row at version %q matched a request for %q — the version compare is deliberately "+
+					"EXACT (see the call site); normalising it is a separate decision with its own ordering policy",
+					v, "0.2.0")
+			}
+		})
+	}
+}
+
+// TestRecoverTimedOutSubmitMatchesARespelledBlockID drives the same site through
+// the REAL transport, so the fix is pinned as a property of `civitai app submit`
+// and not only of the helper. Without it the only coverage of this path would be
+// a direct call, which cannot show that the recovery actually reports success.
+func TestRecoverTimedOutSubmitMatchesARespelledBlockID(t *testing.T) {
+	rows := []Submission{
+		recoverRowSlug("pubreq_ours", " My-Block ", "0.2.0", "pending", "2026-07-29T10:00:00Z"),
+	}
+	srv, listCalls := newRecoverServer(t, func() []Submission { return rows })
+
+	c := recoverClient(srv.URL)
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	if err != nil {
+		t.Fatalf("the submit landed — a row for it is in the listing, spelled %q — but the recovery "+
+			"reported a timeout: %v", rows[0].BlockID, err)
+	}
+	// REACHABILITY: the recovery poll must have run, or nothing here is about
+	// the row scan.
+	if n := atomic.LoadInt32(listCalls); n < 1 {
+		t.Fatalf("the recovery never polled /submissions (%d calls)", n)
+	}
+	if res.PublishRequestID != "pubreq_ours" {
+		t.Errorf("PublishRequestID = %q, want pubreq_ours — this is the id the user hands to "+
+			"`civitai app withdraw`", res.PublishRequestID)
+	}
+	// The SERVER's spelling is what gets reported back, not the caller's — the
+	// row is the authority on its own blockId.
+	if res.Slug != " My-Block " {
+		t.Errorf("Slug = %q, want the row's own spelling %q", res.Slug, " My-Block ")
+	}
+}

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -366,7 +366,39 @@ func warnLocalVersionDrift(ctx context.Context, lister submissionLister, errOut 
 	// The manifest must be for THIS app. Without this, running `civitai app
 	// status some-other-app` from inside an unrelated project would compare two
 	// different apps' versions and report a fabricated regression.
-	if m.BlockID == "" || m.BlockID != s.BlockID {
+	//
+	// 🔴 THIS IS THE SHARED PREDICATE (appapi.SameSlug) ANSWERING A DIFFERENT
+	// QUESTION FROM THE OTHER THREE CALLERS, and the difference is worth stating
+	// because it is what decided the call. The other three ask "does this row
+	// match the slug the CALLER NAMED", request against server row. This one
+	// asks "is the project directory I am standing in the same app as this row"
+	// — LOCAL FILE against server row. It is the same underlying question ("are
+	// these two spellings the same slug?"), so it gets the same predicate.
+	//
+	// 🔴 AND IT IS THE CALLER WITH THE STRONGEST ARGUMENT FOR NORMALISING, not
+	// the weakest. At the other three the unnormalised value could only come
+	// from the server, which by its own route contract cannot emit one (see
+	// slug.go). Here it comes from block.manifest.json via manifest.Load, which
+	// is a bare json.Unmarshal with NO schema validation — so a hand-edited
+	// `"blockId": " Custom-Generators "` reaches this line today, with no server
+	// change required. Still not a demonstrated live break: a manifest spelled
+	// that way is rejected by `civitai app submit`'s own validation, so an
+	// author holding one has not successfully submitted under it.
+	//
+	// The failure it removes is the silent one. An exact compare returns here
+	// and the drift warning never prints, which is indistinguishable from
+	// "nothing is approved yet" — the #412 hazard exactly. The false-positive
+	// direction is closed by the schema: valid slugs are lowercase and unpadded,
+	// so a fold-and-trim match cannot join two DIFFERENT apps, only a
+	// mis-spelling to the app it mis-spells.
+	//
+	// The hand-written `m.BlockID == ""` clause this replaces is now
+	// SameSlug's own guarantee (it rejects an empty side, including
+	// empty-against-empty, and rejects all-whitespace too, which the old clause
+	// did not). Note also that what gets PRINTED below is s.BlockID — the
+	// server's spelling — so a mis-spelled manifest can never put its own
+	// spelling in the warning.
+	if !appapi.SameSlug(m.BlockID, s.BlockID) {
 		return
 	}
 	// 🔴 comparableVersion, NOT isParseableVersion — the SAME strictness the

--- a/internal/cmd/app_submit_version_guard.go
+++ b/internal/cmd/app_submit_version_guard.go
@@ -25,7 +25,7 @@ import (
 // computable here and no server change is involved.
 //
 // 🔴 THE PICK ITSELF IS NOT HERE. `highestApprovedVersion` and everything it is
-// built from (approvedPeak, sameSlug, isApprovedStatus, rowIsServing,
+// built from (approvedPeak, appapi.SameSlug, isApprovedStatus, rowIsServing,
 // comparableVersion) live in approved_version.go, because `civitai app status`'s
 // drift warning — #412's other half, #413 — has to name the SAME version for the
 // SAME rows or the two commands contradict each other. They briefly did: both
@@ -101,7 +101,7 @@ func checkVersionNotRegression(ctx context.Context, lister submissionLister, war
 	// live before this branch existed: submissionsURL omits an empty blockId, so
 	// the read is UNNARROWED and returns every app's rows (which the route caps,
 	// exactly the failure TestVersionGuardNarrowsTheListingToThisApp exists to
-	// prevent); and every one of those rows then fails sameSlug, so slugRows is 0
+	// prevent); and every one of those rows then fails appapi.SameSlug, so slugRows is 0
 	// and the mismatch announcement below fires with the app's name spliced in as
 	// an empty string — "none of them for  — … If  is already published, this is
 	// a blockId mismatch". That misdiagnoses a manifest with NO blockId as a

--- a/internal/cmd/app_submit_version_guard_test.go
+++ b/internal/cmd/app_submit_version_guard_test.go
@@ -933,7 +933,7 @@ func TestHighestApprovedVersionNormalisesTheSlug(t *testing.T) {
 		}
 	}
 	// Negative control, and the reason normalising is safe: a DIFFERENT app is
-	// still a different app. Without this the mutation `sameSlug -> true` passes.
+	// still a different app. Without this the mutation `appapi.SameSlug -> true` passes.
 	for _, blockID := range []string{"gen-matrix", "custom-generators-2", "custom", ""} {
 		rows := []appapi.Submission{
 			{ID: "pubreq_other", BlockID: blockID, Version: "9.9.9", Status: "approved",
@@ -1184,7 +1184,7 @@ func TestAppSubmitNeverCallsAServingRowNotLiveEndToEnd(t *testing.T) {
 // not require blockId and `--skip-validate` waives the schema, so the guard can
 // be handed an EMPTY slug. Before this branch existed the empty slug produced an
 // UNNARROWED listing read (submissionsURL omits an empty blockId), every row
-// then failed sameSlug, and the mismatch announcement fired with the name
+// then failed appapi.SameSlug, and the mismatch announcement fired with the name
 // spliced in blank: "none of them for  — … If  is already published, this is a
 // blockId mismatch rather than a first submit." That misdiagnoses "your manifest
 // has no blockId" as "your blockId does not match the server's".

--- a/internal/cmd/approved_version.go
+++ b/internal/cmd/approved_version.go
@@ -111,7 +111,7 @@ func highestApprovedVersion(subs []appapi.Submission, slug string) approvedPeak 
 	var peak approvedPeak
 	for i := range subs {
 		s := subs[i]
-		if !sameSlug(s.BlockID, slug) {
+		if !appapi.SameSlug(s.BlockID, slug) {
 			continue
 		}
 		peak.slugRows++
@@ -132,30 +132,13 @@ func highestApprovedVersion(subs []appapi.Submission, slug string) approvedPeak 
 	return peak
 }
 
-// sameSlug compares a listing row's blockId to the manifest's slug.
-//
-// 🔴 IT NORMALISES, and that is a deliberate reversal of one copy's original
-// exact match — but it is DEFENCE IN DEPTH against an undocumented server
-// change, NOT a live hazard, and an earlier version of this comment claimed the
-// stronger thing. The route as it stands today cannot hand back a mis-cased
-// blockId: submissions.ts filters with `where.slug = blockId` (an exact Prisma
-// match) and echoes `blockId: row.slug` from the same non-nullable column, so
-// every row it returns matches the value asked for byte-for-byte. In the
-// mis-casing scenario the server returns ZERO rows, not mis-cased ones — which
-// is the announce branch's case, not this one.
-//
-// What the normalisation buys is the asymmetry: status and deployState were
-// already compared case- and whitespace-insensitively while the slug was
-// compared byte-for-byte, and the slug is the field whose mismatch is SILENT (a
-// non-matching slug lands in the "no approved rows" branch, which proceeds
-// without a word because that is what a genuine first submit looks like). So if
-// that server contract ever changed, the whole #412 feature would switch off on
-// exactly the app it exists to protect, with no output to notice. The check is
-// two string compares; keeping it is cheap insurance, and claiming it closes a
-// hazard that exists today is not true.
-func sameSlug(rowBlockID, slug string) bool {
-	return strings.EqualFold(strings.TrimSpace(rowBlockID), strings.TrimSpace(slug))
-}
+// The row-vs-slug compare used to live HERE, as this package's unexported
+// `sameSlug`, and it was the ONLY one of the four blockId comparisons in this
+// binary that normalised. It is now appapi.SameSlug — same two string compares,
+// same defence-in-depth claim, one definition. See internal/appapi/slug.go for
+// why it moved to appapi (that package owns Submission.BlockID and cannot
+// import internal/cmd) and what the normalisation is and is not a defence
+// against.
 
 // isApprovedStatus reports whether a submission row's status means APPROVED.
 //

--- a/internal/cmd/apps.go
+++ b/internal/cmd/apps.go
@@ -258,8 +258,24 @@ func ownedSubmission(ctx context.Context, slug string) *appapi.Submission {
 	// unverified dependency on the route's contract, stated in the ledger rather
 	// than closed. Unverified, not unverifiable: every row carries SubmittedAt, so
 	// a client-side check or sort is possible — it is simply not written.
+	//
+	// 🔴 THE COMPARE IS THE SHARED appapi.SameSlug, not `==`. This site asks the
+	// same question the #412 guard asks — "is this row the app the caller
+	// named?" — and answered it differently until the four copies were
+	// consolidated; see internal/appapi/slug.go. The failure mode an exact
+	// compare has here is the same SILENT one: a row whose blockId differed only
+	// in case or padding would fall through to nil, and nil is deliberately
+	// indistinguishable from "not yours" and "could not ask", so `app view`
+	// would drop the ownership advice with nothing on screen to say why.
+	// Normalising can only join a mis-spelling to the one valid slug it
+	// mis-spells (valid slugs are lowercase and unpadded by schema), so the row
+	// it newly admits is always this app's row and never another's.
+	//
+	// What it does NOT change: appViewOwnedAdvice renders the caller's own
+	// `slug` argument, not this row's BlockID, so a normalised match cannot put
+	// the server's spelling — or the caller's — anywhere it was not already.
 	for i := range subs {
-		if subs[i].BlockID == slug {
+		if appapi.SameSlug(subs[i].BlockID, slug) {
 			return &subs[i]
 		}
 	}

--- a/internal/cmd/slug_predicate_ledger_test.go
+++ b/internal/cmd/slug_predicate_ledger_test.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// THE SLUG-PREDICATE LEDGER — one definition, and a guard that notices a second.
+//
+// The defect this PR fixed was not that any single site was wrong. It was that
+// ONE question had FOUR answers, three of which had never reasoned about the
+// hazard the fourth was written for. Consolidating them fixes today; this ledger
+// is what stops the count going back up, because the next author to write
+// `row.BlockID == slug` will do it in a file none of the behavioural cases
+// above touch, and every one of them will stay green.
+//
+// 🔴 IT IS A ZERO-OFFENDER ASSERTION, NOT A HAND-MAINTAINED LIST OF SITES. A
+// list of names covers the sites somebody thought of — the failure mode the
+// submissions-route ledger (newest_row_pick_test.go) was rewritten to escape.
+// The rule here is structural: in the two packages that speak the submissions
+// route, a blockId may be compared with == or != ONLY against the empty string.
+// Everything else is an identity question and belongs to appapi.SameSlug.
+//
+// 🔴 WHY `== ""` AND `== nil` ARE ALLOWED AND NOT AN OVERSIGHT. "Is this field
+// set?" is a different question from "do these two spellings name the same
+// app", and it has no normalisation to get wrong — SameSlug's own empty guard
+// is written in terms of it. FOURTEEN such presence checks exist in these two
+// packages today — measured, by running this scan with the floor set above the
+// real count and reading the number back — across app_dev_tunnel.go,
+// app_status.go, app_listing.go, app_metrics.go, app_pull.go, appblocks.go and
+// listing.go. Flagging them would make the guard noise, which is the one thing
+// a permanently-red gate reliably achieves.
+//
+// The `nil` half is not a widening of convenience: `Submission.AppBlockID` is a
+// `*string` and — unlike `BlockID` — is NOT a slug. It is the app-block's
+// server-side id, nulled until a version is APPROVED, and all three of its
+// comparisons in this tree (app_listing.go, app_metrics.go, app_pull.go) ask
+// only whether it is populated. A slug field would never be compared to nil; if
+// one ever is, the identifier is a pointer and the comparison is still a
+// presence check.
+//
+// 🔴 WHAT IT CANNOT SEE, measured rather than waved at. It is a line scanner
+// over source text, so: a comparison split across lines; a comparison routed
+// through a local copy (`got := row.BlockID; got == slug`); `strings.EqualFold`
+// open-coded directly, which is the RIGHT answer spelled the wrong way and is
+// therefore the cheapest evasion; a slug field that is not named `*blockId*`;
+// and any package other than the two ledgered ones. The last is bounded by the
+// same thing that bounds the route ledger — a third package would have to
+// obtain a Submission, and appapi is the only client of the route. The
+// EqualFold evasion is deliberately left open: it produces correct behaviour
+// and a duplicated definition, which is a review nit, not the silent defect
+// this guard exists for.
+
+// blockIDComparison matches a blockId-ish identifier compared with == or !=,
+// capturing the right-hand side so a presence check can be told from an identity
+// check.
+//
+// The identifier class allows `.`, `[`, `]` and `*` so a selector, an index and
+// a pointer deref are all caught: `subs[i].BlockID`, `*m.AppBlockID`.
+//
+// 🔴 THERE IS NO `\b` BEFORE `block`, AND THAT IS THE WHOLE POINT. The first
+// draft read `\bblock[A-Za-z0-9_]*id` and silently could not see `AppBlockID`:
+// Go's `\b` is an ASCII word boundary, and inside `AppBlockID` the character
+// before `B` is `p` — both word characters, so no boundary exists there. The
+// scanner still reported "no offenders" over the real tree, because the sites it
+// COULD see were already fixed. It was the calibration case below that caught
+// it, which is the reason that case is written as a deref rather than as another
+// `BlockID`: a control built from the shape you already handle proves nothing.
+var blockIDComparison = regexp.MustCompile(`(?i)([A-Za-z0-9_.\[\]*]*block[A-Za-z0-9_]*id)\s*(==|!=)\s*(\S+)`)
+
+// slugLedgerHit is one comparison the scanner found.
+type slugLedgerHit struct {
+	file, line, rhs string
+}
+
+// scanBlockIDComparisons returns every blockId comparison in src, split into the
+// allowed presence checks and the identity checks that must go through SameSlug.
+//
+// Full-line comments are skipped: this file, slug.go and three call sites all
+// discuss `m.BlockID == ""` in prose, and a guard that flags its own
+// documentation is a guard people delete.
+func scanBlockIDComparisons(file, src string) (identity, presence []slugLedgerHit) {
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		for _, m := range blockIDComparison.FindAllStringSubmatch(line, -1) {
+			rhs := strings.TrimRight(m[3], `,;){`)
+			hit := slugLedgerHit{file: file, line: trimmed, rhs: rhs}
+			if rhs == `""` || rhs == "nil" {
+				presence = append(presence, hit)
+				continue
+			}
+			identity = append(identity, hit)
+		}
+	}
+	return identity, presence
+}
+
+// TestBlockIDComparisonsUseSameSlug is the ledger. Zero identity comparisons,
+// across both packages that speak the submissions route.
+func TestBlockIDComparisonsUseSameSlug(t *testing.T) {
+	var identity, presence []slugLedgerHit
+	for prefix := range submissionsLedgerDirs {
+		for name, src := range submissionsPkgSources(t, prefix) {
+			i, p := scanBlockIDComparisons(prefix+"/"+name, src)
+			identity = append(identity, i...)
+			presence = append(presence, p...)
+		}
+	}
+
+	// 🔴 THE POSITIVE CONTROL, AND IT COMES FIRST. "0 offenders" and "the regex
+	// matched nothing" are the same output, and the second is what a renamed
+	// field or a mis-set working directory produces. The presence checks are the
+	// known-non-zero population this scan must be able to see: if THEY are gone,
+	// the zero below is a fact about the pattern, not about the code.
+	//
+	// The floor sits below the measured 14 on purpose — it is a wired-up check,
+	// not a census, and pinning it exactly would turn every legitimate deletion
+	// of a nil check into a failure of the SLUG ledger, which is how a gate
+	// stops being read.
+	const presenceFloor = 10
+	if len(presence) < presenceFloor {
+		t.Fatalf("the scanner found only %d blockId presence check(s) (floor %d) — it is not seeing the "+
+			"source it claims to check, so its 'no offenders' verdict means nothing", len(presence), presenceFloor)
+	}
+
+	if len(identity) == 0 {
+		return
+	}
+	sort.Slice(identity, func(a, b int) bool { return identity[a].file < identity[b].file })
+	var b strings.Builder
+	for _, h := range identity {
+		b.WriteString("\n  " + h.file + ": " + h.line)
+	}
+	t.Fatalf("%d blockId identity comparison(s) bypass appapi.SameSlug:%s\n\n"+
+		"A blockId compared with == or != against anything but \"\" is asking 'are these the same app?', "+
+		"and that question has ONE answer in this binary: appapi.SameSlug (internal/appapi/slug.go). "+
+		"Open-coding it is how the four copies that this ledger exists to prevent came to disagree — three "+
+		"of them exact, one normalising, and the whole suite green over a cased or padded blockId at all four. "+
+		"If this comparison genuinely is NOT an identity question, say so at the call site and widen the "+
+		"presence rule here on purpose.", len(identity), b.String())
+}
+
+// TestBlockIDComparisonScannerIsCalibrated is the negative control: the scanner
+// must go RED on a source that violates the rule, and stay quiet on the shapes
+// it deliberately allows. Without this, TestBlockIDComparisonsUseSameSlug is a
+// claim about a regex nobody has watched match.
+func TestBlockIDComparisonScannerIsCalibrated(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		src          string
+		wantIdentity int
+		wantPresence int
+		why          string
+	}{
+		{
+			name:         "the exact compare this PR removed, cmd shape",
+			src:          "func f() {\n\tif subs[i].BlockID == slug {\n\t\treturn\n\t}\n}\n",
+			wantIdentity: 1,
+			why:          "internal/cmd/apps.go's original line must be caught, or the ledger could not have found it",
+		},
+		{
+			name:         "the exact compare this PR removed, appapi shape",
+			src:          "func f() {\n\tif s.BlockID != slug || s.Version != version {\n\t\tcontinue\n\t}\n}\n",
+			wantIdentity: 1,
+			why:          "internal/appapi/appblocks.go's original line, with a second unrelated compare on it",
+		},
+		{
+			name:         "the two-row compare, both clauses",
+			src:          "func f() {\n\tif m.BlockID == \"\" || m.BlockID != s.BlockID {\n\t\treturn\n\t}\n}\n",
+			wantIdentity: 1,
+			wantPresence: 1,
+			why:          "app_status.go's original line: one presence check and one identity check, told apart",
+		},
+		{
+			name:         "a pointer deref",
+			src:          "func f() {\n\tif *subs[i].AppBlockID != want {\n\t\treturn\n\t}\n}\n",
+			wantIdentity: 1,
+			why:          "AppBlockID has no word boundary before Block; a \\bBlockID\\b pattern would miss it",
+		},
+		{
+			name:         "presence checks are allowed",
+			src:          "func f() {\n\tif blockID == \"\" {\n\t\treturn\n\t}\n\tif *subs[i].AppBlockID != \"\" {\n\t\treturn\n\t}\n}\n",
+			wantPresence: 2,
+			why:          "'is it set' is a different question with no normalisation to get wrong",
+		},
+		{
+			name:         "nil checks on the nullable AppBlockID are allowed",
+			src:          "func f() {\n\tif subs[i].AppBlockID != nil && *subs[i].AppBlockID != \"\" {\n\t\treturn\n\t}\n}\n",
+			wantPresence: 2,
+			why: "AppBlockID is a *string server id, not a slug, and both clauses ask only whether it is " +
+				"populated — flagging them would make the ledger permanently red on correct code",
+		},
+		{
+			name:         "a nil check does not license an identity check beside it",
+			src:          "func f() {\n\tif sub.AppBlockID != nil && sub.BlockID == slug {\n\t\treturn\n\t}\n}\n",
+			wantIdentity: 1,
+			wantPresence: 1,
+			why:          "the nil allowance is per-comparison, not per-line",
+		},
+		{
+			name: "prose is not code",
+			src: "// The hand-written `m.BlockID == \"\"` clause and m.BlockID != s.BlockID are discussed here.\n" +
+				"func f() {}\n",
+			why: "a guard that flags its own documentation gets deleted",
+		},
+		{
+			name:         "the fixed call sites are clean",
+			src:          "func f() {\n\tif !appapi.SameSlug(subs[i].BlockID, slug) {\n\t\treturn\n\t}\n\tif !SameSlug(s.BlockID, slug) || s.Version != version {\n\t\tcontinue\n\t}\n}\n",
+			wantIdentity: 0,
+			why:          "the POST-fix shape must produce zero, or the ledger fails on the very code it certifies",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			identity, presence := scanBlockIDComparisons("synthetic.go", tc.src)
+			if len(identity) != tc.wantIdentity {
+				t.Errorf("identity comparisons = %d, want %d — %s\nhits: %+v", len(identity), tc.wantIdentity, tc.why, identity)
+			}
+			if len(presence) != tc.wantPresence {
+				t.Errorf("presence comparisons = %d, want %d — %s\nhits: %+v", len(presence), tc.wantPresence, tc.why, presence)
+			}
+		})
+	}
+}
+
+// TestSameSlugHasExactlyOneDefinition closes the evasion the ledger above cannot
+// see from the comparison side: re-deriving the predicate under another name.
+// The consolidation's whole claim is ONE definition, so the count is asserted
+// directly rather than inferred from the absence of `==`.
+func TestSameSlugHasExactlyOneDefinition(t *testing.T) {
+	var defs []string
+	for prefix := range submissionsLedgerDirs {
+		for name, src := range submissionsPkgSources(t, prefix) {
+			if strings.Contains(src, "func SameSlug(") || strings.Contains(src, "func sameSlug(") {
+				defs = append(defs, prefix+"/"+name)
+			}
+		}
+	}
+	sort.Strings(defs)
+	if len(defs) != 1 || defs[0] != "appapi/slug.go" {
+		t.Fatalf("SameSlug is defined in %v, want exactly [appapi/slug.go].\n"+
+			"A second definition is the four-copies bug returning under a new name — the comparison-side "+
+			"ledger cannot see it, because a duplicate definition produces no bare == at all.", defs)
+	}
+}

--- a/internal/cmd/slug_predicate_test.go
+++ b/internal/cmd/slug_predicate_test.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/civitai/cli/internal/appapi"
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// THE SHARED SLUG PREDICATE AT ITS THREE cmd-SIDE CALL SITES.
+//
+// One question — "is this submissions row the app I am talking about?" — was
+// answered four ways: normalising at internal/cmd/approved_version.go (#414) and
+// exact at the other three. The whole suite was green over a cased or padded
+// blockId at ALL FOUR, including the one that already normalised: #414 shipped
+// the predicate and its doc comment but no fixture that exercised it. These
+// cases are the missing fixtures.
+//
+// 🔴 WHICH OF THESE ARE REGRESSION COVERAGE AND WHICH ARE INVARIANT GUARDS —
+// stated, because the two are not worth the same, and measured rather than
+// asserted. "Base" below means origin/main's call sites with appapi.SameSlug
+// present but uncalled, so the only variable is the call site itself.
+//
+//	site                                    converted?          at base   kind
+//	internal/cmd/apps.go ownedSubmission    yes (== -> SameSlug)  RED     regression
+//	internal/cmd/app_status.go drift check  yes (!= -> SameSlug)  RED     regression
+//	internal/cmd/approved_version.go        no, already SameSlug  GREEN   invariant
+//
+// 🔴 SITE 1's CASE IS GREEN AT BASE AND IS NOT REGRESSION COVERAGE. An earlier
+// draft of this header claimed it was red at base; the base run refuted that,
+// and the claim is corrected here rather than quietly dropped. Its value is
+// different and worth having anyway: #414 shipped that normalisation with a doc
+// comment and NO fixture, so reverting it to `==` left the whole suite green.
+// The case below kills that mutant, with its own named reason. Coverage this PR
+// adds for pre-existing behaviour — not a behaviour change at that site.
+
+// slugRespellings are the spellings that name the SAME app as the canonical
+// slug. Every one of them is invalid per schema/app-block.manifest.schema.json's
+// `^[a-z][a-z0-9-]*[a-z0-9]$`, which is the reason accepting them cannot collide
+// with a second registered app — the fold-and-trim is the identity map on the
+// set of valid slugs.
+func slugRespellings(canonical string) []string {
+	return []string{
+		strings.ToUpper(canonical),
+		strings.ToUpper(canonical[:1]) + canonical[1:],
+		" " + canonical,
+		canonical + " ",
+		" " + strings.ToUpper(canonical[:1]) + canonical[1:] + " ",
+	}
+}
+
+// slugRejectsFor builds the four negative controls for a canonical slug: an
+// unrelated app, an extension of it, a prefix of it, and the empty string. A
+// widened predicate that passed every positive case above fails at least one of
+// these, and each names the over-wide implementation it catches.
+func slugRejectsFor(canonical string) []struct{ name, spelling, breaks string } {
+	return []struct{ name, spelling, breaks string }{
+		{"unrelated", "gen-matrix", "a different app entirely"},
+		{"extension", canonical + "-2", "prefix matching would accept a DIFFERENT registered app"},
+		{"prefix", canonical[:strings.Index(canonical, "-")], "suffix/Contains matching would accept a shorter slug"},
+		{"empty", "", "no slug names an app; empty must never be a wildcard"},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 1: internal/cmd/approved_version.go — highestApprovedVersion
+// ---------------------------------------------------------------------------
+
+// TestHighestApprovedVersionMatchesARespelledBlockID pins #414's normalisation,
+// which shipped with a doc comment and no fixture. Reverting that site to `==`
+// on origin/main left the entire suite green (measured), so this is the killing
+// case for that mutant.
+//
+// The assertion is on slugRows as well as on the version, because the two fail
+// differently: slugRows is what tells "this app has rows, none approved yet"
+// apart from "rows came back, none of them for this app", and a slug-blind read
+// collapses both into the silent branch.
+func TestHighestApprovedVersionMatchesARespelledBlockID(t *testing.T) {
+	const canonical = "custom-generators"
+	for _, spelling := range slugRespellings(canonical) {
+		t.Run(spelling, func(t *testing.T) {
+			peak := highestApprovedVersion(driftSubs(
+				[3]string{spelling, "0.5.2", "approved"},
+				[3]string{spelling, "0.4.0", "rejected"},
+			), canonical)
+			if !peak.found {
+				t.Fatalf("highestApprovedVersion found nothing for rows spelled %q against slug %q — "+
+					"those are the same app, and missing them makes the #412 guard a SILENT no-op",
+					spelling, canonical)
+			}
+			if peak.version != "0.5.2" {
+				t.Errorf("peak.version = %q, want 0.5.2", peak.version)
+			}
+			if peak.slugRows != 2 {
+				t.Errorf("peak.slugRows = %d, want 2 — both rows are this app's, and slugRows is what "+
+					"distinguishes 'nothing approved yet' from 'no rows for this app'", peak.slugRows)
+			}
+		})
+	}
+}
+
+// TestHighestApprovedVersionStillRejectsOtherSlugs is the negative control at
+// site 1: found=false AND slugRows=0, because a row for another app must not
+// even be counted as this app's.
+func TestHighestApprovedVersionStillRejectsOtherSlugs(t *testing.T) {
+	const canonical = "custom-generators"
+	for _, r := range slugRejectsFor(canonical) {
+		t.Run(r.name, func(t *testing.T) {
+			peak := highestApprovedVersion(driftSubs(
+				[3]string{r.spelling, "0.9.9", "approved"},
+			), canonical)
+			if peak.found {
+				t.Errorf("a row for blockId %q answered the highest-approved lookup for %q with %q (%s) — "+
+					"`app submit` would refuse a perfectly good version against another app's number",
+					r.spelling, canonical, peak.version, r.breaks)
+			}
+			if peak.slugRows != 0 {
+				t.Errorf("peak.slugRows = %d for blockId %q, want 0 — counting another app's row as this "+
+					"app's row silences the blockId-mismatch signal", peak.slugRows, r.spelling)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 2: internal/cmd/apps.go — ownedSubmission
+// ---------------------------------------------------------------------------
+
+// respelledOwnedBody is the owned-slug listing with the ROW spelled differently
+// from the slug the caller asked for. The request still narrows by the exact
+// slug (appViewServer asserts that), so this is precisely the defence-in-depth
+// scenario: the CLI asked correctly and the server echoed a spelling it does not
+// today emit.
+func respelledOwnedBody(spelling string) string {
+	return `{"submissions":[{
+	  "id":"pubreq_02H","blockId":"` + spelling + `","version":"0.2.0","status":"pending",
+	  "deployState":"building","submittedAt":"2026-07-29T10:00:00Z","updatedAt":"2026-07-29T10:00:00Z",
+	  "createdAt":"2026-07-29T10:00:00Z","liveUrl":null}]}`
+}
+
+// TestAppViewOwnedAdviceMatchesARespelledBlockID is site 2's red-at-base case.
+// With `==`, the row fell through to nil — and nil is deliberately
+// indistinguishable from "not yours" and "could not ask", so `app view` printed
+// the bare 404 and the author lost the advice with nothing on screen saying why.
+func TestAppViewOwnedAdviceMatchesARespelledBlockID(t *testing.T) {
+	for _, spelling := range slugRespellings("buzz-generator") {
+		t.Run(spelling, func(t *testing.T) {
+			probes := appViewServer(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(respelledOwnedBody(spelling)))
+			})
+
+			_, _, err := run(t, "app", "view", "buzz-generator")
+			if err == nil {
+				t.Fatal("expected a not-found error")
+			}
+			// The exit-code contract is untouched by which branch answered.
+			if !errors.Is(err, civitai.ErrNotFound) {
+				t.Errorf("404 must still classify as ErrNotFound (rc=4), got %T: %v", err, err)
+			}
+			if n := atomic.LoadInt32(probes); n != 1 {
+				t.Fatalf("the ownership probe ran %d times, want 1 — without it nothing here is about the row scan", n)
+			}
+			msg := err.Error()
+			for _, want := range appViewAdviceMarkers {
+				if !strings.Contains(msg, want) {
+					t.Errorf("a row spelled %q is the SAME app as buzz-generator, so the owned-slug advice "+
+						"must fire; missing %q. Dropping it is silent: the caller sees only the bare 404.\ngot: %v",
+						spelling, want, err)
+				}
+			}
+			// The advice must report THIS row's fields, not a default — the
+			// positive control that the matched row is what was rendered.
+			assertOwnedStatePair(t, msg, "pending", "building")
+		})
+	}
+}
+
+// TestAppViewOwnedAdviceStillRejectsOtherSlugs is site 2's negative control. A
+// false positive here is the expensive direction: it claims a slug the caller
+// does NOT own is "one of your own apps", and prints another author's submission
+// status and deploy state as fact.
+func TestAppViewOwnedAdviceStillRejectsOtherSlugs(t *testing.T) {
+	for _, r := range slugRejectsFor("buzz-generator") {
+		t.Run(r.name, func(t *testing.T) {
+			probes := appViewServer(t, func(w http.ResponseWriter, r2 *http.Request) {
+				_, _ = w.Write([]byte(respelledOwnedBody(r.spelling)))
+			})
+
+			_, _, err := run(t, "app", "view", "buzz-generator")
+			if err == nil {
+				t.Fatal("expected a not-found error")
+			}
+			if n := atomic.LoadInt32(probes); n != 1 {
+				t.Fatalf("the probe must have RUN (positive control), ran %d times", n)
+			}
+			if strings.Contains(err.Error(), "one of your own apps") {
+				t.Errorf("a row for blockId %q was read as ownership of buzz-generator (%s) — "+
+					"that prints another author's status and deploy state as fact about this slug",
+					r.spelling, r.breaks)
+			}
+			assertNoOwnedAdvice(t, err)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 4: internal/cmd/app_status.go — warnLocalVersionDrift
+// ---------------------------------------------------------------------------
+
+// TestAppStatusDriftMatchesARespelledManifestBlockID is site 4's red-at-base
+// case, and the one site where the unnormalised value does NOT have to come from
+// the server: manifest.Load is a bare json.Unmarshal with no schema validation,
+// so a hand-edited `"blockId": " Custom-Generators "` reaches the compare today.
+//
+// The failure it removes is silent — the drift warning simply does not print,
+// which is indistinguishable from "nothing is approved yet".
+func TestAppStatusDriftMatchesARespelledManifestBlockID(t *testing.T) {
+	for _, spelling := range slugRespellings(driftSlug) {
+		t.Run(spelling, func(t *testing.T) {
+			var calls int32
+			srv := driftServer(t, driftFixture(t), &calls, 0)
+			writeDriftManifest(t, spelling, "0.4.0")
+			setupDriftEnv(t, srv.URL)
+
+			out, errOut, err := run(t, "app", "status", driftSlug)
+			if err != nil {
+				t.Fatalf("app status: %v", err)
+			}
+			if n := atomic.LoadInt32(&calls); n != 1 {
+				t.Fatalf("%d request(s), want 1 — the detail lookup's response IS the listing", n)
+			}
+			// The literal sentence, written by hand from the issue's numbers.
+			if !strings.Contains(errOut, driftWarnLine) {
+				t.Errorf("a manifest whose blockId is %q describes the SAME app as the row, so the drift "+
+					"warning must print.\nwant line: %s\ngot stderr:\n%s", spelling, driftWarnLine, errOut)
+			}
+			// 🔴 THE WARNING NAMES THE SERVER'S SPELLING, NOT THE MANIFEST'S — a
+			// normalising match must not become a route by which a hand-mangled
+			// local value reaches the screen as if the server had said it.
+			//
+			// Asserted POSITIONALLY, on the two literal sentences that embed the
+			// slug, rather than as `!Contains(errOut, spelling)`. That form is a
+			// spelled guard and it fails here for a reason worth recording: a
+			// space-padded spelling like " custom-generators" IS a substring of
+			// "…version of custom-generators," so the check fired on correct
+			// output. Pinning both slots catches every echo the check was aimed
+			// at, and cannot fire on whitespace it did not cause.
+			//
+			// driftWarnLine (asserted above) is slot 1. This is slot 2:
+			const remedy = "civitai app pull . --app " + driftSlug
+			if !strings.Contains(errOut, remedy) {
+				t.Errorf("the remedy must name the SERVER's slug: want %q.\nstderr:\n%s", remedy, errOut)
+			}
+			// And the case-differing spellings are observable directly, since no
+			// correct rendering ever upper-cases the slug.
+			if strings.Contains(errOut, strings.ToUpper(driftSlug[:1])+driftSlug[1:]) ||
+				strings.Contains(errOut, strings.ToUpper(driftSlug)) {
+				t.Errorf("the warning echoed a mis-cased slug; it must render s.BlockID.\nstderr:\n%s", errOut)
+			}
+			if strings.Contains(out, driftWarnCore) {
+				t.Errorf("the warning belongs on stderr; stdout:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestAppStatusDriftStillSilentForOtherSlugs is site 4's negative control. A
+// false positive prints "your repo is BEHIND" by comparing two DIFFERENT apps'
+// versions — a fabricated regression that sends an author to re-pull released
+// code for no reason.
+//
+// It extends TestAppStatusDriftSilentForADifferentApp (which covers
+// `some-other-app` and a manifest with no blockId key at all) with the three
+// shapes an over-wide predicate would fail: an extension, a prefix, and an
+// explicitly EMPTY blockId — the last being the case the hand-written
+// `m.BlockID == ""` clause used to carry and that SameSlug now owns.
+func TestAppStatusDriftStillSilentForOtherSlugs(t *testing.T) {
+	for _, r := range slugRejectsFor(driftSlug) {
+		t.Run(r.name, func(t *testing.T) {
+			var calls int32
+			srv := driftServer(t, driftFixture(t), &calls, 0)
+			writeDriftManifest(t, r.spelling, "0.4.0")
+			setupDriftEnv(t, srv.URL)
+
+			out, errOut, err := run(t, "app", "status", driftSlug)
+			if err != nil {
+				t.Fatalf("app status: %v", err)
+			}
+			if n := atomic.LoadInt32(&calls); n != 1 {
+				t.Fatalf("%d request(s), want 1 — the detail lookup must have happened, or this "+
+					"asserts silence about a command that never ran", n)
+			}
+			assertNoDriftWarning(t, "manifest blockId="+r.spelling+" ("+r.breaks+")", out, errOut)
+		})
+	}
+}
+
+// TestWarnLocalVersionDriftRejectsAnAllWhitespaceBlockID is the strictly-new
+// behaviour, isolated. `m.BlockID == "" || m.BlockID != s.BlockID` DID reject an
+// all-whitespace blockId, but only via the second clause — the explicit empty
+// guard never saw it. SameSlug trims first, so the empty case now covers it, and
+// that is asserted directly rather than left implied.
+func TestWarnLocalVersionDriftRejectsAnAllWhitespaceBlockID(t *testing.T) {
+	for _, spelling := range []string{"   ", "\t", " \n "} {
+		t.Run(strings.TrimSpace("ws"+spelling), func(t *testing.T) {
+			if appapi.SameSlug(spelling, driftSlug) {
+				t.Errorf("SameSlug(%q, %q) = true — an all-whitespace blockId names no app", spelling, driftSlug)
+			}
+		})
+	}
+}


### PR DESCRIPTION
One question — "is this submissions-route row the app I asked about?" — was answered four different ways. `sameSlug` was added deliberately in #414 after an audit showed an exact match makes the #412 version guard a **silent** no-op on a cased or padded `blockId`: it lands in the "no approved rows" branch, which proceeds without a word because that is also what a genuine first submit looks like. The other three sites never got that treatment.

Consolidated into **`appapi.SameSlug`** (`internal/appapi/slug.go`). It lives in `appapi` and not `internal/cmd` because `appapi` owns `Submission.BlockID` — the field on one side of all four comparisons — and `appapi` cannot import `internal/cmd`, while every `cmd` caller already imports `appapi`.

## Per-site decisions

| site | before | decision | why |
|---|---|---|---|
| `internal/cmd/approved_version.go:114` | `sameSlug(...)` | **call site swapped**, no behaviour change | already the normalising copy (#414). Its doc comment moved with it, unchanged in strength. |
| `internal/cmd/apps.go:262` `ownedSubmission` | `subs[i].BlockID == slug` | **converted** | Same question as #412's. The exact miss is silent in the worst way: it falls through to `nil`, and `nil` is *deliberately* indistinguishable from "not yours" and "could not ask", so `app view` prints the bare 404 with nothing saying the advice was dropped. |
| `internal/appapi/appblocks.go:632` `latestMatchingSubmission` | `s.BlockID != slug \|\| s.Version != version` | **slug converted; version deliberately left exact** | The version is an *ordered* value whose policy lives in `comparableVersion` (a pre-release is NOT ORDERABLE). A fold-and-trim compare here would quietly contradict it, and would widen what a timed-out submit may report as "the row that landed" — the id a user hands to `civitai app withdraw`. Stated at the call site so it does not read as an oversight, and pinned by a test. |
| `internal/cmd/app_status.go:369` `warnLocalVersionDrift` | `m.BlockID == "" \|\| m.BlockID != s.BlockID` | **converted** | It *is* a different question — local manifest vs row, not request vs row — and it is the site with the **strongest** case for normalising, not the weakest. At the other three the unnormalised value could only come from the server, which by its own route contract cannot emit one. Here it comes from `block.manifest.json` via `manifest.Load`, a bare `json.Unmarshal` with **no schema validation**, so a hand-edited `"blockId": " Custom-Generators "` reaches the compare today with no server change required. The reasoning is written at the call site. |

### What a normalising match now admits — and why it is intended

A valid slug matches `^[a-z][a-z0-9-]*[a-z0-9]$` (`schema/app-block.manifest.schema.json`, shared with the server's own `block-manifest-validator.service.ts`). It admits no uppercase and no whitespace, so **`EqualFold`+`TrimSpace` is the identity map on the set of valid slugs**: it can only ever join a mis-spelling to the one valid slug it is a mis-spelling *of*, never a second app. Every site also renders the *server's* spelling (or the caller's own argument), never the newly-admitted one — asserted.

One thing is **narrower** than before: `SameSlug` rejects an empty side, including empty-against-empty, which `==` answered `true` at three sites. `app_status.go` already carried a hand-written `m.BlockID == ""` guard for exactly this; it is folded in, and now covers all-whitespace too, which the hand-written clause did not.

## Red-at-base / green-at-HEAD

"Base" = `origin/main`'s call sites with `appapi.SameSlug` present but **uncalled**, so the only variable is the call site, not a missing symbol.

| suite | base | HEAD |
|---|---|---|
| `internal/appapi` new cases | RUN 17 / PASS 11 / **FAIL 6** | RUN 17 / PASS 17 / FAIL 0 |
| `internal/cmd` new cases | RUN 49 / PASS 35 / **FAIL 14** | RUN 49 / PASS 49 / FAIL 0 |

Failing at base: `TestLatestMatchingSubmissionMatchesARespelledBlockID` (4 subtests), `TestRecoverTimedOutSubmitMatchesARespelledBlockID`, `TestAppViewOwnedAdviceMatchesARespelledBlockID` (5), `TestAppStatusDriftMatchesARespelledManifestBlockID` (5), `TestBlockIDComparisonsUseSameSlug`, `TestSameSlugHasExactlyOneDefinition`.

🔴 **`TestHighestApprovedVersionMatchesARespelledBlockID` is GREEN at base and is labelled an invariant guard, not regression coverage** — site 1 already normalised. Its value is that it kills the site-1 mutant, which nothing did before: #414 shipped that normalisation with a doc comment and no fixture.

**Negative controls at every site** (`gen-matrix`, `<slug>-2`, a prefix of the slug, `""`), in both argument orders on the predicate itself, plus version-stays-exact controls at site 3 (` 0.2.0`, `0.2.0 `, `V0.2.0`, `v0.2.0`, `0.2.0-rc.1` must all still miss).

## Mutation

Each call-site mutant reverts **one** site to its exact comparison, leaving the other three converted. The structural ledger is excluded from this column on purpose — it kills every mutant for the *same* reason and would mask a site with no behavioural fixture.

| mutant | killed by | killing assertion |
|---|---|---|
| site 1 `approved_version.go` → `!=` | `TestHighestApprovedVersionMatchesARespelledBlockID` | `highestApprovedVersion found nothing for rows spelled "CUSTOM-GENERATORS" against slug "custom-generators" — … makes the #412 guard a SILENT no-op` |
| site 2 `apps.go` → `==` | `TestAppViewOwnedAdviceMatchesARespelledBlockID` | `a row spelled "BUZZ-GENERATOR" is the SAME app … missing "one of your own apps". Dropping it is silent: the caller sees only the bare 404.` |
| site 3 `appblocks.go` → `!=` | `TestLatestMatchingSubmissionMatchesARespelledBlockID` + `TestRecoverTimedOutSubmitMatchesARespelledBlockID` | `latestMatchingSubmission found no match for a row whose blockId is "My-Block" — … dropping it makes a landed submit report as timed out` |
| site 4 `app_status.go` → `== "" \|\| !=` | `TestAppStatusDriftMatchesARespelledManifestBlockID` | `a manifest whose blockId is "CUSTOM-GENERATORS" describes the SAME app as the row, so the drift warning must print.` |
| predicate: drop empty guard | `TestSameSlugAcceptsOnlyRespellingsOfTheSameSlug` | `SameSlug("", "") = true, want false — an empty slug names no app` |
| predicate: drop `TrimSpace` | same + all 4 site tests | `SameSlug(" my-block", "my-block") = false, want true` |
| predicate: `EqualFold` → `==` | same + all 4 site tests | `SameSlug("My-Block", "my-block") = false, want true` |

**0 surviving mutants.** Each call-site mutant killed *only* its own site's tests (site 3 kills appapi cases and leaves all 37 cmd cases green; sites 1/2/4 the mirror image) — so the coverage is per-site, not one broad test standing in for four.

The empty-guard mutant is killed **only at the unit seam**, not through any call site. That is honest and stated: at site 4 the preceding `s.BlockID == ""` guard makes it structurally unreachable, and at the other three the caller's slug is non-empty on every path a fixture can build.

## The ledger

`TestBlockIDComparisonsUseSameSlug` (`internal/cmd/slug_predicate_ledger_test.go`) is a **zero-offender** assertion, not a hand-maintained list of sites: across both packages that speak the submissions route, a `blockId` may be compared with `==`/`!=` only against `""` or `nil` (presence checks — `Submission.AppBlockID` is a nullable server id, not a slug). A fifth open-coded site fails on the day it is written.

It carries its own controls, and they earned their keep:

- **Positive control first** — 14 presence checks must be visible (floor 10), because "0 offenders" and "the regex matched nothing" are the same output.
- **Calibration suite** (`TestBlockIDComparisonScannerIsCalibrated`, 8 cases) — and it **found a hole in the scanner**: the first draft used `\bblock…id`, and Go's `\b` cannot match inside `AppBlockID` (`p`→`B` is not a word boundary). The scanner still reported "no offenders" over the real tree, because the sites it *could* see were already fixed. That is the reason the deref case is written as `*subs[i].AppBlockID` rather than another `BlockID`.
- `TestSameSlugHasExactlyOneDefinition` closes the evasion the comparison-side scan cannot see — re-deriving the predicate under another name produces no bare `==` at all.

What the ledger cannot see is enumerated in the file (multi-line comparisons, a comparison via a local copy, an open-coded `strings.EqualFold`, a slug field not named `*blockId*`).

Also fixed: one of my own assertions in the site-4 test was a **spelled guard** — `!Contains(errOut, spelling)` fires on correct output, because a space-padded `" custom-generators"` is a substring of `"…version of custom-generators,"`. Replaced with a positional assertion on both sentences that embed the slug.

## Gates

- `make ci` — exit 0
- `make ci-shallow` — `ok=20/20 failing-tests=0 failing-packages=0 timeouts=0 go-test-rc=0`
- `golangci-lint run ./...` from the module root — **0 issues**, and instrument-validated: a planted `declared and not used` in `internal/appapi/slug.go` makes the same invocation report `1 issues`
- Full suite, counted from `-v` output: **4199 `=== RUN` / 4195 `--- PASS` / 0 `--- FAIL` / 4 `--- SKIP`**, `panic: test timed out` grep = 0
- `gofmt -l` clean

## Not verified

- Whether the civitai server can ever emit a mis-cased `blockId`. #414's claim that it cannot (`where.slug = blockId`, echoing `blockId: row.slug` from a non-nullable column) is carried over **verbatim and not upgraded**; it was not re-checked against the server repo in this PR. The predicate remains defence-in-depth on that axis.
- Whether any real user's `block.manifest.json` holds an unnormalised `blockId`. The path is reachable (`manifest.Load` does no schema validation) but no live instance was observed — such a manifest is rejected by `civitai app submit`'s own validation.
