### PR TITLE
docs(release): v0.1.96 shipped — and the changelog fix is now OBSERVED, not asserted

### DIFF
--- a/claudedocs/release-v0.1.96-draft.md
+++ b/claudedocs/release-v0.1.96-draft.md
@@ -1,145 +1,125 @@
-# v0.1.96 — DRAFT (not tagged, not published)
+# v0.1.96 — SHIPPED
 
-**Nothing is released yet.** This file is written *before* the tag so the
-pre-publish checks below happen in the order that makes them worth doing.
+**This release is out.** Tagged at `53a925b`, published 2026-08-16T21:45:53Z,
+`@civitai/cli@0.1.96` on npm (`dist-tags.latest = 0.1.96`), Homebrew cask bumped
+to 0.1.96, **14 assets** (the full cross product, windows/arm64 included).
 
-**8 commits** in `v0.1.95..8570488` — `8570488` being `main` at the time of
-writing. 🔴 **Every count here has an expiry date and must be recomputed as
-`v0.1.95..v0.1.96` once the tag exists**, which is the rule this document family
-enforces and which its first three members each shipped without. Recompute
-before flipping this file to SHIPPED; if `main` moved, the split below is stale,
-not merely imprecise.
+**9 commits** (`v0.1.95..v0.1.96`): **6 excluded** by the changelog filter, **3
+in the notes**, **0 leaking**.
 
-## This is the release that grades the #416 changelog fix
+The draft of this file counted **8** against `v0.1.95..8570488`. Merging the
+draft itself added the ninth — a `docs(release):` commit, which the filter
+excludes. That is the whole reason this document family insists the numbers are
+recomputed **after tagging**: the act of writing the notes changes them.
 
-v0.1.93, v0.1.94 and v0.1.95 each reported "leaking commits" and each re-derived
-the number by hand. #416 traced it to the regex: the exclude anchors matched only
-the **unscoped** conventional-commit form while this repo writes scoped subjects.
-`changelog_filter_ledger_test.go` now pins the patterns' behaviour — and says
-plainly what it cannot check:
+## The #416 changelog fix: CONFIRMED, on the release it was queued to be graded on
+
+`changelog_filter_ledger_test.go` pins the exclude patterns' *behaviour* and says
+plainly what it cannot reach:
 
 > What this does NOT check: that goreleaser applies these patterns to the subject
 > line the way this test assumes, or anything about a real release body. That is a
 > claim about goreleaser, and the honest place to confirm it is the NEXT release's
 > published notes.
 
-**This is that release.** The confirmation is one read of the published body, and
-it has a specific failure shape: **if any of the five EXCLUDED subjects below
-appear in the published notes, the fix is inert and the ledger test is green for
-the wrong reason.** Record the outcome here either way — a filter that matches
-nothing looks identical to a filter with nothing to match.
+**This was that release, and the answer is yes.** The published body carries
+exactly three entries:
 
-### Measured, not eyeballed
+```
+* 73ea7b4 fix(app): name the offsite app instead of `app submit`, which cannot work for it (#422) (#426)
+* 7857a94 fix(pkgzip): exclude `.git` when it is a FILE, not only a directory (#409) (#418)
+* 7652b7d refactor(appapi): one slug predicate, not four — and the three that were exact were silently wrong (#421)
+```
+
+**None of the six excluded subjects appear.** Predicted split and published body
+agree exactly. v0.1.93, v0.1.94 and v0.1.95 each shipped with leaking commits and
+each re-derived the number by hand; this is the first body where the fix is
+observed doing its job rather than asserted to.
+
+### The prediction, made before the tag existed
 
 The three patterns were read out of `.goreleaser.yaml` (not retyped) and applied
-by Go's `regexp` — goreleaser's own engine — to the eight real subjects:
+with Go's `regexp` — goreleaser's own engine — to the real subjects:
 
 | verdict | commit |
 |---|---|
 | EXCLUDED `^docs(\(.*\))?:` | `docs(release):` v0.1.95 shipped … regex bug all along (#416) |
 | EXCLUDED `^chore(\(.*\))?:` | `chore(scaffold):` bump `@civitai/*` pins to published latest (#419) |
-| **IN NOTES** | `fix(pkgzip):` exclude `.git` when it is a FILE, not only a directory (#409) (#418) |
+| **IN NOTES** | `fix(pkgzip):` exclude `.git` when it is a FILE (#409) (#418) |
 | **IN NOTES** | `refactor(appapi):` one slug predicate, not four (#421) |
 | EXCLUDED `^test(\(.*\))?:` | `test(readme):` widen the table-of-contents gate to `###` (#417) |
 | EXCLUDED `^docs(\(.*\))?:` | `docs(handoff):` submit-guards + the five-app drift reconciliation (#425) |
 | **IN NOTES** | `fix(app):` name the offsite app instead of `app submit` (#422) (#426) |
 | EXCLUDED `^docs(\(.*\))?:` | `docs(handoff):` the offsite refusal shipped … (#428) |
+| EXCLUDED `^docs(\(.*\))?:` | `docs(release):` v0.1.96 draft (#429) — *the ninth, added by merging the draft* |
 
-`excluded=5 in-notes=3 leaking=0`. Near-miss negative controls (`chorus:`,
-`documentation:`, `fix(pkgzip):`) all correctly land IN NOTES, so the patterns
-have not been lazily widened.
+Near-miss negative controls (`chorus:`, `documentation:`) correctly stayed IN
+NOTES, so the patterns had not been lazily widened. **Counterfactual on the same
+subjects with the OLD patterns: `excluded=0 in-notes=9`** — all six would have
+leaked, so an inert fix would have been visible here rather than ambiguous.
 
-**Counterfactual, same subjects, the OLD patterns: `excluded=0 in-notes=8`.** All
-five would have leaked. The fix is load-bearing for this release specifically, so
-an inert result is detectable rather than ambiguous.
-
-## What ships
-
-Three user-facing commits, all fixes to paths a user actually walks.
+## What shipped
 
 **1. `.git` is excluded when it is a FILE, not only a directory** (#409 / #418).
-In a git **worktree** or a **submodule**, `.git` is a file holding `gitdir: …`,
-not a directory — so the packager's directory-only exclusion missed it and
-bundled it. That matters beyond bundle size: **`civitai app pull` writes an
-access token into the clone's `.git/config`** (it warns, then does it), so the
-pre-fix packager could carry a credential into an uploaded bundle for anyone
-submitting from a worktree.
+In a git **worktree** or **submodule**, `.git` is a file holding `gitdir: …`, so
+the directory-only exclusion missed it and bundled it. That matters beyond bundle
+size: **`civitai app pull` writes an access token into the clone's `.git/config`**
+(it warns, then does it), so the pre-fix packager could carry a credential into an
+uploaded bundle for anyone submitting from a worktree.
 
 **2. An offsite app is named instead of being told to `civitai app submit`**
-(#422 / #426). `app listing` and `app status <slug>` used to answer a registered
-**URL** app with `no such submission for app "x" — run \`civitai app submit\`
-first`, which cannot succeed for an app that is not a block bundle. Verified live
-against the real API, not only fixtures. This is **outcome 2** of #422; outcome 1
-stays open on purpose (below).
+(#422 / #426). Outcome 2 of #422; outcome 1 stays open, blocked server-side.
 
-**3. One slug predicate instead of four** (#421) — and three of the four
-open-coded copies that looked exact were silently wrong. Cataloged as a refactor,
-kept in the notes deliberately: the consolidation changes matching behaviour at
-the sites that disagreed.
+**3. One slug predicate instead of four** (#421) — three of the four open-coded
+copies that looked exact were silently wrong. Kept in the notes deliberately: the
+consolidation changes matching behaviour at the sites that disagreed.
 
-## What is NOT in this release
+## Verified against the draft artifact, before publishing
 
-- **#420** — `.env.local` / `*.zip` are excluded as **files** but not as
-  **directories**; a planted `.env.d/db.env` containing `API_SECRET=leak` is
-  packaged. The exact mirror of the bug #418 fixes, credential-shaped, and
-  deliberately left out of #418 because a directory rule would start dropping
-  whole trees like `.environment/`. **Highest-severity open defect on this path.**
-- **#411's provenance stamp.** Still blocked on a server field —
-  `appapi.Submission` has no commit/tree/dirty column. Its urgency is now
-  measured rather than assumed: on 2026-08-15 and again 2026-08-16, exactly **2 of
-  22 slugs** (`generate-from-model@0.2.7`, `who-am-i@0.1.0`) carry a
-  `deployState: null` row that the server nonetheless treats as serving, both via
-  the pre-epoch legacy branch; the other two null-serving branches hold **zero**
-  rows and 20 of 22 slugs read `deploy_state='live'`. So #414's liveness fix was
-  load-bearing for two May-era dogfood apps, and the stamp is **hygiene, not
-  urgent**.
-- **#427** — #426's own residuals: the refusal asserts ownership it never checked
-  (the store catalog endpoint is public, so the advice is wrong for a stranger's
-  slug — pre-existing, carried forward in a new shape), and its probe has no off
-  switch. Tracked, not fixed.
-- **#424, #423, #410** — unchanged.
+`linux_amd64` downloaded from the draft, `sha256sum -c` against `checksums.txt`
+→ **OK**; `version` → `0.1.96 / 53a925bf78…`, matching `main` exactly.
 
-## Before publishing, not after
+Then five arms on the real platform. **Two carry a live negative control: the
+same fixture packaged with the v0.1.95 binary, which must show the defect.**
 
-goreleaser cuts a **DRAFT**. Publishing the draft is what fires **npm AND the
-Homebrew tap** (both trigger on `release: published`), and npm unpublish is
-restricted — so every check below happens against the draft's artifact.
-
-`npm/package.json` stays at `0.0.0-dev` and the binary's version comes from
-`-X main.version={{ .Version }}`: **the tag is the only version input, no source
-bump is needed.**
-
-```bash
-D=/tmp/v196; mkdir -p $D
-gh release download v0.1.96 --repo civitai/cli \
-  --pattern 'civitai_0.1.96_linux_amd64' --dir $D --clobber
-# checksum against checksums.txt must print OK, then:
-chmod +x $D/civitai_0.1.96_linux_amd64 && $D/civitai_0.1.96_linux_amd64 version
-```
-
-🔴 **Do not use the `civitai` on `PATH`** for any of this — it is a stale dev
-build, which makes every check vacuous.
-
-Arms specific to what this release changes:
-
-| arm | expected |
+| arm | result |
 |---|---|
-| package from a git **worktree** (`.git` is a FILE) | `.git` absent from the bundle |
-| package from a **submodule** | same |
-| `app listing` / `app status <offsite-slug>` | names the offsite app; never recommends `app submit` |
-| `app status <onsite-slug>` (positive control) | unchanged behaviour |
-| the three guards from v0.1.95 | still refuse: version ≤ highest approved, dirty tree |
+| package from a git **worktree** (`.git` is a FILE) | **86 → 85 files**; the 94-byte `.git` gone. v0.1.95 on the same tree: **present** |
+| package from a **submodule** (`.git` is a FILE) | 28-byte `.git` gone. v0.1.95 on the same tree: **present** |
+| both, `.github/` + `.gitignore` | retained — the exclusion is not over-broad |
+| `app status radio` / `app listing status radio` / `… comfy` (offsite) | names the offsite app and its registered URL; states `app submit` **would not** create one. Exit **4** |
+| `app status custom-generators` / `gen-matrix` (onsite controls) | unchanged — approved / live, exit 0 |
+| v0.1.95's version guard (0.5.3 == highest approved) | refuses, exit **1** |
+| v0.1.95's dirty-tree guard (version raised to 0.9.0 so the version guard passes) | refuses naming ` M block.manifest.json`, exit **1** |
 
-The last row is not ceremony — #421 changed the slug predicate those guards
-resolve rows with.
+The last two are ordered deliberately: raising the version first proves the dirty
+guard is **reached**, not merely shadowed by the guard in front of it. #421
+changed the slug predicate both guards resolve rows with, so "still refuses" is a
+real check here, not ceremony. Both ran with `CIVITAI_SUBMIT_PATH` pointed at a
+non-existent route, so a total guard failure could not have created a submission.
 
-Then, and only then, publish. Check Homebrew the way it actually breaks: every
-archive URL the cask names must answer **200 unauthenticated**.
+**Fixture note worth keeping:** the submodule arm first failed validation on
+`0.4.0`, because `git submodule add` from a local clone checks out **that clone's
+`main`**, which was stale. The stale-local-ref trap, one layer down.
 
 ## After publishing
 
-1. Read the published body and record the #416 verdict above — the five excluded
-   subjects present or absent.
-2. Recompute the counts as `v0.1.95..v0.1.96`.
-3. Flip this file's heading to `# v0.1.96 — SHIPPED` with the tag SHA, publish
-   timestamp, npm version, Homebrew cask version and asset count.
+- **npm** — `@civitai/cli` `dist-tags.latest = 0.1.96`.
+- **Homebrew** — `civitai/homebrew-tap` cask at `version "0.1.96"`; all four
+  archive URLs it names answer **200 unauthenticated** (darwin/linux ×
+  amd64/arm64). That is how the cask actually breaks, so that is how it is
+  checked.
+
+## Still open
+
+- **#420** — `.env.local` / `*.zip` excluded as **files** but not **directories**;
+  a planted `.env.d/db.env` containing `API_SECRET=leak` is packaged. The exact
+  mirror of the bug #418 fixes, credential-shaped. **Highest-severity open defect
+  on this path.**
+- **#411's provenance stamp** — blocked on a server field. Measured on 2026-08-15
+  and again 2026-08-16: exactly **2 of 22 slugs** carry a `deployState: null` row
+  the server treats as serving, both via the pre-epoch legacy branch, with **zero**
+  rows in the other two null-serving branches. Hygiene, not urgent.
+- **#427** — #426's own residuals: the refusal asserts ownership it never checked,
+  and its probe has no off switch.
+- **#424, #423, #422 (outcome 1), #410** — unchanged.


### PR DESCRIPTION
v0.1.96 is out: tagged `53a925b`, published 2026-08-16T21:45:53Z, `@civitai/cli@0.1.96` latest on npm, Homebrew cask 0.1.96, 14 assets.

**The headline is the verdict this release existed to produce.** `changelog_filter_ledger_test.go` states outright that it cannot check whether goreleaser applies its exclude patterns to a real body, and names the next published release as the honest place to confirm it. The published notes carry **exactly the three predicted in-notes commits and none of the six excluded ones** — prediction and observation agree, so #416's fix is now observed rather than inferred from a test that says it cannot see this.

Counts recomputed at the tag: **9 commits, 6 excluded, 3 in notes, 0 leaking.** The draft said 8; merging the draft added the ninth, itself a `docs(release):` commit the filter excludes. That is exactly why this document family recomputes after tagging rather than before.

**Pre-publish verification, all against the draft artifact** (checksum `OK`, `version` = `0.1.96 / 53a925b`):

| arm | result |
|---|---|
| worktree (`.git` is a FILE) | 86 → 85 files, the 94-byte `.git` gone — **v0.1.95 on the same tree: present** |
| submodule (`.git` is a FILE) | 28-byte `.git` gone — **v0.1.95 on the same tree: present** |
| `.github/` + `.gitignore` | retained; the exclusion is not over-broad |
| offsite `radio` / `comfy`, both commands | names the app and its URL, states `app submit` would not help, exit 4 |
| onsite controls | unchanged, exit 0 |
| version guard / dirty guard | both refuse, exit 1 — ordered so the dirty guard is proven **reached**, not shadowed |

Two arms carry a live negative control, and the guard arms ran with `CIVITAI_SUBMIT_PATH` pointed at a non-existent route so a total guard failure could not have created a real submission.

Post-publish: npm `dist-tags.latest = 0.1.96`, cask at `version "0.1.96"`, and all four archive URLs it names answer **200 unauthenticated** — the way the cask actually breaks.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QybSDbsJwEMJdxDRUasTC1