### PR TITLE
docs(agents): split item 29, and retract the "no client path" absolute it asserted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ reason. Item 27 is blockId derivation — the one identity this CLI mints that
 can NEVER be renamed, plus the residuals the refusal knowingly ships with.
 Item 28 is what the CLI may CLAIM about a spend it cannot observe.
 Item 29 is the one place this CLI deliberately REFUSES rather than reaches — the
-offsite app whose listing no client-side selector can address.
+offsite app, whose reachability the item's own evidence file now PARTLY RETRACTS.
 The durable fix for the mirroring is a server-side `civitai app validate` endpoint
 calling the real `BlockManifestValidator`; until that exists, vendoring is on
 purpose.
@@ -406,14 +406,9 @@ item must carry a trigger that is a routing question rather than a label
     reaching for a banned-phrase guard?**
     → evidence: claudedocs/decisions/28-no-claims-about-unobservable-spend.md
 
-29. **The OFFSITE refusal is a refusal, NOT a repair.** No client change makes
-    `app listing` / `app status <slug>` reach an offsite app:
-    `getMyListingForApp` was measured to resolve ONLY by `appBlockId`, which an
-    offsite app has none of — the slug selector 404s for every app, onsite
-    controls included (civitai/cli#422, #424). Dropping the submission lookup
-    just moves the 404 one call later. `internal/cmd/app_offsite.go` detects
-    `kind: offsite` on the ERROR PATH ONLY; reaching these apps needs a
-    SERVER-side selector.
+29. **Reaching an offsite app's listing or submissions from the CLI, editing the
+    refusal that says you cannot, or repeating that no client path exists?**
+    → evidence: claudedocs/decisions/29-offsite-refusal.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -130,6 +130,18 @@ const agentsSplitBaseWave3 = "6e31b4b29a0eb15c83e951a114db2345877d38bd"
 // items 2 and 4, which are smaller than a trigger plus a file read would cost.
 const agentsSplitBaseWave4 = "dfdcc974976ef4d8104f273b28b1f702c5a7f839"
 
+// agentsSplitBaseWave5 is the commit item 29 was moved from — the tip after
+// #428 (the offsite handoff) and #429 (the v0.1.96 draft).
+//
+// 🔴 WAVE 5 IS ONE ITEM, AND IT IS THE CASE WAVE 4 SAID IT COULD NOT DO. Item 29
+// arrived inline in #426 because a FIRST-APPEARANCE item has no base commit where
+// its body already lived in AGENTS.md, so it could not carry a row here without a
+// two-PR dance. #426 was that first PR whether or not anyone planned it: the body
+// has stood in AGENTS.md since 73ea7b4, so the base now exists and the dance is
+// complete. The lesson generalises — a new item is inline ONLY until its first
+// merge, after which converting it is an ordinary wave.
+const agentsSplitBaseWave5 = "53a925bf7810f2e0dadd64ddc9f77f2e390ae8b4"
+
 type splitItem struct {
 	num      int
 	file     string
@@ -169,6 +181,7 @@ var splitItems = []splitItem{
 	{num: 15, file: "claudedocs/decisions/15-two-trpc-envelopes.md", base: agentsSplitBaseWave4, nonBlank: 25, sha: "74a0d1e7746bec2ccec78bfae7616b7398f7c6a44b995cd7ddc3b58e27425fbb"},
 	{num: 16, file: "claudedocs/decisions/16-externalid-is-the-idempotency-key.md", base: agentsSplitBaseWave4, nonBlank: 25, sha: "cf7f2bd23cf64b0421fad49ace38df6dcdef3d3c3104aecef19e7657935caa4f"},
 	{num: 28, file: "claudedocs/decisions/28-no-claims-about-unobservable-spend.md", base: agentsSplitBaseWave4, nonBlank: 31, sha: "41387de27265146eb9c9fc8a507621b27b8b20cdf0db8d7eb9d4903021707478"},
+	{num: 29, file: "claudedocs/decisions/29-offsite-refusal.md", base: agentsSplitBaseWave5, nonBlank: 8, sha: "df86c7a851e2397db48eebd2f4b9d17e91565128ec4550510a62b785f552828d"},
 }
 
 // --- the one deliberate delta, item 3 ---------------------------------------

--- a/claudedocs/decisions/29-offsite-refusal.md
+++ b/claudedocs/decisions/29-offsite-refusal.md
@@ -1,0 +1,114 @@
+# AGENTS.md item 29 — the OFFSITE refusal is a refusal, NOT a repair
+
+Evidence for item 29 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements, the retractions and the enumerated residuals, consulted when
+editing the code they are about rather than on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## 🔴 "NO CLIENT CHANGE MAKES … REACH AN OFFSITE APP" IS RETRACTED IN PART
+
+**Read this before repeating the body's central claim, and before treating the
+refusal as proof that no client path exists.** The body below is byte-pinned
+against the commit it was moved from, so it cannot be edited in place; this
+header is where the correction lives. The *refusal itself* still ships and is
+still right for what it does — what does not survive is the absolute.
+
+**What the body says.** *"No client change makes `app listing` /
+`app status <slug>` reach an offsite app."* The support offered is that
+`getMyListingForApp` resolves only by `appBlockId`, and an offsite app has none.
+
+**Both halves of that support are true. The conclusion does not follow**, because
+`getMyListingForApp` is not the only route to an `AppListing.id`.
+
+**MEASURED (2026-08-16, live, unauthenticated, read-only):**
+
+```
+$ curl -s https://civitai.com/api/v1/apps/radio
+200  {"id":"apl_01KYNB77D490DM6YS0C5Z7KYT7","slug":"radio","kind":"offsite",
+      "iconUrl":"https://image.civitai.com/…","coverUrl":"https://image.civitai.com/…"}
+```
+
+That `id` is the `AppListing` row id — server-side it is `row.id` off
+`dbRead.appListing.findFirst` (`projectListingDetail`,
+`src/server/services/blocks/app-listing.service.ts:402` in `civitai/civitai`).
+**This CLI already calls that exact route and already decodes that exact field:**
+`offsiteApp` in `internal/cmd/app_offsite.go` calls `client.GetApp`, and
+`civitai.AppDetail.ID` (`pkg/civitai/apps.go:136`) is the `apl_` id. So the
+handle the body says cannot be obtained is *already in a variable on the refusal
+path*.
+
+**READ FROM SOURCE, NOT MEASURED** (`civitai/civitai@07a1c537dc`) — the rest of a
+plausible client path:
+
+- `getMyListingForEdit` takes a `listingId` and gates on **ownership and status
+  only** — `loadOwnedEditableListing`, then a `removed`/`rejected`/shadow switch.
+  There is **no kind check**.
+- The asset procs (`setIcon` / `setCover` / `addScreenshot` / `removeScreenshot` /
+  `reorderScreenshots` / `updateScreenshotCaption`) are listing-keyed and gate on
+  `loadOwnedListing`. Again **no kind check**.
+- `listingMedia` — the capability cell that is `false` for offsite — is read
+  **only** by `src/components/Apps/appListingEditorTabs.ts`, a CLIENT tab gate.
+  No service enforces it. (`earnings` and `submitVersion`, the two STRUCTURAL
+  false cells, *are* enforced server-side. `listingMedia` is not.)
+
+So the honest state is **"a client path probably exists for an APPROVED offsite
+app, and is unverified"** — not "ruled out", which is what the body and
+`claudedocs/handoff-offsite-refusal.md` both said.
+
+**WHY IT IS STILL NOT A DROP-IN REPAIR** — three constraints any attempt must
+answer, and the reason the refusal was not simply reverted:
+
+1. `GET /api/v1/apps/{slug}` returns **approved** listings only
+   (`app-listing.service.ts:672`) and is further gated by
+   `resolveStoreVisibilityScope`, the `public-external` kind filter and the
+   mature-rating check (:678, :688). A **draft or pending** offsite listing is
+   invisible there — which is exactly the window an author wants to attach an
+   icon and cover in. An owner can also be refused their own approved app when a
+   visibility or maturity gate excludes it, producing a "no listing" that really
+   means "not publicly visible to you here".
+2. `getMyListingForEdit` **performs a write**. For an approved parent it calls
+   `beginListingRevision` and mints a shadow revision (deliberately — see the
+   🔴 SECURITY note at `offsite-listing.service.ts:1526`). It therefore cannot sit
+   on the read-only `app listing status` path, and it is why hop 2 was NOT probed
+   live: doing so would have minted a shadow on a real production listing.
+3. Two hops through a **public catalog** route to reach your own private listing
+   is a fragile shape to build a command on. It is a workaround for a missing
+   selector, not the selector.
+
+**THE UPSTREAM ASK: `civitai/civitai#3984`** — a slug (or app-id) selector on
+`appListings.getMyListingForApp` that actually resolves offsite listings. One hop,
+works pre-approval, needs no public read. The mechanism it reports, which also
+answers civitai/cli#424: the slug arm **exists** but is scoped
+`where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' }`
+(`offsite-listing.service.ts:1705-1710`), so `kind: 'offsite'` excludes every
+offsite app on the first clause and an approved onsite app fails the other two.
+That is why the body's *"the slug selector 404s for every app"* measurement is
+correct and why it is a scoping fact rather than a missing feature.
+Related upstream: `civitai/civitai#3893` (same resolver, the web Media-tab half —
+it proposes an `appListingId` key, which serves the website but leaves every
+non-web client on constraint 1 above).
+
+**WHAT WOULD SETTLE IT.** One measurement: call `getMyListingForEdit` with an
+offsite app's `apl_` id and see whether it returns assets or refuses on kind.
+Do it against a **throwaway** offsite app, not `radio` / `comfy` / `cosmetic-studio`
+/ `vitrine` — constraint 2 means the probe writes. Until then, do not restate the
+body's absolute, and do not build on the workaround either.
+
+---
+
+29. **The OFFSITE refusal is a refusal, NOT a repair.** No client change makes
+    `app listing` / `app status <slug>` reach an offsite app:
+    `getMyListingForApp` was measured to resolve ONLY by `appBlockId`, which an
+    offsite app has none of — the slug selector 404s for every app, onsite
+    controls included (civitai/cli#422, #424). Dropping the submission lookup
+    just moves the 404 one call later. `internal/cmd/app_offsite.go` detects
+    `kind: offsite` on the ERROR PATH ONLY; reaching these apps needs a
+    SERVER-side selector.

--- a/claudedocs/handoff-offsite-refusal.md
+++ b/claudedocs/handoff-offsite-refusal.md
@@ -25,7 +25,8 @@ whether reaching those apps is possible at all.
   (`offsiteApp`) asked by both call sites (`app_listing.go:200` via `resolveListing`,
   `app_status.go:119`). Error path only, gated on `errors.Is(err, civitai.ErrNotFound)`,
   own 5s deadline, `client.Stderr = io.Discard` so retry notices cannot print above the
-  real error. Exit code stays **4**. AGENTS.md gains **item 29** (inline, no evidence file).
+  real error. Exit code stays **4**. AGENTS.md gains **item 29** — inline in #426, split to
+  `claudedocs/decisions/29-offsite-refusal.md` once that merge gave it a base commit.
 - **DONE — verified LIVE**, not just against fixtures (see *How to verify*).
 - **OPEN by design: #422 stays open.** Only outcome 2 (refuse precisely) shipped. Outcome 1
   (actually reach offsite apps) is blocked server-side — see the investigation below.
@@ -74,8 +75,13 @@ whether reaching those apps is possible at all.
     `httptest` fakes returning `{"appListingId":"apl_draft",…}` **unconditionally**. They
     pin the wire shape the CLI *sends*, never what the server *answers*.
 
-- **Leading hypothesis:** the server's slug selector is narrowed to draft/pending listings
-  and does not match approved ones — or it does not work at all and the comment is wrong.
+- ✅ **Hypothesis CONFIRMED from server source** (`civitai/civitai@07a1c537dc`,
+  `offsite-listing.service.ts:1705-1710`): the slug arm is real but scoped
+  `where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' }`. Every row in the
+  table above is accounted for — the two approved onsite apps carry an `appBlockId` and fail
+  clauses 2 and 3; the offsite apps fail clause 1. So the comment is neither right nor
+  wrong: it is **over-general**. Suggested edit in the #424 thread — keep the slug argument
+  and both tests, narrow the prose to name the three conditions.
 
 - **🔴 The confound I could NOT eliminate:** the only two `appBlockId = nil` submissions I
   could find (`etag-probe-05773`, `dogfood-test-palette`) are **`withdrawn`**, not
@@ -97,27 +103,56 @@ whether reaching those apps is possible at all.
 - **Observed:** `getMyListingForApp` is addressable **only** by `appBlockId`; an offsite app
   has none — that is what `kind: offsite` means. Dropping the submission lookup and falling
   through with an empty `appBlockId` just moves the 404 one call later.
-- **Ruled out:** any client-side fix. This is not a scope cut; it is measured.
+- 🔴 **"Ruled out: any client-side fix" is RETRACTED (2026-08-16).** It was true of
+  `getMyListingForApp` and false as a claim about the CLI, because that proc is not the only
+  route to an `AppListing.id`. **Measured, live, unauthenticated:**
+  `GET /api/v1/apps/radio` → `200 {"id":"apl_01KYNB77D490DM6YS0C5Z7KYT7","kind":"offsite",…}`.
+  That is the listing row id, and **this CLI already decodes it** —
+  `civitai.AppDetail.ID`, off the call `offsiteApp` already makes on the refusal path.
+  Server-side (`civitai/civitai@07a1c537dc`, read not measured) `getMyListingForEdit` and
+  every listing-keyed asset proc gate on **ownership only, no kind check**, and the
+  `listingMedia:false` capability cell is read solely by a client-side tab gate.
+  So: **a client path probably exists for an APPROVED offsite app, and is unverified.**
+  Not a drop-in — `/api/v1/apps/{slug}` is approved-only and scope-gated (a draft or pending
+  offsite listing is invisible to it), and `getMyListingForEdit` **writes** (mints a shadow
+  revision), so it cannot sit on the read-only `app listing status` path. Full account,
+  with the caveats and the probe that would settle it:
+  `claudedocs/decisions/29-offsite-refusal.md`.
 - **Two vendored comments say the row exists** (claims, not measurements):
   `pkg/civitai/apps.go:10-13` — `/api/v1/apps` serves BOTH kinds *"from the durable
   AppListing record"*; `internal/appapi/listing.go:351` — `persistListingAssetImage` is
-  documented against **`offsite-listing.service.ts`**.
-- **Next step:** an issue on **`civitai/civitai`** asking for a `slug` or app-id selector on
-  `appListings.getMyListingForApp`. Not yet filed. It also unblocks #424.
+  documented against **`offsite-listing.service.ts`**. The `id` measurement above turns the
+  first of these from a claim into a confirmed one.
+- **DONE — the upstream issue is filed: `civitai/civitai#3984`**, asking for a slug/app-id
+  selector on `appListings.getMyListingForApp`. It also reports the mechanism that answers
+  #424: the slug arm exists but is scoped
+  `where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' }`
+  (`offsite-listing.service.ts:1705-1710`), so `kind: 'offsite'` excludes every offsite app
+  on the first clause and an approved onsite app fails the other two. Cross-linked from
+  #422, #424 and `civitai/civitai#3893`.
 
 ## Next steps (ranked)
 
-1. **File the server-side selector issue on `civitai/civitai`** — the only thing that
-   unblocks both #422 outcome 1 and #424. Attach the selector table above verbatim.
-2. **Settle #424** with the throwaway-app probe (recipe above). One measurement.
-3. **#420** — `.env.local` / `*.zip` excluded as files but not directories; a planted
+1. ~~**File the server-side selector issue on `civitai/civitai`**~~ — **DONE:
+   `civitai/civitai#3984`.** Note it is no longer "the only thing that unblocks #422
+   outcome 1"; see the retraction above.
+2. **Settle whether the client path is real** — the higher-value probe now. Call
+   `getMyListingForEdit` with an offsite app's `apl_` id and see whether it returns assets
+   or refuses on kind. 🔴 Use a **throwaway** offsite app, never `radio`/`comfy`/
+   `cosmetic-studio`/`vitrine`: the call mints a shadow revision on a live listing.
+   If it resolves, `app listing` can reach approved offsite apps today and item 29's
+   refusal narrows to draft/pending.
+3. **Settle #424** with the throwaway-app probe (recipe above). One measurement. Lower
+   priority now that the server source explains the 404s — the remaining question is only
+   whether the genuinely-pending onsite path works.
+4. **#420** — `.env.local` / `*.zip` excluded as files but not directories; a planted
    `.env.d/db.env` secret is packaged and durably published to Forgejo. Credential-leak
    direction, and the issue asks for a **per-name** decision, not a blanket
    `excludedDirs ⇄ excludedFiles` promotion. Enforce in the shared predicate and extend
    #418's seam test.
-4. **#427** — the residuals: the refusal asserts ownership it never checked (no
+5. **#427** — the residuals: the refusal asserts ownership it never checked (no
    `ownedSubmission` gate, unlike `explainAppViewNotFound`), and the probe has no off switch.
-5. **#411 second half** — provenance stamping at submit (commit SHA + dirty flag). The
+6. **#411 second half** — provenance stamping at submit (commit SHA + dirty flag). The
    dirty-tree refusal already shipped in #415.
 
 ## Gotchas / decisions / dead-ends
@@ -142,9 +177,12 @@ whether reaching those apps is possible at all.
   weaker option demonstrably admits a hazard the shipped one rejects. Residual, documented
   in the source: pure-ASCII, so an IDN host or unencoded UTF-8 path is dropped (message
   says less, stays whole).
-- **Decision: item 29 is INLINE in AGENTS.md**, no `claudedocs/decisions/29-*.md`. A new
-  decisions file needs a `splitItems` sha pinned to a base commit where the body already
-  lived in AGENTS.md, which a first-appearance item cannot have without a two-PR dance.
+- **Decision: item 29 was INLINE in AGENTS.md** — and that was only ever true for one merge.
+  A new decisions file needs a `splitItems` sha pinned to a base commit where the body
+  already lived in AGENTS.md, which a first-appearance item cannot have. #426 WAS that first
+  PR, so the base existed the moment it merged and the split became ordinary
+  (`agentsSplitBaseWave5`). **Generalise it: a new item is inline until its first merge, not
+  forever.**
 - **This checkout is shared.** `main` moved under me mid-session (1b20b99 → 961050e) from
   another session, and a stale agent worktree held `fix/offsite-refusal` checked out,
   blocking a normal `git checkout -B`. Check `git worktree list` before branching.

--- a/internal/cmd/app_offsite.go
+++ b/internal/cmd/app_offsite.go
@@ -28,15 +28,25 @@ import (
 // offsite apps fail that way, 7/7 onsite apps succeed — `kind` predicts it
 // exactly.
 //
-// 🔴 THIS IS THE REFUSAL, NOT THE REPAIR, AND THAT IS A MEASURED CHOICE RATHER
-// THAN A SCOPE CUT. #422's preferred outcome was to make offsite apps reachable
-// by resolving them by slug/app id instead. That is impossible client-side:
-// `appListings.getMyListingForApp` was measured live to resolve ONLY by
-// `appBlockId` (the slug selector 404s for every app, onsite positive controls
-// included), and an offsite app has no appBlockId — that is what `kind: offsite`
-// MEANS. Dropping the submission lookup just moves the 404 one call later.
-// Reaching these apps needs a server-side selector; see #422's thread and #424.
-// So do not "fix" this file by making it resolve something.
+// 🔴 THIS IS THE REFUSAL, NOT THE REPAIR. #422's preferred outcome was to make
+// offsite apps reachable by resolving them by slug/app id instead.
+// `appListings.getMyListingForApp` cannot do it: it was measured live to resolve
+// ONLY by `appBlockId` (the slug selector 404s for every app, onsite positive
+// controls included), and an offsite app has no appBlockId — that is what
+// `kind: offsite` MEANS. Dropping the submission lookup just moves the 404 one
+// call later. The upstream ask is civitai/civitai#3984.
+//
+// 🔴 BUT "NO CLIENT PATH EXISTS" IS RETRACTED IN PART, AND THE COUNTEREXAMPLE IS
+// IN THIS FILE. `offsiteApp` below calls GET /api/v1/apps/{slug}, whose payload
+// carries the `AppListing` row id — `civitai.AppDetail.ID`, an `apl_` ULID,
+// measured non-null for an offsite app (`radio` → `apl_01KYNB77D490DM6YS0C5Z7KYT7`,
+// 2026-08-16). Server-side, `getMyListingForEdit` and every listing-keyed asset
+// proc gate on OWNERSHIP only — no kind check — so a client path plausibly exists
+// for an APPROVED offsite app. It is UNVERIFIED (probing it mints a shadow
+// revision on a live listing) and it is not a drop-in: that route is
+// approved-only and scope-gated, so a draft or pending offsite listing is
+// invisible to it. Read claudedocs/decisions/29-offsite-refusal.md BEFORE either
+// restating the absolute or building on the workaround.
 //
 // 🔴 THE PROBE RUNS ONLY ON THE ERROR PATH, and that is load-bearing. A
 // successful `app listing status` / `app status <slug>` must be byte-identical
@@ -159,11 +169,14 @@ type offsiteRefusal func(slug string, d *civitai.AppDetail) string
 // Appending would leave the dead end on screen above the correction.
 //
 // The classification is re-attached, so the exit code is unchanged at 4 — see
-// AGENTS.md item 29 for why. That item is deliberately INLINE in AGENTS.md and
-// has no `claudedocs/decisions/29-*.md` body: a first-appearance item cannot
-// carry the agents_split_preserved_test.go provenance row a split body needs.
-// (An earlier draft of this line cited a decision file that never existed;
-// TestSourceCitationsOfDecisionFilesResolve now fails on that class.)
+// AGENTS.md item 29 for why. That item's body now lives in
+// claudedocs/decisions/29-offsite-refusal.md; it was inline while #426 was its
+// first appearance, because a first-appearance item has no base commit where its
+// body already stood in AGENTS.md and so cannot carry the
+// agents_split_preserved_test.go provenance row a split body needs. Once #426
+// merged, that base existed. (An earlier draft of this line cited a decision
+// file that did not yet exist; TestSourceCitationsOfDecisionFilesResolve fails on
+// that class, and the citation above now resolves.)
 func explainOffsiteMiss(ctx context.Context, slug string, err error, refuse offsiteRefusal) error {
 	// Only the not-found kind. A 403 from the invite-gated submissions route, a
 	// 5xx or a transport failure are different errors with different exit codes,


### PR DESCRIPTION
Started as "add the upstream issue number to AGENTS.md item 29". The number is
`civitai/civitai#3984`, filed this session. Reading the server source to write that
issue turned up something the citation could not carry: **item 29's central claim
does not survive.**

## What the item claims, and why it does not follow

Item 29 shipped inline in #426 asserting:

> No client change makes `app listing` / `app status <slug>` reach an offsite app:
> `getMyListingForApp` was measured to resolve ONLY by `appBlockId`, which an
> offsite app has none of …

Both halves of that support are true. The conclusion does not follow, because
`getMyListingForApp` is not the only route to an `AppListing.id`.

**MEASURED — live, unauthenticated, read-only:**

```
$ curl -s https://civitai.com/api/v1/apps/radio
200  {"id":"apl_01KYNB77D490DM6YS0C5Z7KYT7","slug":"radio","kind":"offsite",
      "iconUrl":"https://image.civitai.com/…","coverUrl":"https://image.civitai.com/…"}
```

That `id` is the `AppListing` row id (`projectListingDetail` returns `row.id` off
`dbRead.appListing.findFirst`). **This CLI already calls that route and already decodes
that field** — `offsiteApp` in `internal/cmd/app_offsite.go` calls `client.GetApp`, and
`civitai.AppDetail.ID` is the `apl_` ULID. The handle the item says cannot be obtained is
already in a variable on the refusal path.

**READ FROM SOURCE, not measured** (`civitai/civitai@07a1c537dc`) — the rest of a plausible
client path:

* `getMyListingForEdit` takes a `listingId` and gates on ownership + status only. **No kind check.**
* The listing-keyed asset procs (`setIcon`/`setCover`/`addScreenshot`/…) gate on `loadOwnedListing`. **No kind check.**
* `listingMedia` — the capability cell that is `false` for offsite — is read **only** by
  `appListingEditorTabs.ts`, a client-side tab gate. No service enforces it. (`earnings` and
  `submitVersion`, the two genuinely structural false cells, *are* enforced server-side.)

## What this PR does NOT do

It does not implement the path, and it labels it **UNVERIFIED** rather than fixed. Three
constraints, all recorded:

1. `GET /api/v1/apps/{slug}` is **approved-only** and further scope/maturity gated, so a
   **draft or pending** offsite listing is invisible to it — exactly the window an author
   wants to attach an icon and cover in.
2. `getMyListingForEdit` **writes**: for an approved parent it calls `beginListingRevision`
   and mints a shadow. That is why hop 2 was not probed — doing so would mint a shadow on a
   live production listing (`radio`, `comfy`, …).
3. Two hops through a public catalog route to reach your own private listing is a workaround
   for a missing selector, not the selector.

The refusal itself still ships and is still right for what it does. No behaviour changes —
this PR is comments, docs and one test-table row.

## Why a split rather than a one-line citation

Item 29 measures **548 bytes** against the **600-byte** `maxInlineItemBytes` break-even. The
citation alone fits; the citation plus a retraction does not. So the item converts to a
trigger plus `claudedocs/decisions/29-offsite-refusal.md` — header carries the retraction and
the upstream ask, body is the moved text **verbatim**.

**Wave 5 exists because #426 was itself the first PR of the "two-PR dance" its own comment
described.** That comment said a first-appearance item cannot carry a `splitItems` provenance
row, because there is no base commit where its body already stood in AGENTS.md. Once #426
merged there was: the body has stood since `73ea7b4`. `agentsSplitBaseWave5` is
`53a925bf` (current `origin/main`), and the row pins **8 non-blank lines**,
sha `df86c7a8…`. The lesson is written into the constant's comment — *a new item is inline
only until its first merge, not forever.*

This also makes `app_offsite.go`'s citation of `claudedocs/decisions/29-*.md` resolve. That
dangling citation is the one `TestSourceCitationsOfDecisionFilesResolve` was written for; the
comment claiming the file could not exist is now false and is corrected.

## Guards watched to FAIL — each with its own error, naming item 29

Mutation applied to the shipped tree, targeted test re-run, restored from `cp -a`
(never `git checkout --`). Baseline green in both tiers first.

| # | mutation | result |
| --- | --- | --- |
| M1 | alter one word inside the pinned body (`one call later` → `two calls later`) | 🔴 `TestSplitItemBodiesArePreservedVerbatim/item_29` |
| M2 | delete the `→ evidence:` pointer line from AGENTS.md | 🔴 `TestEvidencePointersAndFilesAreTheSameSet` — *"29-offsite-refusal.md exists but no AGENTS.md item points at it"* |
| M3 | corrupt the pinned sha to 64 zeros | 🔴 `TestSplitDigestsAreTheBaseCommitsText/item_29` |

M3 matters most: that test **re-derives** the digest from `53a925bf:AGENTS.md` rather than
from the file this PR wrote, and it was confirmed to **run, not skip** (it skips in a shallow
clone where the base blob is unreachable — so this was checked explicitly, not assumed).

## Gates

* `make ci` — green (full clone).
* `./scripts/ci-shallow.sh` — green on the **committed** SHA: `ok=20/20 failing-tests=0 failing-packages=0 timeouts=0`. Run because this PR adds a base-blob-dependent row and the two tiers see different things.
* `golangci-lint` **v2.12.2** (CI's exact pin, via `nix-shell`) — **0 issues**, with a negative control that reported **1** (`ineffassign`, planted in `app_offsite.go`) before restore. `make ci` does not run lint.

## Also updated

`claudedocs/handoff-offsite-refusal.md` (#428, merged hours ago) carried the same absolute as
a **"Ruled out: any client-side fix"** line. Retracted there too, its next-steps re-ranked
around the probe that would settle it, and its `#424` "leading hypothesis" upgraded to
**confirmed from source**: the slug arm is real but scoped
`where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' }`, which accounts for every
row in that issue's measured table.

Refs #422, #424 · upstream `civitai/civitai#3984`, `civitai/civitai#3893`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNdYjxagYYedKVxuoaQT4T
