### PR TITLE
docs(release): v0.1.97 shipped — the credential-shaped half of #409 is closed

### DIFF
--- a/claudedocs/release-v0.1.97-draft.md
+++ b/claudedocs/release-v0.1.97-draft.md
@@ -1,105 +1,91 @@
-# v0.1.97 — DRAFT (not tagged, not published)
+# v0.1.97 — SHIPPED
 
-**Nothing is released yet.** Written before the tag so the pre-publish checks
-happen in the order that makes them worth doing.
+**This release is out.** Tagged at `b2a9df6`, published 2026-08-17T00:29:39Z,
+`@civitai/cli@0.1.97` on npm (`dist-tags.latest = 0.1.97`), Homebrew cask 0.1.97,
+**14 assets**.
 
-**3 commits** in `v0.1.96..f8eb30f` — `f8eb30f` being `main` at the time of
-writing. 🔴 **Recompute as `v0.1.96..v0.1.97` once the tag exists**, and expect
-the count to move: merging this file adds a fourth commit, itself a
-`docs(release):` the filter excludes. That is the rule this document family
-exists to enforce, and v0.1.96's draft was off by exactly that one.
+**4 commits** (`v0.1.96..v0.1.97`): **3 excluded** by the changelog filter,
+**1 in the notes**, **0 leaking**.
 
-Predicted split, measured by applying `.goreleaser.yaml`'s real patterns with
-Go's `regexp` to the real subjects: **2 excluded, 1 in the notes, 0 leaking.**
-The one in the notes is the whole point of this release.
+The draft predicted 3 commits and flagged that merging it would add a fourth,
+itself a `docs(release):` the filter excludes. It did. That is the second
+consecutive release where the count moved between drafting and tagging, and the
+reason this document family recomputes rather than trusting the pre-tag number.
 
-## One user-facing change, and it is a credential path
+## The changelog filter, observed a second time
 
-**`.env.local` / `*.zip` are now excluded as DIRECTORIES, not only as files**
-(#420 / #433). The exact mirror of #409 — which #418 fixed for `.git` in
-v0.1.96 — with the shapes swapped, and this side points at credentials rather
-than layout.
+The published body carries exactly one entry:
 
-Measured against the **released v0.1.96 binary**: a planted `.env.d/db.env`
-holding `API_SECRET=leak` is packaged into the bundle. That bundle is committed
-to Forgejo `civitai-apps/<slug>` and deployed, so anything in it is durably
-published. On this release it is gone.
-
-🔴 **The file rule never covered for this.** Inside a `.env.d/` the conventional
-names are `db.env`, `api.env`, `local.env` — base names that do **not** start
-with `.env`, so the file rule keeps every one of them. The directory was the
-only thing between those files and the upload, and it was not checking.
-
-The rule is decided per name rather than by promoting one list into the other:
-
-- **Dotenv-shaped directories** — `.env`, or `.env.` + anything — are dropped at
-  any depth. **The dot is required**, unlike the file rule's bare `.env` prefix,
-  because matching too much removes a whole *subtree* silently: `.environment/`
-  and `.envoy/` keep shipping.
-- **The three kept dotenv files are still kept**, by name — but only where every
-  directory above them is itself packaged. `.env-backup/.env.production` is
-  uploaded; `.env.d/.env.production` is dropped with its directory.
-- **Archive-shaped directories** (`*.zip`) go too, through one predicate now
-  shared with the file rule so the two shapes cannot drift apart a third time.
-
-`app submit --help` now prints the directory and file rules as **separate
-lists** under their own headings, names the three kept files explicitly, and
-states the case that reads backwards otherwise: a regular *file* named `build`
-or `dist` **is** packaged, while a *directory* of that name is not.
-
-## What this does NOT close
-
-**#435.** The rules match names, never contents, so a secret still ships when
-neither name is dotenv-shaped. Measured on this code: `db.env` at the project
-root, `envs/prod.env`, `env/local.env`, `.env-backup/db.env`, `x.ZIP/` and
-`.ENV.local/` (both rules are case-sensitive) are **all packaged**. Every one is
-documented in the README's residual table. Do not read this release as closing
-the class.
-
-## Before publishing, not after
-
-goreleaser cuts a **DRAFT**. Publishing it fires **npm AND the Homebrew tap**
-(both trigger on `release: published`), and npm unpublish is restricted — so
-every check below runs against the draft's artifact.
-
-`npm/package.json` stays `0.0.0-dev`; the binary's version comes from
-`-X main.version={{ .Version }}`. **The tag is the only version input — no
-source bump.**
-
-```bash
-D=/tmp/v197; mkdir -p $D
-gh release download v0.1.97 --repo civitai/cli \
-  --pattern 'civitai_0.1.97_linux_amd64' --dir $D --clobber
-# sha256sum -c against checksums.txt must print OK, then:
-chmod +x $D/civitai_0.1.97_linux_amd64 && $D/civitai_0.1.97_linux_amd64 version
+```
+* f8eb30f fix(pkgzip): exclude dotenv- and archive-shaped DIRECTORIES, not only files (#420) (#433)
 ```
 
-🔴 **Do not use the `civitai` on `PATH`** — it is a stale dev build, which makes
-every check vacuous.
+Neither `docs(release):` nor `docs(agents):` nor the draft's own `docs(release):`
+appears. v0.1.96 was the first release to prove #416's scoped-exclude fix works
+against goreleaser itself; this is an independent second observation, not a
+re-derivation of the first.
 
-Arms specific to this release. **The first two carry a negative control: run the
-same fixture through the v0.1.96 binary, which must show the defect** — an arm
-that has never been watched fail proves nothing.
+## What shipped
 
-| arm | expected |
-|---|---|
-| `.env.d/db.env` with a secret, `--package-only` | absent from the bundle; **v0.1.96: present** |
-| `artifact.zip/payload.bin` | absent; **v0.1.96: present** |
-| `.environment/config.yaml`, `.envoy/bootstrap.yaml` | still packaged (over-broad rule check) |
-| `.env-backup/.env.production` | still packaged (the kept-name rule) |
-| `.env.d/.env.production` | dropped with its directory |
-| `app submit --help` | two separate lists; names the three kept files |
-| v0.1.95's guards (version ≤ approved, dirty tree) | still refuse, exit 1 |
-| `.git` as a FILE (worktree/submodule) | still excluded — v0.1.96's fix intact |
+**`.env.local` / `*.zip` are now excluded as DIRECTORIES, not only as files**
+(#420 / #433) — the mirror of #409, which #418 fixed for `.git` in v0.1.96, with
+the shapes swapped. This side points at credentials rather than layout.
 
-Then, and only then, publish. Check Homebrew the way it actually breaks: every
-archive URL the cask names must answer **200 unauthenticated**.
+🔴 **The file rule never covered for it.** Inside a `.env.d/` the conventional
+names are `db.env`, `api.env`, `local.env` — base names that do **not** start
+with `.env`, so the file rule keeps every one. The directory was the only thing
+between those files and a bundle that is committed to Forgejo `civitai-apps/<slug>`
+and deployed.
+
+Also in this release: `app submit --help` prints the directory and file rules as
+**separate lists**, names the three kept dotenv files explicitly, and states the
+case that reads backwards otherwise — a regular *file* named `build` or `dist`
+**is** packaged, a *directory* of that name is not.
+
+## Verified against the draft artifact, before publishing
+
+`linux_amd64` downloaded, `sha256sum -c` → **OK**, `version` → `0.1.97 /
+b2a9df60de…`, matching `main`. Then eight arms, the first two against a **v0.1.96
+negative control on the same fixture** — an arm nobody has watched fail proves
+nothing:
+
+| arm | v0.1.96 (control) | v0.1.97 |
+|---|---|---|
+| `.env.d/db.env` (holds `API_SECRET=`) | **packaged** | **absent** |
+| `.env.d/.env.production` | **packaged** | **absent** |
+| `artifact.zip/payload.bin` | **packaged** | **absent** |
+| `.environment/config.yaml`, `.envoy/bootstrap.yaml` | packaged | **still packaged** |
+| `.env-backup/.env.production` | packaged | **still packaged** |
+| `app submit --help` | — | two lists, three kept files named |
+| `.git` as a FILE (linked worktree) | — | **absent**; `.github/`, `.gitignore` kept |
+| version guard / dirty-tree guard | — | both refuse, exit **1** |
+
+The guard arms ran with `CIVITAI_SUBMIT_PATH` pointed at a non-existent route, so
+a total guard failure could not have created a real submission.
+
+🔴 **One harness bug worth recording, because it produced a confident-looking
+null result.** The first run of the bundle arms globbed `./*.zip` to clean up and
+picked the bundle with `ls -t *.zip` — and the fixture contains a **directory**
+named `artifact.zip`. `rm` refused it, `unzip` was handed the directory, and both
+arms printed an error that looked like the packager had failed. Nothing was
+wrong with the release. The fixture that exercises the rule under test also
+breaks the harness that measures it; target the bundle by its exact name
+(`<blockId>-<version>.zip`).
 
 ## After publishing
 
-1. Read the published body: it must carry the **one** `fix(pkgzip)` entry and
-   neither `docs(...)` commit. v0.1.96 was the first release to prove that
-   filter works; this is the second observation, not a re-derivation.
-2. Recompute the counts as `v0.1.96..v0.1.97`.
-3. Flip this file to `# v0.1.97 — SHIPPED` with the tag SHA, publish timestamp,
-   npm version, cask version and asset count.
+- **npm** — `dist-tags.latest = 0.1.97` (took ~1 min after the cask; polled).
+- **Homebrew** — cask at `0.1.97`; all four archive URLs it names answer **200
+  unauthenticated** (darwin/linux × amd64/arm64).
+
+## What this does NOT close
+
+**#435.** The rules match names, never contents. Measured on this release:
+`db.env` at the project root, `envs/prod.env`, `env/local.env`,
+`.env-backup/db.env`, and the case-variants `x.ZIP/` and `.ENV.local/` are **all
+still packaged**. Every one is in the README's residual table. `envs/` and `env/`
+are at least as conventional as `.env.d/`, so do not read this release as closing
+the class.
+
+Also open: a dropped subtree is still never printed (`Packaged %d file(s)` is all
+the author sees), and `internal/antipattern` keeps a rival exclusion list.


### PR DESCRIPTION
v0.1.97 is out: tagged `b2a9df6`, published 2026-08-17T00:29:39Z, `@civitai/cli@0.1.97` latest on npm, Homebrew cask 0.1.97, 14 assets.

**4 commits: 3 excluded, 1 in the notes, 0 leaking.** The draft predicted 3 and flagged that merging it would add a fourth the filter excludes — it did, for the second release running, which is why this document family recomputes at the tag rather than trusting the pre-tag number.

**Second independent observation** that #416's scoped-exclude fix works against goreleaser: the published body carries the one `fix(pkgzip)` entry and none of the three `docs` commits.

**Eight pre-publish arms**, the first two against a **v0.1.96 negative control on the same fixture**:

| arm | v0.1.96 (control) | v0.1.97 |
|---|---|---|
| `.env.d/db.env` (holds `API_SECRET=`) | **packaged** | **absent** |
| `.env.d/.env.production` | **packaged** | **absent** |
| `artifact.zip/payload.bin` | **packaged** | **absent** |
| `.environment/`, `.envoy/` | packaged | still packaged |
| `.env-backup/.env.production` | packaged | still packaged |
| `.git` as a FILE (worktree) | — | absent; `.github/` + `.gitignore` kept |
| version + dirty-tree guards | — | both refuse, exit 1 |

Guard arms ran with `CIVITAI_SUBMIT_PATH` at a non-existent route, so a total guard failure could not have created a submission.

**One harness bug recorded**, because it produced a confident-looking null: the fixture contains a *directory* named `artifact.zip`, so `rm ./*.zip` and `ls -t *.zip` picked it and both arms printed what looked like a packager failure. Nothing was wrong with the release — the fixture that exercises the rule under test also breaks the harness measuring it.

**Does not close #435** — the rules match names, never contents. `db.env` at the root, `envs/prod.env`, `env/local.env` and the case-variants are all still packaged, and all are in the README's residual table.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QybSDbsJwEMJdxDRUasTC1