### PR TITLE
docs(offsite): `appBlockId` is not a kind discriminator — retract the absolute

### DIFF
--- a/claudedocs/decisions/29-offsite-refusal.md
+++ b/claudedocs/decisions/29-offsite-refusal.md
@@ -25,8 +25,10 @@ still right for what it does — what does not survive is the absolute.
 `app status <slug>` reach an offsite app."* The support offered is that
 `getMyListingForApp` resolves only by `appBlockId`, and an offsite app has none.
 
-**Both halves of that support are true. The conclusion does not follow**, because
-`getMyListingForApp` is not the only route to an `AppListing.id`.
+**The first half is measured and true. The second half is true of every offsite
+app this CLI has measured, but NOT as the absolute the body states it as** — see
+the section below. **And even granting both, the conclusion does not follow**,
+because `getMyListingForApp` is not the only route to an `AppListing.id`.
 
 **MEASURED (2026-08-16, live, unauthenticated, read-only):**
 
@@ -101,6 +103,54 @@ offsite app's `apl_` id and see whether it returns assets or refuses on kind.
 Do it against a **throwaway** offsite app, not `radio` / `comfy` / `cosmetic-studio`
 / `vitrine` — constraint 2 means the probe writes. Until then, do not restate the
 body's absolute, and do not build on the workaround either.
+
+## 🔴 "AN OFFSITE APP HAS NO `appBlockId`" IS ALSO RETRACTED — IT IS NOT A KIND DISCRIMINATOR
+
+**Read this before writing any predicate over `appBlockId`.** The body says
+`getMyListingForApp` resolves "ONLY by `appBlockId`, which an offsite app has
+none of". The measurement is right; the *"which an offsite app has none of"* is a
+false absolute, and the same absolute was in `internal/cmd/app_offsite.go`
+("that is what `kind: offsite` MEANS") until 2026-08-16. Both were corrected
+upstream the same night.
+
+**READ FROM SOURCE** — `civitai/civitai`,
+`packages/civitai-db-schema/prisma/schema.full.prisma:2849-2853`, on
+`AppListing.appBlockId`:
+
+> 1:1 backing AppBlock (UNIQUE) + idempotency key. Set for EVERY backfilled row —
+> on-site AND the #2821 off-site rows (both come from an AppBlock). **It is NOT a
+> kind discriminator: discriminate on `kind`, never on appBlockId nullness.**
+> Only a natively-created off-site listing (no backing AppBlock) leaves it NULL.
+
+`app-listing-backfill.service.ts:32-40` says the same thing about the writer, and
+`resolveLegacyAppRedirect.ts:170-183` carries the *same* retraction, of the same
+absolute, in the same repo — the sizing claim "every listing that carries an
+`appBlockId` is `kind='onsite'`" was withdrawn there for exactly this reason.
+
+**MEASURED (upstream, production, 2026-08-11)** — the `kind:'offsite'` +
+non-null-`appBlockId` shape is **0 rows**
+(`src/components/Apps/appListingEditorTabs.ts:104-108`, via
+`resolveAccessibleAppBlockIds`), which is why the two-clause tab arms there are
+each individually killable rather than redundant.
+
+**So the honest state is three claims, not one:** the shape is **empirically zero
+today**, **structurally possible**, and **a backfilled class for it exists in the
+schema**. "None, by definition" is none of those.
+
+**WHAT DOES NOT CHANGE, stated so this is not read as a reopening:**
+
+- This CLI's own live measurement stands — 4/4 offsite apps fail the submission
+  lookup, 7/7 onsite pass (#422). `kind` predicts it exactly.
+- The refusal is correct behaviour and its wording is unaffected: it is derived
+  from `kind`, never from `appBlockId` nullness (`offsiteApp` branches on
+  `d.Kind` alone).
+- All four measured apps are **natively-created** offsite listings, which
+  genuinely have no backing AppBlock. The absolute is wrong; the instance is not.
+
+**THE OPERATIONAL RULE:** discriminate on `kind`. If you ever need "does this
+listing have a backing block?", ask that question directly — it is a *different*
+question from "is this offsite?", and treating them as one is what both retracted
+sentences did.
 
 ---
 

--- a/claudedocs/handoff-offsite-refusal.md
+++ b/claudedocs/handoff-offsite-refusal.md
@@ -100,9 +100,20 @@ whether reaching those apps is possible at all.
 
 - **Symptom:** offsite apps have no store-listing management path from the CLI. All four on
   this account (`radio`, `comfy`, `cosmetic-studio`, `vitrine`) serve a live icon + cover.
-- **Observed:** `getMyListingForApp` is addressable **only** by `appBlockId`; an offsite app
-  has none — that is what `kind: offsite` means. Dropping the submission lookup and falling
+- **Observed:** `getMyListingForApp` is addressable **only** by `appBlockId`; none of the
+  four offsite apps measured here has one. Dropping the submission lookup and falling
   through with an empty `appBlockId` just moves the 404 one call later.
+- 🔴 **"— that is what `kind: offsite` means" is RETRACTED (2026-08-16).** `appBlockId` is
+  **not** a kind discriminator. `civitai/civitai`,
+  `packages/civitai-db-schema/prisma/schema.full.prisma:2849-2853`: it is "Set for EVERY
+  backfilled row — on-site AND the #2821 off-site rows (both come from an AppBlock) … Only
+  a natively-created off-site listing (no backing AppBlock) leaves it NULL." The
+  `kind:'offsite'` + non-null `appBlockId` shape is **0 rows in production** (measured
+  2026-08-11, `src/components/Apps/appListingEditorTabs.ts`). So: empirically zero today,
+  structurally possible, and a backfilled class exists in the schema. The observation above
+  and the refusal are unaffected — all four apps here are natively-created — but
+  **discriminate on `kind`, never on `appBlockId` nullness.** Full account:
+  `claudedocs/decisions/29-offsite-refusal.md`.
 - 🔴 **"Ruled out: any client-side fix" is RETRACTED (2026-08-16).** It was true of
   `getMyListingForApp` and false as a claim about the CLI, because that proc is not the only
   route to an `AppListing.id`. **Measured, live, unauthenticated:**

--- a/internal/cmd/app_offsite.go
+++ b/internal/cmd/app_offsite.go
@@ -32,9 +32,27 @@ import (
 // offsite apps reachable by resolving them by slug/app id instead.
 // `appListings.getMyListingForApp` cannot do it: it was measured live to resolve
 // ONLY by `appBlockId` (the slug selector 404s for every app, onsite positive
-// controls included), and an offsite app has no appBlockId — that is what
-// `kind: offsite` MEANS. Dropping the submission lookup just moves the 404 one
-// call later. The upstream ask is civitai/civitai#3984.
+// controls included), and none of the offsite apps measured on #422 has an
+// appBlockId to resolve by. Dropping the submission lookup just moves the 404
+// one call later. The upstream ask is civitai/civitai#3984.
+//
+// 🔴 `appBlockId` IS NOT A KIND DISCRIMINATOR, AND THIS COMMENT USED TO SAY IT
+// WAS. The sentence above read "an offsite app has no appBlockId — that is
+// what `kind: offsite` MEANS" until 2026-08-16. That absolute is false. The
+// server schema says so in as many words
+// (`packages/civitai-db-schema/prisma/schema.full.prisma:2849-2853` in
+// `civitai/civitai`): the 1:1 backing AppBlock is "Set for EVERY backfilled row
+// — on-site AND the #2821 off-site rows (both come from an AppBlock). It is NOT
+// a kind discriminator: discriminate on `kind`, never on appBlockId nullness.
+// Only a natively-created off-site listing (no backing AppBlock) leaves it
+// NULL." The `kind: offsite` + non-null `appBlockId` shape is measured at 0 rows
+// in production (2026-08-11, `src/components/Apps/appListingEditorTabs.ts`), so
+// it is EMPIRICALLY ABSENT TODAY, STRUCTURALLY POSSIBLE, and a backfilled class
+// for it exists in the schema. Nothing about the refusal changes: #422's 4/4
+// offsite / 7/7 onsite measurement stands, and a NATIVELY-created offsite app —
+// which is what all four measured ones are — genuinely has no AppBlock. What
+// changes is what may be INFERRED: never read appBlockId nullness as the kind,
+// which is why offsiteApp below branches on `d.Kind` and nothing else.
 //
 // 🔴 BUT "NO CLIENT PATH EXISTS" IS RETRACTED IN PART, AND THE COUNTEREXAMPLE IS
 // IN THIS FILE. `offsiteApp` below calls GET /api/v1/apps/{slug}, whose payload


### PR DESCRIPTION
## What was wrong

`internal/cmd/app_offsite.go:35` asserted:

> …and an offsite app has no appBlockId — that is what `kind: offsite` MEANS.

That absolute is **false**, and it was corrected upstream in `civitai/civitai` the same night, in three places.

**READ FROM SOURCE** — `packages/civitai-db-schema/prisma/schema.full.prisma:2849-2853`, on `AppListing.appBlockId`:

> 1:1 backing AppBlock (UNIQUE) + idempotency key. Set for EVERY backfilled row — on-site AND the #2821 off-site rows (both come from an AppBlock). **It is NOT a kind discriminator: discriminate on `kind`, never on appBlockId nullness.** Only a natively-created off-site listing (no backing AppBlock) leaves it NULL.

`app-listing-backfill.service.ts:32-40` says the same about the writer, and `resolveLegacyAppRedirect.ts:170-183` already carries the *same* retraction of the *same* absolute upstream.

**MEASURED (upstream, production, 2026-08-11):** the `kind:'offsite'` + non-null-`appBlockId` shape is **0 rows** (`src/components/Apps/appListingEditorTabs.ts:104-108`, via `resolveAccessibleAppBlockIds`).

So the honest state is three claims, not one: **empirically zero today, structurally possible, and a backfilled class for it exists in the schema.** "None, by definition" is none of those.

## What does NOT change

**No behaviour and no test expectation moves.** This is comments and docs only.

- The CLI's own live measurement stands — #422's 4/4 offsite apps fail the submission lookup, 7/7 onsite pass. `kind` predicts it exactly.
- The refusal is correct and its user-facing copy is untouched.
- All four measured offsite apps are **natively-created** listings, which genuinely have no backing AppBlock. The absolute is wrong; the instance is not.
- `offsiteApp` already branches on `d.Kind` alone — which is exactly the rule the schema states.

## Files

| File | Change |
|---|---|
| `internal/cmd/app_offsite.go` | The absolute becomes the scoped measurement ("none of the offsite apps measured on #422 has an appBlockId to resolve by"), plus a 🔴 paragraph recording what was wrong, the schema quote, the 0-rows measurement and the operational rule. |
| `claudedocs/decisions/29-offsite-refusal.md` | Correction lives in the **free-form header**. New `## 🔴` section; the "Both halves of that support are true" line is corrected to scope the second half. |
| `claudedocs/handoff-offsite-refusal.md` | Same sentence retracted, in the doc's existing retraction style. |

`AGENTS.md` is **unchanged** — item 29 is already a trigger + pointer and carries no `appBlockId` claim, so the byte ceiling is untouched.

## 🔴 The byte-pinned body is byte-unchanged

`agents_split_preserved_test.go` pins item 29's body (from the `29. **` heading to EOF) at sha256 `df86c7a851e2397db48eebd2f4b9d17e91565128ec4550510a62b785f552828d`. Verified independently of the test:

```
$ diff <(git show HEAD~1:claudedocs/decisions/29-offsite-refusal.md | awk '/^29\. \*\*/{f=1} f') \
       <(awk '/^29\. \*\*/{f=1} f' claudedocs/decisions/29-offsite-refusal.md)   # identical
$ awk '/^29\. \*\*/{f=1} f' claudedocs/decisions/29-offsite-refusal.md | grep -v '^[[:space:]]*$' | sha256sum
df86c7a851e2397db48eebd2f4b9d17e91565128ec4550510a62b785f552828d  -
```

No edit to the sha, the `nonBlank` count, or the test.

## Gates

- `make ci` — 21/21 packages ok.
- `make lint` (via `nix-shell -p golangci-lint`, **v2.12.2**) — **0 issues**.
- `make ci-shallow` — PASSED in a depth-1 clone, **20/20** packages ok, 0 failures, 0 timeouts.
- `gofmt -s -l .` — clean.
- AGENTS gates: `go test -run 'Agents|Evidence|Trigger|Split|Inline|Eviction|Citations' . -count=1 -v` → **86 PASS, 0 FAIL, 0 SKIP**. `TestSplitItemBodiesArePreservedVerbatim/item_29` and `TestSplitDigestsAreTheBaseCommitsText/item_29` both **RAN and PASSED** — the latter did **not** skip (full clone; it re-derived 27 of 27 pinned digests from their own base commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNdYjxagYYedKVxuoaQT4T