### PR TITLE
fix(listing): rm-screenshot must not end by telling you to remove more (#443)

### DIFF
--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -976,7 +976,16 @@ func reportScreenshotRemoved(out io.Writer, live bool) {
 	fmt.Fprintln(out, ui.Success("Screenshot removal staged on an open revision — not submitted for review yet."))
 	fmt.Fprintln(out, "Your live listing still shows this screenshot; the removal reaches the")
 	fmt.Fprintln(out, "public gallery only after a moderator approves the revision.")
-	fmt.Fprintf(out, "Publish it: %s — remove the rest first if you are still curating.\n",
+	// 🔴 THE ALTERNATIVE TO PUBLISHING NOW IS STAGING MORE, NOT REMOVING MORE
+	// (civitai/cli#443). This sentence used to end "remove the rest first if you
+	// are still curating" — an instruction to DELETE MORE grafted onto the
+	// instruction to publish, read by someone who had just asked how to publish.
+	// It is also wrong about what curating involves: an `add-screenshot` or a
+	// `reorder` stages into this same revision, so removal is one kind of
+	// pending change, not the kind. The whole line is pinned by
+	// rmLivePublishLine — naming the command inside a sentence is not the same
+	// claim as the sentence meaning what it should.
+	fmt.Fprintf(out, "Publish it: %s — or stage more changes first if you are still curating.\n",
 		ui.Code("civitai app listing submit-revision"))
 }
 

--- a/internal/cmd/app_listing_rm_screenshot_test.go
+++ b/internal/cmd/app_listing_rm_screenshot_test.go
@@ -46,6 +46,13 @@ const (
 const (
 	rmDraftOutcomeLine = "✓ Screenshot removed"
 	rmLiveOutcomeLine  = "✓ Screenshot removal staged on an open revision — not submitted for review yet."
+	// The publish line, pinned WHOLE (civitai/cli#443). Asserting only that the
+	// output contains `civitai app listing submit-revision` left the rest of the
+	// sentence free to say anything — and what it said was "remove the rest
+	// first if you are still curating", an instruction to DELETE MORE attached
+	// to the instruction to publish. Naming the command is not the same claim as
+	// naming it in a sentence that means what it should.
+	rmLivePublishLine = "Publish it: civitai app listing submit-revision — or stage more changes first if you are still curating."
 )
 
 // rmStub is a listing server that records every listing call it was asked to
@@ -230,6 +237,15 @@ func TestAppListingRmScreenshotOnLiveListingReportsItIsNotPublished(t *testing.T
 	if !strings.Contains(out, "civitai app listing submit-revision") {
 		t.Errorf("live rm-screenshot does not name the command that publishes the removal "+
 			"(`civitai app listing submit-revision`):\n%s", out)
+	}
+	// 🔴 And the WHOLE publish line, not just the command inside it
+	// (civitai/cli#443). The command name alone was already present while the
+	// sentence around it told the user to delete more screenshots; a reword can
+	// only be deliberate if the line is pinned entire.
+	if !hasLine(out, rmLivePublishLine) {
+		t.Errorf("live rm-screenshot's publish line is not %q — the sentence naming "+
+			"`submit-revision` must offer STAGING MORE as the alternative to publishing now, "+
+			"never removing more (civitai/cli#443). Full output:\n%s", rmLivePublishLine, out)
 	}
 
 	// The removal itself still happens, and carries the id the user typed.


### PR DESCRIPTION
Fixes #443.

## The line

Observed live on `v0.1.97-3-gc27b368` while verifying #436 against `model-benchmarking`:

```
✓ Screenshot removal staged on an open revision — not submitted for review yet.
Your live listing still shows this screenshot; the removal reaches the
public gallery only after a moderator approves the revision.
Publish it: civitai app listing submit-revision — remove the rest first if you are still curating.
```

Read left to right, the last line says *publish it — remove the rest first*: an instruction to delete more, grafted onto the instruction to publish. The intent was right (#436 deliberately does not auto-submit, so a curation pass is one review cycle rather than N) but the sentence names the wrong follow-up. The alternative to publishing now is **staging more changes** — an `add-screenshot` or a `reorder` stages into the same revision, so removal is one kind of pending change, not the kind.

Now:

```
Publish it: civitai app listing submit-revision — or stage more changes first if you are still curating.
```

## Why it could drift

The clause was **unpinned**. The test pinned the first outcome line verbatim (`rmLiveOutcomeLine`) and separately asserted the output *contains* `civitai app listing submit-revision` — which the old sentence satisfied while saying the wrong thing. `git grep "remove the rest first"` returned exactly one hit: the source line itself. No test, no README copy.

That is the spelled-guard hazard the suite's own notes warn about, in reverse: naming the command inside a sentence is not the same claim as the sentence meaning what it should. `rmLivePublishLine` now pins the whole normalised line via the existing `hasLine` helper, so a reword costs a deliberate test edit.

## Verification

- **Red at `483441e`** — new assertion against the old copy, failing on its own message and printing the old line.
- **Green** after the copy change.
- **Mutation, isolated to the copy string alone** (the enclosing `Fprintf`, the `ui.Code` call and every other assertion untouched): reverting just the string kills the test, on this assertion's specific message rather than another test's.
- `make ci` green, 20/20 packages, 0 FAIL. `golangci-lint` 0 issues (run inside this worktree — confirmed by `make -C` entering the directory).

## Scope

Copy plus its test pin. **No behaviour change** — the removal still stages without submitting, which is AGENTS.md item 30 and stays. README does not quote this line, so nothing there moves.