### PR TITLE
feat(listing): `app listing status --json`, which names the two ids the human output never shows (#447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message` — **`field` is always present and never `null`**) for scriptable parsing — still exits non-zero on failure. 🔴 **BREAKING:** a `[dir]` that does not exist, or is not a directory, is now a **usage error** — exit `2` with **no JSON object** on stdout, where it used to print `{"ok": false, …}` and exit `1`. See [Validate fidelity](#validate-fidelity) and [The `--json` result shape](#the---json-result-shape). |
 | `civitai app submit [dir] [--yes] [--package-only] [--out f.zip] [--skip-validate] [--allow-downgrade] [--allow-dirty]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). **A submit that would really upload asks for confirmation, and in a non-interactive shell it refuses without `--yes`** — `civitai app submit --yes` is the CI form. (The refusal is reached only when there is a token to upload with: `--package-only`, and the no-token fallback that just writes the .zip, never submit and so never ask.) **It also refuses a version that is not strictly above the highest APPROVED version of that app** — approving an older (or identical) version replaces the newer live deployment — with `--allow-downgrade` as the deliberate-rollback escape hatch. **And it refuses a dirty git work tree** — the bundle is packaged from what is on disk, so approving one deploys code that exists in no commit — with `--allow-dirty` as the escape hatch; that guard degrades rather than enforcing, so a directory in no git repo (every scaffolded app starts that way) submits unchanged, and a clean tree whose `HEAD` is on no remote warns instead of refusing. All three refusals are skipped on the routes that never reach the server. |
 | `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
-| `civitai app listing status\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>\|submit-revision` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires. The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. **On a listing that is already LIVE, every change — including `reorder` — opens a REVISION for moderator re-review rather than editing the live listing**, and `listing status` reports that in-progress revision's media (so the `alsc_…` ids it prints are the revision's, which is what `reorder` addresses). `rm-screenshot` is the one change deliberately left **staged**: it does **not** submit the revision (curating a gallery is usually several removals), so `submit-revision` is what sends it to moderator review and makes the change public. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
+| `civitai app listing status [--json]\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>\|submit-revision` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires, and `listing status --json` emits the same read as one object — including **`parentId` and `shadowId`, the two listing ids a change is addressed to**, which the human output shows neither of. 🔴 **`--json` is not a pure read: on a live listing it opens the revision draft described below, so do not poll it.** The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. **On a listing that is already LIVE, every change — including `reorder` — opens a REVISION for moderator re-review rather than editing the live listing**, and `listing status` reports that in-progress revision's media (so the `alsc_…` ids it prints are the revision's, which is what `reorder` addresses). `rm-screenshot` is the one change deliberately left **staged**: it does **not** submit the revision (curating a gallery is usually several removals), so `submit-revision` is what sends it to moderator review and makes the change public. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
 | `civitai app status [blockId] [--id <pubreq>] [--limit N] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; `--limit N` shows only the newest N (display-side — this route cannot page); a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). Run from **inside** an app checkout it also warns on **stderr** when your local `block.manifest.json` is **BEHIND** your highest approved version — advisory only, the exit code never changes. See [Submission status](#submission-status) and [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>] [--yes]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. **Also deletes a first-version app's store listing — icon, cover and every captioned screenshot**, so it asks first and needs `--yes` in a script. Idempotent for the submission only; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
@@ -817,6 +817,17 @@ Both properties hold for `civitai generate` and `civitai workflows …` too, but
 their payloads are **not** Site API REST shapes — generation has no REST route,
 so those commands pass through the raw *orchestrator* reply. Read
 [Generation `--json`](#generation---json) before scripting against them.
+
+Two `app` commands emit a shape this **CLI composes**, not a wire payload:
+`civitai app validate --json` (see
+[The `--json` result shape](#the---json-result-shape)) and
+`civitai app listing status --json`, which joins the two listing reads into one
+object naming `parentId` and `shadowId` (see
+[After you submit](#after-you-submit-review--approve--deploy)). Both keep the two
+properties above; only the *provenance* of the fields differs. 🔴 **And
+`app listing status --json` is a read with a server-side SIDE EFFECT** — on a
+live listing it opens a revision draft — so, unlike the reads above, it must not
+be polled.
 
 ### Cursor pagination loop
 
@@ -1372,6 +1383,45 @@ Details worth knowing before you start:
 - **Screenshots** are managed by id (the `alsc_…` ids `listing status` prints):
   `rm-screenshot <id>` removes one, and `reorder <id...>` takes **all** the
   current ids in the new order — a partial set is rejected.
+- **`civitai app listing status --json` is the scriptable form, and it names the
+  two listing ids the human output never shows.** A live listing has a *parent*
+  and, once a revision is open, a *shadow* — and which one a change is addressed
+  to is what decides whether the server accepts it (that gap is what
+  [#430](https://github.com/civitai/cli/issues/430) was). `--json` reports both:
+
+  ```console
+  $ civitai app listing status --slug my-app --json
+  {
+    "slug": "my-app",
+    "parentId": "apl_01KXPENN7GJV51HBG649P3Y99M",
+    "shadowId": "apl_01M064YJGDR973P73WHC1FGDP9",
+    "status": "approved",
+    "hasPendingRevision": false,
+    "assets": {
+      "icon":  { "present": true,  "imageId": 4711 },
+      "cover": { "present": false, "imageId": null },
+      "screenshots": [
+        { "id": "alsc_01M0…", "order": 0, "caption": "Grid view", "imageId": 8123 }
+      ]
+    },
+    "floor": { "met": false, "missing": ["cover"] }
+  }
+  ```
+
+  `shadowId` is **`null`** when no revision draft exists (every draft or pending
+  listing, and a live one nobody has edited), never absent — so `.shadowId`
+  answers on every listing. `status` is the **parent's** lifecycle status;
+  `hasPendingRevision` means *submitted for review*, not "a shadow exists".
+  `floor.missing` is `[]` when the floor is met. The server's own
+  **`editTargetId` is deliberately not there**: this CLI does not decode that
+  field, and printing an id it never read would be a guess — use `shadowId` when
+  it is non-null and `parentId` otherwise.
+- 🔴 **`listing status --json` is NOT a pure read, so do not poll it in a loop.**
+  On a LIVE listing the read behind it opens the revision draft (idempotently —
+  the same one each time), so a script calling it repeatedly keeps a revision
+  open on your listing. Whether that should still be classified a read is
+  [#389](https://github.com/civitai/cli/issues/389), which is open. Reading it
+  once per change is fine; a watch loop is a writer.
 - 🔴 **`reorder` addresses the same listing `status` printed, and on a live
   listing that is the *revision*, not the live one.** The server validates a
   reorder against the screenshot ids of the listing it is *addressed to*, and

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -71,6 +71,14 @@ var (
 // unambiguous about what it returns. Decoding `editTargetId` is a reasonable
 // LATER optimisation (one fewer round-trip); it is not a prerequisite for
 // anything, and it should not arrive as a side effect of some other change.
+//
+// 🔴 RE-ASKED AND RE-REFUSED BY civitai/cli#447, the `app listing status --json`
+// payload — the surface with the strongest claim on it, since the issue asked
+// for the field BY NAME. That payload emits `parentId` and `shadowId`, which
+// this CLI really reads, and says in its own doc comment and in the README that
+// `editTargetId` is absent because reporting an id the server did not hand it
+// on that call would be a guess. So the refusal now has a user-visible
+// consequence: adding the decode means adding the field there too.
 type ListingRef struct {
 	AppListingID       string `json:"appListingId"`
 	Status             string `json:"status"` // draft|pending|approved|rejected|removed

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -215,6 +215,7 @@ func resolveListing(ctx context.Context, client *appapi.Client, slug string) (*a
 
 func newAppListingStatusCmd() *cobra.Command {
 	var lc listingCommon
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show attached media and what's missing vs the publish floor",
@@ -226,10 +227,24 @@ Your store listing exists as a DRAFT from the moment you run
 
 Note: on a LIVE (approved) listing this opens an in-progress revision draft and
 reports ITS media (idempotent — it reuses any existing draft, and nothing is
-submitted for moderator review until you run a set-/add- command and confirm).`,
+submitted for moderator review until you run a set-/add- command and confirm).
+
+--json emits the same read as one object: parentId, shadowId (null when there
+is no revision draft), status, hasPendingRevision, the attached media with
+their image ids, and the publish-floor verdict. The parent and the shadow are
+DIFFERENT listings and a change is addressed to one of them, so a script that
+has to decide which needs both ids. The server's own editTargetId is NOT in
+there: this CLI does not decode that field, and reporting an id it never read
+would be a guess.
+
+🔴 --json is not a pure read, so do not poll it in a loop: on a LIVE listing
+this opens the shadow revision described above, so a script calling it
+repeatedly keeps a revision draft open on your listing. Whether that makes this
+a read at all is civitai/cli#389, which is open.`,
 		Example: `  civitai app listing status
   civitai app listing status --slug my-app
-  civitai app listing status --dir ./my-app`,
+  civitai app listing status --dir ./my-app
+  civitai app listing status --json | jq -r .shadowId`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := newListingClient()
@@ -252,12 +267,118 @@ submitted for moderator review until you run a set-/add- command and confirm).`,
 			if err != nil {
 				return err
 			}
+			// 🔴 The JSON path does NOT go through printListingStatus, and must
+			// not: `internal/ui/CONVENTION.md` rule 1 is that machine-readable
+			// output carries no styling at all, and that renderer emits
+			// ui.Success/ui.Warn/ui.Code.
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), listingStatusPayload(slug, ref, view))
+			}
 			printListingStatus(cmd.OutOrStdout(), slug, ref, view)
 			return nil
 		},
 	}
 	lc.bind(cmd)
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the listing as JSON (scriptable) — includes the parent and shadow listing ids; NOT a pure read (see the note in --help)")
 	return cmd
+}
+
+// listingStatusJSON is the machine-readable shape of `app listing status`
+// (civitai/cli#447). It is a PUBLISHED CONTRACT — README documents it — so a
+// field is renamed or dropped only deliberately.
+//
+// 🔴 IT NAMES THE TWO ID SPACES, WHICH IS THE WHOLE REASON IT EXISTS. The human
+// rendering prints neither `parentId` nor `shadowId`, and civitai/cli#430 was a
+// bug that lived entirely in the gap between them: `reorder` addressed the
+// PARENT while `status` printed the SHADOW revision's screenshot rows, so the
+// server rejected ids the CLI had just displayed and diagnosing it took
+// hand-written tRPC calls.
+//
+// 🔴 `editTargetId` IS DELIBERATELY ABSENT, and it is what the issue asked for.
+// The server sends it on an approved listing, but `appapi.ListingRef` does not
+// decode it (see the 🔴 note on that type for why — it has been observed once,
+// and it would be a fourth way to name an edit target). This payload therefore
+// reports the two ids the CLI actually read; inventing the third from
+// `shadowId` would be this CLI asserting a value the server never handed it on
+// this call. If that decode ever lands, adding the field here is the follow-on.
+type listingStatusJSON struct {
+	// Slug is the app this was resolved for — the value the human line prints
+	// as "App:", from --slug or block.manifest.json, NOT from the server.
+	Slug string `json:"slug"`
+	// ParentID is the listing that owns the media, from getMyListingForEdit.
+	ParentID string `json:"parentId"`
+	// ShadowID is the in-flight revision draft, or null when there is none.
+	// 🔴 Explicitly null rather than omitted: `.shadowId` must answer for every
+	// listing, so a consumer never has to tell "no revision" from "old CLI".
+	ShadowID *string `json:"shadowId"`
+	// Status is the PARENT's lifecycle status (draft|pending|approved|…), from
+	// the getMyListingForApp lookup — the same value the human line prints.
+	Status string `json:"status"`
+	// HasPendingRevision means SUBMITTED, not "a shadow exists" — see the
+	// measurement in printListingStatus. It is the edit read's value.
+	HasPendingRevision bool              `json:"hasPendingRevision"`
+	Assets             listingAssetsJSON `json:"assets"`
+	Floor              listingFloorJSON  `json:"floor"`
+}
+
+type listingAssetsJSON struct {
+	Icon  listingAssetJSON `json:"icon"`
+	Cover listingAssetJSON `json:"cover"`
+	// Screenshots is never null — an empty gallery is [].
+	Screenshots []listingScreenshotJSON `json:"screenshots"`
+}
+
+// listingAssetJSON is one required slot. `present` is the CLI's own predicate
+// (appapi.ListingAsset.Present: a positive imageId), stated rather than left for
+// a consumer to re-derive from the id.
+type listingAssetJSON struct {
+	Present bool `json:"present"`
+	ImageID *int `json:"imageId"`
+}
+
+// listingScreenshotJSON is one gallery row. `id` is the `alsc_…` value
+// `rm-screenshot` and `reorder` take, and on a live listing it belongs to the
+// SHADOW named above — which is exactly the pairing #430 needed and could not
+// see.
+type listingScreenshotJSON struct {
+	ID      string  `json:"id"`
+	Order   int     `json:"order"`
+	Caption *string `json:"caption"`
+	ImageID *int    `json:"imageId"`
+}
+
+// listingFloorJSON is the publish-floor verdict. `missing` is never null — a met
+// floor is [] — and it holds the same names, in the same order, that the human
+// rendering prints.
+type listingFloorJSON struct {
+	Met     bool     `json:"met"`
+	Missing []string `json:"missing"`
+}
+
+// listingStatusPayload builds the --json object from the two reads the command
+// has already made. No styling, no writer: everything it returns is data.
+func listingStatusPayload(slug string, ref *appapi.ListingRef, view *appapi.ListingEditView) listingStatusJSON {
+	out := listingStatusJSON{
+		Slug:               slug,
+		ParentID:           view.ParentID,
+		ShadowID:           view.ShadowID,
+		Status:             ref.Status,
+		HasPendingRevision: view.HasPendingRevision,
+		Floor: listingFloorJSON{
+			Met:     floorMet(view),
+			Missing: floorMissing(view),
+		},
+	}
+	out.Assets.Icon = listingAssetJSON{Present: view.Assets.Icon.Present(), ImageID: view.Assets.Icon.ImageID}
+	out.Assets.Cover = listingAssetJSON{Present: view.Assets.Cover.Present(), ImageID: view.Assets.Cover.ImageID}
+	out.Assets.Screenshots = make([]listingScreenshotJSON, 0, len(view.Assets.Screenshots))
+	for _, s := range view.Assets.Screenshots {
+		out.Assets.Screenshots = append(out.Assets.Screenshots, listingScreenshotJSON{
+			ID: s.ID, Order: s.Order, Caption: s.Caption, ImageID: s.ImageID,
+		})
+	}
+	return out
 }
 
 func printListingStatus(w io.Writer, slug string, ref *appapi.ListingRef, view *appapi.ListingEditView) {
@@ -283,14 +404,7 @@ func printListingStatus(w io.Writer, slug string, ref *appapi.ListingRef, view *
 	if floorMet(view) {
 		fmt.Fprintln(w, ui.Success("Publish floor met — icon and cover are set."))
 	} else {
-		missing := []string{}
-		if !iconOK {
-			missing = append(missing, "icon")
-		}
-		if !coverOK {
-			missing = append(missing, "cover")
-		}
-		fmt.Fprintln(w, ui.Warn(fmt.Sprintf("Not publishable yet — missing %s.", strings.Join(missing, " and "))))
+		fmt.Fprintln(w, ui.Warn(fmt.Sprintf("Not publishable yet — missing %s.", strings.Join(floorMissing(view), " and "))))
 		if !iconOK {
 			fmt.Fprintf(w, "  Add one:  %s\n", ui.Code("civitai app listing set-icon <file>"))
 		}
@@ -866,6 +980,25 @@ func printFloorAfter(ctx context.Context, out io.Writer, client *appapi.Client, 
 // deliberate one.
 func floorMet(view *appapi.ListingEditView) bool {
 	return view.Assets.Icon.Present() && view.Assets.Cover.Present()
+}
+
+// floorMissing names WHAT the floor is still missing, in the order the human
+// rendering has always listed them (icon before cover). It is empty — never nil
+// — when the floor is met, because it is marshalled straight into `--json` and
+// `.floor.missing` must be an array on every listing.
+//
+// One rule, one place, for the same reason floorMet is: the human line and the
+// `--json` verdict answer the same question and must not be able to disagree
+// about which asset is absent.
+func floorMissing(view *appapi.ListingEditView) []string {
+	missing := []string{}
+	if !view.Assets.Icon.Present() {
+		missing = append(missing, "icon")
+	}
+	if !view.Assets.Cover.Present() {
+		missing = append(missing, "cover")
+	}
+	return missing
 }
 
 // printFloorLine prints the remaining floor gap for an ALREADY-READ view, so a

--- a/internal/cmd/app_listing_status_json_test.go
+++ b/internal/cmd/app_listing_status_json_test.go
@@ -1,0 +1,502 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/ui"
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// `app listing status --json` (civitai/cli#447).
+//
+// 🔴 THE POINT OF THE FLAG IS THAT THE TWO ID SPACES BECOME READABLE.
+// civitai/cli#430 was a two-id-space bug — `reorder` addressed the PARENT while
+// `status` printed the SHADOW revision's screenshot rows — and the human output
+// shows NEITHER id, so diagnosing it took hand-written tRPC calls. So the
+// assertions below are on the PARSED payload and pin `parentId` and `shadowId`
+// as distinct values; a `strings.Contains` on the blob would pass on output that
+// prints one id twice.
+//
+// Everything here runs against an httptest fake. Nothing in this file has been
+// run against a real listing.
+
+// The fixture ids. Pairwise distinct, and distinct from every other string in
+// the payload, so an assertion cannot pass on a value the code copied from
+// somewhere else.
+const (
+	jsonFixtureSlug     = "listing-json-app"
+	jsonFixtureParentID = "apl_PARENT7Q1"
+	jsonFixtureShadowID = "apl_SHADOW9Z2"
+	jsonFixtureShotA    = "alsc_SHOT4A1"
+	jsonFixtureShotB    = "alsc_SHOT4B2"
+)
+
+// listingStatusPayloadShape mirrors what `--json` emits. It is hand-written
+// rather than reusing the production type on purpose: a test that unmarshals
+// into the very struct it is checking agrees with any renaming of a field, which
+// is the published contract this test exists to pin.
+type listingStatusPayloadShape struct {
+	Slug               string  `json:"slug"`
+	ParentID           string  `json:"parentId"`
+	ShadowID           *string `json:"shadowId"`
+	Status             string  `json:"status"`
+	HasPendingRevision bool    `json:"hasPendingRevision"`
+	Assets             struct {
+		Icon struct {
+			Present bool `json:"present"`
+			ImageID *int `json:"imageId"`
+		} `json:"icon"`
+		Cover struct {
+			Present bool `json:"present"`
+			ImageID *int `json:"imageId"`
+		} `json:"cover"`
+		Screenshots []struct {
+			ID      string  `json:"id"`
+			Order   int     `json:"order"`
+			Caption *string `json:"caption"`
+			ImageID *int    `json:"imageId"`
+		} `json:"screenshots"`
+	} `json:"assets"`
+	Floor struct {
+		Met     bool     `json:"met"`
+		Missing []string `json:"missing"`
+	} `json:"floor"`
+}
+
+// approvedListingServer answers the two reads `app listing status` makes for an
+// APPROVED listing whose media is resolved through an open shadow revision.
+//
+// 🔴 Two fields are deliberately given DIFFERENT values on the two replies —
+// `status` and `hasPendingRevision`. In production the parent lookup
+// (getMyListingForApp) and the edit read (getMyListingForEdit) are expected to
+// agree on both; the fixture disagrees only so the assertions can pin WHICH read
+// each JSON field comes from. That is a claim about this CLI's rendering, not a
+// claim about the server.
+func approvedListingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, jsonFixtureSlug, "block_json_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{
+				"appListingId":       jsonFixtureParentID,
+				"status":             "approved",
+				"contentRating":      "g",
+				"hasPendingRevision": false,
+			})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{
+				"parentId":           jsonFixtureParentID,
+				"slug":               jsonFixtureSlug,
+				"status":             "draft",
+				"hasPendingRevision": true,
+				"shadowId":           jsonFixtureShadowID,
+				"assets": map[string]any{
+					"icon":  map[string]any{"imageId": 4711, "url": "http://x/icon.png"},
+					"cover": map[string]any{"imageId": nil, "url": nil},
+					"screenshots": []any{
+						map[string]any{"id": jsonFixtureShotA, "imageId": 8123, "url": "http://x/a.png", "caption": "Side by side", "order": 0},
+						map[string]any{"id": jsonFixtureShotB, "imageId": 8124, "url": "http://x/b.png", "caption": nil, "order": 3},
+					},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+// draftListingServer answers for a DRAFT listing: no shadow revision exists, and
+// the server omits `shadowId` from the reply entirely. Both required assets are
+// attached, so the floor is met.
+func draftListingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, jsonFixtureSlug, "block_json_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			trpcData(w, map[string]any{
+				"appListingId":       jsonFixtureParentID,
+				"status":             "draft",
+				"contentRating":      "g",
+				"hasPendingRevision": false,
+			})
+		case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+			trpcData(w, map[string]any{
+				"parentId":           jsonFixtureParentID,
+				"slug":               jsonFixtureSlug,
+				"status":             "draft",
+				"hasPendingRevision": false,
+				"assets": map[string]any{
+					"icon":        map[string]any{"imageId": 4711, "url": "http://x/icon.png"},
+					"cover":       map[string]any{"imageId": 5322, "url": "http://x/cover.png"},
+					"screenshots": []any{},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+// decodeListingStatusJSON parses stdout as ONE JSON value and fails when
+// anything else shares the stream. `--json` stdout is a published contract:
+// `… --json | jq -e .` must always parse (README, "Scripting with --json").
+func decodeListingStatusJSON(t *testing.T, stdout string) listingStatusPayloadShape {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var got listingStatusPayloadShape
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("stdout is not valid JSON (%v); stdout was:\n%s", err, stdout)
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		t.Fatalf("stdout carries more than the JSON payload (next token err = %v); stdout was:\n%s", err, stdout)
+	}
+	return got
+}
+
+// rawKeys re-parses stdout as a generic object so a test can assert on KEY
+// PRESENCE and on an explicit `null` — neither of which survives unmarshalling
+// into a typed struct.
+func rawKeys(t *testing.T, stdout string) map[string]json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("stdout is not a JSON object (%v); stdout was:\n%s", err, stdout)
+	}
+	return raw
+}
+
+// TestAppListingStatusJSONApprovedNamesBothIdSpaces is the #447 assertion:
+// an approved listing's payload names the PARENT and the SHADOW separately, so
+// the id a mutation must be addressed to is readable by machine.
+func TestAppListingStatusJSONApprovedNamesBothIdSpaces(t *testing.T) {
+	srv := approvedListingServer(t)
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	got := decodeListingStatusJSON(t, stdout)
+
+	if got.ParentID != jsonFixtureParentID {
+		t.Errorf("parentId = %q, want %q", got.ParentID, jsonFixtureParentID)
+	}
+	if got.ShadowID == nil {
+		t.Fatalf("shadowId is null on an approved listing whose read opened a shadow — "+
+			"the two id spaces are what #447 exists to expose; stdout was:\n%s", stdout)
+	}
+	if *got.ShadowID != jsonFixtureShadowID {
+		t.Errorf("shadowId = %q, want %q", *got.ShadowID, jsonFixtureShadowID)
+	}
+	// 🔴 The whole bug class in one assertion: the two ids must not be the same
+	// value. #430 shipped because the id the user could SEE and the id the CLI
+	// ADDRESSED were from different spaces and nothing showed both.
+	if *got.ShadowID == got.ParentID {
+		t.Errorf("shadowId and parentId are the same value (%q) — the payload must distinguish them", got.ParentID)
+	}
+	if got.Slug != jsonFixtureSlug {
+		t.Errorf("slug = %q, want %q", got.Slug, jsonFixtureSlug)
+	}
+	// `status` is the PARENT's lifecycle status (what the human line prints);
+	// the edit read says "draft" in this fixture, and must not win.
+	if got.Status != "approved" {
+		t.Errorf("status = %q, want %q (the parent lookup's value)", got.Status, "approved")
+	}
+	// `hasPendingRevision` comes from the EDIT read (again, matching the human
+	// line); the parent lookup says false in this fixture.
+	if !got.HasPendingRevision {
+		t.Errorf("hasPendingRevision = false, want true (the edit read's value)")
+	}
+
+	if !got.Assets.Icon.Present {
+		t.Errorf("assets.icon.present = false, want true")
+	}
+	if got.Assets.Icon.ImageID == nil || *got.Assets.Icon.ImageID != 4711 {
+		t.Errorf("assets.icon.imageId = %v, want 4711", got.Assets.Icon.ImageID)
+	}
+	if got.Assets.Cover.Present {
+		t.Errorf("assets.cover.present = true, want false (this fixture has no cover)")
+	}
+	if got.Assets.Cover.ImageID != nil {
+		t.Errorf("assets.cover.imageId = %v, want null", *got.Assets.Cover.ImageID)
+	}
+
+	if len(got.Assets.Screenshots) != 2 {
+		t.Fatalf("assets.screenshots has %d rows, want 2; stdout was:\n%s", len(got.Assets.Screenshots), stdout)
+	}
+	first, second := got.Assets.Screenshots[0], got.Assets.Screenshots[1]
+	if first.ID != jsonFixtureShotA || second.ID != jsonFixtureShotB {
+		t.Errorf("screenshot ids = %q, %q; want %q, %q", first.ID, second.ID, jsonFixtureShotA, jsonFixtureShotB)
+	}
+	// The orders are 0 and 3 — NOT 0 and 1 — so a payload that emitted the slice
+	// index instead of the server's `order` cannot pass.
+	if first.Order != 0 || second.Order != 3 {
+		t.Errorf("screenshot orders = %d, %d; want 0, 3 (the server's own order values)", first.Order, second.Order)
+	}
+	if first.Caption == nil || *first.Caption != "Side by side" {
+		t.Errorf("first screenshot caption = %v, want %q", first.Caption, "Side by side")
+	}
+	if second.Caption != nil {
+		t.Errorf("second screenshot caption = %q, want null (the fixture has none)", *second.Caption)
+	}
+	if first.ImageID == nil || *first.ImageID != 8123 || second.ImageID == nil || *second.ImageID != 8124 {
+		t.Errorf("screenshot imageIds = %v, %v; want 8123, 8124", first.ImageID, second.ImageID)
+	}
+
+	if got.Floor.Met {
+		t.Errorf("floor.met = true, want false (no cover is attached)")
+	}
+	if len(got.Floor.Missing) != 1 || got.Floor.Missing[0] != "cover" {
+		t.Errorf("floor.missing = %v, want [cover]", got.Floor.Missing)
+	}
+}
+
+// TestAppListingStatusJSONDraftReportsANullShadow pins the OTHER arm: a draft
+// listing has no shadow revision, and the payload says so with an explicit
+// `null` rather than by dropping the key. A consumer must be able to ask
+// `.shadowId` on every listing and get an answer.
+func TestAppListingStatusJSONDraftReportsANullShadow(t *testing.T) {
+	srv := draftListingServer(t)
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	got := decodeListingStatusJSON(t, stdout)
+	if got.ShadowID != nil {
+		t.Errorf("shadowId = %q on a draft listing, want null", *got.ShadowID)
+	}
+	raw := rawKeys(t, stdout)
+	shadow, ok := raw["shadowId"]
+	if !ok {
+		t.Fatalf("the `shadowId` key is ABSENT on a draft listing — it must be present and null "+
+			"so a script can read it unconditionally; stdout was:\n%s", stdout)
+	}
+	if string(shadow) != "null" {
+		t.Errorf("shadowId = %s, want null", shadow)
+	}
+	if got.Status != "draft" {
+		t.Errorf("status = %q, want draft", got.Status)
+	}
+	if got.HasPendingRevision {
+		t.Errorf("hasPendingRevision = true, want false")
+	}
+	if !got.Floor.Met {
+		t.Errorf("floor.met = false, want true (icon and cover are both attached)")
+	}
+	// Empty COLLECTIONS, never null: `jq '.floor.missing | length'` and
+	// `.assets.screenshots[]` must work without a null check.
+	if got.Floor.Missing == nil {
+		t.Errorf("floor.missing is null, want an empty array")
+	}
+	if len(got.Floor.Missing) != 0 {
+		t.Errorf("floor.missing = %v, want empty", got.Floor.Missing)
+	}
+	if got.Assets.Screenshots == nil {
+		t.Errorf("assets.screenshots is null, want an empty array")
+	}
+	if len(got.Assets.Screenshots) != 0 {
+		t.Errorf("assets.screenshots has %d rows, want 0", len(got.Assets.Screenshots))
+	}
+	if got.Assets.Cover.ImageID == nil || *got.Assets.Cover.ImageID != 5322 {
+		t.Errorf("assets.cover.imageId = %v, want 5322", got.Assets.Cover.ImageID)
+	}
+}
+
+// TestAppListingStatusJSONIsTheOnlyThingOnStdout — no human line may share the
+// JSON stream. decodeListingStatusJSON already fails on trailing tokens; this
+// adds the direction it cannot see, a human line PREPENDED as valid JSON is not,
+// plus the specific strings the human renderer emits.
+func TestAppListingStatusJSONIsTheOnlyThingOnStdout(t *testing.T) {
+	srv := approvedListingServer(t)
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json")
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimLeft(stdout, " \t\r\n"), "{") {
+		t.Fatalf("stdout does not start with the JSON object; stdout was:\n%s", stdout)
+	}
+	decodeListingStatusJSON(t, stdout)
+	for _, human := range []string{
+		"App:", "Listing status:", "Screenshots:", "Publish floor met", "Not publishable yet",
+		"This listing is live", "under moderator review",
+	} {
+		if strings.Contains(stdout, human) {
+			t.Errorf("human output %q leaked onto the --json stdout:\n%s", human, stdout)
+		}
+	}
+}
+
+// TestAppListingStatusJSONEmitsNoANSIEvenWithColorForced is the
+// `internal/ui/CONVENTION.md` rule ("machine-readable output stays raw"), tested
+// in the ONLY configuration that can see a violation.
+//
+// 🔴 A run with color OFF proves nothing here: the test harness captures stdout
+// into a bytes.Buffer, which is not a TTY, so `ui.*` returns plain text and a
+// JSON path routed through `ui.Success` would still be escape-free. So color is
+// FORCED — once by flag, once by env — and each arm carries a POSITIVE CONTROL
+// on the human path in the same configuration: if the control does not show
+// escapes, the forcing did not work and the arm proves nothing.
+func TestAppListingStatusJSONEmitsNoANSIEvenWithColorForced(t *testing.T) {
+	// The ui package's color mode is process-global. Every run() reconfigures it
+	// from that command's own flags, but restore a plain default so nothing after
+	// this test inherits forced color.
+	t.Cleanup(func() { ui.Configure(ui.Options{Writer: io.Discard}) })
+
+	const esc = "\x1b["
+
+	t.Run("--color flag", func(t *testing.T) {
+		srv := approvedListingServer(t)
+		defer srv.Close()
+		listingEnv(t, srv.URL)
+
+		human, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--color")
+		if err != nil {
+			t.Fatalf("status --color: %v", err)
+		}
+		if !strings.Contains(human, esc) {
+			t.Fatalf("POSITIVE CONTROL FAILED: --color produced no ANSI on the HUMAN path, so this "+
+				"test cannot see a violation on the JSON path either; human stdout was:\n%q", human)
+		}
+		stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json", "--color")
+		if err != nil {
+			t.Fatalf("status --json --color: %v", err)
+		}
+		if strings.Contains(stdout, esc) {
+			t.Errorf("--json emitted an ANSI escape with --color (internal/ui/CONVENTION.md rule 1):\n%q", stdout)
+		}
+		decodeListingStatusJSON(t, stdout)
+	})
+
+	t.Run("CLICOLOR_FORCE", func(t *testing.T) {
+		srv := approvedListingServer(t)
+		defer srv.Close()
+		listingEnv(t, srv.URL)
+		t.Setenv("CLICOLOR_FORCE", "1")
+
+		human, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug)
+		if err != nil {
+			t.Fatalf("status: %v", err)
+		}
+		if !strings.Contains(human, esc) {
+			t.Fatalf("POSITIVE CONTROL FAILED: CLICOLOR_FORCE produced no ANSI on the HUMAN path, so "+
+				"this test cannot see a violation on the JSON path either; human stdout was:\n%q", human)
+		}
+		stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json")
+		if err != nil {
+			t.Fatalf("status --json: %v", err)
+		}
+		if strings.Contains(stdout, esc) {
+			t.Errorf("--json emitted an ANSI escape under CLICOLOR_FORCE (internal/ui/CONVENTION.md rule 1):\n%q", stdout)
+		}
+		decodeListingStatusJSON(t, stdout)
+	})
+}
+
+// TestAppListingStatusJSONWritesNothingOnAFailedRead pins the error half of the
+// published `--json` contract: the error goes to the returned error (stderr in
+// the real binary) and stdout stays EMPTY, so `jq` never sees prose.
+//
+// The exit code is asserted with errors.Is, never on message text — AGENTS.md
+// item 7 (claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md): the
+// classification sentinels carry no visible text, so a message assertion says
+// nothing at all about the exit code.
+func TestAppListingStatusJSONWritesNothingOnAFailedRead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, jsonFixtureSlug, "block_json_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"json":{"message":"No listing found","code":-32004}}}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	stdout, _, err := run(t, "app", "listing", "status", "--slug", jsonFixtureSlug, "--json")
+	if err == nil {
+		t.Fatalf("expected an error; stdout was:\n%s", stdout)
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("error is not classified ErrNotFound (exit 4): %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("--json wrote to stdout on a failed read, so a pipe sees a partial object:\n%q", stdout)
+	}
+}
+
+// TestAppListingStatusJSONUsageErrorPrintsNothingAtAll pins the OTHER published
+// rule (README, exit code 2): a usage error emits no JSON object in any mode.
+//
+// 🔴 LABELLED HONESTLY: this one is an INVARIANT GUARD, not regression coverage.
+// It is the only test in this file that PASSES on the pre-flag code, because
+// there `--json` is an unknown flag — itself a usage error with an empty stdout.
+// It earns its keep from the mutation direction instead: writing an empty object
+// before the resolve (mutant M9) kills it.
+func TestAppListingStatusJSONUsageErrorPrintsNothingAtAll(t *testing.T) {
+	listingEnv(t, "http://127.0.0.1:1") // never reached — the flag check fails first
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "block.manifest.json"), []byte(`{"version":"0.1.0"}`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	stdout, _, err := run(t, "app", "listing", "status", "--dir", dir, "--json")
+	if err == nil {
+		t.Fatalf("expected a usage error; stdout was:\n%s", stdout)
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("error is not classified ErrUsage (exit 2): %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("--json wrote to stdout on a usage error, which the README says prints nothing at all:\n%q", stdout)
+	}
+}
+
+// TestAppListingStatusJSONHelpWarnsAboutTheShadowSideEffect — the flag's own
+// documentation must say that this "read" is not a pure one.
+//
+// 🔴 getMyListingForEdit OPENS A SHADOW REVISION on an APPROVED listing as a
+// server-side side effect (idempotently). A script polling `--json` in a loop is
+// therefore a WRITER, and the whole reason to give this command a machine
+// interface is that somebody will poll it. Its classification as a "read" is the
+// open question in civitai/cli#389; this test does not settle that, it only
+// pins that the help text tells the truth about it.
+func TestAppListingStatusJSONHelpWarnsAboutTheShadowSideEffect(t *testing.T) {
+	cmd := newAppListingStatusCmd()
+	if cmd.Flags().Lookup("json") == nil {
+		t.Fatal("`app listing status` has no --json flag")
+	}
+	long := cmd.Long
+	for _, want := range []string{"--json", "poll", "shadow revision", "389"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("`app listing status` Long does not mention %q — a machine interface that "+
+				"invites polling must say that polling it opens a revision:\n%s", want, long)
+		}
+	}
+	// The `editTargetId` absence is a decision, not an oversight, so the help
+	// says so rather than leaving a script author to wonder where it went.
+	if !strings.Contains(long, "editTargetId") {
+		t.Errorf("`app listing status` Long does not say why `editTargetId` is absent from the payload:\n%s", long)
+	}
+}


### PR DESCRIPTION
Closes #447.

`civitai app listing status` had only `--slug` and `--dir`. It now takes `--json`.

```console
$ civitai app listing status --slug my-app --json
{
  "slug": "my-app",
  "parentId": "apl_01KXPENN7GJV51HBG649P3Y99M",
  "shadowId": "apl_01M064YJGDR973P73WHC1FGDP9",
  "status": "approved",
  "hasPendingRevision": false,
  "assets": {
    "icon":  { "present": true,  "imageId": 4711 },
    "cover": { "present": false, "imageId": null },
    "screenshots": [
      { "id": "alsc_01M0…", "order": 0, "caption": "Grid view", "imageId": 8123 }
    ]
  },
  "floor": { "met": false, "missing": ["cover"] }
}
```

*(that block is the shape, with the ids from #430's own write-up; the values in
CI come from an `httptest` fake — see "What was NOT verified" at the bottom.)*

## The shape, and the refinements to what the issue suggested

The issue's list is followed, with three deliberate calls:

- **`slug` is included** — the app the command resolved, so a payload pasted
  into an issue says which listing it is about.
- **`imageId` on screenshots too**, not only on icon/cover. An asymmetry there
  would be odd, and it is the field that joins a gallery row to a scan status.
- **`order` is the SERVER's `order` value, not the array index.** The fixture
  uses orders `0` and `3` precisely so a payload emitting the index cannot pass.

Collections are never `null`: `floor.missing` is `[]` when the floor is met and
`assets.screenshots` is `[]` for an empty gallery. `shadowId` is explicitly
`null` rather than omitted, so `.shadowId` answers on every listing instead of
making a consumer tell "no revision" from "old CLI".

Two fields have a source that had to be chosen, and the tests pin the choice by
making the two reads disagree in the fixture: `status` is the **parent's**
lifecycle status (from `getMyListingForApp`, the value the human line prints)
and `hasPendingRevision` is the **edit read's** (also matching the human line,
and it means SUBMITTED, not "a shadow exists").

`floorMissing` is factored out of the human renderer and shared with the
payload, so the human line and `.floor.missing` cannot disagree about which
asset is absent — the same argument the existing `floorMet` comment makes.

## Decision 1 — `editTargetId` is NOT decoded, and the comment moved with it

The issue asks for `editTargetId`. `appapi.ListingRef`'s doc comment (added by
#437) records why the CLI deliberately does not decode it: the server sends it
on an approved listing, but it has been **observed exactly once** (in #430's
manual tRPC read), and decoding it would give this CLI a **fourth** way to name
an edit target beside `AppListingID`, `ListingEditView.ShadowID` and
`BeginListingRevision`'s return.

**I kept the refusal.** The payload reports `parentId` + `shadowId` — both
already decoded, both really read on this call — and inventing the third from
`shadowId` would be the CLI asserting a value the server never handed it here.

Per the "a comment is a claim" rule, **the comment did not stay untouched**: it
now records that the question was re-asked by #447 (the surface with the
strongest claim on the field, since the issue named it), that the refusal was
re-affirmed, and that it now has a **user-visible consequence** — adding the
decode means adding the field to this payload too. Where the field went is
stated in the payload's own doc comment and in the README, not left as a
silence.

## Decision 2 — exit/error behaviour is the existing contract, not a third one

Nothing new was invented. The payload is written only after both reads have
succeeded, so:

- a failed read writes **nothing** to stdout and returns the classified error
  (exit 4 for the not-found arm), and
- a usage error prints **no JSON object at all** and exits 2,

which is what `app status --json` / `app metrics --json` do and what the README
already promises. Both are asserted with `errors.Is` (`civitai.ErrNotFound`,
`cmd.ErrUsage`) and never on message text — AGENTS item 7.

## Decision 3 — this "read" is not pure, and it says so

`app listing status` renders `getMyListingForEdit`, which on an **APPROVED**
listing **opens a shadow revision as a side effect** (idempotently). A `--json`
consumer polling in a loop is therefore a **writer**. That is stated in three
places: the `--json` flag's own usage string, a 🔴 paragraph in `--help`, and
the README (both the command-table row and a dedicated bullet). Each names
#389, which is where the classification is argued. **#389 is not touched here.**

## Tests

`internal/cmd/app_listing_status_json_test.go`, house pattern (`httptest` + the
real cobra tree). Every assertion is on the **parsed** payload; there is no
`strings.Contains` on a JSON blob.

| | |
|---|---|
| red at `bb7d7f2` (base + the test file only) | 6 of 7 fail — `status --json: unknown flag: --json` |
| red with the flag landed but the payload `{}` | the SHAPE assertions fail on their own terms: `parentId = "", want "apl_PARENT7Q1"`, ``the `shadowId` key is ABSENT on a draft listing`` |
| green at HEAD | 7/7 PASS |

The intermediate step is why the shape assertions are proven red rather than
merely failing at the flag lookup.

`TestAppListingStatusJSONUsageErrorPrintsNothingAtAll` **passes at base too** —
`--json` is an unknown flag there, which is itself a usage error with an empty
stdout. It is labelled in the file as an **invariant guard**, not counted as
regression coverage; it earns its keep from mutant M9.

Coverage: the approved arm (shadow present) and the draft arm (no shadow, floor
met, empty collections); stdout is asserted to be exactly one JSON value and
nothing else; **no ANSI with color FORCED** — both `--color` and
`CLICOLOR_FORCE`, each arm carrying a **positive control on the human path**,
because the harness's buffers are not TTYs so a color-off run cannot see a
`ui/CONVENTION.md` violation at all.

### Mutants (isolated; M0 is the harness's own negative control)

| mutant | verdict |
|---|---|
| M0 no-op change | **SURVIVED** (control — the harness does not kill for unrelated reasons) |
| M1 `shadowId := parentId` | KILLED — `shadowId and parentId are the same value` |
| M2 a `ui.Success` line on the JSON stdout | KILLED — `emitted an ANSI escape` |
| M3 `floor.missing` nil instead of `[]` | KILLED — `floor.missing is null` |
| M4 `shadowId` `omitempty` | KILLED — `key is ABSENT` |
| M5 `status` from the edit read | KILLED — `status = "draft", want "approved"` |
| M6 `order` := slice index | KILLED — `screenshot orders = 0, 1` |
| M7 `screenshots` nil instead of `[]` | KILLED — `assets.screenshots is null` |
| M8 a human line printed before the JSON | KILLED, but by the **prefix** check, not the human-string check |
| M8b prose carried **inside** the payload | KILLED — `human output "Publish floor met" leaked onto the --json stdout` |
| M9 `{}` written before any error | KILLED — `wrote to stdout` |
| M10 the #389 caveat dropped from `--help` | KILLED — `does not mention "389"` |
| M11 `parentId` from `ref.AppListingID` | **SURVIVED** |

Two of those need saying out loud rather than tidying away:

- **M8 died for the wrong reason.** The "no human string" loop never ran,
  because the earlier "stdout must start with `{`" check `Fatal`s first. So M8b
  was constructed to reach that specific guard — prose carried *inside* the
  payload, which parses fine and starts with `{` — and it kills it by name. The
  guard is **reachable**, not merely breakable.
- **M11 survives on purpose.** `getMyListingForApp.appListingId` and
  `getMyListingForEdit.parentId` name the **same listing**, so a fixture where
  they disagree would pin a distinction the server does not make. Left
  surviving and reported rather than patched around. (Related: `parentId` is
  emitted exactly as the edit read gave it, with no fallback — a server that
  omitted it should show as empty rather than be papered over by a
  substitution.)

## Docs — "README is not one place"

Grepped the whole file; three surfaces name this behaviour and all three moved:

1. the `app listing` **command-table row** (now spells `status [--json]`),
2. the `app listing` **prose section** — the payload, the `null`/`[]` rules,
   the `editTargetId` absence, and a 🔴 do-not-poll bullet,
3. **"Scripting with `--json`"**, which claimed every `--json` is a raw REST
   passthrough — it now names `app listing status --json` (with
   `app validate --json`) as a shape **this CLI composes**, and flags it as the
   read with a server-side side effect.

The exit-code and Troubleshooting surfaces were read and need no edit: this
command's exit codes are unchanged, and the generic "a usage error emits no
JSON object, in every mode" rule already covers the new flag. No generated
prose (`internal/cmd/exitcodes_doc.go`) or provenanced fixture text was touched.

## No AGENTS.md item — considered, declined, reasons

A new `--json` shape *is* a published contract (items 6 and 23 exist for that on
other commands), so this was weighed properly:

- both decisions already have enforcing homes — `editTargetId` in
  `appapi.ListingRef`'s doc comment (updated here, and now naming this payload),
  the side effect in `GetMyListingForEdit` / the `listingOp` comment and #389 —
  and the shape itself is pinned by tests plus the README;
- a **new** item cannot carry an evidence file (`agents_split_preserved_test.go`
  requires a base commit where the body already stood in AGENTS.md), so it would
  have to arrive inline, and AGENTS.md has **1,130 bytes** under its ceiling.
  Spending most of the remaining budget here is exactly what its own size guard
  warns against.

Happy to add one if you disagree — say the word and it goes in as item 31.

## Gate

- `make ci` — green (full clone).
- `make lint` — `0 issues.`, run as
  `nix-shell -p golangci-lint --run "make -C <worktree> lint"`; the
  `Entering directory` line confirms it ran in this worktree, and a deliberate
  `declared and not used` was injected first to confirm the linter can go red
  (it reported `1 issues: typecheck: 1`).
- `./scripts/ci-shallow.sh` — `PASSED`, `HEAD=754f02e73a7e`, 20/20 packages, on
  the committed state.

## What was NOT verified

**No live API call was made and no real listing was touched.** Everything here
is measured against an `httptest` fake. The live confirmation — that a real
approved listing's `--json` reports its true `parentId`/`shadowId` pair — is
yours to run; the one-liner is
`civitai app listing status --slug <app> --json | jq '{parentId, shadowId}'`,
and it will open a shadow revision on that listing if one is not already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
