### PR TITLE
chore(nix): bump flake vendorHash to match go.sum

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
           # Computed from go.sum (this module is not vendored). To recompute
           # after a go.mod/go.sum change: set this to `lib.fakeHash`, run
           # `nix build`, and copy the `got: sha256-…` value from the error.
-          vendorHash = "sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=";
+          vendorHash = "sha256-l0RyxhS7+tdL9FngitiUhrciQbZfyDmTp5tP3Kd6NGQ=";
 
           # The module root is `package cli` (a library that embeds the schema);
           # the executable lives in ./cmd/civitai (package main). Build only it.

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/kkfnywjqbl2gmgnghrcxynxz07i8p4v2-civitai-4e35eaa-dirty


### PR DESCRIPTION
Automated by the `bump-flake-vendorhash` workflow.

The Nix flake's `vendorHash` is a fixed-output hash derived from
`go.sum`. It drifted from the current `go.mod`/`go.sum` (a dep was
added or bumped), which makes the `flake` CI build fail and silently
breaks `nix run github:civitai/cli`. This PR recomputes the correct
hash via the `lib.fakeHash` dance (write a fake hash → `nix build` →
parse the real `got: sha256-…` → write it back) and updates
`flake.nix`.

**Validated in-job before opening this PR:** `nix build .#default`
succeeds with the new hash and `./result/bin/civitai version` runs.

**CI note:** this PR is opened with the scoped fine-grained token
(`secrets.BUMP_SCAFFOLD_PINS_TOKEN`, Contents + Pull requests RW on
this repo only), not the default `GITHUB_TOKEN` — so the repo's
`flake` check re-runs the build on it as an independent confirmation.