### PR TITLE
docs(release): v0.1.98 shipped — and two instruments lied in the reassuring direction

### DIFF
--- a/claudedocs/release-v0.1.98-draft.md
+++ b/claudedocs/release-v0.1.98-draft.md
@@ -1,27 +1,27 @@
-# v0.1.98 — DRAFT (not tagged, not published)
+# v0.1.98 — SHIPPED
 
-**Nothing is released yet.** Written before the tag so the pre-publish checks
-happen in the order that makes them worth doing.
+**This release is out.** Tagged at `71a374e`, published 2026-08-17T19:07:22Z,
+`@civitai/cli@0.1.98` on npm (`dist-tags.latest`), Homebrew cask 0.1.98
+(tap commit `b23ef87`, 10 s after publish), **14 assets**.
 
-**12 commits** in `v0.1.97..6980b14` — `6980b14` being `main` at the time of
-writing. 🔴 **Recompute as `v0.1.97..v0.1.98` once the tag exists**, and expect
-13: merging this file adds a `docs(release):` commit the filter excludes. That
-has happened on both of the last two releases and is the whole reason this
-document family recomputes rather than trusting the pre-tag number.
+**13 commits** (`v0.1.97..v0.1.98`): **7 excluded**, **6 in the notes**,
+**0 leaking** — the third consecutive release where the published body carries
+exactly the predicted set and none of the `docs(`/`chore(` commits.
 
-⚠️ It moved once already. This file first said **10 commits / 5-and-5**, written
-against `d3d2798`; two more landed while the draft's own CI was blocked on a
-GitHub CDN outage, one of them user-facing (#452). A pre-tag count is a
-measurement of a moving branch, which is exactly why the number that ships is
+The draft predicted 12-and-13 and the tag came in at 13. It had already been
+wrong once at 10, corrected to 12 mid-flight. Three releases running, the count
+has moved between drafting and tagging.
+
+⚠️ The pre-tag count moved twice. This file first said **10 commits / 5-and-5**,
+written against `d3d2798`; two more landed while its own CI was blocked on a
+GitHub CDN outage, one of them user-facing (#452), so it was corrected to
+**12 / 6-and-6** before merge; and merging it added the thirteenth. A pre-tag
+count measures a moving branch — which is exactly why the number that ships is
 the one recomputed at the tag.
-
-Predicted split, measured by applying `.goreleaser.yaml`'s real patterns with
-Go's `regexp` to the real subjects: **6 excluded, 6 in the notes, 0 leaking.**
 
 🔴 **THIS RELEASE IS MOSTLY NOT MINE.** Five of the six user-facing commits are
 App-listing and submit work from a concurrent session (#434, #437, #444, #449,
-#452). They are
-merged, reviewed and CI-green, but I did not write or audit them, and the arms
+#452). They are merged, reviewed and CI-green, but I did not write or audit them, and the arms
 below verify the packager changes properly and the listing changes only as a
 smoke check. Whoever reads this later should not take the depth of the pkgzip
 verification as covering the listing commits.
@@ -57,7 +57,52 @@ shows (#449), and **#452 closing #423** — an oversized bundle used to fail as 
 opaque `400: Invalid JSON`; submit now reports the base64 JSON body size and
 says what was sent.
 
-## Before publishing, not after
+## Verified before publishing
+
+`linux_amd64` downloaded, `sha256sum -c` → **OK**, `version` → `0.1.98 /
+71a374e296…`, matching `main`. Then nine arms; the packager rows ran against a
+**v0.1.97 negative control on the same fixture**:
+
+| arm | v0.1.97 | v0.1.98 |
+|---|---|---|
+| `db.env`, `DB.ENV`, `envs/prod.env`, `env/local.env`, `.env-backup/db.env` | **packaged** | absent |
+| `x.ZIP/a.txt`, `.ENV.local/b.txt` | **packaged** | absent |
+| `.env.d/credentials.json` | packaged | absent (container rule) |
+| `src/environment.ts`, `src/app.env.ts`, `config.env/settings.ts` | packaged | **still packaged** |
+| `.env-backup/.env.production` | packaged | **still packaged** (kept name) |
+| `.git` as a FILE (worktree) | — | absent; `.github/`, `.gitignore` kept |
+| version + dirty-tree guards | — | both refuse, exit 1 |
+| `app listing status --json` | — | valid JSON, exit 0 |
+| oversized bundle (#452) | — | names the sizes, not `Invalid JSON` |
+
+Secret count in the produced bytes: **0**. The #452 arm printed
+`10724159 bytes on the wire — a 8043103-byte zip, base64-encoded into a JSON
+body`, which is the whole point of that fix.
+
+## After publishing
+
+- **npm** — `dist-tags.latest = 0.1.98`.
+- **Homebrew** — cask `0.1.98`; every archive URL **read out of the cask itself**
+  answers 200 unauthenticated.
+
+🔴 **TWO INSTRUMENTS LIED DURING THIS RELEASE, IN THE REASSURING DIRECTION.**
+
+1. **`raw.githubusercontent.com` is CACHED.** Polling it for the cask version
+   returned `0.1.97` for five straight minutes after the tap had already been
+   updated — the workflow succeeded at 19:07:24 and the tap commit `b23ef87`
+   landed at 19:07:32. A cache-buster query param, or the commits API, returns
+   the truth immediately. **Poll the git history, not the raw CDN.**
+2. **The URL check was aimed at URLs the cask did not name.** While the cask
+   still read `0.1.97` to me, I was constructing `v0.1.98` URLs by hand and
+   confirming they answered 200 — a green that could not have detected a cask
+   pointing at the wrong version, which is the failure it exists to catch. The
+   corrected form reads the URLs *out of the cask file* and substitutes its own
+   `version`.
+
+Both are the same shape as the `rm ./*.zip` trap below: the check passed, and
+the passing told you nothing about the thing you cared about.
+
+## Superseded pre-publish plan
 
 goreleaser cuts a **DRAFT**. Publishing it fires **npm AND the Homebrew tap**,
 and npm unpublish is restricted. `npm/package.json` stays `0.0.0-dev`; the tag is
@@ -97,14 +142,6 @@ failure. That produced five false results while this work was being done.
 
 Then publish, and check Homebrew the way it actually breaks: every archive URL
 the cask names must answer **200 unauthenticated**.
-
-## After publishing
-
-1. Read the published body: 6 entries, none of them `docs(` or `chore(`. This is
-   the third consecutive observation of #416's filter working.
-2. Recompute as `v0.1.97..v0.1.98`.
-3. Flip to `# v0.1.98 — SHIPPED` with tag SHA, publish time, npm + cask versions
-   and asset count.
 
 ## Still open
 


### PR DESCRIPTION
v0.1.98 is out: tagged `71a374e`, published 19:07:22Z, `@civitai/cli@0.1.98` latest on npm, Homebrew cask 0.1.98 (tap commit `b23ef87`, 10 s after publish), 14 assets.

**13 commits: 7 excluded, 6 in the notes, 0 leaking** — the third consecutive release whose published body carries exactly the predicted set.

**The pre-tag count moved twice.** Written at 10 against `d3d2798`; corrected to 12 when two more commits merged while the draft's own CI was stuck on a GitHub codeload outage (one of them **#452, which closes #423**); then 13 at the tag from merging the notes. A pre-tag count measures a moving branch — which is why the number that ships is recomputed at the tag.

**Nine arms**, packager rows against a **v0.1.97 negative control on the same fixture**: seven leak paths present in v0.1.97 and absent here, controls (`src/environment.ts`, `src/app.env.ts`, `config.env/settings.ts`, `.env-backup/.env.production`) still packaged, `.git`-as-a-FILE still excluded, both submit guards still refusing, `app listing status --json` valid, and #452's arm printing `10724159 bytes on the wire — a 8043103-byte zip, base64-encoded into a JSON body` instead of an opaque `Invalid JSON`.

🔴 **Two instruments gave me a reassuring wrong answer, and both are recorded:**

1. **`raw.githubusercontent.com` is cached.** It told me the cask was still `0.1.97` for five minutes after the tap had been updated. The commits API said otherwise immediately. Poll the git history, not the raw CDN.
2. **My URL check was aimed at URLs the cask did not name.** While the cask read `0.1.97` to me, I was hand-constructing `v0.1.98` URLs and confirming 200 — a green that could not have detected a cask pointing at the wrong version, which is the single failure that check exists to catch. The corrected form reads URLs *out of the cask* and substitutes its own `version`.

Both are the same shape as the `rm ./*.zip` trap already recorded in this file: the check passed, and the passing told you nothing about the thing you cared about.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QybSDbsJwEMJdxDRUasTC1