### PR TITLE
fix(antipattern): scan exactly what the packager ships (#435 part 3)

### DIFF
--- a/internal/antipattern/antipattern.go
+++ b/internal/antipattern/antipattern.go
@@ -56,6 +56,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/civitai/cli/internal/pkgzip"
 )
 
 // Rule is one curated anti-pattern: a regexp that, when it matches a line of a
@@ -195,14 +197,37 @@ var scannedExts = map[string]bool{
 	".md": true, ".txt": true,
 }
 
-// skipDirs are directory names never descended into (build output, deps, vcs).
-var skipDirs = map[string]bool{
-	"node_modules": true, ".git": true, "dist": true, "build": true,
-	"coverage": true, "out": true, ".vite": true, ".next": true,
-}
-
 // ScanDir walks dir and returns every anti-pattern Finding in its source files,
 // sorted by file then line. A clean tree returns nil, nil.
+//
+// 🔴 WHAT IT SCANS IS EXACTLY WHAT THE PACKAGER SHIPS — pkgzip owns that rule and
+// this package does NOT keep a copy of it (issue #435, part 3). It used to: an
+// 8-name `skipDirs` (node_modules, .git, dist, build, coverage, out, .vite,
+// .next) against pkgzip's fixed names plus its two directory PATTERN rules
+// (dotenv-shaped and archive-shaped, both case-insensitive). So the walk
+// descended into `.venv/`, `.pnpm-store/`, `.turbo/`, `.cache/`, `.env.d/`,
+// `old.zip/` and the rest, and a finding there is one an author cannot act on:
+// the code it names is not in the bundle, and most of it is not theirs.
+// TestScanDirSkipsExactlyWhatThePackagerDrops is the ledger — it builds its
+// roster FROM pkgzip.ExcludedNames(), so neither side can move alone. No count
+// is restated here on purpose; both lists are read, never quoted.
+//
+// A duplicated predicate is the drift that produced #409 and #420 — one shape of
+// a name fixed, the other left behind — so this delegates rather than mirrors.
+// The FILE rule (pkgzip.IsExcludedFile) is applied too, ahead of the scannedExts
+// test: today scannedExts hides most of that divergence by accident (`.envrc`,
+// `db.env` and `old.zip` all have extensions it does not scan), but `.env.json`
+// does not, and "a finding is in a file that ships" should hold structurally
+// rather than by coincidence of the extension table.
+//
+// scannedExts stays exactly as it is. It answers a different question — which
+// file types are worth grepping — and is not part of this rule.
+//
+// 🔴 THE ROOT IS NEVER SKIPPED, mirroring pkgzip.Build's own `p == dir` guard.
+// Without it a project directory that happens to be named `dist`, `build` or
+// `x.zip` scans NOTHING and reports a clean tree — a reassuring zero from a
+// walk that never opened a file. Scanning a tree the packager would drop is
+// correct here: the caller named that tree, so it is the subject, not content.
 func ScanDir(dir string) ([]Finding, error) {
 	rules := Rules()
 	var findings []Finding
@@ -212,9 +237,19 @@ func ScanDir(dir string) ([]Finding, error) {
 			return err
 		}
 		if d.IsDir() {
-			if skipDirs[d.Name()] {
+			// The scanned root is the subject of the scan, not content inside
+			// it — see the doc comment.
+			if path == dir {
+				return nil
+			}
+			if pkgzip.IsExcluded(d.Name()) {
 				return fs.SkipDir
 			}
+			return nil
+		}
+		// The packager drops these by NAME regardless of extension, so a finding
+		// in one names code that will not be in the bundle.
+		if pkgzip.IsExcludedFile(d.Name()) {
 			return nil
 		}
 		if !scannedExts[strings.ToLower(filepath.Ext(d.Name()))] {

--- a/internal/antipattern/exclusions_test.go
+++ b/internal/antipattern/exclusions_test.go
@@ -1,0 +1,350 @@
+package antipattern
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/pkgzip"
+)
+
+// findingLine is a line that fires the buzz-rest rule (a REMOVED REST route).
+// It is the same shape in every fixture below so a missing finding can only mean
+// the file was never scanned, never that the rule failed to match it.
+const findingLine = `const bal = await fetch('/api/v1/blocks/buzz');` + "\n"
+
+// writeFinding creates <root>/<rel> and fills it with a line that MUST produce a
+// finding if the scanner reads the file at all.
+func writeFinding(t *testing.T, root, rel string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(p, []byte(findingLine), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// reportedDirs is the set of top-level directory names ScanDir produced a
+// finding under, plus "" for findings at the root.
+func reportedDirs(findings []Finding) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range findings {
+		parts := strings.Split(filepath.ToSlash(f.File), "/")
+		if len(parts) == 1 {
+			out[""] = true
+			continue
+		}
+		out[parts[0]] = true
+	}
+	return out
+}
+
+// TestScanDirSkipsExactlyWhatThePackagerDrops is the SEAM GUARD for issue #435
+// part 3: this package must keep NO exclusion list of its own, so the set of
+// directories it refuses to descend into IS pkgzip's.
+//
+// 🔴 IT PINS A RELATIONSHIP, NOT A SNAPSHOT OF NAMES. The roster is built FROM
+// pkgzip.ExcludedNames(), so a fixed name added or removed on the pkgzip side
+// enters or leaves this test's tree automatically and is re-asserted against
+// pkgzip's own predicate — the two cannot drift apart silently the way #409 and
+// #420 did. Pattern-shaped names (dotenv, archive) have no enumeration to read,
+// so they are listed by hand, exactly as pkgzip's own
+// TestDirectoryRuleIsDocumentedForAuthors roster is.
+//
+// 🔴 THE ORACLE HALF CANNOT SEE A MUTANT THAT MOVES BOTH SIDES TOGETHER — a
+// pkgzip.IsExcluded that returned true for everything would agree with a
+// ScanDir that scanned nothing, and the whole test would pass while the scanner
+// was inert. So there is a second half whose expectations are LITERAL: a fixed
+// table of names, written down here, not computed from anything under test.
+func TestScanDirSkipsExactlyWhatThePackagerDrops(t *testing.T) {
+	// Pattern-shaped directory names (pkgzip's isDotenvShaped / isArchiveArtifact,
+	// both case-insensitive) plus the documented lookalikes that are NOT dropped.
+	patternNames := []string{
+		".env", ".env.d", ".ENV.D", ".env.local", ".env.production",
+		"old.zip", "X.ZIP",
+		// Deliberately NOT excluded by pkgzip — the residual its isDotenvShaped
+		// doc calls out. They must still be SCANNED, which is what makes this
+		// test fail if antipattern ever widens BEYOND pkgzip.
+		".envrc", ".env-backup", ".envs", ".environment",
+	}
+	// Ordinary source directories: the positive control. Without these the suite
+	// cannot tell this change from one that disables scanning outright.
+	ordinaryNames := []string{"src", "public", "lib", ".github", "components"}
+
+	roster := append([]string{}, pkgzip.ExcludedNames()...)
+	roster = append(roster, patternNames...)
+	roster = append(roster, ordinaryNames...)
+
+	root := t.TempDir()
+	for _, name := range roster {
+		writeFinding(t, root, name+"/probe.ts")
+	}
+	// A finding at the root itself — nothing may skip that.
+	writeFinding(t, root, "probe.ts")
+
+	findings, err := ScanDir(root)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+	got := reportedDirs(findings)
+
+	// ── half 1: the relationship, against pkgzip's own predicate ──────────────
+	var skipped, scanned int
+	for _, name := range roster {
+		wantReported := !pkgzip.IsExcluded(name)
+		if got[name] != wantReported {
+			verb := "did NOT report"
+			if got[name] {
+				verb = "REPORTED"
+			}
+			t.Errorf("ScanDir %s a finding under %q, but pkgzip.IsExcluded(%q)=%v — "+
+				"antipattern's skipped set must BE pkgzip's, not a copy of it (#435)",
+				verb, name, name, pkgzip.IsExcluded(name))
+		}
+		if wantReported {
+			scanned++
+		} else {
+			skipped++
+		}
+	}
+	// Both arms must be non-empty, or "they agree" is a claim about nothing.
+	if skipped == 0 {
+		t.Fatal("no roster name was excluded — this test observed only the scanned arm")
+	}
+	if scanned == 0 {
+		t.Fatal("no roster name was scanned — this test observed only the skipped arm")
+	}
+	if !got[""] {
+		t.Error("no finding at the scanned root — the walk never read a file there")
+	}
+
+	// ── half 2: literal expectations, derived from NOTHING under test ─────────
+	// If pkgzip.IsExcluded were mutated to answer the same wrong thing ScanDir
+	// answers, half 1 stays green and this half does not.
+	literal := map[string]bool{ // name -> must a finding under it be REPORTED?
+		".venv":        false,
+		".pnpm-store":  false,
+		".turbo":       false,
+		".cache":       false,
+		"node_modules": false,
+		".env.d":       false,
+		".ENV.D":       false,
+		"X.ZIP":        false,
+		"src":          true,
+		"public":       true,
+		".envrc":       true,
+		".environment": true,
+	}
+	for name, wantReported := range literal {
+		if got[name] != wantReported {
+			t.Errorf("finding under %q reported=%v, want %v (literal expectation, not computed)",
+				name, got[name], wantReported)
+		}
+	}
+
+	// The roster must cover every fixed pkgzip name, so a name added there is
+	// automatically asserted here rather than quietly untested.
+	for _, name := range pkgzip.ExcludedNames() {
+		if !containsStr(roster, name) {
+			t.Errorf("pkgzip excludes %q but the roster does not carry it", name)
+		}
+	}
+	if len(pkgzip.ExcludedNames()) < 10 {
+		t.Fatalf("pkgzip.ExcludedNames() returned %d names — too few to be the real list; "+
+			"the roster was built from an empty or broken enumeration",
+			len(pkgzip.ExcludedNames()))
+	}
+}
+
+// TestScanDirSkipsFilesThePackagerDropsByName covers the FILE half of the same
+// rule. scannedExts hides most of the divergence by accident — `.envrc`,
+// `db.env` and `old.zip` all have extensions it does not scan — but `.env.json`
+// has one it does, so without pkgzip.IsExcludedFile the scanner reports findings
+// in a file the packager drops.
+//
+// The control is in the SAME directory with the SAME content and a name nothing
+// excludes: if it also vanished, the test would be pinning "scanning is off"
+// rather than "this name is dropped".
+func TestScanDirSkipsFilesThePackagerDropsByName(t *testing.T) {
+	root := t.TempDir()
+	dropped := []string{".env.json", ".env.local.json", ".ENV.json", ".env.staging.md"}
+	for _, name := range dropped {
+		writeFinding(t, root, "src/"+name)
+	}
+	writeFinding(t, root, "src/config.json") // control: an ordinary scanned file
+
+	findings, err := ScanDir(root)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+	byBase := map[string]bool{}
+	for _, f := range findings {
+		byBase[filepath.Base(f.File)] = true
+	}
+
+	for _, name := range dropped {
+		if !pkgzip.IsExcludedFile(name) {
+			t.Fatalf("fixture error: pkgzip does NOT drop %q, so this case proves nothing", name)
+		}
+		if byBase[name] {
+			t.Errorf("ScanDir reported a finding in %q, which pkgzip.IsExcludedFile drops — "+
+				"a finding must name a file that ships (#435)", name)
+		}
+	}
+	if !byBase["config.json"] {
+		t.Fatal("the control file src/config.json produced no finding — this test would have " +
+			"passed with scanning disabled entirely")
+	}
+}
+
+// TestScanDirReportsOrdinarySourceFindings is the standalone positive control:
+// the whole rest of this file asserts ABSENCES, and an absence is what a
+// scanner wired to nothing produces too.
+func TestScanDirReportsOrdinarySourceFindings(t *testing.T) {
+	root := t.TempDir()
+	writeFinding(t, root, "src/App.tsx")
+	writeFinding(t, root, "src/lib/api.ts")
+	writeFinding(t, root, "README.md")
+
+	findings, err := ScanDir(root)
+	if err != nil {
+		t.Fatalf("ScanDir: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("got %d finding(s), want 3:\n%s", len(findings), Format(findings))
+	}
+	for _, f := range findings {
+		if f.Rule.ID != "buzz-rest" {
+			t.Errorf("finding %s:%d fired rule %q, want buzz-rest", f.File, f.Line, f.Rule.ID)
+		}
+	}
+}
+
+// TestScanDirNeverSkipsTheScannedRoot pins the `path == dir` guard, mirroring
+// pkgzip.Build's own. Widening the rule to pkgzip's set made this reachable: a
+// project directory named `dist`, `build` or `x.zip` would otherwise scan
+// NOTHING and report a clean tree — a reassuring zero from a walk that never
+// opened a file. The caller NAMED this tree, so it is the subject of the scan,
+// not content found inside one.
+func TestScanDirNeverSkipsTheScannedRoot(t *testing.T) {
+	for _, rootName := range []string{"dist", "build", "node_modules", ".env.d", "app.zip"} {
+		t.Run(rootName, func(t *testing.T) {
+			if !pkgzip.IsExcluded(rootName) {
+				t.Fatalf("fixture error: pkgzip does not exclude %q, so this case proves nothing", rootName)
+			}
+			root := filepath.Join(t.TempDir(), rootName)
+			writeFinding(t, root, "src/App.tsx")
+
+			findings, err := ScanDir(root)
+			if err != nil {
+				t.Fatalf("ScanDir: %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("scanning a root named %q produced %d finding(s), want 1 — the root "+
+					"must never be skipped by the directory rule", rootName, len(findings))
+			}
+		})
+	}
+}
+
+// TestAntipatternKeepsNoExclusionListOfItsOwn is the structural half of the seam
+// guard: the behavioural test above proves the two AGREE today, and this proves
+// there is nothing here that COULD disagree tomorrow.
+//
+// It walks the package's own non-test sources and fails on any string literal
+// that pkgzip would exclude — the shape a reintroduced `skipDirs` (or a slice,
+// or a switch) inevitably takes. It is not a grep: the AST sees literals
+// wherever they are written, and ignores comments, which is why the doc comment
+// above ScanDir may name the eight dead entries without tripping it.
+func TestAntipatternKeepsNoExclusionListOfItsOwn(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	sort.Strings(files)
+
+	examined, literals := 0, 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		examined++
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		bad, n := rivalExclusionLiterals(t, f, string(src))
+		literals += n
+		for _, b := range bad {
+			t.Errorf("%s declares the string literal %q, which pkgzip already excludes — "+
+				"this package must delegate to pkgzip.IsExcluded / pkgzip.IsExcludedFile, "+
+				"not keep a rival list (#435)", f, b)
+		}
+	}
+
+	// Positive controls: a zero here must mean "no rival literal", never "the
+	// detector read nothing".
+	if examined == 0 {
+		t.Fatal("examined 0 non-test source files — the glob observed nothing")
+	}
+	if literals < 10 {
+		t.Fatalf("examined only %d string literal(s) across %d file(s) — the AST walk is not "+
+			"reading the source", literals, examined)
+	}
+	// …and the detector must be able to FIRE. This source is not the code under
+	// test and its expectation is written here, literally.
+	planted := "package antipattern\n\nvar skipDirs = map[string]bool{\"node_modules\": true, \".git\": true}\n"
+	bad, _ := rivalExclusionLiterals(t, "planted.go", planted)
+	if len(bad) != 2 {
+		t.Fatalf("the detector found %v in a source that plants two rival names — it cannot "+
+			"observe the thing this test reports zero of", bad)
+	}
+}
+
+// rivalExclusionLiterals returns every string literal in src that pkgzip already
+// excludes (as a directory or as a file), plus the total number of string
+// literals it examined.
+func rivalExclusionLiterals(t *testing.T, name, src string) ([]string, int) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, name, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+	var bad []string
+	total := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		total++
+		v, err := strconv.Unquote(lit.Value)
+		if err != nil || v == "" {
+			return true
+		}
+		if pkgzip.IsExcluded(v) || pkgzip.IsExcludedFile(v) {
+			bad = append(bad, v)
+		}
+		return true
+	})
+	sort.Strings(bad)
+	return bad, total
+}
+
+func containsStr(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Part 3 of the residual tracked in #435. Parts 1 and 2 are separate; **#435 stays open** for the residual name rules (`secrets.json`, `src/credentials.yaml`, a `.GIT` file, `.env-backup/.env.production`).

## The defect

`internal/antipattern/antipattern.go` kept its own 8-name `skipDirs` —
`node_modules .git dist build coverage out .vite .next` — against `internal/pkgzip`'s
fixed-name `excludedDirs` plus the two directory PATTERN rules `isExcludedDir` applies
(dotenv-shaped and archive-shaped, both case-insensitive since #435 part 1). So `ScanDir`
descended into `.hg/ .svn/ .venv/ venv/ .pnpm-store/ .cache/ .pytest_cache/ .mypy_cache/
.ruff_cache/ .turbo/`, plus `.env.d/`, `.ENV.D/`, `old.zip/`, `X.ZIP/` — and could report a
finding in code that will never be in the bundle. An author cannot act on that, and most of
it is not their code.

A duplicated predicate is exactly the drift that produced #409 and #420 (one shape of a name
fixed, the other left behind).

## The change

- directories → `pkgzip.IsExcluded(name)`; `skipDirs` is **deleted**, not shadowed.
- regular files → `pkgzip.IsExcludedFile(name)`, applied **before** the `scannedExts` test.
- `scannedExts` is **untouched**. It answers a different question (which file types are worth
  grepping) and hides most of the file-level divergence only by accident: `.envrc`, `db.env`
  and `old.zip` have extensions it does not scan — but `.env.json` does.
- the scanned **root** is never skipped, mirroring `pkgzip.Build`'s own `p == dir` guard.
  With the wider rule in place a project directory named `dist`, `build` or `x.zip` would
  otherwise scan **nothing** and report a clean tree — a reassuring zero from a walk that
  never opened a file.

No import cycle: `pkgzip` imports only `internal/manifest`, and nothing in `pkgzip`'s import
graph reaches `antipattern`. Verified by `go build ./...`.

**Scope note, because the issue's wording overstates the blast radius:** `antipattern.ScanDir`
is not wired into `civitai app validate` today. Its two callers are the CI `scaffold-currency`
job (via `TestScanDirFromEnv`) and the hermetic `TestScaffoldedTemplatesHaveNoAntipatterns`
in `internal/scaffold`. The consolidation is still right — the same divergence would surface
the day anything author-facing calls it — but nothing user-visible changes in this PR.

## Measured before/after — the honest number is ZERO

`ScanDir` run over six real block projects, each with `block.manifest.json` and installed
`node_modules`, at `origin/main` (728d558) and with this change applied:

| project | findings before | findings after | delta |
| --- | --- | --- | --- |
| civitai-block-gen-matrix | 0 | 0 | 0 |
| civitai-block-buzz-generator | 1 | 1 | 0 |
| civitai-app-custom-generators | 0 | 0 | 0 |
| civitai-block-playable-collections | 9 | 9 | 0 |
| civitai-app-model-benchmarking | 0 | 0 | 0 |
| civitai-block-prompt-library | 0 | 0 | 0 |

The finding LISTS are byte-identical, not just the counts:
buzz-generator = `src/Harness.tsx:100 resize-iframe-page`; playable-collections =
`README.md:{140,143,144}`, `src/App.tsx:{84,92}`, `src/lib/api.ts:{69,70}`,
`src/lib/popular.ts:{5,6}` — all in `src/` or the root README, all still reported.

**Nothing disappeared anywhere, so no finding disappeared from a directory the packager
keeps.** The delta is zero on today's corpus and this PR is a drift fix, not a bug fix.

What it does change on that corpus, measured: exactly one pkgzip-only directory exists there —
`civitai-block-buzz-generator/.venv/` — holding **859 files, of which 5 have scanned
extensions**. Those 5 were opened and grepped before and are not now; none of them matched a
rule, which is why the finding count did not move.

**The measurement instrument can see a delta** (otherwise the zero above is
indistinguishable from a harness wired to nothing). On a synthetic tree planting one
finding-bearing file in each excluded location plus two ordinary ones, the same harness
reports **8 findings before, 2 after**:

| dropped by this change | kept |
| --- | --- |
| `.env.d/creds.json`, `.env.json`, `.pnpm-store/x/pkg.json`, `.turbo/cache.js`, `.venv/lib/vendored.js`, `old.zip/x.js` | `src/App.tsx`, `ok.json` |

## Red at base

New tests, run unchanged against `origin/main` (728d558) in a second worktree — all four
**compile** at base, so these are behavioural reds, not compile-reds:

| test | at base (728d558) | at HEAD | base failure message |
| --- | --- | --- | --- |
| `TestScanDirSkipsExactlyWhatThePackagerDrops` | **FAIL** | PASS | `ScanDir REPORTED a finding under ".venv", but pkgzip.IsExcluded(".venv")=true — antipattern's skipped set must BE pkgzip's, not a copy of it (#435)` (16 names) + `finding under ".pnpm-store" reported=true, want false (literal expectation, not computed)` (7 names) |
| `TestScanDirSkipsFilesThePackagerDropsByName` | **FAIL** | PASS | `ScanDir reported a finding in ".env.json", which pkgzip.IsExcludedFile drops — a finding must name a file that ships (#435)` (×4) |
| `TestScanDirNeverSkipsTheScannedRoot` | **FAIL** (3 of 5 subtests) | PASS | `scanning a root named "dist" produced 0 finding(s), want 1 — the root must never be skipped by the directory rule` (dist, build, node_modules; `.env.d` and `app.zip` PASS at base because the old list did not contain them — stated rather than rounded up) |
| `TestAntipatternKeepsNoExclusionListOfItsOwn` | **FAIL** | PASS | `antipattern.go declares the string literal ".git", which pkgzip already excludes — this package must delegate to pkgzip.IsExcluded / pkgzip.IsExcludedFile, not keep a rival list (#435)` (×8, the whole old `skipDirs`) |
| `TestScanDirReportsOrdinarySourceFindings` | PASS | PASS | the positive control — green in **both** arms on purpose; without it the suite could not tell this change from one that disables scanning |

## The seam guard pins a relationship, not a snapshot

`TestScanDirSkipsExactlyWhatThePackagerDrops` builds its roster **from
`pkgzip.ExcludedNames()`**, so a fixed name added or removed on the pkgzip side enters or
leaves the tree automatically and is re-asserted against pkgzip's own predicate. Pattern-shaped
names have no enumeration to read, so they are listed by hand (as pkgzip's own
`TestDirectoryRuleIsDocumentedForAuthors` roster is) — including the four documented
lookalikes `.envrc/ .env-backup/ .envs/ .environment/` that pkgzip deliberately does **not**
drop, which is what makes the test fail if `antipattern` ever widens BEYOND pkgzip.

Half the expectations come from `pkgzip.IsExcluded` (the relationship) and half are **literal**
(`".venv": false`, `"src": true`, …). A mutant that moved both sides together — an
`IsExcluded` returning true for everything agreeing with a `ScanDir` that scans nothing — is
caught by the literal half, which is derived from nothing under test. Both arms are asserted
non-empty, and `len(pkgzip.ExcludedNames()) < 10` fails, so a broken enumeration cannot
produce a vacuous green.

## Mutation table — 7 mutants, 0 survivors

Every mutation is the narrowest expression that can be wrong, and each is reported with the
guard's **own** assertion message (not merely "a test failed"):

| # | mutation | killed by | died with |
| --- | --- | --- | --- |
| M1 | `pkgzip.IsExcluded(d.Name())` → `false && …` | `TestScanDirSkipsExactlyWhatThePackagerDrops`, `TestScanDir/node_modules_is_not_descended_into` | `ScanDir REPORTED a finding under ".cache", but pkgzip.IsExcluded(".cache")=true — … must BE pkgzip's, not a copy of it (#435)` |
| M2 | reintroduce the pre-change 8-name `skipDirs` verbatim | `TestScanDirSkipsExactlyWhatThePackagerDrops` **and** `TestAntipatternKeepsNoExclusionListOfItsOwn` | `… REPORTED a finding under ".pnpm-store" …` / `… declares the string literal "node_modules" … not keep a rival list (#435)` |
| M3 | `pkgzip.IsExcludedFile(d.Name())` → `false && …` | `TestScanDirSkipsFilesThePackagerDropsByName` | `ScanDir reported a finding in ".env.json", which pkgzip.IsExcludedFile drops — a finding must name a file that ships (#435)` |
| M4 | delete the `path == dir` root guard | `TestScanDirNeverSkipsTheScannedRoot` (5/5 subtests) | `scanning a root named "dist" produced 0 finding(s), want 1 — the root must never be skipped by the directory rule` |
| M5 | narrow the directory rule to `pkgzip.ExcludedNames()` only (drops both PATTERN rules) | `TestScanDirSkipsExactlyWhatThePackagerDrops` | `… REPORTED a finding under ".env.d" …` / `".ENV.D"` / `"old.zip"` / `"X.ZIP"` |
| M6 | inverse control: skip **every** directory | 6 tests incl. `TestScanDirReportsOrdinarySourceFindings` | `ScanDir did NOT report a finding under "src", but pkgzip.IsExcluded("src")=false …` |
| M7 | reachability control for the AST guard: declare a rival list that is **never consulted** (behaviour unchanged) | `TestAntipatternKeepsNoExclusionListOfItsOwn` **only** | `antipattern.go declares the string literal ".turbo", which pkgzip already excludes …` |

M7 exists because M2 kills two guards at once, which would leave the AST guard's kill
attributable to the behavioural test. With behaviour held constant only the AST guard fires —
so it is reachable on its own, not riding on its neighbour. Its detector also carries an
in-test positive control (a planted source that must yield exactly 2 hits) and a floor on the
number of literals examined, so a broken parse cannot report a clean zero.

**Survivors: none.** One mutation was deliberately not run: moving the `IsExcludedFile` test
to *after* the `scannedExts` test is behaviourally identical (it only changes which gate
rejects first), so a guard for it would be pinning an implementation detail.

## Suite

Counted from `-v` output, not an exit code:

- `go test ./... -count=1 -v` → **RUN 4411, PASS 4407, FAIL 0, SKIP 4**, 20 packages `ok`,
  0 `panic: test timed out`. The 4 skips are the pre-existing network/env-gated ones
  (`TestScanDirFromEnv`, `TestSubmissionsCapDriftAgainstLiveAPI`,
  `TestScaffoldPinsSatisfyPublished`, `TestScaffoldedReadyAckActuallyFires`).
- `go vet ./...` → clean.
- `gofmt -s -l .` → 0 files, over **411** `.go` files found (the positive control: a clean
  gofmt over zero files looks identical).
- `go build ./...` → clean.
- `golangci-lint run ./...` → **0 issues** — with a negative control first: a planted
  `var mutUnused = 42` produced `1 issues: internal/antipattern/antipattern.go:101:5: var
  mutUnused is unused (unused)`, so the zero is a statement about the code, not about a lint
  run that analysed nothing.

## Not touched

pkgzip's exclusion behaviour, the drop-messaging from #458, `scannedExts`, and
`internal/appapi/listing.go` and friends.

`README.md` is unchanged deliberately: `ScanDir` has no user-facing surface (see the scope
note above), so there is no published contract this moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
