### PR TITLE
docs(listing): #389's open question is measured — every 400 precedes the write

### DIFF
--- a/README.md
+++ b/README.md
@@ -1535,18 +1535,21 @@ Details worth knowing before you start:
   in a loop.** On a LIVE (approved) listing the read behind it
   (`getMyListingForEdit`) opens the revision draft server-side, idempotently —
   the same one each time — so a script calling it repeatedly keeps a revision
-  open on your listing. Whether that should still be classified a read is
-  [#389](https://github.com/civitai/cli/issues/389), which is open. Reading it
-  once per change is fine; a watch loop is a writer.
+  open on your listing. [#389](https://github.com/civitai/cli/issues/389) asked
+  the narrower question of whether a call that FAILS could leave a revision
+  behind; it cannot, because every refusal the server can return here is raised
+  before the revision is opened. **That settles the error path only — the write
+  on success is unchanged.** Reading it once per change is fine; a watch loop is
+  a writer.
   ⚠ **This now applies to OFFSITE apps too.** Before
   [#422](https://github.com/civitai/cli/issues/422) every `app listing`
   subcommand refused for an offsite app and therefore could not write anything;
   now that they resolve by slug, `app listing status` against an **approved**
   offsite listing mints that shadow revision like any other. Every offsite app
   measured on civitai.com is approved, so this is the *normal* state there, not
-  an edge case. #422 retired the "cannot be addressed" refusal; it did not
-  retire #389 — the shadow is a property of `getMyListingForEdit`, not of how
-  the listing id was obtained.
+  an edge case. #422 retired the "cannot be addressed" refusal, and #389
+  retired nothing about the write — the shadow is a property of
+  `getMyListingForEdit`, not of how the listing id was obtained.
 - 🔴 **`reorder` addresses the same listing `status` printed, and on a live
   listing that is the *revision*, not the live one.** The server validates a
   reorder against the screenshot ids of the listing it is *addressed to*, and

--- a/claudedocs/decisions/29-offsite-refusal.md
+++ b/claudedocs/decisions/29-offsite-refusal.md
@@ -130,9 +130,18 @@ offsite app measured on civitai.com (`radio`, `comfy`, `cosmetic-studio`,
 **NOT HYPOTHETICAL: IT HAPPENED TWICE DURING THIS PR'S OWN DEVELOPMENT**, to
 `radio` and to `gen-matrix`, each time by running `app listing status` against a
 real app to check the repair worked. Tracked as **civitai/cli#389** ("is this a
-read at all?"), which is OPEN and which #422 does not close. The README now says
-so for `app listing status` with and without `--json`, and the command's own
-`--help` says it too.
+read at all?"). #422 does not close it, and neither does the measurement below:
+#389's own open question was whether a call that FAILS could leave a revision
+behind, and reading `getMyListingForEdit` at `civitai/civitai@3ff050f` settles
+that it cannot — every refusal (`loadOwnedEditableListing` at :1494, the
+`revisionOfId` check at :1496, the status switch at :1502) is raised above the
+`if (listing.status === 'approved') beginListingRevision(...)` at :1540, and the
+proc's zod input and `appDeveloperProcedure` middleware reject before the
+resolver runs at all. **That is the ERROR arm. The write on SUCCESS is exactly
+as described above and is unchanged** — an approved offsite listing still gets a
+shadow minted by a command that reads like a read. The README says so for
+`app listing status` with and without `--json`, and the command's own `--help`
+says it too.
 
 **The rule for anyone testing this path: use the `httptest` fakes.** If you need
 live shape, `civitai app view <slug>` is genuinely read-only. Do not reach for a

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -466,11 +466,47 @@ func trpcName(path string) string {
 // server documents a side effect — for an APPROVED parent it idempotently opens
 // a shadow revision (see GetMyListingForEdit). Classifying it `change` would
 // tell someone whose `listingId` was rejected to go fix a value they never sent.
-// The residual is real and stated rather than papered over: this CLI cannot see
-// whether the server opened a revision before rejecting the input, so "nothing
-// was changed" is a claim about the REQUEST, not a proof about the database.
-// Tracked as civitai/cli#389, which names the measurement that would settle it;
-// do not "fix" it by re-labelling the route before that measurement exists.
+//
+// 🔴 THE 400 ARM IS MEASURED, AND `listingOpRead`'s WORDING SURVIVES IT.
+// civitai/cli#389 doubted exactly one thing: this CLI cannot see the database,
+// so "nothing was changed" on a 400 was a claim about the REQUEST. The question
+// it named was whether the server opens the revision BEFORE or AFTER validating
+// the input. It is AFTER: the open is the LAST thing the resolver does before
+// reading, and every refusal it can raise precedes it. Read in
+// `civitai/civitai` at 3ff050f2568504aa0c4c302f53818baaa35fbe11,
+// `src/server/services/blocks/offsite-listing.service.ts`, in source order:
+//
+//	:1494  loadOwnedEditableListing  → NOT_FOUND / NOT_OWNED
+//	:1496  listing.revisionOfId != null → INVALID_REVISION
+//	:1502  the status switch → removed FORBIDDEN, rejected MUST_RESUBMIT,
+//	       anything not draft/pending/approved INVALID_REVISION
+//	:1540  if (listing.status === 'approved') { beginListingRevision(...) }
+//
+// Every refusal the resolver can raise sits ABOVE :1540, so each one returns
+// before the INSERT is attempted. The proc's zod input (`listingId` 1..64, in
+// `src/server/schema/blocks/offsite-listing.schema.ts:247`) and the
+// `appDeveloperProcedure` middleware both reject before the resolver is entered
+// at all. `mapOffsiteError` (`src/server/routers/app-listings.router.ts:252`)
+// sends NOT_FOUND→404, NOT_OWNED/FORBIDDEN→403, and every other typed code —
+// INVALID_REVISION, MUST_RESUBMIT — to 400; an untyped failure becomes a 500
+// with a generic message. AFTER the shadow-open only 404 (loadListingEditView's
+// NOT_FOUND) and 500 are reachable. The single 400 that can fire once the
+// INSERT has been ATTEMPTED is `beginListingRevision`'s `if (!winner)`
+// INVALID_REVISION (:1143), and it fires only when no shadow row exists for the
+// parent — i.e. precisely when nothing was written.
+//
+// So a 400 from this route means nothing was changed, and this classification
+// is correct rather than merely convenient.
+//
+// 🔴 THAT SETTLES THE ERROR ARM ONLY — THE WRITE ON SUCCESS STANDS, AND GOT
+// BIGGER. A SUCCESSFUL call against an APPROVED parent still mints a shadow
+// revision. Since civitai/cli#453 (#422 outcome 1) `app listing` also reaches
+// OFFSITE apps by slug, and every offsite app measured on civitai.com is
+// approved — so minting a shadow is now the NORMAL outcome there, not an edge
+// case. `app listing status` is still not a
+// pure read and still must not be polled; the warnings in its `Long` and in
+// README.md say so and stay. Nothing here licenses re-labelling this route, and
+// nothing here makes it safe to point a live-app probe at it.
 //
 // 🔴 IT IS NOT THE HTTP VERB, and civitai/cli#374 is what that cost: keying it
 // on the verb at the three call sites (trpcQuery → read, trpcMutation → change,

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -318,8 +318,9 @@ would be a guess.
 🔴 This is not a pure read — with or without --json — so do not poll it in a
 loop: on a LIVE listing it opens the shadow revision described above, so a
 script calling it repeatedly keeps a revision draft open on your listing. That
-holds for an OFFSITE app too, and they are approved in practice. Whether this
-is a read at all is civitai/cli#389, which is open.`,
+holds for an OFFSITE app too, and they are approved in practice.
+civitai/cli#389 settled that a FAILED call writes nothing; a successful one
+still does.`,
 		Example: `  civitai app listing status
   civitai app listing status --slug my-app
   civitai app listing status --dir ./my-app
@@ -1415,9 +1416,16 @@ stages WITHOUT submitting, and exits 0. A DRAFT listing is reordered directly.`,
 // comment for why not, and note it would save a round-trip rather than enable
 // anything. (b) Reusing `ListingEditView.ShadowID`, which IS already decoded:
 // that would build this command on `getMyListingForEdit`, a route classified
-// `listingOpRead` while its own doc records that it OPENS a revision — the
-// contradiction tracked as civitai/cli#389. A fix resting on the side effect of
-// a route whose classification is an open question inherits that question.
+// `listingOpRead` while its own doc records that it OPENS a revision —
+// civitai/cli#389. The classification is now MEASURED correct on the arm #389
+// doubted (every refusal that proc can raise precedes the INSERT, so its 400
+// wording tells the truth — see the `listingOp` doc in
+// `internal/appapi/listing.go`), and the reason to keep this command off it
+// never rested on that doubt: the revision that route opens is a SIDE EFFECT of
+// a look-up, so staging a reorder on it would mint the shadow through a route
+// that tells a rejected caller nothing was changed. This command opens it
+// through `beginListingRevision` instead, which is classified `listingOpChange`
+// because opening it is what the caller asked for.
 //
 // There is deliberately NO interactive confirmation here, unlike runSetMedia's
 // step 3. That gate refuses in a non-TTY without --changelog/--yes, and adding

--- a/internal/cmd/app_listing_status_json_test.go
+++ b/internal/cmd/app_listing_status_json_test.go
@@ -479,9 +479,11 @@ func TestAppListingStatusJSONUsageErrorPrintsNothingAtAll(t *testing.T) {
 // 🔴 getMyListingForEdit OPENS A SHADOW REVISION on an APPROVED listing as a
 // server-side side effect (idempotently). A script polling `--json` in a loop is
 // therefore a WRITER, and the whole reason to give this command a machine
-// interface is that somebody will poll it. Its classification as a "read" is the
-// open question in civitai/cli#389; this test does not settle that, it only
-// pins that the help text tells the truth about it.
+// interface is that somebody will poll it. civitai/cli#389 doubted the route's
+// "read" classification and has since been measured: every refusal the server
+// can return precedes the write, so the 400 wording is honest — but the write on
+// SUCCESS is untouched by that, which is what this help text is about. This test
+// pins only that the help text tells the truth about the side effect.
 func TestAppListingStatusJSONHelpWarnsAboutTheShadowSideEffect(t *testing.T) {
 	cmd := newAppListingStatusCmd()
 	if cmd.Flags().Lookup("json") == nil {
@@ -531,15 +533,17 @@ const listing389IssueLink = "https://github.com/civitai/cli/issues/389"
 const wantREADMEListingWriteWarning = "- 🔴 **`listing status` is NOT a pure read — `--json` or not — so do not poll it in a loop.** On " +
 	"a LIVE (approved) listing the read behind it (`getMyListingForEdit`) opens the revision draft " +
 	"server-side, idempotently — the same one each time — so a script calling it repeatedly keeps a " +
-	"revision open on your listing. Whether that should still be classified a read is " +
-	"[#389](https://github.com/civitai/cli/issues/389), which is open. Reading it once per change is " +
+	"revision open on your listing. [#389](https://github.com/civitai/cli/issues/389) asked the " +
+	"narrower question of whether a call that FAILS could leave a revision behind; it cannot, because " +
+	"every refusal the server can return here is raised before the revision is opened. **That settles " +
+	"the error path only — the write on success is unchanged.** Reading it once per change is " +
 	"fine; a watch loop is a writer. ⚠ **This now applies to OFFSITE apps too.** Before " +
 	"[#422](https://github.com/civitai/cli/issues/422) every `app listing` subcommand refused for an " +
 	"offsite app and therefore could not write anything; now that they resolve by slug, `app listing " +
 	"status` against an **approved** offsite listing mints that shadow revision like any other. Every " +
 	"offsite app measured on civitai.com is approved, so this is the *normal* state there, not an " +
-	"edge case. #422 retired the \"cannot be addressed\" refusal; it did not retire #389 — the shadow " +
-	"is a property of `getMyListingForEdit`, not of how the listing id was obtained."
+	"edge case. #422 retired the \"cannot be addressed\" refusal, and #389 retired nothing about the " +
+	"write — the shadow is a property of `getMyListingForEdit`, not of how the listing id was obtained."
 
 // readmeTopLevelBullets splits md into its top-level markdown bullets: a line
 // beginning `- ` at column 0, plus every indented continuation line under it.


### PR DESCRIPTION
## What this settles

**civitai/cli#389** asks whether `getMyListingForEdit` — which this CLI classifies
`listingOpRead`, whose 400 wording is *"nothing was changed"* — can open its shadow
revision **before** validating the input. Its explicit open question: *"nobody here has
established whether the server opens the revision BEFORE or AFTER validating the
input"*.

**It is AFTER. Every refusal precedes the write.**

Read in `civitai/civitai` at `3ff050f2568504aa0c4c302f53818baaa35fbe11`,
`src/server/services/blocks/offsite-listing.service.ts`, in source order:

| line | step | on failure |
|---|---|---|
| `:1494` | `loadOwnedEditableListing` | `NOT_FOUND` / `NOT_OWNED` |
| `:1496` | `listing.revisionOfId != null` | `INVALID_REVISION` |
| `:1502` | the status switch | `removed`→`FORBIDDEN`, `rejected`→`MUST_RESUBMIT`, anything not `draft`/`pending`/`approved`→`INVALID_REVISION` |
| `:1540` | **`if (listing.status === 'approved') { beginListingRevision(...) }`** | — this is the write |

Everything that can refuse sits above `:1540`. The proc's zod input
(`getMyListingForEditSchema`, `offsite-listing.schema.ts:247`) and the
`appDeveloperProcedure` middleware reject before the resolver is entered at all.
`mapOffsiteError` (`app-listings.router.ts:252`) sends `NOT_FOUND`→404,
`NOT_OWNED`/`FORBIDDEN`→403, and every other typed code to 400. After the shadow-open
only 404 (`loadListingEditView`'s `NOT_FOUND`) and 500 are reachable. The one 400 that
can fire once the INSERT has been *attempted* — `beginListingRevision`'s
`if (!winner)` at `:1143` — fires only when no shadow row exists for the parent, i.e.
exactly when nothing was written.

So a 400 from this route means nothing was changed. `listingOpRead` is correct rather
than merely convenient — **#389's outcome A**.

## 🔴 What this does NOT settle

**The write on SUCCESS stands, and it got bigger.** A successful call against an
**approved** parent still mints a shadow revision. Since **#453** (#422 outcome 1)
`app listing` reaches **offsite** apps by slug, and every offsite app measured on
civitai.com is `approved` — so `app listing status` minting a shadow is now the
**normal** outcome there, not an edge case.

Every user-facing warning is kept verbatim in substance. Only the *"#389 is
open/unsettled"* framing changes. `app listing status` is still not a pure read, still
must not be polled, and still must not be pointed at a real app.

## Surfaces updated

- `internal/appapi/listing.go` — the `listingOp` doc. **This is where the measurement
  now lives**: the ordering, what it establishes, and an explicit 🔴 paragraph on what
  it does not.
- `internal/cmd/app_listing.go` — `status`'s `Long`, and `runReorder`'s rejection of
  route (b) (whose stated reason *was* "the classification is an open question"; the
  rejection stands on a different, unchanged reason).
- `README.md` — the write-warning bullet, and its whole-string pin
  (`wantREADMEListingWriteWarning`).
- `claudedocs/decisions/29-offsite-refusal.md` — "which is OPEN".

`internal/cmd/exitcodes_doc.go` does not mention this, so no generated prose moved.

## Guards

Four fought this, all correct, none weakened:

- `TestAppListingStatusJSONHelpWarnsAboutTheShadowSideEffect` — kept `"389"`,
  `"--json"`, `"poll"`, `"shadow revision"`, `"editTargetId"`.
- `TestREADMEPinsTheListingStatusWriteWarning` — literal moved with the bullet.
- `TestTheShadowWriteWarningIsOnBothPublishedSurfaces` — the seam ledger still sees
  both surfaces.
- `TestListingHelpStaysWithinTheBudget` — **caught the first draft** of the `Long` at
  1608 runes against a 1400 budget. Satisfied by compressing the new sentence to two
  lines, not by raising the budget.

Mutation-checked, each dying with its own message: rewording one clause of the README
bullet reddens `TestREADMEPinsTheListingStatusWriteWarning` **only** (the seam ledger
stays green — it asserts a different thing); replacing the `civitai/cli#389` citation in
the `Long` reddens **both** the help-text guard and the seam ledger.

## Gate

- `make ci` — 21/21 packages `ok`, 0 FAIL.
- `golangci-lint` v2.12.2 — **0 issues**.
- `./scripts/ci-shallow.sh` on the committed tree (`c3954e1`) — `ok=20/20
  failing-tests=0 failing-packages=0 timeouts=0 go-test-rc=0`.
- `gofmt -s -l .` — 0 files.

No live `app listing` call was made against any real app; all verification is against
the server source and the `httptest` fakes.

**#389 is deliberately left open** — close it when this merges, so the code and the
issue never disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
