### PR TITLE
fix(ci): stage only flake.nix in the vendorHash bot's PR, and ignore nix out-links

### DIFF
--- a/.github/workflows/bump-flake-vendorhash.yml
+++ b/.github/workflows/bump-flake-vendorhash.yml
@@ -232,6 +232,29 @@ jobs:
           # the repo's normal CI (the `flake` build check). Shared with the
           # other drift-bots (bump-scaffold-pins / revendor-canonical-schema).
           token: ${{ secrets.BUMP_SCAFFOLD_PINS_TOKEN }}
+          # 🔴 STAGE ONLY flake.nix. Without `add-paths` this action stages
+          # EVERYTHING in the tree, untracked files included — and the two
+          # validate steps directly above run `nix build`, which drops a
+          # `result` symlink into the repo root on success. So the bot committed
+          # a pointer into /nix/store alongside its hash bump: PR #450 shipped
+          # `result -> /nix/store/kkfnywjq…-civitai-4e35eaa-dirty`, and all 13
+          # CI checks were green on it — nothing here detects the artifact, so
+          # the guard has to be that it is never staged.
+          #
+          # Note the ordering that hid this: `detect changes` runs BEFORE the
+          # validate steps, so its `git status --porcelain` is clean of `result`
+          # and the changed=true/false gate is unaffected. The symlink only
+          # exists during the window between validation and this step.
+          #
+          # This value is the COMPLETE set of paths the job may write, not a
+          # convenience filter. Audited against every step: the recompute step's
+          # two `sed -i`s and its `git checkout --` restore touch flake.nix and
+          # nothing else, and its nix log goes to `$RUNNER_TEMP`. If a future
+          # step writes another file that BELONGS in the PR, add it here — an
+          # unlisted path is silently dropped from the commit, and a bot that
+          # opens an incomplete PR is worse than the artifact this prevents.
+          # `.gitignore` also carries `/result`, as a second, independent layer.
+          add-paths: flake.nix
           branch: automation/bump-flake-vendorhash
           delete-branch: true
           commit-message: "chore(nix): bump flake vendorHash to match go.sum"

--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -238,6 +238,28 @@ jobs:
           npm run typecheck
           npm run build
 
+      # NO `add-paths:` here, deliberately — and that is a decision, not an
+      # oversight. This action stages `git add -A` when `add-paths` is absent,
+      # so ANY file a step leaves in the workspace rides into the PR. That is
+      # exactly how the sibling `bump-flake-vendorhash` committed a `result`
+      # symlink into /nix/store (#450, green on all 13 checks); it now pins
+      # `add-paths: flake.nix`.
+      #
+      # This job was audited against that failure and does not have it: the only
+      # step that writes into the repo is the bumper, and `bump-pins` writes
+      # exclusively under its `--dir` (default `internal/scaffold`) to three
+      # constant sites. Everything else writes outside the tree — `go test`
+      # writes nothing, and `validate — scaffold builds` scaffolds and runs npm
+      # in `$RUNNER_TEMP` on purpose (see that step's comment). Measured, not
+      # just read: `git status --porcelain` is clean of artifacts after the test
+      # suite and after a `civitai app init --dir "$RUNNER_TEMP/…"`.
+      #
+      # 🔴 If you add a step that builds/installs/generates INTO the workspace,
+      # add `add-paths` naming the complete set of files this bot may commit —
+      # `internal/scaffold` is the bumper's provable write root. Note the
+      # trade-off before reaching for it as a reflex: a path that is written but
+      # NOT listed is silently dropped from the commit, and a bot that opens an
+      # incomplete PR is worse than the artifact the filter prevents.
       - name: open PR if pins changed
         id: pr
         if: steps.changed.outputs.changed == 'true'

--- a/.github/workflows/revendor-canonical-schema.yml
+++ b/.github/workflows/revendor-canonical-schema.yml
@@ -152,6 +152,25 @@ jobs:
         # examples/*.block.manifest.json) runs too, not just internal/validate.
         run: go test ./...
 
+      # NO `add-paths:` here, deliberately — and that is a decision, not an
+      # oversight. This action stages `git add -A` when `add-paths` is absent,
+      # so ANY file a step leaves in the workspace rides into the PR. That is
+      # exactly how the sibling `bump-flake-vendorhash` committed a `result`
+      # symlink into /nix/store (#450, green on all 13 checks); it now pins
+      # `add-paths: flake.nix`.
+      #
+      # This job was audited against that failure and does not have it: the only
+      # step that writes into the repo is the re-vendor script, which `cp`s to a
+      # single path it computes from its own location
+      # (`schema/app-block.manifest.schema.json`) and downloads via `mktemp`
+      # outside the tree; `go test ./...` writes nothing. Measured, not just
+      # read: `git status --porcelain` is clean of artifacts after the suite.
+      #
+      # 🔴 If you add a step that builds/installs/generates INTO the workspace,
+      # add `add-paths` naming the complete set of files this bot may commit.
+      # Note the trade-off before reaching for it as a reflex: a path that is
+      # written but NOT listed is silently dropped from the commit, and a bot
+      # that opens an incomplete PR is worse than the artifact it prevents.
       - name: open PR if schema changed
         id: pr
         if: steps.changed.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ coverage.html
 .DS_Store
 .venv/
 /.claude/worktrees
+
+# `nix build` drops an out-link symlink into the invocation cwd (the repo root),
+# named `result` — or `result-<output>`/`result-<n>` when a build has several
+# outputs or several installables are built at once. It is a pointer into
+# /nix/store and must never be committed. This is DEFENCE IN DEPTH behind the
+# `add-paths:` on the `bump-flake-vendorhash` bot: that bot runs `nix build`
+# before opening its PR, and with neither guard the symlink rode along into the
+# PR diff (#450 committed `result -> /nix/store/kkfnywjq…-civitai-4e35eaa-dirty`
+# and all 13 CI checks stayed green).
+/result
+/result-*

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
           # Computed from go.sum (this module is not vendored). To recompute
           # after a go.mod/go.sum change: set this to `lib.fakeHash`, run
           # `nix build`, and copy the `got: sha256-…` value from the error.
-          vendorHash = "sha256-prgKRC+357KX7vJ9jcIq2+1FUD91a2Gg5Q89R+FTZ+g=";
+          vendorHash = "sha256-l0RyxhS7+tdL9FngitiUhrciQbZfyDmTp5tP3Kd6NGQ=";
 
           # The module root is `package cli` (a library that embeds the schema);
           # the executable lives in ./cmd/civitai (package main). Build only it.


### PR DESCRIPTION
Supersedes #450 — do not merge that one as-is; it carries the artifact this PR exists to prevent. Leaving it open is a decision for a human; see "What to do with #450" below.

## The defect

The `bump-flake-vendorhash` bot commits a nix build artifact into its own PR. #450 changed two things:

1. `flake.nix` — `vendorHash` → `sha256-l0RyxhS7+tdL9FngitiUhrciQbZfyDmTp5tP3Kd6NGQ=` (legitimate)
2. **`result`** — a new symlink to `/nix/store/kkfnywjqbl2gmgnghrcxynxz07i8p4v2-civitai-4e35eaa-dirty` (must never land)

All 13 CI checks were green on #450. Nothing in this repo detects the artifact, so the guard has to be that it is never staged.

## Mechanism

In `.github/workflows/bump-flake-vendorhash.yml`:

- the two validate steps run `nix build .#default` and `./result/bin/civitai version`. A **successful** `nix build` drops a `result` out-link symlink into the invocation cwd — the repo root.
- `result` was not in `.gitignore` (`git check-ignore result` found nothing).
- the `open PR if vendorHash changed` step uses `peter-evans/create-pull-request` with no `add-paths`, and in that case the action runs `git add -A`, staging every change in the tree including untracked files.

That last point is read from the action's own source at the SHA this repo pins (`c5a7806`), not from memory — `src/create-or-update-branch.ts`:

```ts
if (await git.isDirty(true, addPaths)) {
  const aopts = ['add']
  if (addPaths.length > 0) {
    aopts.push(...['--', ...addPaths])
  } else {
    aopts.push('-A')
  }
```

**The ordering is why this hid.** `detect changes` runs *before* the validate steps, so its `git status --porcelain` gate never sees `result` and the changed=true/false decision is unaffected. The symlink exists only in the window between validation and the PR step — which is exactly the window the action reads.

## The fix — two independent guards

**1. `add-paths: flake.nix` on the create-pull-request step.** The authoritative fix: the action stages exactly the file the workflow is allowed to change, so no future artifact can ride along regardless of what a later step leaves in the workspace. A comment on the step records why it is there and what changing it costs.

I audited every step in the job that writes to the working tree, because an unlisted path is silently dropped from the commit and a bot that opens an incomplete PR is worse than the artifact:

| Step | Writes to the tree? |
|---|---|
| `actions/checkout` / `install-nix-action` | no |
| `recompute flake vendorHash` | `flake.nix` only — two `sed -i`s and a `git checkout -- flake.nix` restore. Its nix log goes to `$RUNNER_TEMP/nix-build.log` |
| `detect changes` | no — `git status` only |
| `validate — flake builds` | the `result` out-link (the artifact) |
| `validate — the built binary runs` | no |
| `classify the outcome` | no — writes `$GITHUB_OUTPUT` |

`flake.nix` is the complete set of files this job may commit.

**2. `/result` + `/result-*` in `.gitignore`.** Defence in depth, covering nix's numbered/named out-link variants (`result-1`, `result-bin`). Anchored to the repo root so a legitimately named file deeper in the tree is unaffected — verified that `flake.nix` and `schema/app-block.manifest.schema.json` are still *not* ignored, so neither this bot nor its siblings can be broken by the rule.

**3. The vendorHash bump itself**, so the flake is correct on `main` even though the superseded PR never lands.

## Sibling drift-bot audit

Three workflows use `peter-evans/create-pull-request`; **none** had `add-paths`. Only one is actually exposed.

| Workflow | `add-paths` before | Can a step leave an artifact? | Verdict |
|---|---|---|---|
| `bump-flake-vendorhash` | none | **Yes** — `nix build` drops `result` in the repo root, and it is not ignored | **EXPOSED. Fixed** (`add-paths: flake.nix` + `.gitignore`) |
| `bump-scaffold-pins` | none | No. `bump-pins` writes only under its `--dir` (default `internal/scaffold`) to three constant sites; `go test` writes nothing; `validate — scaffold builds` deliberately scaffolds and runs `npm install`/`typecheck`/`build` in `$RUNNER_TEMP` (its own comment says "so the generated app never pollutes the auto-PR diff") | Safe. **Comment only** — records the audit and names `internal/scaffold` as the write root to use if a future step changes this |
| `revendor-canonical-schema` | none | No. `scripts/revendor-canonical-schema.sh` downloads to a `mktemp` outside the tree and `cp`s to one path it computes from its own location (`schema/app-block.manifest.schema.json`); `go test ./...` writes nothing | Safe. **Comment only**, same rationale |

Both "safe" verdicts are **measured, not only read**: `git status --porcelain` was clean of artifacts after the full `go test ./...` suite and after a real `go run ./cmd/civitai app init … --dir "$RUNNER_TEMP/…" --template page-money`.

I deliberately did **not** add `add-paths` to the two safe bots. It would be a reflex rather than a fix: neither can currently leak, and a path that is written but not listed is silently dropped from the commit. The comments say what to do if that changes.

## What I verified, and what I did not

**Verified by execution:**

- **The vendorHash, independently re-derived — not copied.** With `vendorHash` set to the workflow's own fake, `nix build .#default` reported `got: sha256-l0RyxhS7+tdL9FngitiUhrciQbZfyDmTp5tP3Kd6NGQ=`, matching #450 exactly. `go.mod`/`go.sum` are byte-identical between #450's head and `main`.
- **End-to-end with the new hash:** `nix build .#default` succeeds and `./result/bin/civitai version` runs (`civitai a3720f6-dirty`, go1.26.4).
- **The leak itself reproduces:** after that successful build, `git status --porcelain` showed ` M flake.nix` **and** `?? result` — the exact pair the action would have staged.
- **The `.gitignore` rule works, with both controls:** `git check-ignore -v` matches `result` (`.gitignore:19`) and `result-1` (`.gitignore:20`); `git status --untracked-files=all` no longer surfaces either; and as a negative control `flake.nix` and the schema file are still not ignored.
- **`add-paths` is a real input at the pinned SHA** (`c5a7806`) — checked against the action's `action.yml`, because an unrecognized `with:` key is only a *warning* in Actions and would have silently done nothing.
- **The YAML still parses** and `add-paths: flake.nix` is attached to the intended step (asserted programmatically), with no `add-paths` anywhere in the two sibling files.
- **Repo gates, counted rather than read off an exit code:** `go build ./...` clean, `go vet ./...` clean, `gofmt -s -l .` empty, `golangci-lint run` → `0 issues.`, and `go test ./... -count=1 -v` → **4416 `=== RUN`, 4412 `--- PASS`, 0 `--- FAIL`, 4 `--- SKIP`** (the four skips are the network/env-gated ones), no `panic: test timed out`. The FAIL counter was positive-controlled against a synthetic `--- FAIL` line so a zero means zero rather than a broken pattern.

**NOT verified — stated plainly:**

- **I did not run the workflow.** The `add-paths` change is unexercised. The honest claim is: *the value names the only file this job writes, confirmed by reading every step that touches the working tree, and the action's own source at the pinned SHA shows `add-paths` selects `git add -- <paths>` instead of `git add -A`.* I am **not** claiming "the artifact can no longer leak" — that becomes a verified statement on the bot's next real run.
- **What to watch on the next run:** that the bot still opens a PR at all when the hash drifts (an over-narrow `add-paths` would make it open none), and that the PR touches `flake.nix` only.
- My diff contains **zero Go changes**, so build/vet/test/lint here are regression backstops, not evidence about the fix.

## What to do with #450

**My recommendation: close it, do not fix it in place.** This PR carries #450's entire legitimate payload (the identical one-line hash change, independently re-derived), so there is nothing left in it to salvage. Fixing it in place would mean pushing to `automation/bump-flake-vendorhash`, a branch the bot owns and recreates — and `delete-branch: true` means the next run will churn it anyway. Once this merges, the bot's next run recomputes the same hash, finds no drift, and opens nothing.

Not closing it automatically from here, and no close keyword is used anywhere in this body — that is deliberate.
