### PR TITLE
feat(submit): stamp the commit a bundle was built from, and surface it in `app status` (#411)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,7 @@ published, and why the command that publishes it exits NON-ZERO on a refusal the
 attach path reports as progress.
 Item 31 is a deliberate non-mirror on the submit path: the packager's own size
 caps, and the server ceiling behind them that #423 bracketed but could not pin.
+Item 32 is what a submit may CLAIM about the source it was built from.
 The durable fix for the mirroring is a server-side `civitai app validate` endpoint
 calling the real `BlockManifestValidator`; until that exists, vendoring is on
 purpose.
@@ -430,6 +431,12 @@ item must carry a trigger that is a routing question rather than a label
     than refuses: `appapi.SubmitBodySize` (base64-in-JSON, so the wire size is
     ~4/3 of "compressed" — that is what a body limit applies to) and
     `pkgzip.LargestEntries`, only under a failed submit. Name no server ceiling.
+
+32. **Sending or showing the commit an app was built from — the 40-hex gate,
+    `sourceDirty`'s null-vs-false, or the submit body's size?** An UNVERIFIED
+    client claim: word none of it as verified, never `?? false`, and send
+    nothing rather than a value `^[0-9a-f]{40}$` rejects — malformed is a 400
+    that fails the submit (#411).
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ contract, and **packages/submits** it for review.
   - [After you submit: review → approve → deploy](#after-you-submit-review--approve--deploy)
   - [Listing media requirements](#listing-media-requirements)
 - [Submission status](#submission-status)
+  - [Build provenance: which commit is live?](#build-provenance-which-commit-is-live)
   - [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped)
   - [Deployed is not the same as listed in the store](#deployed-is-not-the-same-as-listed-in-the-store)
 - [Pull your app's repository (`app pull`)](#pull-your-apps-repository-app-pull)
@@ -317,10 +318,10 @@ README. For the end-to-end walkthrough, see
 | `civitai app dev-token <slug> [--env] [--spend] [--budget <n>]` | **Mint a short-lived (~4h) dev block token for `npm run dev:live`.** `--spend` must be asked for explicitly to request real-Buzz spend — without it the CLI filters `ai:write:budgeted` out of the mint request. `--env` prints a paste-ready `VITE_LIVE_BLOCK_TOKEN=<token>`. See [Local dev loop](#local-dev-loop-harness-mock-vs-live). |
 | `civitai app dev-tunnel [blockId] [--block <id>] [--port <n>] [--local-host <host>] [--tunnel-endpoint <h:p>] [--idle-timeout <d>] [--ready-timeout <d>] [--no-wait]` | **(Pre-GA / invite-gated)** Preview your **local** dev server inside the **real** Civitai host at `civitai.com/apps/dev/<blockId>` — a prod-fidelity inner-dev-loop. Pre-flights whether the host can actually **embed** your dev server and warns (never fatally) when it cannot. See [Preview in the real host](#preview-in-the-real-host-app-dev-tunnel). |
 | `civitai app validate [dir] [--strict] [--json]` | Best-effort local pre-check of `block.manifest.json`; emits non-fatal warnings (`--strict` fails on them). `--json` emits the structured result (`ok`, plus `errors`/`warnings` each with `field`/`message` — **`field` is always present and never `null`**) for scriptable parsing — still exits non-zero on failure. 🔴 **BREAKING:** a `[dir]` that does not exist, or is not a directory, is now a **usage error** — exit `2` with **no JSON object** on stdout, where it used to print `{"ok": false, …}` and exit `1`. See [Validate fidelity](#validate-fidelity) and [The `--json` result shape](#the---json-result-shape). |
-| `civitai app submit [dir] [--yes] [--package-only] [--out f.zip] [--skip-validate] [--allow-downgrade] [--allow-dirty]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). **A submit that would really upload asks for confirmation, and in a non-interactive shell it refuses without `--yes`** — `civitai app submit --yes` is the CI form. (The refusal is reached only when there is a token to upload with: `--package-only`, and the no-token fallback that just writes the .zip, never submit and so never ask.) **It also refuses a version that is not strictly above the highest APPROVED version of that app** — approving an older (or identical) version replaces the newer live deployment — with `--allow-downgrade` as the deliberate-rollback escape hatch. **And it refuses a dirty git work tree** — the bundle is packaged from what is on disk, so approving one deploys code that exists in no commit — with `--allow-dirty` as the escape hatch; that guard degrades rather than enforcing, so a directory in no git repo (every scaffolded app starts that way) submits unchanged, and a clean tree whose `HEAD` is on no remote warns instead of refusing. All three refusals are skipped on the routes that never reach the server. |
+| `civitai app submit [dir] [--yes] [--package-only] [--out f.zip] [--skip-validate] [--allow-downgrade] [--allow-dirty]` | Validate + package the source tree + upload it with your stored token (or, with no token, write the bundle + print next steps). **A submit that would really upload asks for confirmation, and in a non-interactive shell it refuses without `--yes`** — `civitai app submit --yes` is the CI form. (The refusal is reached only when there is a token to upload with: `--package-only`, and the no-token fallback that just writes the .zip, never submit and so never ask.) **It also refuses a version that is not strictly above the highest APPROVED version of that app** — approving an older (or identical) version replaces the newer live deployment — with `--allow-downgrade` as the deliberate-rollback escape hatch. **And it refuses a dirty git work tree** — the bundle is packaged from what is on disk, so approving one deploys code that exists in no commit — with `--allow-dirty` as the escape hatch; that guard degrades rather than enforcing, so a directory in no git repo (every scaffolded app starts that way) submits unchanged, and a clean tree whose `HEAD` is on no remote warns instead of refusing. All three refusals are skipped on the routes that never reach the server. **A submit that really uploads also STAMPS the commit it was built from** (`sourceCommit`, plus `sourceDirty` when it could establish it), so `civitai app status` can say which source a live version came from — a client CLAIM the server stores unverified, absent entirely where there is no repo, no `git`, or no commit. |
 | `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
 | `civitai app listing status [--json]\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>\|submit-revision` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires, and `listing status --json` emits the same read as one object — including **`parentId` and `shadowId`, the two listing ids a change is addressed to**, which the human output shows neither of. 🔴 **`--json` is not a pure read: on a live listing it opens the revision draft described below, so do not poll it.** The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. **On a listing that is already LIVE, every change — including `reorder` — opens a REVISION for moderator re-review rather than editing the live listing**, and `listing status` reports that in-progress revision's media (so the `alsc_…` ids it prints are the revision's, which is what `reorder` addresses). `rm-screenshot` is the one change deliberately left **staged**: it does **not** submit the revision (curating a gallery is usually several removals), so `submit-revision` is what sends it to moderator review and makes the change public. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
-| `civitai app status [blockId] [--id <pubreq>] [--limit N] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; `--limit N` shows only the newest N (display-side — this route cannot page); a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). Run from **inside** an app checkout it also warns on **stderr** when your local `block.manifest.json` is **BEHIND** your highest approved version — advisory only, the exit code never changes. See [Submission status](#submission-status) and [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped). |
+| `civitai app status [blockId] [--id <pubreq>] [--limit N] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; `--limit N` shows only the newest N (display-side — this route cannot page); a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). Run from **inside** an app checkout it also warns on **stderr** when your local `block.manifest.json` is **BEHIND** your highest approved version — advisory only, the exit code never changes. A **SOURCE** column shows the commit the submitting client claimed (short sha, `(dirty)` when it said the tree was uncommitted, `-` when it claimed nothing); the detail view and `--json` carry the full 40 characters, and `sourceDirty` is a tri-state — `null` is *not reported*, `false` is *reported clean*. See [Submission status](#submission-status), [Build provenance](#build-provenance-which-commit-is-live) and [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>] [--yes]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. **Also deletes a first-version app's store listing — icon, cover and every captioned screenshot**, so it asks first and needs `--yes` in a script. Idempotent for the submission only; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--out-name <template>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
@@ -1219,6 +1220,13 @@ of the compressed size. That number is exact, not an estimate, and it is printed
 on every path — including `--package-only`, which is how you inspect a bundle
 you cannot submit.
 
+A submit that carries [build provenance](#build-provenance-which-commit-is-live)
+sends `sourceCommit` and `sourceDirty` in that same document, so its body is
+about **70 bytes larger**. The printed number accounts for it: it is computed
+from the body *this run* will send, not from a fixed envelope — which is why the
+`--package-only` and no-token paths, which stamp nothing, print exactly the
+number they always did.
+
 **The size caps this CLI enforces are its own, not the server's.** They are
 generous (2000 files, 10 MiB per file, 50 MiB compressed, 200 MiB decompressed)
 and clearing them is **not** a prediction that the submit will be accepted.
@@ -1787,10 +1795,10 @@ With no argument it lists every submission, newest first:
 
 ```text
 $ civitai app status
-BLOCK_ID    VERSION  STATUS    DEPLOY    SUBMITTED   URL
-gen-matrix  0.6.0    approved  live      2026-06-22  https://gen-matrix.civit.ai/
-my-block    0.2.0    pending   -         2026-06-21  -
-old-app     0.1.0    approved  building  2026-06-19  -
+BLOCK_ID    VERSION  STATUS    DEPLOY    SOURCE            SUBMITTED   URL
+gen-matrix  0.6.0    approved  live      a1b2c3d           2026-06-22  https://gen-matrix.civit.ai/
+my-block    0.2.0    pending   -         9f4e0aa (dirty)   2026-06-21  -
+old-app     0.1.0    approved  building  -                 2026-06-19  -
 ```
 
 Pass a `blockId` (app slug) or `--id <pubreq_id>` to see one in detail — including
@@ -1804,8 +1812,10 @@ Version:          0.6.0
 Publish request:  pubreq_01HZX
 Status:           rejected
 Deploy state:     -
+Source commit:    a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 (reported clean)
 Submitted:        2026-06-22 09:05 CDT
 Reviewed:         2026-06-22 11:40 CDT
+  Reported by the client that submitted it; the server stores it unverified.
 
 Rejection reason:
   the budgeted scope needs the per-app Sybil cap signed off first
@@ -1848,8 +1858,8 @@ the cap.
 
 ```text
 $ civitai app status --limit 5
-BLOCK_ID    VERSION  STATUS    DEPLOY    SUBMITTED   URL
-gen-matrix  0.6.0    approved  live      2026-06-22  https://gen-matrix.civit.ai/
+BLOCK_ID    VERSION  STATUS    DEPLOY    SOURCE   SUBMITTED   URL
+gen-matrix  0.6.0    approved  live      a1b2c3d  2026-06-22  https://gen-matrix.civit.ai/
 …
 ```
 
@@ -1870,6 +1880,54 @@ silently ignoring the flag would be worse than saying so.
 "run `civitai app submit`" hint; with no token it points you at `civitai login`.
 Notes like the cap caveat go to stderr, so `--json` stdout stays pure and the
 exit code stays 0.
+
+### Build provenance: which commit is live?
+
+`civitai app submit` records **which source it was built from**, and
+`civitai app status` shows it. The bundle is packaged from what is on disk, so
+before this a live version could not be traced to a commit at all — five
+first-party apps were live at a version their repo had never held
+([#411](https://github.com/civitai/cli/issues/411)).
+
+What the CLI sends with a submit that really uploads:
+
+- **`sourceCommit`** — the full 40-character sha of `HEAD` in the packaged
+  directory's repository.
+- **`sourceDirty`** — `true` when files that go into the bundle were
+  uncommitted (only reachable with `--allow-dirty`, which is exactly the case
+  worth recording), `false` when the tree was clean.
+
+🔴 **It is a CLAIM, not a proof.** The server stores what the client reports and
+cannot check that the bundle was built from that commit — a different machine,
+a different client, or a modified one all produce a row that looks identical.
+The CLI says so wherever it prints the value, and you should read it the same
+way: it is a very good pointer and it is not an attestation.
+
+🔴 **It degrades rather than guessing, and a missing stamp never fails a
+submit.** Nothing is sent when the packaged directory is in no git repo (every
+scaffolded app starts that way), when there is no `git` on `PATH`, when the repo
+has no commits yet, or when the CLI cannot resolve a value in exactly the shape
+the server accepts (`^[0-9a-f]{40}$`). The server answers a malformed
+`sourceCommit` with a `400` that fails the whole upload, so the CLI sends
+*nothing* rather than something it is unsure of — a provenance stamp must never
+cost you the submit it is describing.
+
+Reading it back, `sourceDirty` is a **tri-state** and the difference is
+load-bearing:
+
+| `--json` value | `SOURCE` column | meaning |
+| --- | --- | --- |
+| `null` (or absent) | `-`, or `a1b2c3d (dirty?)` when only the commit is known | **nobody reported it** — submitted before this shipped, from a non-repo, or by another client |
+| `false` | `a1b2c3d` | a client **asserted** the tree was clean |
+| `true` | `a1b2c3d (dirty)` | a client asserted uncommitted changes went into the bundle |
+
+`null` and `false` are different answers: do not collapse them in a script. The
+table abbreviates to 7 characters for width; `civitai app status <blockId>` and
+`--json` both carry all forty.
+
+The dirty-tree **refusal** is the other half of the same issue and is unchanged:
+see [Exit code 1](#exit-code-1). `--allow-dirty` still submits, still refuses
+nothing, and now marks what it let through.
 
 ### Is your repo behind what you shipped?
 
@@ -3051,6 +3109,7 @@ fi
 - A resource that **exists but is not ready** lands here too, and deliberately not on `4`: `civitai app metrics <slug>` for an app whose submitted version is still in review exits `1`, because the slug is right and the app does exist — only its analytics do not exist yet, and the error names `civitai app status <slug>` as the next command. `4` stays reserved for a slug with no submissions at all, so the two remain separately actionable: fix the slug, versus wait for approval.
 - A **version regression** lands here for the same reason: `civitai app submit` refuses when the manifest version is not strictly **above the highest approved version** of that app, because approving an older (or identical) version replaces the newer live deployment. Nothing about the invocation is wrong, so it is a verdict about the project, not a `2`. `--allow-downgrade` is the deliberate-rollback escape hatch, and the guard is skipped entirely by `--package-only` or a run with no token — neither reaches the server.
 - A **dirty git work tree** lands here too: `civitai app submit` refuses while files that go into the bundle are uncommitted, because the bundle is packaged from what is on disk and approving one deploys code that exists in no commit. `--allow-dirty` submits the tree as it is. It **degrades rather than enforcing** — a directory that is not in a git repo, or a machine with no `git` on `PATH`, submits exactly as before (scaffolded apps have no repo, and that path must keep working), and a clean tree whose `HEAD` is on no remote **warns** instead of refusing. Like the version guard it is skipped by `--package-only` and by a run with no token.
+- The **build-provenance stamp** those two guards now also collect (issue #411 — the commit `civitai app submit` reports and `civitai app status` shows) changes no exit code at all, in either direction. It is sent only when the CLI can establish a value in exactly the shape the server accepts (`^[0-9a-f]{40}$`); every branch that cannot — no repo, no `git` on `PATH`, a repo with no commits, or an answer it does not recognise — sends nothing and submits exactly as it did before. A submit that would have succeeded cannot fail because of it, and a missing stamp is never an error.
 - **"Wait for approval" is the *pending* case only.** The same `1` covers an app whose latest submission was **rejected** or **withdrawn** — nothing is in review there, so `civitai app metrics <slug>` says so and names a new `civitai app submit` as the next step instead of a review to wait for. What separates `1` from `4` is unchanged: the slug is right and the app exists.
 
 ### Exit code 2

--- a/internal/appapi/api_extra_test.go
+++ b/internal/appapi/api_extra_test.go
@@ -34,7 +34,7 @@ func TestSubmitVersionStatusErrors(t *testing.T) {
 			_, _ = w.Write([]byte(`{"error":"boom"}`))
 		}))
 		c := New(srv.URL, "tok", "")
-		_, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0")
+		_, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0", Provenance{})
 		srv.Close()
 		if err == nil {
 			t.Errorf("status %d: expected error", tc.status)
@@ -52,7 +52,7 @@ func TestSubmitVersionGarbageResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 	c := New(srv.URL, "tok", "")
-	if _, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0"); err == nil {
+	if _, err := c.SubmitVersion(context.Background(), []byte("z"), "my-block", "0.1.0", Provenance{}); err == nil {
 		t.Fatal("expected error for non-JSON 200 response")
 	}
 }

--- a/internal/appapi/api_test.go
+++ b/internal/appapi/api_test.go
@@ -56,7 +56,7 @@ func TestSubmitVersionSendsBearerAndBase64(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok123", "/api/blocks/submit-version")
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIPDATA"), "my-block", "0.1.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIPDATA"), "my-block", "0.1.0", Provenance{})
 	if err != nil {
 		t.Fatalf("SubmitVersion: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestSubmitVersionSurfacesServerMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok", "")
-	_, err := c.SubmitVersion(context.Background(), []byte("x"), "my-block", "0.1.0")
+	_, err := c.SubmitVersion(context.Background(), []byte("x"), "my-block", "0.1.0", Provenance{})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -32,7 +33,61 @@ import (
 // lost to a timeout, the submit path can poll for a landed submission and
 // recover rather than reporting a false failure (see SubmitVersion).
 type Submitter interface {
-	SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string) (*SubmitResult, error)
+	SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string, prov Provenance) (*SubmitResult, error)
+}
+
+// Provenance is what the CLI CLAIMS about the source the bundle was built from
+// (issue #411, the stamp half). It is a claim and never a proof: the server
+// stores what it is told and cannot check that these bytes were built from that
+// commit, so nothing rendered from it may be worded as verified fact.
+//
+// Both halves are optional and independently unknown, which is why Dirty is a
+// pointer:
+//
+//	Commit == "" , Dirty == nil   → unknown (no repo, no git, unborn HEAD)
+//	Commit == sha, Dirty == false → the client asserted a CLEAN tree
+//	Commit == sha, Dirty == true  → the client asserted a DIRTY tree (--allow-dirty)
+//	Commit == sha, Dirty == nil   → the commit is known, dirtiness is not
+//
+// 🔴 nil AND false ARE DIFFERENT ANSWERS ON BOTH SIDES OF THE WIRE. `null` (or
+// an absent key) means nobody said; `false` means a client looked and said
+// clean. Collapsing them with `?? false` invents an assertion the CLI never
+// made, and it is the same tri-state the READ path carries back on
+// Submission.SourceDirty.
+type Provenance struct {
+	// Commit is the full 40-character lowercase hex sha of HEAD, or "" when it
+	// is not known. Anything that is not sourceCommitRe is treated as unknown —
+	// see sanitised.
+	Commit string
+	// Dirty is the client's assertion about its own work tree. nil ⇒ unknown.
+	Dirty *bool
+}
+
+// sourceCommitRe is the server's own validator, mirrored (civitai/civitai#4061,
+// POST /api/v1/blocks/submit-version): `sourceCommit` must be 40 lowercase hex
+// characters.
+//
+// 🔴 IT IS MIRRORED HERE BECAUSE A MALFORMED VALUE IS A HARD 400 THAT FAILS THE
+// WHOLE SUBMIT. The server rejects the request rather than dropping the field —
+// deliberately, because silently dropping is the inert-feature shape — so the
+// burden is on this side: a provenance stamp is a diagnostic nicety and an
+// upload is the user's actual job, and the nicety must never cost the job. Every
+// value that does not match is sent as ABSENT.
+var sourceCommitRe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// sanitised returns the fields that may go on the wire, and it is the ONE gate
+// they pass through — SubmitVersion and SubmitBodySize both call it, so the size
+// the CLI reports and the body it sends cannot disagree about what was included.
+//
+// 🔴 AN UNUSABLE COMMIT DROPS THE DIRTY FLAG WITH IT. `sourceDirty` alone says
+// "the tree I cannot name was dirty", which is not a fact anyone can act on, and
+// the matrix in issue #411 spells every branch that cannot resolve HEAD as
+// "send nothing" rather than "send half".
+func (p Provenance) sanitised() (string, *bool) {
+	if !sourceCommitRe.MatchString(p.Commit) {
+		return "", nil
+	}
+	return p.Commit, p.Dirty
 }
 
 // Verifier verifies a token and returns the authenticated identity.
@@ -78,6 +133,19 @@ type Submission struct {
 	UpdatedAt       string  `json:"updatedAt"`
 	CreatedAt       string  `json:"createdAt"`
 	LiveURL         *string `json:"liveUrl"` // set once serving (approved+live)
+	// SourceCommit / SourceDirty are the submitting CLIENT'S CLAIM about the
+	// source the bundle was built from (issue #411; server side
+	// civitai/civitai#4061). The server stores them unverified — it cannot check
+	// that the bundle came from that commit — so every rendering says who said
+	// it. Both are pointers because the tri-state is the whole point:
+	//
+	//	nil   → UNKNOWN: a row from before the feature, or a client that sent nothing
+	//	false → the client asserted a CLEAN work tree
+	//	true  → the client asserted a DIRTY work tree
+	//
+	// 🔴 nil AND false ARE DIFFERENT ANSWERS. Never `?? false`.
+	SourceCommit *string `json:"sourceCommit"`
+	SourceDirty  *bool   `json:"sourceDirty"`
 }
 
 // Subject identifies the credential behind a token as returned by
@@ -429,20 +497,68 @@ func (c *Client) doOnceWith(httpClient *http.Client, build func() (*http.Request
 	return resp.StatusCode, raw, nil
 }
 
-// submitBody mirrors submitVersionSchema: a base64-encoded ZIP.
+// submitBody mirrors submitVersionSchema: a base64-encoded ZIP, plus the
+// optional provenance the client claims for it (issue #411).
+//
+// 🔴 BOTH PROVENANCE FIELDS ARE `omitempty`, AND FOR SourceDirty THAT IS A
+// DECISION ABOUT THE TRI-STATE, NOT A TIDINESS ONE. It is a *bool: omitempty
+// drops a NIL pointer and keeps a pointer to false, so "unknown" leaves the key
+// out (the documented wire spelling of UNKNOWN — the server also accepts null)
+// while "the client looked and the tree was clean" is sent as an explicit
+// `false`. A value bool would make those two indistinguishable and would assert
+// CLEAN for every scaffolded app with no repo at all.
 type submitBody struct {
 	BundleBase64 string `json:"bundleBase64"`
+	SourceCommit string `json:"sourceCommit,omitempty"`
+	SourceDirty  *bool  `json:"sourceDirty,omitempty"`
 }
 
 // submitBodyEnvelope is the literal JSON document json.Marshal produces for an
-// EMPTY submitBody — i.e. everything the marshaller adds around the payload.
-// Keep it beside the struct: adding a field to submitBody changes this, and the
-// two must move together. TestSubmitBodySizeMatchesRealMarshal pins the
-// arithmetic against json.Marshal itself rather than against this constant.
+// EMPTY submitBody — i.e. everything the marshaller adds around the payload,
+// with NO provenance. Keep it beside the struct: adding a field to submitBody
+// can change this, and the two must move together.
+// TestSubmitBodySizeMatchesRealMarshal pins the arithmetic against json.Marshal
+// itself rather than against this constant, and
+// TestSubmitBodyEnvelopeIsTheEmptyMarshal pins the constant itself.
 const submitBodyEnvelope = `{"bundleBase64":""}`
 
+// submitEnvelopeLen returns the length of everything the marshaller puts around
+// the base64 payload for THIS submit — the constant above when no provenance is
+// carried, and the real marshalled envelope when some is.
+//
+// 🔴 IT IS MEASURED, NOT ADDED UP. The obvious alternative — keep the constant
+// and add `len(",\"sourceCommit\":\"\"")+40` and so on — is a second model of
+// what encoding/json does, and the whole reason SubmitBodySize exists is that
+// the number it prints is compared against a real limit. Marshalling a struct
+// whose payload field is empty costs nothing and cannot drift from the struct
+// above, so a field added to submitBody is accounted for here without anyone
+// remembering to update an arithmetic term.
+func submitEnvelopeLen(prov Provenance) int {
+	commit, dirty := prov.sanitised()
+	if commit == "" && dirty == nil {
+		return len(submitBodyEnvelope)
+	}
+	env, err := json.Marshal(submitBody{SourceCommit: commit, SourceDirty: dirty})
+	if err != nil {
+		// Unreachable for these field types; degrade to the no-provenance
+		// envelope rather than reporting a nonsense size.
+		return len(submitBodyEnvelope)
+	}
+	return len(env)
+}
+
 // SubmitBodySize returns the exact size, in bytes, of the HTTP request body
-// SubmitVersion sends for a zip of zipLen bytes.
+// SubmitVersion sends for a zip of zipLen bytes carrying provenance prov.
+//
+// 🔴 IT TAKES THE PROVENANCE BECAUSE THE BODY DOES. This number is PRINTED TO
+// USERS — on the `Packaged …` line and again under a failed submit — as "what
+// this CLI sent", and #411's stamp makes a submit that carries provenance ~70
+// bytes larger than one that does not. A signature that could not see the
+// provenance would have kept reporting the smaller number, which is a small
+// error in the quantity and a total one in the claim: the point of the line is
+// that it is EXACT (see below), so it may not be an estimate the moment a
+// feature lands. Pass a zero Provenance for a path that sends none
+// (--package-only, the no-token fallback) and the number is unchanged.
 //
 // 🔴 THE ZIP IS NOT WHAT GOES ON THE WIRE, AND THE DIFFERENCE IS THE WHOLE OF
 // ISSUE #423. SubmitVersion base64-encodes the archive into a JSON document, so
@@ -457,8 +573,8 @@ const submitBodyEnvelope = `{"bundleBase64":""}`
 // and the envelope is a constant. Do not substitute a 1.37 multiplier for it —
 // the point of printing the number is that the author can compare it with a
 // limit, and a rounded number cannot be compared with anything.
-func SubmitBodySize(zipLen int) int {
-	return base64.StdEncoding.EncodedLen(zipLen) + len(submitBodyEnvelope)
+func SubmitBodySize(zipLen int, prov Provenance) int {
+	return base64.StdEncoding.EncodedLen(zipLen) + submitEnvelopeLen(prov)
 }
 
 // submitClient returns an *http.Client for the submit upload: it mirrors the
@@ -496,9 +612,17 @@ func (c *Client) submitClient() *http.Client {
 // one is now present, reports it as a success — surfacing the pubreq id. If no
 // matching submission is found, it returns a clear error telling the user to
 // check `civitai app status` before resubmitting.
-func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string) (*SubmitResult, error) {
+func (c *Client) SubmitVersion(ctx context.Context, zipBytes []byte, slug, version string, prov Provenance) (*SubmitResult, error) {
+	// 🔴 sanitised(), NOT the caller's word. This is the last line before the
+	// wire, so it is where the server's `^[0-9a-f]{40}$` is enforced: a value
+	// that would not survive it is sent as ABSENT, because the server answers a
+	// malformed sourceCommit with a hard 400 that fails the upload. A provenance
+	// stamp must never be able to turn a working submit into a failed one.
+	commit, dirty := prov.sanitised()
 	body, err := json.Marshal(submitBody{
 		BundleBase64: base64.StdEncoding.EncodeToString(zipBytes),
+		SourceCommit: commit,
+		SourceDirty:  dirty,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/appapi/client_refresh_test.go
+++ b/internal/appapi/client_refresh_test.go
@@ -95,7 +95,7 @@ func TestSubmitVersionUsesV1RouteAndRefreshes(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "tok", "")
-	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.1.0"); err != nil {
+	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.1.0", Provenance{}); err != nil {
 		t.Fatalf("SubmitVersion: %v", err)
 	}
 	if path != DefaultSubmitPath {

--- a/internal/appapi/slug_test.go
+++ b/internal/appapi/slug_test.go
@@ -166,7 +166,7 @@ func TestRecoverTimedOutSubmitMatchesARespelledBlockID(t *testing.T) {
 	srv, listCalls := newRecoverServer(t, func() []Submission { return rows })
 
 	c := recoverClient(srv.URL)
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err != nil {
 		t.Fatalf("the submit landed — a row for it is in the listing, spelled %q — but the recovery "+
 			"reported a timeout: %v", rows[0].BlockID, err)

--- a/internal/appapi/submit_body_size_test.go
+++ b/internal/appapi/submit_body_size_test.go
@@ -30,8 +30,8 @@ func TestSubmitBodySizeMatchesRealMarshal(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := SubmitBodySize(zipLen); got != len(want) {
-			t.Errorf("SubmitBodySize(%d) = %d, but the real marshalled body is %d bytes",
+		if got := SubmitBodySize(zipLen, Provenance{}); got != len(want) {
+			t.Errorf("SubmitBodySize(%d, none) = %d, but the real marshalled body is %d bytes",
 				zipLen, got, len(want))
 		}
 	}
@@ -43,7 +43,7 @@ func TestSubmitBodySizeMatchesRealMarshal(t *testing.T) {
 // Growth is ~4/3, so any non-trivial zip must produce a strictly larger body.
 func TestSubmitBodySizeIsNotTheZipSize(t *testing.T) {
 	for _, zipLen := range []int{1, 97, 811, 8_201_270} {
-		if got := SubmitBodySize(zipLen); got <= zipLen {
+		if got := SubmitBodySize(zipLen, Provenance{}); got <= zipLen {
 			t.Errorf("SubmitBodySize(%d) = %d, which is not larger than the zip — base64 in JSON "+
 				"cannot shrink anything, so this is not the quantity that goes on the wire", zipLen, got)
 		}

--- a/internal/appapi/submit_fs_not_timeout_test.go
+++ b/internal/appapi/submit_fs_not_timeout_test.go
@@ -369,7 +369,7 @@ func driveSubmitWithTokenError(t *testing.T, tokenErr error) submitObservation {
 	zero := time.Duration(0)
 	c.SubmitPollDelay = &zero
 
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	return submitObservation{
 		tokenCalls: int(atomic.LoadInt32(&src.calls)),
 		submitPOST: int(atomic.LoadInt32(posts)),
@@ -469,7 +469,7 @@ func TestSubmitVersionStillRecoversFromARealTimeout(t *testing.T) {
 	zero := time.Duration(0)
 	c.SubmitPollDelay = &zero
 
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err != nil {
 		t.Fatalf("a REAL request timeout must still recover, got error: %v", err)
 	}
@@ -499,7 +499,7 @@ func TestSubmitVersionStillRecoversFromARealTimeoutWithNothingLanded(t *testing.
 	zero := time.Duration(0)
 	c.SubmitPollDelay = &zero
 
-	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err == nil {
 		t.Fatal("a real timeout with nothing landed produced no error")
 	}

--- a/internal/appapi/submit_provenance_test.go
+++ b/internal/appapi/submit_provenance_test.go
@@ -1,0 +1,349 @@
+package appapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TESTS FOR THE PROVENANCE STAMP ON THE SUBMIT BODY (issue #411; server side
+// civitai/civitai#4061).
+//
+// 🔴 THE ONE PROPERTY THAT MATTERS MOST IS NOT "THE FIELD ARRIVES". It is that a
+// submit which used to work cannot be broken by the stamp. The server validates
+// `sourceCommit` against `^[0-9a-f]{40}$` and answers a malformed one with a hard
+// 400 that fails the WHOLE upload — deliberately, because silently dropping a bad
+// value is the inert-feature shape. So the CLI carries the burden: anything that
+// is not that shape must leave as ABSENT, and a diagnostic nicety must never cost
+// the user their actual job. TestSubmitVersionCanNeverSendAValueTheServerRejects
+// is that guard, driven from hostile inputs rather than from tidy ones.
+//
+// The second property is the TRI-STATE. `sourceDirty` absent/null means nobody
+// said; `false` means a client looked and said clean. Those are different
+// answers, and a value bool with omitempty would silently merge them — which is
+// why the field is a *bool and why the table below carries both cases with
+// DIFFERENT expected wire text.
+
+// bodyOf runs one SubmitVersion against a recording server and returns the
+// request body as raw JSON fields, so ABSENCE is observable. Decoding into a
+// struct cannot see the difference between "key missing" and "zero value",
+// which is the entire question here.
+func bodyOf(t *testing.T, prov Provenance) map[string]json.RawMessage {
+	t.Helper()
+	var got map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"publishRequestId": "pubreq_1", "slug": "my-block", "version": "0.2.0", "status": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tok", "")
+	if _, err := c.SubmitVersion(context.Background(), []byte("ZIPDATA"), "my-block", "0.2.0", prov); err != nil {
+		t.Fatalf("SubmitVersion: %v", err)
+	}
+	if got == nil {
+		t.Fatal("CONTROL failure: the server recorded no request body at all, so every assertion below " +
+			"would be about an empty map")
+	}
+	if _, ok := got["bundleBase64"]; !ok {
+		t.Fatal("CONTROL failure: the recorded body carries no bundleBase64, so it is not the submit body")
+	}
+	return got
+}
+
+func boolp(b bool) *bool { return &b }
+
+// The fixture sha is a real-shaped 40-hex value whose characters are NOT all the
+// same and which is distinct from every other constant in this file, so a mutant
+// that hardcodes or truncates cannot land on it by accident.
+const fixtureSHA = "9f2c41ab7de305619c8bd4a0e7f13c25db806e4f"
+
+// TestSubmitVersionSendsTheProvenanceItWasGiven is the wire contract, stated as
+// the exact JSON text of each field. Presence, absence and VALUE are asserted
+// separately, because a mutant that sends `"sourceDirty":true` for a clean tree
+// passes any presence-only check.
+func TestSubmitVersionSendsTheProvenanceItWasGiven(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		prov       Provenance
+		wantCommit string // "" ⇒ the key must be ABSENT
+		wantDirty  string // "" ⇒ the key must be ABSENT
+	}{
+		{
+			name: "unknown — a scaffolded app with no repo sends NOTHING",
+			prov: Provenance{},
+		},
+		{
+			name:       "clean tree — the commit, and an EXPLICIT false",
+			prov:       Provenance{Commit: fixtureSHA, Dirty: boolp(false)},
+			wantCommit: `"` + fixtureSHA + `"`,
+			wantDirty:  "false",
+		},
+		{
+			name:       "--allow-dirty — the commit, and an explicit true",
+			prov:       Provenance{Commit: fixtureSHA, Dirty: boolp(true)},
+			wantCommit: `"` + fixtureSHA + `"`,
+			wantDirty:  "true",
+		},
+		{
+			name:       "commit known, dirtiness NOT established — the key stays out",
+			prov:       Provenance{Commit: fixtureSHA},
+			wantCommit: `"` + fixtureSHA + `"`,
+		},
+		{
+			name: "dirtiness without a commit is not a fact — BOTH stay out",
+			prov: Provenance{Dirty: boolp(true)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bodyOf(t, tc.prov)
+			assertField(t, body, "sourceCommit", tc.wantCommit)
+			assertField(t, body, "sourceDirty", tc.wantDirty)
+		})
+	}
+}
+
+func assertField(t *testing.T, body map[string]json.RawMessage, key, want string) {
+	t.Helper()
+	raw, present := body[key]
+	if want == "" {
+		if present {
+			t.Errorf("%s must be ABSENT from the body, but the server received %s.\n"+
+				"Absent is the documented wire spelling of UNKNOWN; sending a value asserts something nobody established.",
+				key, raw)
+		}
+		return
+	}
+	if !present {
+		t.Fatalf("%s is missing from the body; want %s", key, want)
+	}
+	if string(raw) != want {
+		t.Errorf("%s = %s, want %s", key, raw, want)
+	}
+}
+
+// serverSourceCommitRe is the SERVER's rule, written out here independently of
+// the implementation's own copy. Asserting against `sourceCommitRe` would be a
+// restatement of the code under test.
+var serverSourceCommitRe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// TestSubmitVersionCanNeverSendAValueTheServerRejects is the highest-value test
+// in this file: it feeds the seam the shapes a real `git rev-parse` can produce
+// when something has gone wrong, and asserts the request body either omits
+// `sourceCommit` or carries a value the server's own regex accepts. Never a
+// third thing.
+//
+// 🔴 THE FAILURE IT PREVENTS IS NOT A MISSING STAMP, IT IS A FAILED SUBMIT. A
+// value outside `^[0-9a-f]{40}$` is a 400 on the whole request, so every row here
+// is a way the provenance feature could take away an upload that worked before
+// it existed.
+func TestSubmitVersionCanNeverSendAValueTheServerRejects(t *testing.T) {
+	hostile := []struct{ name, commit string }{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"a tab", "\t"},
+		{"uppercase — git never emits it, and the server rejects it", strings.ToUpper(fixtureSHA)},
+		{"mixed case", "9F2c41ab7de305619c8bd4a0e7f13c25db806e4F"},
+		{"an abbreviated sha", fixtureSHA[:7]},
+		{"39 characters — one short", fixtureSHA[:39]},
+		{"41 characters — one long", fixtureSHA + "0"},
+		{"a trailing newline", fixtureSHA + "\n"},
+		{"a trailing CR", fixtureSHA + "\r"},
+		{"a leading space", " " + fixtureSHA},
+		{"the literal ref name", "HEAD"},
+		{"a detached-HEAD message rather than a sha", "HEAD detached at 9f2c41a"},
+		{"a git error on stdout", "fatal: ambiguous argument 'HEAD': unknown revision"},
+		{"non-hex characters of the right length", strings.Repeat("z", 40)},
+		{"a sha with an embedded NUL", fixtureSHA[:20] + "\x00" + fixtureSHA[21:]},
+		{"two shas on one line", fixtureSHA + " " + fixtureSHA},
+		{"a JSON-breaking value", `","sourceDirty":true,"x":"`},
+	}
+	for _, h := range hostile {
+		for _, dirty := range []*bool{nil, boolp(false), boolp(true)} {
+			t.Run(h.name, func(t *testing.T) {
+				body := bodyOf(t, Provenance{Commit: h.commit, Dirty: dirty})
+				raw, present := body["sourceCommit"]
+				if !present {
+					// The required outcome for every row here — and the dirty
+					// flag must go with it, or the row claims a dirtiness for a
+					// commit it could not name.
+					if _, d := body["sourceDirty"]; d {
+						t.Errorf("sourceCommit was dropped but sourceDirty was still sent — "+
+							"that asserts a work-tree state for a commit the CLI could not name (input %q)", h.commit)
+					}
+					return
+				}
+				var s string
+				if err := json.Unmarshal(raw, &s); err != nil {
+					t.Fatalf("sourceCommit is not even a JSON string: %s", raw)
+				}
+				if !serverSourceCommitRe.MatchString(s) {
+					t.Errorf("the CLI put %q on the wire for input %q.\n"+
+						"The server validates ^[0-9a-f]{40}$ and answers a malformed value with a 400 that FAILS THE SUBMIT. "+
+						"A provenance stamp must be dropped, never guessed at.", s, h.commit)
+				}
+			})
+		}
+	}
+
+	// POSITIVE CONTROL: the same harness must be able to see a GOOD value
+	// arrive, or "nothing malformed was sent" is indistinguishable from a
+	// recorder wired to nothing.
+	body := bodyOf(t, Provenance{Commit: fixtureSHA, Dirty: boolp(true)})
+	if _, ok := body["sourceCommit"]; !ok {
+		t.Fatal("CONTROL failure: a well-formed sha did NOT reach the body, so the loop above proves nothing — " +
+			"it would report the same result if the field had been deleted from submitBody entirely")
+	}
+}
+
+// TestSubmitBodyEnvelopeIsTheEmptyMarshal pins the constant the size arithmetic
+// starts from against the marshaller itself. Adding a field to submitBody
+// WITHOUT omitempty would change this document, and the number printed to users
+// would silently stop being exact.
+func TestSubmitBodyEnvelopeIsTheEmptyMarshal(t *testing.T) {
+	got, err := json.Marshal(submitBody{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != submitBodyEnvelope {
+		t.Errorf("json.Marshal(submitBody{}) = %s, but submitBodyEnvelope is %s.\n"+
+			"The two must move together: SubmitBodySize adds len(submitBodyEnvelope) to the base64 length and "+
+			"prints the result to users as the EXACT number a request-body limit applies to.", got, submitBodyEnvelope)
+	}
+}
+
+// TestSubmitBodySizeCountsTheProvenanceItSends is the #423 contract re-derived
+// with #411's fields present.
+//
+// 🔴 THE EXPECTATION IS AN INDEPENDENT MARSHAL, NOT THE FUNCTION'S OWN
+// ARITHMETIC. It builds the request document with a map — the same JSON
+// encoder, no shared code with submitEnvelopeLen — so a dropped term, a wrong
+// envelope or a field that is sent but not counted all show up here.
+func TestSubmitBodySizeCountsTheProvenanceItSends(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		prov Provenance
+	}{
+		{"no provenance", Provenance{}},
+		{"commit only", Provenance{Commit: fixtureSHA}},
+		{"commit + clean", Provenance{Commit: fixtureSHA, Dirty: boolp(false)}},
+		{"commit + dirty", Provenance{Commit: fixtureSHA, Dirty: boolp(true)}},
+		{"a rejected commit is not on the wire and must not be counted",
+			Provenance{Commit: strings.ToUpper(fixtureSHA), Dirty: boolp(true)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Lengths cover every base64 padding residue.
+			for _, zipLen := range []int{0, 1, 2, 3, 97, 811, 65_537} {
+				payload := make([]byte, zipLen)
+				for i := range payload {
+					payload[i] = byte(i*17 + 3)
+				}
+				doc := map[string]any{"bundleBase64": base64.StdEncoding.EncodeToString(payload)}
+				commit, dirty := tc.prov.sanitised()
+				if commit != "" {
+					doc["sourceCommit"] = commit
+				}
+				if dirty != nil {
+					doc["sourceDirty"] = *dirty
+				}
+				want, err := json.Marshal(doc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := SubmitBodySize(zipLen, tc.prov); got != len(want) {
+					t.Errorf("SubmitBodySize(%d, %+v) = %d, but the real marshalled body is %d bytes",
+						zipLen, tc.prov, got, len(want))
+				}
+			}
+		})
+	}
+}
+
+// TestSubmitBodySizeGrowsWithProvenance is the reason the signature changed,
+// stated as a measurement: a submit that carries the stamp really is a bigger
+// request than one that does not, so a size function that could not see the
+// provenance would print a number that is no longer the one on the wire.
+func TestSubmitBodySizeGrowsWithProvenance(t *testing.T) {
+	const zipLen = 8_201_270 // #423's real bundle
+	bare := SubmitBodySize(zipLen, Provenance{})
+	stamped := SubmitBodySize(zipLen, Provenance{Commit: fixtureSHA, Dirty: boolp(true)})
+	if stamped <= bare {
+		t.Fatalf("a stamped body (%d) is not larger than a bare one (%d) — either the fields are not being "+
+			"marshalled or the size function is ignoring them", stamped, bare)
+	}
+	// And the no-provenance answer is unchanged from the pre-#411 arithmetic, so
+	// every path that sends nothing prints exactly the number it used to.
+	if want := base64.StdEncoding.EncodedLen(zipLen) + len(submitBodyEnvelope); bare != want {
+		t.Errorf("SubmitBodySize(%d, none) = %d, want %d — the no-provenance path must be byte-identical "+
+			"to the pre-#411 number", zipLen, bare, want)
+	}
+}
+
+// TestSubmissionDecodesTheSourceTriState is the READ half. Three server answers
+// that a `?? false` reader would flatten into one.
+func TestSubmissionDecodesTheSourceTriState(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		row        string
+		wantCommit *string
+		wantDirty  *bool
+	}{
+		{
+			name: "a pre-feature row carries neither key",
+			row:  `{"id":"pubreq_1","blockId":"a","version":"0.1.0","status":"approved","submittedAt":"x","updatedAt":"x","createdAt":"x"}`,
+		},
+		{
+			name: "explicit nulls are UNKNOWN, exactly like absence",
+			row:  `{"id":"pubreq_1","blockId":"a","version":"0.1.0","status":"approved","submittedAt":"x","updatedAt":"x","createdAt":"x","sourceCommit":null,"sourceDirty":null}`,
+		},
+		{
+			name:       "false is an ASSERTION of clean, and is not null",
+			row:        `{"id":"pubreq_1","blockId":"a","version":"0.1.0","status":"approved","submittedAt":"x","updatedAt":"x","createdAt":"x","sourceCommit":"` + fixtureSHA + `","sourceDirty":false}`,
+			wantCommit: strp(fixtureSHA),
+			wantDirty:  boolp(false),
+		},
+		{
+			name:       "true is an assertion of dirty",
+			row:        `{"id":"pubreq_1","blockId":"a","version":"0.1.0","status":"approved","submittedAt":"x","updatedAt":"x","createdAt":"x","sourceCommit":"` + fixtureSHA + `","sourceDirty":true}`,
+			wantCommit: strp(fixtureSHA),
+			wantDirty:  boolp(true),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Submission
+			if err := json.Unmarshal([]byte(tc.row), &s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			switch {
+			case tc.wantCommit == nil && s.SourceCommit != nil:
+				t.Errorf("sourceCommit decoded as %q, want nil (UNKNOWN)", *s.SourceCommit)
+			case tc.wantCommit != nil && s.SourceCommit == nil:
+				t.Errorf("sourceCommit decoded as nil, want %q", *tc.wantCommit)
+			case tc.wantCommit != nil && *s.SourceCommit != *tc.wantCommit:
+				t.Errorf("sourceCommit = %q, want %q", *s.SourceCommit, *tc.wantCommit)
+			}
+			switch {
+			case tc.wantDirty == nil && s.SourceDirty != nil:
+				t.Errorf("sourceDirty decoded as %v, want nil.\n"+
+					"null and false are DIFFERENT answers: null is 'nobody said', false is 'a client looked and said clean'.",
+					*s.SourceDirty)
+			case tc.wantDirty != nil && s.SourceDirty == nil:
+				t.Errorf("sourceDirty decoded as nil, want %v", *tc.wantDirty)
+			case tc.wantDirty != nil && *s.SourceDirty != *tc.wantDirty:
+				t.Errorf("sourceDirty = %v, want %v", *s.SourceDirty, *tc.wantDirty)
+			}
+		})
+	}
+}
+
+func strp(s string) *string { return &s }

--- a/internal/appapi/submit_recover_newest_test.go
+++ b/internal/appapi/submit_recover_newest_test.go
@@ -128,7 +128,7 @@ func TestRecoverTimedOutSubmitReadsTheNewestMatchingRow(t *testing.T) {
 			srv, listCalls := newRecoverServer(t, func() []Submission { return rows })
 
 			c := recoverClient(srv.URL)
-			res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+			res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 			if err != nil {
 				t.Fatalf("SubmitVersion should recover on timeout, got error: %v", err)
 			}
@@ -163,7 +163,7 @@ func TestRecoverTimedOutSubmitIgnoresOtherVersionsAmongMatches(t *testing.T) {
 	srv, _ := newRecoverServer(t, func() []Submission { return rows })
 
 	c := recoverClient(srv.URL)
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err != nil {
 		t.Fatalf("SubmitVersion should recover on timeout, got error: %v", err)
 	}

--- a/internal/appapi/submit_recover_test.go
+++ b/internal/appapi/submit_recover_test.go
@@ -62,7 +62,7 @@ func TestSubmitVersionRecoversWhenSubmissionLanded(t *testing.T) {
 	})
 
 	c := recoverClient(srv.URL)
-	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	res, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err != nil {
 		t.Fatalf("SubmitVersion should recover on timeout, got error: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestSubmitVersionRecoveryErrorsWhenAbsent(t *testing.T) {
 	})
 
 	c := recoverClient(srv.URL)
-	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err == nil {
 		t.Fatal("expected an error when no matching submission landed")
 	}
@@ -107,7 +107,7 @@ func TestSubmitVersionRecoveryMatchesOnlyExactSlugVersion(t *testing.T) {
 	})
 
 	c := recoverClient(srv.URL)
-	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0")
+	_, err := c.SubmitVersion(context.Background(), []byte("ZIP"), "my-block", "0.2.0", Provenance{})
 	if err == nil {
 		t.Fatal("expected an error: only a different version is pending, not 0.2.0")
 	}

--- a/internal/cmd/app_status.go
+++ b/internal/cmd/app_status.go
@@ -49,6 +49,14 @@ printed on stderr — a repo behind its own live deployment is how an accidental
 downgrade gets submitted. It is advisory only: the exit code never changes, and
 nothing is said when the versions cannot be compared.
 
+The SOURCE column (and the detail view's "Source commit" line) is the commit the
+submitting client CLAIMED it built the bundle from — abbreviated in the table,
+full in the detail view and in --json. It is stored unverified: the server
+records what the client reported and cannot check it. A "-" means nothing was
+reported (a submission from before the CLI sent it, or from a directory that is
+in no git repo), which is NOT the same as a clean build; "(dirty)" means the
+client said uncommitted changes went into that bundle.
+
 Note: a submission's <blockId>.civit.ai surface only serves AFTER it is approved
 and deployed (deployState 'live').`,
 		Example: `  civitai app status                 # list all your submissions
@@ -218,18 +226,82 @@ func writeJSON(w io.Writer, v any) error {
 
 func printSubmissionTable(w io.Writer, subs []appapi.Submission) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "BLOCK_ID\tVERSION\tSTATUS\tDEPLOY\tSUBMITTED\tURL")
+	fmt.Fprintln(tw, "BLOCK_ID\tVERSION\tSTATUS\tDEPLOY\tSOURCE\tSUBMITTED\tURL")
 	for _, s := range subs {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			s.BlockID,
 			s.Version,
 			s.Status,
 			deployLabel(s.DeployState),
+			sourceLabel(s.SourceCommit, s.SourceDirty),
 			shortDate(s.SubmittedAt),
 			strOr(s.LiveURL, "-"),
 		)
 	}
 	_ = tw.Flush()
+}
+
+// shortSHALen is how much of the commit the TABLE shows. Seven is git's own
+// default abbreviation and is what an author will paste into `git show`; the
+// detail view and `--json` both carry the full forty, because a script that
+// compares a sha needs the whole one.
+const shortSHALen = 7
+
+// sourceLabel renders the SOURCE column: the commit the submitting client
+// CLAIMED, abbreviated, with the dirty flag when it is set.
+//
+// 🔴 THE TRI-STATE SURVIVES INTO THE COLUMN, AND "-" MEANS NOBODY SAID. A row
+// from before this feature, or one submitted from a directory with no git repo,
+// carries no commit at all — that is UNKNOWN, and it must not render as anything
+// that reads like a clean build. Where a commit IS claimed, a `dirty` flag is
+// printed and a CLEAN tree is left unmarked: the absence of the word means the
+// client asserted clean, which the header of the detail view spells out.
+//
+// 🔴 A COMMIT WITH sourceDirty NULL IS "COMMIT, DIRTINESS UNKNOWN" AND SAYS SO.
+// Rendering it bare would be indistinguishable from an asserted-clean row, which
+// is the `?? false` collapse wearing a different hat.
+func sourceLabel(commit *string, dirty *bool) string {
+	if commit == nil || *commit == "" {
+		return "-"
+	}
+	short := *commit
+	if len(short) > shortSHALen {
+		short = short[:shortSHALen]
+	}
+	switch {
+	case dirty == nil:
+		return short + " (dirty?)"
+	case *dirty:
+		return short + " (dirty)"
+	default:
+		return short
+	}
+}
+
+// sourceClaimNote is the one sentence that keeps every rendering of the
+// provenance inside what the CLI is entitled to say.
+//
+// 🔴 IT IS A CLAIM, NOT A MEASUREMENT, AND THIS CLI IS NOT THE ONE WHO MADE IT.
+// The server stores whatever the submitting client sent and cannot check that
+// the bundle was built from that commit — a different machine, a different
+// client, or the same one lying, all produce a row that looks identical. Item 28
+// is the precedent: where the CLI cannot observe the thing, it may report what
+// it was told and must attribute it. Anything reading "built from a1b2c3d" would
+// assert exactly the verification nobody performed.
+const sourceClaimNote = "Reported by the client that submitted it; the server stores it unverified."
+
+// sourceDirtySuffix renders the tri-state for the DETAIL view, in words rather
+// than in the table's shorthand. Each of the three says who established what:
+// nothing was said, a client said clean, a client said dirty.
+func sourceDirtySuffix(dirty *bool) string {
+	switch {
+	case dirty == nil:
+		return " (clean or dirty: not reported)"
+	case *dirty:
+		return " (reported DIRTY — uncommitted changes went into the bundle)"
+	default:
+		return " (reported clean)"
+	}
 }
 
 func printSubmissionDetail(w io.Writer, s *appapi.Submission) {
@@ -242,6 +314,12 @@ func printSubmissionDetail(w io.Writer, s *appapi.Submission) {
 	if s.DeployDetail != nil && *s.DeployDetail != "" {
 		fmt.Fprintf(tw, "Deploy detail:\t%s\n", *s.DeployDetail)
 	}
+	// The provenance the submitting client claimed (#411). The FULL sha here —
+	// the table abbreviates, this view is where someone goes to get the value
+	// they will paste into `git show`.
+	if s.SourceCommit != nil && *s.SourceCommit != "" {
+		fmt.Fprintf(tw, "Source commit:\t%s%s\n", *s.SourceCommit, sourceDirtySuffix(s.SourceDirty))
+	}
 	fmt.Fprintf(tw, "Submitted:\t%s\n", fullDate(s.SubmittedAt))
 	if s.ReviewedAt != nil && *s.ReviewedAt != "" {
 		fmt.Fprintf(tw, "Reviewed:\t%s\n", fullDate(*s.ReviewedAt))
@@ -250,6 +328,13 @@ func printSubmissionDetail(w io.Writer, s *appapi.Submission) {
 		fmt.Fprintf(tw, "Deploy updated:\t%s\n", fullDate(*s.DeployUpdatedAt))
 	}
 	_ = tw.Flush()
+
+	// Attribution goes with the fact, on the same screen, and only when there is
+	// a fact to attribute — a note under a row that claims nothing would be
+	// noise, and would imply the CLI had checked something.
+	if s.SourceCommit != nil && *s.SourceCommit != "" {
+		fmt.Fprintf(w, "  %s\n", sourceClaimNote)
+	}
 
 	if s.Status == "rejected" && s.RejectionReason != nil && *s.RejectionReason != "" {
 		fmt.Fprintf(w, "\nRejection reason:\n  %s\n", *s.RejectionReason)

--- a/internal/cmd/app_status_provenance_test.go
+++ b/internal/cmd/app_status_provenance_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TESTS FOR THE READ HALF OF THE PROVENANCE STAMP (issue #411) — what
+// `civitai app status` shows, and what `--json` carries.
+//
+// 🔴 THE TRI-STATE IS THE WHOLE THING, AND IT IS EASY TO LOSE IN A RENDERER.
+// `null` is "nobody said", `false` is "a client looked and said clean", `true`
+// is "a client said dirty". A renderer that prints nothing for the first two
+// merges an UNKNOWN row into a CLEAN one, which is the `?? false` collapse
+// arriving through the display layer instead of through the decoder. So the
+// three rows below assert three DIFFERENT strings, and the `--json` case asserts
+// the raw JSON text rather than a decoded Go value — a decode into a value type
+// would flatten null to false before any assertion could see it.
+//
+// 🔴 AND NOTHING HERE MAY READ AS VERIFIED. The server stores an unverified
+// client claim; the detail view says so in one sentence, and this file pins that
+// the sentence is present whenever a commit is.
+
+const (
+	provSHAClean   = "1c4f8ab30d5e97624bd0af31e6c857920dbe4a68"
+	provSHADirty   = "77b0e3d9142ca8e5630fb84c02d1975ae6cf3b20"
+	provSHAUnknown = "acd51e6027f9b3184dc7a05e29b6f4d38017ce42"
+)
+
+// provRows is the fixture listing: four submissions covering every state the
+// column can be in. The shas are pairwise distinct AND distinct from any
+// constant this file asserts against, so a renderer that hardcoded one could not
+// pass by luck.
+func provRows() []map[string]any {
+	return []map[string]any{
+		{"id": "pubreq_4", "blockId": "with-clean", "version": "0.4.0", "status": "approved",
+			"deployState": "live", "submittedAt": "2026-08-14T09:00:00.000Z", "liveUrl": "https://with-clean.civit.ai/",
+			"sourceCommit": provSHAClean, "sourceDirty": false},
+		{"id": "pubreq_3", "blockId": "with-dirty", "version": "0.3.0", "status": "approved",
+			"deployState": "live", "submittedAt": "2026-08-13T09:00:00.000Z", "liveUrl": nil,
+			"sourceCommit": provSHADirty, "sourceDirty": true},
+		{"id": "pubreq_2", "blockId": "half-known", "version": "0.2.0", "status": "pending",
+			"deployState": nil, "submittedAt": "2026-08-12T09:00:00.000Z", "liveUrl": nil,
+			"sourceCommit": provSHAUnknown, "sourceDirty": nil},
+		{"id": "pubreq_1", "blockId": "pre-feature", "version": "0.1.0", "status": "approved",
+			"deployState": "live", "submittedAt": "2026-08-11T09:00:00.000Z", "liveUrl": nil},
+	}
+}
+
+func provStatusEnv(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-prov")
+	t.Setenv("CIVITAI_BASE_URL", url)
+}
+
+// TestAppStatusTableShowsTheClaimedSource pins the SOURCE column, one distinct
+// rendering per state.
+func TestAppStatusTableShowsTheClaimedSource(t *testing.T) {
+	srv := statusServer(t, map[string]any{"submissions": provRows()}, http.StatusOK, nil)
+	defer srv.Close()
+	provStatusEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "status")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if !strings.Contains(out, "SOURCE") {
+		t.Fatalf("the table has no SOURCE column, so the stamp is invisible where a reader looks for it:\n%s", out)
+	}
+
+	for _, want := range []struct{ row, cell, why string }{
+		{"with-clean", provSHAClean[:7],
+			"a clean build shows the abbreviated commit and no flag"},
+		{"with-dirty", provSHADirty[:7] + " (dirty)",
+			"a dirty build must be marked — that is the state #411 was filed about"},
+		{"half-known", provSHAUnknown[:7] + " (dirty?)",
+			"a commit whose dirtiness was never reported must not render like an asserted-clean row"},
+		{"pre-feature", "-",
+			"a row that claims nothing must read as UNKNOWN, never as a clean build"},
+	} {
+		line := lineContaining(out, want.row)
+		if line == "" {
+			t.Fatalf("no row for %q in:\n%s", want.row, out)
+		}
+		if !strings.Contains(line, want.cell) {
+			t.Errorf("row %q renders %q, want it to carry %q — %s", want.row, line, want.cell, want.why)
+		}
+	}
+
+	// The table abbreviates on purpose; a full sha would push the URL column off
+	// an 80-column terminal. Assert the abbreviation is real, or "short sha" is
+	// just a claim in a comment.
+	if strings.Contains(out, provSHAClean) {
+		t.Errorf("the table printed the FULL sha; it is supposed to abbreviate to %d characters "+
+			"(the full value lives in the detail view and in --json):\n%s", shortSHALen, out)
+	}
+}
+
+// TestAppStatusDetailShowsTheFullShaAndAttributesIt — the detail view is where
+// someone goes for the value they will paste into `git show`, so it carries the
+// whole forty characters, and the sentence saying who claimed them.
+func TestAppStatusDetailShowsTheFullShaAndAttributesIt(t *testing.T) {
+	for _, tc := range []struct {
+		name, row string
+		wantParts []string
+	}{
+		{
+			name: "a dirty claim", row: "with-dirty",
+			wantParts: []string{provSHADirty, "reported DIRTY", sourceClaimNote},
+		},
+		{
+			name: "a clean claim", row: "with-clean",
+			wantParts: []string{provSHAClean, "reported clean", sourceClaimNote},
+		},
+		{
+			name: "a commit with no dirtiness reported", row: "half-known",
+			wantParts: []string{provSHAUnknown, "not reported", sourceClaimNote},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := statusServer(t, map[string]any{"submissions": rowsFor(tc.row)}, http.StatusOK, nil)
+			defer srv.Close()
+			provStatusEnv(t, srv.URL)
+
+			out, _, err := run(t, "app", "status", tc.row)
+			if err != nil {
+				t.Fatalf("app status %s: %v", tc.row, err)
+			}
+			for _, want := range tc.wantParts {
+				if !strings.Contains(out, want) {
+					t.Errorf("the detail view does not carry %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+
+	// A row that claims nothing must not print an empty "Source commit:" line,
+	// and must not print the attribution sentence — there is nothing to
+	// attribute, and a note under no fact implies the CLI checked something.
+	t.Run("a pre-feature row says nothing at all", func(t *testing.T) {
+		srv := statusServer(t, map[string]any{"submissions": rowsFor("pre-feature")}, http.StatusOK, nil)
+		defer srv.Close()
+		provStatusEnv(t, srv.URL)
+
+		out, _, err := run(t, "app", "status", "pre-feature")
+		if err != nil {
+			t.Fatalf("app status: %v", err)
+		}
+		if strings.Contains(out, "Source commit") {
+			t.Errorf("a submission that reported no commit printed a Source commit line:\n%s", out)
+		}
+		if strings.Contains(out, sourceClaimNote) {
+			t.Errorf("the attribution note printed with nothing to attribute:\n%s", out)
+		}
+	})
+}
+
+func rowsFor(blockID string) []map[string]any {
+	var out []map[string]any
+	for _, r := range provRows() {
+		if r["blockId"] == blockID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestAppStatusJSONCarriesTheFullTriState is the scriptable contract.
+//
+// 🔴 IT ASSERTS THE RAW JSON TEXT. Decoding into a Go value type is exactly the
+// collapse being guarded against: `null` and `false` both land on `false` and
+// the assertion passes over a payload that has lost the distinction.
+func TestAppStatusJSONCarriesTheFullTriState(t *testing.T) {
+	srv := statusServer(t, map[string]any{"submissions": provRows()}, http.StatusOK, nil)
+	defer srv.Close()
+	provStatusEnv(t, srv.URL)
+
+	out, _, err := run(t, "app", "status", "--json")
+	if err != nil {
+		t.Fatalf("app status --json: %v", err)
+	}
+
+	// The full sha, not the abbreviation a script would have to guess at.
+	for _, sha := range []string{provSHAClean, provSHADirty, provSHAUnknown} {
+		if !strings.Contains(out, sha) {
+			t.Errorf("--json does not carry the FULL sha %q — a script comparing commits needs all forty:\n%s", sha, out)
+		}
+	}
+
+	var doc struct {
+		Submissions []map[string]json.RawMessage `json:"submissions"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("--json is not valid JSON: %v\n%s", err, out)
+	}
+	if len(doc.Submissions) != len(provRows()) {
+		t.Fatalf("CONTROL failure: --json carried %d row(s), want %d", len(doc.Submissions), len(provRows()))
+	}
+	want := map[string]string{
+		"with-clean":  "false",
+		"with-dirty":  "true",
+		"half-known":  "null",
+		"pre-feature": "null",
+	}
+	seen := 0
+	for _, row := range doc.Submissions {
+		var id string
+		if err := json.Unmarshal(row["blockId"], &id); err != nil {
+			t.Fatal(err)
+		}
+		w, ok := want[id]
+		if !ok {
+			continue
+		}
+		seen++
+		got := string(row["sourceDirty"])
+		if got != w {
+			t.Errorf("%s: sourceDirty is %q in --json, want %q.\n"+
+				"null and false are DIFFERENT answers and both are scriptable: null means nobody reported, "+
+				"false means a client asserted a clean tree.", id, got, w)
+		}
+	}
+	if seen != len(want) {
+		t.Fatalf("CONTROL failure: matched %d of %d rows by blockId, so the assertions above ran on the wrong payload",
+			seen, len(want))
+	}
+}
+
+// TestAppStatusJSONStaysColourFree keeps the new rendering inside
+// internal/ui/CONVENTION.md rule 1: `--json` never passes through ui.
+func TestAppStatusJSONStaysColourFree(t *testing.T) {
+	const esc = "\x1b["
+	// with-clean is the row that carries a liveUrl, and the live URL is the
+	// coloured element — a row without one produces no ANSI at all and the
+	// positive control below could not fire.
+	srv := statusServer(t, map[string]any{"submissions": rowsFor("with-clean")}, http.StatusOK, nil)
+	defer srv.Close()
+	provStatusEnv(t, srv.URL)
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	human, _, err := run(t, "app", "status", "with-clean")
+	if err != nil {
+		t.Fatalf("app status: %v", err)
+	}
+	if !strings.Contains(human, esc) {
+		t.Fatalf("POSITIVE CONTROL FAILED: CLICOLOR_FORCE produced no ANSI on the HUMAN path, so this "+
+			"test cannot see a violation on the JSON path either:\n%q", human)
+	}
+	out, _, err := run(t, "app", "status", "with-clean", "--json")
+	if err != nil {
+		t.Fatalf("app status --json: %v", err)
+	}
+	if strings.Contains(out, esc) {
+		t.Errorf("--json emitted an ANSI escape under CLICOLOR_FORCE:\n%q", out)
+	}
+}
+
+// TestSourceLabelIsTheOneRenderer drives the column renderer directly, so the
+// tri-state is pinned at the seam a future caller would inherit rather than only
+// through the command that happens to call it today.
+func TestSourceLabelIsTheOneRenderer(t *testing.T) {
+	yes, no := true, false
+	empty := ""
+	sha := provSHAClean
+	for _, tc := range []struct {
+		name   string
+		commit *string
+		dirty  *bool
+		want   string
+	}{
+		{"nothing reported", nil, nil, "-"},
+		{"nothing reported, dirty somehow set", nil, &no, "-"},
+		{"an empty commit is not a commit", &empty, &no, "-"},
+		{"clean", &sha, &no, sha[:shortSHALen]},
+		{"dirty", &sha, &yes, sha[:shortSHALen] + " (dirty)"},
+		{"dirtiness unknown", &sha, nil, sha[:shortSHALen] + " (dirty?)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sourceLabel(tc.commit, tc.dirty); got != tc.want {
+				t.Errorf("sourceLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/app_submit.go
+++ b/internal/cmd/app_submit.go
@@ -44,10 +44,10 @@ const submitDiagnosisEntries = 5
 // and the size already appears on the `Packaged …` line for anyone who wants
 // it — printing an entry table after every submit would train people to skip
 // the block, which is precisely when it is worth reading.
-func printSubmitSizeDiagnosis(w io.Writer, zipBytes []byte) {
+func printSubmitSizeDiagnosis(w io.Writer, zipBytes []byte, prov appapi.Provenance) {
 	fmt.Fprintf(w, "\nWhat this CLI sent (it cannot tell whether that is why the submit failed):\n")
 	fmt.Fprintf(w, "  %d bytes on the wire — a %d-byte zip, base64-encoded into a JSON body.\n",
-		appapi.SubmitBodySize(len(zipBytes)), len(zipBytes))
+		appapi.SubmitBodySize(len(zipBytes), prov), len(zipBytes))
 
 	entries, err := pkgzip.LargestEntries(zipBytes, submitDiagnosisEntries)
 	if err == nil && len(entries) > 0 {
@@ -219,6 +219,16 @@ Dirty-tree guard:
   submits exactly as before, and a clean tree whose HEAD is on no remote warns
   rather than refusing.
 
+Build provenance:
+  A submit that really uploads also STAMPS the commit it was built from — the
+  40-character sha of HEAD, plus whether the work tree was dirty — so
+  ` + "`civitai app status`" + ` can later say which source a live version came from.
+  It is a CLAIM, not a proof: the server records what this CLI reports and
+  cannot verify the bundle was built from that commit. It degrades the same way
+  the guard does — no repo, no git, or a repo with no commits sends nothing at
+  all rather than a guess — and --allow-dirty still stamps, marking the
+  submission dirty, because that is the case worth being able to look up.
+
 Defaults to the current directory.`,
 		Example: `  civitai app submit                    # validate + package + confirm + submit
   civitai app submit --yes              # skip the confirmation prompt (scripts/CI)
@@ -300,6 +310,11 @@ Defaults to the current directory.`,
 			// here, then packages + submits below. The --package-only / no-token
 			// fallback path never submits, so it skips the gate and just packages.
 			canUpload := !packageOnly && cfg.Token() != ""
+			// The provenance this run will claim. It stays ZERO on every path
+			// that does not upload (--package-only, the no-token fallback):
+			// those paths run no git at all, and the size line below then
+			// reports the body they would send, which carries none.
+			var prov appapi.Provenance
 			var client *appapi.Client
 			if canUpload {
 				client = appapi.NewWithSource(cfg.BaseURL(), auth.New(cfg), submitPath)
@@ -323,7 +338,14 @@ Defaults to the current directory.`,
 				// version guard does: --package-only and the no-token fallback
 				// never reach the server, so nothing there can publish an
 				// untraceable bundle.
-				if err := checkWorkTreeClean(gitOutput, cmd.ErrOrStderr(), dir, m.BlockID, m.Version, allowDirty); err != nil {
+				// It also returns the PROVENANCE this submit will claim
+				// (#411's stamp half): the commit the bundle was built from
+				// and whether the tree was dirty. Every branch that cannot
+				// establish those returns them absent — see the matrix on
+				// checkWorkTreeClean — and absent is what reaches the wire as
+				// "no key at all", never as a default.
+				prov, err = checkWorkTreeClean(gitOutput, cmd.ErrOrStderr(), dir, m.BlockID, m.Version, allowDirty)
+				if err != nil {
 					return err
 				}
 
@@ -374,7 +396,7 @@ Defaults to the current directory.`,
 			// --package-only, because --package-only is how you inspect a
 			// bundle you cannot submit.
 			fmt.Fprintf(out, "Packaged %d file(s) (%d bytes compressed, %d decompressed; %d bytes as the base64 JSON submit body)\n",
-				len(pkg.Files), len(pkg.Zip), pkg.DecompressedBy, appapi.SubmitBodySize(len(pkg.Zip)))
+				len(pkg.Files), len(pkg.Zip), pkg.DecompressedBy, appapi.SubmitBodySize(len(pkg.Zip), prov))
 			// 🔴 WHAT WAS LEFT OUT, ON EVERY PATH INCLUDING --package-only (#435).
 			// Printed here, above the canUpload branch, for the same reason the
 			// size line is: --package-only is how an author inspects a bundle,
@@ -387,7 +409,7 @@ Defaults to the current directory.`,
 			// 3a. Programmatic submit if we have a token (OAuth or personal key).
 			// The gate above already confirmed (or --yes bypassed) it.
 			if canUpload {
-				return doUpload(cmd, client, pkg.Zip, m, cfg.BaseURL())
+				return doUpload(cmd, client, pkg.Zip, m, cfg.BaseURL(), prov)
 			}
 
 			// 3b. Fallback: write the canonical .zip + print next steps.
@@ -452,7 +474,7 @@ func confirmSubmit(cmd *cobra.Command, m *manifest.Manifest, baseURL string, ass
 	}
 }
 
-func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *manifest.Manifest, baseURL string) error {
+func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *manifest.Manifest, baseURL string, prov appapi.Provenance) error {
 	out := cmd.OutOrStdout()
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -466,7 +488,7 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 	err := ui.WithSpinner(ctx, out, fmt.Sprintf("Submitting %s@%s", m.BlockID, m.Version),
 		func(ctx context.Context) error {
 			var e error
-			r, e = client.SubmitVersion(ctx, zipBytes, m.BlockID, m.Version)
+			r, e = client.SubmitVersion(ctx, zipBytes, m.BlockID, m.Version, prov)
 			return e
 		})
 	if err != nil {
@@ -488,7 +510,7 @@ func doUpload(cmd *cobra.Command, client appapi.Submitter, zipBytes []byte, m *m
 		// nothing to do with the bundle) or a 429, where an entry list is noise
 		// on top of an error that already says what to do.
 		if !errors.Is(err, civitai.ErrUnauthorized) && !errors.Is(err, civitai.ErrRateLimited) {
-			printSubmitSizeDiagnosis(cmd.ErrOrStderr(), zipBytes)
+			printSubmitSizeDiagnosis(cmd.ErrOrStderr(), zipBytes, prov)
 		}
 		return err
 	}

--- a/internal/cmd/app_submit_dirty_guard.go
+++ b/internal/cmd/app_submit_dirty_guard.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/civitai/cli/internal/appapi"
 	"github.com/civitai/cli/internal/pkgzip"
 	"github.com/civitai/cli/pkg/civitai"
 )
@@ -24,10 +25,16 @@ import (
 // `custom-generators@0.5.2` exists in no commit anywhere.
 //
 // This guard is the PREVENTER: it refuses a submit whose bundle would carry
-// bytes that are in no commit, and names them. It is not the provenance stamp
-// the issue also asks for — that needs a server-side field on Submission
-// (internal/appapi/appblocks.go carries no commit/tree/dirty column), so the CLI
-// cannot send what the API will not accept, and #411 stays open for it.
+// bytes that are in no commit, and names them.
+//
+// 🔴 IT IS NOW ALSO THE FACT-GATHERER, AND THAT IS WHY IT RETURNS A VALUE. The
+// issue's other half — the provenance STAMP — needed a server-side column that
+// did not exist when the refusal shipped; civitai/civitai#4061 added it, so this
+// function now answers WHICH commit and WHETHER dirty as well as pass/fail.
+// There is exactly ONE git-invocation seam (gitOutputFunc) and it stays that
+// way: a second function asking the same repo the same questions is how the two
+// answers start disagreeing — the refusal naming a dirty path while the stamp
+// claims `sourceDirty: false`.
 //
 // 🔴 IT MUST DEGRADE, NOT ENFORCE. A hard refusal on "there is no git repo here"
 // would break the scaffold path outright: `civitai app scaffold` produces a
@@ -196,18 +203,42 @@ const dirtyPathListCap = 10
 // not exclude — `notes.md`, `App.tsx.orig`, a `.swp` — which genuinely ships.
 //
 // Every non-refusal branch:
-//   - --allow-dirty: returns immediately, before any subprocess.
+//   - --allow-dirty: never refuses and never warns, but still gathers the facts.
 //   - no repo, or no `git` on PATH: proceed SILENTLY. The scaffold path, and the
 //     one the issue says must not break.
 //   - `git status` failed on a tree that IS a repo: WARN and proceed. This is an
 //     accident preventer, not an authorization check.
 //   - clean, HEAD on no remote: WARN and proceed.
-func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version string, allowDirty bool) error {
-	if allowDirty {
-		return nil
-	}
+//
+// 🔴 IT ALSO RETURNS THE PROVENANCE (#411's stamp half), AND THE MATRIX IS THE
+// SAME ONE THE REFUSAL DEGRADES THROUGH — every branch that cannot establish a
+// fact reports it as UNKNOWN rather than as a default:
+//
+//	no repo / no git / bare repo / inside .git → Provenance{} (send nothing)
+//	unborn HEAD (rev-parse HEAD fails)         → Provenance{} (send nothing)
+//	`git status` failed                        → commit only, Dirty nil
+//	clean                                      → commit + Dirty=false
+//	dirty + --allow-dirty                      → commit + Dirty=TRUE
+//
+// 🔴 THE LAST ROW IS THE ONE WITH THE MOST DIAGNOSTIC VALUE, so --allow-dirty no
+// longer short-circuits before the subprocesses. It used to return before making
+// a single git call, on the reasoning that a release script which has already
+// decided should not pay for an answer it discards — but that answer is no
+// longer discarded: `--allow-dirty` is exactly the invocation that produces a
+// bundle carrying bytes in no commit, which is the state #411 was filed about,
+// and refusing to record it is refusing to record the only case anyone will need
+// to explain later. WHAT DID NOT CHANGE, and is the published contract of #415:
+// the flag still cannot refuse, and it still prints nothing. Both are enforced
+// here by construction — the warn writer is discarded and the dirty branch
+// returns a nil error — rather than by remembering to check the flag twice.
+func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version string, allowDirty bool) (appapi.Provenance, error) {
+	var prov appapi.Provenance
 	if git == nil {
-		return nil
+		return prov, nil
+	}
+	if allowDirty {
+		// The flag's whole meaning: no verdict, no advisories. Facts only.
+		warn = io.Discard
 	}
 
 	// One call answers both "is this a work tree at all" and "where is it inside
@@ -218,11 +249,11 @@ func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version st
 	// directory; neither has a working tree to be dirty, so both proceed.
 	out, err := git(dir, "rev-parse", "--is-inside-work-tree", "--show-prefix")
 	if err != nil {
-		return nil
+		return prov, nil
 	}
 	lines := strings.Split(strings.ReplaceAll(out, "\r\n", "\n"), "\n")
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "true" {
-		return nil
+		return prov, nil
 	}
 	prefix := ""
 	if len(lines) > 1 {
@@ -236,6 +267,15 @@ func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version st
 		// \n, so a lone \r from a CRLF-ish environment is the whole risk.
 		prefix = strings.TrimSuffix(lines[1], "\r")
 	}
+
+	// The commit half of the provenance, asked through the SAME seam. A failure
+	// is the unborn-HEAD case (a repo with no commits, which `app init` +
+	// `git init` produces before the first commit) and every other reason git
+	// cannot name HEAD; all of them mean "there is no commit to claim", which is
+	// UNKNOWN and never a default. Whatever comes back is trimmed and nothing
+	// else: the shape gate is appapi.Provenance.sanitised, one place, so this
+	// function cannot disagree with the wire about what is sendable.
+	prov.Commit = headCommit(git, dir)
 
 	// `-c status.relativePaths=false` pins the path spelling AS FUTURE-PROOFING,
 	// and the honest scope of that is narrower than it used to read here.
@@ -290,12 +330,21 @@ func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version st
 	raw, err := git(dir, "-c", "status.relativePaths=false", "status", "--porcelain", "-z", "--untracked-files=all", "--", ".")
 	if err != nil {
 		warnf(warn, "could not check whether %s is a clean git work tree (%v) — submitting without the dirty-tree guard.", dir, err)
-		return nil
+		// The commit is still known; the dirtiness is not. Provenance.Dirty
+		// stays nil — UNKNOWN — rather than defaulting to the reassuring answer
+		// for a question this run failed to ask.
+		return prov, nil
 	}
 
 	dirty := bundleDirtyPaths(raw, prefix, dir)
-	if len(dirty) > 0 {
-		return dirtyWorkTreeError(slug, version, dirty)
+	isDirty := len(dirty) > 0
+	prov.Dirty = &isDirty
+	if isDirty {
+		if allowDirty {
+			// Facts recorded, verdict withheld — see the 🔴 note above.
+			return prov, nil
+		}
+		return prov, dirtyWorkTreeError(slug, version, dirty)
 	}
 
 	// Clean. The remaining question is whether the commit it is clean AGAINST
@@ -310,7 +359,25 @@ func checkWorkTreeClean(git gitOutputFunc, warn io.Writer, dir, slug, version st
 		warnf(warn, "the work tree is clean, but HEAD is on no remote — this bundle's source exists only on this machine. "+
 			"Push the branch so the submitted version can be traced back to a commit.")
 	}
-	return nil
+	return prov, nil
+}
+
+// headCommit asks the one git seam for HEAD's sha, and returns "" for every
+// reason it cannot be established.
+//
+// 🔴 IT TRIMS AND JUDGES NOTHING ELSE. `git rev-parse HEAD` emits a lowercase
+// 40-hex sha and a trailing newline, so the trim is the whole of the normalising
+// this layer is entitled to do: a value that arrives in any other shape is a
+// signal that this is not the answer we asked for, and appapi's
+// `^[0-9a-f]{40}$` gate drops it. Uppercasing, truncating or lower-casing it
+// here would turn a value we do not understand into one that LOOKS right on the
+// wire, which is the only way this feature could make a submit worse.
+func headCommit(git gitOutputFunc, dir string) string {
+	out, err := git(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
 }
 
 // gitStatusEntry is one porcelain record: its two status letters and the path.

--- a/internal/cmd/app_submit_dirty_guard_test.go
+++ b/internal/cmd/app_submit_dirty_guard_test.go
@@ -184,7 +184,7 @@ func mkdirAllT(t *testing.T, dir string) string {
 func guardOn(t *testing.T, dir string, allowDirty bool) (string, error) {
 	t.Helper()
 	var warn bytes.Buffer
-	err := checkWorkTreeClean(gitOutput, &warn, dir, dirtySlug, "0.6.1", allowDirty)
+	_, err := checkWorkTreeClean(gitOutput, &warn, dir, dirtySlug, "0.6.1", allowDirty)
 	return warn.String(), err
 }
 
@@ -687,7 +687,7 @@ func TestDirtyGuardScopesTheStatusCallToThePackagedSubtree(t *testing.T) {
 		return "", nil
 	}
 	var warn bytes.Buffer
-	if err := checkWorkTreeClean(spy, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
+	if _, err := checkWorkTreeClean(spy, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
 		t.Fatalf("the stub reports a clean tree; got %v", err)
 	}
 	if len(statusArgs) < 2 || statusArgs[len(statusArgs)-2] != "--" || statusArgs[len(statusArgs)-1] != "." {
@@ -964,7 +964,7 @@ func TestDirtyGuardIsNotRelocatedByGIT_DIR(t *testing.T) {
 		return out.String(), nil
 	}
 	var ctlWarn bytes.Buffer
-	if err := checkWorkTreeClean(unscrubbed, &ctlWarn, target.root, dirtySlug, "0.6.1", false); err != nil {
+	if _, err := checkWorkTreeClean(unscrubbed, &ctlWarn, target.root, dirtySlug, "0.6.1", false); err != nil {
 		t.Fatalf("control: an UNSCRUBBED runner should be relocated by GIT_DIR and report clean; "+
 			"got a refusal, so this test cannot attribute anything to the scrub: %v", err)
 	}
@@ -1049,8 +1049,17 @@ func TestDirtyGuardCleanRepoProceeds(t *testing.T) {
 }
 
 // TestDirtyGuardAllowDirtySubmitsAnyway — the escape hatch, on the same tree the
-// positive control refuses. It short-circuits before any subprocess: a release
-// script that has already decided should not pay for an answer it discards.
+// positive control refuses.
+//
+// 🔴 THE "ZERO SUBPROCESSES" HALF OF THIS TEST WAS DELIBERATELY RETIRED IN #411,
+// AND THE REFUSAL CONTRACT WAS NOT. It used to assert `calls == 0`: the flag
+// short-circuited before any git call, on the reasoning that a release script
+// which has already decided should not pay for an answer it discards. The stamp
+// half of #411 makes that answer the single most useful one the CLI can record —
+// `--allow-dirty` is precisely the invocation that ships bytes in no commit — so
+// the facts are now gathered and `sourceDirty: true` is sent. What #415 published
+// and what this test still pins: the flag CANNOT refuse, and it prints NOTHING.
+// The provenance half is asserted in app_submit_provenance_test.go.
 func TestDirtyGuardAllowDirtySubmitsAnyway(t *testing.T) {
 	f := cleanAppFixture(t, "")
 	f.write("src/App.tsx", "uncommitted")
@@ -1061,17 +1070,9 @@ func TestDirtyGuardAllowDirtySubmitsAnyway(t *testing.T) {
 		t.Fatal("control: this tree must be refused WITHOUT --allow-dirty, or the flag proves nothing")
 	}
 
-	calls := 0
-	counting := func(dir string, args ...string) (string, error) {
-		calls++
-		return gitOutput(dir, args...)
-	}
 	var warn bytes.Buffer
-	if err := checkWorkTreeClean(counting, &warn, f.root, dirtySlug, "0.6.1", true); err != nil {
+	if _, err := checkWorkTreeClean(gitOutput, &warn, f.root, dirtySlug, "0.6.1", true); err != nil {
 		t.Fatalf("--allow-dirty must permit a dirty tree, got: %v", err)
-	}
-	if calls != 0 {
-		t.Errorf("--allow-dirty made %d git call(s); it must short-circuit before any subprocess", calls)
 	}
 	if warn.String() != "" {
 		t.Errorf("--allow-dirty must be silent, got:\n%s", warn.String())
@@ -1123,7 +1124,7 @@ func TestDirtyGuardIsSilentOncePushed(t *testing.T) {
 func TestDirtyGuardTreatsAMissingGitLikeNoRepo(t *testing.T) {
 	noGit := func(dir string, args ...string) (string, error) { return "", errGitUnavailable }
 	var warn bytes.Buffer
-	if err := checkWorkTreeClean(noGit, &warn, t.TempDir(), dirtySlug, "0.6.1", false); err != nil {
+	if _, err := checkWorkTreeClean(noGit, &warn, t.TempDir(), dirtySlug, "0.6.1", false); err != nil {
 		t.Fatalf("no git binary must degrade like no repo, got: %v", err)
 	}
 	if warn.String() != "" {
@@ -1145,7 +1146,7 @@ func TestDirtyGuardWarnsAndProceedsWhenStatusFails(t *testing.T) {
 		return "", boom
 	}
 	var warn bytes.Buffer
-	if err := checkWorkTreeClean(stub, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
+	if _, err := checkWorkTreeClean(stub, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
 		t.Fatalf("a failed status read must not block the submit, got: %v", err)
 	}
 	s := warn.String()
@@ -1167,7 +1168,7 @@ func TestDirtyGuardProceedsOnABareRepo(t *testing.T) {
 		return "", errors.New("nothing else should be asked")
 	}
 	var warn bytes.Buffer
-	if err := checkWorkTreeClean(stub, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
+	if _, err := checkWorkTreeClean(stub, &warn, "/some/dir", dirtySlug, "0.6.1", false); err != nil {
 		t.Fatalf("no working tree means nothing can be dirty, got: %v", err)
 	}
 	if warn.String() != "" {

--- a/internal/cmd/app_submit_provenance_test.go
+++ b/internal/cmd/app_submit_provenance_test.go
@@ -1,0 +1,495 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/appapi"
+)
+
+// TESTS FOR THE PROVENANCE STAMP'S FACT-GATHERING HALF (issue #411).
+//
+// The refusal half (#415) is app_submit_dirty_guard_test.go; this file is about
+// what checkWorkTreeClean now RETURNS, and about the two seams that value
+// crosses on its way to the server:
+//
+//	git stdout → checkWorkTreeClean → appapi.Provenance → submitBody → HTTP body
+//
+// 🔴 A UNIT TEST ON EACH END PROVES NEITHER. appapi's own tests prove a bad
+// value cannot leave the client; the fixtures here prove which value real git
+// produces. The defect that would survive both is in the SEAM — a gathering step
+// that hands over something the sender then dutifully drops (a stamp that never
+// arrives), or one that hands over something the sender happily forwards (a 400
+// that kills the submit). So the hostile-input test below drives the REAL
+// gathering function into the REAL client against an httptest server, and reads
+// the bytes that came out the far end.
+
+// fullSHARe is the SERVER's rule, spelled out here rather than imported, so an
+// assertion in this file is never a restatement of the code it is testing.
+var fullSHARe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// guardFacts runs the guard over a real repository and returns everything it
+// answered: the provenance, the warnings, the verdict.
+func guardFacts(t *testing.T, dir string, allowDirty bool) (appapi.Provenance, string, error) {
+	t.Helper()
+	var warn bytes.Buffer
+	prov, err := checkWorkTreeClean(gitOutput, &warn, dir, dirtySlug, "0.6.1", allowDirty)
+	return prov, warn.String(), err
+}
+
+func dirtyStr(d *bool) string {
+	if d == nil {
+		return "nil (UNKNOWN)"
+	}
+	return strconv.FormatBool(*d)
+}
+
+// TestProvenanceOnACleanTreeIsTheRealHeadSHA — the ordinary case, and the
+// expectation is git's own answer rather than a literal, so a truncation, a
+// different ref or a stale cache all show up.
+func TestProvenanceOnACleanTreeIsTheRealHeadSHA(t *testing.T) {
+	f := cleanAppFixture(t, "")
+	want := f.gitIn(f.root, "rev-parse", "HEAD")
+
+	prov, warn, err := guardFacts(t, f.root, false)
+	if err != nil {
+		t.Fatalf("a clean tree must proceed: %v", err)
+	}
+	if prov.Commit != want {
+		t.Errorf("sourceCommit = %q, want the tree's real HEAD %q (warnings: %s)", prov.Commit, want, warn)
+	}
+	if !fullSHARe.MatchString(prov.Commit) {
+		t.Errorf("sourceCommit %q is not the shape the server accepts — it would 400 the submit", prov.Commit)
+	}
+	if prov.Dirty == nil || *prov.Dirty {
+		t.Errorf("a clean tree must claim sourceDirty=false (an ASSERTION of clean, not silence), got %s",
+			dirtyStr(prov.Dirty))
+	}
+}
+
+// TestProvenanceUnderAllowDirtyClaimsDirty is the row with the most diagnostic
+// value, and the one the old --allow-dirty short-circuit made impossible.
+//
+// 🔴 IT IS ALSO A CONTRACT REGRESSION GUARD FOR #415: the same call must not
+// refuse and must not print. Gathering facts is allowed to cost a subprocess; it
+// is not allowed to change the verdict.
+func TestProvenanceUnderAllowDirtyClaimsDirty(t *testing.T) {
+	f := cleanAppFixture(t, "")
+	f.write("src/App.tsx", "uncommitted")
+	want := f.gitIn(f.root, "rev-parse", "HEAD")
+
+	// Control: the same tree really is refused without the flag.
+	if _, _, err := guardFacts(t, f.root, false); err == nil {
+		t.Fatal("control: this tree must be refused WITHOUT --allow-dirty, or the row below proves nothing")
+	}
+
+	prov, warn, err := guardFacts(t, f.root, true)
+	if err != nil {
+		t.Fatalf("--allow-dirty must never refuse: %v", err)
+	}
+	if warn != "" {
+		t.Errorf("--allow-dirty must stay silent, got:\n%s", warn)
+	}
+	if prov.Commit != want {
+		t.Errorf("sourceCommit = %q, want %q — a dirty bundle still has a commit it is dirty AGAINST, "+
+			"and that is the value someone will need to explain it later", prov.Commit, want)
+	}
+	if prov.Dirty == nil || !*prov.Dirty {
+		t.Errorf("--allow-dirty on a dirty tree must claim sourceDirty=true, got %s", dirtyStr(prov.Dirty))
+	}
+}
+
+// TestProvenanceIsAbsentWhereNoFactExists walks every branch that cannot
+// establish a commit. All of them must return the ZERO provenance: the wire
+// spelling of UNKNOWN is an absent key, and a default here would be a claim
+// nobody made.
+//
+// 🔴 THE FIRST ROW IS THE SCAFFOLD PATH THE ISSUE SAYS MUST NOT BREAK.
+func TestProvenanceIsAbsentWhereNoFactExists(t *testing.T) {
+	t.Run("a directory in no git repo", func(t *testing.T) {
+		requireGit(t)
+		gitFixtureEnv(t)
+		dir := t.TempDir()
+		prov, warn, err := guardFacts(t, dir, false)
+		if err != nil {
+			t.Fatalf("a scaffolded app with no repo must submit exactly as before: %v", err)
+		}
+		if warn != "" {
+			t.Errorf("the no-repo path must stay silent, got:\n%s", warn)
+		}
+		assertNoProvenance(t, prov)
+	})
+
+	t.Run("no git binary at all", func(t *testing.T) {
+		noGit := func(string, ...string) (string, error) { return "", errGitUnavailable }
+		var w bytes.Buffer
+		prov, err := checkWorkTreeClean(noGit, &w, "/some/dir", dirtySlug, "0.6.1", false)
+		if err != nil {
+			t.Fatalf("no git binary must degrade like no repo: %v", err)
+		}
+		assertNoProvenance(t, prov)
+	})
+
+	t.Run("an unborn HEAD — a repo with no commits", func(t *testing.T) {
+		f := newGitFixture(t) // init only; nothing committed
+		writeManifestVersion(t, f.root, dirtySlug, "0.6.1")
+		// --allow-dirty, because an unborn HEAD's tree is untracked by
+		// definition; the flag isolates the question to the COMMIT.
+		prov, _, err := guardFacts(t, f.root, true)
+		if err != nil {
+			t.Fatalf("an unborn HEAD must not break a submit: %v", err)
+		}
+		if prov.Commit != "" {
+			t.Errorf("sourceCommit = %q for a repo with no commits — there is no commit to claim", prov.Commit)
+		}
+	})
+
+	t.Run("a bare repo / inside .git", func(t *testing.T) {
+		stub := func(_ string, args ...string) (string, error) {
+			if len(args) > 0 && args[0] == "rev-parse" {
+				return "false\n", nil
+			}
+			return "", errors.New("nothing else should be asked")
+		}
+		var w bytes.Buffer
+		prov, err := checkWorkTreeClean(stub, &w, "/some/dir", dirtySlug, "0.6.1", false)
+		if err != nil {
+			t.Fatalf("no working tree means nothing can be dirty: %v", err)
+		}
+		assertNoProvenance(t, prov)
+	})
+}
+
+func assertNoProvenance(t *testing.T, prov appapi.Provenance) {
+	t.Helper()
+	if prov.Commit != "" {
+		t.Errorf("sourceCommit = %q where no commit could be established; want \"\" so the key is ABSENT on the wire", prov.Commit)
+	}
+	if prov.Dirty != nil {
+		t.Errorf("sourceDirty = %v where nothing was established; want nil.\n"+
+			"false is an ASSERTION that a client looked and the tree was clean — it must never be a default.", *prov.Dirty)
+	}
+}
+
+// TestProvenanceKeepsDirtinessUnknownWhenStatusFails is the half-known row. The
+// commit resolved; the question about the work tree failed. `false` here would
+// be the `?? false` collapse: a claim of clean built out of a failure.
+func TestProvenanceKeepsDirtinessUnknownWhenStatusFails(t *testing.T) {
+	const sha = "3b1d90c07af4e5628ba1d7c9f0e24587ac6bd913"
+	stub := func(_ string, args ...string) (string, error) {
+		switch {
+		case len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD":
+			return sha + "\n", nil
+		case len(args) > 0 && args[0] == "rev-parse":
+			return "true\n\n", nil
+		}
+		return "", errors.New("fatal: index file corrupt")
+	}
+	var w bytes.Buffer
+	prov, err := checkWorkTreeClean(stub, &w, "/some/dir", dirtySlug, "0.6.1", false)
+	if err != nil {
+		t.Fatalf("a failed status read must not block the submit: %v", err)
+	}
+	if prov.Commit != sha {
+		t.Errorf("sourceCommit = %q, want %q — the commit was established even though the status read was not", prov.Commit, sha)
+	}
+	if prov.Dirty != nil {
+		t.Errorf("sourceDirty = %v after a FAILED status read; want nil (UNKNOWN). "+
+			"A question this run could not ask has no answer, and the reassuring answer is the wrong default.", *prov.Dirty)
+	}
+	if !strings.Contains(w.String(), "could not check") {
+		t.Errorf("the fail-open must still be announced, got:\n%s", w.String())
+	}
+}
+
+// --- THE SEAM: git stdout → guard → client → HTTP body ---------------------
+
+// submitThrough sends prov through the REAL appapi client to a recording server
+// and returns the request body's raw fields.
+func submitThrough(t *testing.T, prov appapi.Provenance) map[string]json.RawMessage {
+	t.Helper()
+	var got map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"publishRequestId": "pubreq_x", "slug": dirtySlug, "version": "0.6.1", "status": "pending",
+		})
+	}))
+	defer srv.Close()
+
+	c := appapi.New(srv.URL, "tok", "")
+	if _, err := c.SubmitVersion(context.Background(), []byte("ZIP"), dirtySlug, "0.6.1", prov); err != nil {
+		t.Fatalf("SubmitVersion: %v", err)
+	}
+	if _, ok := got["bundleBase64"]; !ok {
+		t.Fatal("CONTROL failure: the recorded body is not a submit body")
+	}
+	return got
+}
+
+// TestHostileGitOutputNeverReachesTheWire is the guard that matters most, and it
+// is deliberately built at the SEAM rather than at either end.
+//
+// Every row is a string a real `git rev-parse HEAD` could hand this CLI when
+// something is wrong — a stale git, a hook-mangled environment, a detached-HEAD
+// message, an error printed to stdout. The assertion is not "the stamp is
+// right"; it is that the request body carries either NO sourceCommit or one the
+// server's `^[0-9a-f]{40}$` accepts. Anything else is a 400 on the whole upload:
+// the provenance feature would have taken away a submit that used to work.
+func TestHostileGitOutputNeverReachesTheWire(t *testing.T) {
+	const good = "9f2c41ab7de305619c8bd4a0e7f13c25db806e4f"
+	rows := []struct{ name, revParseHEAD string }{
+		{"an empty answer", ""},
+		{"whitespace only", "   \n"},
+		{"an uppercase sha", strings.ToUpper(good)},
+		{"an abbreviated sha", good[:7]},
+		{"39 characters", good[:39]},
+		{"41 characters", good + "0"},
+		{"a sha with a trailing CRLF", good + "\r\n"},
+		{"a detached-HEAD description", "HEAD detached at 9f2c41a"},
+		{"the ref name instead of the sha", "HEAD"},
+		{"an error on stdout", "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."},
+		{"a sha with a NUL", good[:20] + "\x00" + good[21:]},
+		{"two shas", good + " " + good},
+		{"a value that would break out of the JSON string", `","sourceDirty":true,"evil":"`},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			// A repo that says it is clean, so the ONLY variable is HEAD's text.
+			stub := func(_ string, args ...string) (string, error) {
+				switch {
+				case len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD":
+					return row.revParseHEAD, nil
+				case len(args) > 0 && args[0] == "rev-parse":
+					return "true\n\n", nil
+				case len(args) > 0 && args[0] == "for-each-ref":
+					return "origin/main\n", nil
+				}
+				return "", nil // an empty porcelain status: clean
+			}
+			var w bytes.Buffer
+			prov, err := checkWorkTreeClean(stub, &w, "/some/dir", dirtySlug, "0.6.1", false)
+			if err != nil {
+				t.Fatalf("the tree is clean; the guard must not refuse: %v", err)
+			}
+
+			body := submitThrough(t, prov)
+			raw, present := body["sourceCommit"]
+			if !present {
+				if _, d := body["sourceDirty"]; d {
+					t.Errorf("no sourceCommit was sent, but sourceDirty was — that claims a work-tree "+
+						"state for a commit the CLI could not name (git said %q)", row.revParseHEAD)
+				}
+				return
+			}
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				t.Fatalf("sourceCommit is not a JSON string: %s", raw)
+			}
+			if !fullSHARe.MatchString(s) {
+				t.Errorf("git printed %q and the CLI put %q on the wire.\n"+
+					"The server answers a malformed sourceCommit with a HARD 400 that fails the whole submit — "+
+					"a provenance stamp must never turn a working submit into a failed one.", row.revParseHEAD, s)
+			}
+		})
+	}
+
+	// POSITIVE CONTROL on the whole chain: a good sha must actually arrive, or
+	// every row above would pass against a chain that sends nothing at all.
+	stub := func(_ string, args ...string) (string, error) {
+		switch {
+		case len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD":
+			return good + "\n", nil
+		case len(args) > 0 && args[0] == "rev-parse":
+			return "true\n\n", nil
+		case len(args) > 0 && args[0] == "for-each-ref":
+			return "origin/main\n", nil
+		}
+		return "", nil
+	}
+	var w bytes.Buffer
+	prov, err := checkWorkTreeClean(stub, &w, "/some/dir", dirtySlug, "0.6.1", false)
+	if err != nil {
+		t.Fatalf("control: %v", err)
+	}
+	body := submitThrough(t, prov)
+	if got := string(body["sourceCommit"]); got != `"`+good+`"` {
+		t.Fatalf("CONTROL failure: a well-formed sha did not survive the chain (got %s). "+
+			"Every row above would report the same 'nothing malformed was sent' with the feature deleted.", got)
+	}
+	if got := string(body["sourceDirty"]); got != "false" {
+		t.Fatalf("CONTROL failure: a clean tree did not send an explicit false (got %q)", got)
+	}
+}
+
+// --- END TO END: the command, a real repo, a recording server ---------------
+
+// submitRecorder is a server that answers both routes `app submit` touches and
+// records the submit body plus its exact byte length.
+type submitRecorder struct {
+	body   map[string]json.RawMessage
+	nbytes int
+}
+
+func newSubmitRecorder(t *testing.T) (*submitRecorder, *httptest.Server) {
+	t.Helper()
+	rec := &submitRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "submit-version") {
+			var buf bytes.Buffer
+			n, _ := buf.ReadFrom(r.Body)
+			rec.nbytes = int(n)
+			if err := json.Unmarshal(buf.Bytes(), &rec.body); err != nil {
+				t.Errorf("decode submit body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"publishRequestId": "pubreq_e2e", "slug": dirtySlug, "version": "0.6.1", "status": "pending",
+			})
+			return
+		}
+		// The version guard's listing read.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"submissions": []any{}})
+	}))
+	return rec, srv
+}
+
+func runSubmitIn(t *testing.T, dir, srvURL string, extra ...string) (string, string, error) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CIVITAI_TOKEN", "tok-prov")
+	t.Setenv("CIVITAI_BASE_URL", srvURL)
+	t.Setenv("CIVITAI_SUBMIT_PATH", "")
+	return run(t, append([]string{"app", "submit", dir, "--yes"}, extra...)...)
+}
+
+// TestAppSubmitStampsTheCommitEndToEnd drives the whole command over a real git
+// repository and reads what the server received. The three rows are the three
+// answers the feature can give.
+func TestAppSubmitStampsTheCommitEndToEnd(t *testing.T) {
+	t.Run("a clean repo stamps the commit and an explicit false", func(t *testing.T) {
+		f := cleanAppFixture(t, "")
+		f.publishHEAD()
+		want := f.gitIn(f.root, "rev-parse", "HEAD")
+
+		rec, srv := newSubmitRecorder(t)
+		defer srv.Close()
+		stdout, stderr, err := runSubmitIn(t, f.root, srv.URL)
+		if err != nil {
+			t.Fatalf("submit: %v\n%s\n%s", err, stdout, stderr)
+		}
+		if got := string(rec.body["sourceCommit"]); got != `"`+want+`"` {
+			t.Errorf("the server received sourceCommit=%s, want %q", got, want)
+		}
+		if got := string(rec.body["sourceDirty"]); got != "false" {
+			t.Errorf("the server received sourceDirty=%q, want an explicit false", got)
+		}
+	})
+
+	t.Run("--allow-dirty stamps the commit and true", func(t *testing.T) {
+		f := cleanAppFixture(t, "")
+		f.publishHEAD()
+		f.write("src/App.tsx", "uncommitted")
+		want := f.gitIn(f.root, "rev-parse", "HEAD")
+
+		rec, srv := newSubmitRecorder(t)
+		defer srv.Close()
+		stdout, stderr, err := runSubmitIn(t, f.root, srv.URL, "--allow-dirty")
+		if err != nil {
+			t.Fatalf("submit --allow-dirty: %v\n%s\n%s", err, stdout, stderr)
+		}
+		if got := string(rec.body["sourceCommit"]); got != `"`+want+`"` {
+			t.Errorf("the server received sourceCommit=%s, want %q", got, want)
+		}
+		if got := string(rec.body["sourceDirty"]); got != "true" {
+			t.Errorf("the server received sourceDirty=%q, want true — this is the case worth recording", got)
+		}
+	})
+
+	// 🔴 THE REGRESSION ROW. A scaffolded app is a directory with no repo, and
+	// that submit must be byte-identical to what it was before #411: no keys.
+	t.Run("a directory in no repo sends no provenance at all", func(t *testing.T) {
+		requireGit(t)
+		gitFixtureEnv(t)
+		dir := t.TempDir()
+		writeManifestVersion(t, dir, dirtySlug, "0.6.1")
+
+		rec, srv := newSubmitRecorder(t)
+		defer srv.Close()
+		stdout, stderr, err := runSubmitIn(t, dir, srv.URL)
+		if err != nil {
+			t.Fatalf("submit from a non-repo must still work: %v\n%s\n%s", err, stdout, stderr)
+		}
+		for _, k := range []string{"sourceCommit", "sourceDirty"} {
+			if raw, ok := rec.body[k]; ok {
+				t.Errorf("a directory in no git repo sent %s=%s; it must send NOTHING — "+
+					"there is no fact here, and every scaffolded app starts this way", k, raw)
+			}
+		}
+		if _, ok := rec.body["bundleBase64"]; !ok {
+			t.Error("CONTROL failure: no bundle was uploaded, so the absence above is not evidence about provenance")
+		}
+	})
+}
+
+// TestPackagedLineReportsTheSizeOfTheBodyThatWasSENT is the #423 contract under
+// #411's fields, measured end to end.
+//
+// 🔴 THIS IS WHY SubmitBodySize TAKES THE PROVENANCE. The number on the
+// `Packaged …` line is published to users as the EXACT size a request-body limit
+// applies to. A stamped submit is bigger than a bare one, so a size function
+// that could not see the stamp would print a number that is no longer the one
+// that left the machine — a small error in the quantity and a total one in the
+// claim. The expectation here is the byte count the SERVER measured, not
+// anything the CLI computed.
+func TestPackagedLineReportsTheSizeOfTheBodyThatWasSENT(t *testing.T) {
+	f := cleanAppFixture(t, "")
+	f.publishHEAD()
+
+	rec, srv := newSubmitRecorder(t)
+	defer srv.Close()
+	stdout, stderr, err := runSubmitIn(t, f.root, srv.URL)
+	if err != nil {
+		t.Fatalf("submit: %v\n%s\n%s", err, stdout, stderr)
+	}
+	m := packagedLineRe.FindStringSubmatch(stdout)
+	if m == nil {
+		t.Fatalf("no `Packaged …` line in:\n%s", stdout)
+	}
+	reported := atoiOrFatal(t, m[4])
+	if rec.nbytes == 0 {
+		t.Fatal("CONTROL failure: the server measured a zero-byte request body")
+	}
+	if reported != rec.nbytes {
+		t.Errorf("the CLI printed %d bytes as the submit-body size, but the server received %d.\n"+
+			"The difference is the provenance stamp (%s): the printed number is documented as EXACT, "+
+			"so it has to be computed from the body this run actually sends.",
+			reported, rec.nbytes, provFields(rec.body))
+	}
+}
+
+func provFields(body map[string]json.RawMessage) string {
+	var parts []string
+	for _, k := range []string{"sourceCommit", "sourceDirty"} {
+		if raw, ok := body[k]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, raw))
+		}
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cmd/app_submit_test.go
+++ b/internal/cmd/app_submit_test.go
@@ -16,14 +16,16 @@ type fakeSubmitter struct {
 	got        []byte
 	gotSlug    string
 	gotVersion string
+	gotProv    appapi.Provenance
 	result     *appapi.SubmitResult
 	err        error
 }
 
-func (f *fakeSubmitter) SubmitVersion(_ context.Context, zip []byte, slug, version string) (*appapi.SubmitResult, error) {
+func (f *fakeSubmitter) SubmitVersion(_ context.Context, zip []byte, slug, version string, prov appapi.Provenance) (*appapi.SubmitResult, error) {
 	f.got = zip
 	f.gotSlug = slug
 	f.gotVersion = version
+	f.gotProv = prov
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -39,7 +41,7 @@ func TestDoUploadHandsBytesToSubmitter(t *testing.T) {
 	c.SetOut(&out)
 
 	m := &manifest.Manifest{BlockID: "demo", Version: "0.1.0", Name: "Demo"}
-	if err := doUpload(c, fs, []byte("ZIPBYTES"), m, "https://civitai.com/"); err != nil {
+	if err := doUpload(c, fs, []byte("ZIPBYTES"), m, "https://civitai.com/", appapi.Provenance{}); err != nil {
 		t.Fatalf("doUpload: %v", err)
 	}
 	if string(fs.got) != "ZIPBYTES" {
@@ -67,7 +69,7 @@ func TestDoUploadSuccessOutput(t *testing.T) {
 
 	m := &manifest.Manifest{BlockID: "my-block", Version: "0.2.0", Name: "My Block"}
 	// trailing slash on baseURL must be trimmed when composing the link.
-	if err := doUpload(c, fs, []byte("ZIP"), m, "https://civitai.com/"); err != nil {
+	if err := doUpload(c, fs, []byte("ZIP"), m, "https://civitai.com/", appapi.Provenance{}); err != nil {
 		t.Fatalf("doUpload: %v", err)
 	}
 	s := out.String()

--- a/internal/cmd/exitcodes_doc.go
+++ b/internal/cmd/exitcodes_doc.go
@@ -144,6 +144,11 @@ var exitCodeDocs = []ExitCodeDoc{
 			// working tree against its own history. Pinned by
 			// TestDirtyWorkTreeExitsGeneric.
 			"A **dirty git work tree** lands here too: `civitai app submit` refuses while files that go into the bundle are uncommitted, because the bundle is packaged from what is on disk and approving one deploys code that exists in no commit. `--allow-dirty` submits the tree as it is. It **degrades rather than enforcing** — a directory that is not in a git repo, or a machine with no `git` on `PATH`, submits exactly as before (scaffolded apps have no repo, and that path must keep working), and a clean tree whose `HEAD` is on no remote **warns** instead of refusing. Like the version guard it is skipped by `--package-only` and by a run with no token.",
+			// 🔴 ADDED for the provenance STAMP half of the same issue (#411).
+			// It is here because the question a reader arrives with is "can this
+			// new field fail my submit?", and the answer belongs beside the
+			// guard's own bullet rather than only in the README section.
+			"The **build-provenance stamp** those two guards now also collect (issue #411 — the commit `civitai app submit` reports and `civitai app status` shows) changes no exit code at all, in either direction. It is sent only when the CLI can establish a value in exactly the shape the server accepts (`^[0-9a-f]{40}$`); every branch that cannot — no repo, no `git` on `PATH`, a repo with no commits, or an answer it does not recognise — sends nothing and submits exactly as it did before. A submit that would have succeeded cannot fail because of it, and a missing stamp is never an error.",
 			"**\"Wait for approval\" is the *pending* case only.** The same `1` covers an app whose latest submission was **rejected** or **withdrawn** — nothing is in review there, so `civitai app metrics <slug>` says so and names a new `civitai app submit` as the next step instead of a review to wait for. What separates `1` from `4` is unchanged: the slug is right and the app exists.",
 		},
 	},


### PR DESCRIPTION
Closes the CLI half of #411. The server half is civitai/civitai#4061 (merged; both databases migrated).

`civitai app submit` now records **which source the bundle was built from**, and `civitai app status` shows it.

## What ships

**1. The facts** — `checkWorkTreeClean` (the #415 dirty-tree guard) now returns an `appapi.Provenance` alongside its verdict. There is still exactly **one** git-invocation seam (`gitOutputFunc`): a second function asking the same repo the same questions is how the refusal ("these paths are uncommitted") and the stamp (`sourceDirty: false`) start disagreeing.

Every branch that cannot establish a fact reports it **absent**, never as a default:

| situation | `sourceCommit` | `sourceDirty` |
| --- | --- | --- |
| no repo / no `git` on PATH / bare repo / inside `.git` | absent | absent |
| unborn HEAD (repo with no commits) | absent | absent |
| `git status` failed | the sha | **absent (unknown)** |
| clean tree | the sha | `false` |
| dirty tree + `--allow-dirty` | the sha | `true` |

`--allow-dirty` no longer short-circuits before the subprocesses — it is precisely the invocation that ships bytes in no commit, so it is the case most worth recording. **#415's published contract is unchanged**: the flag still cannot refuse and still prints nothing, both by construction (the warn writer is discarded; the dirty branch returns a nil error).

**2. Sending them** — `submitBody` gains `sourceCommit`/`sourceDirty`, both `omitempty`. `sourceDirty` is a `*bool` so `omitempty` drops *unknown* while keeping an explicit `false`.

`Provenance.sanitised()` is the **one gate** before the wire and mirrors the server's `^[0-9a-f]{40}$`. A malformed `sourceCommit` is a hard 400 that fails the *whole* submit, so anything else is sent as absent — and the dirty flag goes with it, because dirtiness without a commit is not a fact anyone can act on.

**3. `SubmitBodySize` — the decision.** The signature became `SubmitBodySize(zipLen int, prov Provenance) int`. That number is published to users on the `Packaged …` line and again under a failed submit, documented as **exact** (#423, AGENTS.md item 31); a stamped body is ~70 bytes larger than a bare one, so a signature that could not see the provenance would keep printing a number that is no longer the one on the wire — a small error in the quantity and a total one in the claim. The envelope is **measured by marshalling** rather than by a second arithmetic model, so a field added to `submitBody` is accounted for without anyone remembering to update a term. A run that sends no provenance (`--package-only`, the no-token fallback) prints the byte-identical number it always did, and `TestPackagedLineReportsTheSizeOfTheBodyThatWasSENT` compares the printed number against the byte count the **server** measured.

**4. Reading them back** — `Submission.SourceCommit *string` / `SourceDirty *bool`. `null` (unknown) and `false` (a client asserted clean) are different answers and stay different all the way to `--json`. `app status` grows a `SOURCE` column (`a1b2c3d`, `a1b2c3d (dirty)`, `a1b2c3d (dirty?)` when only the commit is known, `-` for unknown); the detail view carries the full 40 characters plus one attribution sentence. These are **unverified client claims** — the server stores what it is told — so nothing is worded as verified (AGENTS.md item 28 is the precedent). `--json` never passes through `internal/ui`.

## Docs

README is not one place, so: the command-table rows for `app submit` **and** `app status`, a new `### Build provenance: which commit is live?` section (+ TOC entry), the bundle-size section (the JSON envelope is no longer one fixed shape), both `app status` transcripts, the detail transcript, and a **generated** exit-code-1 clause (`internal/cmd/exitcodes_doc.go`) stating that the stamp changes no exit code in either direction. The Troubleshooting index gained **no** row on purpose: it is keyed on strings the CLI really prints (enforced by `TestREADMETroubleshootingSymptomsExistInTheSource`) and this feature emits no message.

AGENTS.md gains **item 32, inline**. A first-appearance item has no base commit whose AGENTS.md held its body, so it cannot carry a `splitItems` digest until it merges — the wave-5 note in `agents_split_preserved_test.go` documents exactly this dance. ⚠️ AGENTS.md is now **28,746 bytes against the 28,758 ceiling — 12 bytes of headroom**. The next docs edit there will fail `TestAgentsMDStaysUnderItsCeiling`; converting item 32 (or 30/31, which now have base commits) in a follow-up wave is the repo's own remedy.

## Verification

- `make ci` rc=0, 20/20 packages ok. `make ci-shallow` at `50c2ff5` (depth-1, the environment CI actually has): **20/20 ok, 0 failures, 0 timeouts**.
- `golangci-lint run ./...` at CI's pinned **v2.12.2**: `0 issues.`
- Full `go test ./... -v`: **4530 PASS / 0 FAIL / 4 SKIP**, no timeout panics.
- **Mutation battery: 19/19 killed.** Every mutant edited one narrow expression in production source, was re-read from disk to confirm it landed, and the tree was restored and re-hashed afterwards. Semantic ones, not just deletions: uppercase the sha before sending; truncate it to 7; drop `omitempty` from either field; keep the dirty flag when the commit is unusable; disable the regex gate; ignore provenance in `SubmitBodySize`; invert the dirty flag; skip provenance under `--allow-dirty`; default dirtiness to `false` when `git status` fails; drop the newline trim; collapse UNKNOWN dirtiness into clean in the renderer; drop the attribution sentence; abbreviate the detail-view sha; pass a zero `Provenance` at the call site. (`M1`/`M2`, which delete a struct field, are compile-level kills — weaker evidence, stated as such.)
- **The hostile-git-output test is the one that matters**: 13 shapes a real `git rev-parse HEAD` could produce when something is wrong (uppercase, abbreviated, 39/41 chars, trailing CRLF, a detached-HEAD description, an error on stdout, an embedded NUL, a JSON-breaking string, …) are driven through the **real** gathering function into the **real** client against an httptest server, asserting the request body either omits `sourceCommit` or carries a value the server's own regex accepts. It has a positive control proving a good sha survives the same chain, so "nothing malformed was sent" is not satisfiable by a chain that sends nothing.

## What was NOT verified

**No real `source_commit` has been written through a real submit into a real row.** Every "end to end" test here ends at an `httptest` server; nothing in this PR was exercised against dev or prod. The wire contract is implemented from civitai/civitai#4061 as described, not confirmed against a live 200.

The base-ref RED matrix is also weaker than usual and is stated plainly: the new tests name types the base commit does not have (`appapi.Provenance`, `sourceLabel`, the 5-argument `SubmitVersion`), so restoring the four production files to `origin/main` produces a **compile failure**, not a behavioural red. The substantive negative evidence is the mutation battery above.

One deliberate test change: `TestDirtyGuardAllowDirtySubmitsAnyway` lost its `calls == 0` assertion (the flag used to make zero git calls). The refusal and silence contracts it also pins are unchanged and still asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
