### PR TITLE
docs(agents): evict item 32 to its evidence file — the ceiling had 12 bytes left

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,10 +433,8 @@ item must carry a trigger that is a routing question rather than a label
     `pkgzip.LargestEntries`, only under a failed submit. Name no server ceiling.
 
 32. **Sending or showing the commit an app was built from — the 40-hex gate,
-    `sourceDirty`'s null-vs-false, or the submit body's size?** An UNVERIFIED
-    client claim: word none of it as verified, never `?? false`, and send
-    nothing rather than a value `^[0-9a-f]{40}$` rejects — malformed is a 400
-    that fails the submit (#411).
+    `sourceDirty`'s null-vs-false, or the submit body's size?**
+    → evidence: claudedocs/decisions/32-submit-provenance-claim.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -142,6 +142,20 @@ const agentsSplitBaseWave4 = "dfdcc974976ef4d8104f273b28b1f702c5a7f839"
 // merge, after which converting it is an ordinary wave.
 const agentsSplitBaseWave5 = "53a925bf7810f2e0dadd64ddc9f77f2e390ae8b4"
 
+// agentsSplitBaseWave6 is the commit item 32 was moved from: the tip after #471
+// (the `app submit` provenance stamp), which is where item 32's body first
+// landed inline.
+//
+// Wave 6 is wave 5's lesson applied on purpose rather than discovered. Item 32
+// arrived inline in #471 for the same structural reason item 29 did — a
+// first-appearance item has no base commit whose AGENTS.md already held its body
+// — and the conversion was queued as the follow-up in the same breath, not left
+// to be noticed later. What forced the follow-up to happen NOW rather than
+// eventually: #471 left AGENTS.md 12 bytes under agentsMaxBytes, so the next
+// docs edit of any kind would have failed the ceiling. The eviction is the
+// repo's own remedy, and it is cheapest immediately after the item merges.
+const agentsSplitBaseWave6 = "8e51494c8549cdb838d3861de0dcc63c38d294d5"
+
 type splitItem struct {
 	num      int
 	file     string
@@ -182,6 +196,7 @@ var splitItems = []splitItem{
 	{num: 16, file: "claudedocs/decisions/16-externalid-is-the-idempotency-key.md", base: agentsSplitBaseWave4, nonBlank: 25, sha: "cf7f2bd23cf64b0421fad49ace38df6dcdef3d3c3104aecef19e7657935caa4f"},
 	{num: 28, file: "claudedocs/decisions/28-no-claims-about-unobservable-spend.md", base: agentsSplitBaseWave4, nonBlank: 31, sha: "41387de27265146eb9c9fc8a507621b27b8b20cdf0db8d7eb9d4903021707478"},
 	{num: 29, file: "claudedocs/decisions/29-offsite-refusal.md", base: agentsSplitBaseWave5, nonBlank: 8, sha: "df86c7a851e2397db48eebd2f4b9d17e91565128ec4550510a62b785f552828d"},
+	{num: 32, file: "claudedocs/decisions/32-submit-provenance-claim.md", base: agentsSplitBaseWave6, nonBlank: 5, sha: "45d00151610d87af805502b0113bd6195417ec26ae5c4a4b0d797e0ef7ca5ad9"},
 }
 
 // --- the one deliberate delta, item 3 ---------------------------------------

--- a/claudedocs/decisions/32-submit-provenance-claim.md
+++ b/claudedocs/decisions/32-submit-provenance-claim.md
@@ -1,0 +1,73 @@
+# AGENTS.md item 32 — what a submit may CLAIM about the source it was built from
+
+Evidence for item 32 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements and the residuals, consulted when editing the code they are
+about rather than on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## Why this item exists
+
+`civitai app submit` used to package whatever was in the directory and record
+**nothing** about where it came from, so deploy-vs-source drift could be
+observed but never diagnosed. Five first-party apps were found behind their live
+version, and `custom-generators` had never held its live `0.5.2` anywhere in git
+history; reconciling them took a session of archaeology (`civitai/cli#411`).
+
+The server half is `civitai/civitai#4061` — two nullable columns,
+`source_commit` and `source_dirty`, on `app_block_publish_requests`. The CLI
+half is `civitai/cli#471`.
+
+## The two front doors — read this before touching the wire
+
+🔴 **Two routes parse `submitVersionSchema`, and the CLI uses only one of them.**
+`/api/blocks/submit-version` is the cookie/moderator-browser route;
+`/api/v1/blocks/submit-version` is the bearer-token route, and it is the one
+this CLI posts to (`appapi.DefaultSubmitPath`). Wiring provenance into only the
+first would leave the real client's claim silently stripped — the exact
+inert-feature shape the whole issue exists to close, with a fully green suite.
+The generalisation: *"the server accepts a new field" is a question about every
+parse site, not about the schema.*
+
+## Why a malformed value must never be sent
+
+The server validates `sourceCommit` against `^[0-9a-f]{40}$` and **hard-400s** a
+malformed one — deliberately, because silently dropping it is the inert shape
+above. That decision moves the burden to this client: a CLI that sends garbage
+turns a working submit into a failed one. Hence `Provenance.sanitised()`, the
+single gate before the wire, and the hostile-git-output tests behind it. Send
+nothing rather than something bad.
+
+## `source_dirty` is TRI-STATE
+
+`null` = UNKNOWN (a pre-feature row, no git repo, an unborn HEAD, or a client
+that sent nothing) · `false` = the client asserted the tree was CLEAN · `true` =
+the client asserted it was DIRTY. `null` and `false` are different answers.
+Never `?? false`, in the client or anywhere downstream — coercing turns "nobody
+looked" into "someone looked and it was clean", which is the opposite of what
+this feature is for.
+
+## Residual: measured, and still open at the time of writing
+
+The client half was proven correct against a capture server — correct route,
+true HEAD sha, `sourceDirty: false` rather than `null` — while a real production
+submit produced a row with `source_commit` **NULL**, because production had not
+yet deployed the server half. `app status` showing no provenance is therefore
+expected, not broken, until that deploy lands. The check that closes it: submit
+a throwaway from a clean repo and confirm a non-null `source_commit` matching
+local `HEAD`.
+
+---
+
+32. **Sending or showing the commit an app was built from — the 40-hex gate,
+    `sourceDirty`'s null-vs-false, or the submit body's size?** An UNVERIFIED
+    client claim: word none of it as verified, never `?? false`, and send
+    nothing rather than a value `^[0-9a-f]{40}$` rejects — malformed is a 400
+    that fails the submit (#411).


### PR DESCRIPTION
Converts AGENTS.md item 32 from inline body to trigger + evidence file. **This is a ceiling fix, not tidying.**

## Why now

`#471` landed item 32 inline, as a first-appearance item must — there is no base commit whose AGENTS.md already holds the body, so it cannot carry a `splitItems` provenance row on arrival. That left:

```
agentsMaxBytes = 28,758
AGENTS.md      = 28,746   ->  12 bytes of headroom
```

The next docs edit to `AGENTS.md` of any kind, by anyone, on any unrelated change, would have failed `TestAgentsMDStaysUnderItsCeiling`. I did not raise the constant — its own comment forbids raising it to make an item fit, and the repo's stated remedy is an eviction wave.

This is wave 6, and it is wave 5's lesson applied deliberately rather than discovered: **a new item is inline only until its FIRST MERGE**, after which converting it is an ordinary wave. `#471` was that first PR, so the base exists and the two-PR dance is complete.

## The pinned row

```
base     agentsSplitBaseWave6 = 8e51494c8549cdb838d3861de0dcc63c38d294d5
body     5 non-blank lines
sha256   45d00151610d87af805502b0113bd6195417ec26ae5c4a4b0d797e0ef7ca5ad9
```

The digest was derived from `git show 8e51494:AGENTS.md` by replicating `baseItemBody` / `nonBlank` / `digestLines` exactly — **not** from the file this PR writes. `TestSplitDigestsAreTheBaseCommitsText` then re-derived it independently and passed (0.04s, **not skipped**, this being a full clone). That test is the reason to believe the constant rather than my arithmetic.

## What the evidence file adds

The body sits verbatim below the `---` rule. The free-form header above it carries what the item could not say in five lines:

- **The two front doors.** `/api/blocks/submit-version` (cookie/mod) and `/api/v1/blocks/submit-version` (bearer, the one this CLI posts to). Wiring provenance into only the first ships a feature inert on exactly the path that matters, with a green suite.
- **Why a malformed value must never be sent.** The server hard-400s a bad `sourceCommit` by design, which moves the burden to this client: send nothing rather than something bad.
- **The tri-state.** `null` = unknown, `false` = asserted clean, `true` = asserted dirty. Never `?? false`.
- **The open residual.** The client half is proven correct against a capture server while a real production submit still returns `source_commit` NULL — the server half is merged but not yet deployed. `app status` showing no provenance is expected, not broken, until then.

## Verification

| gate | result |
|---|---|
| AGENTS guard tests | **9 ran, 9 passed, 0 skipped** (counted from `-v`, not an exit code) |
| `make ci` | green, 20/20 packages |
| `make ci-shallow` | **`ok=20/20 failing-tests=0 failing-packages=0 timeouts=0`** — run because `make ci` itself warns this change touches git-history-reading tests, and depth-1 is the tier CI actually has |
| `golangci-lint run ./...` (CI's pin) | `0 issues.` |

On that last one: my first invocation printed `0 issues.` **together with a typechecking error** — a reassuring zero from an instrument that had analysed nothing, because it ran from outside the module. Re-run from inside the module it reports `0 issues.` with no error. The contrast between the two runs is the control; I am reporting the second.

## Residual

Headroom is now **145 bytes, not 12**. Better, not comfortable. Items 2, 4, 30 and 31 remain inline, and 30/31 already have base commits — so the next eviction wave has somewhere obvious to start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
