### PR TITLE
fix(listing): "ONLY BY SLUG" was a claim about the SELECTOR, not the server (#424)

### DIFF
--- a/claudedocs/handoff-offsite-refusal.md
+++ b/claudedocs/handoff-offsite-refusal.md
@@ -199,6 +199,12 @@ Two nullable columns on `app_block_publish_requests`, accepted at submit and ret
 
 ### #424 — does the `slug` selector on `appListings.getMyListingForApp` EVER resolve?
 
+🔴 **SUPERSEDED, KEPT FOR PROVENANCE — do not act on the readings below.** They were taken
+against a server whose slug arm has since been rescoped by `civitai/civitai#3989`, so
+*"Live, the slug selector resolves nothing"* is no longer true. The current state of this
+question is the `civitai/cli#424` section further down; the over-general comment those
+readings were about has since been narrowed in `internal/cmd/app_listing.go`.
+
 - **Symptom + exact repro:** `internal/cmd/app_listing.go:186-192` carries a 🔴 comment
   asserting a pre-approval draft listing has `appBlockId = NULL` and is *"resolvable ONLY
   BY SLUG"*, with the slug argument *"load-bearing when it is absent"*. Live, the slug
@@ -322,9 +328,13 @@ Two nullable columns on `app_block_publish_requests`, accepted at submit and ret
 - **Resolved from server source** (`civitai/civitai@07a1c537dc`): the old arm was
   `where: { slug, kind:'onsite', appBlockId:null, status:'draft' }`, which accounts for every row
   in #424's measured table — approved onsite apps carry an `appBlockId` and fail clauses 2-3;
-  offsite fails clause 1. So the `app_listing.go:186-192` comment is **over-general, not wrong**.
+  offsite fails clause 1. So the `app_listing.go:186-192` comment was **over-general, not wrong**.
+  **Now narrowed**, and the corrected claim is pinned WHOLE
+  (`TestResolveListingScopeClaimIsPinnedWhole`), alongside a guard on the slug being
+  sent on BOTH lookup arms (`TestListingLookupCarriesTheSlugOnBothArms`).
 - **Still unmeasured:** the pending-onsite case itself. #424's two `appBlockId = nil` submissions
   were **withdrawn**, and the clause keys on the *listing's* status, not the submission's.
+  The narrowed comment says so in the code rather than only here.
 - **Next probe:** submit a throwaway app; before review, `GetMyListingForApp(ctx, "", "<slug>")`.
 - **Note:** #3989 widened past this shape entirely, so the answer now changes nothing operationally.
 

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -241,9 +241,13 @@ func decodeTRPCData(raw []byte, out any, route listingRoute) error {
 //
 // 🔴 The SLUG path is what reaches a PRE-APPROVAL DRAFT. A first-version app has no
 // backing AppBlock while it is pending review, so its draft listing (minted at
-// `civitai app submit`) has `appBlockId = NULL` and is resolvable ONLY by slug. That
-// is the whole reason listing media is settable while pending — resolving by
-// appBlockId alone can never see it.
+// `civitai app submit`) has `appBlockId = NULL` and there is no appBlockId to send:
+// resolving by appBlockId alone can never see it. That is the whole reason listing
+// media is settable while pending — and it is a fact about which SELECTOR this client
+// holds, not about how wide the server's slug arm is. The scope of that arm has
+// already moved once (civitai/civitai#3989) and is stated in ONE place, next to the
+// caller that depends on it: see `resolveListing` in `internal/cmd/app_listing.go`,
+// and civitai/cli#424 for the over-general claim this replaced.
 //
 // NOT_FOUND (404) means no listing row exists for the app at all.
 func (c *Client) GetMyListingForApp(ctx context.Context, appBlockID, slug string) (*ListingRef, error) {

--- a/internal/appapi/listing_test.go
+++ b/internal/appapi/listing_test.go
@@ -62,10 +62,17 @@ func TestGetMyListingForApp(t *testing.T) {
 }
 
 // 🔴 The PRE-APPROVAL DRAFT path: a first-version app pending review has NO backing
-// AppBlock, so its draft listing is resolvable ONLY by slug. If the request ever
-// carried an empty `appBlockId` key instead of omitting it, the server's
+// AppBlock, so the slug is the only selector this client can send for it. If the
+// request ever carried an empty `appBlockId` key instead of omitting it, the server's
 // "either appBlockId or slug" schema would still see a supplied-but-empty id — so
 // pin that the key is OMITTED entirely and the slug is what's sent.
+//
+// 🔴 THIS IS A CLAIM ABOUT THE REQUEST, AND ONLY ABOUT THE REQUEST. The fake below
+// answers with a draft UNCONDITIONALLY — it never inspects the input it just captured
+// — so a green here is evidence that the CLI sends the right wire shape and evidence
+// of NOTHING about what a real server resolves for that shape. civitai/cli#424 was
+// filed because the prose around this test read as the latter; the scope of the
+// server's slug arm lives with `resolveListing` in `internal/cmd/app_listing.go`.
 func TestGetMyListingForAppBySlugOnlyOmitsAppBlockID(t *testing.T) {
 	var gotInput string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/app_listing.go
+++ b/internal/cmd/app_listing.go
@@ -189,11 +189,33 @@ func resolveListingSlug(lc listingCommon) (string, error) {
 //
 // 🔴 A submission with NO appBlockId is a FIRST-version app still pending review. It
 // still has a store listing: `civitai app submit` mints one as a pre-approval DRAFT
-// so its media is settable while pending. That draft has `appBlockId = NULL` and is
-// resolvable ONLY BY SLUG, so we must still call through — short-circuiting to a
-// "no listing" error here would make the pending-media flow unreachable from the CLI
-// even though the server supports it. The slug is passed on BOTH paths (harmless when
-// the appBlockId resolves; load-bearing when it is absent).
+// so its media is settable while pending. That draft has `appBlockId = NULL`, so the
+// SLUG IS THE ONLY SELECTOR THAT CAN NAME IT — the appBlockId arm is skipped entirely
+// when the CLI has none to send. That is why the slug goes on BOTH calls (redundant
+// when the appBlockId resolves, the only handle when it is absent) and why
+// short-circuiting to a "no listing" error here would strand the pending-media flow.
+//
+// 🔴 "ONLY BY SLUG" IS A CLAIM ABOUT WHICH SELECTOR THE CLI CAN SEND, NEVER ABOUT HOW
+// WIDE THE SERVER'S SLUG ARM IS — civitai/cli#424, where this comment asserted the
+// second while only ever having evidence for the first. Against the server it was
+// written for, the arm was `{slug, kind:'onsite', appBlockId:null, status:'draft'}`:
+// four clauses that admitted the pre-approval draft and nothing else, so every OTHER
+// shape 404ed by slug — `gen-matrix` and `custom-generators` (onsite, approved, so
+// carrying an appBlockId) failed clauses 2-3, `radio` and `comfy` failed clause 1.
+// civitai/civitai#3989 then dropped it to `{slug, revisionOfId: null}`, which is what
+// the paragraph below rests on; re-verified against civitai/civitai origin/main at
+// `src/server/services/blocks/offsite-listing.service.ts:1746`. The pre-approval draft
+// is now ONE MEMBER of a wide set rather than the only thing the arm admits, so do not
+// re-derive a narrow server scope from this paragraph — read the server, it moves.
+//
+// 🟡 AND THE PENDING CASE IS ASSERTED FROM SERVER SOURCE, NOT MEASURED. No genuinely
+// `pending` first-version onsite app was ever probed: the only two `appBlockId = nil`
+// rows reachable on 2026-08-17 were WITHDRAWN, and the old clause keyed on the
+// LISTING's status rather than the submission's, so they could not answer it either
+// way. "The server supports it" is therefore unverified, not proven — do not upgrade
+// it to a measurement, and do not downgrade it to a doubt either. Nothing turns on it
+// today: the widened clause admits the row on the slug whatever its status, so this is
+// archaeology. civitai/cli#424 carries the recipe if anyone wants to settle it.
 //
 // 🔴 THE SUBMISSION LOOKUP IS THE ONSITE PATH, NOT THE ONLY PATH — civitai/cli#422
 // outcome 1, and this ordering is the whole of it. An OFFSITE app is a registered

--- a/internal/cmd/app_listing_scope_test.go
+++ b/internal/cmd/app_listing_scope_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// civitai/cli#424 — the narrowed scope claim on `resolveListing`.
+//
+// The defect #424 reported was in PROSE: the doc comment said a pre-approval draft is
+// "resolvable ONLY BY SLUG" with the slug argument "load-bearing when it is absent",
+// which reads as a claim about how wide the SERVER's slug arm is. The CLI only ever
+// had evidence for a claim about which SELECTOR it can send. This file holds the two
+// things that outlive the wording: the wire-shape relationship the narrowed comment
+// still rests on, and the corrected paragraphs themselves.
+
+// TestListingLookupCarriesTheSlugOnBothArms pins the RELATIONSHIP the narrowed
+// comment rests on: the slug goes on BOTH `getMyListingForApp` calls — the one that
+// also carries the submission's appBlockId, and the one that carries nothing else.
+//
+// 🟡 THIS IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE. The bug was in the prose;
+// the code already sent the slug on both arms, so this is green at the base commit by
+// construction and must not be counted as evidence that anything was broken. It is
+// here because the old comment was the only thing calling the slug "load-bearing", and
+// narrowing that comment removes the stated reason a future reader would keep the
+// argument on the appBlockId arm.
+//
+// 🔴 NOTHING PINNED THE PAIR BEFORE — each arm was covered ALONE.
+// TestOnsiteHappyPathMakesNoExtraCall asserts only that the appBlockId is present on
+// the onsite arm and says nothing about the slug; TestAppListingPendingReachesDraftBySlug
+// only ever exercises the arm where no appBlockId exists. Dropping `slug` from the
+// appBlockId call left both of them green. So this is driven as ONE table over both
+// arms, and the arm COUNT is asserted: the claim is about the set, and a third arm
+// that quietly dropped the slug would otherwise not be seen by it.
+func TestListingLookupCarriesTheSlugOnBothArms(t *testing.T) {
+	cases := []struct {
+		name       string
+		appBlockID string // what the submission row carries
+		wantBlock  bool   // must the lookup input carry an appBlockId key?
+	}{
+		{"submission HAS an appBlockId", "block_1", true},
+		{"submission has NO appBlockId (pending first version)", "", false},
+	}
+	if len(cases) != 2 {
+		t.Fatalf("resolveListing has exactly two lookup arms; the table covers %d", len(cases))
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var lookups int
+			var input string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+					submissionRow(w, "my-app", tc.appBlockID)
+				case strings.Contains(r.URL.Path, "getMyListingForApp"):
+					lookups++
+					input = r.URL.Query().Get("input")
+					trpcData(w, listingRefBody("apl_1", "draft"))
+				case strings.Contains(r.URL.Path, "getMyListingForEdit"):
+					trpcData(w, map[string]any{
+						"parentId": "apl_1", "slug": "my-app", "status": "draft",
+						"hasPendingRevision": false, "shadowId": nil,
+						"assets": map[string]any{
+							"icon":        map[string]any{"imageId": 11, "url": "http://x/i.png"},
+							"cover":       map[string]any{"imageId": 12, "url": "http://x/c.png"},
+							"screenshots": []any{},
+						},
+					})
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			listingEnv(t, srv.URL)
+
+			if _, _, err := run(t, "app", "listing", "status", "--slug", "my-app"); err != nil {
+				t.Fatalf("PREMISE BROKEN — this arm must resolve: %v", err)
+			}
+			// PREMISE: the lookup really ran, exactly once. Without this the slug
+			// assertion below is vacuous for a CLI that never asks.
+			if lookups != 1 {
+				t.Fatalf("getMyListingForApp must run exactly once on this arm, ran %d times", lookups)
+			}
+			// THE CLAIM: the slug is on this arm, whichever arm it is.
+			if !strings.Contains(input, `"slug":"my-app"`) {
+				t.Errorf("the slug must be sent on BOTH arms — a pre-approval draft has "+
+					"appBlockId = NULL, so the slug is the only selector that can name it; input was %q", input)
+			}
+			// And the appBlockId is present exactly when the submission had one: an
+			// empty id must be OMITTED, not sent as "", or the server's "either
+			// appBlockId or slug" schema sees a supplied-but-empty id.
+			if got := strings.Contains(input, "appBlockId"); got != tc.wantBlock {
+				t.Errorf("appBlockId present = %v, want %v; input was %q", got, tc.wantBlock, input)
+			}
+		})
+	}
+}
+
+// TestAppBlockIDArmNotFoundIsNotRetriedBySlug is the error path the narrowed comment
+// implies and nothing covered: when the submission RESOLVED, its appBlockId is the
+// answer, and a not-found from that lookup is final.
+//
+// 🟡 INVARIANT GUARD (green at base). It exists because the obvious "fix" suggested by
+// #424's own framing — "the slug arm is wide now, so retry by slug whenever anything
+// misses" — would be wrong here in two separate ways, and neither is currently pinned:
+//
+//	(a) it would spend a third request on a case the server already answered, and
+//	(b) the listing the submission NAMES is the one that just missed, so whatever a
+//	    slug retry resolved would by construction be a different row — and the CLI
+//	    has no basis for preferring it. (`appBlockId` WINS over a conflicting slug
+//	    inside one call; that precedence says nothing about a second call.)
+//
+// It also pins that the offsite explanation does NOT run on this arm: explainOffsiteMiss
+// is reached only when the SUBMISSION lookup failed, so an app that has a submission
+// must never be described as offsite.
+func TestAppBlockIDArmNotFoundIsNotRetriedBySlug(t *testing.T) {
+	var lookups, storeProbes int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			submissionRow(w, "my-app", "block_1")
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			lookups++
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"json":{"message":"no listing found for app my-app"}}}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/apps/"):
+			storeProbes++
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+
+	_, _, err := run(t, "app", "listing", "status", "--slug", "my-app")
+	if err == nil {
+		t.Fatal("expected an error when the appBlockId lookup answers not-found")
+	}
+	// AGENTS.md item 7 — the classification, not the wording. The listing is
+	// genuinely absent, so this stays not-found (exit 4).
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("a not-found listing must stay not-found (exit 4), got %T: %v", err, err)
+	}
+	// THE CLAIM: exactly one lookup. A by-slug retry would make it two.
+	if lookups != 1 {
+		t.Errorf("a resolved submission's appBlockId is the answer — a not-found from it "+
+			"must not be retried by slug; getMyListingForApp ran %d times", lookups)
+	}
+	// The submission lookup SUCCEEDED, so the offsite diagnosis has nothing to
+	// explain and its probe must not run.
+	if storeProbes != 0 {
+		t.Errorf("the store-catalog probe belongs to the submission-miss path only, ran %d times", storeProbes)
+	}
+	if strings.Contains(err.Error(), "OFFSITE app") {
+		t.Errorf("an app that HAS a block submission must never be described as offsite:\n%s", err)
+	}
+}
+
+// TestResolveListingScopeClaimIsPinnedWhole pins the corrected #424 prose as a WHOLE
+// NORMALISED STRING rather than by checking for keywords.
+//
+// 🔴 WHICH GUARD THIS IS, AND WHY THAT ONE. A guard on WORDS is walkable by
+// REWORDING — the class this package already met in TestAppListingOffsiteRefusesPrecisely,
+// where a banned absolute was re-inserted as a SYNONYM and survived the whole suite.
+// The defect #424 reported was a comment claiming more than the server does, so
+// `strings.Contains(comment, "onsite")` would be satisfied by any number of
+// restatements of the over-general claim, including the original one. So the two
+// paragraphs carrying the claim are compared IN FULL, and the paragraph COUNT is
+// asserted as well: deleting one, or adding a third that re-broadens the claim, fails
+// too. That is the "pin the whole normalised string" option, not the enumerated-set
+// one — the claim is prose about a moving server contract, and an enumeration of
+// conditions would go stale the next time the server moves (it already has once).
+//
+// 🔴 REGRESSION GUARD, NOT AN INVARIANT ONE — but on the prose, not on behaviour. It
+// is red at the base commit because the base carries the over-general text. It cannot
+// go red for a behavioural reason; there is no behaviour here.
+//
+// A cosmetic reword now fails this test. That is the price of a machine-readable
+// claim: re-read the paragraphs against the server before updating the literal, never
+// weaken the comparison back to a keyword.
+func TestResolveListingScopeClaimIsPinnedWhole(t *testing.T) {
+	const marker = "civitai/cli#424"
+	paras := docCommentParagraphs(t, "app_listing.go", "func resolveListing(")
+
+	// INSTRUMENT CONTROL: the extractor must have found a real doc comment. A silent
+	// zero here would make every assertion below vacuously true.
+	if len(paras) < 2 {
+		t.Fatalf("extractor found %d doc-comment paragraphs on resolveListing — it is wired to nothing", len(paras))
+	}
+	var claim []string
+	for _, p := range paras {
+		if strings.Contains(p, marker) {
+			claim = append(claim, p)
+		}
+	}
+	if len(claim) != 2 {
+		t.Fatalf("the #424 scope claim is exactly TWO paragraphs (the selector-vs-arm correction "+
+			"and the unmeasured-pending caveat); found %d carrying %q. Deleting one, or adding a "+
+			"third, is a change to the claim — update this test deliberately.", len(claim), marker)
+	}
+
+	const wantSelectorClaim = "🔴 \"ONLY BY SLUG\" IS A CLAIM ABOUT WHICH SELECTOR THE CLI CAN SEND, NEVER " +
+		"ABOUT HOW WIDE THE SERVER'S SLUG ARM IS — civitai/cli#424, where this comment asserted the " +
+		"second while only ever having evidence for the first. Against the server it was written for, " +
+		"the arm was `{slug, kind:'onsite', appBlockId:null, status:'draft'}`: four clauses that " +
+		"admitted the pre-approval draft and nothing else, so every OTHER shape 404ed by slug — " +
+		"`gen-matrix` and `custom-generators` (onsite, approved, so carrying an appBlockId) failed " +
+		"clauses 2-3, `radio` and `comfy` failed clause 1. civitai/civitai#3989 then dropped it to " +
+		"`{slug, revisionOfId: null}`, which is what the paragraph below rests on; re-verified against " +
+		"civitai/civitai origin/main at `src/server/services/blocks/offsite-listing.service.ts:1746`. " +
+		"The pre-approval draft is now ONE MEMBER of a wide set rather than the only thing the arm " +
+		"admits, so do not re-derive a narrow server scope from this paragraph — read the server, it moves."
+
+	const wantPendingCaveat = "🟡 AND THE PENDING CASE IS ASSERTED FROM SERVER SOURCE, NOT MEASURED. No " +
+		"genuinely `pending` first-version onsite app was ever probed: the only two `appBlockId = nil` " +
+		"rows reachable on 2026-08-17 were WITHDRAWN, and the old clause keyed on the LISTING's status " +
+		"rather than the submission's, so they could not answer it either way. \"The server supports " +
+		"it\" is therefore unverified, not proven — do not upgrade it to a measurement, and do not " +
+		"downgrade it to a doubt either. Nothing turns on it today: the widened clause admits the row " +
+		"on the slug whatever its status, so this is archaeology. civitai/cli#424 carries the recipe " +
+		"if anyone wants to settle it."
+
+	for i, want := range []string{wantSelectorClaim, wantPendingCaveat} {
+		if claim[i] != want {
+			t.Errorf("#424 paragraph %d is pinned WHOLE, not by banned spellings.\nIf you changed it "+
+				"on purpose, re-read it against the server and update the literal.\n want: %s\n got:  %s",
+				i+1, want, claim[i])
+		}
+	}
+}
+
+// docCommentParagraphs returns the doc comment immediately above the first line of
+// file that starts with decl, split into paragraphs on bare `//` lines, with each
+// paragraph's `// ` prefixes stripped and its whitespace collapsed.
+//
+// Kept deliberately dumb — no go/ast — because the thing being pinned is the literal
+// text a human reads, and a parser that normalised it would pin something else.
+func docCommentParagraphs(t *testing.T, file, decl string) []string {
+	t.Helper()
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	lines := strings.Split(string(src), "\n")
+	declAt := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, decl) {
+			declAt = i
+			break
+		}
+	}
+	if declAt < 0 {
+		t.Fatalf("%s: no line starting with %q — the extractor is pointed at nothing", file, decl)
+	}
+	start := declAt
+	for start > 0 && strings.HasPrefix(lines[start-1], "//") {
+		start--
+	}
+	var paras []string
+	var cur []string
+	flush := func() {
+		if len(cur) > 0 {
+			paras = append(paras, normaliseMessage(strings.Join(cur, " ")))
+			cur = nil
+		}
+	}
+	for _, l := range lines[start:declAt] {
+		body := strings.TrimPrefix(strings.TrimPrefix(l, "//"), " ")
+		if strings.TrimSpace(body) == "" {
+			flush()
+			continue
+		}
+		cur = append(cur, body)
+	}
+	flush()
+	return paras
+}

--- a/internal/cmd/app_listing_test.go
+++ b/internal/cmd/app_listing_test.go
@@ -847,14 +847,24 @@ func TestReadmeDocumentsAppListing(t *testing.T) {
 
 // 🔴 TestAppListingPendingReachesDraftBySlug — the whole point of draft-at-submit.
 // A first-version app pending review has NO backing appBlockId, but `civitai app
-// submit` minted its store listing as a pre-approval DRAFT, resolvable ONLY BY SLUG.
+// submit` minted its store listing as a pre-approval DRAFT, and the slug is the only
+// selector the CLI can send for it.
 //
 // This INVERTS the old TestAppListingPendingNoListingYet, which asserted the CLI
 // short-circuits to a "listing is created on approval" error. That short-circuit is
-// now the bug: it would make the pending-media flow unreachable from the CLI even
-// though the server supports it. So this pins that the CLI (a) does NOT bail before
-// the lookup, (b) sends the SLUG (the only thing that can resolve a null-appBlockId
-// draft) and omits the empty appBlockId, and (c) renders the draft's media.
+// now the bug: it would make the pending-media flow unreachable from the CLI. So this
+// pins that the CLI (a) does NOT bail before the lookup, (b) sends the SLUG (the only
+// selector that can name a null-appBlockId draft) and omits the empty appBlockId, and
+// (c) renders the draft's media.
+//
+// 🔴 THE FAKE ANSWERS THE LOOKUP UNCONDITIONALLY, SO THIS PINS WHAT THE CLI SENDS AND
+// NOTHING ABOUT WHAT A SERVER RESOLVES. The handler branches on PATH only; it never
+// reads the input it captured, so it would hand back the same draft for a request
+// carrying no slug at all. That is fine for the claim being made — but the comment
+// this test used to carry ("even though the server supports it") turned it into
+// evidence for a server behaviour that was never measured. See civitai/cli#424 and
+// the doc comment on `resolveListing`: the genuinely PENDING first-version case is
+// asserted from server source and remains unmeasured to this day.
 func TestAppListingPendingReachesDraftBySlug(t *testing.T) {
 	var listingForAppInput string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes the prose half of #424. **Does not close the issue** — its remaining item is a live measurement nobody has taken (below).

## The defect

`resolveListing` said a pre-approval draft listing is *"resolvable **ONLY BY SLUG**"*, with the slug argument *"load-bearing when it is absent"*. Neither half is false. Together they read as a claim about how wide the **server's** slug arm is, and the CLI only ever had evidence for a claim about which **selector it can send**. #424 measured the gap: against the server that prose was written for, the arm was `{slug, kind:'onsite', appBlockId:null, status:'draft'}`, so every shape but the pre-approval draft 404ed by slug — `gen-matrix` / `custom-generators` failed clauses 2-3, `radio` / `comfy` failed clause 1.

## 🔴 The brief for this change was stale, and the code won

I was told to narrow the comment to name **three conditions**. Re-verifying first, as the repo requires: that clause no longer exists. `civitai/civitai#3989` rescoped it, and `civitai/civitai` `origin/main` (`a55fe05f3c`) now reads:

```ts
// src/server/services/blocks/offsite-listing.service.ts:1744-1749
if (!listing && slug) {
  listing = await dbRead.appListing.findFirst({
    where: { slug, revisionOfId: null },
    select: entrySelect,
  });
}
```

So the corrected prose names **both** scopes — the retired one (why the old claim was over-general) and the current one — and says outright that this scope moves and must be read from the server, not re-derived from the comment. Writing "the three conditions" would have shipped a second over-general claim with a shorter half-life.

## The caveat that survives, deliberately

The genuinely **PENDING** first-version onsite case has **never been measured**. #424's only two `appBlockId = nil` rows were **withdrawn**, and the old clause keyed on the *listing's* status rather than the *submission's*, so they could not answer it either way. The comment now says "asserted from server source, not measured" and instructs the reader neither to upgrade it to a measurement nor downgrade it to a doubt. Nothing turns on it today: the widened clause admits the row on the slug whatever its status.

## Every surface carrying the claim

| Surface | Action |
|---|---|
| `internal/cmd/app_listing.go` `resolveListing` | Narrowed — the primary fix |
| `internal/appapi/listing.go` `GetMyListingForApp` | Corrected, and now **defers** to `resolveListing` for the scope, so there is one place to keep true |
| `internal/appapi/listing_test.go:~69` | Comment corrected — the fake answers **unconditionally** |
| `internal/cmd/app_listing_test.go:~888` | Comment corrected — same, and it used to say "even though the server supports it" |
| `claudedocs/handoff-offsite-refusal.md` | Marked the superseded #424 diagnosis section |
| `README.md` — command section, exit-code table, Troubleshooting index | **Grepped all three. No change needed** — #453 already rewrote them to the post-#3989 truth. |
| `claudedocs/decisions/29-offsite-refusal.md` | **No change.** Its byte-pinned body is untouched; its existing header already carries the #3989 correction and does not repeat the over-general claim. |

Both flagged tests are **kept**. That wire shape is worth pinning; only the prose around them implied more.

## Test coverage

New file `internal/cmd/app_listing_scope_test.go`.

### Red-at-base / green-at-HEAD matrix

Base = `origin/main` `afb9613`, measured by copying the new file into a detached worktree of that commit.

| Test | at `afb9613` | at HEAD | Kind |
|---|---|---|---|
| `TestResolveListingScopeClaimIsPinnedWhole` | **FAIL** | PASS | **Regression guard (on the prose)** |
| `TestListingLookupCarriesTheSlugOnBothArms` | PASS | PASS | **Invariant guard** |
| `TestAppBlockIDArmNotFoundIsNotRetriedBySlug` | PASS | PASS | **Invariant guard** |

```
$ go test -C <base-worktree> ./internal/cmd/ -run '...' -v -count=1
--- PASS: TestListingLookupCarriesTheSlugOnBothArms (0.00s)
    --- PASS: .../submission_HAS_an_appBlockId (0.00s)
    --- PASS: .../submission_has_NO_appBlockId_(pending_first_version) (0.00s)
--- PASS: TestAppBlockIDArmNotFoundIsNotRetriedBySlug (0.00s)
    app_listing_scope_test.go:202: the #424 scope claim is exactly TWO paragraphs ...; found 0 carrying "civitai/cli#424".
--- FAIL: TestResolveListingScopeClaimIsPinnedWhole (0.00s)
```

**The two invariant guards are not regression coverage and are not counted as such** — the bug was in prose, so no behavioural test can go red at base for it. They are labelled as invariant guards in their own doc comments.

### Why the prose guard is a whole-string pin

Per the house rule, a guard on **words** is walkable by **rewording** — this package already met that (a banned absolute re-inserted as a synonym survived the whole suite, see `TestAppListingOffsiteRefusesPrecisely`). The defect here was prose claiming more than the code, so `strings.Contains(comment, "onsite")` would be satisfied by the original claim itself. So the two paragraphs are compared **in full**, and the paragraph **count** is asserted so deleting one — or adding a third that re-broadens the claim — also fails. The enumerated-set option was rejected on purpose: an enumeration of server conditions is exactly the thing that already went stale once.

### Mutation matrix

Each mutation isolated to the **narrowest expression that can be wrong**, full package run each time, then restored.

| Mutation | Result |
|---|---|
| `slug` dropped from the **appBlockId arm only** (`slugArg = ""` when `appBlockID != ""`) | **1 failure repo-wide — ours.** `the slug must be sent on BOTH arms … input was {"json":{"appBlockId":"block_1"}}`. `TestOnsiteHappyPathMakesNoExtraCall`, `TestAppListingPendingReachesDraftBySlug`, `TestSuccessfulCommandsMakeNoStoreProbe` and the rest all stayed **green** — this is the measurement behind "nothing pinned the pair". |
| `if appBlockID != ""` → `if true` in `appapi` | `appBlockId present = true, want false; input was {"json":{"appBlockId":"","slug":"my-app"}}` |
| By-slug **retry** added on the appBlockId arm | **1 failure repo-wide — ours.** `a resolved submission's appBlockId is the answer … getMyListingForApp ran 2 times` |
| One word reworded inside a pinned paragraph (`wide` → `broad`) | `#424 paragraph 1 is pinned WHOLE, not by banned spellings` — proves the **string comparison** is reachable, not only the count branch the base-red exercised |
| Extractor pointed at a nonexistent decl | `no line starting with "func resolveListingNOPE(" — the extractor is pointed at nothing` — it cannot report a silent zero |

A coarser first attempt (`slug` → `""` on the shared `return`) killed both arms **and** `TestAppListingPendingReachesDraftBySlug`, proving nothing about the pair. It was discarded and re-run isolated; that is the number reported above.

## Gates

- `make ci` — **green** (all packages `ok`).
- `golangci-lint run ./...` from inside the module — **0 issues**, at **v2.12.2**, the exact version `.github/workflows/ci.yml` pins. `make lint` alone fails on this host (golangci-lint is not on `PATH`); run via `nix-shell -p golangci-lint`.
- **Instrument validated:** the `0 issues` is only meaningful because a planted violation made the same invocation report `2 issues` (`govet: 1`, `unused: 1`). Removed afterwards.

## What I did NOT verify

**No live/credentialed probe was run in this session.** Every live reading cited (the #424 404 table, the 2026-08-17 by-slug table) is quoted from the issue and from `claudedocs/decisions/29-offsite-refusal.md`, not re-measured. The server-side clause **was** re-read first-hand at `civitai/civitai` `origin/main`. The pending-first-version case remains unmeasured, which is precisely what the new prose says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
