### PR TITLE
test(offsite): pin the not-found path's request LEDGER, and measure what it costs (#427)

### DIFF
--- a/claudedocs/decisions/29-offsite-refusal.md
+++ b/claudedocs/decisions/29-offsite-refusal.md
@@ -98,6 +98,21 @@ radio` refused before the change and printed the listing after it.
   budget rather than the probe's 5 s — for an offsite app it is the ANSWER, not
   a diagnostic, so capping it at a diagnostic's deadline would fail the repair
   on a slow-but-working server. Stated in `resolveListing`'s own comment.
+  🔴 **CORRECTED, `cli#427` (2026-08-18): "three" is `app listing <sub>`'s
+  number, not the error path's.** `app status <slug>` calls `explainOffsiteMiss`
+  straight off `GetSubmissionRows` and never reaches `resolveListing`, so it has
+  no fallback in its chain and pays **two**; `app status --id` and any
+  not-a-not-found failure pay **one**. All five counts are now MEASURED by
+  driving the real commands (`TestNotFoundErrorPathRequestLedger` pins the
+  ordered request ledger, failing on growth *and* shrink) and the numbers written
+  in `app_offsite.go`'s residual 2 are compared against that measurement
+  (`TestDocumentedRequestCountsAreTheMeasuredOnes`) — which is what stops this
+  count going stale again. Cost, measured hermetically at two round-trip points:
+  the diagnosis is N extra round trips of whatever the link costs (2 for
+  `app listing`, 1 for `app status`), 0.2 ms extra on loopback and 403 ms extra
+  at 200 ms/request. Pathological ceiling is ARITHMETIC, not measured:
+  30 + 30 + 5 = 65 s, and it needs a server answering 404 *slowly* — a hung link
+  stops at the first request, because a timeout is not a not-found.
 
 **THE THREE CONSTRAINTS LISTED FURTHER DOWN ARE NOT ALL RETIRED, AND THIS
 PARAGRAPH USED TO SAY THEY WERE.** It read: those constraints "applied to the

--- a/claudedocs/handoff-offsite-refusal.md
+++ b/claudedocs/handoff-offsite-refusal.md
@@ -86,6 +86,18 @@ still says it, this is the correction.
 - **Issues closed:** `cli#422`, `cli#389` (outcome A, measured), `civitai#3984`, `civitai#4003`,
   `civitai#4008`, **`civitai#4059`** (delivered by #4061).
 - **Issues open on purpose:** `cli#424`, `cli#427` (both narrowed), `civitai#3893`.
+  🔴 **`cli#427` residual 2 is now MEASURED, and the issue's "three requests on every
+  `no such submission`" is `app listing <sub>`'s number only.** `app status <slug>` never
+  reaches `resolveListing`, so it has no by-slug fallback in its chain and pays **two**;
+  `app status --id` and any not-a-not-found failure pay **one**. Measured hermetically at two
+  round-trip points (httptest, no live network, median of 7): the diagnosis costs N extra round
+  trips of whatever the link costs — 2 for `app listing`, 1 for `app status` — i.e. +0.2 ms on
+  loopback and +403 ms at 200 ms/request. The pathological ceiling is ARITHMETIC, not a
+  measurement: 30 s + 30 s + 5 s = **65 s** before the error prints, and it needs a server that
+  answers 404 *slowly* — a hung or blackholed link never gets past the first request, because a
+  timeout is not a not-found so neither the fallback nor the probe runs. **No knob was shipped**
+  (the operator's call, deliberately deferred); what shipped is the request LEDGER guard that
+  would have caught the silent 1→3 growth.
   **`cli#411` and `civitai#4057` are both CLOSED** — see the top of this doc, and #4057's block
   below.
 - 🔴 **The prod-deployed revision IS readable, and the previous revision of this doc said it was

--- a/internal/cmd/app_offsite.go
+++ b/internal/cmd/app_offsite.go
@@ -132,18 +132,52 @@ import (
 //    listings route does not answer for it. Anything added to this message that
 //    presumes the reader owns the app reopens this residual.
 //
-// 2. THE ERROR PATH NOW COSTS THREE BOUNDED REQUESTS, WITH NO OFF SWITCH. Every
-//    `no such submission` — the ordinary "I have not submitted yet" case, which
-//    is far more common than an offsite app — pays the submissions lookup that
-//    already failed, then resolveListing's by-slug fallback (30s, the client's
-//    own per-request budget — see the 🟡 note on resolveListing for why that one
-//    is deliberately NOT capped at a diagnostic's 5s), then this probe (5s)
-//    before printing. It was ONE extra request when #422 outcome 2 shipped; the
-//    fallback added the second, and this line said "one" for the length of that
-//    PR. That is a COST, not a defect: it buys the diagnosis and the offsite
-//    repair, it cannot make the command fail differently (every probe failure
-//    collapses to today's message, pinned), and no flag or env var disables it.
-//    If that cost is ever measured to matter, the knob goes here.
+// 2. THE ERROR PATH COSTS UP TO THREE BOUNDED REQUESTS, WITH NO OFF SWITCH —
+//    AND THE COUNT IS PER COMMAND, NOT ONE NUMBER. `app listing <sub>` resolves
+//    through resolveListing and pays THREE: the submissions lookup that already
+//    failed, then resolveListing's by-slug fallback (30s, the client's own
+//    per-request budget — see the 🟡 note on resolveListing for why that one is
+//    deliberately NOT capped at a diagnostic's 5s), then this probe (5s).
+//    `app status <slug>` calls explainOffsiteMiss straight off
+//    GetSubmissionRows, never reaches resolveListing, and pays TWO. This line
+//    said THREE for BOTH commands until civitai/cli#427 measured them, and said
+//    ONE for the length of the PR in which the fallback added the second — which
+//    is why the counts below are now re-derived from a measurement instead of
+//    restated by hand. The ordinary "I have not submitted yet" case — far more
+//    common than an offsite app — pays exactly the same as the offsite one:
+//    `kind` is not known until the store answers.
+//
+//    MEASURED HERMETICALLY by driving the real command path against an httptest
+//    server (TestNotFoundErrorPathRequestLedger, which pins the ordered LEDGER of
+//    requests and fails when it GROWS or SHRINKS). Each count below is re-derived
+//    from that measurement and compared with this text by
+//    TestDocumentedRequestCountsAreTheMeasuredOnes, so editing a number here
+//    without changing the code fails, and so does the reverse:
+//
+//      LEDGER app listing <sub> not-found = 3
+//      LEDGER app listing <sub> not-found (onsite) = 3
+//      LEDGER app status <slug> not-found = 2
+//      LEDGER app status --id not-found = 1
+//      LEDGER app listing <sub> non-not-found = 1
+//
+//    LATENCY, measured at TWO points on the dimension that decides it — the
+//    per-request round trip (2026-08-18, httptest on loopback, no live network,
+//    median of 7 runs each). At ~0 injected latency: 3-request path 0.7ms,
+//    2-request 0.5ms, 1-request 0.5ms. At 200ms injected per request: 604ms,
+//    402ms, 201ms. So the diagnostic costs N EXTRA ROUND TRIPS OF WHATEVER THE
+//    LINK COSTS — two for `app listing`, one for `app status` — and nothing else;
+//    it is a multiple of the link, never a constant and never a timeout.
+//
+//    THE PATHOLOGICAL CASE IS ARITHMETIC, NOT A MEASUREMENT: 30s (submissions) +
+//    30s (fallback) + 5s (probe) = 65s before the message prints. It needs a
+//    server that answers 404 SLOWLY; a hung or blackholed link never gets past
+//    the first request, because a timeout is not a not-found, so neither the
+//    fallback nor this probe runs and the ceiling there is the client's own 30s.
+//
+//    That is a COST, not a defect: it buys the diagnosis and the offsite repair,
+//    it cannot make the command fail differently (every probe failure collapses
+//    to today's message, pinned), and no flag or env var disables it. If that
+//    cost is ever measured to matter, the knob goes here.
 
 // appKindOnsite / appKindOffsite are the two `kind` discriminators GET
 // /api/v1/apps/{slug} returns (civitai.AppDetail.Kind). They are the store's

--- a/internal/cmd/app_offsite_ledger_test.go
+++ b/internal/cmd/app_offsite_ledger_test.go
@@ -1,0 +1,352 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// civitai/cli#427 residual 2 — THE REQUEST LEDGER OF THE NOT-FOUND ERROR PATH.
+//
+// 🔴 WHAT THIS FILE PINS IS THE SET OF REQUESTS, NOT THEIR TIMING. The drift it
+// exists to catch already happened once and nobody saw it: the diagnostic probe
+// cost ONE extra request when #422 outcome 2 shipped, resolveListing's by-slug
+// fallback (#422 outcome 1) silently made it two, and app_offsite.go's own
+// comment went on saying "one" for the length of a whole PR. Every test on this
+// path asserted a per-route COUNT for the one route it cared about
+// (`ps.appCalls == 1`, `ps.listingCalls == 1`), which is structurally blind to a
+// route nobody thought to count — a new request added tomorrow is invisible to
+// all of them. This asserts the WHOLE ordered ledger, so it fails when the set
+// GROWS (the drift that happened) and when it SHRINKS (a diagnosis silently
+// dropped).
+//
+// 🔴 NO TIMING ASSERTION LIVES HERE, DELIBERATELY. Latency was measured for
+// #427 and is reported in the PR, not asserted: this repo already carries one
+// elapsed-time assertion it tolerates for a reason no other test can borrow
+// (TestOffsiteProbeDoesNotHoldTheCommandOpen — a context deadline is not
+// observable from the server side), and a second one would be a flake with no
+// such justification. A request ledger is deterministic; a duration is not.
+//
+// 🔴 IT IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE, AND SAYING SO IS THE
+// POINT. The 1→2→3 growth predates this file's base commit, so this cannot be
+// shown red at base for the defect it is named after — it pins the invariant
+// that the growth violated, going forward. What IS red at base is the
+// documentation half below: the residual-2 paragraph in app_offsite.go said
+// THREE requests for "every `no such submission`", and `app status <slug>` has
+// only ever paid TWO (it does not resolve through resolveListing, so there is no
+// by-slug fallback in its chain at all).
+
+// ledgerLabel is the canonical name this file gives one outbound request. It is
+// the METHOD plus the PATH — a structural identity, not a word a future feature
+// could also spell — with the submissions route's selector appended because
+// `?id=` and `?blockId=` are different lookups reached by different flags and
+// the ledger must not read them as one.
+func ledgerLabel(r *http.Request) string {
+	p := r.URL.Path
+	if strings.HasPrefix(p, "/api/v1/blocks/submissions") {
+		switch {
+		case r.URL.Query().Get("id") != "":
+			return r.Method + " " + p + "?id"
+		case r.URL.Query().Get("blockId") != "":
+			return r.Method + " " + p + "?blockId"
+		}
+	}
+	return r.Method + " " + p
+}
+
+// ledgerServer is a fake civitai.com that RECORDS every request it receives, in
+// order, rather than counting the handful of routes a test remembered to count.
+//
+// subStatus selects which failure the submissions route reports: 0 means the
+// #422 wall (200 with an empty list, which appapi maps to ErrNotFound), and any
+// other value is returned verbatim — 403 is the not-a-not-found case, which must
+// buy no diagnosis at all.
+type ledgerServer struct {
+	*httptest.Server
+	mu        sync.Mutex
+	requests  []string
+	apps      map[string]string
+	subStatus int
+}
+
+func newLedgerServer(t *testing.T, apps map[string]string, subStatus int) *ledgerServer {
+	t.Helper()
+	ls := &ledgerServer{apps: apps, subStatus: subStatus}
+	ls.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ls.mu.Lock()
+		ls.requests = append(ls.requests, ledgerLabel(r))
+		ls.mu.Unlock()
+
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/blocks/submissions"):
+			if ls.subStatus != 0 {
+				w.WriteHeader(ls.subStatus)
+				_, _ = w.Write([]byte(`{"error":"refused"}`))
+				return
+			}
+			if r.URL.Query().Get("id") != "" {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"submissions":[]}`))
+		case strings.Contains(r.URL.Path, "getMyListingForApp"):
+			// A server that predates civitai/civitai#3989, or an app with no
+			// listing row: the by-slug arm misses, which is the only shape that
+			// still reaches the refusal.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"json":{"message":"No listing found for this app","code":-32004}}}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/apps/"):
+			body, ok := ls.apps[strings.TrimPrefix(r.URL.Path, "/api/v1/apps/")]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(body))
+		default:
+			// Any route this file does not model is itself ledger drift — record
+			// it (above) and fail loudly rather than answering it.
+			t.Errorf("unexpected path %s — a request this ledger does not model", r.URL.Path)
+			w.WriteHeader(http.StatusTeapot)
+		}
+	}))
+	t.Cleanup(ls.Close)
+	listingEnv(t, ls.URL)
+	return ls
+}
+
+func (ls *ledgerServer) ledger() []string {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return append([]string(nil), ls.requests...)
+}
+
+const (
+	ledgerSubmissionsBySlug = "GET /api/v1/blocks/submissions?blockId"
+	ledgerSubmissionsByID   = "GET /api/v1/blocks/submissions?id"
+	ledgerListingBySlug     = "GET /api/trpc/appListings.getMyListingForApp"
+)
+
+func ledgerStoreProbe(slug string) string { return "GET /api/v1/apps/" + slug }
+
+// errorPathLedgerCase is one command driven to its not-found (or refused) end,
+// with the EXACT ordered request ledger it may make. The `key` is the string the
+// residual-2 paragraph in app_offsite.go must use for the same case — see
+// TestDocumentedRequestCountsAreTheMeasuredOnes, which is what stops the prose
+// and the code drifting apart again.
+type errorPathLedgerCase struct {
+	key       string
+	args      []string
+	subStatus int
+	want      []string
+}
+
+func errorPathLedgerCases() []errorPathLedgerCase {
+	return []errorPathLedgerCase{
+		{
+			// The `app listing` chain, the expensive one: the submissions lookup
+			// that failed, resolveListing's by-slug fallback, then the kind probe.
+			key:  "app listing <sub> not-found",
+			args: []string{"app", "listing", "status", "--slug", offsiteSlugA},
+			want: []string{ledgerSubmissionsBySlug, ledgerListingBySlug, ledgerStoreProbe(offsiteSlugA)},
+		},
+		{
+			// 🔴 THE ONSITE, NEVER-SUBMITTED CASE PAYS THE SAME THREE. This is
+			// the ordinary "I have not submitted yet" path — far more common
+			// than an offsite app — and the probe runs on it too: `kind` is not
+			// known until the store answers. Pinned so a claim that the cost is
+			// paid only by offsite apps cannot be made.
+			key:  "app listing <sub> not-found (onsite)",
+			args: []string{"app", "listing", "status", "--slug", onsiteSlug},
+			want: []string{ledgerSubmissionsBySlug, ledgerListingBySlug, ledgerStoreProbe(onsiteSlug)},
+		},
+		{
+			// 🔴 `app status <slug>` PAYS TWO, NOT THREE. It calls
+			// explainOffsiteMiss directly off GetSubmissionRows and never
+			// touches resolveListing, so the by-slug fallback is not in its
+			// chain. The residual-2 comment said three for BOTH commands until
+			// civitai/cli#427 measured it.
+			key:  "app status <slug> not-found",
+			args: []string{"app", "status", offsiteSlugB},
+			want: []string{ledgerSubmissionsBySlug, ledgerStoreProbe(offsiteSlugB)},
+		},
+		{
+			// `--id` names a publish request, not an app, so there is no slug to
+			// ask the store about and the probe is a no-op with no request.
+			key:  "app status --id not-found",
+			args: []string{"app", "status", "--id", "pr_zzz_missing"},
+			want: []string{ledgerSubmissionsByID},
+		},
+		{
+			// Not a not-found: a 403 from the invite-gated submissions route is
+			// no evidence about the app's kind, so neither the fallback nor the
+			// probe may run. One request, and the diagnosis is not bought.
+			key:       "app listing <sub> non-not-found",
+			args:      []string{"app", "listing", "status", "--slug", offsiteSlugA},
+			subStatus: http.StatusForbidden,
+			want:      []string{ledgerSubmissionsBySlug},
+		},
+	}
+}
+
+// TestNotFoundErrorPathRequestLedger drives each case through the REAL command
+// path (NewRootCmd + SetArgs, via run) and asserts the whole ordered ledger.
+//
+// INVARIANT GUARD — see the file header. It is green at base by construction;
+// what it buys is that the next request added to this path fails a test instead
+// of being noticed a PR later.
+func TestNotFoundErrorPathRequestLedger(t *testing.T) {
+	for _, tc := range errorPathLedgerCases() {
+		t.Run(tc.key, func(t *testing.T) {
+			ls := newLedgerServer(t, bothOffsiteAndOnsite(), tc.subStatus)
+			_, _, err := run(t, tc.args...)
+			// PREMISE: every case here is an ERROR path. A case that started
+			// succeeding would otherwise pin the ledger of a different command.
+			if err == nil {
+				t.Fatalf("PREMISE BROKEN — %v must fail; the ledger below is not the error path's", tc.args)
+			}
+			got := ls.ledger()
+			if len(got) != len(tc.want) || !equalLedger(got, tc.want) {
+				t.Errorf("the not-found error path's request ledger changed — this fails on GROWTH and on SHRINK.\n"+
+					"A request added here is paid by every user who has simply not submitted yet; a request removed here\n"+
+					"is a diagnosis silently dropped. If the change is deliberate, update this table AND the LEDGER lines\n"+
+					"in app_offsite.go's residual 2 (they are compared against this measurement).\n"+
+					"want (%d): %v\ngot  (%d): %v",
+					len(tc.want), tc.want, len(got), got)
+			}
+		})
+	}
+}
+
+func equalLedger(got, want []string) bool {
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ledgerDocLine matches the machine-readable rows residual 2 carries:
+//
+//	//      LEDGER app status <slug> not-found = 2
+var ledgerDocLine = regexp.MustCompile(`(?m)^//\s*LEDGER (.+?) = (\d+)$`)
+
+// TestDocumentedRequestCountsAreTheMeasuredOnes is the prose half, and it is the
+// half that would have caught the drift this issue is about.
+//
+// 🔴 A COMMENT IS A CLAIM, AND THIS ONE IS NOW PINNED TO A MEASUREMENT RATHER
+// THAN TO A WORD. app_offsite.go's residual 2 states what the error path costs;
+// that sentence was wrong about `app status <slug>` (it said three, the measured
+// answer is two) and was wrong about `app listing` for the length of a whole PR
+// (it said one, the answer was three). A guard on the WORDS — "the comment must
+// contain the word three" — is walked by rewording and is satisfied by a comment
+// nobody re-measured. This instead re-derives the numbers by driving the real
+// commands and compares them with the documented ones, so:
+//
+//   - editing the prose alone fails (the number no longer matches the code),
+//   - adding a request to the path alone fails (the code no longer matches the
+//     prose), and
+//   - the ledger is BIDIRECTIONAL: a documented case with no measurement, or a
+//     measured case with no documented line, is itself a failure.
+func TestDocumentedRequestCountsAreTheMeasuredOnes(t *testing.T) {
+	src, err := os.ReadFile("app_offsite.go")
+	if err != nil {
+		t.Fatalf("read app_offsite.go: %v", err)
+	}
+	matches := ledgerDocLine.FindAllStringSubmatch(string(src), -1)
+	// POSITIVE CONTROL on the extractor itself: a regexp that matches nothing
+	// reports a perfectly clean bidirectional ledger of zero rows against zero
+	// rows, which is the reassuring shape of a guard wired to nothing.
+	if len(matches) == 0 {
+		t.Fatalf("no `// LEDGER <case> = <n>` lines in app_offsite.go — the extractor is wired to nothing, "+
+			"so every comparison below is vacuous. Pattern: %s", ledgerDocLine)
+	}
+	documented := map[string]int{}
+	for _, m := range matches {
+		n, cerr := strconv.Atoi(m[2])
+		if cerr != nil {
+			t.Fatalf("undecodable count %q on LEDGER line %q: %v", m[2], m[0], cerr)
+		}
+		if _, dup := documented[m[1]]; dup {
+			t.Errorf("duplicate LEDGER line for %q — two claims about one case", m[1])
+		}
+		documented[m[1]] = n
+	}
+
+	measured := map[string]int{}
+	for _, tc := range errorPathLedgerCases() {
+		tc := tc
+		t.Run(tc.key, func(t *testing.T) {
+			ls := newLedgerServer(t, bothOffsiteAndOnsite(), tc.subStatus)
+			if _, _, rerr := run(t, tc.args...); rerr == nil {
+				t.Fatalf("PREMISE BROKEN — %v must fail", tc.args)
+			}
+			n := len(ls.ledger())
+			measured[tc.key] = n
+			want, ok := documented[tc.key]
+			if !ok {
+				t.Errorf("app_offsite.go's residual 2 documents no request count for %q, which the CLI really pays %d "+
+					"requests for. Add a `// LEDGER %s = %d` line there.", tc.key, n, tc.key, n)
+				return
+			}
+			if want != n {
+				t.Errorf("app_offsite.go claims %q costs %d request(s); driving the real command measured %d.\n"+
+					"The comment and the code disagree — re-measure before editing either.", tc.key, want, n)
+			}
+		})
+	}
+
+	for key := range documented {
+		if _, ok := measured[key]; !ok {
+			t.Errorf("app_offsite.go documents a LEDGER case %q that no measurement covers — a claim with no witness. "+
+				"Known cases: %s", key, strings.Join(sortedLedgerKeys(measured), ", "))
+		}
+	}
+}
+
+func sortedLedgerKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestLedgerLabelSeparatesTheSubmissionsSelectors is the control ON the label
+// function. `?id=` and `?blockId=` are two different lookups on one path, and a
+// label that collapsed them would make the `--id` row below indistinguishable
+// from the slug row — a ledger that cannot tell two cases apart pins neither.
+func TestLedgerLabelSeparatesTheSubmissionsSelectors(t *testing.T) {
+	mk := func(raw string) *http.Request {
+		r, err := http.NewRequest(http.MethodGet, "http://x"+raw, nil)
+		if err != nil {
+			t.Fatalf("build %q: %v", raw, err)
+		}
+		return r
+	}
+	bySlug := ledgerLabel(mk("/api/v1/blocks/submissions?blockId=a"))
+	byID := ledgerLabel(mk("/api/v1/blocks/submissions?id=b"))
+	if bySlug == byID {
+		t.Fatalf("the two submissions selectors must not share a label; both rendered %q", bySlug)
+	}
+	if bySlug != ledgerSubmissionsBySlug || byID != ledgerSubmissionsByID {
+		t.Errorf("label drift: blockId=%q (want %q), id=%q (want %q)", bySlug, ledgerSubmissionsBySlug, byID, ledgerSubmissionsByID)
+	}
+	if got, want := ledgerLabel(mk("/api/v1/apps/"+offsiteSlugA)), ledgerStoreProbe(offsiteSlugA); got != want {
+		t.Errorf("store probe label: got %q want %q", got, want)
+	}
+	// The store probe's label carries the SLUG, so a probe for the wrong app is
+	// a different ledger row rather than an equal one.
+	if ledgerStoreProbe(offsiteSlugA) == ledgerStoreProbe(offsiteSlugB) {
+		t.Error("the store probe label must distinguish two slugs")
+	}
+}


### PR DESCRIPTION
Closes nothing — `civitai/cli#427` stays open for the knob decision. This is residual 2's **measurement** and the **guard that would have caught its drift**, with no behaviour change and no user-facing knob.

## What the issue said, and what the code says

The issue reports that every `no such submission` now pays **three** bounded requests. Verified against the code and then measured by driving the real commands: **three is `app listing <sub>`'s number, not the error path's.**

`app status <slug>` calls `explainOffsiteMiss` straight off `GetSubmissionRows` (`app_status.go:127`) and never reaches `resolveListing`, so the by-slug fallback is not in its chain at all — it pays **two**. `app_offsite.go`'s residual-2 paragraph said three for *both* commands; that is corrected here.

### The verified chain, with each timeout and its source

| # | request | issued by | budget | source of the budget |
|---|---|---|---|---|
| 1 | `GET /api/v1/blocks/submissions?blockId=<slug>` | `appapi.Client.GetSubmission` → `authedDo` | 30 s | `internal/appapi/client.go:15` `defaultTimeout`, on `http.Client.Timeout`; no ctx deadline (`cmdCtx` returns the cobra ctx, which carries none) |
| 2 | `GET /api/trpc/appListings.getMyListingForApp?input=…` | `resolveListing`'s by-slug fallback (`app_listing.go`) | 30 s | same `appapi` client budget — **deliberately not capped** at a diagnostic's 5 s (the 🟡 note on `resolveListing`); `app listing` only |
| 3 | `GET /api/v1/apps/<slug>` | `offsiteApp`'s kind probe | 5 s | `offsiteProbeTimeout`, a `context.WithTimeout` **on top of** the 30 s `pkg/civitai` client |

Two amplifiers worth naming, neither of which changes the ledger:
* Requests 1 and 2 each carry one transparent **401-refresh replay** (`authedDoWith`) — a second HTTP attempt on a 401 only.
* Request 3 goes through `pkg/civitai`'s read-GET retry loop (`readMaxAttempts = 4`), so a *transient* failure can mean up to four HTTP attempts — all inside the 5 s deadline, and silent (`client.Stderr = io.Discard`).

## Measured cost — hermetic, two points, no live network

`httptest` on loopback, injected per-handler latency, `CIVITAI_BASE_URL` pointed at it, median of 7 runs per cell. **No live or credentialed call to civitai.com was made.**

| command (requests) | ~0 ms injected | 200 ms injected per request |
|---|---|---|
| `app listing status --slug <slug>` (3) | 0.7 ms | 604 ms |
| `app status <slug>` (2) | 0.5 ms | 402 ms |
| `app status --id <id>` (1) | 0.5 ms | 201 ms |

So the diagnosis costs **N extra round trips of whatever the link costs** — 2 for `app listing`, 1 for `app status` — and nothing else. On loopback that is +0.2 ms; at a 200 ms round trip it is +403 ms.

### Pathological case — this is arithmetic, not a measurement

30 s (submissions) + 30 s (fallback) + 5 s (probe) = **65 s** before the message prints. It requires a server that answers **404 slowly** on the first two hops. A hung or blackholed link never gets past request 1: a timeout is not `ErrNotFound`, so neither the fallback nor the probe runs, and the ceiling there is the client's own 30 s with **one** request. The issue's "an error message could take tens of seconds to print" is therefore true, and only on a slow-but-answering server.

## What ships: the request LEDGER, not a timing assertion

`internal/cmd/app_offsite_ledger_test.go`.

* **`TestNotFoundErrorPathRequestLedger`** — drives each case through the real command path (`NewRootCmd` + `SetArgs`) against a server that records every inbound request in order, and asserts the whole ordered ledger. It fails when the set **grows** (the drift that happened) and when it **shrinks** (a diagnosis silently dropped). The existing tests on this path each assert a per-route count for the one route they care about (`appCalls == 1`, `listingCalls == 1`), which is structurally blind to a route nobody thought to count.
* **`TestDocumentedRequestCountsAreTheMeasuredOnes`** — the prose half, and the half that would have caught the 1→3 drift. `app_offsite.go`'s residual 2 now carries machine-readable rows, and this test re-derives every number by driving the commands and compares. Editing the prose alone fails; changing the code alone fails; and the mapping is bidirectional, so a documented case with no measurement, or a measured case with no documented row, is also a failure. It has a positive control on its own extractor: zero matched rows is a `t.Fatalf`, not a clean zero.
* **`TestLedgerLabelSeparatesTheSubmissionsSelectors`** — control on the label function, so `?id=` and `?blockId=` cannot collapse into one indistinguishable row.

**No timing assertion is added.** Latency here is data for this PR, never an assertion — the repo already tolerates exactly one elapsed-time assertion (`TestOffsiteProbeDoesNotHoldTheCommandOpen`, where a context deadline is not observable from the server side) and a second would be a flake with no such justification.

## Red-at-base / green-at-HEAD

Run with the new test file against `origin/main`'s `app_offsite.go` + `app_listing.go` (`git checkout origin/main -- …`):

```
--- PASS: TestNotFoundErrorPathRequestLedger (0.01s)          # all 5 subtests PASS at base
--- FAIL: TestDocumentedRequestCountsAreTheMeasuredOnes (0.00s)
    no `// LEDGER <case> = <n>` lines in app_offsite.go — the extractor is wired to nothing
--- PASS: TestLedgerLabelSeparatesTheSubmissionsSelectors (0.00s)
```

Stated plainly: **`TestNotFoundErrorPathRequestLedger` and `TestLedgerLabelSeparatesTheSubmissionsSelectors` are INVARIANT GUARDS, not regression coverage** — the 1→2→3 growth predates this base commit, so nothing here can be shown red for it. `TestDocumentedRequestCountsAreTheMeasuredOnes` is red at base only because its fixture (the machine-readable rows) is new; what it substantively catches is mutant M9 below — restating base's own claim that `app status <slug>` costs three.

At HEAD all three are green, `internal/cmd` reports `RUN=2504 PASS=2504 FAIL=0 SKIP=0`, no timeout panic.

## Mutation matrix

Each mutant is the narrowest expression that can be wrong; each was restored and the file checksum re-verified afterwards.

| # | mutant | killed by | its own message |
|---|---|---|---|
| M1 | delete the by-slug fallback block in `resolveListing` (shrink 3→2) | both guards | `ledger changed … want (3) … got (2)` / `claims "app listing <sub> not-found" costs 3 …; measured 2` |
| M2 | add one extra `client.GetApp` in `offsiteApp` (growth 3→4) | both guards | `want (3) … got (4)` / `costs 3 …; measured 4` |
| M3 | `d := offsiteApp(ctx, slug)` → `var d *civitai.AppDetail` (probe removed) | both guards | `want (3) … got (2)`, `want (2) … got (1)` |
| M4 | **prose only**: a documented count 3 → 4 | `TestDocumentedRequestCountsAreTheMeasuredOnes` **alone** (the ledger test stayed green) | `claims … costs 4 request(s); driving the real command measured 3` |
| M5 | **prose only**: delete one LEDGER row | same | `documents no request count for "app status <slug> not-found", which the CLI really pays 2 requests for` |
| M6 | **prose only**: document a case nothing measures | same | `documents a LEDGER case "app whoami not-found" that no measurement covers — a claim with no witness` |
| M7 | **positive control**: remove every LEDGER row | same | `the extractor is wired to nothing, so every comparison below is vacuous` |
| M8 | collapse the two submissions selectors in `ledgerLabel` | `TestLedgerLabelSeparatesTheSubmissionsSelectors` | `the two submissions selectors must not share a label` |
| M9 | **prose only**: restate base's claim, `app status <slug> = 3` | `TestDocumentedRequestCountsAreTheMeasuredOnes` | `claims "app status <slug> not-found" costs 3 request(s); measured 2` |

M4–M7 and M9 are the load-bearing ones: they prove a prose edit alone cannot satisfy the guard, which is what a comment-only claim about a request count needs.

## Docs moved with the measurement

* `internal/cmd/app_offsite.go` — residual 2 rewritten: per-command counts, the LEDGER rows, the two-point latency numbers, and the 65 s ceiling labelled as arithmetic.
* `claudedocs/decisions/29-offsite-refusal.md` — correction in the **header**, above the `---`; the byte-pinned body is untouched.
* `claudedocs/handoff-offsite-refusal.md` — the measurement recorded beside the "open on purpose" line.
* `README.md` — **checked, not changed.** No user-visible behaviour or message moves here. The two surfaces that quote a request count (the `app listing` section and the exit-code note) say *"naming the app as offsite takes **one** extra lookup against the public store catalog"*, which is scoped to the probe alone and remains exactly true.

## The off switch: recommended shape, deliberately NOT built here

**Recommendation: do not ship a user-facing knob for the typical case; if anything is added, tighten the diagnostic budget rather than exposing a flag.**

The measurement says the cost is 1–2 extra round trips on a path that has *already failed*. At any plausible round trip that is tens to a few hundred milliseconds added to an error message — real, but not what a user reaches for a flag to fix, and every knob added here is a permanently supported surface plus a README row, a Troubleshooting row and its own tests.

The one number that *is* uncomfortable is the 65 s ceiling, and a user-facing flag is the wrong tool for it: nobody sets `--no-probe` before the command they did not expect to fail. If it is to be addressed, the cheapest deterministic fix is to give **request 2 its own diagnostic-scoped deadline on the error path only** — `resolveListing`'s fallback keeps the full 30 s when it is the *answer* for an offsite app, which is exactly the reason its 🟡 note gives, so the change would have to be scoped to the path that has already missed rather than to the call. That is a behaviour change with its own micro-decision (what deadline, and whether a slow-but-working server should lose the offsite repair), which is why it is not in this PR.

If a knob is wanted anyway, the shape I would build: an **env var**, not a flag — `CIVITAI_NO_OFFSITE_PROBE=1` — gating `offsiteApp` at its top, next to `offsiteProbeTimeout`. Env over flag because it must apply to every `app listing` subcommand and `app status` at once without seven new flag registrations, and because the people who would set it (CI, scripted callers) set env vars. Cost: ~5 lines, one test that the ledger drops to 2/1, a README Troubleshooting row, and a row in this PR's ledger table. Deliberately not built — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
