### PR TITLE
chore(scaffold): bump @civitai/* pins to published latest

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -150,7 +150,7 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.42.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.43.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.35.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -372,7 +372,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.35.0` + `@civitai/blocks-react@^0.42.0` (already pinned in
+`@civitai/app-sdk@^0.35.0` + `@civitai/blocks-react@^0.43.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.35.0",
-    "@civitai/blocks-react": "^0.42.0",
+    "@civitai/blocks-react": "^0.43.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
Automated by the `bump-scaffold-pins` workflow (`internal/scaffold/cmd/bump-pins`).

One or more `@civitai/*` packages published a new minor, so the
page-money scaffold's pre-1.0 caret pins fell behind npm and the
`pins-vs-published` guard would go red. This PR rewrites the literal
pins in all three sites:

- `internal/scaffold/templates/page-money/package.json.tmpl`
- `internal/scaffold/templates/page-money/README.md.tmpl`
- `internal/scaffold/scaffold_test.go` (the `mustContain` canary)

The pins are rewritten as **literals** (not templated) on purpose:
the guard reads the raw `^X.Y.Z` bytes out of the `.tmpl`, so
templating the value would blind it.

**CI note:** this PR is opened with a scoped fine-grained token
(`secrets.BUMP_SCAFFOLD_PINS_TOKEN`, Contents + Pull requests RW on
this repo only), not the default `GITHUB_TOKEN` — so the repo's
normal checks (`pins-vs-published` / `scaffold-currency`) DO run on
it. As defense-in-depth the bump job also validates BEFORE opening
the PR: the network guard (`CIVITAI_CHECK_PUBLISHED_PINS=1 go test
-run TestScaffoldPinsSatisfyPublished`), the full offline scaffold
suite, AND a fresh `civitai app init` scaffold that installs +
typechecks + **builds** against the bumped SDK (catching a
removed/renamed export).