### PR TITLE
ci(revendor): run the canonical-schema re-vendor every 6h, not weekly

### DIFF
--- a/.github/workflows/bump-flake-vendorhash.yml
+++ b/.github/workflows/bump-flake-vendorhash.yml
@@ -58,8 +58,8 @@ name: bump-flake-vendorhash
 on:
   schedule:
     # Weekly, Mondays 07:47 UTC — a distinct minute from the other drift-bots
-    # (bump-scaffold-pins 07:17, revendor-canonical-schema 07:37). Cron literal
-    # in YAML needs quoting so the `*` isn't parsed as a YAML alias.
+    # (bump-scaffold-pins 07:17, revendor-canonical-schema :37 every 6h). Cron
+    # literal in YAML needs quoting so the `*` isn't parsed as a YAML alias.
     - cron: "47 7 * * 1"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bump-scaffold-pins.yml
+++ b/.github/workflows/bump-scaffold-pins.yml
@@ -35,9 +35,9 @@ name: bump-scaffold-pins
 on:
   schedule:
     # DAILY at 07:17 UTC (off the top-of-hour rush; the minute is offset from the
-    # sibling drift-bots — revendor-canonical-schema 07:37, bump-flake-vendorhash
-    # 07:47). Cron literal in YAML needs quoting so the `*` isn't parsed as a
-    # YAML alias.
+    # sibling drift-bots — revendor-canonical-schema :37 every 6h,
+    # bump-flake-vendorhash 07:47). Cron literal in YAML needs quoting so the `*`
+    # isn't parsed as a YAML alias.
     #
     # This was weekly (`17 7 * * 1`) and that cadence was measurably too slow.
     # `pins-vs-published` is a REQUIRED check on `main` and it reads npm's

--- a/.github/workflows/revendor-canonical-schema.yml
+++ b/.github/workflows/revendor-canonical-schema.yml
@@ -34,10 +34,39 @@ name: revendor-canonical-schema
 
 on:
   schedule:
-    # Weekly, Mondays 07:37 UTC — offset from bump-scaffold-pins (07:17) so the
-    # two automations don't open PRs in the same minute. Cron literal quoted so
-    # the `*` isn't parsed as a YAML alias.
-    - cron: "37 7 * * 1"
+    # Every 6 hours at :37 past the hour — 00:37, 06:37, 12:37, 18:37 UTC.
+    #
+    # WHY THIS CADENCE IS LOAD-BEARING, and why it is no longer weekly. This
+    # number is not a politeness setting; it IS the bound on how long this
+    # repo's CI stays red after a canonical schema change.
+    #
+    # The chain: `check-canonical-schema` byte-compares the go:embedded mirror
+    # (`schema/app-block.manifest.schema.json`) against the schema published
+    # LIVE at the canonical URL. That publish happens on a civitai `release`
+    # cut — an event this repo cannot observe. There is no webhook from
+    # civitai, no repository_dispatch, nothing to subscribe to. So the ONLY
+    # thing that closes the gap between "the canonical changed" and "the mirror
+    # was re-vendored" is this cron firing. Until it does, `schema-drift` is red
+    # on every PR in this repo and nothing clears it but a human noticing and
+    # dispatching this workflow by hand.
+    #
+    # The concrete case this was raised for: civitai PR #4314 added an optional
+    # `repository` property to the canonical manifest schema and merged to
+    # civitai `main` on 2026-08-23. dp-prod deploys from `release`, not `main`,
+    # so the published schema does not carry it yet and this mirror is still
+    # green. It goes red the moment a `main` -> `release` cut publishes the new
+    # bytes — and that cut is invisible from here. On the old weekly cron
+    # ("37 7 * * 1", Mondays) that was up to SEVEN DAYS of red CI; at 6-hourly
+    # it is at most ~6 hours.
+    #
+    # The minute is deliberately :37 and NOT :00. GitHub delays cron jobs
+    # scheduled on the hour, because everyone schedules on the hour. :37 also
+    # keeps this off the minute of every sibling drift-bot in this repo
+    # (bump-scaffold-pins :17, bump-flake-vendorhash :47, release-homebrew :23),
+    # so no two of them open PRs in the same minute.
+    #
+    # Cron literal quoted so the `*` isn't parsed as a YAML alias.
+    - cron: "37 */6 * * *"
   workflow_dispatch:
     inputs:
       drill:
@@ -86,9 +115,11 @@ jobs:
       # the classifier as its own state (`canonical-unreachable`). The job still
       # succeeds; only the report says the mirror was not checked.
       #
-      # KNOWN COST, stated rather than hidden: a single transient blip at 07:37
-      # on a Monday opens an issue that sits until the next weekly run closes it.
-      # That is one issue and zero comments (failure-issue.yml's rules), and the
+      # KNOWN COST, stated rather than hidden: a single transient blip opens an
+      # issue that sits until the next scheduled run closes it — at the 6-hourly
+      # cadence above that is at most ~6 hours, where on the old weekly cron it
+      # was up to 7 days. That is one issue and zero comments
+      # (failure-issue.yml's rules), and the
       # backstop for the underlying risk is the `schema-drift` CI job, which
       # reds on every PR once the mirror actually drifts. If the false alarms
       # outweigh that, delete the `canonical-unreachable` arm in `classify` —


### PR DESCRIPTION
## What changed

`.github/workflows/revendor-canonical-schema.yml:69` — the schedule goes from weekly to every 6 hours:

```diff
-    - cron: "37 7 * * 1"
+    - cron: "37 */6 * * *"
```

That is the **only** non-comment change in this PR. Everything else is comment/rationale:

| File | Line | Change |
|---|---|---|
| `.github/workflows/revendor-canonical-schema.yml` | 36–69 | new rationale block + the cron literal |
| `.github/workflows/revendor-canonical-schema.yml` | 118–126 | the `KNOWN COST` note said a blip "sits until the next **weekly** run" — corrected |
| `.github/workflows/bump-scaffold-pins.yml` | 38 | its comment named `revendor-canonical-schema 07:37`; that slot no longer exists |
| `.github/workflows/bump-flake-vendorhash.yml` | 61 | same stale cross-reference |

`workflow_dispatch` (including the `drill` input) is unchanged, and no step was touched.

## Why — the cron cadence IS the red-window bound

`check-canonical-schema` byte-compares the `go:embed`ed mirror at `schema/app-block.manifest.schema.json` against the schema published **live** at `https://civitai.com/schemas/app-block/v1.json`.

That publish happens on a **civitai `release` cut** — an event this repo cannot observe. There is no webhook from civitai, no `repository_dispatch`, nothing to subscribe to. So the only thing that closes the gap between "the canonical changed" and "the mirror was re-vendored" is this cron firing. Until it does, `schema-drift` is red on every PR here and nothing clears it but a human noticing and dispatching this workflow by hand.

Weekly made that window **up to 7 days**. At 6-hourly it is **at most ~6 hours**.

### The concrete case this was raised for

civitai PR #4314 added an optional `repository` property to the canonical manifest schema and merged to civitai `main` (squash `2a662ac739`) on 2026-08-23.

dp-prod deploys from `release`, not `main` — so as of this PR the published schema **does not carry it yet** and this mirror is still green. Verified at time of writing:

```
$ curl -s https://civitai.com/schemas/app-block/v1.json | jq '.properties.repository'
null
```

It goes red the moment a `main` -> `release` cut publishes the new bytes, and that cut is invisible from here. This PR is what bounds how long we sit red afterwards.

This is the same argument that already moved `bump-scaffold-pins` from weekly to daily — see the rationale block at `bump-scaffold-pins.yml:42-59`.

## 🔴 This PR does NOT re-vendor anything

It changes **only the schedule**. The vendored schema, `scripts/revendor-canonical-schema.sh`, `scripts/check-canonical-schema.sh` and `ci.yml` are all untouched. Nothing here mirrors the new `repository` property — it only shortens the window in which nobody notices that it needs mirroring. When the release cut lands, the bot opens its own re-vendor PR as usual.

## Validated

**Cron parsed, not eyeballed** (`croniter`, base 2026-08-23 12:00 UTC):

```
'37 */6 * * *'  is_valid=True
    -> 2026-08-23 12:37 UTC (Sun)
    -> 2026-08-23 18:37 UTC (Sun)
    -> 2026-08-24 00:37 UTC (Mon)
    -> 2026-08-24 06:37 UTC (Mon)
```

So it fires at **00:37 / 06:37 / 12:37 / 18:37 UTC** daily. For contrast the old `37 7 * * 1` gave `2026-08-24 07:37`, then `2026-08-31`, then `2026-09-07` — a 7-day gap.

Negative controls on the parser: `'37 */6 * *'`, `'99 */6 * * *'` and `'abc */6 * * *'` were all correctly rejected.

**YAML parses**, and the trigger round-trips to the intended values — `python3 -c "import yaml; yaml.safe_load(...)"` on all three changed files:

```
OK parse cli/revendor:              cron=['37 */6 * * *'] workflow_dispatch_present=True
OK parse cli/bump-scaffold-pins:    cron=['17 7 * * *']   workflow_dispatch_present=True
OK parse cli/bump-flake-vendorhash: cron=['47 7 * * 1']   workflow_dispatch_present=True
```
(the two siblings' crons are unchanged — comment-only edits). A malformed-YAML positive control was correctly rejected.

**actionlint**: clean, 0 findings, exit 0 on all three files. Instrument validated first — fed a `cron: "99 */6 * * *"` control, and it went red with `invalid CRON format ... above maximum (59)`, so it does genuinely parse the cron field rather than skipping it.

## Why `:37` and not `:00`

GitHub delays crons scheduled on the hour, because everyone schedules on the hour. `:37` also keeps this off the minute of every sibling drift-bot in this repo — `bump-scaffold-pins` `:17`, `bump-flake-vendorhash` `:47`, `release-homebrew` `:23` — so no two of them open PRs in the same minute.

## Cost

A no-op run is cheap: `detect changes` gates every downstream step, so an already-current sweep is just checkout + `setup-go` + one `curl`. 4 runs/day instead of 1/week.

One known trade-off, stated rather than hidden: the `canonical-unreachable` arm files an issue when the canonical URL is unreachable, so a transient blip now has 4 chances a day to fire instead of 1 a week. `failure-issue.yml`'s anti-spam rules cap that at one open issue with no comments, and the next green run closes it — but it is a real increase in exposure to that path. If it turns noisy, the `elif` is documented as safe to delete at `revendor-canonical-schema.yml:118-126`.
