### PR TITLE
feat(validate): gloss the new `repository` pattern, and re-vendor the schema that carries it

### DIFF
--- a/internal/validate/pattern.go
+++ b/internal/validate/pattern.go
@@ -80,6 +80,13 @@ var patternRules = map[string]patternRule{
 		rule:    "must contain at least one non-whitespace character",
 		example: "A tiny image tool",
 	},
+	// repository — the optional public source-repository link. The regex is a
+	// coarse SHAPE check, not the whole server-side rule, so the gloss claims
+	// only what the regex itself enforces.
+	`^https://(github\.com|gitlab\.com|codeberg\.org)/[^/]+/[^/]+/?$`: {
+		rule:    "must be a repository root URL on github.com, gitlab.com or codeberg.org — exactly https://<host>/<owner>/<repo>, with no deeper path",
+		example: "https://github.com/civitai/civitai",
+	},
 	// minApiVersion
 	`^\d+(\.\d+)*$`: {
 		rule:    "must be dot-separated numbers only",

--- a/internal/validate/pattern_test.go
+++ b/internal/validate/pattern_test.go
@@ -77,6 +77,17 @@ func patternFixtures() []patternFixture {
 			got:      "   ",
 		},
 		{
+			// A DEEP LINK rather than a wrong host: the host arm and the
+			// path-depth arm are separate halves of this regex, and a deep
+			// link is the mistake an author actually makes (pasting the URL
+			// out of the browser bar while looking at a file).
+			name:     "repository",
+			pattern:  `^https://(github\.com|gitlab\.com|codeberg\.org)/[^/]+/[^/]+/?$`,
+			manifest: `{"blockId":"ok-app","repository":"https://github.com/civitai/civitai/tree/main",` + base + `}`,
+			field:    "repository",
+			got:      "https://github.com/civitai/civitai/tree/main",
+		},
+		{
 			name:     "minApiVersion",
 			pattern:  `^\d+(\.\d+)*$`,
 			manifest: `{"blockId":"ok-app","minApiVersion":"v1",` + base + `}`,
@@ -202,6 +213,11 @@ func TestPatternGlossesAreTheRightWayRound(t *testing.T) {
 			"exactly three numeric components plus an optional prerelease"},
 		{`\S`, "non-whitespace", "A tiny image tool",
 			"the only requirement is that SOMETHING is there"},
+		// "repository root URL" rather than a fragment naming the hosts or the
+		// scheme: the assetBundleUrl row below already owns "https:// URL", and
+		// a fragment quoting the scheme would sit inside this rule too.
+		{`^https://(github\.com|gitlab\.com|codeberg\.org)/[^/]+/[^/]+/?$`, "repository root URL", "https://github.com/civitai/civitai",
+			"an exact host allowlist plus a path that is exactly two segments"},
 		// "dot-separated numbers ONLY" rather than the bare phrase: the version
 		// rule above says "three dot-separated numbers", so the shorter
 		// fragment appears in two rules and the absence half stops working.

--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -35,6 +35,13 @@
       "maxLength": 140,
       "pattern": "\\S"
     },
+    "repository": {
+      "type": "string",
+      "description": "Optional PUBLIC SOURCE-REPOSITORY link for an open-source app, rendered as a `Source` row on the app's `/apps` store DETAIL page (never on a store grid card). Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version; remove the key and the link is cleared. This is NOT your app's internal Civitai repository — it is a link you publish. Must be an `https://` URL, carrying no embedded credentials and no port, whose host is EXACTLY one of github.com, gitlab.com or codeberg.org (an exact-host allowlist — `www.github.com`, `gist.github.com` and `raw.githubusercontent.com` are all rejected), and whose path is exactly `/<owner>/<repo>`, the repository ROOT (a deep link such as `/owner/repo/tree/main` is rejected). A trailing `/` or `.git`, a query string and a fragment are accepted and STRIPPED — the stored value is normalised to `https://<host>/<owner>/<repo>`. Capped at 200 characters, kept in lockstep with MAX_REPOSITORY_URL_LENGTH in src/server/schema/blocks/external-app.schema.ts (a drift-guard test enforces equality, and enforces that this description names exactly the hosts REPOSITORY_HOST_ALLOWLIST contains). NOTE: as with `tagline`, the server measures the TRIMMED string while this maxLength counts the raw one, so the LENGTH bound here is never looser than the server's. The `pattern`, however, is a coarse SHAPE check and NOT the whole rule, so unlike `tagline` this field CAN pass local validation and still be rejected at submit. The server additionally requires each of the two path segments to begin with an ASCII letter or digit and to contain only letters, digits, `.`, `-` and `_`, and it strips a trailing `.git` BEFORE applying that test. Values such as a repository segment that is only `.git`, one starting with a dash, one containing a percent-escape, and one containing a non-ASCII character all match this pattern and are refused by the server. The pattern is deliberately left coarse rather than tightened: the CLI and the starter templates byte-mirror this file, and a stricter regex would be a compatibility change for every vendored copy. Treat passing local validation as necessary, not sufficient — `validateRepositoryUrl` in src/server/schema/blocks/external-app.schema.ts is authoritative.",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$"
+    },
     "type": {
       "type": "string",
       "description": "Free-form descriptor used by some examples (e.g. \"block\"). Not validated by the platform.",


### PR DESCRIPTION
Unblocks the `revendor-canonical-schema` bot, which has been unable to land the new `repository` property. Closes the loop on #486.

## What the guard caught

The canonical schema at https://civitai.com/schemas/app-block/v1.json grew an optional `repository` property (21 properties now). The bot re-vendored it, then failed in its own `validate — schema compiles + examples validate` step ([run 32764071489](https://github.com/civitai/cli/actions/runs/32764071489)) and opened no PR:

```
--- FAIL: TestPatternRulesCoverTheVendoredSchema
pattern_test.go:417: schema pattern "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$"
  has no gloss in patternRules — an author hitting it gets a bare regex back
```

That is the ledger working exactly as designed — the bot re-vendors *bytes*, and this schema change carries author-facing semantics, which the workflow's own body calls out as "a deliberate human call".

## Why both halves are one commit

`TestPatternRulesCoverTheVendoredSchema` is **bidirectional**, so neither half compiles a green suite on its own:

- **re-vendor without the gloss** → growth direction fails: a schema pattern with no gloss.
- **gloss without the re-vendor** → shrink direction fails: `patternRules glosses "…", which is not a reachable pattern in the vendored schema — a stale row looks like coverage`.

A split PR would be red on both branches and green only after the merge, which is the shape the ledger exists to make impossible. Hence one atomic commit.

## What changed

1. **`schema/app-block.manifest.schema.json`** — re-vendored with the repo's own `scripts/revendor-canonical-schema.sh`, which is a raw `cp` of the fetched body (no `jq` re-serialisation), so the byte-identity gate still passes. Diff is purely additive: the one new `repository` property, +7 lines.
2. **`internal/validate/pattern.go`** — one `patternRules` row. The map key was extracted with `jq -r '.properties.repository.pattern'` from the newly-vendored file and compared by sha256 against the Go raw-string literal, rather than retyped from the (Go-escaped) error message.
3. **`internal/validate/pattern_test.go`** — two rows the brief for this work did not anticipate, both required because they assert `len(...) == len(patternRules)`:
   - a `patternFixtures()` entry, so `TestPatternFindingsCarryTheRuleAndAnExample` reaches the new gloss through the real validator;
   - a `TestPatternGlossesAreTheRightWayRound` ledger row, hand-spelled from what the regex *means* rather than read out of the table.

   The fixture trips the pattern with a **deep link** (`…/civitai/civitai/tree/main`) rather than a wrong host: the host arm and the path-depth arm are separate halves of the regex, and the deep link is the mistake an author actually makes — pasting the URL out of the browser bar while looking at a file.

The `ruleFragment` is `repository root URL`, deliberately not something quoting the scheme: `assetBundleUrl` already owns `https:// URL`, and the ledger's pairwise non-containment check would have caught the overlap.

### The gloss claims only what the REGEX enforces

The schema's own description for this field is explicit that the `pattern` is "a coarse SHAPE check and NOT the whole rule", and that a value can pass local validation and still be refused at submit (the server also constrains the segment alphabet, strips `.git`, rejects credentials/ports). The rule text therefore stops at *host + exactly two path segments* and does not imply local validation is sufficient — matching `patternRule.rule`'s contract that it "describes the REGEX, not the field".

Real output, from a build of this branch:

```
✗ 1 validation error(s) in …/app:
  - repository: 'https://github.com/civitai/civitai/tree/main' does not match
    pattern
    '^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$' — must
    be a repository root URL on github.com, gitlab.com or codeberg.org —
    exactly https://<host>/<owner>/<repo>, with no deeper path (example:
    "https://github.com/civitai/civitai")
```

## Verification

Counts read from `-v` output, not exit codes.

| check | result |
|---|---|
| `go test ./internal/validate -count=1 -v` | **333 RUN / 333 PASS / 0 FAIL / 0 SKIP** |
| `go test ./...` | 21 packages ok, 0 FAIL |
| `go build ./...` / `go vet ./...` | clean |
| `golangci-lint run` (v2.12.2, the version `ci.yml` pins) | `0 issues.` |
| `scripts/check-canonical-schema.sh` | `OK: vendored schema matches the canonical` |

Before the test-file rows were added, that package ran **325 RUN / 323 PASS / 2 FAIL** — the two totality ledgers above. Recording it because it is the evidence those two rows are load-bearing rather than tidying.

### Mutation results

Both directions of the new gloss were broken on purpose and watched go red **with the specific assertion that owns them**, then restored (sha256 of `pattern.go` confirmed identical to pre-mutation) and re-run green.

**(a) one character of the map KEY** (`codeberg` → `codeburg`) — `TestPatternRulesCoverTheVendoredSchema`, red from *both* ledger directions:

```
pattern_test.go:433: schema pattern "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$" has no gloss in patternRules — an author hitting it gets a bare regex back
pattern_test.go:439: patternRules glosses "^https://(github\\.com|gitlab\\.com|codeburg\\.org)/[^/]+/[^/]+/?$", which is not a reachable pattern in the vendored schema — a stale row looks like coverage
--- FAIL: TestPatternRulesCoverTheVendoredSchema
```

**(b) the `example` given a deeper path segment** — `TestPatternRuleExamplesSatisfyTheirPattern`:

```
pattern_test.go:456: example "https://github.com/civitai/civitai/tree/main" does NOT satisfy its own pattern "^https://(github\\.com|gitlab\\.com|codeberg\\.org)/[^/]+/[^/]+/?$"
--- FAIL: TestPatternRuleExamplesSatisfyTheirPattern
```

### Negative control on the byte-identity gate

`check-canonical-schema.sh` reporting OK is only worth reading if it can report otherwise, so it was fed a one-token edit (`maxLength: 200` → `201`) and watched fail:

```
201c201
<       "maxLength": 201,
---
>       "maxLength": 200,

FAIL: schema/app-block.manifest.schema.json has DRIFTED from the canonical.
```

The file was then restored (sha256 verified) and the gate re-run green.

## Not verified

- `golangci-lint` was **not** negative-controlled — I ran the version CI pins and read `0 issues.`, but did not feed it a known-bad file to prove it can go red on this tree.
- Nothing here exercises the **server-side** `validateRepositoryUrl`. The gloss is a claim about the vendored regex only; whether the server accepts a value that passes it is out of scope and, per the schema's own description, deliberately not the same question.
