### PR TITLE
feat(app): `civitai app doctor` — a listing diagnosis whose EXIT CODE gates a release [DO NOT MERGE until #4341 is on release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2142,6 +2142,8 @@ transport. The shape:
 | `ok` | The verdict, and the structured form of the exit code. Follows `summary.gating`, **not** `summary.blocking`. |
 | `apps[]` | Every listing checked, **gating apps first, delisted last**. Each carries `slug`, `name`, `appListingId`, `appBlockId` (null for offsite), `status`, `role`, `delisted`, and a `blocking` and an `advisory` array — never null, `[]` when empty. |
 | `apps[].delisted` | `true` when this listing's status is `removed`, i.e. its blocking problems were reported and not counted. |
+| `apps[].kind` | `onsite` or `offsite`. Carried because it **decides** `fix` for the three text codes — without it a consumer sees two different fixes for one code and cannot reproduce the branch. |
+| `summary.truncated` | `true` when the server's page cap may have hidden listings. Computed from the **server's page**, so it is reported on a single-app run too: that run filters the same capped page client-side, because `listMine` takes no input. |
 | `summary.blocking` | **Every** blocking problem found, so it matches the arrays you can see. |
 | `summary.gating` | The subset on listings that can still publish. **This is the exit code.** |
 | `summary.advisory` / `summary.apps` / `summary.delisted` | Advisory findings, apps checked, and how many of them are delisted. |
@@ -2151,11 +2153,21 @@ a choice between a total that disagrees with the arrays and a verdict that
 disagrees with the exit code. Ask `ok` for "may this ship", `summary.blocking`
 for "is anything wrong anywhere".
 
-**Each finding names its fix, and only fixes that exist.** The three media
-problems (and `blocked-media`, where replacing the asset *is* the fix) print the
-exact `civitai app listing set-icon` / `set-cover` / `add-screenshot` command,
-`--slug` already filled in. `scanning-media` prints no command at all, because
-the scan finishes on its own. The three **text** problems — description,
+**Each finding names its fix, and only fixes that exist — and only fixes that are
+*sufficient*.** `missing-icon` / `missing-cover` / `no-screenshots` print the exact
+`civitai app listing set-icon` / `set-cover` / `add-screenshot` command, `--slug`
+already filled in. `scanning-media` prints no command at all, because the scan
+finishes on its own.
+
+🔴 **`blocked-media` depends on the slot**, which the CLI reads from the server's
+label (the code itself is kind-less). An icon or a cover is **replaced** — the
+new asset overwrites the slot and dereferences the blocked image. A **screenshot
+must be REMOVED**: `add-screenshot` *appends*, so the blocked row stays attached
+and go-live is still refused. That arm therefore prints three commands —
+`listing status` to find the `alsc_` id, `rm-screenshot`, and, on an approved
+listing, `submit-revision`, because the removal lands in a revision that is
+deliberately not auto-submitted. An unrecognised label falls back to an arm that
+still names the removal, losing precision but never sufficiency. The three **text** problems — description,
 tagline, category — are **kind-aware**, because who owns that copy differs:
 
 | kind | fix printed | why |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ contract, and **packages/submits** it for review.
   - [Build provenance: which commit is live?](#build-provenance-which-commit-is-live)
   - [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped)
   - [Deployed is not the same as listed in the store](#deployed-is-not-the-same-as-listed-in-the-store)
+- [Listing doctor (`app doctor`)](#listing-doctor-app-doctor) — **gates a release on exit code**
 - [Pull your app's repository (`app pull`)](#pull-your-apps-repository-app-pull)
 - [Browse the App store](#browse-the-app-store)
 - [App metrics](#app-metrics)
@@ -322,7 +323,8 @@ README. For the end-to-end walkthrough, see
 | `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
 | `civitai app listing status [--json]\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>\|submit-revision` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires, and `listing status --json` emits the same read as one object — including **`parentId` and `shadowId`, the two listing ids a change is addressed to**, which the human output shows neither of. 🔴 **`--json` is not a pure read: on a live listing it opens the revision draft described below, so do not poll it.** The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. **On a listing that is already LIVE, every change — including `reorder` — opens a REVISION for moderator re-review rather than editing the live listing**, and `listing status` reports that in-progress revision's media (so the `alsc_…` ids it prints are the revision's, which is what `reorder` addresses). `rm-screenshot` is the one change deliberately left **staged**: it does **not** submit the revision (curating a gallery is usually several removals), so `submit-revision` is what sends it to moderator review and makes the change public. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
 | `civitai app status [blockId] [--id <pubreq>] [--limit N] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; `--limit N` shows only the newest N (display-side — this route cannot page); a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). Run from **inside** an app checkout it also warns on **stderr** when your local `block.manifest.json` is **BEHIND** your highest approved version — advisory only, the exit code never changes. A **SOURCE** column shows the commit the submitting client claimed (short sha, `(dirty)` when it said the tree was uncommitted, `-` when it claimed nothing); the detail view and `--json` carry the full 40 characters, and `sourceDirty` is a tri-state — `null` is *not reported*, `false` is *reported clean*. See [Submission status](#submission-status), [Build provenance](#build-provenance-which-commit-is-live) and [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped). |
-| `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs a **personal API key** (an OAuth login is refused). See [App metrics](#app-metrics). |
+| `civitai app doctor [slug] [--json]` | **Diagnose what is incomplete or blocked on your App store listings, and how to fix it.** No arg checks every listing you own **or hold an accepted collaborator seat on** (a wider set than `app status`, which is scoped to what *you submitted*); a slug checks just that one. Findings are the platform's, grouped per app, **BLOCKING first** (`missing-icon`, `missing-cover`, `blocked-media` — the listing cannot publish) then **ADVISORY** (`no-screenshots`, `empty-description`, `empty-tagline`, `empty-category`, `scanning-media`). Each one prints the command or URL that fixes it. 🔴 **Exits `1` when anything is blocking, `0` otherwise** — so `civitai app doctor my-app || exit 1` gates a release; `--json` uses the same codes. Unlike `app listing status` it is a **pure read** and opens no revision draft. See [Listing doctor](#listing-doctor-app-doctor). |
+| `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs the **Apps submit scope** — an OAuth `civitai login` or a full-scope personal API key; the same bit `app submit` and `app status` use. An OAuth token minted before that scope existed is refused `403`; re-run `civitai login`. See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>] [--yes]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. **Also deletes a first-version app's store listing — icon, cover and every captioned screenshot**, so it asks first and needs `--yes` in a script. Idempotent for the submission only; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--out-name <template>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
 | `civitai workflows list [--limit <n>] [--cursor <c>] [--tag <t>] [--json]` | **List the generation workflows you have submitted**, newest first — status, when, cost, and `deliverable/total` outputs. Where the server recorded **an account of what happened** to a workflow, it is printed in full on indented lines under that workflow's row. Cursor-paged: the next cursor is printed on stdout when more results exist. Reading spends nothing. See [Generate](#listing-and-cancelling-workflows). |
@@ -2089,6 +2091,63 @@ flag while the store is pre-GA. When the 404 lands on a slug **you own**, the CL
 detects that and says so, naming both next commands, instead of leaving you with
 a bare "App not found".
 
+## Listing doctor (`app doctor`)
+
+`civitai app doctor` answers one question — **is this listing ready to
+publish, and if not, what do I do about it?** — for every App you own or hold an
+accepted collaborator seat on, or for just the one you name:
+
+```bash
+civitai app doctor                 # every app you can work on
+civitai app doctor my-app          # just one
+civitai app doctor --json | jq -e .ok
+```
+
+The findings are the **platform's**, not the CLI's. They arrive already
+classified into two severities, and the report keeps that split because it is
+what the exit code is computed from:
+
+| Severity | Codes | Meaning |
+| --- | --- | --- |
+| **BLOCKING** | `missing-icon`, `missing-cover`, `blocked-media` | The listing **cannot publish** until it is fixed. |
+| **ADVISORY** | `no-screenshots`, `empty-description`, `empty-tagline`, `empty-category`, `scanning-media` | Recommended, but nothing is held up. |
+
+**The exit code is the point.** `1` when any blocking problem was found, `0`
+otherwise — including when only advisories were found, and when you have no
+listings at all. So it gates a release script without parsing anything:
+
+```bash
+civitai app doctor my-app || exit 1
+```
+
+`--json` emits the same verdict as one object (`ok`, `apps[]` with a `blocking`
+and an `advisory` array each, and a `summary`) and uses the **same** exit codes,
+so a script must branch on the code before trusting the payload. Every other
+code keeps its usual meaning — `3` not authorized, `4` no such app of yours, `5`
+transport.
+
+**Each finding names its fix, and only fixes that exist.** The three media
+problems (and `blocked-media`, where replacing the asset *is* the fix) print the
+exact `civitai app listing set-icon` / `set-cover` / `add-screenshot` command,
+`--slug` already filled in. `scanning-media` prints no command at all, because
+the scan finishes on its own. The three **text** problems — description,
+tagline, category — print the listing's **web editor URL**: the procedures that
+write those fields are reachable by a CLI token, but `doctor` is a diagnosis and
+deliberately mutates nothing, so a CLI route for them is a separate command.
+
+Two properties worth knowing:
+
+- **It is a PURE READ.** Unlike `civitai app listing status`, it opens no
+  revision draft on a live listing, so it is safe to run in a loop or in CI.
+- **It sees apps `civitai app status` cannot.** `app status` reads the
+  submissions route, which is scoped to what *you submitted* — a listing you
+  acquired by ownership transfer, or one you hold a collaborator seat on, is
+  invisible there. `doctor` reads the ownership-plus-seats listing, so both show
+  up.
+
+An app with nothing wrong is reported as complete, explicitly. A blank space is
+not an answer: a missing section is indistinguishable from a read that failed.
+
 ## Pull your app's repository (`app pull`)
 
 `civitai app pull` is the **read side of git authoring**: it clones (or, if
@@ -2250,12 +2309,15 @@ believable-but-wrong reading:
   dashboard in that case and tells you to check `civitai whoami` /
   `civitai app status <slug>` instead — a silently-empty dashboard that looks
   like real data is the failure mode this command is built to avoid.
-- **It needs a personal API key.** The query is full-scope, so an OAuth
-  `civitai login` token gets a 403. Both refusals — the 403 *and* the
-  no-token-at-all case — name the route that actually works
-  (`civitai login --token <key>`, created at `civitai.com/user/account`) rather
-  than the generic "run `civitai login`", which here is the one route that
-  cannot succeed.
+- **An OAuth login works, and a personal API key works.** The query needs the
+  **Apps submit scope** — the same bit `civitai app submit` and
+  `civitai app status` require — so one `civitai login` serves all three. (This
+  used to need a full-scope personal API key, and this README said so long after
+  it stopped being true: `civitai/civitai#3572` scope-annotated the procedure
+  precisely so the CLI's login token could read its own analytics.) An OAuth
+  token minted **before** that scope existed does not carry it and still gets a
+  403 — re-run `civitai login`. Both refusals, the 403 and the no-token-at-all
+  case, name both working routes rather than the generic "run `civitai login`".
 
 Two data caveats.
 
@@ -3236,7 +3298,7 @@ credited it to the wrong command.)
 | `not logged in (401)` | The credential is present but invalid or expired. OAuth tokens refresh themselves; when the *refresh* token has also expired, log in again. For a personal key, mint a new one at `civitai.com/user/account`. | [Submit & auth](#submit--auth) |
 | `forbidden (403)` | Usually the invite-only Apps beta rather than a broken token — the same account reads the public API fine. | [Submit & auth](#submit--auth) |
 | `not permitted for your account (403)` | Managing a **store listing** needs Apps-author access, which is a narrower grant than being able to submit. | [Listing media requirements](#listing-media-requirements) |
-| `not permitted to read this app's analytics (403)` | `app metrics` needs a **full-scope personal API key**. An OAuth login is refused here even when it can submit. | [App metrics](#app-metrics) |
+| `not permitted to read this app's analytics (403)` | `app metrics` needs the **Apps submit scope**. An OAuth `civitai login` carries it — unless the token was minted before the scope existed, in which case re-run `civitai login`. A full-scope personal API key also works. | [App metrics](#app-metrics) |
 | `block lacks ai:write:budgeted scope` | Printed by your app at runtime under `dev:live`. The dev token was minted **without** `--spend`, so the CLI filtered the budgeted-spend scope out — it never requests that scope implicitly, even when your manifest declares it. | [Local dev loop](#local-dev-loop-harness-mock-vs-live) |
 | `insufficient Buzz` / `generation disabled` | Not credential problems, which is why they exit `1` rather than `3` — a script must not loop on `civitai login` for either. | [Exit codes specific to `generate`](#exit-codes-specific-to-generate) |
 | `rate limited (429)` | Throttled; exit `6`. For deep paging use `--cursor` rather than `--page`. | [Exit codes](#exit-codes) |
@@ -3256,7 +3318,7 @@ credited it to the wrong command.)
 | --- | --- | --- |
 | `… not found at project root …` | **`civitai app validate`** found no `block.manifest.json` in the directory you named — the finding reads `block.manifest.json not found at project root <dir>`, which the terminal wraps onto a second line for a long path (`--json` carries it as one `message` string). `app submit` prints it too, because it validates first. `app submit --skip-validate` never prints it, because it waives the validation that produces it — that run fails on the row below instead. The path itself was fine, which is why this exits `1` and not `2`. | [Exit code 1](#exit-code-1) |
 | `is this an App project?` | The same cause, reported by a command that did not validate first: `civitai app listing …`, which has to work out *which* app you mean from the working directory, and `app submit --skip-validate`, which waived the check that produces the row above. `app validate` and a plain `app submit` never print it, because validation reports the row above first. Run `app listing` from the app directory, or name the app with `--slug` / `--dir`. | [After you submit](#after-you-submit-review--approve--deploy) |
-| `the server rejected this store-listing lookup (400)` | A **read** was refused — resolving your app's listing, reading it for edit, or polling an asset's scan state. Nothing was changed. The value at fault is one the CLI derived (an app slug, a listing id, an image id), so start from `civitai app status` and check the app you named. Exit `2`. | [Listing media requirements](#listing-media-requirements) |
+| `the server rejected this store-listing lookup (400)` | A **read** was refused — resolving your app's listing, reading it for edit, polling an asset's scan state, or enumerating your listings for `app doctor`. Nothing was changed. Three of those four carry a value the CLI derived (an app slug, a listing id, an image id); the `app doctor` enumeration carries **no input at all**, which is why the message no longer blames a value you named. `civitai app doctor` lists every app you can work on. Exit `2`. | [Listing doctor](#listing-doctor-app-doctor) |
 | `the server rejected the image-upload request (400)` | The **image** was refused while being ingested — the presigned upload mint, the inline icon upload, or the row that records the uploaded file. **No listing was changed** by any of those three: an image is attached to nothing until `set-icon` / `set-cover` / `add-screenshot` runs. The server's own reason follows the code and names the bound it applied — read it rather than guessing which limit you crossed. Exit `2`. **The raw upload of the bytes is a fourth step and reports differently** — see the row below. | [Listing media requirements](#listing-media-requirements) |
 | `image upload PUT failed` | The full-resolution upload of the **bytes themselves**, to the presigned URL, was refused by storage (e.g. `EntityTooLarge`) — the step between minting the URL and recording the row. No listing was changed. ⚠️ Unlike the three ingest steps above it is **not** classified as a bad request, so it exits **`1`, not `2`**, and the message leads with the HTTP mechanism rather than with what you were doing. That inconsistency is known and tracked ([#388](https://github.com/civitai/cli/issues/388)), not intended. | [Listing media requirements](#listing-media-requirements) |
 | `the server rejected this store-listing change (400)` | The **listing** was refused — an attach, a removal, a reorder, opening a revision, or submitting one. Unlike the rows above, this one may have **partially applied**, which is why it points you at `civitai app listing status` rather than claiming nothing happened. It deliberately does **not** tell you to go fix a value, because the seven routes it covers do not all carry one. Where the CLI can name something concrete it does so on the lines that follow, and only there: `set-icon`, `set-cover` and `add-screenshot` print the bytes, pixel dimensions and MIME type of the **file** you sent — never the `--caption`. `rm-screenshot`, `reorder` and the two revision steps print this line **alone**, so for those the server's own reason is the whole story; *opening* a revision in particular sends nothing but a listing id the CLI derived from a lookup that had already succeeded. Exit `2`. **One refusal is deliberately not reported here at all**: a revision *submit* refused because the listing is still below the publish floor is not a failure of the command that ran — the change was written to the revision, and the floor takes two commands to clear — so that case prints `staged on an open revision` and exits `0`. The CLI decides that from the listing's own state, never from the server's wording. It reports progress only when all three hold: the refusal was a **400** (a `500`/`503` is an outage, not the floor, and still fails with its usual exit code), what it just wrote is really there — matched by **image id** for an icon or cover, by the `alsc_…` row id for a screenshot (a listing being re-branded already has an *old* icon, which proves nothing), and for `reorder` by the revision's gallery holding **exactly the ids you passed, in the order you passed them** (a revision that exists but was never reordered proves nothing either) — and the floor is really unmet. If it cannot read the listing back it claims nothing — you get this row and exit `2`. **This applies to `reorder` since [#430](https://github.com/civitai/cli/issues/430)**, which is also when a live `reorder` started reaching the revision routes at all: before it, a reorder of a live listing could only ever produce this row, because it was addressed to the parent listing while the ids it carried belonged to the open revision. 🔴 **That exception is scoped to the commands whose job was the STAGED CHANGE — the three attaches and `reorder` — and `civitai app listing submit-revision` is deliberately not one of them**: there the submit *is* what you asked for, so a below-floor refusal is a real failure — you get this row and exit `2`, with the floor gap printed alongside it as context. Reporting `0` there would be [#436](https://github.com/civitai/cli/issues/436)'s own false success, rebuilt in the command that fixes it. | [Listing media requirements](#listing-media-requirements) |

--- a/README.md
+++ b/README.md
@@ -2156,9 +2156,24 @@ problems (and `blocked-media`, where replacing the asset *is* the fix) print the
 exact `civitai app listing set-icon` / `set-cover` / `add-screenshot` command,
 `--slug` already filled in. `scanning-media` prints no command at all, because
 the scan finishes on its own. The three **text** problems — description,
-tagline, category — print the listing's **web editor URL**: the procedures that
-write those fields are reachable by a CLI token, but `doctor` is a diagnosis and
-deliberately mutates nothing, so a CLI route for them is a separate command.
+tagline, category — are **kind-aware**, because who owns that copy differs:
+
+| kind | fix printed | why |
+| --- | --- | --- |
+| **off-site** | the listing's **web editor URL** | the copy is author-supplied through the submit wizard |
+| **on-site** | **`block.manifest.json`**, then `civitai app submit` a new version | the copy is **manifest-governed** |
+
+🔴 That distinction is not cosmetic. On an on-site listing the platform
+overwrites `name` / `tagline` / `description` / `category` **from the manifest on
+every subsequent-version moderator approve** — so telling an on-site author to
+edit them in the browser is advice the platform silently reverts: they follow it,
+`doctor` goes quiet, and the problem comes back with nothing explaining why. An
+unrecognised or absent kind takes the **browser** arm, deliberately: naming a
+manifest an app may not have is confusing and self-correcting, while the reverse
+is the silent failure.
+
+`doctor` itself still mutates nothing — it is a diagnosis, so a CLI route for
+writing those fields is a separate command.
 
 Two properties worth knowing:
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ README. For the end-to-end walkthrough, see
 | `civitai app pull [dir] --app <slug\|appBlockId>` | **Clone (or sync) the canonical git repository behind one of your approved Apps** — the read side of git authoring. ⚠ The clone URL embeds your access token, and a fresh clone persists it into `.git/config`. See [Pull your app's repository](#pull-your-apps-repository-app-pull). |
 | `civitai app listing status [--json]\|set-icon <file>\|set-cover <file>\|add-screenshot <file>\|rm-screenshot <id>\|reorder <id...>\|submit-revision` | **Attach the store-listing media your App needs before it can be published** — an **icon and a cover are mandatory** (screenshots are optional, up to 8). `listing status` prints what is attached vs. what the publish floor still requires, and `listing status --json` emits the same read as one object — including **`parentId` and `shadowId`, the two listing ids a change is addressed to**, which the human output shows neither of. 🔴 **`--json` is not a pure read: on a live listing it opens the revision draft described below, so do not poll it.** The CLI checks format + byte size locally; **dimensions and aspect ratio are checked by the platform at attach**. **On a listing that is already LIVE, every change — including `reorder` — opens a REVISION for moderator re-review rather than editing the live listing**, and `listing status` reports that in-progress revision's media (so the `alsc_…` ids it prints are the revision's, which is what `reorder` addresses). `rm-screenshot` is the one change deliberately left **staged**: it does **not** submit the revision (curating a gallery is usually several removals), so `submit-revision` is what sends it to moderator review and makes the change public. See [After you submit](#after-you-submit-review--approve--deploy) and [Listing media requirements](#listing-media-requirements). |
 | `civitai app status [blockId] [--id <pubreq>] [--limit N] [--json]` | Check the review/deploy status of **your own** submissions. No arg lists them all; `--limit N` shows only the newest N (display-side — this route cannot page); a `blockId` (app slug) or `--id` shows one in detail (rejection reason if rejected, live URL once deployed). Run from **inside** an app checkout it also warns on **stderr** when your local `block.manifest.json` is **BEHIND** your highest approved version — advisory only, the exit code never changes. A **SOURCE** column shows the commit the submitting client claimed (short sha, `(dirty)` when it said the tree was uncommitted, `-` when it claimed nothing); the detail view and `--json` carry the full 40 characters, and `sourceDirty` is a tri-state — `null` is *not reported*, `false` is *reported clean*. See [Submission status](#submission-status), [Build provenance](#build-provenance-which-commit-is-live) and [Is your repo behind what you shipped?](#is-your-repo-behind-what-you-shipped). |
-| `civitai app doctor [slug] [--json]` | **Diagnose what is incomplete or blocked on your App store listings, and how to fix it.** No arg checks every listing you own **or hold an accepted collaborator seat on** (a wider set than `app status`, which is scoped to what *you submitted*); a slug checks just that one. Findings are the platform's, grouped per app, **BLOCKING first** (`missing-icon`, `missing-cover`, `blocked-media` — the listing cannot publish) then **ADVISORY** (`no-screenshots`, `empty-description`, `empty-tagline`, `empty-category`, `scanning-media`). Each one prints the command or URL that fixes it. 🔴 **Exits `1` when anything is blocking, `0` otherwise** — so `civitai app doctor my-app || exit 1` gates a release; `--json` uses the same codes. Unlike `app listing status` it is a **pure read** and opens no revision draft. See [Listing doctor](#listing-doctor-app-doctor). |
+| `civitai app doctor [slug] [--json]` | **Diagnose what is incomplete or blocked on your App store listings, and how to fix it.** No arg checks every listing you own **or hold an accepted collaborator seat on** (a wider set than `app status`, which is scoped to what *you submitted*); a slug checks just that one. Findings are the platform's, grouped per app, **BLOCKING first** (`missing-icon`, `missing-cover`, `blocked-media` — the listing cannot publish) then **ADVISORY** (`no-screenshots`, `empty-description`, `empty-tagline`, `empty-category`, `scanning-media`). Each one prints the command or URL that fixes it. A listing whose status is `removed` is still reported, in its own section, but does **not** set the exit code — the publish floor is meaningless for a delisted app. 🔴 **Exits `1` when a blocking problem sits on a listing that can still publish, `0` otherwise** — so `civitai app doctor my-app || exit 1` gates a release; `--json` uses the same codes and publishes both `summary.blocking` (everything found) and `summary.gating` (what set the code). Unlike `app listing status` it is a **pure read** and opens no revision draft. See [Listing doctor](#listing-doctor-app-doctor). |
 | `civitai app metrics <slug> [--from <d>] [--to <d>] [--json]` | **Owner-only analytics for one of your Apps** — installs, runs + Buzz spent, Buzz purchased, and API engagement. Always prints the window the **server** served (it defaults to 30 days and clamps to 366), so a zero is never ambiguous. Needs the **Apps submit scope** — an OAuth `civitai login` or a full-scope personal API key; the same bit `app submit` and `app status` use. An OAuth token minted before that scope existed is refused `403`; re-run `civitai login`. See [App metrics](#app-metrics). |
 | `civitai app withdraw [pubreq-id] [--id <pubreq>] [--yes]` | **Withdraw your own pending submission** (the `pubreq_…` id from `civitai app status`). Frees the slug so a fresh `civitai app submit` can replace it. **Also deletes a first-version app's store listing — icon, cover and every captioned screenshot**, so it asks first and needs `--yes` in a script. Idempotent for the submission only; only a `pending` request can be withdrawn. See [Submission status](#submission-status). |
 | `civitai generate "<prompt>" [--negative-prompt <p>] [--quantity <n>] [--aspect-ratio <r>] [--checkpoint <version-id>] [--lora <version-id>[:strength]] [--image <path-or-url>] [--ecosystem <key>] [--input <file>] [--print-input] [--dry-run] [--json] [--max-cost <buzz>] [--fail-on-substitution] [--yes] [--no-wait] [--timeout <dur>] [--out-dir <dir>] [--out-name <template>] [--no-download] [--force] [--external-id <key>]` | **Generate images from a text prompt — this SPENDS REAL BUZZ.** Prices the job with the server's estimator, shows the cost + your balance, asks before spending, submits, then **waits and downloads** the results. `--dry-run` prices it and exits without submitting; `--max-cost` is an **estimate check, not a spending cap**. Needs the AI Services scopes — `civitai login --scopes generate` or a full-scope **personal API key**; a **default** OAuth login is refused. See [Generate](#generate) for the wait/download flags, image-to-image, raw graphs, and [silent model substitution](#-silent-model-substitution). |
@@ -2109,22 +2109,47 @@ what the exit code is computed from:
 
 | Severity | Codes | Meaning |
 | --- | --- | --- |
-| **BLOCKING** | `missing-icon`, `missing-cover`, `blocked-media` | The listing **cannot publish** until it is fixed. |
+| **BLOCKING** | `missing-icon`, `missing-cover`, `blocked-media` | The listing **cannot publish** until it is fixed. Sets the exit code — unless the listing is delisted (below). |
 | **ADVISORY** | `no-screenshots`, `empty-description`, `empty-tagline`, `empty-category`, `scanning-media` | Recommended, but nothing is held up. |
 
-**The exit code is the point.** `1` when any blocking problem was found, `0`
-otherwise — including when only advisories were found, and when you have no
-listings at all. So it gates a release script without parsing anything:
+**Delisted listings are reported but do not gate.** An app whose status is
+`removed` still gets a full row, in its own section — the verdict shrinks, the
+report does not. Its blocking problems are counted in `summary.blocking` and
+excluded from `summary.gating`. Without this one old removed app would fail
+every run forever: measured on production, an account with 21 listings had 11
+blocking problems and **ten of them sat on `removed` apps**. Republish a listing
+and it gates again on the next run, with no flag to remember. Only an explicit
+`removed` is excluded — an unrecognised status still gates, because "we could
+not tell it is delisted" is not "it is delisted".
+
+**The exit code is the point.** `1` when a blocking problem was found on a
+listing that **can still publish**, `0` otherwise — including when only
+advisories were found, when the only blocking problems are on delisted
+listings, and when you have no listings at all. So it gates a release script
+without parsing anything:
 
 ```bash
 civitai app doctor my-app || exit 1
 ```
 
-`--json` emits the same verdict as one object (`ok`, `apps[]` with a `blocking`
-and an `advisory` array each, and a `summary`) and uses the **same** exit codes,
+`--json` emits the same verdict as one object and uses the **same** exit codes,
 so a script must branch on the code before trusting the payload. Every other
 code keeps its usual meaning — `3` not authorized, `4` no such app of yours, `5`
-transport.
+transport. The shape:
+
+| Field | Meaning |
+| --- | --- |
+| `ok` | The verdict, and the structured form of the exit code. Follows `summary.gating`, **not** `summary.blocking`. |
+| `apps[]` | Every listing checked, **gating apps first, delisted last**. Each carries `slug`, `name`, `appListingId`, `appBlockId` (null for offsite), `status`, `role`, `delisted`, and a `blocking` and an `advisory` array — never null, `[]` when empty. |
+| `apps[].delisted` | `true` when this listing's status is `removed`, i.e. its blocking problems were reported and not counted. |
+| `summary.blocking` | **Every** blocking problem found, so it matches the arrays you can see. |
+| `summary.gating` | The subset on listings that can still publish. **This is the exit code.** |
+| `summary.advisory` / `summary.apps` / `summary.delisted` | Advisory findings, apps checked, and how many of them are delisted. |
+
+Two counts rather than one is deliberate: publishing a single number would force
+a choice between a total that disagrees with the arrays and a verdict that
+disagrees with the exit code. Ask `ok` for "may this ship", `summary.blocking`
+for "is anything wrong anywhere".
 
 **Each finding names its fix, and only fixes that exist.** The three media
 problems (and `blocked-media`, where replacing the asset *is* the fix) print the

--- a/cmd/civitai/doctor_e2e_exitcode_test.go
+++ b/cmd/civitai/doctor_e2e_exitcode_test.go
@@ -64,7 +64,14 @@ func e2eDoctorRowWithStatus(slug, listingID, status string, problems ...map[stri
 		"status":       status,
 		"role":         "owner",
 		"appBlockId":   nil,
-		"problems":     problems,
+		// 🔴 THE REAL SERVER ALWAYS SENDS A KIND, SO THE FAKE MUST TOO. Omitting
+		// it left this whole process-level suite running on the unknown-kind
+		// arm, i.e. structurally blind to every kind-dependent behaviour —
+		// benign here, but it is the same fake-omits-a-field shape that hid the
+		// shadowId defect on the sibling command. The unit fixtures already do
+		// this and say why; this brings the e2e along.
+		"kind":     "offsite",
+		"problems": problems,
 	}
 }
 

--- a/cmd/civitai/doctor_e2e_exitcode_test.go
+++ b/cmd/civitai/doctor_e2e_exitcode_test.go
@@ -251,3 +251,64 @@ func TestDoctorProcessExitStatusEndToEnd(t *testing.T) {
 		}
 	})
 }
+
+// TestDoctorVerdictPrintsNoErrorPrefix measures the property at the only level
+// it exists: the PROCESS's stderr.
+//
+// 🔴 THIS REPLACES A TEST THAT COULD NOT SEE IT. The in-package version asserted
+// on `err.Error()`, which is the string BEFORE `main.go` prepends "Error: " — so
+// it passed while the prefix was printed on every run, and an attempt to fix the
+// problem by rewording the sentinel changed only the text AFTER the prefix. The
+// emitter is `main.go`'s `errorLine`, not cobra (the root sets
+// `SilenceErrors: true`), and this reads what that emitter actually produced.
+//
+// The pair is the point. A verdict must print bare; a real failure must keep the
+// prefix. Asserting only the first would be satisfied by deleting the prefix
+// everywhere, which would hide genuine errors from the same CI scraper.
+func TestDoctorVerdictPrintsNoErrorPrefix(t *testing.T) {
+	bin := buildCLI(t)
+	blocked := []map[string]any{e2eDoctorRowWithStatus("e2e-verdict", "apl_E2EVERD", "draft",
+		e2eDoctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"))}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != doctorListMinePath {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": map[string]any{"data": map[string]any{"json": blocked}},
+		})
+	}))
+	defer srv.Close()
+	env := []string{
+		"HOME=" + t.TempDir(), "XDG_CONFIG_HOME=" + t.TempDir(),
+		"CIVITAI_TOKEN=tok-e2e", "CIVITAI_BASE_URL=" + srv.URL,
+		"CIVITAI_NO_UPDATE_CHECK=1", "NO_COLOR=1",
+	}
+
+	rc, _, stderr := runCLIAnyStatus(t, bin, env, "app", "doctor")
+	if rc != exitGeneric {
+		t.Fatalf("verdict exited %d, want %d", rc, exitGeneric)
+	}
+	// 🔴 THE ASSERTION IS ON THE PROCESS'S OWN STDERR, and it is anchored: a
+	// `Contains` would be satisfied by "Error:" appearing anywhere, while what
+	// matters is whether the line LEADS with it, which is what a scraper greps.
+	if strings.HasPrefix(strings.TrimSpace(stderr), "Error:") {
+		t.Errorf("the verdict line still leads with %q — a CI scraper watching stderr for it flags a run "+
+			"that worked exactly as designed.\nstderr: %s", "Error:", stderr)
+	}
+	if !strings.Contains(stderr, "not ready to publish") {
+		t.Errorf("the verdict should still be reported on stderr, got: %s", stderr)
+	}
+
+	// 🔴 NEGATIVE CONTROL, same binary, same run shape: a REAL failure must KEEP
+	// the prefix. Without this, deleting the prefix unconditionally would pass.
+	rc2, _, stderr2 := runCLIAnyStatus(t, bin, env, "app", "doctor", "not-an-app-of-mine")
+	if rc2 != exitNotFound {
+		t.Fatalf("control exited %d, want %d", rc2, exitNotFound)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(stderr2), "Error:") {
+		t.Errorf("a genuine failure must still lead with \"Error:\" — suppressing it everywhere would hide "+
+			"real errors from the same scraper.\nstderr: %s", stderr2)
+	}
+}

--- a/cmd/civitai/doctor_e2e_exitcode_test.go
+++ b/cmd/civitai/doctor_e2e_exitcode_test.go
@@ -1,0 +1,197 @@
+package main
+
+// THE PROCESS EXIT STATUS OF `civitai app doctor`, MEASURED END TO END.
+//
+// 🔴 WHY THIS FILE EXISTS, AND IT IS NOT REDUNDANT WITH
+// doctor_exitcode_test.go. That file hands `exitCode` a HAND-BUILT error and
+// checks the routing — which is a claim about the mapper, not about the command.
+// A mutation battery caught the gap: tagging the REAL verdict with
+// `civitai.ErrBadRequest` inside `runAppDoctor` moves the published exit code
+// from 1 to 2, and the whole suite — that unit test included — stayed green,
+// because nothing anywhere took the error the COMMAND actually returns and asked
+// what code it produces.
+//
+// That is the "verified in isolation" shape: `internal/cmd` owns the verdict,
+// `cmd/civitai` owns the mapping, both were tested, and the SEAM between them
+// was owned by nobody. So this file builds the real binary, drives it against a
+// fake `appListings.listMine`, and reads the process's own status — the number
+// `civitai app doctor my-app || exit 1` actually branches on.
+//
+// It measures all FOUR arms. Three of them are the same number twice over (0),
+// and that is the point: with only the blocking arm, an implementation that
+// always exits 1 would pass.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// doctorListMinePath is spelled here rather than imported: this package cannot
+// see internal/appapi's unexported route vars, and a literal is what makes the
+// fake answer the route the binary really asks for.
+const doctorListMinePath = "/api/trpc/appListings.listMine"
+
+// e2eDoctorProblem / e2eDoctorRow build server-shaped fixtures. The slugs and
+// ids are distinct from anything asserted, so no assertion can pass on a value
+// copied from elsewhere.
+func e2eDoctorProblem(code, label, severity string) map[string]any {
+	return map[string]any{"code": code, "label": label, "severity": severity}
+}
+
+func e2eDoctorRow(problems ...map[string]any) map[string]any {
+	if problems == nil {
+		problems = []map[string]any{}
+	}
+	return map[string]any{
+		"appListingId": "apl_E2E77",
+		"slug":         "e2e-doctor-app",
+		"name":         "E2E Doctor App",
+		"status":       "draft",
+		"role":         "owner",
+		"appBlockId":   nil,
+		"problems":     problems,
+	}
+}
+
+// runCLIAnyStatus is runCLI's sibling for a command that may legitimately
+// SUCCEED. runCLI t.Fatals on a zero status (it exists for failure paths), which
+// is exactly the arm this file must be able to observe.
+func runCLIAnyStatus(t *testing.T, bin string, env []string, args ...string) (int, string, string) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append([]string{"PATH=" + os.Getenv("PATH")}, env...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return 0, stdout.String(), stderr.String()
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("could not run the binary: %v", err)
+	}
+	return ee.ExitCode(), stdout.String(), stderr.String()
+}
+
+func TestDoctorProcessExitStatusEndToEnd(t *testing.T) {
+	bin := buildCLI(t)
+
+	cases := []struct {
+		name     string
+		rows     []map[string]any
+		args     []string
+		want     int
+		wantWhy  string
+		mustSay  string
+		mustExit string
+	}{
+		{
+			name: "a blocking problem fails the build",
+			rows: []map[string]any{e2eDoctorRow(
+				e2eDoctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"))},
+			args:    []string{"app", "doctor"},
+			want:    exitGeneric,
+			wantWhy: "a verdict about the LISTING, the same class as an invalid manifest — not a usage mistake",
+			mustSay: "missing-icon",
+		},
+		{
+			name: "blocked-media is blocking too",
+			rows: []map[string]any{e2eDoctorRow(
+				e2eDoctorProblem("blocked-media", "Replace the blocked icon before it can publish", "blocking"))},
+			args:    []string{"app", "doctor"},
+			want:    exitGeneric,
+			wantWhy: "an asset the scan BLOCKED stops a publish exactly as a missing one does",
+			mustSay: "blocked-media",
+		},
+		{
+			name: "advisories alone do not fail the build",
+			rows: []map[string]any{e2eDoctorRow(
+				e2eDoctorProblem("no-screenshots", "No screenshots (recommended, optional)", "advisory"),
+				e2eDoctorProblem("scanning-media", "Icon is still being scanned", "advisory"))},
+			args:    []string{"app", "doctor"},
+			want:    0,
+			wantWhy: "an advisory holds nothing up, so a release script must not stop on one",
+			mustSay: "no-screenshots",
+		},
+		{
+			name:    "a complete listing exits clean",
+			rows:    []map[string]any{e2eDoctorRow()},
+			args:    []string{"app", "doctor"},
+			want:    0,
+			wantWhy: "nothing is wrong",
+			mustSay: "No problems",
+		},
+		{
+			name: "--json uses the same codes",
+			rows: []map[string]any{e2eDoctorRow(
+				e2eDoctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"))},
+			args:    []string{"app", "doctor", "--json"},
+			want:    exitGeneric,
+			wantWhy: "a script must be able to branch on the code before parsing the payload",
+			mustSay: `"ok": false`,
+		},
+		{
+			name:    "an unknown slug is NOT FOUND, not a pass",
+			rows:    []map[string]any{e2eDoctorRow()},
+			args:    []string{"app", "doctor", "not-an-app-of-mine"},
+			want:    exitNotFound,
+			wantWhy: "`you own no app called that` and `that app is fine` are opposite answers",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := tc.rows
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != doctorListMinePath {
+					t.Errorf("unexpected request to %s", r.URL.Path)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"result": map[string]any{"data": map[string]any{"json": rows}},
+				})
+			}))
+			defer srv.Close()
+
+			env := []string{
+				"HOME=" + t.TempDir(),
+				"XDG_CONFIG_HOME=" + t.TempDir(),
+				"CIVITAI_TOKEN=tok-e2e",
+				"CIVITAI_BASE_URL=" + srv.URL,
+				"CIVITAI_NO_UPDATE_CHECK=1",
+				"NO_COLOR=1",
+			}
+			rc, stdout, stderr := runCLIAnyStatus(t, bin, env, tc.args...)
+			if rc != tc.want {
+				t.Errorf("`civitai %s` exited %d, want %d — %s.\nstdout:\n%s\nstderr:\n%s",
+					strings.Join(tc.args, " "), rc, tc.want, tc.wantWhy, stdout, stderr)
+			}
+			if tc.mustSay != "" && !strings.Contains(stdout, tc.mustSay) {
+				t.Errorf("stdout does not carry %q:\n%s", tc.mustSay, stdout)
+			}
+		})
+	}
+
+	// 🔴 NEGATIVE CONTROL ON THE HARNESS. Every number above is read from the
+	// same runner, so a runner that always reported the same status would make
+	// the whole table agree with itself. A usage mistake must come back as 2 —
+	// a code no row above expects.
+	t.Run("control: the harness observes a DIFFERENT code", func(t *testing.T) {
+		rc, _, stderr := runCLIAnyStatus(t, buildCLI(t),
+			[]string{"HOME=" + t.TempDir(), "NO_COLOR=1", "CIVITAI_NO_UPDATE_CHECK=1"},
+			"app", "doctor", "--no-such-flag")
+		if rc != exitUsage {
+			t.Errorf("a bad flag exited %d, want %d — the harness is not observing differentiated codes.\nstderr: %s",
+				rc, exitUsage, stderr)
+		}
+	})
+}

--- a/cmd/civitai/doctor_e2e_exitcode_test.go
+++ b/cmd/civitai/doctor_e2e_exitcode_test.go
@@ -46,14 +46,22 @@ func e2eDoctorProblem(code, label, severity string) map[string]any {
 }
 
 func e2eDoctorRow(problems ...map[string]any) map[string]any {
+	return e2eDoctorRowWithStatus("e2e-doctor-app", "apl_E2E77", "draft", problems...)
+}
+
+// e2eDoctorRowWithStatus is the same fixture with the lifecycle status — and a
+// distinct slug and listing id — under the caller's control, so the DELISTED
+// arms below can put a `removed` listing beside a live one and tell which of the
+// two moved the process status.
+func e2eDoctorRowWithStatus(slug, listingID, status string, problems ...map[string]any) map[string]any {
 	if problems == nil {
 		problems = []map[string]any{}
 	}
 	return map[string]any{
-		"appListingId": "apl_E2E77",
-		"slug":         "e2e-doctor-app",
-		"name":         "E2E Doctor App",
-		"status":       "draft",
+		"appListingId": listingID,
+		"slug":         slug,
+		"name":         "E2E " + slug,
+		"status":       status,
 		"role":         "owner",
 		"appBlockId":   nil,
 		"problems":     problems,
@@ -144,6 +152,47 @@ func TestDoctorProcessExitStatusEndToEnd(t *testing.T) {
 			args:    []string{"app", "doctor", "not-an-app-of-mine"},
 			want:    exitNotFound,
 			wantWhy: "`you own no app called that` and `that app is fine` are opposite answers",
+		},
+
+		// 🔴 THE DELISTED ARMS, MEASURED AT THE PROCESS LEVEL. This rule changes
+		// the verdict->exit-code path, which is EXACTLY where the M15 seam defect
+		// lived: `internal/cmd` computed a verdict, `cmd/civitai` mapped it, both
+		// were tested, and the join was owned by nobody. Any change to that path
+		// gets re-measured here, from the process status, not from a fixture
+		// error handed to the mapper.
+		{
+			name: "a REMOVED listing with blocking problems exits 0",
+			rows: []map[string]any{e2eDoctorRowWithStatus("e2e-gone", "apl_E2EGONE", "removed",
+				e2eDoctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"))},
+			args:    []string{"app", "doctor"},
+			want:    0,
+			wantWhy: "the publish floor is meaningless for a delisted app; before this rule one old removed app failed every run forever",
+			mustSay: "Delisted",
+		},
+		{
+			name: "a removed listing next to a LIVE blocked one still exits 1",
+			rows: []map[string]any{
+				e2eDoctorRowWithStatus("e2e-gone", "apl_E2EGONE", "removed",
+					e2eDoctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking")),
+				e2eDoctorRowWithStatus("e2e-live", "apl_E2ELIVE", "draft",
+					e2eDoctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")),
+			},
+			args:    []string{"app", "doctor"},
+			want:    exitGeneric,
+			wantWhy: "a delisted app must not MASK a real one — this is the arm a naive filter gets wrong",
+			mustSay: "e2e-live",
+		},
+		{
+			name: "a removed listing next to a CLEAN live one exits 0",
+			rows: []map[string]any{
+				e2eDoctorRowWithStatus("e2e-gone", "apl_E2EGONE", "removed",
+					e2eDoctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking")),
+				e2eDoctorRowWithStatus("e2e-live", "apl_E2ELIVE", "approved"),
+			},
+			args:    []string{"app", "doctor"},
+			want:    0,
+			wantWhy: "nothing publishable is blocked",
+			mustSay: "No problems",
 		},
 	}
 

--- a/cmd/civitai/doctor_exitcode_test.go
+++ b/cmd/civitai/doctor_exitcode_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/civitai/cli/internal/cmd"
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// THE EXIT CODE OF `civitai app doctor`'s BLOCKING VERDICT.
+//
+// The classification and the PROCESS contract are two different claims, and the
+// second is the one a release script reads. `internal/cmd` can tag the verdict
+// perfectly while `exitCode` routes it somewhere else — the same gap
+// submit_version_guard_exitcode_test.go in this package exists to close for a
+// different path.
+//
+// The verdict is 1, not 2, and that is a DECISION rather than a fallthrough:
+// exit 2 is documented as a mistake about the INVOCATION, and every flag and
+// argument in `civitai app doctor my-app` is well-formed when this fires. What
+// is wrong is the LISTING — a verdict about the subject, which exitCodeDocs
+// already publishes under code 1 (`app validate` lands there for the same
+// reason).
+//
+// 🔴 The verdict is left UNTAGGED for the exit mapper on purpose, so this test
+// is what makes that silence deliberate rather than accidental: tagging it
+// civitai.ErrBadRequest — the only route from a command error to exit 2 — would
+// move it, and nothing else in the suite would notice.
+
+func TestDoctorBlockingExitsGeneric(t *testing.T) {
+	err := fmt.Errorf("%w: 2 blocking problem(s) across 1 app(s) — see the report above", cmd.ErrListingBlocked)
+
+	if !errors.Is(err, cmd.ErrListingBlocked) {
+		t.Fatal("fixture is not tagged with ErrListingBlocked — the test would prove nothing")
+	}
+	if got := exitCode(err); got != exitGeneric {
+		t.Errorf("exitCode(doctor blocking verdict) = %d, want %d (generic — a verdict about the listing).\n"+
+			"2 is a mistake about the INVOCATION; the flags and arguments here are all well-formed.", got, exitGeneric)
+	}
+
+	// Wrapped by an outer message (cobra/RunE chains do this) it must keep its
+	// code — an errors.Is walk, never a top-level type check.
+	wrapped := fmt.Errorf("app doctor: %w", err)
+	if got := exitCode(wrapped); got != exitGeneric {
+		t.Errorf("wrapped: exitCode = %d, want %d", got, exitGeneric)
+	}
+
+	// NEGATIVE CONTROL: exitCode CAN return something other than exitGeneric, so
+	// the assertion above is not a fact about a function that always says 1.
+	if got := exitCode(civitai.Tag(civitai.ErrBadRequest, errors.New("bad enum"))); got != exitUsage {
+		t.Fatalf("negative control: exitCode(ErrBadRequest) = %d, want %d — the instrument is not discriminating", got, exitUsage)
+	}
+}
+
+// TestDoctorBlockingSentinelIsNotAnAPIKind pins the OTHER half: the sentinel
+// must not accidentally satisfy one of the API classification kinds, which would
+// silently move the verdict onto 2/3/4/5/6 — and 4 in particular, because
+// `app doctor <unknown-slug>` deliberately DOES exit 4 and the two answers must
+// stay separately actionable.
+func TestDoctorBlockingSentinelIsNotAnAPIKind(t *testing.T) {
+	err := fmt.Errorf("%w: 1 blocking problem(s)", cmd.ErrListingBlocked)
+	kinds := map[string]error{
+		"ErrBadRequest":   civitai.ErrBadRequest,
+		"ErrUnauthorized": civitai.ErrUnauthorized,
+		"ErrNotFound":     civitai.ErrNotFound,
+		"ErrRateLimited":  civitai.ErrRateLimited,
+		"ErrNetwork":      civitai.ErrNetwork,
+	}
+	for name, kind := range kinds {
+		if errors.Is(err, kind) {
+			t.Errorf("a doctor blocking verdict must not match civitai.%s — that would move its exit code", name)
+		}
+	}
+	// POSITIVE CONTROL on the loop: an error that IS one of these kinds must be
+	// seen, or the five negatives above are a fact about a walk that matches
+	// nothing.
+	if !errors.Is(civitai.Tag(civitai.ErrNotFound, errors.New("x")), kinds["ErrNotFound"]) {
+		t.Fatal("the errors.Is walk cannot see a kind it should — the negatives above prove nothing")
+	}
+	// And the sibling verdict `app doctor` really does emit for an unknown slug
+	// must land on 4, so a script can tell "not ready" from "no such app".
+	if got := exitCode(civitai.Tag(civitai.ErrNotFound, errors.New(`no listing of yours is called "nope"`))); got != exitNotFound {
+		t.Errorf("exitCode(unknown-slug refusal) = %d, want %d", got, exitNotFound)
+	}
+}
+
+// TestDoctorCleanRunExitsZero is the third arm of the exit contract at the
+// PROCESS level: `runCLI` must map a nil error to 0. Without it, the two
+// assertions above are equally true of a binary that never returns 0 at all.
+func TestDoctorCleanRunExitsZero(t *testing.T) {
+	if got := exitCode(nil); got != 0 {
+		t.Errorf("exitCode(nil) = %d, want 0 — a clean `app doctor` run must not fail a release script", got)
+	}
+}

--- a/cmd/civitai/main.go
+++ b/cmd/civitai/main.go
@@ -46,9 +46,40 @@ const (
 func main() {
 	cmd.SetBuildInfo(version, commit, date)
 	if err := cmd.NewRootCmd().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		// 🔴 THIS LINE IS THE ONLY SOURCE OF THE "Error: " PREFIX. cobra prints
+		// nothing — the root sets `SilenceErrors: true` (internal/cmd/root.go) —
+		// so every non-nil error from Execute() is rendered here and nowhere
+		// else. An earlier attempt to stop `app doctor` reading as a tool
+		// failure edited the SENTINEL's text instead, which was a fix aimed at
+		// the wrong emitter: the prefix survived untouched, and the test written
+		// to prove otherwise asserted on `err.Error()` — the string as it exists
+		// BEFORE this line prepends anything, so it was structurally incapable
+		// of observing the property it was named for.
+		fmt.Fprintln(os.Stderr, errorLine(err))
 		os.Exit(exitCode(err))
 	}
+}
+
+// errorLine renders a command error for stderr.
+//
+// 🔴 A VERDICT IS NOT A FAILURE, AND THE PREFIX IS WHAT SAYS WHICH. `civitai app
+// doctor` returns non-nil when it successfully diagnoses an incomplete listing:
+// the command did exactly its job, the report is already on stdout, and the
+// non-zero exit is the ANSWER rather than a malfunction. Prefixing that with
+// "Error: " makes a CI scraper watching stderr for `Error:` flag a run that
+// worked as designed — and, worse, tells a human the tool broke.
+//
+// So the one sentinel that means "a verdict about the subject" renders bare.
+// Everything else keeps the prefix, because everything else really is a failure.
+//
+// It is a WHITELIST of one, deliberately: a predicate like "any error carrying a
+// documented exit code" would silently un-prefix future failures. Adding a
+// second verdict here should be a decision someone makes on purpose.
+func errorLine(err error) string {
+	if errors.Is(err, cmd.ErrListingBlocked) {
+		return err.Error()
+	}
+	return "Error: " + err.Error()
 }
 
 // exitCode maps a command error to a differentiated process exit code so

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -239,6 +239,18 @@ type MyListing struct {
 	Problems []ListingProblem `json:"problems"`
 }
 
+// ListMineCap is the server's hard ceiling on a `listMine` page
+// (`MY_APP_LISTINGS_LIMIT` in
+// `<civitai>/src/server/services/blocks/app-access.service.ts:1242`, read at
+// origin/release 2026-08-25).
+//
+// 🔴 THE ROUTE OFFERS NO CURSOR, NO TOTAL AND NO `hasMore`, and it orders
+// `serialId desc` then `take: limit` — so past the cap the OLDEST listings are
+// dropped with nothing on the wire to say so. That is exactly the shape
+// `appapi.ListSubmissionsCap` exists for on the sibling read, whose own comment
+// names the failure: "silently reporting a truncated list as complete".
+const ListMineCap = 200
+
 // ListMyListings reads every listing the caller owns or holds an accepted editor
 // seat on, each with its completeness `problems[]`.
 //

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -36,6 +36,11 @@ var (
 	trpcGetMyListingForApp   = listingRoute{"/api/trpc/appListings.getMyListingForApp", listingOpRead}
 	trpcGetMyListingForEdit  = listingRoute{"/api/trpc/appListings.getMyListingForEdit", listingOpRead}
 	trpcGetAssetScanStatuses = listingRoute{"/api/trpc/appListings.getAssetScanStatuses", listingOpRead}
+	// listMine is the read behind `civitai app doctor`: every listing the caller
+	// owns OR holds an accepted editor seat on, each carrying `problems[]`.
+	// Unlike getMyListingForEdit it has NO server-side side effect — it opens no
+	// shadow revision — which is what makes `doctor` safe to run in a loop.
+	trpcListMine = listingRoute{"/api/trpc/appListings.listMine", listingOpRead}
 
 	// 🔴 INGEST, not change — and both are POSTs, which is exactly why the verb
 	// is not the answer. Each creates an Image row and touches NO listing;
@@ -160,6 +165,85 @@ type ScanStatus struct {
 	Status  string `json:"status"` // "scanned" | "blocked" | "pending"
 }
 
+// Severity values carried by ListingProblem.Severity. They are the SERVER's
+// vocabulary (`ListingProblemSeverity` in
+// civitai:src/server/services/blocks/listing-problems.ts), reproduced here as
+// constants so the CLI compares against one spelling rather than a literal at
+// each site.
+//
+// 🔴 THE CLI DOES NOT RE-DERIVE SEVERITY FROM THE CODE, and that is deliberate.
+// `computeListingProblems` owns which codes are blocking; a second table here
+// would be the two-copies-of-one-predicate shape that this repo keeps finding
+// wrong at N-1 sites. So an UNKNOWN severity string is neither promoted to
+// blocking nor silently dropped — see doctorIsBlocking in
+// internal/cmd/app_doctor.go for what the command does with one.
+const (
+	SeverityBlocking = "blocking"
+	SeverityAdvisory = "advisory"
+)
+
+// ListingProblem is one row of a listing's completeness advisory, exactly as
+// `computeListingProblems` emits it: a stable `code`, a human `label` the SERVER
+// writes, and a `severity`.
+//
+// 🔴 `Label` IS THE SERVER'S SENTENCE AND THE CLI DOES NOT REWRITE IT. For
+// `blocked-media` and `scanning-media` the label is the only place the affected
+// asset KIND appears — the code itself is kind-less ("Replace the blocked icon
+// before it can publish"). A CLI-side label table would therefore lose the one
+// fact those two codes carry.
+type ListingProblem struct {
+	Code     string `json:"code"`
+	Label    string `json:"label"`
+	Severity string `json:"severity"`
+}
+
+// MyListing is one row of appListings.listMine — a listing the caller OWNS or
+// holds an ACCEPTED editor seat on.
+//
+// 🔴 IT IS NOT A SUBMISSIONS ROW. `GET /api/v1/blocks/submissions` (what `app
+// status` reads) is scoped to what the caller SUBMITTED, so a listing acquired
+// by ownership transfer is invisible there to its new owner and a collaborator
+// who submitted nothing sees none at all. This read is scoped by ownership ∪
+// accepted seats, which is why `app doctor` uses it and not the submissions
+// route.
+//
+// Only the fields `app doctor` renders are decoded. The server also sends
+// `kind`, `capabilities`, `iconUrl`, `coverUrl` and `updatedAt`; adding one here
+// is a decision to render it, not a formality.
+type MyListing struct {
+	AppListingID string `json:"appListingId"`
+	Slug         string `json:"slug"`
+	Name         string `json:"name"`
+	// Status is the listing lifecycle: draft|pending|approved|rejected|removed.
+	Status string `json:"status"`
+	// Role is "owner" or "editor" — an accepted collaborator seat.
+	Role string `json:"role"`
+	// AppBlockID is null for an OFF-SITE listing, and for an on-site app whose
+	// first version has not been approved yet. Legitimately absent, not missing.
+	AppBlockID *string `json:"appBlockId"`
+	// Problems is never null on a current server — an all-complete listing sends
+	// `[]`. A nil slice here therefore reads the same as an empty one and no
+	// caller has to tell them apart.
+	Problems []ListingProblem `json:"problems"`
+}
+
+// ListMyListings reads every listing the caller owns or holds an accepted editor
+// seat on, each with its completeness `problems[]`.
+//
+// The proc takes NO input (see trpcQuery's nil-input note). It is a pure read:
+// unlike GetMyListingForEdit it opens no shadow revision, so it is safe to poll.
+//
+// 🔴 An empty result is a REAL answer — "you can work on no listings" — and is
+// returned as an empty slice with a nil error. It is not a 404: the server
+// answers `[]` for a caller with the author flag and nothing to show.
+func (c *Client) ListMyListings(ctx context.Context) ([]MyListing, error) {
+	var out []MyListing
+	if err := c.trpcQuery(ctx, trpcListMine, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SubmitRevisionResult mirrors submitListingRevision's result.
 type SubmitRevisionResult struct {
 	PublishRequestID string `json:"publishRequestId"`
@@ -168,14 +252,24 @@ type SubmitRevisionResult struct {
 }
 
 // trpcQuery issues a tRPC GET query and decodes result.data.json into out.
+//
+// 🔴 A nil `input` sends NO `?input=` parameter at all, and that is not the same
+// wire request as `?input={"json":null}`. A tRPC procedure declared with no
+// `.input()` schema (appListings.listMine is the one such route this client
+// speaks) parses whatever arrives; sending an explicit null is a value the
+// server never has to accept, and the CLI has no reason to make it. Omitting the
+// key is what the tRPC client itself does for an input-less query.
 func (c *Client) trpcQuery(ctx context.Context, route listingRoute, input any, out any) error {
-	inputJSON, err := json.Marshal(map[string]any{"json": input})
-	if err != nil {
-		return err
+	reqURL := c.BaseURL + route.path
+	if input != nil {
+		inputJSON, err := json.Marshal(map[string]any{"json": input})
+		if err != nil {
+			return err
+		}
+		q := url.Values{}
+		q.Set("input", string(inputJSON))
+		reqURL += "?" + q.Encode()
 	}
-	q := url.Values{}
-	q.Set("input", string(inputJSON))
-	reqURL := c.BaseURL + route.path + "?" + q.Encode()
 	build := func() (*http.Request, error) {
 		return http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	}
@@ -608,7 +702,23 @@ func listingError(status int, raw []byte, route listingRoute) (err error) {
 		// reported as a change that did not happen.
 		switch route.op {
 		case listingOpRead:
-			return fmt.Errorf("the server rejected this store-listing lookup (400): %s — nothing was changed; check the app you named (list your apps with `civitai app status`)", msg)
+			// 🔴 IT NO LONGER SAYS "check the app you named", and adding the
+			// FOURTH read (appListings.listMine, the `app doctor` read) is why.
+			// That route takes NO INPUT AT ALL — no slug, no listing id, no
+			// image id — so the old remedy presumed a value its caller had never
+			// supplied. That is civitai/cli#391's wrong-subject class exactly,
+			// regenerated on the read arm instead of the change arm: one arm
+			// answering for N routes may only claim what is true of all N.
+			//
+			// The replacement keeps the diagnostic value without the
+			// presumption, because the command it names PRINTS the valid app
+			// names — so a caller who did mis-name an app still gets the list
+			// they needed. It also corrects the pointer: `civitai app status`
+			// reads the SUBMISSIONS route, which is scoped to what the caller
+			// submitted, so it cannot list a listing acquired by ownership
+			// transfer or held on a collaborator seat. `app doctor` reads
+			// listMine, which is scoped by ownership ∪ accepted seats.
+			return fmt.Errorf("the server rejected this store-listing lookup (400): %s — nothing was changed; `civitai app doctor` lists every app you can work on", msg)
 		case listingOpIngest:
 			return fmt.Errorf("the server rejected the image-upload request (400): %s — no listing was changed; check the image and retry", msg)
 		case listingOpChange:

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -218,6 +218,18 @@ type MyListing struct {
 	Status string `json:"status"`
 	// Role is "owner" or "editor" — an accepted collaborator seat.
 	Role string `json:"role"`
+	// Kind is "onsite" or "offsite", and it decides WHO OWNS THE TEXT.
+	//
+	// 🔴 IT IS DECODED BECAUSE THE REMEDY DEPENDS ON IT, not for completeness.
+	// An ONSITE listing's name/tagline/description/category are MANIFEST-governed
+	// and have no author surface other than `block.manifest.json`: on every
+	// subsequent-version moderator approve, the `(3b-sync)` re-sync in
+	// `<civitai>/src/server/services/blocks/publish-request.service.ts:2742-2800`
+	// overwrites all four from `buildListingScalarSync`, scoped `kind: 'onsite'`.
+	// So telling an onsite author to edit those fields anywhere but the manifest
+	// is advice whose effect the platform reverts. Verified at origin/main,
+	// 2026-08-24.
+	Kind string `json:"kind"`
 	// AppBlockID is null for an OFF-SITE listing, and for an on-site app whose
 	// first version has not been approved yet. Legitimately absent, not missing.
 	AppBlockID *string `json:"appBlockId"`

--- a/internal/appapi/listing_op_test.go
+++ b/internal/appapi/listing_op_test.go
@@ -105,6 +105,16 @@ func listingRouteCases() []listingRouteCase {
 			},
 		},
 		{
+			// The `app doctor` read. It takes no input and opens no shadow
+			// revision — the ONLY listing route of which both are true — so it
+			// is a lookup in the strictest sense available here.
+			name: "listMine", route: trpcListMine, wantOp: listingOpRead, serverMsg: "refused: listing enumeration",
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.ListMyListings(ctx)
+				return err
+			},
+		},
+		{
 			// Step 1 of the full-res upload. Not a listing write.
 			name: "imageUploadMint", route: imageUploadRoute, wantOp: listingOpIngest, serverMsg: "refused: mint",
 			call: func(ctx context.Context, c *Client) error {
@@ -251,7 +261,14 @@ func exactForOp(op listingOp, serverMsg string) string {
 	switch op {
 	case listingOpRead:
 		return "the server rejected this store-listing lookup (400): " + serverMsg +
-			" — nothing was changed; check the app you named (list your apps with `civitai app status`)"
+			// 🔴 RE-READ AGAINST EVERY ROUTE THAT REACHES THIS ARM, which is
+			// what this guard's own doc comment asks for. There are now FOUR,
+			// and the fourth (listMine) takes no input, so the old "check the
+			// app you named" clause named a value one of its four callers never
+			// sends. The sentence below is true of all four: it asserts only
+			// that nothing changed, and points at a command that prints the
+			// valid app names rather than presuming the caller typed one.
+			" — nothing was changed; `civitai app doctor` lists every app you can work on"
 	case listingOpIngest:
 		return "the server rejected the image-upload request (400): " + serverMsg +
 			" — no listing was changed; check the image and retry"
@@ -292,15 +309,15 @@ func wantForOp(op listingOp) (want, notWant []string) {
 // wrong op; this is what does not.
 func TestListingBadRequestSubjectIsReachablePerRoute(t *testing.T) {
 	cases := listingRouteCases()
-	if len(cases) < 13 {
+	if len(cases) < 14 {
 		// civitai/cli#391 N3: the floor is a positive control against a table
-		// that quietly emptied, NOT a claim that thirteen is forever. Retiring a
-		// route is a legitimate reason to see twelve, so the message says which
+		// that quietly emptied, NOT a claim that fourteen is forever. Retiring a
+		// route is a legitimate reason to see thirteen, so the message says which
 		// edit is expected instead of only reporting the count.
 		t.Fatalf("positive control: this table drives %d routes, and %d were expected.\n"+
 			"If a route was RETIRED, lower this floor in the same commit that deletes its case, "+
 			"its entry in TestListingRouteOpsAreExactlyThisSpelledSet and its row in procname_leak_test.go. "+
-			"If nothing was retired, the table lost a case.", len(cases), 13)
+			"If nothing was retired, the table lost a case.", len(cases), 14)
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -676,12 +693,12 @@ func TestEveryListingRouteHasAReachabilityCase(t *testing.T) {
 
 	// Positive control on the PARSER: a walker that silently matches nothing
 	// would make this test pass with an empty ledger. civitai/cli#391 N3: a
-	// count short of 13 also happens when a route is legitimately retired, so
+	// count short of 14 also happens when a route is legitimately retired, so
 	// the message names that reading too rather than only blaming the sweep.
-	if len(declared) < 13 {
+	if len(declared) < 14 {
 		t.Fatalf("the sweep found %d listingRoute declarations in %s, and %d were expected.\n"+
 			"If a route was RETIRED, lower this floor in the commit that removes it. "+
-			"Otherwise the sweep is not reading what it thinks it is.", len(declared), mustGetwd(t), 13)
+			"Otherwise the sweep is not reading what it thinks it is.", len(declared), mustGetwd(t), 14)
 	}
 	for _, must := range []string{"/api/trpc/appListings.setIcon", ImageUploadPath} {
 		if _, ok := declared[must]; !ok {
@@ -747,6 +764,7 @@ func TestListingRouteOpsAreExactlyThisSpelledSet(t *testing.T) {
 		"/api/trpc/appListings.getMyListingForApp":   "listingOpRead",
 		"/api/trpc/appListings.getMyListingForEdit":  "listingOpRead",
 		"/api/trpc/appListings.getAssetScanStatuses": "listingOpRead",
+		"/api/trpc/appListings.listMine":             "listingOpRead",
 
 		"/api/v1/image-upload":                         "listingOpIngest",
 		"/api/trpc/appListings.ingestAssetFromDataUri": "listingOpIngest",

--- a/internal/appapi/procname_leak_test.go
+++ b/internal/appapi/procname_leak_test.go
@@ -82,6 +82,16 @@ const changeSubject = "store-listing change"
 // states the one thing every change route has in common.
 const changeRemedy = "may have partially applied"
 
+// 🔴 The READ arm's retired clause, kept as a PROHIBITION rather than deleted
+// with it — the same treatment valueBlame gets above, and for the same reason.
+// "check the app you named" was true of the three reads that carry a slug or an
+// id, and became false the moment a fourth read (appListings.listMine, the
+// `app doctor` enumeration) reached the same arm carrying no input at all. One
+// arm answering for N routes may only claim what is true of all N. Deleting the
+// phrase without banning it would retire the lesson silently, and the next
+// author to want a friendlier read message would write it straight back.
+const namedValueBlame = "check the app you named"
+
 // listingWordingRows is the third guard's table, lifted out of its test so the
 // set of routes it covers can itself be checked. See
 // TestEveryListingRouteHasAWordingRow: without that, the table was enforced only
@@ -107,6 +117,20 @@ func listingWordingRows() []listingWordingRow {
 			route:   trpcGetAssetScanStatuses,
 			want:    []string{readSubject, "nothing was changed"},
 			notWant: []string{changeSubject, ingestSubject, changeRemedy, valueBlame},
+		},
+		{
+			// 🔴 Written from what listMine DOES, not copied from the row above
+			// it — and the difference is the whole reason this row was worth
+			// writing by hand. listMine sends NO input: no slug, no listing id,
+			// no image id. So beyond the shared "nothing was changed" it may not
+			// blame a value, and it may not tell the caller to check something
+			// they named, because they named nothing. `namedValueBlame` below is
+			// in notWant for exactly that: it is the clause this route's arrival
+			// made false, and it stays banned so it cannot drift back.
+			name:    "listMine enumerates and blames no value the caller sent",
+			route:   trpcListMine,
+			want:    []string{readSubject, "nothing was changed"},
+			notWant: []string{changeSubject, ingestSubject, changeRemedy, valueBlame, namedValueBlame},
 		},
 
 		// ---- ingests: an Image row, attached to nothing ----

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -25,6 +25,7 @@ with a no-build static default (back-compat alias).`,
   civitai app validate ./my-block
   civitai app submit ./my-block
   civitai app status
+  civitai app doctor
   civitai app metrics my-block
   civitai app withdraw pubreq_01H
   civitai app dev-token my-block`,
@@ -36,6 +37,7 @@ with a no-build static default (back-compat alias).`,
 	cmd.AddCommand(newAppValidateCmd())
 	cmd.AddCommand(newAppSubmitCmd())
 	cmd.AddCommand(newAppStatusCmd())
+	cmd.AddCommand(newAppDoctorCmd())
 	cmd.AddCommand(newAppMetricsCmd())
 	cmd.AddCommand(newAppWithdrawCmd())
 	cmd.AddCommand(newAppDevTokenCmd())

--- a/internal/cmd/app_doctor.go
+++ b/internal/cmd/app_doctor.go
@@ -141,6 +141,40 @@ func doctorIsBlocking(p appapi.ListingProblem) bool {
 	return p.Severity == appapi.SeverityBlocking
 }
 
+// listingStatusRemoved is the ONE lifecycle status that takes a listing out of
+// the gate. The server's vocabulary is `draft|pending|approved|rejected|removed`
+// (`AppListing.status`), and `removed` is the only member that is not on a path
+// to publication: `rejected` is resubmitted, `draft` and `pending` are on their
+// way in, `approved` is live.
+const listingStatusRemoved = "removed"
+
+// doctorGates reports whether an app's BLOCKING problems set the exit code.
+//
+// 🔴 A DELISTED LISTING IS REPORTED BUT DOES NOT GATE. The publish floor is a
+// statement about a listing that is trying to publish; a `removed` one is not,
+// so letting it fail the build makes the no-arg form permanently red for a
+// reason nobody can act on. Measured on production 2026-08-24: of 11 blocking
+// problems across 21 real listings, TEN were on `removed` apps. The command
+// would have exited 1 forever and told nobody anything.
+//
+// 🔴 THE ROWS ARE STILL PRINTED, and that is not a detail. Hiding a population
+// by default is how it stops existing for anyone — this codebase already paid
+// for that once, with rejected submissions that had no surface at all. The
+// verdict shrinks; the report does not.
+//
+// 🔴 ONLY AN EXPLICIT `removed` IS EXCLUDED, and an unrecognised status GATES.
+// "We could not tell that it is delisted" is not "it is delisted", and the two
+// directions are not symmetric: wrongly excluding means a real blocking problem
+// silently stops failing the build, which is the failure this command exists to
+// prevent. So the unknown case takes the loud direction.
+//
+// The exclusion is not permanent, and nothing is stranded by it: an owner who
+// republishes a removed listing moves its status off `removed`, and the next run
+// gates on it again with no CLI change.
+func doctorGates(status string) bool {
+	return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)
+}
+
 // doctorAppJSON is one app in the `--json` payload. PUBLISHED CONTRACT — the
 // README documents it, so a field is renamed or dropped only deliberately.
 //
@@ -155,11 +189,21 @@ type doctorAppJSON struct {
 	AppListingID string `json:"appListingId"`
 	// AppBlockID is explicitly null for an offsite listing and for an app whose
 	// first version is not approved yet — a real state, not an omission.
-	AppBlockID *string             `json:"appBlockId"`
-	Status     string              `json:"status"`
-	Role       string              `json:"role"`
-	Blocking   []doctorProblemJSON `json:"blocking"`
-	Advisory   []doctorProblemJSON `json:"advisory"`
+	AppBlockID *string `json:"appBlockId"`
+	Status     string  `json:"status"`
+	Role       string  `json:"role"`
+	// Delisted means this listing's status is `removed`, so its blocking
+	// problems are REPORTED but do NOT set the exit code.
+	//
+	// 🔴 IT IS A FIELD ON THE ROW, NOT A SEPARATE ARRAY, AND THAT IS THE
+	// DISCLOSURE DECISION. Moving delisted apps into a sibling key would let a
+	// consumer iterate `apps` and never see them — the population-becomes-
+	// unreachable failure this codebase already paid for once, when 100% of
+	// rejected submissions had no surface at all. Every app the caller can work
+	// on is in `apps`; this bit says which of them the verdict counted.
+	Delisted bool                `json:"delisted"`
+	Blocking []doctorProblemJSON `json:"blocking"`
+	Advisory []doctorProblemJSON `json:"advisory"`
 }
 
 // doctorProblemJSON is one finding. `code`, `label` and `severity` are the
@@ -174,18 +218,36 @@ type doctorProblemJSON struct {
 
 // doctorSummaryJSON is the whole-run verdict, so a script can branch without
 // walking the apps.
+//
+// 🔴 `Blocking` AND `Gating` ARE DIFFERENT NUMBERS AND ONLY ONE OF THEM SETS
+// `ok`. `Blocking` counts every blocking problem found, so it matches the
+// `blocking` arrays a consumer can see. `Gating` counts only those on listings
+// that can still publish — delisted (`removed`) listings are excluded — and
+// THAT is the exit code. Publishing one number would have forced a choice
+// between a total that disagrees with the arrays and a verdict that disagrees
+// with the exit code; both are worse than naming the two quantities.
+//
+// Measured on production 2026-08-24 with 21 real listings: 11 blocking, of
+// which 10 sat on `removed` apps. A single number would have made the no-arg
+// form permanently red for reasons nobody can act on.
 type doctorSummaryJSON struct {
 	Apps     int `json:"apps"`
 	Blocking int `json:"blocking"`
 	Advisory int `json:"advisory"`
+	// Gating is the subset of Blocking that sets the exit code.
+	Gating int `json:"gating"`
+	// Delisted is how many of Apps are `removed`.
+	Delisted int `json:"delisted"`
 }
 
 // doctorJSON is the `--json` payload.
 //
 // 🔴 `ok` IS THE SAME FIELD `app validate --json` PUBLISHES, and it means the
 // same thing: the command's verdict, and the structured form of the exit code.
-// It is FALSE exactly when a blocking problem exists — advisories never move it,
-// because they never move the exit code either.
+// It follows `summary.gating`, NOT `summary.blocking` — advisories never move
+// it, and neither does a blocking problem on a DELISTED listing. A script that
+// wants "is anything wrong anywhere" reads `summary.blocking`; a script that
+// wants "may this ship" reads `ok`.
 type doctorJSON struct {
 	OK      bool              `json:"ok"`
 	Apps    []doctorAppJSON   `json:"apps"`
@@ -217,9 +279,15 @@ browser: this command prints the listing's editor URL. The media problems are
 fixed with ` + "`civitai app listing set-icon`" + ` / ` + "`set-cover`" + ` /
 ` + "`add-screenshot`" + `, and the exact command is printed beside each finding.
 
-EXIT CODES: 1 when ANY blocking problem was found, 0 otherwise — including when
-only advisories were found, and when you have no listings at all. So it gates a
-release script directly:
+DELISTED LISTINGS: an app whose status is 'removed' is still reported, in its
+own section, but its blocking problems do NOT set the exit code. The publish
+floor is a statement about a listing that is trying to publish, and a delisted
+one is not — without this, one old removed app would fail every run forever.
+
+EXIT CODES: 1 when a blocking problem was found on a listing that can still
+publish, 0 otherwise — including when only advisories were found, when the only
+blocking problems are on delisted listings, and when you have no listings at
+all. So it gates a release script directly:
 
     civitai app doctor my-app || exit 1
 
@@ -315,12 +383,16 @@ func runAppDoctor(out io.Writer, rows []appapi.MyListing, slug, baseURL string, 
 	} else {
 		printDoctorReport(out, payload)
 	}
-	if payload.Summary.Blocking > 0 {
+	// 🔴 `Gating`, NOT `Blocking`. See doctorGates: a delisted listing's blocking
+	// problems are printed and do not set the exit code.
+	if payload.Summary.Gating > 0 {
 		// 🔴 The findings are already on stdout; this error exists ONLY to carry
 		// the exit code, so its message must not read as a second, competing
-		// report of the same facts.
-		return fmt.Errorf("%w: %d blocking problem(s) across %d app(s) — see the report above",
-			ErrListingBlocked, payload.Summary.Blocking, payload.Summary.Apps)
+		// report of the same facts. It quotes the GATING count for the same
+		// reason — a message naming a bigger number than the verdict acted on
+		// would send a reader hunting for problems the gate deliberately ignored.
+		return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",
+			ErrListingBlocked, payload.Summary.Gating)
 	}
 	return nil
 }
@@ -334,8 +406,25 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 		Apps:    make([]doctorAppJSON, 0, len(rows)),
 		Summary: doctorSummaryJSON{Apps: len(rows)},
 	}
+	// 🔴 GATING APPS FIRST, DELISTED LAST — in the PAYLOAD, not only in the
+	// human rendering. The renderer and `--json` read the same slice, which is
+	// what keeps them from disagreeing about a finding or a count; ordering here
+	// rather than at the printer keeps that property. Stable within each group,
+	// so the server's own order survives.
+	ordered := make([]appapi.MyListing, 0, len(rows))
 	for _, r := range rows {
+		if doctorGates(r.Status) {
+			ordered = append(ordered, r)
+		}
+	}
+	for _, r := range rows {
+		if !doctorGates(r.Status) {
+			ordered = append(ordered, r)
+		}
+	}
+	for _, r := range ordered {
 		editURL := editBase + fmt.Sprintf(listingEditPath, r.AppListingID)
+		gates := doctorGates(r.Status)
 		app := doctorAppJSON{
 			Slug:         r.Slug,
 			Name:         r.Name,
@@ -343,6 +432,7 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 			AppBlockID:   r.AppBlockID,
 			Status:       r.Status,
 			Role:         r.Role,
+			Delisted:     !gates,
 			Blocking:     []doctorProblemJSON{},
 			Advisory:     []doctorProblemJSON{},
 		}
@@ -361,9 +451,15 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 		}
 		out.Summary.Blocking += len(app.Blocking)
 		out.Summary.Advisory += len(app.Advisory)
+		if gates {
+			// The ONLY place the exit code is accumulated.
+			out.Summary.Gating += len(app.Blocking)
+		} else {
+			out.Summary.Delisted++
+		}
 		out.Apps = append(out.Apps, app)
 	}
-	out.OK = out.Summary.Blocking == 0
+	out.OK = out.Summary.Gating == 0
 	return out
 }
 
@@ -378,9 +474,19 @@ func printDoctorReport(w io.Writer, payload doctorJSON) {
 			st.Code("civitai app submit"))
 		return
 	}
+	delistedHeaderShown := false
 	for i, app := range payload.Apps {
 		if i > 0 {
 			fmt.Fprintln(w)
+		}
+		// 🔴 THE DELISTED SECTION IS ANNOUNCED, ONCE, WHERE IT STARTS. The
+		// payload is already ordered gating-first (see doctorPayload), so this
+		// fires on the first delisted row. Without the heading a reader sees an
+		// app carrying BLOCKING findings while the command exits 0 and has no
+		// way to tell that from a broken gate.
+		if app.Delisted && !delistedHeaderShown {
+			delistedHeaderShown = true
+			fmt.Fprintln(w, st.Info("Delisted (status 'removed') — reported for completeness; these do NOT set the exit code."))
 		}
 		fmt.Fprintf(w, "%s  (%s, %s)\n", st.Bold(app.Slug), app.Status, app.Role)
 		if len(app.Blocking) == 0 && len(app.Advisory) == 0 {
@@ -397,6 +503,15 @@ func printDoctorReport(w io.Writer, payload doctorJSON) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%d app(s) checked — %d blocking, %d advisory.\n",
 		payload.Summary.Apps, payload.Summary.Blocking, payload.Summary.Advisory)
+	// 🔴 THE DISCREPANCY IS EXPLAINED WHEREVER IT CAN EXIST, which is whenever a
+	// delisted app was reported at all — not only when one carries a blocking
+	// problem. A reader who sees the section above needs the rule stated whether
+	// or not it changed the arithmetic this time, and a line that appears only
+	// sometimes is a line nobody learns to look for.
+	if payload.Summary.Delisted > 0 {
+		fmt.Fprintf(w, "%d of them are delisted; %d blocking problem(s) on publishable listings set the exit code.\n",
+			payload.Summary.Delisted, payload.Summary.Gating)
+	}
 }
 
 // printDoctorGroup renders one severity group, or nothing when it is empty.

--- a/internal/cmd/app_doctor.go
+++ b/internal/cmd/app_doctor.go
@@ -39,7 +39,7 @@ import (
 // same reason. It is deliberately left UNTAGGED for the exit mapper (tagging it
 // civitai.ErrBadRequest — the only route to exit 2 — would move it), which
 // TestDoctorBlockingExitsGeneric in cmd/civitai is what makes deliberate.
-var ErrListingBlocked = errors.New("the listing has blocking problems")
+var ErrListingBlocked = errors.New("listing not ready to publish")
 
 // listingEditPath is the web listing editor, the fix route for the three TEXT
 // problems. `%s` is the appListingId `listMine` returned.
@@ -104,14 +104,38 @@ func doctorRemedy(p appapi.ListingProblem, slug, editURL, kind string) string {
 	case problemNoScreenshots:
 		return "civitai app listing add-screenshot <file> --slug " + slug
 	case problemBlockedMedia:
-		// 🔴 THE LABEL ON THE LINE ABOVE NAMES THE SLOT, AND THIS ARM DOES NOT
-		// TRY TO. `blocked-media` is emitted once per affected asset KIND and
-		// the kind lives ONLY in the server's label ("Replace the blocked icon
-		// …"); the code is kind-less. Guessing one of the three here would name
-		// the wrong command two times out of three, so all three are offered and
-		// the label is what disambiguates.
-		return "replace the blocked asset named above, with --slug " + slug + " — " +
-			"civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot"
+		// 🔴 THE THREE SLOTS DO NOT HAVE THE SAME REMEDY, AND OFFERING ALL THREE
+		// WAS WRONG FOR ONE OF THEM. `set-icon` and `set-cover` OVERWRITE the
+		// slot, so the blocked Image is dereferenced and the listing can publish.
+		// `add-screenshot` APPENDS — the blocked row stays attached, and
+		// `assertAssetsScanClean`
+		// (`<civitai>/src/server/services/blocks/app-listing-assets.service.ts:857-894`)
+		// refuses go-live while ANY attached screenshot is Blocked. So an author
+		// who followed the old advice for a blocked screenshot added a second
+		// image and stayed blocked, with the command that actually fixes it —
+		// `rm-screenshot` — never named.
+		//
+		// The kind lives ONLY in the server's label ("Replace the blocked
+		// <kind> before it can publish", listing-problems.ts:144); the code is
+		// kind-less. So the label is parsed for it, and an UNRECOGNISED label
+		// falls back to naming every route including the removal — losing the
+		// precision, never the sufficiency.
+		switch blockedMediaKind(p.Label) {
+		case "icon":
+			return "replace it — the new icon overwrites the blocked one: civitai app listing set-icon <file> --slug " + slug
+		case "cover":
+			return "replace it — the new cover overwrites the blocked one: civitai app listing set-cover <file> --slug " + slug
+		case "screenshot":
+			// 🔴 REMOVE, DO NOT ADD. Adding leaves the blocked row attached and
+			// the listing still refused at go-live. The id is an `alsc_…` this
+			// command never sees — `listMine` does not carry screenshot rows —
+			// so the read that prints it has to be named too.
+			return "REMOVE the blocked screenshot — adding another does not clear it: " +
+				"civitai app listing status --slug " + slug + " to find its alsc_ id, then " +
+				"civitai app listing rm-screenshot <id> --slug " + slug
+		}
+		return "replace or remove the blocked asset named above, with --slug " + slug + " — " +
+			"civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot"
 	case problemScanningMedia:
 		// 🔴 NO COMMAND AT ALL, deliberately. A still-scanning asset resolves
 		// itself; printing a fix would tell an author to act on a state that is
@@ -144,16 +168,46 @@ func doctorRemedy(p appapi.ListingProblem, slug, editURL, kind string) string {
 	return "no CLI route for this problem yet — open the listing in the browser: " + editURL
 }
 
-// doctorSeverity classifies one problem for RENDERING and for the exit verdict.
+// blockedMediaKind extracts the asset slot from a `blocked-media` label.
 //
-// 🔴 UNKNOWN IS NOT BLOCKING. A severity string this CLI does not recognise is
-// grouped with the advisories and reported under its own heading rather than
-// failing the build: a release gate that starts refusing every release the day
-// the server adds a ninth vocabulary word is a gate people disable. The finding
-// is never hidden — it is printed with its code, its label and its severity
-// verbatim.
+// 🔴 PARSING A LABEL IS NOT IDEAL AND IS THE ONLY OPTION. `blocked-media` is
+// emitted once per affected KIND and the code carries none of it; the kind
+// appears only in the sentence the server writes. The match is a
+// case-insensitive word search over a fixed three-word vocabulary rather than a
+// format assumption, so a re-worded label degrades to the generic arm instead of
+// mis-naming a slot — and the generic arm names the REMOVAL too, which is the
+// clause whose absence was the defect.
+func blockedMediaKind(label string) string {
+	l := strings.ToLower(label)
+	for _, kind := range []string{"screenshot", "cover", "icon"} {
+		if strings.Contains(l, kind) {
+			return kind
+		}
+	}
+	return ""
+}
+
+// doctorIsBlocking classifies one problem for RENDERING and for the exit verdict.
+//
+// 🔴 IT NORMALISES, LIKE doctorGates AND listingIsOnsite, AND THE ASYMMETRY IT
+// REMOVES POINTED THE UNSAFE WAY. This was a byte-exact `==` while both sibling
+// predicates folded case and trimmed — and this is the one that owns the EXIT
+// CODE. A server sending `"Blocking"` would have produced `gating: 0`, `ok:
+// true`, exit 0, with the finding filed under `advisory[]` while carrying
+// `"severity": "Blocking"`: a contradiction the CLI itself manufactured, in a
+// payload a script is meant to trust. Not reachable today — the server's union
+// is lowercase literals — so this is latent, and fixed for the same reason the
+// others were: unknown STATUS gated loudly while unknown SEVERITY failed
+// quietly, which are opposite defaults for one class of drift.
+//
+// 🔴 AN UNRECOGNISED WORD IS STILL NOT BLOCKING, and that is deliberate rather
+// than an omission. Normalisation makes a CASING change safe; it cannot make a
+// new vocabulary word meaningful. A release gate that started refusing every
+// release the day the server adds a ninth severity is a gate people disable, so
+// the finding is grouped with the advisories — never hidden: it prints with its
+// code, its label and its severity verbatim.
 func doctorIsBlocking(p appapi.ListingProblem) bool {
-	return p.Severity == appapi.SeverityBlocking
+	return strings.EqualFold(strings.TrimSpace(p.Severity), appapi.SeverityBlocking)
 }
 
 // listingStatusRemoved is the ONE lifecycle status that takes a listing out of
@@ -223,6 +277,10 @@ type doctorAppJSON struct {
 	AppBlockID *string `json:"appBlockId"`
 	Status     string  `json:"status"`
 	Role       string  `json:"role"`
+	// Kind is "onsite" or "offsite" — carried because it DECIDES `fix` for the
+	// three text codes. Without it a consumer sees two different `fix` strings
+	// for one `code` and cannot reproduce the branch that chose between them.
+	Kind string `json:"kind"`
 	// Delisted means this listing's status is `removed`, so its blocking
 	// problems are REPORTED but do NOT set the exit code.
 	//
@@ -269,6 +327,16 @@ type doctorSummaryJSON struct {
 	Gating int `json:"gating"`
 	// Delisted is how many of Apps are `removed`.
 	Delisted int `json:"delisted"`
+	// Truncated is true when the server's page cap may have hidden listings.
+	//
+	// 🔴 `ok: true` MEANS "NOTHING BLOCKING IN WHAT I COULD SEE", AND WITHOUT
+	// THIS FIELD A CONSUMER CANNOT TELL THAT APART FROM "NOTHING BLOCKING".
+	// `listMine` clamps to appapi.ListMineCap, orders `serialId desc` and offers
+	// no cursor and no total, so past the cap the OLDEST listings are dropped
+	// silently. An account over the cap with a blocking problem on a hidden
+	// listing would otherwise get `ok: true`, exit 0, and a release that cannot
+	// publish.
+	Truncated bool `json:"truncated"`
 }
 
 // doctorJSON is the `--json` payload.
@@ -353,7 +421,7 @@ revision draft on a live listing, so it is safe to run in a loop.`,
 			if err != nil {
 				return err
 			}
-			return runAppDoctor(cmd.OutOrStdout(), rows, slug, cfg.BaseURL(), jsonOut)
+			return runAppDoctor(cmd.OutOrStdout(), cmd.ErrOrStderr(), rows, slug, cfg.BaseURL(), jsonOut)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
@@ -385,7 +453,7 @@ func doctorNoSuchApp(slug string, rows []appapi.MyListing) error {
 // selects, renders and returns the verdict. Separated from the cobra wiring so
 // the verdict can be exercised without a server, and so the SAME selection and
 // the SAME counting feed both renderings.
-func runAppDoctor(out io.Writer, rows []appapi.MyListing, slug, baseURL string, jsonOut bool) error {
+func runAppDoctor(out, errOut io.Writer, rows []appapi.MyListing, slug, baseURL string, jsonOut bool) error {
 	selected := rows
 	if slug != "" {
 		selected = nil
@@ -414,6 +482,11 @@ func runAppDoctor(out io.Writer, rows []appapi.MyListing, slug, baseURL string, 
 	} else {
 		printDoctorReport(out, payload)
 	}
+	// 🔴 AFTER BOTH RENDERINGS AND BEFORE THE VERDICT — on STDERR, so `--json`
+	// stdout stays a pure payload and the exit code is untouched. It has to run
+	// on the JSON path too: a script reading `ok: true` from a truncated page is
+	// exactly who this caveat is for.
+	warnDoctorTruncated(errOut, payload)
 	// 🔴 `Gating`, NOT `Blocking`. See doctorGates: a delisted listing's blocking
 	// problems are printed and do not set the exit code.
 	if payload.Summary.Gating > 0 {
@@ -422,7 +495,15 @@ func runAppDoctor(out io.Writer, rows []appapi.MyListing, slug, baseURL string, 
 		// report of the same facts. It quotes the GATING count for the same
 		// reason — a message naming a bigger number than the verdict acted on
 		// would send a reader hunting for problems the gate deliberately ignored.
-		return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",
+		// 🔴 IT DOES NOT LEAD WITH A WORD THAT READS AS A TOOL FAILURE. cobra
+		// prefixes a returned error with "Error: " on stderr, so a completely
+		// successful diagnosis of an incomplete listing printed
+		// `Error: the listing has blocking problems…` — and a CI scraper
+		// watching stderr for `Error:` flags a run that worked exactly as
+		// designed. The verdict is a FINDING about the listing, not a failure of
+		// the command, and the sentence now says so.
+		return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — the report above lists them; "+
+			"this exit code is the verdict, not a failure of the command",
 			ErrListingBlocked, payload.Summary.Gating)
 	}
 	return nil
@@ -463,6 +544,7 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 			AppBlockID:   r.AppBlockID,
 			Status:       r.Status,
 			Role:         r.Role,
+			Kind:         r.Kind,
 			Delisted:     !gates,
 			Blocking:     []doctorProblemJSON{},
 			Advisory:     []doctorProblemJSON{},
@@ -490,6 +572,12 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 		}
 		out.Apps = append(out.Apps, app)
 	}
+	// The comparison is `>=`, not `==`, and it is computed from what the SERVER
+	// returned: at or beyond the cap this CLI cannot claim the listing is
+	// complete. A caller holding exactly the cap gets a caveat while nothing is
+	// missing — accepted, because the opposite error is the one this exists to
+	// prevent, and the wording says "may".
+	out.Summary.Truncated = len(rows) >= appapi.ListMineCap
 	out.OK = out.Summary.Gating == 0
 	return out
 }
@@ -543,6 +631,20 @@ func printDoctorReport(w io.Writer, payload doctorJSON) {
 		fmt.Fprintf(w, "%d of them are delisted; %d blocking problem(s) on publishable listings set the exit code.\n",
 			payload.Summary.Delisted, payload.Summary.Gating)
 	}
+}
+
+// warnDoctorTruncated writes the page-cap caveat to STDERR, so `--json` stdout
+// stays a pure payload and the exit code is unchanged — the same shape
+// `app status` uses for the sibling read's cap.
+func warnDoctorTruncated(errOut io.Writer, payload doctorJSON) {
+	if !payload.Summary.Truncated {
+		return
+	}
+	fmt.Fprintf(errOut,
+		"note: the server returned %d listings — it caps this read and offers no way to page, so older "+
+			"listings may exist and were NOT checked. A blocking problem on one of them would not appear "+
+			"here, and would not change the exit code. Check a specific app with `civitai app doctor <slug>`.\n",
+		payload.Summary.Apps)
 }
 
 // printDoctorGroup renders one severity group, or nothing when it is empty.

--- a/internal/cmd/app_doctor.go
+++ b/internal/cmd/app_doctor.go
@@ -1,0 +1,412 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/civitai/cli/internal/appapi"
+	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/ui"
+	"github.com/civitai/cli/pkg/civitai"
+	"github.com/spf13/cobra"
+)
+
+// `civitai app doctor` — the listing-completeness diagnosis (civitai/civitai
+// #4341's client half).
+//
+// 🔴 IT IS A DIAGNOSIS, NOT A REPAIR. Every finding it prints is the SERVER's
+// (`computeListingProblems`); the CLI adds only the route that fixes it. That
+// split is what lets the command be a pure read — `appListings.listMine` opens
+// no shadow revision, unlike `app listing status`, so this one IS safe to poll.
+//
+// 🔴 THE EXIT CODE IS THE PRODUCT. A release script's question is "may this ship
+// yet", and the answer has to be readable without parsing stderr: any BLOCKING
+// problem on any app the command reported exits 1, everything else exits 0. See
+// ErrListingBlocked for why 1 and not 2.
+
+// ErrListingBlocked is the sentinel `app doctor` returns when at least one
+// BLOCKING problem was found. It carries the non-zero exit, and nothing else —
+// the findings have already been printed by the time it is returned.
+//
+// 🔴 EXIT 1, AND THAT IS A DECISION RATHER THAN A FALLTHROUGH. Exit 2 is
+// documented as a mistake about the INVOCATION, and every flag and argument is
+// well-formed when this fires; what is wrong is the LISTING. That is the same
+// shape as an invalid manifest, which exitCodeDocs already publishes under code
+// 1 as a validation verdict, and it is the code `app validate` uses for the
+// same reason. It is deliberately left UNTAGGED for the exit mapper (tagging it
+// civitai.ErrBadRequest — the only route to exit 2 — would move it), which
+// TestDoctorBlockingExitsGeneric in cmd/civitai is what makes deliberate.
+var ErrListingBlocked = errors.New("the listing has blocking problems")
+
+// listingEditPath is the web listing editor, the fix route for the three TEXT
+// problems. `%s` is the appListingId `listMine` returned.
+//
+// 🔴 IT IS AN appListingId PATH, NOT A SLUG PATH, and the two are different id
+// spaces — `civitai/civitai:src/pages/apps/listing/[appListingId]/edit.tsx`.
+// Building it from the slug would produce a well-formed URL that 404s.
+const listingEditPath = "/apps/listing/%s/edit"
+
+// The eight problem codes `computeListingProblems` emits, spelled out.
+//
+// 🔴 THIS IS A REMEDY TABLE, NOT A SEVERITY TABLE. The CLI never decides whether
+// a code blocks — the server sends `severity` and the command reads it (see
+// appapi.SeverityBlocking). What lives here is the only thing the server does
+// not know: which CLI command, if any, repairs the finding.
+const (
+	problemMissingIcon      = "missing-icon"
+	problemMissingCover     = "missing-cover"
+	problemNoScreenshots    = "no-screenshots"
+	problemEmptyDescription = "empty-description"
+	problemEmptyTagline     = "empty-tagline"
+	problemEmptyCategory    = "empty-category"
+	problemBlockedMedia     = "blocked-media"
+	problemScanningMedia    = "scanning-media"
+)
+
+// doctorRemedy renders the FIX line for one problem code.
+//
+// 🔴 EVERY ROUTE NAMED HERE IS ONE THIS CREDENTIAL CAN ACTUALLY TAKE, and that
+// is the rule the table is built to, not a nicety. Advice pointing at a proc the
+// CLI's OAuth token 403s on is worse than no advice: the author follows it, is
+// refused, and concludes the CLI is broken.
+//
+//   - The three media codes route to `app listing set-icon|set-cover|
+//     add-screenshot`, whose procs have carried `AppBlocksSubmit` since
+//     civitai/civitai#3472 and are owner-or-accepted-seat bound — so they work
+//     for `role: editor` too, and for an OFFSITE listing (civitai/cli#422's
+//     by-slug fallback, measured live 2026-08-17).
+//   - `blocked-media` routes to the same three, because replacing the asset IS
+//     the fix. Which of the three is named by the SERVER's label, not by the
+//     code — see appapi.ListingProblem.Label — so this arm cannot narrow it and
+//     does not pretend to.
+//   - `scanning-media` has NO fix route at all and says so. Printing a command
+//     for it would tell an author to act on a state that resolves itself.
+//   - The three TEXT codes route to the WEB editor, and NOT to a CLI flag. The
+//     `appListings.updateListing` / `updateRevisionDraft` procs that write them
+//     became CLI-reachable in civitai/civitai#4341, so a CLI route is now
+//     possible — it is deliberately not in THIS command. `doctor` exits non-zero
+//     as a release gate; a diagnostic that also mutates the thing it is grading
+//     is a different command with a different contract. And the write itself is
+//     state-dependent in a way that needs its own tests: on an APPROVED listing
+//     a material change stages onto a shadow revision (`updateListing` refuses a
+//     shadow id outright; `updateRevisionDraft` refuses a top-level listing), so
+//     "set the tagline" is two procs and a branch, not a flag. Tracked as the
+//     follow-on to this PR.
+func doctorRemedy(p appapi.ListingProblem, slug, editURL string) string {
+	switch p.Code {
+	case problemMissingIcon:
+		return "civitai app listing set-icon <file> --slug " + slug
+	case problemMissingCover:
+		return "civitai app listing set-cover <file> --slug " + slug
+	case problemNoScreenshots:
+		return "civitai app listing add-screenshot <file> --slug " + slug
+	case problemBlockedMedia:
+		// 🔴 THE LABEL ON THE LINE ABOVE NAMES THE SLOT, AND THIS ARM DOES NOT
+		// TRY TO. `blocked-media` is emitted once per affected asset KIND and
+		// the kind lives ONLY in the server's label ("Replace the blocked icon
+		// …"); the code is kind-less. Guessing one of the three here would name
+		// the wrong command two times out of three, so all three are offered and
+		// the label is what disambiguates.
+		return "replace the blocked asset named above, with --slug " + slug + " — " +
+			"civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot"
+	case problemScanningMedia:
+		// 🔴 NO COMMAND AT ALL, deliberately. A still-scanning asset resolves
+		// itself; printing a fix would tell an author to act on a state that is
+		// already in motion, and the likeliest action (re-attaching) restarts
+		// the very scan they are waiting for.
+		return "nothing to do — the scan finishes on its own; re-run `civitai app doctor` in a minute"
+	case problemEmptyDescription, problemEmptyTagline, problemEmptyCategory:
+		return "edit the listing in the browser: " + editURL
+	}
+	// 🔴 An UNKNOWN code is a NEW server code, not a bug in the caller, and it
+	// gets the honest answer rather than a guessed command. The label and the
+	// severity still print, so a code this CLI has never heard of is still
+	// actionable — and still counted toward the exit verdict, which is what
+	// matters most.
+	return "no CLI route for this problem yet — open the listing in the browser: " + editURL
+}
+
+// doctorSeverity classifies one problem for RENDERING and for the exit verdict.
+//
+// 🔴 UNKNOWN IS NOT BLOCKING. A severity string this CLI does not recognise is
+// grouped with the advisories and reported under its own heading rather than
+// failing the build: a release gate that starts refusing every release the day
+// the server adds a ninth vocabulary word is a gate people disable. The finding
+// is never hidden — it is printed with its code, its label and its severity
+// verbatim.
+func doctorIsBlocking(p appapi.ListingProblem) bool {
+	return p.Severity == appapi.SeverityBlocking
+}
+
+// doctorAppJSON is one app in the `--json` payload. PUBLISHED CONTRACT — the
+// README documents it, so a field is renamed or dropped only deliberately.
+//
+// 🔴 `blocking` AND `advisory` ARE SEPARATE ARRAYS RATHER THAN ONE LIST PLUS A
+// severity FIELD, because the question a consumer has is "may this ship" and
+// that must be answerable without re-implementing the severity split the human
+// rendering already did. Each array is never null — an app with none gets `[]`,
+// so `.blocking | length` answers for every app.
+type doctorAppJSON struct {
+	Slug         string `json:"slug"`
+	Name         string `json:"name"`
+	AppListingID string `json:"appListingId"`
+	// AppBlockID is explicitly null for an offsite listing and for an app whose
+	// first version is not approved yet — a real state, not an omission.
+	AppBlockID *string             `json:"appBlockId"`
+	Status     string              `json:"status"`
+	Role       string              `json:"role"`
+	Blocking   []doctorProblemJSON `json:"blocking"`
+	Advisory   []doctorProblemJSON `json:"advisory"`
+}
+
+// doctorProblemJSON is one finding. `code`, `label` and `severity` are the
+// SERVER's own values, passed through unmodified; `fix` is the CLI's contribution
+// and is the same sentence the human rendering prints.
+type doctorProblemJSON struct {
+	Code     string `json:"code"`
+	Label    string `json:"label"`
+	Severity string `json:"severity"`
+	Fix      string `json:"fix"`
+}
+
+// doctorSummaryJSON is the whole-run verdict, so a script can branch without
+// walking the apps.
+type doctorSummaryJSON struct {
+	Apps     int `json:"apps"`
+	Blocking int `json:"blocking"`
+	Advisory int `json:"advisory"`
+}
+
+// doctorJSON is the `--json` payload.
+//
+// 🔴 `ok` IS THE SAME FIELD `app validate --json` PUBLISHES, and it means the
+// same thing: the command's verdict, and the structured form of the exit code.
+// It is FALSE exactly when a blocking problem exists — advisories never move it,
+// because they never move the exit code either.
+type doctorJSON struct {
+	OK      bool              `json:"ok"`
+	Apps    []doctorAppJSON   `json:"apps"`
+	Summary doctorSummaryJSON `json:"summary"`
+}
+
+func newAppDoctorCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "doctor [slug]",
+		Short: "Diagnose what is incomplete or blocked on your App store listings",
+		Long: `Report what is missing or blocked on your App store listings, and how to fix it.
+
+With no argument it checks EVERY listing you own or hold an accepted
+collaborator seat on. Pass an app slug to check just that one.
+
+Findings come from the platform, grouped per app, blocking first:
+
+  BLOCKING   the listing cannot publish until it is fixed — a missing icon or
+             cover, or an asset the content scan BLOCKED.
+  ADVISORY   recommended, but nothing is held up — no screenshots, or an empty
+             description, tagline or category.
+
+An app with nothing wrong is reported as complete, explicitly. A blank space is
+not an answer.
+
+The three TEXT problems (description / tagline / category) are fixed in the
+browser: this command prints the listing's editor URL. The media problems are
+fixed with ` + "`civitai app listing set-icon`" + ` / ` + "`set-cover`" + ` /
+` + "`add-screenshot`" + `, and the exact command is printed beside each finding.
+
+EXIT CODES: 1 when ANY blocking problem was found, 0 otherwise — including when
+only advisories were found, and when you have no listings at all. So it gates a
+release script directly:
+
+    civitai app doctor my-app || exit 1
+
+Every other exit code keeps its usual meaning (3 not authorized, 4 no such app,
+5 transport). --json emits the same verdict as one object and uses the same exit
+codes, so a script must branch on the code before trusting the payload.
+
+Unlike ` + "`civitai app listing status`" + `, this is a PURE READ — it opens no
+revision draft on a live listing, so it is safe to run in a loop.`,
+		Example: `  civitai app doctor                 # every app you can work on
+  civitai app doctor my-app          # just one
+  civitai app doctor --json | jq -e .ok
+  civitai app doctor my-app || echo "not ready to publish"`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if cfg.Token() == "" {
+				return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)"))
+			}
+			client, err := newListingClient()
+			if err != nil {
+				return err
+			}
+			slug := ""
+			if len(args) == 1 {
+				slug = strings.TrimSpace(args[0])
+			}
+			rows, err := client.ListMyListings(cmdCtx(cmd))
+			if err != nil {
+				return err
+			}
+			return runAppDoctor(cmd.OutOrStdout(), rows, slug, cfg.BaseURL(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the findings as JSON (scriptable); the exit code is unchanged — 1 when anything is blocking")
+	return cmd
+}
+
+// doctorNoSuchApp is the refusal for a slug that names none of the caller's
+// listings. It is tagged ErrNotFound (exit 4) rather than being reported as a
+// clean run, because "you own no app called that" and "that app is fine" are
+// opposite answers and a release gate must not confuse them.
+func doctorNoSuchApp(slug string, rows []appapi.MyListing) error {
+	known := make([]string, 0, len(rows))
+	for _, r := range rows {
+		known = append(known, r.Slug)
+	}
+	sort.Strings(known)
+	msg := fmt.Sprintf("no listing of yours is called %q", slug)
+	switch {
+	case len(known) == 0:
+		msg += " — you own no App listings and hold no collaborator seats yet; `civitai app submit` creates one"
+	default:
+		msg += " — you can work on: " + strings.Join(known, ", ")
+	}
+	return civitai.Tag(civitai.ErrNotFound, errors.New(msg))
+}
+
+// runAppDoctor is the command core: given the rows the server returned, it
+// selects, renders and returns the verdict. Separated from the cobra wiring so
+// the verdict can be exercised without a server, and so the SAME selection and
+// the SAME counting feed both renderings.
+func runAppDoctor(out io.Writer, rows []appapi.MyListing, slug, baseURL string, jsonOut bool) error {
+	selected := rows
+	if slug != "" {
+		selected = nil
+		for _, r := range rows {
+			// 🔴 appapi.SameSlug, not `==` — the shared predicate (see
+			// internal/appapi/slug.go). The user types this value, so a padded
+			// or mis-cased spelling reaches here routinely, and an exact compare
+			// would answer "no such app" for an app the caller owns.
+			if appapi.SameSlug(slug, r.Slug) {
+				selected = append(selected, r)
+			}
+		}
+		if len(selected) == 0 {
+			return doctorNoSuchApp(slug, rows)
+		}
+	}
+
+	payload := doctorPayload(selected, baseURL)
+	if jsonOut {
+		// 🔴 The JSON path does NOT go through the human renderer, and must not:
+		// internal/ui/CONVENTION.md rule 1 is that machine-readable output
+		// carries no styling, and that renderer emits ui.Success/ui.Warn/ui.Code.
+		if err := writeJSON(out, payload); err != nil {
+			return err
+		}
+	} else {
+		printDoctorReport(out, payload)
+	}
+	if payload.Summary.Blocking > 0 {
+		// 🔴 The findings are already on stdout; this error exists ONLY to carry
+		// the exit code, so its message must not read as a second, competing
+		// report of the same facts.
+		return fmt.Errorf("%w: %d blocking problem(s) across %d app(s) — see the report above",
+			ErrListingBlocked, payload.Summary.Blocking, payload.Summary.Apps)
+	}
+	return nil
+}
+
+// doctorPayload builds the whole verdict — the ONE place the severity split and
+// the counting happen, so the human rendering and `--json` can never disagree
+// about whether a run was clean.
+func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
+	editBase := strings.TrimRight(baseURL, "/")
+	out := doctorJSON{
+		Apps:    make([]doctorAppJSON, 0, len(rows)),
+		Summary: doctorSummaryJSON{Apps: len(rows)},
+	}
+	for _, r := range rows {
+		editURL := editBase + fmt.Sprintf(listingEditPath, r.AppListingID)
+		app := doctorAppJSON{
+			Slug:         r.Slug,
+			Name:         r.Name,
+			AppListingID: r.AppListingID,
+			AppBlockID:   r.AppBlockID,
+			Status:       r.Status,
+			Role:         r.Role,
+			Blocking:     []doctorProblemJSON{},
+			Advisory:     []doctorProblemJSON{},
+		}
+		for _, p := range r.Problems {
+			row := doctorProblemJSON{
+				Code:     p.Code,
+				Label:    p.Label,
+				Severity: p.Severity,
+				Fix:      doctorRemedy(p, r.Slug, editURL),
+			}
+			if doctorIsBlocking(p) {
+				app.Blocking = append(app.Blocking, row)
+				continue
+			}
+			app.Advisory = append(app.Advisory, row)
+		}
+		out.Summary.Blocking += len(app.Blocking)
+		out.Summary.Advisory += len(app.Advisory)
+		out.Apps = append(out.Apps, app)
+	}
+	out.OK = out.Summary.Blocking == 0
+	return out
+}
+
+// printDoctorReport renders the human view from the SAME payload `--json`
+// emits, so the two cannot disagree about a finding or a count.
+func printDoctorReport(w io.Writer, payload doctorJSON) {
+	st := ui.For(w)
+	if len(payload.Apps) == 0 {
+		// 🔴 An empty run gets a SENTENCE, not a blank. Silence here is
+		// indistinguishable from a read that failed and was swallowed.
+		fmt.Fprintf(w, "No App listings to check — you own none and hold no collaborator seats. %s creates one.\n",
+			st.Code("civitai app submit"))
+		return
+	}
+	for i, app := range payload.Apps {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s  (%s, %s)\n", st.Bold(app.Slug), app.Status, app.Role)
+		if len(app.Blocking) == 0 && len(app.Advisory) == 0 {
+			// 🔴 EXPLICITLY CLEAN. An app with nothing wrong must not render as
+			// a gap: a missing section reads the same as a broken read, and the
+			// whole point of the command is a verdict a script and a human can
+			// both trust.
+			fmt.Fprintln(w, "  "+st.Success("No problems — this listing is complete."))
+			continue
+		}
+		printDoctorGroup(w, st, "BLOCKING (cannot publish until fixed)", app.Blocking, st.Warn)
+		printDoctorGroup(w, st, "ADVISORY (recommended, nothing is held up)", app.Advisory, st.Info)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%d app(s) checked — %d blocking, %d advisory.\n",
+		payload.Summary.Apps, payload.Summary.Blocking, payload.Summary.Advisory)
+}
+
+// printDoctorGroup renders one severity group, or nothing when it is empty.
+func printDoctorGroup(w io.Writer, st ui.Styler, heading string, problems []doctorProblemJSON, style func(string) string) {
+	if len(problems) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "  %s\n", style(heading))
+	for _, p := range problems {
+		fmt.Fprintf(w, "    %s  %s\n", p.Code, p.Label)
+		fmt.Fprintf(w, "      Fix: %s\n", st.Code(p.Fix))
+	}
+}

--- a/internal/cmd/app_doctor.go
+++ b/internal/cmd/app_doctor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -78,10 +79,14 @@ const (
 //     civitai/civitai#3472 and are owner-or-accepted-seat bound — so they work
 //     for `role: editor` too, and for an OFFSITE listing (civitai/cli#422's
 //     by-slug fallback, measured live 2026-08-17).
-//   - `blocked-media` routes to the same three, because replacing the asset IS
-//     the fix. Which of the three is named by the SERVER's label, not by the
-//     code — see appapi.ListingProblem.Label — so this arm cannot narrow it and
-//     does not pretend to.
+//   - `blocked-media` NARROWS to the slot, from the SERVER's label (the code is
+//     kind-less). It has to: the three slots do not share a remedy — overwriting
+//     fixes an icon or a cover, while a blocked SCREENSHOT must be REMOVED,
+//     because `add-screenshot` appends and leaves the blocked row attached. An
+//     unrecognised label falls back to an arm that still names the removal.
+//     (This paragraph said the opposite until the arm below started narrowing;
+//     a godoc twenty lines above the code it contradicts is how the next reader
+//     is told not to look.)
 //   - `scanning-media` has NO fix route at all and says so. Printing a command
 //     for it would tell an author to act on a state that resolves itself.
 //   - The three TEXT codes route to the WEB editor, and NOT to a CLI flag. The
@@ -130,12 +135,34 @@ func doctorRemedy(p appapi.ListingProblem, slug, editURL, kind string) string {
 			// the listing still refused at go-live. The id is an `alsc_…` this
 			// command never sees — `listMine` does not carry screenshot rows —
 			// so the read that prints it has to be named too.
+			// 🔴 THREE COMMANDS, AND THE THIRD IS NOT OPTIONAL ON A LIVE
+			// LISTING. `rm-screenshot` on an APPROVED listing lands in the open
+			// shadow revision and is deliberately NOT submitted (its own docs
+			// say so). `listMine` reads the PARENT, so until the revision is
+			// submitted and approved `doctor` keeps reporting `blocked-media`
+			// and keeps exiting 1 — an author who followed a two-command remedy
+			// would remove the asset, see no change, and have nothing to try.
 			return "REMOVE the blocked screenshot — adding another does not clear it: " +
 				"civitai app listing status --slug " + slug + " to find its alsc_ id, then " +
-				"civitai app listing rm-screenshot <id> --slug " + slug
+				"civitai app listing rm-screenshot <id> --slug " + slug +
+				". On an approved listing that stages a revision, so finish with " +
+				"civitai app listing submit-revision --slug " + slug
 		}
+		// The fallback names the READ too: `rm-screenshot` needs an `alsc_` id
+		// that appears in no output this command produces, so naming the removal
+		// without naming where the id comes from is an unfollowable instruction.
+		// 🔴 EVERY COMMAND HERE IS TERMINATED BY PUNCTUATION, not by prose. The
+		// first draft read "civitai app listing status to find the alsc_ id",
+		// and the ledger that resolves these strings against the real command
+		// tree correctly refused it: the trailing words parse as arguments, so
+		// the reference names a command that does not exist. Prose between
+		// commands has to be parenthesised or separated, or the advice is
+		// unfollowable in exactly the way this ledger exists to catch.
 		return "replace or remove the blocked asset named above, with --slug " + slug + " — " +
-			"civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot"
+			"civitai app listing set-icon, civitai app listing set-cover, or " +
+			"civitai app listing rm-screenshot (find the alsc_ id with " +
+			"civitai app listing status; on an approved listing finish with " +
+			"civitai app listing submit-revision)"
 	case problemScanningMedia:
 		// 🔴 NO COMMAND AT ALL, deliberately. A still-scanning asset resolves
 		// itself; printing a fix would tell an author to act on a state that is
@@ -177,10 +204,23 @@ func doctorRemedy(p appapi.ListingProblem, slug, editURL, kind string) string {
 // format assumption, so a re-worded label degrades to the generic arm instead of
 // mis-naming a slot — and the generic arm names the REMOVAL too, which is the
 // clause whose absence was the defect.
+var blockedKindWord = map[string]*regexp.Regexp{
+	"screenshot": regexp.MustCompile(`(?i)\bscreenshots?\b`),
+	"cover":      regexp.MustCompile(`(?i)\bcovers?\b`),
+	"icon":       regexp.MustCompile(`(?i)\bicons?\b`),
+}
+
 func blockedMediaKind(label string) string {
-	l := strings.ToLower(label)
+	// 🔴 A WORD MATCH, WHICH IS WHAT THE DOC AND THE TEST NAME ALREADY CLAIMED.
+	// This was `strings.Contains`, so any label with the letters "icon" inside
+	// another word — "iconography", "semiconductor" — would have selected the
+	// icon arm and printed the wrong command. Latent against today's labels and
+	// one line to close, and the alternative was to weaken the doc to match the
+	// code, which is the wrong direction when the doc describes the safer rule.
+	// Order still matters: "screenshot" is checked first so a label naming both
+	// resolves to the slot with the stricter remedy.
 	for _, kind := range []string{"screenshot", "cover", "icon"} {
-		if strings.Contains(l, kind) {
+		if blockedKindWord[kind].MatchString(label) {
 			return kind
 		}
 	}
@@ -373,10 +413,11 @@ Findings come from the platform, grouped per app, blocking first:
 An app with nothing wrong is reported as complete, explicitly. A blank space is
 not an answer.
 
-The three TEXT problems (description / tagline / category) are fixed in the
-browser: this command prints the listing's editor URL. The media problems are
-fixed with ` + "`civitai app listing set-icon`" + ` / ` + "`set-cover`" + ` /
-` + "`add-screenshot`" + `, and the exact command is printed beside each finding.
+Each finding prints the command or URL that fixes it. The three TEXT problems
+(description / tagline / category) depend on the app KIND: an on-site app's copy
+comes from block.manifest.json, an off-site app's from the web listing editor.
+A blocked asset is REPLACED for an icon or cover, but a blocked screenshot must
+be REMOVED — adding another does not clear it.
 
 DELISTED LISTINGS: an app whose status is 'removed' is still reported, in its
 own section, but its blocking problems do NOT set the exit code. The publish
@@ -440,6 +481,18 @@ func doctorNoSuchApp(slug string, rows []appapi.MyListing) error {
 	}
 	sort.Strings(known)
 	msg := fmt.Sprintf("no listing of yours is called %q", slug)
+	// 🔴 A CAPPED PAGE MAKES THIS ANSWER UNCERTAIN, AND IT MUST SAY SO. The slug
+	// is matched against the page the server returned, which is clamped — so an
+	// app the caller really owns, sitting beyond the cap, is indistinguishable
+	// here from one that does not exist. Reporting a bare not-found would be the
+	// silent-pass class this command exists to close, moved from exit 0 to exit
+	// 4.
+	if doctorPageTruncated(len(rows)) {
+		return civitai.Tag(civitai.ErrNotFound, fmt.Errorf(
+			"%s in the %d listings the server returned — but it CAPS this read at %d and offers no way to "+
+				"page, so an app you own beyond that cap looks identical to one that does not exist. "+
+				"This answer is not conclusive", msg, len(rows), appapi.ListMineCap))
+	}
 	switch {
 	case len(known) == 0:
 		msg += " — you own no App listings and hold no collaborator seats yet; `civitai app submit` creates one"
@@ -471,7 +524,14 @@ func runAppDoctor(out, errOut io.Writer, rows []appapi.MyListing, slug, baseURL 
 		}
 	}
 
+	// 🔴 THE TRUNCATION FLAG IS COMPUTED FROM THE SERVER'S PAGE (`rows`), NOT
+	// FROM THE FILTERED SLICE. It used to be derived inside doctorPayload from
+	// whatever it was handed, and the by-slug path hands it ONE row — so
+	// `truncated` was dead-false on exactly the path the caveat tells you to
+	// use. See doctorPageTruncated for why the precedent this was copied from
+	// does not transfer.
 	payload := doctorPayload(selected, baseURL)
+	payload.Summary.Truncated = doctorPageTruncated(len(rows))
 	if jsonOut {
 		// 🔴 The JSON path does NOT go through the human renderer, and must not:
 		// internal/ui/CONVENTION.md rule 1 is that machine-readable output
@@ -495,13 +555,16 @@ func runAppDoctor(out, errOut io.Writer, rows []appapi.MyListing, slug, baseURL 
 		// report of the same facts. It quotes the GATING count for the same
 		// reason — a message naming a bigger number than the verdict acted on
 		// would send a reader hunting for problems the gate deliberately ignored.
-		// 🔴 IT DOES NOT LEAD WITH A WORD THAT READS AS A TOOL FAILURE. cobra
-		// prefixes a returned error with "Error: " on stderr, so a completely
-		// successful diagnosis of an incomplete listing printed
-		// `Error: the listing has blocking problems…` — and a CI scraper
-		// watching stderr for `Error:` flags a run that worked exactly as
-		// designed. The verdict is a FINDING about the listing, not a failure of
-		// the command, and the sentence now says so.
+		// 🔴 THE "Error: " PREFIX IS NOT ADDED HERE AND NOT BY COBRA — it comes
+		// from `cmd/civitai/main.go`, which is the only writer of it (the root
+		// sets `SilenceErrors: true`, so cobra prints nothing). An earlier
+		// version of this comment blamed cobra and "fixed" the problem by
+		// rewording the sentinel, which changed the text after the prefix and
+		// left the prefix exactly where it was. The suppression now lives at the
+		// real emitter, in `errorLine`, keyed on ErrListingBlocked.
+		//
+		// What this sentence still owes the reader is the same thing: the
+		// non-zero exit is a FINDING about the listing, not a malfunction.
 		return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — the report above lists them; "+
 			"this exit code is the verdict, not a failure of the command",
 			ErrListingBlocked, payload.Summary.Gating)
@@ -572,12 +635,6 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 		}
 		out.Apps = append(out.Apps, app)
 	}
-	// The comparison is `>=`, not `==`, and it is computed from what the SERVER
-	// returned: at or beyond the cap this CLI cannot claim the listing is
-	// complete. A caller holding exactly the cap gets a caveat while nothing is
-	// missing — accepted, because the opposite error is the one this exists to
-	// prevent, and the wording says "may".
-	out.Summary.Truncated = len(rows) >= appapi.ListMineCap
 	out.OK = out.Summary.Gating == 0
 	return out
 }
@@ -633,6 +690,32 @@ func printDoctorReport(w io.Writer, payload doctorJSON) {
 	}
 }
 
+// doctorPageTruncated reports whether the server's page may have hidden
+// listings. `n` is the length of the read as it came OFF THE WIRE — never a
+// filtered subset.
+//
+// 🔴 THE `app status` PRECEDENT DOES NOT TRANSFER, AND COPYING IT PAST ITS
+// PREMISE IS WHAT BROKE THIS. `submissionsListTruncated` is applied only to the
+// UNFILTERED submissions listing, because that route narrows BY SLUG
+// SERVER-SIDE: its `where.slug` precedes the `take`, so a slug lookup is already
+// complete and cannot be truncated. `listMine` takes NO INPUT AT ALL — pinned by
+// TestDoctorSendsNoInputParameter — so the CLI fetches the whole capped page and
+// filters in Go. Every by-slug run here is therefore a truncated-page read
+// wearing a one-row result, and deriving the flag from the filtered slice made
+// it structurally false there.
+//
+// That mattered most in the case the caveat itself points at: a slug that IS
+// owned but sits BEYOND the cap resolves to "no listing of yours is called
+// that" — a confidently wrong answer about the caller's own app. That is the
+// same silent-pass class this caveat exists to close, relocated from exit 0 to
+// exit 4, which is why doctorNoSuchApp now says so.
+//
+// `>=`, not `==`: at or beyond the cap this CLI cannot claim the read is
+// complete. A caller holding exactly the cap gets a caveat while nothing is
+// missing — accepted, because the opposite error is the one this prevents, and
+// every sentence it produces says "may".
+func doctorPageTruncated(n int) bool { return n >= appapi.ListMineCap }
+
 // warnDoctorTruncated writes the page-cap caveat to STDERR, so `--json` stdout
 // stays a pure payload and the exit code is unchanged — the same shape
 // `app status` uses for the sibling read's cap.
@@ -640,11 +723,22 @@ func warnDoctorTruncated(errOut io.Writer, payload doctorJSON) {
 	if !payload.Summary.Truncated {
 		return
 	}
+	// 🔴 IT QUOTES THE CAP, NOT `Summary.Apps`. That field is the count AFTER
+	// slug filtering, so on a by-slug run the sentence would have read "the
+	// server returned 1 listings" about a 200-row page. The cap is the fact the
+	// caveat is actually about.
+	//
+	// 🔴 AND IT NO LONGER TELLS THE READER TO GO USE `doctor <slug>`. That was
+	// the advice while the by-slug path was the one place the caveat was
+	// suppressed — it directed people at the blind spot. The by-slug path now
+	// warns too, and what it cannot do is see a listing past the cap at all, so
+	// the remedy has to be something else.
 	fmt.Fprintf(errOut,
-		"note: the server returned %d listings — it caps this read and offers no way to page, so older "+
-			"listings may exist and were NOT checked. A blocking problem on one of them would not appear "+
-			"here, and would not change the exit code. Check a specific app with `civitai app doctor <slug>`.\n",
-		payload.Summary.Apps)
+		"note: the server caps this read at %d listings and offers no way to page, so older listings may "+
+			"exist and were NOT checked. A blocking problem on one of them would not appear here and would "+
+			"not change the exit code. This applies to a single-app run too: the app is picked out of the "+
+			"same capped page, so a listing beyond the cap reads as not-found.\n",
+		appapi.ListMineCap)
 }
 
 // printDoctorGroup renders one severity group, or nothing when it is empty.

--- a/internal/cmd/app_doctor.go
+++ b/internal/cmd/app_doctor.go
@@ -95,7 +95,7 @@ const (
 //     shadow id outright; `updateRevisionDraft` refuses a top-level listing), so
 //     "set the tagline" is two procs and a branch, not a flag. Tracked as the
 //     follow-on to this PR.
-func doctorRemedy(p appapi.ListingProblem, slug, editURL string) string {
+func doctorRemedy(p appapi.ListingProblem, slug, editURL, kind string) string {
 	switch p.Code {
 	case problemMissingIcon:
 		return "civitai app listing set-icon <file> --slug " + slug
@@ -119,6 +119,21 @@ func doctorRemedy(p appapi.ListingProblem, slug, editURL string) string {
 		// the very scan they are waiting for.
 		return "nothing to do — the scan finishes on its own; re-run `civitai app doctor` in a minute"
 	case problemEmptyDescription, problemEmptyTagline, problemEmptyCategory:
+		// 🔴 KIND-AWARE, AND THE ONSITE ARM IS NOT A STYLE CHOICE. An ONSITE
+		// listing's name/tagline/description/category are MANIFEST-governed:
+		// `(3b-sync)` in `<civitai>/publish-request.service.ts:2742-2800`
+		// overwrites all four from the manifest (and `category` from
+		// `AppBlock.category`) on EVERY subsequent-version moderator approve,
+		// scoped `kind: 'onsite'`. Its own comment says these fields "have NO
+		// author surface other than the manifest". So the browser-editor advice
+		// — which is what this arm used to give everyone — sends an onsite
+		// author to make an edit the platform reverts at the next approve,
+		// silently. That is worse than no advice: they follow it, `doctor` goes
+		// quiet, and the problem returns without explanation.
+		if listingIsOnsite(kind) {
+			return "these fields come from block.manifest.json on an on-site app — " +
+				"edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+		}
 		return "edit the listing in the browser: " + editURL
 	}
 	// 🔴 An UNKNOWN code is a NEW server code, not a bug in the caller, and it
@@ -171,6 +186,22 @@ const listingStatusRemoved = "removed"
 // The exclusion is not permanent, and nothing is stranded by it: an owner who
 // republishes a removed listing moves its status off `removed`, and the next run
 // gates on it again with no CLI change.
+// listingIsOnsite reports whether a listing's TEXT is manifest-governed.
+//
+// 🔴 ONLY AN EXPLICIT `onsite` TAKES THE MANIFEST ARM, and an unrecognised or
+// ABSENT kind falls through to the browser-editor advice. The two directions are
+// not symmetric. Wrongly sending an OFF-SITE author to the manifest names a file
+// their app does not have — confusing, but they stop and ask. Wrongly sending an
+// ON-SITE author to the browser tells them to make an edit the platform reverts
+// at the next approve, silently, and `doctor` reports the same problem again
+// with no explanation. The recoverable mistake is the default.
+//
+// It normalises, because `kind` is a server string this CLI compares and a
+// spelling change must not silently re-route the advice.
+func listingIsOnsite(kind string) bool {
+	return strings.EqualFold(strings.TrimSpace(kind), "onsite")
+}
+
 func doctorGates(status string) bool {
 	return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)
 }
@@ -441,7 +472,7 @@ func doctorPayload(rows []appapi.MyListing, baseURL string) doctorJSON {
 				Code:     p.Code,
 				Label:    p.Label,
 				Severity: p.Severity,
-				Fix:      doctorRemedy(p, r.Slug, editURL),
+				Fix:      doctorRemedy(p, r.Slug, editURL, r.Kind),
 			}
 			if doctorIsBlocking(p) {
 				app.Blocking = append(app.Blocking, row)

--- a/internal/cmd/app_doctor_test.go
+++ b/internal/cmd/app_doctor_test.go
@@ -36,6 +36,11 @@ const (
 	docListingA = "apl_ALPHA111"
 	docListingB = "apl_BRAVO222"
 	docBlockA   = "block_ALPHA333"
+	// The DELISTED fixture. Distinct from every other slug and id, so an
+	// assertion about the delisted arm cannot pass on a value copied from the
+	// gating one.
+	docSlugC    = "doctor-charlie"
+	docListingC = "apl_CHARLIE333"
 )
 
 // listMinePath is the ONE route `app doctor` is allowed to speak. It is spelled
@@ -286,7 +291,12 @@ func TestDoctorPositiveControlOnTheFindingCount(t *testing.T) {
 // published contract (README documents it); a substring assertion agrees with a
 // payload that has quietly grown, lost or renamed a sibling key.
 func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
+	// 🔴 THE DELISTED ROW IS SENT FIRST ON THE WIRE and must come LAST in the
+	// payload. Feeding them already in the right order would make the ordering
+	// assertion pass against code that does no ordering at all.
 	newDoctorServer(t,
+		doctorRow(docSlugC, docListingC, "removed", "owner", nil,
+			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")),
 		doctorRow(docSlugA, docListingA, "draft", "owner", nil,
 			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
 			doctorProblem("empty-tagline", "Missing tagline", "advisory"),
@@ -296,13 +306,18 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
 	base := envBaseURL(t)
 	stdout, _, err := run(t, "app", "doctor", "--json")
 	if err == nil {
-		t.Fatalf("the first app is blocked, so this must exit non-zero; stdout:\n%s", stdout)
+		t.Fatalf("the DRAFT app is blocked, so this must exit non-zero; stdout:\n%s", stdout)
 	}
 	// 🔴 `<file>` arrives as `\u003cfile\u003e`. That is the SHARED writeJSON
 	// encoder's HTML escaping (json.Encoder does it by default), not this
 	// command's doing, and it is pinned here rather than worked around: a
 	// consumer decoding the payload gets `<file>` back, and changing the shared
 	// encoder would silently change every other `--json` contract in the CLI.
+	//
+	// 🔴 THE NUMBERS ARE ALL DIFFERENT FROM EACH OTHER: 3 apps, 2 blocking,
+	// 1 advisory, 1 gating, 1 delisted. `blocking` and `gating` differ, which is
+	// the whole point of publishing both — a payload that emitted one twice
+	// cannot pass.
 	want := `{
   "ok": false,
   "apps": [
@@ -313,6 +328,7 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "appBlockId": null,
       "status": "draft",
       "role": "owner",
+      "delisted": false,
       "blocking": [
         {
           "code": "missing-icon",
@@ -337,14 +353,35 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "appBlockId": "` + docBlockA + `",
       "status": "approved",
       "role": "editor",
+      "delisted": false,
       "blocking": [],
+      "advisory": []
+    },
+    {
+      "slug": "` + docSlugC + `",
+      "name": "Doctor-charlie Display Name",
+      "appListingId": "` + docListingC + `",
+      "appBlockId": null,
+      "status": "removed",
+      "role": "owner",
+      "delisted": true,
+      "blocking": [
+        {
+          "code": "missing-icon",
+          "label": "Missing icon (required before publishing)",
+          "severity": "blocking",
+          "fix": "civitai app listing set-icon \u003cfile\u003e --slug ` + docSlugC + `"
+        }
+      ],
       "advisory": []
     }
   ],
   "summary": {
-    "apps": 2,
-    "blocking": 1,
-    "advisory": 1
+    "apps": 3,
+    "blocking": 2,
+    "advisory": 1,
+    "gating": 1,
+    "delisted": 1
   }
 }
 `
@@ -697,10 +734,23 @@ func TestDoctorHelpDocumentsTheExitCodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("app doctor --help: %v", err)
 	}
-	for _, want := range []string{"EXIT CODES", "1 when ANY blocking problem", "0 otherwise"} {
+	for _, want := range []string{
+		"EXIT CODES",
+		"1 when a blocking problem was found on a listing that can still\npublish",
+		"0 otherwise",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("`app doctor --help` must document the exit codes (missing %q):\n%s", want, out)
 		}
+	}
+	// 🔴 THE OLD WORDING IS BANNED, NOT MERELY REPLACED. `--help` used to say "1
+	// when ANY blocking problem was found", which was true until delisted
+	// listings stopped gating and is now an OVER-BROAD claim about the exit
+	// code: a reader who believes it will read a 0 on a delisted app as a bug in
+	// the tool. Keeping it as a prohibition is what stops a future edit
+	// shortening the sentence straight back into the falsehood.
+	if strings.Contains(out, "ANY blocking problem") {
+		t.Errorf("`app doctor --help` claims ANY blocking problem exits 1 — delisted listings do not gate:\n%s", out)
 	}
 }
 
@@ -720,6 +770,7 @@ type doctorPayloadShape struct {
 		AppBlockID   *string `json:"appBlockId"`
 		Status       string  `json:"status"`
 		Role         string  `json:"role"`
+		Delisted     bool    `json:"delisted"`
 		Blocking     []struct {
 			Code     string `json:"code"`
 			Label    string `json:"label"`
@@ -737,6 +788,8 @@ type doctorPayloadShape struct {
 		Apps     int `json:"apps"`
 		Blocking int `json:"blocking"`
 		Advisory int `json:"advisory"`
+		Gating   int `json:"gating"`
+		Delisted int `json:"delisted"`
 	} `json:"summary"`
 }
 
@@ -813,4 +866,217 @@ func envBaseURL(t *testing.T) string {
 		t.Fatal("CIVITAI_BASE_URL is unset — listingEnv did not run, so the URL assertions below would compare against nothing")
 	}
 	return strings.TrimRight(v, "/")
+}
+
+// ---------------------------------------------------------------------------
+// Delisted listings: reported, but they do not set the exit code.
+// ---------------------------------------------------------------------------
+
+// TestDoctorDelistedListingsDoNotSetTheExitCode is the THREE-ARM table, and the
+// third arm is the one that matters.
+//
+// 🔴 THE MIXED ARM IS WHAT A NAIVE FILTER GETS WRONG. An implementation that
+// drops delisted rows from the payload entirely passes arms 1 and 2 and passes
+// arm 3 too — but an implementation that computes the verdict from "are there
+// any delisted apps" instead of "are there gating problems" passes arms 1 and 2
+// and FAILS arm 3. Two arms cannot tell those apart.
+//
+// Measured motivation, not a hypothetical: on production 2026-08-24 this
+// account held 21 listings with 11 blocking problems, TEN of them on `removed`
+// apps. Before this rule the no-arg form exited 1 forever.
+func TestDoctorDelistedListingsDoNotSetTheExitCode(t *testing.T) {
+	blocked := func(slug, id, status string) map[string]any {
+		return doctorRow(slug, id, status, "owner", nil,
+			doctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"))
+	}
+
+	cases := []struct {
+		name    string
+		rows    []map[string]any
+		wantErr bool
+		why     string
+		// wantGating / wantBlocking are asserted from --json in the same run, so
+		// the arm pins WHY it exited that way and not merely that it did.
+		wantBlocking int
+		wantGating   int
+	}{
+		{
+			name:         "a removed listing with blocking problems exits 0",
+			rows:         []map[string]any{blocked(docSlugC, docListingC, "removed")},
+			wantErr:      false,
+			why:          "the publish floor is meaningless for a delisted app",
+			wantBlocking: 1,
+			wantGating:   0,
+		},
+		{
+			name:         "a live listing with blocking problems exits 1",
+			rows:         []map[string]any{blocked(docSlugA, docListingA, "draft")},
+			wantErr:      true,
+			why:          "this is the case the gate exists for",
+			wantBlocking: 1,
+			wantGating:   1,
+		},
+		{
+			name: "BOTH present exits 1",
+			rows: []map[string]any{
+				blocked(docSlugC, docListingC, "removed"),
+				blocked(docSlugA, docListingA, "draft"),
+			},
+			wantErr:      true,
+			why:          "a delisted app must not MASK a real one — the naive filter's failure",
+			wantBlocking: 2,
+			wantGating:   1,
+		},
+		{
+			name: "a removed listing next to a CLEAN live one still exits 0",
+			rows: []map[string]any{
+				blocked(docSlugC, docListingC, "removed"),
+				doctorRow(docSlugB, docListingB, "approved", "owner", ptr(docBlockA)),
+			},
+			wantErr:      false,
+			why:          "nothing publishable is blocked",
+			wantBlocking: 1,
+			wantGating:   0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			newDoctorServer(t, tc.rows...)
+			stdout, _, err := run(t, "app", "doctor", "--json")
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected a non-zero verdict — %s; stdout:\n%s", tc.why, stdout)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected exit 0 — %s; got %v; stdout:\n%s", tc.why, err, stdout)
+			}
+			if tc.wantErr && !errors.Is(err, ErrListingBlocked) {
+				t.Errorf("the verdict must be ErrListingBlocked, got %T: %v", err, err)
+			}
+			got := decodeDoctorJSON(t, stdout)
+			if got.Summary.Blocking != tc.wantBlocking {
+				t.Errorf("summary.blocking = %d, want %d — every blocking problem must still be COUNTED",
+					got.Summary.Blocking, tc.wantBlocking)
+			}
+			if got.Summary.Gating != tc.wantGating {
+				t.Errorf("summary.gating = %d, want %d — gating is what sets the exit code",
+					got.Summary.Gating, tc.wantGating)
+			}
+			if got.OK != (tc.wantGating == 0) {
+				t.Errorf("ok = %v with gating = %d — `ok` must follow gating, not blocking", got.OK, got.Summary.Gating)
+			}
+		})
+	}
+}
+
+// TestDoctorDelistedRowsAreStillVisible: the verdict shrinks, the report does
+// not. Hiding a population by default is how it stops existing for anyone.
+func TestDoctorDelistedRowsAreStillVisible(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugC, docListingC, "removed", "owner", nil,
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
+		doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err != nil {
+		t.Fatalf("a delisted-only run must exit 0, got %v; stdout:\n%s", err, stdout)
+	}
+	for _, want := range []string{
+		docSlugC,                   // the row itself
+		"missing-icon",             // its blocking finding, not swallowed
+		"empty-tagline",            // and its advisory
+		"BLOCKING",                 // still under the honest heading
+		"Delisted",                 // announced as a section
+		"do NOT set the exit code", // and the rule stated where the reader meets it
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("a delisted app must still be fully reported (missing %q):\n%s", want, stdout)
+		}
+	}
+	// The trailing explanation of the discrepancy.
+	if !strings.Contains(stdout, "1 of them are delisted; 0 blocking problem(s) on publishable listings set the exit code.") {
+		t.Errorf("the summary must explain why the exit code disagrees with the blocking count:\n%s", stdout)
+	}
+}
+
+// TestDoctorDelistedRowsSortLast pins the ORDER, in the payload both renderings
+// read from. A reader scanning the top of the report must meet the apps that
+// can actually block a release first.
+func TestDoctorDelistedRowsSortLast(t *testing.T) {
+	// Sent delisted-FIRST on the wire, so passing requires real ordering work.
+	newDoctorServer(t,
+		doctorRow(docSlugC, docListingC, "removed", "owner", nil),
+		doctorRow(docSlugA, docListingA, "draft", "owner", nil),
+		doctorRow(docSlugB, docListingB, "approved", "owner", ptr(docBlockA)),
+	)
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	var order []string
+	for _, a := range got.Apps {
+		order = append(order, a.Slug)
+	}
+	want := []string{docSlugA, docSlugB, docSlugC}
+	if !equalStrings(order, want) {
+		t.Errorf("app order = %v, want %v (gating first, delisted last, stable within each group)", order, want)
+	}
+}
+
+// TestDoctorUnknownStatusStillGates: only an explicit `removed` is excluded.
+// "We could not tell that it is delisted" is not "it is delisted", and the two
+// directions are not symmetric — wrongly excluding means a real blocking problem
+// silently stops failing the build.
+func TestDoctorUnknownStatusStillGates(t *testing.T) {
+	for _, status := range []string{"draft", "pending", "approved", "rejected", "a-status-from-the-future", ""} {
+		t.Run("status="+status, func(t *testing.T) {
+			newDoctorServer(t, doctorRow(docSlugA, docListingA, status, "owner", nil,
+				doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")))
+			stdout, _, err := run(t, "app", "doctor")
+			if err == nil {
+				t.Fatalf("status %q is not `removed`, so a blocking problem must still gate; stdout:\n%s", status, stdout)
+			}
+		})
+	}
+	// POSITIVE CONTROL on the loop: the ONE status that is excluded must really
+	// be excluded, or every assertion above is a fact about a predicate that
+	// never returns false.
+	t.Run("control: removed IS excluded", func(t *testing.T) {
+		newDoctorServer(t, doctorRow(docSlugA, docListingA, "removed", "owner", nil,
+			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")))
+		if _, _, err := run(t, "app", "doctor"); err != nil {
+			t.Fatalf("control: `removed` must be excluded, got %v — the predicate never returns false", err)
+		}
+	})
+}
+
+// TestDoctorDelistedStatusMatchIsNormalised: the status is a server string and
+// the CLI compares it. Case and padding must not silently turn a delisted
+// listing back into a gating one.
+func TestDoctorDelistedStatusMatchIsNormalised(t *testing.T) {
+	for _, spelling := range []string{"removed", "REMOVED", "Removed", " removed "} {
+		t.Run(strings.TrimSpace(spelling), func(t *testing.T) {
+			newDoctorServer(t, doctorRow(docSlugA, docListingA, spelling, "owner", nil,
+				doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")))
+			stdout, _, err := run(t, "app", "doctor")
+			if err != nil {
+				t.Errorf("status %q must read as delisted, got %v; stdout:\n%s", spelling, err, stdout)
+			}
+		})
+	}
+}
+
+// TestDoctorHelpDocumentsTheDelistedRule: the exit code is the command's
+// product, and a rule that changes it belongs in the contract a reader has
+// offline.
+func TestDoctorHelpDocumentsTheDelistedRule(t *testing.T) {
+	out, _, err := run(t, "app", "doctor", "--help")
+	if err != nil {
+		t.Fatalf("app doctor --help: %v", err)
+	}
+	for _, want := range []string{"DELISTED LISTINGS", "'removed'", "do NOT set the exit code"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`app doctor --help` must document the delisted rule (missing %q):\n%s", want, out)
+		}
+	}
 }

--- a/internal/cmd/app_doctor_test.go
+++ b/internal/cmd/app_doctor_test.go
@@ -307,7 +307,14 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
 			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
 			doctorProblem("empty-tagline", "Missing tagline", "advisory"),
 		),
-		doctorRow(docSlugB, docListingB, "approved", "editor", ptr(docBlockA)),
+		// 🔴 THIS ROW IS `onsite` ON PURPOSE. Every other fixture reaching this
+		// pin was "offsite", so `Kind: r.Kind` -> `Kind: "offsite"` was a
+		// HARDCODING mutant no test could see — the documented blind spot where
+		// a fixture that can only ever produce the constant's own value cannot
+		// observe a mutant that hardcodes the literal. M39 nulled the field and
+		// died; hardcoding survived a fully green suite. Two distinct kinds in
+		// the pinned payload is the mechanical control.
+		doctorRowKind(docSlugB, docListingB, "approved", "onsite"),
 	)
 	base := envBaseURL(t)
 	stdout, _, err := run(t, "app", "doctor", "--json")
@@ -357,10 +364,10 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "slug": "` + docSlugB + `",
       "name": "Doctor-bravo Display Name",
       "appListingId": "` + docListingB + `",
-      "appBlockId": "` + docBlockA + `",
+      "appBlockId": null,
       "status": "approved",
-      "role": "editor",
-      "kind": "offsite",
+      "role": "owner",
+      "kind": "onsite",
       "delisted": false,
       "blocking": [],
       "advisory": []
@@ -458,8 +465,26 @@ func TestDoctorFixAdviceNamesOnlyCommandsThatExist(t *testing.T) {
 	base := "https://example.invalid"
 	editURL := base + fmt.Sprintf(listingEditPath, docListingA)
 	seen := 0
+	// 🔴 EVERY CODE, AND `blocked-media` ONCE PER SLOT. `problemWithCode` builds
+	// an EMPTY label, so `blocked-media` always took the FALLBACK arm here — the
+	// three per-slot arms, which is where the new commands live, were never
+	// resolved against the command tree at all. A ledger that walks "all eight
+	// codes" while silently skipping three branches is the narrower-than-its-
+	// description shape.
+	type probe struct {
+		code  string
+		label string
+	}
+	probes := []probe{}
 	for _, code := range allEightCodes() {
-		fix := doctorRemedy(problemWithCode(code), docSlugA, editURL, "offsite")
+		probes = append(probes, probe{code, ""})
+	}
+	for _, kind := range []string{"icon", "cover", "screenshot"} {
+		probes = append(probes, probe{"blocked-media", "Replace the blocked " + kind + " before it can publish"})
+	}
+	for _, pr := range probes {
+		code := pr.code
+		fix := doctorRemedy(appapi.ListingProblem{Code: pr.code, Label: pr.label}, docSlugA, editURL, "offsite")
 		if fix == "" {
 			t.Errorf("code %q produced an EMPTY fix line — every finding must say what to do", code)
 			continue
@@ -479,11 +504,12 @@ func TestDoctorFixAdviceNamesOnlyCommandsThatExist(t *testing.T) {
 	// against 7 actual references the `blocked-media` arm could lose two
 	// commands and this control would still pass — a positive control with two
 	// references of slack is a control for a scan that has half stopped working.
-	if seen < 7 {
+	// The floor rises with the per-slot arms now being walked.
+	if seen < 12 {
 		t.Fatalf("the fix-line scan found only %d command references across the eight codes — "+
 			"the regex is not reading what it thinks it is, so the resolutions above prove nothing", seen)
 	}
-	t.Logf("resolved %d command references across %d codes", seen, len(allEightCodes()))
+	t.Logf("resolved %d command references across %d probes (8 codes + 3 blocked-media slots)", seen, len(probes))
 }
 
 // TestDoctorMediaFixesCarryASlugFlagThatExists: the printed commands pass
@@ -1280,9 +1306,18 @@ func TestBlockedMediaRemedyIsSufficientPerSlot(t *testing.T) {
 			mustNotSay: []string{"add-screenshot", "rm-screenshot", "set-icon"},
 		},
 		{
-			// 🔴 The whole finding: REMOVE, and name the read that shows the id.
+			// 🔴 THREE CLAUSES, AND `submit-revision` IS THE ONE THAT WAS
+			// UNASSERTED. A mutation sweep caught it: deleting the
+			// submit-revision clause left this test green, because it only
+			// demanded the removal and the read. On an APPROVED listing
+			// `rm-screenshot` lands in the open shadow and is deliberately NOT
+			// submitted, and `listMine` reads the PARENT — so without that
+			// clause the author removes the asset, `doctor` keeps reporting
+			// `blocked-media`, keeps exiting 1, and they have nothing left to
+			// try. Asserting two of three clauses is asserting an insufficient
+			// remedy.
 			label:      "Replace the blocked screenshot before it can publish",
-			mustSay:    []string{"rm-screenshot", "civitai app listing status"},
+			mustSay:    []string{"rm-screenshot", "civitai app listing status", "submit-revision"},
 			mustNotSay: []string{"add-screenshot"},
 		},
 	}
@@ -1312,8 +1347,11 @@ func TestBlockedMediaUnknownLabelKeepsTheRemoval(t *testing.T) {
 	fix := doctorRemedy(
 		appapi.ListingProblem{Code: "blocked-media", Label: "this asset was rejected by the scanner", Severity: "blocking"},
 		docSlugA, "https://example.invalid/x", "offsite")
-	if !strings.Contains(fix, "rm-screenshot") {
-		t.Errorf("the fallback arm must still name the REMOVAL, or a blocked screenshot is unfixable: %s", fix)
+	for _, want := range []string{"rm-screenshot", "civitai app listing status", "submit-revision"} {
+		if !strings.Contains(fix, want) {
+			t.Errorf("the fallback arm must still name %q — losing precision is acceptable, losing "+
+				"SUFFICIENCY is the defect returning: %s", want, fix)
+		}
 	}
 	if strings.Contains(fix, "add-screenshot") {
 		t.Errorf("the fallback must not advise appending, which never clears a blocked row: %s", fix)
@@ -1368,38 +1406,117 @@ func TestDoctorSeverityIsNormalised(t *testing.T) {
 	}
 }
 
-// TestDoctorReportsTruncationAtThePageCap.
-//
-// 🔴 `ok: true` OTHERWISE MEANS "NOTHING BLOCKING IN WHAT I COULD SEE" AND SAYS
-// "NOTHING BLOCKING". `listMine` clamps to appapi.ListMineCap, orders
-// `serialId desc`, and offers no cursor and no total — so past the cap the
-// OLDEST listings vanish silently and `doctor || exit 1` passes for a listing
-// that cannot publish. This is the same failure `submissionsListTruncated`
-// exists for on the sibling read.
-func TestDoctorReportsTruncationAtThePageCap(t *testing.T) {
-	rows := make([]map[string]any, 0, appapi.ListMineCap)
-	for i := 0; i < appapi.ListMineCap; i++ {
+// bulkRows builds n clean listings, plus (optionally) a blocking one at the END
+// so a by-slug lookup has to reach past the head of the page.
+func bulkRows(n int, tailSlug string) []map[string]any {
+	rows := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
 		rows = append(rows, doctorRow(fmt.Sprintf("bulk-app-%03d", i), fmt.Sprintf("apl_BULK%03d", i),
 			"approved", "owner", nil))
 	}
-	newDoctorServer(t, rows...)
-	stdout, stderr, err := run(t, "app", "doctor", "--json")
-	if err != nil {
-		t.Fatalf("all clean, so exit 0: %v", err)
+	if tailSlug != "" && n > 0 {
+		rows[n-1] = doctorRow(tailSlug, "apl_TAIL", "draft", "owner", nil,
+			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"))
+	}
+	return rows
+}
+
+// TestDoctorTruncationBoundary is the Cap-1 / Cap / Cap+1 table the sibling
+// guard carries and this one lacked.
+//
+// 🔴 A SINGLE AT-CAP CASE CANNOT TELL `>=` FROM `>`, and the off-by-one is the
+// likely drift: the commonest truncated read is EXACTLY at the cap, because that
+// is what a clamp produces.
+func TestDoctorTruncationBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		n    int
+		want bool
+	}{
+		{appapi.ListMineCap - 1, false},
+		{appapi.ListMineCap, true},
+		{appapi.ListMineCap + 1, true},
+	} {
+		t.Run(fmt.Sprintf("n=%d", tc.n), func(t *testing.T) {
+			newDoctorServer(t, bulkRows(tc.n, "")...)
+			stdout, stderr, err := run(t, "app", "doctor", "--json")
+			if err != nil {
+				t.Fatalf("all clean, so exit 0: %v", err)
+			}
+			if got := decodeDoctorJSON(t, stdout).Summary.Truncated; got != tc.want {
+				t.Errorf("n=%d truncated=%v, want %v", tc.n, got, tc.want)
+			}
+			if strings.Contains(stderr, "caps this read") != tc.want {
+				t.Errorf("n=%d caveat presence = %v, want %v", tc.n, !tc.want, tc.want)
+			}
+		})
+	}
+}
+
+// TestDoctorTruncationIsReportedOnTheBySlugPathToo is the defect itself.
+//
+// 🔴 `truncated` USED TO BE COMPUTED FROM THE FILTERED SLICE, so a by-slug run
+// saw len(rows)==1 and reported false — on the exact path the caveat used to
+// tell the reader to use. The flag is a property of the SERVER'S PAGE.
+// `listMine` takes no input (TestDoctorSendsNoInputParameter), so every by-slug
+// run is a capped read filtered client-side.
+func TestDoctorTruncationIsReportedOnTheBySlugPathToo(t *testing.T) {
+	newDoctorServer(t, bulkRows(appapi.ListMineCap, "tail-app")...)
+	stdout, stderr, err := run(t, "app", "doctor", "tail-app", "--json")
+	if err == nil {
+		t.Fatalf("tail-app is blocked, so this must exit non-zero; stdout:\n%s", stdout)
 	}
 	got := decodeDoctorJSON(t, stdout)
-	if !got.Summary.Truncated {
-		t.Errorf("a full-length page must set summary.truncated — `ok:true` on a truncated read is " +
-			"indistinguishable from `ok:true` on a complete one")
+	if len(got.Apps) != 1 {
+		t.Fatalf("by-slug must select exactly one app, got %d", len(got.Apps))
 	}
-	for _, want := range []string{"caps this read", "were NOT checked", "would not change the exit code"} {
-		if !strings.Contains(stderr, want) {
-			t.Errorf("the caveat must reach stderr (missing %q):\n%s", want, stderr)
+	if !got.Summary.Truncated {
+		t.Errorf("a by-slug run reads the SAME capped page — truncated must be true, not false-by-construction")
+	}
+	if !strings.Contains(stderr, "caps this read") {
+		t.Errorf("the caveat must print on the by-slug path:\n%s", stderr)
+	}
+	// 🔴 The caveat must NOT quote the FILTERED count. It used to interpolate
+	// Summary.Apps, which is 1 here, producing "the server returned 1 listings"
+	// about a 200-row page.
+	if strings.Contains(stderr, "returned 1 listings") {
+		t.Errorf("the caveat quotes the filtered count, not the cap:\n%s", stderr)
+	}
+	// And it must not send the reader to the path it was blind on.
+	if strings.Contains(stderr, "Check a specific app with") {
+		t.Errorf("the caveat still directs the reader at the by-slug path as a remedy:\n%s", stderr)
+	}
+}
+
+// TestDoctorNotFoundOnACappedPageIsNotConclusive.
+//
+// 🔴 THE WORST ARM. A slug the caller REALLY OWNS, sitting beyond the cap,
+// resolves to "no listing of yours is called that" — a confidently wrong answer
+// about their own app. That is the same silent-pass class this caveat exists to
+// close, relocated from exit 0 to exit 4, so the refusal has to say it is not
+// conclusive.
+func TestDoctorNotFoundOnACappedPageIsNotConclusive(t *testing.T) {
+	newDoctorServer(t, bulkRows(appapi.ListMineCap, "")...)
+	_, _, err := run(t, "app", "doctor", "an-app-past-the-cap")
+	if err == nil {
+		t.Fatal("expected a not-found")
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("still exit 4, got %T: %v", err, err)
+	}
+	for _, want := range []string{"CAPS this read", "not conclusive"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("a not-found off a capped page must say it is uncertain (missing %q): %v", want, err)
 		}
 	}
-	// STDERR only — `--json` stdout stays a pure payload.
-	if strings.Contains(stdout, "caps this read") {
-		t.Errorf("the caveat leaked into --json stdout")
+	// NEGATIVE CONTROL: below the cap the answer IS conclusive and must not be
+	// hedged, or the hedge becomes noise on every miss.
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil))
+	_, _, err2 := run(t, "app", "doctor", "no-such-app-of-mine")
+	if err2 == nil {
+		t.Fatal("control: expected a not-found")
+	}
+	if strings.Contains(err2.Error(), "not conclusive") {
+		t.Errorf("below the cap the answer is conclusive and must not be hedged: %v", err2)
 	}
 }
 
@@ -1419,22 +1536,53 @@ func TestDoctorDoesNotCryTruncationBelowTheCap(t *testing.T) {
 	}
 }
 
-// TestDoctorVerdictDoesNotReadAsAToolFailure: cobra prefixes a returned error
-// with "Error: ", so a successful diagnosis of an incomplete listing printed
-// `Error: the listing has blocking problems` — and a CI scraper watching stderr
-// for `Error:` flags a run that worked exactly as designed.
-func TestDoctorVerdictDoesNotReadAsAToolFailure(t *testing.T) {
+// TestListMineCapMatchesTheServer is the drift guard the sibling constant
+// carries and this one lacked. It cannot reach the server, so it pins the value
+// and names where to re-read it — a stale cap silently changes what "truncated"
+// means in both directions.
+func TestListMineCapMatchesTheServer(t *testing.T) {
+	const want = 200
+	if appapi.ListMineCap != want {
+		t.Errorf("ListMineCap = %d, want %d. Re-read `MY_APP_LISTINGS_LIMIT` in "+
+			"<civitai>/src/server/services/blocks/app-access.service.ts and change this pin deliberately: "+
+			"a cap that is too HIGH never warns on a truncated page, and one that is too LOW warns on every "+
+			"complete one.", appapi.ListMineCap, want)
+	}
+}
+
+// TestDoctorVerdictSentinelIsDistinguishable is what remains here of a test that
+// used to claim more than it could see.
+//
+// 🔴 THE OLD TEST WAS NAMED `…DoesNotReadAsAToolFailure` AND ASSERTED ON
+// `err.Error()` — the string as it exists BEFORE `cmd/civitai/main.go` prepends
+// "Error: ". It was therefore structurally incapable of observing the prefix it
+// was named for, and it passed while the prefix was still being printed. The
+// property is a PROCESS-level one and is now measured where it happens, in
+// cmd/civitai's TestDoctorVerdictPrintsNoErrorPrefix, which reads the real
+// binary's stderr.
+//
+// What stays in-package is the one thing this level CAN establish: the verdict
+// is reachable and carries the sentinel that main.go branches on. Without that,
+// the process-level test could pass for the wrong reason.
+func TestDoctorVerdictSentinelIsDistinguishable(t *testing.T) {
 	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
 		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")))
 	_, _, err := run(t, "app", "doctor")
 	if err == nil {
 		t.Fatal("expected the blocking verdict")
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "not ready to publish") {
+	if !errors.Is(err, ErrListingBlocked) {
+		t.Fatalf("the verdict must carry ErrListingBlocked — main.go's errorLine branches on it: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not ready to publish") {
 		t.Errorf("the verdict should describe the LISTING, got: %v", err)
 	}
-	if !strings.Contains(msg, "not a failure of the command") {
-		t.Errorf("the verdict should say it is a finding, not a tool failure, got: %v", err)
+	// NEGATIVE CONTROL: an ordinary failure must NOT carry the sentinel, or
+	// main.go would strip the prefix from real errors too.
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil))
+	if _, _, err := run(t, "app", "doctor", "no-such-app-of-mine"); err == nil {
+		t.Fatal("control: expected a not-found error")
+	} else if errors.Is(err, ErrListingBlocked) {
+		t.Error("control: a not-found must NOT carry the verdict sentinel — it is a real failure")
 	}
 }

--- a/internal/cmd/app_doctor_test.go
+++ b/internal/cmd/app_doctor_test.go
@@ -1,0 +1,816 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/civitai/cli/internal/appapi"
+	"github.com/civitai/cli/pkg/civitai"
+	"github.com/spf13/cobra"
+)
+
+// `civitai app doctor` (civitai/civitai#4341's client half).
+//
+// Everything here runs against an httptest fake. Nothing in this file has been
+// run against a real listing.
+//
+// 🔴 THE FIXTURE CONSTANTS ARE PAIRWISE DISTINCT AND DISTINCT FROM EVERY
+// CONSTANT AN ASSERTION NAMES. A fixture that can only ever produce the value
+// the assertion spells is invisible to a mutant that hardcodes that literal —
+// so the slugs, the listing ids and the block ids below share no substring with
+// each other or with any command name, and the two apps in the multi-app
+// fixtures disagree on every field.
+
+const (
+	docSlugA    = "doctor-alpha"
+	docSlugB    = "doctor-bravo"
+	docListingA = "apl_ALPHA111"
+	docListingB = "apl_BRAVO222"
+	docBlockA   = "block_ALPHA333"
+)
+
+// listMinePath is the ONE route `app doctor` is allowed to speak. It is spelled
+// here, in the test, rather than read from the production route var: a test that
+// reads the value it is checking agrees with any change to it.
+const listMinePath = "/api/trpc/appListings.listMine"
+
+// doctorProblem builds one server-shaped problem row.
+func doctorProblem(code, label, severity string) map[string]any {
+	return map[string]any{"code": code, "label": label, "severity": severity}
+}
+
+// doctorRow builds one server-shaped listMine row.
+func doctorRow(slug, listingID, status, role string, blockID *string, problems ...map[string]any) map[string]any {
+	if problems == nil {
+		problems = []map[string]any{}
+	}
+	return map[string]any{
+		"appListingId": listingID,
+		"slug":         slug,
+		"name":         strings.ToUpper(slug[:1]) + slug[1:] + " Display Name",
+		"status":       status,
+		"role":         role,
+		"appBlockId":   blockID,
+		"problems":     problems,
+	}
+}
+
+// doctorServer answers listMine with rows, and RECORDS every path it is asked
+// for. The recording is what makes the request-ledger test possible; every other
+// test gets it for free and fails loudly if the command starts making a second
+// call.
+type doctorServer struct {
+	*httptest.Server
+	mu    sync.Mutex
+	paths []string
+}
+
+func (d *doctorServer) seen() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]string, len(d.paths))
+	copy(out, d.paths)
+	return out
+}
+
+func newDoctorServer(t *testing.T, rows ...map[string]any) *doctorServer {
+	t.Helper()
+	d := &doctorServer{}
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	d.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		d.mu.Lock()
+		d.paths = append(d.paths, r.URL.Path)
+		d.mu.Unlock()
+		if r.URL.Path != listMinePath {
+			// 🔴 A 500 rather than a t.Errorf alone: a command that made an
+			// unexpected call must FAIL, not merely be noted, or a test can pass
+			// while the CLI quietly reaches a proc that 403s in production.
+			t.Errorf("unexpected request to %s — `app doctor` speaks only %s", r.URL.Path, listMinePath)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		trpcData(w, rows)
+	}))
+	t.Cleanup(d.Close)
+	listingEnv(t, d.URL)
+	return d
+}
+
+// ---------------------------------------------------------------------------
+// The exit-code contract. Three arms, because two cannot tell "correct" from
+// "always exits 0" — or from "always exits 1".
+// ---------------------------------------------------------------------------
+
+// TestDoctorExitsNonZeroOnABlockingProblem is the arm the whole command exists
+// for: a release script's `civitai app doctor my-app || exit 1`.
+func TestDoctorExitsNonZeroOnABlockingProblem(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err == nil {
+		t.Fatalf("a blocking problem must exit non-zero; stdout was:\n%s", stdout)
+	}
+	if !errors.Is(err, ErrListingBlocked) {
+		t.Errorf("error must be tagged ErrListingBlocked (that is what carries the exit code), got %T: %v", err, err)
+	}
+	if !strings.Contains(stdout, "missing-icon") {
+		t.Errorf("the finding must be on stdout before the exit, got:\n%s", stdout)
+	}
+}
+
+// TestDoctorExitsZeroOnACleanListing is the arm that keeps the one above from
+// being satisfied by a command that always fails.
+func TestDoctorExitsZeroOnACleanListing(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "approved", "owner", ptr(docBlockA)))
+	stdout, _, err := run(t, "app", "doctor")
+	if err != nil {
+		t.Fatalf("a listing with no problems must exit 0, got %v; stdout was:\n%s", err, stdout)
+	}
+	// 🔴 EXPLICITLY CLEAN, not a gap. An empty section is indistinguishable
+	// from a read that failed and was swallowed.
+	if !strings.Contains(stdout, "No problems") {
+		t.Errorf("a clean listing must SAY it is complete, got:\n%s", stdout)
+	}
+}
+
+// TestDoctorExitsZeroOnAdvisoryOnly is the third arm, and the one that pins the
+// severity split to the exit code rather than to "any problem at all".
+func TestDoctorExitsZeroOnAdvisoryOnly(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "approved", "owner", ptr(docBlockA),
+		doctorProblem("no-screenshots", "No screenshots (recommended, optional)", "advisory"),
+		doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err != nil {
+		t.Fatalf("advisories alone must exit 0, got %v; stdout was:\n%s", err, stdout)
+	}
+	// The findings must still be REPORTED — exiting 0 is not the same as
+	// staying quiet, and an author who never sees the advisory never acts on it.
+	for _, want := range []string{"no-screenshots", "empty-tagline", "ADVISORY"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("advisory-only run must still print %q, got:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "BLOCKING") {
+		t.Errorf("an advisory-only run must not print a BLOCKING heading, got:\n%s", stdout)
+	}
+}
+
+// TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp: a mixed app is blocked. The
+// count in the summary is what a mutant that stops at the first finding, or that
+// counts apps instead of problems, gets wrong.
+func TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("no-screenshots", "No screenshots (recommended, optional)", "advisory"),
+		doctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"),
+		doctorProblem("empty-category", "Missing category", "advisory"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err == nil {
+		t.Fatalf("a mixed app with one blocking problem must exit non-zero; stdout:\n%s", stdout)
+	}
+	// 1 blocking and 2 advisory — three DIFFERENT numbers (1, 2, 3 findings on
+	// 1 app), so a summary that reports the wrong quantity cannot look right.
+	if !strings.Contains(stdout, "1 app(s) checked — 1 blocking, 2 advisory.") {
+		t.Errorf("summary line is wrong; got:\n%s", stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Every one of the eight codes, including the two that could not fire anywhere
+// before civitai/civitai#4341 wired assetScans into listMine.
+// ---------------------------------------------------------------------------
+
+// allEightProblems is a fixture that emits every code `computeListingProblems`
+// can produce, at the severity the server gives it.
+//
+// 🔴 IT INCLUDES `blocked-media` AND `scanning-media`. Those two were
+// structurally unreachable on every pre-#4341 surface, so a fixture set without
+// them leaves their handling — including the fact that one of them is BLOCKING —
+// untested while this file reads green.
+func allEightProblems() []map[string]any {
+	return []map[string]any{
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
+		doctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"),
+		doctorProblem("blocked-media", "Replace the blocked cover before it can publish", "blocking"),
+		doctorProblem("no-screenshots", "No screenshots (recommended, optional)", "advisory"),
+		doctorProblem("empty-description", "Missing description", "advisory"),
+		doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+		doctorProblem("empty-category", "Missing category", "advisory"),
+		doctorProblem("scanning-media", "Icon is still being scanned", "advisory"),
+	}
+}
+
+// TestDoctorReportsAllEightCodesInTheRightGroup drives every code through the
+// real command and asserts each lands under the heading its SERVER-GIVEN
+// severity puts it under.
+func TestDoctorReportsAllEightCodesInTheRightGroup(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil, allEightProblems()...))
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err == nil {
+		t.Fatalf("three of the eight are blocking, so this must exit non-zero; stdout:\n%s", stdout)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	if len(got.Apps) != 1 {
+		t.Fatalf("want 1 app, got %d", len(got.Apps))
+	}
+	wantBlocking := []string{"missing-icon", "missing-cover", "blocked-media"}
+	wantAdvisory := []string{"no-screenshots", "empty-description", "empty-tagline", "empty-category", "scanning-media"}
+	if diff := codesOf(got.Apps[0].Blocking); !equalStrings(diff, wantBlocking) {
+		t.Errorf("blocking codes = %v, want %v", diff, wantBlocking)
+	}
+	if diff := codesOf(got.Apps[0].Advisory); !equalStrings(diff, wantAdvisory) {
+		t.Errorf("advisory codes = %v, want %v", diff, wantAdvisory)
+	}
+	// 3 and 5 are different numbers from each other and from 8 and 1, so a
+	// summary that counted the wrong thing cannot coincide.
+	if got.Summary.Blocking != 3 || got.Summary.Advisory != 5 || got.Summary.Apps != 1 {
+		t.Errorf("summary = %+v, want {apps:1 blocking:3 advisory:5}", got.Summary)
+	}
+	if got.OK {
+		t.Error("ok must be false when anything is blocking")
+	}
+}
+
+// TestDoctorPositiveControlOnTheFindingCount is the pair the rules ask for: a
+// reassuring ZERO is indistinguishable from a probe wired to nothing, so the
+// same command is driven against a payload that MUST produce eight findings and
+// against one that must produce none, and BOTH numbers are reported.
+func TestDoctorPositiveControlOnTheFindingCount(t *testing.T) {
+	// Control arm: eight findings must be counted.
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil, allEightProblems()...))
+	stdout, _, _ := run(t, "app", "doctor", "--json")
+	control := decodeDoctorJSON(t, stdout)
+	controlTotal := control.Summary.Blocking + control.Summary.Advisory
+	if controlTotal != 8 {
+		t.Fatalf("POSITIVE CONTROL FAILED: a payload carrying 8 problems produced %d findings. "+
+			"Every zero this file reports is a fact about a probe wired to nothing until this passes.", controlTotal)
+	}
+
+	// Test arm: the same command, the same code path, a clean payload.
+	srv2 := newDoctorServer(t, doctorRow(docSlugB, docListingB, "approved", "owner", ptr(docBlockA)))
+	_ = srv2
+	stdout2, _, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("clean arm must exit 0: %v", err)
+	}
+	under := decodeDoctorJSON(t, stdout2)
+	underTotal := under.Summary.Blocking + under.Summary.Advisory
+	if underTotal != 0 {
+		t.Errorf("clean payload produced %d findings, want 0", underTotal)
+	}
+	t.Logf("positive-control pair: %d findings on the control, %d under test", controlTotal, underTotal)
+}
+
+// ---------------------------------------------------------------------------
+// The `--json` contract. Pinned WHOLE, not by a handful of keys.
+// ---------------------------------------------------------------------------
+
+// TestDoctorJSONShapeIsPinnedWhole compares the ENTIRE marshalled payload
+// against a literal, so a renamed field, a dropped field, a reordered struct or
+// a changed null-vs-omitted decision is visible.
+//
+// 🔴 A FEW `Contains` CHECKS WOULD NOT DO THIS. `app doctor --json` is a
+// published contract (README documents it); a substring assertion agrees with a
+// payload that has quietly grown, lost or renamed a sibling key.
+func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
+	newDoctorServer(t,
+		doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
+			doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+		),
+		doctorRow(docSlugB, docListingB, "approved", "editor", ptr(docBlockA)),
+	)
+	base := envBaseURL(t)
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err == nil {
+		t.Fatalf("the first app is blocked, so this must exit non-zero; stdout:\n%s", stdout)
+	}
+	// 🔴 `<file>` arrives as `\u003cfile\u003e`. That is the SHARED writeJSON
+	// encoder's HTML escaping (json.Encoder does it by default), not this
+	// command's doing, and it is pinned here rather than worked around: a
+	// consumer decoding the payload gets `<file>` back, and changing the shared
+	// encoder would silently change every other `--json` contract in the CLI.
+	want := `{
+  "ok": false,
+  "apps": [
+    {
+      "slug": "` + docSlugA + `",
+      "name": "Doctor-alpha Display Name",
+      "appListingId": "` + docListingA + `",
+      "appBlockId": null,
+      "status": "draft",
+      "role": "owner",
+      "blocking": [
+        {
+          "code": "missing-icon",
+          "label": "Missing icon (required before publishing)",
+          "severity": "blocking",
+          "fix": "civitai app listing set-icon \u003cfile\u003e --slug ` + docSlugA + `"
+        }
+      ],
+      "advisory": [
+        {
+          "code": "empty-tagline",
+          "label": "Missing tagline",
+          "severity": "advisory",
+          "fix": "edit the listing in the browser: ` + base + `/apps/listing/` + docListingA + `/edit"
+        }
+      ]
+    },
+    {
+      "slug": "` + docSlugB + `",
+      "name": "Doctor-bravo Display Name",
+      "appListingId": "` + docListingB + `",
+      "appBlockId": "` + docBlockA + `",
+      "status": "approved",
+      "role": "editor",
+      "blocking": [],
+      "advisory": []
+    }
+  ],
+  "summary": {
+    "apps": 2,
+    "blocking": 1,
+    "advisory": 1
+  }
+}
+`
+	if stdout != want {
+		t.Errorf("--json payload changed.\n--- got ---\n%s\n--- want ---\n%s", stdout, want)
+	}
+}
+
+// TestDoctorJSONIsTheWholeOfStdout: `… --json | jq -e .` must always parse, so
+// nothing else may share the stream.
+func TestDoctorJSONIsTheWholeOfStdout(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("missing-cover", "Missing cover image (required before publishing)", "blocking"),
+	))
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err == nil {
+		t.Fatal("expected a non-zero verdict")
+	}
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		t.Fatalf("stdout is not valid JSON (%v); stdout was:\n%s", err, stdout)
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		t.Fatalf("stdout carries more than the JSON payload (next token err = %v); stdout was:\n%s", err, stdout)
+	}
+	// internal/ui/CONVENTION.md rule 1: machine-readable output carries no
+	// styling. The human renderer's own glyphs are the cheapest tell.
+	for _, glyph := range []string{"✓", "⚠", "\x1b["} {
+		if strings.Contains(stdout, glyph) {
+			t.Errorf("--json stdout carries the styling marker %q — machine output must be unstyled:\n%s", glyph, stdout)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The fix advice: only routes that exist.
+// ---------------------------------------------------------------------------
+
+// civitaiCommandRef matches a `civitai …` command invocation inside prose,
+// stopping at the first token that is not a lowercase command word — so
+// `<file>`, `--slug` and a URL's `civitai.com` are all excluded.
+var civitaiCommandRef = regexp.MustCompile(`civitai(?: [a-z][a-z0-9-]*)+`)
+
+// TestDoctorFixAdviceNamesOnlyCommandsThatExist resolves every command named in
+// every fix line against the REAL cobra tree.
+//
+// 🔴 IT PARSES RATHER THAN SPELLING THE COMMANDS OUT. A literal assertion
+// ("the fix contains `civitai app listing set-icon`") agrees with any string,
+// including one no CLI would accept — the same argument
+// TestDriftRemedyCommandIsRunnableFromTheWarningsOwnDirectory rests on. And a
+// fix naming a command that does not exist is worse than no fix: the author
+// follows it, is refused, and concludes the tool is broken.
+func TestDoctorFixAdviceNamesOnlyCommandsThatExist(t *testing.T) {
+	root := NewRootCmd()
+
+	// 🔴 THE NEGATIVE CONTROL COMES FIRST. "Every reference resolved" and "the
+	// resolver says yes to everything" are the same output.
+	if err := resolveCommandRef(root, "civitai app listing set-banner"); err == nil {
+		t.Fatal("negative control: the resolver accepted a command that does not exist — " +
+			"every positive below would be a fact about the resolver, not about the advice")
+	}
+
+	base := "https://example.invalid"
+	editURL := base + fmt.Sprintf(listingEditPath, docListingA)
+	seen := 0
+	for _, code := range allEightCodes() {
+		fix := doctorRemedy(problemWithCode(code), docSlugA, editURL)
+		if fix == "" {
+			t.Errorf("code %q produced an EMPTY fix line — every finding must say what to do", code)
+			continue
+		}
+		refs := civitaiCommandRef.FindAllString(fix, -1)
+		for _, ref := range refs {
+			seen++
+			if err := resolveCommandRef(root, ref); err != nil {
+				t.Errorf("code %q advises %q, which does not resolve in the command tree: %v", code, ref, err)
+			}
+		}
+	}
+	// Positive control on the SCAN: if the regex stopped matching (a reworded
+	// fix line, a changed command spelling) every check above would silently
+	// become vacuous.
+	if seen < 5 {
+		t.Fatalf("the fix-line scan found only %d command references across the eight codes — "+
+			"the regex is not reading what it thinks it is, so the resolutions above prove nothing", seen)
+	}
+	t.Logf("resolved %d command references across %d codes", seen, len(allEightCodes()))
+}
+
+// TestDoctorMediaFixesCarryASlugFlagThatExists: the printed commands pass
+// `--slug`, which only works if those commands actually declare it. A fix that
+// names a real command with a flag it does not have is refused at exit 2.
+func TestDoctorMediaFixesCarryASlugFlagThatExists(t *testing.T) {
+	root := NewRootCmd()
+	for _, path := range [][]string{
+		{"app", "listing", "set-icon"},
+		{"app", "listing", "set-cover"},
+		{"app", "listing", "add-screenshot"},
+	} {
+		cmd, _, err := root.Find(path)
+		if err != nil || cmd.Name() != path[len(path)-1] {
+			t.Fatalf("%v does not resolve: %v", path, err)
+		}
+		if cmd.Flags().Lookup("slug") == nil {
+			t.Errorf("`civitai %s` has no --slug flag, but `app doctor` prints it", strings.Join(path, " "))
+		}
+	}
+	// Negative control on the flag lookup itself.
+	cmd, _, _ := root.Find([]string{"app", "listing", "set-icon"})
+	if cmd.Flags().Lookup("no-such-flag-here") != nil {
+		t.Fatal("negative control: the flag lookup returns something for a flag that does not exist")
+	}
+}
+
+// TestDoctorTextFixesPointAtTheListingEditorNotTheSlug pins the id space. The
+// editor page is keyed by appListingId; building the URL from the slug would
+// produce a well-formed URL that 404s, and nothing in the payload would look
+// wrong.
+func TestDoctorTextFixesPointAtTheListingEditorNotTheSlug(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("empty-description", "Missing description", "advisory"),
+		doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+		doctorProblem("empty-category", "Missing category", "advisory"),
+	))
+	base := envBaseURL(t)
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("advisory-only must exit 0: %v", err)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	wantURL := base + "/apps/listing/" + docListingA + "/edit"
+	for _, p := range got.Apps[0].Advisory {
+		if !strings.Contains(p.Fix, wantURL) {
+			t.Errorf("code %q fix = %q, want it to name %q", p.Code, p.Fix, wantURL)
+		}
+		// 🔴 The slug must NOT appear in the URL's position. docSlugA and
+		// docListingA share no substring, so this cannot pass by coincidence.
+		if strings.Contains(p.Fix, "/apps/listing/"+docSlugA+"/edit") {
+			t.Errorf("code %q built the editor URL from the SLUG, which 404s: %q", p.Code, p.Fix)
+		}
+	}
+}
+
+// TestDoctorScanningMediaOffersNoAction: the one code with no remedy says so
+// instead of naming a command that would restart the scan.
+func TestDoctorScanningMediaOffersNoAction(t *testing.T) {
+	fix := doctorRemedy(problemWithCode("scanning-media"), docSlugA, "https://example.invalid/x")
+	if !strings.Contains(fix, "nothing to do") {
+		t.Errorf("scanning-media must say there is nothing to do, got %q", fix)
+	}
+	for _, banned := range []string{"set-icon", "set-cover", "add-screenshot"} {
+		if strings.Contains(fix, banned) {
+			t.Errorf("scanning-media must not advise %q — re-attaching restarts the scan; got %q", banned, fix)
+		}
+	}
+}
+
+// TestDoctorUnknownCodeStillReportsAndStillCounts: a NINTH server code is a
+// server change, not a caller bug. It must still be printed, still be classified
+// by the server's own severity, and still move the verdict.
+func TestDoctorUnknownCodeStillReportsAndStillCounts(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("a-code-from-the-future", "Something new is wrong", "blocking"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err == nil {
+		t.Fatalf("an unknown BLOCKING code must still block; stdout:\n%s", stdout)
+	}
+	for _, want := range []string{"a-code-from-the-future", "Something new is wrong", "no CLI route for this problem yet"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("unknown code must still be reported with %q, got:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestDoctorUnknownSeverityIsNotBlocking: an unrecognised severity is grouped
+// with the advisories rather than failing every release.
+func TestDoctorUnknownSeverityIsNotBlocking(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "catastrophic"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err != nil {
+		t.Fatalf("an unrecognised severity must not block a release, got %v; stdout:\n%s", err, stdout)
+	}
+	// It is grouped, not hidden: the code and its verbatim severity still print.
+	if !strings.Contains(stdout, "missing-icon") {
+		t.Errorf("an unrecognised severity must still be reported, got:\n%s", stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Selection, and the empty case.
+// ---------------------------------------------------------------------------
+
+// TestDoctorSlugSelectsOneApp: the positional argument narrows to one row, and
+// the OTHER app must not appear.
+func TestDoctorSlugSelectsOneApp(t *testing.T) {
+	newDoctorServer(t,
+		doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+			doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")),
+		doctorRow(docSlugB, docListingB, "approved", "owner", ptr(docBlockA)),
+	)
+	stdout, _, err := run(t, "app", "doctor", docSlugB)
+	if err != nil {
+		t.Fatalf("the selected app is clean, so this must exit 0, got %v; stdout:\n%s", err, stdout)
+	}
+	if strings.Contains(stdout, docSlugA) || strings.Contains(stdout, "missing-icon") {
+		t.Errorf("selecting %q must not report %q, got:\n%s", docSlugB, docSlugA, stdout)
+	}
+	if !strings.Contains(stdout, docSlugB) {
+		t.Errorf("the selected app is missing from the report:\n%s", stdout)
+	}
+}
+
+// TestDoctorSlugSelectionNormalises: the slug is TYPED, so a padded or mis-cased
+// spelling reaches the filter routinely. It goes through appapi.SameSlug, the
+// shared predicate, not an exact compare.
+func TestDoctorSlugSelectionNormalises(t *testing.T) {
+	for _, typed := range []string{docSlugA, strings.ToUpper(docSlugA), "  " + docSlugA + "  "} {
+		t.Run(strings.TrimSpace(typed), func(t *testing.T) {
+			newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil))
+			stdout, _, err := run(t, "app", "doctor", typed)
+			if err != nil {
+				t.Fatalf("%q should resolve to %q, got %v; stdout:\n%s", typed, docSlugA, err, stdout)
+			}
+			if !strings.Contains(stdout, docSlugA) {
+				t.Errorf("%q did not select the app:\n%s", typed, stdout)
+			}
+		})
+	}
+}
+
+// TestDoctorUnknownSlugIsNotFoundNotAPass: "you own no app called that" and
+// "that app is fine" are opposite answers, and a release gate must not confuse
+// them. Exit 4, not 0.
+func TestDoctorUnknownSlugIsNotFoundNotAPass(t *testing.T) {
+	newDoctorServer(t,
+		doctorRow(docSlugA, docListingA, "draft", "owner", nil),
+		doctorRow(docSlugB, docListingB, "approved", "owner", ptr(docBlockA)),
+	)
+	stdout, _, err := run(t, "app", "doctor", "no-such-app-of-mine")
+	if err == nil {
+		t.Fatalf("an unknown slug must NOT read as a clean run; stdout:\n%s", stdout)
+	}
+	if !errors.Is(err, civitai.ErrNotFound) {
+		t.Errorf("an unknown slug must be ErrNotFound (exit 4), got %T: %v", err, err)
+	}
+	if errors.Is(err, ErrListingBlocked) {
+		t.Error("an unknown slug is not a blocking-problem verdict — the two exit codes mean different things")
+	}
+	// It names what the caller CAN work on, so the mistake is fixable from the
+	// message alone.
+	for _, want := range []string{docSlugA, docSlugB} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal must list the apps you can work on (missing %q): %v", want, err)
+		}
+	}
+}
+
+// TestDoctorNoListingsIsASentenceAndExitsZero: an empty result is a real answer.
+// A blank screen is indistinguishable from a read that failed.
+func TestDoctorNoListingsIsASentenceAndExitsZero(t *testing.T) {
+	newDoctorServer(t)
+	stdout, _, err := run(t, "app", "doctor")
+	if err != nil {
+		t.Fatalf("no listings must exit 0, got %v", err)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatal("an empty run printed NOTHING — that is indistinguishable from a swallowed read")
+	}
+	if !strings.Contains(stdout, "No App listings to check") {
+		t.Errorf("an empty run must say so, got:\n%s", stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The request ledger — the D3 measurement.
+// ---------------------------------------------------------------------------
+
+// TestDoctorIssuesExactlyOneRequestAndItIsListMine pins the whole request set.
+//
+// 🔴 THIS IS WHAT DECIDES WHETHER `doctor` TRIPS THE `getAssetScanStatuses`
+// OWNER FILTER. That proc filters `Image.userId = caller` for non-moderators, so
+// an asset attached by a COLLABORATOR, or one surviving an ownership transfer,
+// is silently omitted from its answer. `listMine`'s own scan batch
+// (`loadListingAssetScansBatch`) applies no such filter, so the DIAGNOSIS is
+// complete either way. The gap can only bite a command that goes on to ask
+// `getAssetScanStatuses` which asset row is blocked — and this ledger is the
+// proof that this command never does.
+//
+// A ledger rather than a "did not call X" check: a set assertion fails when the
+// set GROWS as well as when it shrinks, so a later change that adds a second
+// read has to come here and say so.
+func TestDoctorIssuesExactlyOneRequestAndItIsListMine(t *testing.T) {
+	srv := newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("blocked-media", "Replace the blocked icon before it can publish", "blocking"),
+	))
+	stdout, _, err := run(t, "app", "doctor")
+	if err == nil {
+		t.Fatalf("blocked-media is blocking; stdout:\n%s", stdout)
+	}
+	got := srv.seen()
+	// Positive control: a zero-length ledger would make the assertion below
+	// pass for a command that made no request at all.
+	if len(got) == 0 {
+		t.Fatal("the request ledger is EMPTY — the command made no request, so this test measures nothing")
+	}
+	if len(got) != 1 || got[0] != listMinePath {
+		t.Errorf("`app doctor` issued %v.\nIt must issue EXACTLY [%s]. If a second read was added deliberately, "+
+			"re-derive the getAssetScanStatuses owner-filter argument in this test's doc comment before widening it.",
+			got, listMinePath)
+	}
+	// And the finding is still complete: the SERVER's label names the slot, so
+	// the CLI never needed the per-asset read to be actionable.
+	if !strings.Contains(stdout, "Replace the blocked icon") {
+		t.Errorf("the blocked-media label (which is where the asset KIND lives) must survive into the report:\n%s", stdout)
+	}
+}
+
+// TestDoctorSendsNoInputParameter: `appListings.listMine` declares no input
+// schema, so the CLI sends no `?input=`. Pinned because the alternative
+// (`?input={"json":null}`) is a value the server never has to accept, and the
+// difference is invisible in every other test.
+func TestDoctorSendsNoInputParameter(t *testing.T) {
+	var raw string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw = r.URL.RawQuery
+		trpcData(w, []map[string]any{})
+	}))
+	defer srv.Close()
+	listingEnv(t, srv.URL)
+	if _, _, err := run(t, "app", "doctor"); err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if raw != "" {
+		t.Errorf("listMine was sent with a query string %q — it takes no input, so none should be sent", raw)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Help.
+// ---------------------------------------------------------------------------
+
+// TestDoctorHelpDocumentsTheExitCodes: the exit code is the command's product,
+// and `--help` is the contract a reader has offline.
+func TestDoctorHelpDocumentsTheExitCodes(t *testing.T) {
+	out, _, err := run(t, "app", "doctor", "--help")
+	if err != nil {
+		t.Fatalf("app doctor --help: %v", err)
+	}
+	for _, want := range []string{"EXIT CODES", "1 when ANY blocking problem", "0 otherwise"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`app doctor --help` must document the exit codes (missing %q):\n%s", want, out)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// doctorPayloadShape mirrors what `--json` emits. Hand-written rather than
+// reusing the production type: a test that unmarshals into the very struct it
+// is checking agrees with any renaming of a field.
+type doctorPayloadShape struct {
+	OK   bool `json:"ok"`
+	Apps []struct {
+		Slug         string  `json:"slug"`
+		Name         string  `json:"name"`
+		AppListingID string  `json:"appListingId"`
+		AppBlockID   *string `json:"appBlockId"`
+		Status       string  `json:"status"`
+		Role         string  `json:"role"`
+		Blocking     []struct {
+			Code     string `json:"code"`
+			Label    string `json:"label"`
+			Severity string `json:"severity"`
+			Fix      string `json:"fix"`
+		} `json:"blocking"`
+		Advisory []struct {
+			Code     string `json:"code"`
+			Label    string `json:"label"`
+			Severity string `json:"severity"`
+			Fix      string `json:"fix"`
+		} `json:"advisory"`
+	} `json:"apps"`
+	Summary struct {
+		Apps     int `json:"apps"`
+		Blocking int `json:"blocking"`
+		Advisory int `json:"advisory"`
+	} `json:"summary"`
+}
+
+func decodeDoctorJSON(t *testing.T, stdout string) doctorPayloadShape {
+	t.Helper()
+	var got doctorPayloadShape
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("stdout is not the doctor payload (%v); stdout was:\n%s", err, stdout)
+	}
+	return got
+}
+
+// codesOf works over either problem array (they are structurally identical but
+// are distinct anonymous types, so this takes the codes via a tiny interface of
+// its own rather than a shared type).
+func codesOf[T any](rows []T) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		b, _ := json.Marshal(r)
+		var v struct {
+			Code string `json:"code"`
+		}
+		_ = json.Unmarshal(b, &v)
+		out = append(out, v.Code)
+	}
+	return out
+}
+
+// allEightCodes is the code vocabulary, spelled out here rather than read from
+// app_doctor.go's constants: a table derived from the thing it checks agrees
+// with any change to it.
+func allEightCodes() []string {
+	return []string{
+		"missing-icon", "missing-cover", "no-screenshots",
+		"empty-description", "empty-tagline", "empty-category",
+		"blocked-media", "scanning-media",
+	}
+}
+
+// problemWithCode builds the minimal problem doctorRemedy reads: only the code
+// selects a remedy, so the label and severity are deliberately left empty —
+// a remedy that needed either would fail loudly here rather than quietly work.
+func problemWithCode(code string) appapi.ListingProblem {
+	return appapi.ListingProblem{Code: code}
+}
+
+// resolveCommandRef checks that a `civitai …` string names a real command, with
+// no leftover arguments.
+func resolveCommandRef(root *cobra.Command, ref string) error {
+	parts := strings.Fields(ref)
+	if len(parts) < 2 || parts[0] != "civitai" {
+		return fmt.Errorf("%q is not a civitai command reference", ref)
+	}
+	args := parts[1:]
+	cmd, rest, err := root.Find(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("%q leaves unresolved arguments %v", ref, rest)
+	}
+	if cmd.Name() != args[len(args)-1] {
+		return fmt.Errorf("%q resolved to %q, not to the command it names", ref, cmd.Name())
+	}
+	return nil
+}
+
+// envBaseURL is the base URL the current test env points the CLI at — the same
+// value the editor URL is built from.
+func envBaseURL(t *testing.T) string {
+	t.Helper()
+	v := os.Getenv("CIVITAI_BASE_URL")
+	if v == "" {
+		t.Fatal("CIVITAI_BASE_URL is unset — listingEnv did not run, so the URL assertions below would compare against nothing")
+	}
+	return strings.TrimRight(v, "/")
+}

--- a/internal/cmd/app_doctor_test.go
+++ b/internal/cmd/app_doctor_test.go
@@ -334,6 +334,7 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "appBlockId": null,
       "status": "draft",
       "role": "owner",
+      "kind": "offsite",
       "delisted": false,
       "blocking": [
         {
@@ -359,6 +360,7 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "appBlockId": "` + docBlockA + `",
       "status": "approved",
       "role": "editor",
+      "kind": "offsite",
       "delisted": false,
       "blocking": [],
       "advisory": []
@@ -370,6 +372,7 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
       "appBlockId": null,
       "status": "removed",
       "role": "owner",
+      "kind": "offsite",
       "delisted": true,
       "blocking": [
         {
@@ -387,7 +390,8 @@ func TestDoctorJSONShapeIsPinnedWhole(t *testing.T) {
     "blocking": 2,
     "advisory": 1,
     "gating": 1,
-    "delisted": 1
+    "delisted": 1,
+    "truncated": false
   }
 }
 `
@@ -471,7 +475,11 @@ func TestDoctorFixAdviceNamesOnlyCommandsThatExist(t *testing.T) {
 	// Positive control on the SCAN: if the regex stopped matching (a reworded
 	// fix line, a changed command spelling) every check above would silently
 	// become vacuous.
-	if seen < 5 {
+	// 🔴 THE FLOOR IS THE REAL COUNT, NOT A SAFE-LOOKING SMALLER ONE. At 5
+	// against 7 actual references the `blocked-media` arm could lose two
+	// commands and this control would still pass — a positive control with two
+	// references of slack is a control for a scan that has half stopped working.
+	if seen < 7 {
 		t.Fatalf("the fix-line scan found only %d command references across the eight codes — "+
 			"the regex is not reading what it thinks it is, so the resolutions above prove nothing", seen)
 	}
@@ -776,6 +784,7 @@ type doctorPayloadShape struct {
 		AppBlockID   *string `json:"appBlockId"`
 		Status       string  `json:"status"`
 		Role         string  `json:"role"`
+		Kind         string  `json:"kind"`
 		Delisted     bool    `json:"delisted"`
 		Blocking     []struct {
 			Code     string `json:"code"`
@@ -791,11 +800,12 @@ type doctorPayloadShape struct {
 		} `json:"advisory"`
 	} `json:"apps"`
 	Summary struct {
-		Apps     int `json:"apps"`
-		Blocking int `json:"blocking"`
-		Advisory int `json:"advisory"`
-		Gating   int `json:"gating"`
-		Delisted int `json:"delisted"`
+		Apps      int  `json:"apps"`
+		Blocking  int  `json:"blocking"`
+		Advisory  int  `json:"advisory"`
+		Gating    int  `json:"gating"`
+		Delisted  int  `json:"delisted"`
+		Truncated bool `json:"truncated"`
 	} `json:"summary"`
 }
 
@@ -1233,5 +1243,198 @@ func TestDoctorKindMatchIsNormalised(t *testing.T) {
 				t.Errorf("kind %q must read as onsite, got fix %q", spelling, fix)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// blocked-media: the three slots do NOT share a remedy.
+// ---------------------------------------------------------------------------
+
+// TestBlockedMediaRemedyIsSufficientPerSlot is the correctness fix, and the
+// reason the previous guard could not catch it is worth stating:
+// TestDoctorFixAdviceNamesOnlyCommandsThatExist asserts the named commands
+// RESOLVE IN THE COBRA TREE. Resolving is not sufficiency. `add-screenshot` is a
+// real command that does not fix a blocked screenshot.
+//
+// 🔴 `add-screenshot` APPENDS. `assertAssetsScanClean`
+// (`<civitai>/src/server/services/blocks/app-listing-assets.service.ts:857-894`)
+// refuses go-live while ANY attached screenshot is Blocked, so adding a second
+// image leaves the listing exactly as blocked and the author out of ideas. Only
+// `rm-screenshot` clears it — and its `alsc_` id is not in `listMine`, so the
+// read that prints it has to be named too.
+func TestBlockedMediaRemedyIsSufficientPerSlot(t *testing.T) {
+	cases := []struct {
+		label      string
+		mustSay    []string
+		mustNotSay []string
+	}{
+		{
+			// set-icon OVERWRITES the slot, dereferencing the blocked Image.
+			label:      "Replace the blocked icon before it can publish",
+			mustSay:    []string{"set-icon"},
+			mustNotSay: []string{"add-screenshot", "rm-screenshot", "set-cover"},
+		},
+		{
+			label:      "Replace the blocked cover before it can publish",
+			mustSay:    []string{"set-cover"},
+			mustNotSay: []string{"add-screenshot", "rm-screenshot", "set-icon"},
+		},
+		{
+			// 🔴 The whole finding: REMOVE, and name the read that shows the id.
+			label:      "Replace the blocked screenshot before it can publish",
+			mustSay:    []string{"rm-screenshot", "civitai app listing status"},
+			mustNotSay: []string{"add-screenshot"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			fix := doctorRemedy(
+				appapi.ListingProblem{Code: "blocked-media", Label: tc.label, Severity: "blocking"},
+				docSlugA, "https://example.invalid/x", "offsite")
+			for _, w := range tc.mustSay {
+				if !strings.Contains(fix, w) {
+					t.Errorf("missing %q in: %s", w, fix)
+				}
+			}
+			for _, w := range tc.mustNotSay {
+				if strings.Contains(fix, w) {
+					t.Errorf("must not advise %q — it does not clear this slot: %s", w, fix)
+				}
+			}
+		})
+	}
+}
+
+// TestBlockedMediaUnknownLabelKeepsTheRemoval: a re-worded label must degrade to
+// an arm that is still SUFFICIENT. Losing precision is acceptable; losing the
+// removal is the defect returning.
+func TestBlockedMediaUnknownLabelKeepsTheRemoval(t *testing.T) {
+	fix := doctorRemedy(
+		appapi.ListingProblem{Code: "blocked-media", Label: "this asset was rejected by the scanner", Severity: "blocking"},
+		docSlugA, "https://example.invalid/x", "offsite")
+	if !strings.Contains(fix, "rm-screenshot") {
+		t.Errorf("the fallback arm must still name the REMOVAL, or a blocked screenshot is unfixable: %s", fix)
+	}
+	if strings.Contains(fix, "add-screenshot") {
+		t.Errorf("the fallback must not advise appending, which never clears a blocked row: %s", fix)
+	}
+}
+
+// TestBlockedMediaKindExtractionIsWordBased, with a negative control so the
+// helper is not merely returning the first thing it sees.
+func TestBlockedMediaKindExtractionIsWordBased(t *testing.T) {
+	for label, want := range map[string]string{
+		"Replace the blocked icon before it can publish":       "icon",
+		"Replace the blocked COVER before it can publish":      "cover",
+		"replace the blocked Screenshot before it can publish": "screenshot",
+		"something else entirely":                              "",
+	} {
+		if got := blockedMediaKind(label); got != want {
+			t.Errorf("blockedMediaKind(%q) = %q, want %q", label, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// severity normalisation, and the page cap.
+// ---------------------------------------------------------------------------
+
+// TestDoctorSeverityIsNormalised: a cased severity must not silently become an
+// advisory. Latent today (the server's union is lowercase), and fixed because
+// unknown STATUS gated loudly while unknown SEVERITY failed quietly.
+func TestDoctorSeverityIsNormalised(t *testing.T) {
+	for _, spelling := range []string{"blocking", "BLOCKING", "Blocking", " blocking "} {
+		t.Run(strings.TrimSpace(spelling), func(t *testing.T) {
+			newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+				doctorProblem("missing-icon", "Missing icon (required before publishing)", spelling)))
+			stdout, _, err := run(t, "app", "doctor", "--json")
+			if err == nil {
+				t.Fatalf("severity %q must gate; stdout:\n%s", spelling, stdout)
+			}
+			got := decodeDoctorJSON(t, stdout)
+			if len(got.Apps[0].Blocking) != 1 || got.Summary.Gating != 1 || got.OK {
+				t.Errorf("severity %q filed wrong: blocking=%d gating=%d ok=%v — a payload that files a "+
+					"'blocking' finding under advisory[] while echoing its severity is a contradiction the CLI made",
+					spelling, len(got.Apps[0].Blocking), got.Summary.Gating, got.OK)
+			}
+		})
+	}
+	// POSITIVE CONTROL: an unrecognised WORD is still advisory. Normalisation
+	// makes casing safe; it cannot make a new vocabulary word meaningful.
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("missing-icon", "Missing icon", "catastrophic")))
+	if _, _, err := run(t, "app", "doctor"); err != nil {
+		t.Fatalf("control: an unrecognised severity word must NOT gate, got %v", err)
+	}
+}
+
+// TestDoctorReportsTruncationAtThePageCap.
+//
+// 🔴 `ok: true` OTHERWISE MEANS "NOTHING BLOCKING IN WHAT I COULD SEE" AND SAYS
+// "NOTHING BLOCKING". `listMine` clamps to appapi.ListMineCap, orders
+// `serialId desc`, and offers no cursor and no total — so past the cap the
+// OLDEST listings vanish silently and `doctor || exit 1` passes for a listing
+// that cannot publish. This is the same failure `submissionsListTruncated`
+// exists for on the sibling read.
+func TestDoctorReportsTruncationAtThePageCap(t *testing.T) {
+	rows := make([]map[string]any, 0, appapi.ListMineCap)
+	for i := 0; i < appapi.ListMineCap; i++ {
+		rows = append(rows, doctorRow(fmt.Sprintf("bulk-app-%03d", i), fmt.Sprintf("apl_BULK%03d", i),
+			"approved", "owner", nil))
+	}
+	newDoctorServer(t, rows...)
+	stdout, stderr, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("all clean, so exit 0: %v", err)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	if !got.Summary.Truncated {
+		t.Errorf("a full-length page must set summary.truncated — `ok:true` on a truncated read is " +
+			"indistinguishable from `ok:true` on a complete one")
+	}
+	for _, want := range []string{"caps this read", "were NOT checked", "would not change the exit code"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("the caveat must reach stderr (missing %q):\n%s", want, stderr)
+		}
+	}
+	// STDERR only — `--json` stdout stays a pure payload.
+	if strings.Contains(stdout, "caps this read") {
+		t.Errorf("the caveat leaked into --json stdout")
+	}
+}
+
+// TestDoctorDoesNotCryTruncationBelowTheCap is the negative control: a caveat
+// that always prints is one nobody reads.
+func TestDoctorDoesNotCryTruncationBelowTheCap(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "approved", "owner", nil))
+	stdout, stderr, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if decodeDoctorJSON(t, stdout).Summary.Truncated {
+		t.Error("one listing is not a truncated page")
+	}
+	if strings.Contains(stderr, "caps this read") {
+		t.Errorf("the cap caveat must not print below the cap:\n%s", stderr)
+	}
+}
+
+// TestDoctorVerdictDoesNotReadAsAToolFailure: cobra prefixes a returned error
+// with "Error: ", so a successful diagnosis of an incomplete listing printed
+// `Error: the listing has blocking problems` — and a CI scraper watching stderr
+// for `Error:` flags a run that worked exactly as designed.
+func TestDoctorVerdictDoesNotReadAsAToolFailure(t *testing.T) {
+	newDoctorServer(t, doctorRow(docSlugA, docListingA, "draft", "owner", nil,
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking")))
+	_, _, err := run(t, "app", "doctor")
+	if err == nil {
+		t.Fatal("expected the blocking verdict")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not ready to publish") {
+		t.Errorf("the verdict should describe the LISTING, got: %v", err)
+	}
+	if !strings.Contains(msg, "not a failure of the command") {
+		t.Errorf("the verdict should say it is a finding, not a tool failure, got: %v", err)
 	}
 }

--- a/internal/cmd/app_doctor_test.go
+++ b/internal/cmd/app_doctor_test.go
@@ -61,11 +61,17 @@ func doctorRow(slug, listingID, status, role string, blockID *string, problems .
 	return map[string]any{
 		"appListingId": listingID,
 		"slug":         slug,
-		"name":         strings.ToUpper(slug[:1]) + slug[1:] + " Display Name",
-		"status":       status,
-		"role":         role,
-		"appBlockId":   blockID,
-		"problems":     problems,
+		// 🔴 EVERY FIXTURE ROW CARRIES A KIND, because the real server always
+		// sends one and a fake that omits it would encode the same blind spot
+		// the code had. `offsite` is the default here so the existing
+		// browser-editor assertions keep testing the arm they were written for;
+		// the onsite arm has its own dedicated cases.
+		"kind":       "offsite",
+		"name":       strings.ToUpper(slug[:1]) + slug[1:] + " Display Name",
+		"status":     status,
+		"role":       role,
+		"appBlockId": blockID,
+		"problems":   problems,
 	}
 }
 
@@ -449,7 +455,7 @@ func TestDoctorFixAdviceNamesOnlyCommandsThatExist(t *testing.T) {
 	editURL := base + fmt.Sprintf(listingEditPath, docListingA)
 	seen := 0
 	for _, code := range allEightCodes() {
-		fix := doctorRemedy(problemWithCode(code), docSlugA, editURL)
+		fix := doctorRemedy(problemWithCode(code), docSlugA, editURL, "offsite")
 		if fix == "" {
 			t.Errorf("code %q produced an EMPTY fix line — every finding must say what to do", code)
 			continue
@@ -529,7 +535,7 @@ func TestDoctorTextFixesPointAtTheListingEditorNotTheSlug(t *testing.T) {
 // TestDoctorScanningMediaOffersNoAction: the one code with no remedy says so
 // instead of naming a command that would restart the scan.
 func TestDoctorScanningMediaOffersNoAction(t *testing.T) {
-	fix := doctorRemedy(problemWithCode("scanning-media"), docSlugA, "https://example.invalid/x")
+	fix := doctorRemedy(problemWithCode("scanning-media"), docSlugA, "https://example.invalid/x", "offsite")
 	if !strings.Contains(fix, "nothing to do") {
 		t.Errorf("scanning-media must say there is nothing to do, got %q", fix)
 	}
@@ -1078,5 +1084,154 @@ func TestDoctorHelpDocumentsTheDelistedRule(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("`app doctor --help` must document the delisted rule (missing %q):\n%s", want, out)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The three TEXT codes are KIND-AWARE. An onsite app's copy is manifest-governed.
+// ---------------------------------------------------------------------------
+
+// textCodes are the three problems whose fix route depends on the listing kind.
+func textCodes() []map[string]any {
+	return []map[string]any{
+		doctorProblem("empty-description", "Missing description", "advisory"),
+		doctorProblem("empty-tagline", "Missing tagline", "advisory"),
+		doctorProblem("empty-category", "Missing category", "advisory"),
+	}
+}
+
+// doctorRowKind is doctorRow with the listing KIND under the caller's control.
+func doctorRowKind(slug, listingID, status, kind string, problems ...map[string]any) map[string]any {
+	r := doctorRow(slug, listingID, status, "owner", nil, problems...)
+	r["kind"] = kind
+	return r
+}
+
+// TestDoctorOnsiteTextRemedyNamesTheManifest is the correctness fix.
+//
+// 🔴 THE BROWSER-EDITOR ADVICE IS WRONG FOR AN ONSITE APP, and wrong in the
+// silent direction. `(3b-sync)` in
+// `<civitai>/src/server/services/blocks/publish-request.service.ts:2742-2800`
+// overwrites name/tagline/description/category from the manifest on EVERY
+// subsequent-version moderator approve, scoped `kind: 'onsite'` — its own
+// comment says these fields "have NO author surface other than the manifest".
+// So an onsite author who followed the old advice made an edit the platform
+// reverted at the next approve, and `doctor` reported the same problem again
+// with nothing explaining why.
+func TestDoctorOnsiteTextRemedyNamesTheManifest(t *testing.T) {
+	newDoctorServer(t, doctorRowKind(docSlugA, docListingA, "approved", "onsite", textCodes()...))
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("advisory-only must exit 0: %v", err)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	if len(got.Apps) != 1 || len(got.Apps[0].Advisory) != 3 {
+		t.Fatalf("want 1 app with 3 advisories, got %+v", got.Apps)
+	}
+	for _, p := range got.Apps[0].Advisory {
+		if !strings.Contains(p.Fix, "block.manifest.json") {
+			t.Errorf("onsite %q must be fixed in the manifest, got %q", p.Code, p.Fix)
+		}
+		if !strings.Contains(p.Fix, "civitai app submit") {
+			t.Errorf("onsite %q must name the resubmit step, got %q", p.Code, p.Fix)
+		}
+		// 🔴 THE WRONG ROUTE MUST BE ABSENT, not merely outranked. A fix line
+		// that names BOTH still sends the author to the browser.
+		if strings.Contains(p.Fix, "/apps/listing/") {
+			t.Errorf("onsite %q still points at the browser editor, whose edit `(3b-sync)` reverts: %q", p.Code, p.Fix)
+		}
+	}
+}
+
+// TestDoctorOffsiteTextRemedyStillPointsAtTheEditor is the other arm, and
+// without it the test above is equally true of a build that names the manifest
+// for everyone — which would be wrong: an off-site listing's copy is
+// AUTHOR-supplied through the submit wizard, not manifest-governed, and such an
+// app has no block.manifest.json at all.
+func TestDoctorOffsiteTextRemedyStillPointsAtTheEditor(t *testing.T) {
+	newDoctorServer(t, doctorRowKind(docSlugB, docListingB, "approved", "offsite", textCodes()...))
+	base := envBaseURL(t)
+	stdout, _, err := run(t, "app", "doctor", "--json")
+	if err != nil {
+		t.Fatalf("advisory-only must exit 0: %v", err)
+	}
+	got := decodeDoctorJSON(t, stdout)
+	for _, p := range got.Apps[0].Advisory {
+		if !strings.Contains(p.Fix, base+"/apps/listing/"+docListingB+"/edit") {
+			t.Errorf("offsite %q must point at the listing editor, got %q", p.Code, p.Fix)
+		}
+		if strings.Contains(p.Fix, "block.manifest.json") {
+			t.Errorf("offsite %q names a manifest an off-site app does not have: %q", p.Code, p.Fix)
+		}
+	}
+}
+
+// TestDoctorMediaRemediesAreKindIndependent: only the THREE TEXT codes branch.
+// The media procs are listing-keyed and seat-aware and work for both kinds, so
+// a kind gate on them would refuse a route that works.
+func TestDoctorMediaRemediesAreKindIndependent(t *testing.T) {
+	media := []map[string]any{
+		doctorProblem("missing-icon", "Missing icon (required before publishing)", "blocking"),
+		doctorProblem("no-screenshots", "No screenshots (recommended, optional)", "advisory"),
+	}
+	fixes := map[string][]string{}
+	for _, kind := range []string{"onsite", "offsite"} {
+		newDoctorServer(t, doctorRowKind(docSlugA, docListingA, "draft", kind, media...))
+		stdout, _, _ := run(t, "app", "doctor", "--json")
+		got := decodeDoctorJSON(t, stdout)
+		for _, p := range append(got.Apps[0].Blocking, got.Apps[0].Advisory...) {
+			fixes[kind] = append(fixes[kind], p.Code+"="+p.Fix)
+		}
+	}
+	if !equalStrings(fixes["onsite"], fixes["offsite"]) {
+		t.Errorf("media remedies differ by kind, but the asset procs work for both:\n onsite=%v\noffsite=%v",
+			fixes["onsite"], fixes["offsite"])
+	}
+	// Positive control: the comparison saw a non-empty population.
+	if len(fixes["onsite"]) != 2 {
+		t.Fatalf("collected %d media remedies, want 2 — the comparison above is vacuous", len(fixes["onsite"]))
+	}
+}
+
+// TestDoctorUnknownKindTakesTheRecoverableArm: an absent or unrecognised kind
+// must NOT take the manifest arm. Naming a manifest an app may not have is
+// confusing but self-correcting; the reverse — sending an onsite author to the
+// browser — is the silent failure this fix exists to remove, so the DEFAULT is
+// the recoverable mistake.
+func TestDoctorUnknownKindTakesTheRecoverableArm(t *testing.T) {
+	for _, kind := range []string{"", "a-kind-from-the-future"} {
+		t.Run("kind="+kind, func(t *testing.T) {
+			newDoctorServer(t, doctorRowKind(docSlugA, docListingA, "draft", kind,
+				doctorProblem("empty-tagline", "Missing tagline", "advisory")))
+			stdout, _, _ := run(t, "app", "doctor", "--json")
+			got := decodeDoctorJSON(t, stdout)
+			fix := got.Apps[0].Advisory[0].Fix
+			if strings.Contains(fix, "block.manifest.json") {
+				t.Errorf("kind %q must not take the manifest arm: %q", kind, fix)
+			}
+		})
+	}
+	// POSITIVE CONTROL: `onsite` really does take it, or the negatives above are
+	// a fact about a predicate that never returns true.
+	newDoctorServer(t, doctorRowKind(docSlugA, docListingA, "draft", "onsite",
+		doctorProblem("empty-tagline", "Missing tagline", "advisory")))
+	stdout, _, _ := run(t, "app", "doctor", "--json")
+	if fix := decodeDoctorJSON(t, stdout).Apps[0].Advisory[0].Fix; !strings.Contains(fix, "block.manifest.json") {
+		t.Fatalf("control: `onsite` did not take the manifest arm (%q) — the negatives prove nothing", fix)
+	}
+}
+
+// TestDoctorKindMatchIsNormalised: `kind` is a server string the CLI compares,
+// and a spelling change must not silently re-route the advice.
+func TestDoctorKindMatchIsNormalised(t *testing.T) {
+	for _, spelling := range []string{"onsite", "ONSITE", "Onsite", " onsite "} {
+		t.Run(strings.TrimSpace(spelling), func(t *testing.T) {
+			newDoctorServer(t, doctorRowKind(docSlugA, docListingA, "draft", spelling,
+				doctorProblem("empty-category", "Missing category", "advisory")))
+			stdout, _, _ := run(t, "app", "doctor", "--json")
+			if fix := decodeDoctorJSON(t, stdout).Apps[0].Advisory[0].Fix; !strings.Contains(fix, "block.manifest.json") {
+				t.Errorf("kind %q must read as onsite, got fix %q", spelling, fix)
+			}
+		})
 	}
 }

--- a/internal/cmd/app_metrics.go
+++ b/internal/cmd/app_metrics.go
@@ -29,18 +29,34 @@ const wireTimeLayout = "2006-01-02T15:04:05.000Z"
 // regardless of where they run the CLI.
 const dateOnlyLayout = "2006-01-02"
 
-// appMetricsCredentialRoute names the ONE credential that works for this
-// command, and it is deliberately NOT login.go's spendCredentialRoutes.
+// appMetricsCredentialRoute names the credentials that work for this command,
+// and it is deliberately NOT login.go's spendCredentialRoutes.
 //
-// 🔴 That constant names BOTH routes because generation accepts either. The
-// analytics proc does not: it is full-scope, so an OAuth browser login is
-// refused with 403 (see the Long text, and item 5 in AGENTS.md). Until issue
-// #260 the no-token error here was the generic "run `civitai login`" — which is
-// the ONE route this command cannot use, so following the CLI's own advice
-// landed the author on a second refusal. `generate` and `workflows` already name
-// their working routes; this mirrors that shape for the route that works here.
-const appMetricsCredentialRoute = "a full-scope personal API key " +
-	"(`civitai login --token <key>`, created at " + accountAPIKeysURL + ")"
+// 🔴 CORRECTED — THE OAuth BROWSER LOGIN WORKS, AND THIS CONSTANT SAID FOR A
+// YEAR THAT IT DID NOT. The claim was true when issue #260 wrote it: the
+// analytics proc carried no `.meta`, and `enforceTokenScope` defaults an
+// un-annotated proc to `TokenScope.Full`, which the scoped `civitai login` token
+// is not — so it 403'd. `civitai/civitai#3572` (`7c529f1eea`) annotated it
+// `requiredScope: TokenScope.AppBlocksSubmit` precisely so the CLI's login token
+// could read its own analytics, and the `civitai-cli` OAuth client's
+// `allowedScopes` carries that bit. Re-verified against civitai/civitai
+// `origin/main` at `src/server/routers/blocks.router.ts:5483`.
+//
+// So the CLI was telling authors to go mint a personal API key to run a command
+// their existing browser login could already run — and doing it in three places
+// (this constant, `--help`, and the no-token error). What survives from #260 is
+// the SHAPE of the fix, not its content: name the routes that work, from ONE
+// constant, so the branches cannot drift apart again.
+//
+// 🔴 It is still not spendCredentialRoutes. That constant offers `civitai login
+// --scopes generate`, which opts into the AI-Services bits and says nothing
+// about the Apps submit bit this proc requires — naming it here would walk an
+// author into a second refusal, which is the defect #260 was filed for.
+//
+// The scope is the SAME bit `civitai app submit` and `civitai app status`
+// require, which is why one login serves all three.
+const appMetricsCredentialRoute = "an OAuth login (`civitai login`) carrying the Apps submit scope, " +
+	"or a full-scope personal API key (`civitai login --token <key>`, created at " + accountAPIKeysURL + ")"
 
 // appMetricsDeps are the two network seams `app metrics` needs: slug →
 // appBlockId resolution (the existing submissions route) and the analytics query
@@ -71,8 +87,11 @@ command therefore always prints the window the SERVER served (echoed from the
 response), not the one you asked for. Pass --from / --to as a plain YYYY-MM-DD
 date (midnight UTC) or a full RFC3339 timestamp to widen it.
 
-CREDENTIAL: the analytics query is full-scope, so it needs ` + appMetricsCredentialRoute + `;
-an OAuth browser login is refused with 403.
+CREDENTIAL: the analytics query needs the Apps submit scope — the same bit
+` + "`civitai app submit`" + ` and ` + "`civitai app status`" + ` require — so it accepts
+` + appMetricsCredentialRoute + `. An OAuth
+token minted before that scope existed does not carry it and is refused with
+403; re-run ` + "`civitai login`" + ` to mint one that does.
 
 DATA CAVEAT: engagement counts only AUTHENTICATED, scope-gated API calls. An app
 that ships no scoped API surface will show real installs and revenue with a flat
@@ -107,11 +126,12 @@ engagement section — that is expected, not a bug.`,
 				return err
 			}
 			if cfg.Token() == "" {
-				// Name the route that WORKS, not the generic one: an OAuth
-				// browser login is refused here with 403 (see
-				// appMetricsCredentialRoute).
+				// Name the routes that WORK, from the one constant. Both do —
+				// see appMetricsCredentialRoute for why the "an OAuth login is
+				// refused with 403" claim this branch used to make was true when
+				// it was written and has not been since civitai/civitai#3572.
 				return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf(
-					"no token configured — app analytics need %s; a browser login (`civitai login`) is full-scope-refused with 403 here. Or set CIVITAI_TOKEN to that key",
+					"no token configured — app analytics need %s. Or set CIVITAI_TOKEN to either one",
 					appMetricsCredentialRoute))
 			}
 

--- a/internal/cmd/app_metrics_credential_test.go
+++ b/internal/cmd/app_metrics_credential_test.go
@@ -11,11 +11,25 @@ import (
 // TestAppMetricsNoTokenNamesTheRouteThatWorks is the issue-#260 guard.
 //
 // The no-token branch used to return the house-standard "run `civitai login`"
-// — which is the ONE credential this command cannot use. The analytics proc is
-// full-scope, so an OAuth browser login is refused with 403 (item 5 in
-// AGENTS.md, and TestAppMetricsForbiddenAsksForPersonalAPIKey pins that half).
-// Following the CLI's own advice therefore landed an author on a SECOND
-// refusal.
+// with no further detail. Following the CLI's own advice therefore landed an
+// author on a SECOND refusal, because the analytics proc carried no `.meta` and
+// an un-annotated proc implicitly requires `TokenScope.Full`, which the scoped
+// `civitai login` token is not.
+//
+// 🔴 THAT SECOND SENTENCE IS NO LONGER TRUE, and this test used to assert it.
+// `civitai/civitai#3572` (`7c529f1eea`) annotated the proc
+// `requiredScope: TokenScope.AppBlocksSubmit` so the CLI's login token could
+// read its own analytics — verified against civitai/civitai `origin/main` at
+// `src/server/routers/blocks.router.ts:5483`. The assertion that the message
+// must contain "403" is therefore GONE from this test rather than merely
+// unsatisfied: it was pinning a claim about the server that had been false for
+// months, which is the shape a docs guard rots into.
+//
+// What the test still pins is the SHAPE of #260's fix, which is what was
+// actually valuable: name the routes that WORK, name where to get one, and do
+// it from one constant so the branches cannot drift apart again. It now demands
+// BOTH routes, because both work and a message naming only one sends an author
+// to mint a key they do not need.
 //
 // The exit code is pinned with errors.Is and never from the text (AGENTS item
 // 7): stripping the ErrUnauthorized tag leaves every character of this message
@@ -41,36 +55,47 @@ func TestAppMetricsNoTokenNamesTheRouteThatWorks(t *testing.T) {
 		"no token configured",
 		"personal API key",
 		"civitai login --token <key>",
-		accountAPIKeysURL, // where to actually mint one
+		accountAPIKeysURL,   // where to actually mint one
+		"Apps submit scope", // the bit that decides it
+		"(`civitai login`)", // the OAuth route, which DOES work
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("the no-token error must name %q so the advice is followable, got: %v", want, err)
 		}
 	}
 
-	// And it must SAY that the obvious route is refused — otherwise a reader who
-	// already has a browser login has no reason to mint a key.
-	if !strings.Contains(msg, "403") {
-		t.Errorf("the no-token error should say a browser login is refused with 403, got: %v", err)
+	// 🔴 And it must NOT tell the reader the browser login is refused. That
+	// sentence stood here for months after the server stopped refusing it, and a
+	// reader who already had a login was sent to mint a key for nothing. Kept as
+	// a PROHIBITION rather than deleted with the claim, so it cannot drift back.
+	for _, banned := range []string{"refused with 403", "full-scope-refused"} {
+		if strings.Contains(msg, banned) {
+			t.Errorf("the no-token error still claims an OAuth login is refused (%q) — "+
+				"civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: %v", banned, err)
+		}
 	}
 }
 
 // TestAppMetricsCredentialRouteIsNotTheSpendRoute is the discriminating check.
 //
 // login.go's spendCredentialRoutes names BOTH credentials because `generate`
-// accepts either, and it is the obvious constant to reach for here. It is the
-// WRONG one: `civitai login --scopes generate` does not make an OAuth token
-// full-scope, so offering it would be the same "walk them into a second
-// refusal" defect in a new spelling. Every message assertion above stays green
-// under that substitution, so the divergence is asserted directly.
+// accepts either, and it is the obvious constant to reach for here — more so now
+// that this command accepts both too. It is still the WRONG one, and the reason
+// SURVIVED the #3572 correction above while its old phrasing did not: that
+// constant offers `civitai login --scopes generate`, which opts a token into the
+// AI-Services (Buzz-spend) bits and says NOTHING about the Apps submit bit this
+// proc requires. Offering it would be the same "walk them into a second refusal"
+// defect in a new spelling. Every message assertion above stays green under that
+// substitution — both constants name a personal API key and the account URL — so
+// the divergence is asserted directly.
 func TestAppMetricsCredentialRouteIsNotTheSpendRoute(t *testing.T) {
 	if appMetricsCredentialRoute == spendCredentialRoutes {
 		t.Fatal("appMetricsCredentialRoute has been collapsed into spendCredentialRoutes — " +
-			"the analytics proc is full-scope and refuses an OAuth login however it was scoped")
+			"that constant opts a login into the AI-Services scopes, which are not the Apps submit bit this proc needs")
 	}
 	if strings.Contains(appMetricsCredentialRoute, "--scopes generate") {
-		t.Errorf("appMetricsCredentialRoute offers `login --scopes generate`, which cannot satisfy "+
-			"a full-scope proc: %q", appMetricsCredentialRoute)
+		t.Errorf("appMetricsCredentialRoute offers `login --scopes generate`, which grants the "+
+			"AI-Services bits and not the Apps submit bit this proc requires: %q", appMetricsCredentialRoute)
 	}
 	if !strings.Contains(appMetricsCredentialRoute, accountAPIKeysURL) {
 		t.Errorf("appMetricsCredentialRoute does not say where to mint the key: %q", appMetricsCredentialRoute)

--- a/scripts/mutation/README.md
+++ b/scripts/mutation/README.md
@@ -1,0 +1,35 @@
+# Mutation batteries
+
+These are the mutation sweeps referenced by PR descriptions, committed so a
+reviewer can **recount** them instead of taking a number on trust. A battery
+that lives only in a transcript is a claim; one that lives here is evidence.
+
+```bash
+MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py            # all mutants
+MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py M1 M7      # named ones
+```
+
+Each mutant applies the **narrowest expression that can be wrong**, runs the
+FULL relevant packages (never a `-run` filter, which can exclude the killing
+test), restores the file, and asserts the tree is byte-identical afterwards.
+
+## Reading the verdict
+
+The final line reconciles **defined** against **produced**:
+
+```
+==== VERDICT ==== ran=N killed=N survived=0 not_run=0
+```
+
+🔴 **`not_run` is the number that matters most.** A mutant whose search text has
+gone stale never executes, and an earlier version of this harness printed that
+as `PATTERN MATCHED 0 TIMES` — different vocabulary from every other verdict, so
+a reader's grep dropped it silently and three mutants read as "not in the list"
+rather than "never ran". One of them was a mutant that had **already survived
+once**. A skip is now reported as `BAD-PATTERN`, in the same vocabulary, and the
+process **exits 2**, so a run containing one cannot be read as clean.
+
+Exit codes: `0` all killed · `1` a survivor · `2` a mutant never ran · `3` the
+baseline was not green (in which case every result is meaningless).
+
+`RESULTS-*.txt` is the committed output of the last full run.

--- a/scripts/mutation/README.md
+++ b/scripts/mutation/README.md
@@ -26,10 +26,31 @@ gone stale never executes, and an earlier version of this harness printed that
 as `PATTERN MATCHED 0 TIMES` — different vocabulary from every other verdict, so
 a reader's grep dropped it silently and three mutants read as "not in the list"
 rather than "never ran". One of them was a mutant that had **already survived
-once**. A skip is now reported as `BAD-PATTERN`, in the same vocabulary, and the
-process **exits 2**, so a run containing one cannot be read as clean.
+once**. A skip is now reported as `BAD-PATTERN`, in the same vocabulary.
 
-Exit codes: `0` all killed · `1` a survivor · `2` a mutant never ran · `3` the
-baseline was not green (in which case every result is meaningless).
+| exit | meaning |
+| --- | --- |
+| `0` | every mutant ran, compiled, and was killed |
+| `1` | a mutant **SURVIVED** — a real coverage hole |
+| `2` | a mutant **never ran** (`BAD-PATTERN`) or **never compiled** (`BUILD-FAIL`) — evidence of nothing |
+| `3` | the **baseline was not green**, so every result is meaningless |
+
+🔴 `3` is deliberately not `1`. They used to share a code, which made "the
+suite was already broken" indistinguishable from "you have a coverage hole" —
+the one pair a reader most needs separated. And `BUILD-FAIL` used to leave the
+process exiting `0` while the summary reported `killed < ran`, so the
+arithmetic disagreed with itself.
+
+## What the harness can and cannot substantiate
+
+- **Which tests failed under a mutant is exact.**
+- 🔴 **The reason printed beside each killer is approximate.** Attribution scans
+  backward from a `--- FAIL` header for a nearby `_test.go:NN:` line, which
+  cross-attributes across subtests. Do not quote it as "each killed by an
+  assertion naming the specific defect" without reading the run.
+- **A run that dies part-way is flagged.** One mutant once reported a third of
+  the baseline's verdicts — legitimately killed, but by a run that never
+  finished. Each mutant's total is now compared against the baseline's and any
+  shortfall or `panic:` prints a `⚠ TRUNCATED RUN` line.
 
 `RESULTS-*.txt` is the committed output of the last full run.

--- a/scripts/mutation/README.md
+++ b/scripts/mutation/README.md
@@ -5,52 +5,87 @@ reviewer can **recount** them instead of taking a number on trust. A battery
 that lives only in a transcript is a claim; one that lives here is evidence.
 
 ```bash
-MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py            # all mutants
-MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py M1 M7      # named ones
+MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py                 # all mutants
+MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py M1 M7           # by prefix
+MUTATE_TREE=$PWD python3 scripts/mutation/<battery>.py M15-exit-tag    # by full id
 ```
 
-Each mutant applies the **narrowest expression that can be wrong**, runs the
-FULL relevant packages (never a `-run` filter, which can exclude the killing
-test), restores the file, and asserts the tree is byte-identical afterwards.
+A selector matches a full id or an id **prefix at the `-` boundary**, so `M1`
+selects `M1-exit-gate` and not `M10-…`. 🔴 A selector matching **no** mutant is a
+hard refusal (exit `2`), not a quiet no-op — this exact invocation used to select
+nothing, run nothing, and exit `0`, which this file defined as "every mutant ran,
+compiled, and was killed". An instrument that reports success having run nothing
+is the failure class the whole battery exists to prevent, and it was in the
+battery.
+
+Each mutant applies the **narrowest expression that can be wrong**, runs the FULL
+relevant packages (never a `-run` filter, which can exclude the killing test),
+and restores the file in a `finally` — so an interrupt cannot leave the tree
+mutated, and the post-condition is a real check rather than an `assert`, which
+`python3 -O` would strip. A full run also asserts `EXPECTED_MUTANTS`, so a table
+that quietly emptied cannot report a serene `killed=0`.
 
 ## Reading the verdict
 
-The final line reconciles **defined** against **produced**:
-
 ```
-==== VERDICT ==== ran=N killed=N survived=0 not_run=0
+==== VERDICT ==== defined=N ran=N killed=N survived=0 build_fail=0 not_run=0 truncated=0
 ```
 
-🔴 **`not_run` is the number that matters most.** A mutant whose search text has
-gone stale never executes, and an earlier version of this harness printed that
-as `PATTERN MATCHED 0 TIMES` — different vocabulary from every other verdict, so
-a reader's grep dropped it silently and three mutants read as "not in the list"
-rather than "never ran". One of them was a mutant that had **already survived
-once**. A skip is now reported as `BAD-PATTERN`, in the same vocabulary.
+- **`defined`** — mutants in the table. Reconcile it against the per-mutant lines.
+- **`ran`** — `defined` minus everything that is evidence of nothing: `not_run`
+  **and** `build_fail`. 🔴 `ran` used to subtract only `not_run` while still
+  counting build failures, so the summary could print `ran=39 killed=38
+  build_fail=1` — arithmetic disagreeing with itself.
+- **`not_run`** — a mutant whose search text went stale. An earlier harness
+  printed this as `PATTERN MATCHED 0 TIMES`, different vocabulary from every
+  other verdict, so a reader's grep dropped it silently and three mutants read as
+  "not in the list" rather than "never ran". One had **already survived once**.
+- **`build_fail`** — the mutant did not compile, so it tested nothing. A build
+  error now wins over a concurrent test failure; scoring it `KILLED` because some
+  unrelated test also failed was wrong.
+- **`truncated`** — the run died part-way (a `panic:`, or a verdict count well
+  short of the baseline). The kill may be real but its BREADTH is not: one
+  recorded mutant saw 798 of 3064 verdicts. Such a mutant is tagged
+  `KILLED (TRUNCATED)` **in the table**, not only in the stream, so it survives
+  into the committed artifact.
 
 | exit | meaning |
 | --- | --- |
 | `0` | every mutant ran, compiled, and was killed |
 | `1` | a mutant **SURVIVED** — a real coverage hole |
-| `2` | a mutant **never ran** (`BAD-PATTERN`) or **never compiled** (`BUILD-FAIL`) — evidence of nothing |
-| `3` | the **baseline was not green**, so every result is meaningless |
+| `2` | a mutant never ran, never compiled, a selector matched nothing, or the table is short |
+| `3` | the **baseline was not green or did not build** — every result is meaningless |
 
-🔴 `3` is deliberately not `1`. They used to share a code, which made "the
-suite was already broken" indistinguishable from "you have a coverage hole" —
-the one pair a reader most needs separated. And `BUILD-FAIL` used to leave the
-process exiting `0` while the summary reported `killed < ran`, so the
-arithmetic disagreed with itself.
+## 🔴 A SURVIVED verdict is only as good as the mutant
+
+A mutant that does not actually produce the defect it names is a **false alarm**,
+and it is exactly as misleading as a phantom KILL. Measured here:
+`M45-screenshot-omits-submit` replaced the PROSE clause introducing
+`submit-revision` but left the command string on the following line, so the
+rendered advice still contained `submit-revision`, the assertion still passed,
+and the sweep reported **SURVIVED** for a mutation that had removed nothing. It
+sent a real coverage hole and a broken mutant back as one indistinguishable
+signal.
+
+**Before believing a SURVIVED, confirm the mutant CHANGES THE OBSERVABLE.** For a
+string-building expression that usually means spanning every line of the
+concatenation, not just the one carrying the words you were thinking about. The
+cheap check is to apply the mutant by hand and read the value the code now
+produces.
+
+(In that instance both were true at once: the mutant was non-productive *and* the
+clause was genuinely unasserted. Fixing the mutant then produced a real KILL
+against a newly added assertion — but the first SURVIVED was not evidence for
+either conclusion.)
 
 ## What the harness can and cannot substantiate
 
-- **Which tests failed under a mutant is exact.**
-- 🔴 **The reason printed beside each killer is approximate.** Attribution scans
-  backward from a `--- FAIL` header for a nearby `_test.go:NN:` line, which
-  cross-attributes across subtests. Do not quote it as "each killed by an
-  assertion naming the specific defect" without reading the run.
-- **A run that dies part-way is flagged.** One mutant once reported a third of
-  the baseline's verdicts — legitimately killed, but by a run that never
-  finished. Each mutant's total is now compared against the baseline's and any
-  shortfall or `panic:` prints a `⚠ TRUNCATED RUN` line.
+- **Which tests failed under a mutant: exact.**
+- 🔴 **The reason printed beside each killer: approximate, and DOCUMENTED rather
+  than FIXED.** Attribution scans backward from a `--- FAIL` header for a nearby
+  `_test.go:NN:`, which cross-attributes across subtests. In the committed
+  output, 15 of 112 killer rows read `(no assertion line captured)` and 20 of 39
+  mutants share byte-identical reasons. Do not quote it as "each killed by an
+  assertion naming the specific defect".
 
 `RESULTS-*.txt` is the committed output of the last full run.

--- a/scripts/mutation/RESULTS-app-doctor.txt
+++ b/scripts/mutation/RESULTS-app-doctor.txt
@@ -1,17 +1,301 @@
-harness_rc=0
-==== VERDICT ==== ran=32 killed=32 survived=0 not_run=0
---- new mutants ---
+BASELINE: {'PASS': 3049, 'FAIL': 0, 'SKIP': 1}
+M1-exit-gate: KILLED ({'PASS': 3028, 'FAIL': 21, 'SKIP': 1})
+    <- TestDoctorExitsNonZeroOnABlockingProblem
+       app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
+    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
+       app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorJSONIsTheWholeOfStdout
+       app_doctor_test.go:407: expected a non-zero verdict
+M2-severity-compare: KILLED ({'PASS': 766, 'FAIL': 31, 'SKIP': 1})
+    <- TestDoctorExitsNonZeroOnABlockingProblem
+       app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
+    <- TestDoctorExitsZeroOnAdvisoryOnly
+       app_doctor_test.go:168: advisories alone must exit 0, got the listing has blocking problems: 2 blocking problem(s) on publishable listing(s) — see the report above; stdout was:
+    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
+       app_doctor_test.go:198: summary line is wrong; got:
+    <- TestDoctorReportsAllEightCodesInTheRightGroup
+       app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0}, want {apps:1 blocking:3 advisory:5}
+M3-ok-field: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+    <- TestDoctorReportsAllEightCodesInTheRightGroup
+       app_doctor_test.go:254: ok must be false when anything is blocking
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1
+       app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
+M4-icon-remedy: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+M5-slug-predicate: KILLED ({'PASS': 3047, 'FAIL': 2, 'SKIP': 1})
+    <- TestDoctorSlugSelectionNormalises
+       app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+    <- TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA
+       app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+M6-unknown-slug: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+    <- TestDoctorUnknownSlugIsNotFoundNotAPass
+       app_doctor_test.go:635: an unknown slug must NOT read as a clean run; stdout:
+    <- TestDoctorProcessExitStatusEndToEnd
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+    <- TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+M7-edit-url-id-space: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
+       app_doctor_test.go:530: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:42281/apps/listing/doctor-alpha/edit"
+    <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
+       app_doctor_test.go:1161: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:45253/apps/listing/doctor-bravo/edit"
+M8-empty-sentence: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorNoListingsIsASentenceAndExitsZero
+       app_doctor_test.go:661: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+M9-clean-sentence: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+    <- TestDoctorExitsZeroOnACleanListing
+       app_doctor_test.go:155: a clean listing must SAY it is complete, got:
+    <- TestDoctorProcessExitStatusEndToEnd
+       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+    <- TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean
+       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+    <- TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0
+       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+M10-trpc-input: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorSendsNoInputParameter
+       app_doctor_test.go:728: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+M11-extra-request: KILLED ({'PASS': 2989, 'FAIL': 60, 'SKIP': 1})
+    <- TestDoctorExitsNonZeroOnABlockingProblem
+       app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
+    <- TestDoctorExitsZeroOnACleanListing
+       app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
+    <- TestDoctorExitsZeroOnAdvisoryOnly
+       app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
+    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
+       app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
+M12-scanning-remedy: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorScanningMediaOffersNoAction
+       app_doctor_test.go:544: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+M13-unknown-severity: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorUnknownSeverityIsNotBlocking
+       app_doctor_test.go:575: an unrecognised severity must not block a release, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M14-summary-count: KILLED ({'PASS': 3044, 'FAIL': 5, 'SKIP': 1})
+    <- TestDoctorReportsAllEightCodesInTheRightGroup
+       app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0}, want {apps:1 blocking:3 advisory:5}
+    <- TestDoctorPositiveControlOnTheFindingCount
+       app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:964: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+M15-exit-tag: KILLED ({'PASS': 3044, 'FAIL': 5, 'SKIP': 1})
+    <- TestDoctorProcessExitStatusEndToEnd
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+    <- TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+    <- TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+    <- TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes
+       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+M16-metrics-403-claim: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestAppMetricsNoTokenNamesTheRouteThatWorks
+       app_metrics_credential_test.go:73: the no-token error still claims an OAuth login is refused ("full-scope-refused") — civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: no token configured — app analytics need an OAuth login (`civitai login`) carrying the Apps submit scope, 
+M17-gates-inverted: KILLED ({'PASS': 3017, 'FAIL': 32, 'SKIP': 1})
+    <- TestDoctorExitsNonZeroOnABlockingProblem
+       app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
+    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
+       app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:
+    <- TestDoctorReportsAllEightCodesInTheRightGroup
+       (no assertion line captured)
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+M18-gates-always-true: KILLED ({'PASS': 3032, 'FAIL': 17, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M19-gates-always-false: KILLED ({'PASS': 3026, 'FAIL': 23, 'SKIP': 1})
+    <- TestDoctorExitsNonZeroOnABlockingProblem
+       app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
+    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
+       app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:
+    <- TestDoctorReportsAllEightCodesInTheRightGroup
+       (no assertion line captured)
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+M20-exit-reads-blocking: KILLED ({'PASS': 3035, 'FAIL': 14, 'SKIP': 1})
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedRowsAreStillVisible
+       app_doctor_test.go:987: a delisted-only run must exit 0, got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M21-ok-reads-blocking: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
+       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+M22-gating-tally-unconditional: KILLED ({'PASS': 3033, 'FAIL': 16, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
+       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M23-delisted-rows-hidden: KILLED ({'PASS': 3040, 'FAIL': 9, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M24-delisted-status-not-normalised: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+    <- TestDoctorDelistedStatusMatchIsNormalised
+       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedStatusMatchIsNormalised/REMOVED
+       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedStatusMatchIsNormalised/Removed
+       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+    <- TestDoctorDelistedStatusMatchIsNormalised/removed#01
+       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M25-ordering-dropped: KILLED ({'PASS': 3040, 'FAIL': 9, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+    <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
+       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M26-delisted-heading-dropped: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+    <- TestDoctorDelistedRowsAreStillVisible
+       app_doctor_test.go:998: a delisted app must still be fully reported (missing "do NOT set the exit code"):
+    <- TestDoctorProcessExitStatusEndToEnd
+       doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
+    <- TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0
+       doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
+M27-summary-explanation-dropped: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+    <- TestDoctorDelistedRowsAreStillVisible
+       app_doctor_test.go:1003: the summary must explain why the exit code disagrees with the blocking count:
 M28-onsite-arm-dropped: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+    <- TestDoctorOnsiteTextRemedyNamesTheManifest
+       app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:35537/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorUnknownKindTakesTheRecoverableArm
+       app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:41463/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+    <- TestDoctorKindMatchIsNormalised
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorKindMatchIsNormalised/onsite
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
 M29-onsite-arm-always: KILLED ({'PASS': 3043, 'FAIL': 6, 'SKIP': 1})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+    <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
+       app_doctor_test.go:525: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:39531/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
+       app_doctor_test.go:1164: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+    <- TestDoctorUnknownKindTakesTheRecoverableArm
+       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M30-kind-not-normalised: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+    <- TestDoctorKindMatchIsNormalised
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorKindMatchIsNormalised/ONSITE
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorKindMatchIsNormalised/Onsite
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorKindMatchIsNormalised/onsite#01
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
 M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+    <- TestDoctorUnknownKindTakesTheRecoverableArm
+       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+    <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=
+       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+    <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future
+       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M32-kind-not-passed-through: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
-M28-onsite-arm-dropped	KILLED	an onsite app is told to edit the browser, whose edit (3b-sync) reverts
-M29-onsite-arm-always	KILLED	an offsite app is told to edit a block.manifest.json it does not have
-M30-kind-not-normalised	KILLED	a padded or mis-cased kind silently re-routes the text advice
-M31-kind-unknown-takes-manifest	KILLED	an absent/unknown kind takes the manifest arm instead of the recoverable one
-M32-kind-not-passed-through	KILLED	the row's kind never reaches the remedy, so every app gets the offsite arm
---- reconcile ---
-defined=32 verdicts=31
+    <- TestDoctorOnsiteTextRemedyNamesTheManifest
+       app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:44627/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorUnknownKindTakesTheRecoverableArm
+       app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:42511/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+    <- TestDoctorKindMatchIsNormalised
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
+    <- TestDoctorKindMatchIsNormalised/onsite
+       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
 
-[exited with code 0]
+==== TABLE ====
+M1-exit-gate	KILLED	off-by-one on the exit gate: one blocking problem stops failing the build
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorJSONIsTheWholeOfStdout :: app_doctor_test.go:407: expected a non-zero verdict
+M2-severity-compare	KILLED	the severity split is inverted
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:168: advisories alone must exit 0, got the listing has blocking problems: 2 blocking problem(s) on publishable listing(s) — see the report above; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:198: summary line is wrong; got:; TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0}, want {apps:1 blocking:3 advisory:5}
+M3-ok-field	KILLED	--json `ok` always says the listing is fine
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:254: ok must be false when anything is blocking; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1 :: app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
+M4-icon-remedy	KILLED	missing-icon advises the cover command
+	TestDoctorJSONShapeIsPinnedWhole :: (no line)
+M5-slug-predicate	KILLED	the typed slug is compared byte-for-byte instead of through the shared predicate
+	TestDoctorSlugSelectionNormalises :: app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:; TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA :: app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+M6-unknown-slug	KILLED	an unknown slug reads as a clean run
+	TestDoctorUnknownSlugIsNotFoundNotAPass :: app_doctor_test.go:635: an unknown slug must NOT read as a clean run; stdout:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.; TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass :: doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+M7-edit-url-id-space	KILLED	the listing editor URL is built from the slug, so it 404s
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:530: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:42281/apps/listing/doctor-alpha/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1161: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:45253/apps/listing/doctor-bravo/edit"
+M8-empty-sentence	KILLED	an empty run prints nothing at all
+	TestDoctorNoListingsIsASentenceAndExitsZero :: app_doctor_test.go:661: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+M9-clean-sentence	KILLED	a clean app renders as a gap instead of a verdict
+	TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:155: a clean listing must SAY it is complete, got:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0 :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+M10-trpc-input	KILLED	an input-less tRPC query is sent with ?input={"json":null}
+	TestDoctorSendsNoInputParameter :: app_doctor_test.go:728: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+M11-extra-request	KILLED	doctor starts asking getAssetScanStatuses (the owner-filtered proc)
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
+M12-scanning-remedy	KILLED	scanning-media advises re-attaching, which restarts the scan
+	TestDoctorScanningMediaOffersNoAction :: app_doctor_test.go:544: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+M13-unknown-severity	KILLED	an unrecognised severity is promoted to blocking
+	TestDoctorUnknownSeverityIsNotBlocking :: app_doctor_test.go:575: an unrecognised severity must not block a release, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M14-summary-count	KILLED	the summary counts blocked APPS instead of blocking PROBLEMS
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0}, want {apps:1 blocking:3 advisory:5}; TestDoctorPositiveControlOnTheFindingCount :: app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+M15-exit-tag	KILLED	the verdict is tagged ErrBadRequest, moving its exit code from 1 to 2
+	TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+M16-metrics-403-claim	KILLED	the corrected D2 claim drifts back to the false one
+	TestAppMetricsNoTokenNamesTheRouteThatWorks :: app_metrics_credential_test.go:73: the no-token error still claims an OAuth login is refused ("full-scope-refused") — civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: no token configured — app analytics need an OAuth login (`civitai login`) carrying the Apps submit scope, 
+M17-gates-inverted	KILLED	the predicate is inverted: ONLY delisted listings gate
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
+M18-gates-always-true	KILLED	delisted listings gate again — the defect this rule exists to remove
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M19-gates-always-false	KILLED	NOTHING gates — the exit code can never be 1
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
+M20-exit-reads-blocking	KILLED	the exit gate reads the total instead of the gating subset
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:987: a delisted-only run must exit 0, got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M21-ok-reads-blocking	KILLED	--json `ok` disagrees with the exit code on a delisted-only run
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+M22-gating-tally-unconditional	KILLED	every app's blocking problems are tallied as gating
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M23-delisted-rows-hidden	KILLED	delisted apps are DROPPED from the report — the population-becomes-unreachable failure
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M24-delisted-status-not-normalised	KILLED	a padded or mis-cased `removed` silently gates again
+	TestDoctorDelistedStatusMatchIsNormalised :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/REMOVED :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/Removed :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/removed#01 :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+M25-ordering-dropped	KILLED	delisted apps are dropped from the ordering pass, so they no longer sort last
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M26-delisted-heading-dropped	KILLED	the delisted section loses its heading, so a 0 exit beside BLOCKING findings is unexplained
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:998: a delisted app must still be fully reported (missing "do NOT set the exit code"):; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":; TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0 :: doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
+M27-summary-explanation-dropped	KILLED	the summary stops explaining why blocking and the exit code disagree
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1003: the summary must explain why the exit code disagrees with the blocking count:
+M28-onsite-arm-dropped	KILLED	an onsite app is told to edit the browser, whose edit (3b-sync) reverts
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:35537/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:41463/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
+M29-onsite-arm-always	KILLED	an offsite app is told to edit a block.manifest.json it does not have
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:525: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:39531/apps/listing/apl_ALPHA111/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1164: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M30-kind-not-normalised	KILLED	a padded or mis-cased kind silently re-routes the text advice
+	TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/ONSITE :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/Onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite#01 :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+M31-kind-unknown-takes-manifest	KILLED	an absent/unknown kind takes the manifest arm instead of the recoverable one
+	TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind= :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M32-kind-not-passed-through	KILLED	the row's kind never reaches the remedy, so every app gets the offsite arm
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:44627/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:42511/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
+
+==== VERDICT ==== ran=32 killed=32 survived=0 not_run=0

--- a/scripts/mutation/RESULTS-app-doctor.txt
+++ b/scripts/mutation/RESULTS-app-doctor.txt
@@ -1,5 +1,5 @@
-BASELINE: {'PASS': 3049, 'FAIL': 0, 'SKIP': 1}
-M1-exit-gate: KILLED ({'PASS': 3028, 'FAIL': 21, 'SKIP': 1})
+BASELINE: {'PASS': 3063, 'FAIL': 0, 'SKIP': 1, 'PANIC': 0} total=3064
+M1-exit-gate: KILLED ({'PASS': 3036, 'FAIL': 27, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -7,63 +7,64 @@ M1-exit-gate: KILLED ({'PASS': 3028, 'FAIL': 21, 'SKIP': 1})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorJSONIsTheWholeOfStdout
-       app_doctor_test.go:407: expected a non-zero verdict
-M2-severity-compare: KILLED ({'PASS': 766, 'FAIL': 31, 'SKIP': 1})
+       app_doctor_test.go:411: expected a non-zero verdict
+M2-severity-compare: KILLED ({'PASS': 766, 'FAIL': 31, 'SKIP': 1, 'PANIC': 1})
+  ⚠ TRUNCATED RUN: 798 verdicts vs baseline 3064 (2266 missing, panics=1) — the verdict below is about a run that did not finish; treat the KILL as unattributed.
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorExitsZeroOnAdvisoryOnly
-       app_doctor_test.go:168: advisories alone must exit 0, got the listing has blocking problems: 2 blocking problem(s) on publishable listing(s) — see the report above; stdout was:
+       app_doctor_test.go:168: advisories alone must exit 0, got listing not ready to publish: 2 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
        app_doctor_test.go:198: summary line is wrong; got:
     <- TestDoctorReportsAllEightCodesInTheRightGroup
-       app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0}, want {apps:1 blocking:3 advisory:5}
-M3-ok-field: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+       app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
+M3-ok-field: KILLED ({'PASS': 3051, 'FAIL': 12, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorReportsAllEightCodesInTheRightGroup
        app_doctor_test.go:254: ok must be false when anything is blocking
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
+       app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1
-       app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
-M4-icon-remedy: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
+M4-icon-remedy: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M5-slug-predicate: KILLED ({'PASS': 3047, 'FAIL': 2, 'SKIP': 1})
+M5-slug-predicate: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorSlugSelectionNormalises
-       app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+       app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
     <- TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA
-       app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
-M6-unknown-slug: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+       app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+M6-unknown-slug: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownSlugIsNotFoundNotAPass
-       app_doctor_test.go:635: an unknown slug must NOT read as a clean run; stdout:
+       app_doctor_test.go:643: an unknown slug must NOT read as a clean run; stdout:
     <- TestDoctorProcessExitStatusEndToEnd
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
     <- TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
-M7-edit-url-id-space: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+M7-edit-url-id-space: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
-       app_doctor_test.go:530: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:42281/apps/listing/doctor-alpha/edit"
+       app_doctor_test.go:538: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:39599/apps/listing/doctor-alpha/edit"
     <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
-       app_doctor_test.go:1161: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:45253/apps/listing/doctor-bravo/edit"
-M8-empty-sentence: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       app_doctor_test.go:1171: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:41743/apps/listing/doctor-bravo/edit"
+M8-empty-sentence: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorNoListingsIsASentenceAndExitsZero
-       app_doctor_test.go:661: an empty run printed NOTHING — that is indistinguishable from a swallowed read
-M9-clean-sentence: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+       app_doctor_test.go:669: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+M9-clean-sentence: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsZeroOnACleanListing
        app_doctor_test.go:155: a clean listing must SAY it is complete, got:
     <- TestDoctorProcessExitStatusEndToEnd
-       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+       doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
     <- TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean
-       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+       doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
     <- TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0
-       doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
-M10-trpc-input: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
+M10-trpc-input: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorSendsNoInputParameter
-       app_doctor_test.go:728: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
-M11-extra-request: KILLED ({'PASS': 2989, 'FAIL': 60, 'SKIP': 1})
+       app_doctor_test.go:736: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+M11-extra-request: KILLED ({'PASS': 2995, 'FAIL': 68, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
     <- TestDoctorExitsZeroOnACleanListing
@@ -72,34 +73,36 @@ M11-extra-request: KILLED ({'PASS': 2989, 'FAIL': 60, 'SKIP': 1})
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
-M12-scanning-remedy: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+M12-scanning-remedy: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorScanningMediaOffersNoAction
-       app_doctor_test.go:544: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
-M13-unknown-severity: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       app_doctor_test.go:552: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+M13-unknown-severity: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownSeverityIsNotBlocking
-       app_doctor_test.go:575: an unrecognised severity must not block a release, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
-M14-summary-count: KILLED ({'PASS': 3044, 'FAIL': 5, 'SKIP': 1})
+       app_doctor_test.go:583: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+    <- TestDoctorSeverityIsNormalised
+       app_doctor_test.go:1367: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
+M14-summary-count: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorReportsAllEightCodesInTheRightGroup
-       app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0}, want {apps:1 blocking:3 advisory:5}
+       app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
     <- TestDoctorPositiveControlOnTheFindingCount
        app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:964: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
-M15-exit-tag: KILLED ({'PASS': 3044, 'FAIL': 5, 'SKIP': 1})
+       app_doctor_test.go:974: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+M15-exit-tag: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorProcessExitStatusEndToEnd
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
     <- TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
     <- TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
     <- TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes
-       doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
-M16-metrics-403-claim: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+M16-metrics-403-claim: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestAppMetricsNoTokenNamesTheRouteThatWorks
        app_metrics_credential_test.go:73: the no-token error still claims an OAuth login is refused ("full-scope-refused") — civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: no token configured — app analytics need an OAuth login (`civitai login`) carrying the Apps submit scope, 
-M17-gates-inverted: KILLED ({'PASS': 3017, 'FAIL': 32, 'SKIP': 1})
+M17-gates-inverted: KILLED ({'PASS': 3025, 'FAIL': 38, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -108,16 +111,16 @@ M17-gates-inverted: KILLED ({'PASS': 3017, 'FAIL': 32, 'SKIP': 1})
        (no assertion line captured)
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M18-gates-always-true: KILLED ({'PASS': 3032, 'FAIL': 17, 'SKIP': 1})
+M18-gates-always-true: KILLED ({'PASS': 3046, 'FAIL': 17, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
-M19-gates-always-false: KILLED ({'PASS': 3026, 'FAIL': 23, 'SKIP': 1})
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M19-gates-always-false: KILLED ({'PASS': 3034, 'FAIL': 29, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -126,176 +129,219 @@ M19-gates-always-false: KILLED ({'PASS': 3026, 'FAIL': 23, 'SKIP': 1})
        (no assertion line captured)
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M20-exit-reads-blocking: KILLED ({'PASS': 3035, 'FAIL': 14, 'SKIP': 1})
+M20-exit-reads-blocking: KILLED ({'PASS': 3049, 'FAIL': 14, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:987: a delisted-only run must exit 0, got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
-M21-ok-reads-blocking: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+       app_doctor_test.go:997: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M21-ok-reads-blocking: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
-       app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
-M22-gating-tally-unconditional: KILLED ({'PASS': 3033, 'FAIL': 16, 'SKIP': 1})
+       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
+M22-gating-tally-unconditional: KILLED ({'PASS': 3047, 'FAIL': 16, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
-M23-delisted-rows-hidden: KILLED ({'PASS': 3040, 'FAIL': 9, 'SKIP': 1})
+       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M23-delisted-rows-hidden: KILLED ({'PASS': 3054, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
-M24-delisted-status-not-normalised: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M24-delisted-status-not-normalised: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedStatusMatchIsNormalised
-       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/REMOVED
-       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/Removed
-       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/removed#01
-       app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
-M25-ordering-dropped: KILLED ({'PASS': 3040, 'FAIL': 9, 'SKIP': 1})
+       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M25-ordering-dropped: KILLED ({'PASS': 3054, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
-M26-delisted-heading-dropped: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M26-delisted-heading-dropped: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:998: a delisted app must still be fully reported (missing "do NOT set the exit code"):
+       app_doctor_test.go:1008: a delisted app must still be fully reported (missing "do NOT set the exit code"):
     <- TestDoctorProcessExitStatusEndToEnd
-       doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
+       doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
     <- TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0
-       doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
-M27-summary-explanation-dropped: KILLED ({'PASS': 3048, 'FAIL': 1, 'SKIP': 1})
+       doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
+M27-summary-explanation-dropped: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:1003: the summary must explain why the exit code disagrees with the blocking count:
-M28-onsite-arm-dropped: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+       app_doctor_test.go:1013: the summary must explain why the exit code disagrees with the blocking count:
+M28-onsite-arm-dropped: KILLED ({'PASS': 3056, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorOnsiteTextRemedyNamesTheManifest
-       app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:35537/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:37571/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:41463/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+       app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:44909/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
-M29-onsite-arm-always: KILLED ({'PASS': 3043, 'FAIL': 6, 'SKIP': 1})
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
+M29-onsite-arm-always: KILLED ({'PASS': 3057, 'FAIL': 6, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
-       app_doctor_test.go:525: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:39531/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:533: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:36531/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
-       app_doctor_test.go:1164: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1174: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
-M30-kind-not-normalised: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M30-kind-not-normalised: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/ONSITE
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/Onsite
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite#01
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
-M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
+M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=
-       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future
-       app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
-M32-kind-not-passed-through: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M32-kind-not-passed-through: KILLED ({'PASS': 3056, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorOnsiteTextRemedyNamesTheManifest
-       app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:44627/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:33229/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:42511/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+       app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:35035/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite
-       app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
+M33-screenshot-advice-appends: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
+    <- TestBlockedMediaRemedyIsSufficientPerSlot
+       app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish
+       app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+M34-blocked-kind-always-empty: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
+    <- TestBlockedMediaRemedyIsSufficientPerSlot
+       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_icon_before_it_can_publish
+       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_cover_before_it_can_publish
+       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish
+       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+M35-fallback-drops-removal: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestBlockedMediaUnknownLabelKeepsTheRemoval
+       app_doctor_test.go:1319: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot
+M36-truncation-never-reported: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorReportsTruncationAtThePageCap
+       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M37-truncation-off-by-one: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorReportsTruncationAtThePageCap
+       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M38-truncation-caveat-silent: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorReportsTruncationAtThePageCap
+       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M39-json-drops-kind: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
 
 ==== TABLE ====
 M1-exit-gate	KILLED	off-by-one on the exit gate: one blocking problem stops failing the build
-	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorJSONIsTheWholeOfStdout :: app_doctor_test.go:407: expected a non-zero verdict
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorJSONIsTheWholeOfStdout :: app_doctor_test.go:411: expected a non-zero verdict
 M2-severity-compare	KILLED	the severity split is inverted
-	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:168: advisories alone must exit 0, got the listing has blocking problems: 2 blocking problem(s) on publishable listing(s) — see the report above; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:198: summary line is wrong; got:; TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0}, want {apps:1 blocking:3 advisory:5}
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:168: advisories alone must exit 0, got listing not ready to publish: 2 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:198: summary line is wrong; got:; TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
 M3-ok-field	KILLED	--json `ok` always says the listing is fine
-	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:254: ok must be false when anything is blocking; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1 :: app_doctor_test.go:972: ok = true with gating = 1 — `ok` must follow gating, not blocking
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:254: ok must be false when anything is blocking; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1 :: app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
 M4-icon-remedy	KILLED	missing-icon advises the cover command
 	TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M5-slug-predicate	KILLED	the typed slug is compared byte-for-byte instead of through the shared predicate
-	TestDoctorSlugSelectionNormalises :: app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:; TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA :: app_doctor_test.go:616: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+	TestDoctorSlugSelectionNormalises :: app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:; TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA :: app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
 M6-unknown-slug	KILLED	an unknown slug reads as a clean run
-	TestDoctorUnknownSlugIsNotFoundNotAPass :: app_doctor_test.go:635: an unknown slug must NOT read as a clean run; stdout:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.; TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass :: doctor_e2e_exitcode_test.go:224: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+	TestDoctorUnknownSlugIsNotFoundNotAPass :: app_doctor_test.go:643: an unknown slug must NOT read as a clean run; stdout:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.; TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass :: doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
 M7-edit-url-id-space	KILLED	the listing editor URL is built from the slug, so it 404s
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:530: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:42281/apps/listing/doctor-alpha/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1161: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:45253/apps/listing/doctor-bravo/edit"
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:538: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:39599/apps/listing/doctor-alpha/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1171: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:41743/apps/listing/doctor-bravo/edit"
 M8-empty-sentence	KILLED	an empty run prints nothing at all
-	TestDoctorNoListingsIsASentenceAndExitsZero :: app_doctor_test.go:661: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+	TestDoctorNoListingsIsASentenceAndExitsZero :: app_doctor_test.go:669: an empty run printed NOTHING — that is indistinguishable from a swallowed read
 M9-clean-sentence	KILLED	a clean app renders as a gap instead of a verdict
-	TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:155: a clean listing must SAY it is complete, got:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0 :: doctor_e2e_exitcode_test.go:228: stdout does not carry "No problems":
+	TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:155: a clean listing must SAY it is complete, got:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0 :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
 M10-trpc-input	KILLED	an input-less tRPC query is sent with ?input={"json":null}
-	TestDoctorSendsNoInputParameter :: app_doctor_test.go:728: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+	TestDoctorSendsNoInputParameter :: app_doctor_test.go:736: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
 M11-extra-request	KILLED	doctor starts asking getAssetScanStatuses (the owner-filtered proc)
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
 M12-scanning-remedy	KILLED	scanning-media advises re-attaching, which restarts the scan
-	TestDoctorScanningMediaOffersNoAction :: app_doctor_test.go:544: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+	TestDoctorScanningMediaOffersNoAction :: app_doctor_test.go:552: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
 M13-unknown-severity	KILLED	an unrecognised severity is promoted to blocking
-	TestDoctorUnknownSeverityIsNotBlocking :: app_doctor_test.go:575: an unrecognised severity must not block a release, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+	TestDoctorUnknownSeverityIsNotBlocking :: app_doctor_test.go:583: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorSeverityIsNormalised :: app_doctor_test.go:1367: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
 M14-summary-count	KILLED	the summary counts blocked APPS instead of blocking PROBLEMS
-	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0}, want {apps:1 blocking:3 advisory:5}; TestDoctorPositiveControlOnTheFindingCount :: app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}; TestDoctorPositiveControlOnTheFindingCount :: app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
 M15-exit-tag	KILLED	the verdict is tagged ErrBadRequest, moving its exit code from 1 to 2
-	TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes :: doctor_e2e_exitcode_test.go:224: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
+	TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
 M16-metrics-403-claim	KILLED	the corrected D2 claim drifts back to the false one
 	TestAppMetricsNoTokenNamesTheRouteThatWorks :: app_metrics_credential_test.go:73: the no-token error still claims an OAuth login is refused ("full-scope-refused") — civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: no token configured — app analytics need an OAuth login (`civitai login`) carrying the Apps submit scope, 
 M17-gates-inverted	KILLED	the predicate is inverted: ONLY delisted listings gate
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M18-gates-always-true	KILLED	delisted listings gate again — the defect this rule exists to remove
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M19-gates-always-false	KILLED	NOTHING gates — the exit code can never be 1
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M20-exit-reads-blocking	KILLED	the exit gate reads the total instead of the gating subset
-	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:987: a delisted-only run must exit 0, got the listing has blocking problems: 0 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:997: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M21-ok-reads-blocking	KILLED	--json `ok` disagrees with the exit code on a delisted-only run
-	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:972: ok = false with gating = 0 — `ok` must follow gating, not blocking
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
 M22-gating-tally-unconditional	KILLED	every app's blocking problems are tallied as gating
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:957: expected exit 0 — nothing publishable is blocked; got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M23-delisted-rows-hidden	KILLED	delisted apps are DROPPED from the report — the population-becomes-unreachable failure
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
 M24-delisted-status-not-normalised	KILLED	a padded or mis-cased `removed` silently gates again
-	TestDoctorDelistedStatusMatchIsNormalised :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/REMOVED :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/Removed :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:; TestDoctorDelistedStatusMatchIsNormalised/removed#01 :: app_doctor_test.go:1069: status " removed " must read as delisted, got the listing has blocking problems: 1 blocking problem(s) on publishable listing(s) — see the report above; stdout:
+	TestDoctorDelistedStatusMatchIsNormalised :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/REMOVED :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/Removed :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/removed#01 :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M25-ordering-dropped	KILLED	delisted apps are dropped from the ordering pass, so they no longer sort last
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:964: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
 M26-delisted-heading-dropped	KILLED	the delisted section loses its heading, so a 0 exit beside BLOCKING findings is unexplained
-	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:998: a delisted app must still be fully reported (missing "do NOT set the exit code"):; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":; TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0 :: doctor_e2e_exitcode_test.go:228: stdout does not carry "Delisted":
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1008: a delisted app must still be fully reported (missing "do NOT set the exit code"):; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":; TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0 :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
 M27-summary-explanation-dropped	KILLED	the summary stops explaining why blocking and the exit code disagree
-	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1003: the summary must explain why the exit code disagrees with the blocking count:
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1013: the summary must explain why the exit code disagrees with the blocking count:
 M28-onsite-arm-dropped	KILLED	an onsite app is told to edit the browser, whose edit (3b-sync) reverts
-	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:35537/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:41463/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:43531/apps/listing/apl_ALPHA111/edit"
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:37571/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:44909/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
 M29-onsite-arm-always	KILLED	an offsite app is told to edit a block.manifest.json it does not have
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:525: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:39531/apps/listing/apl_ALPHA111/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1164: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:533: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:36531/apps/listing/apl_ALPHA111/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1174: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M30-kind-not-normalised	KILLED	a padded or mis-cased kind silently re-routes the text advice
-	TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/ONSITE :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/Onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite#01 :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39537/apps/listing/apl_ALPHA111/edit"
+	TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/ONSITE :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/Onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite#01 :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
 M31-kind-unknown-takes-manifest	KILLED	an absent/unknown kind takes the manifest arm instead of the recoverable one
-	TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind= :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future :: app_doctor_test.go:1210: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+	TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind= :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M32-kind-not-passed-through	KILLED	the row's kind never reaches the remedy, so every app gets the offsite arm
-	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1141: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:44627/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:42511/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1233: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44679/apps/listing/apl_ALPHA111/edit"
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:33229/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:35035/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
+M33-screenshot-advice-appends	KILLED	a blocked SCREENSHOT is answered with add-screenshot, which appends and leaves it blocked
+	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+M34-blocked-kind-always-empty	KILLED	the slot is never extracted, so every blocked asset gets the generic arm
+	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_icon_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_cover_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+M35-fallback-drops-removal	KILLED	the unknown-label fallback loses the REMOVAL, which is the only sufficient screenshot fix
+	TestBlockedMediaUnknownLabelKeepsTheRemoval :: app_doctor_test.go:1319: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot
+M36-truncation-never-reported	KILLED	a truncated page reports ok:true indistinguishably from a complete one
+	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M37-truncation-off-by-one	KILLED	an exactly-at-cap page is called complete, though it is the commonest truncated case
+	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M38-truncation-caveat-silent	KILLED	the stderr caveat never prints, so only a JSON reader can learn the page was capped
+	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+M39-json-drops-kind	KILLED	--json omits the field that decides `fix`, so a consumer cannot reproduce the branch
+	TestDoctorJSONShapeIsPinnedWhole :: (no line)
 
-==== VERDICT ==== ran=32 killed=32 survived=0 not_run=0
+==== VERDICT ==== ran=39 killed=39 survived=0 not_run=0

--- a/scripts/mutation/RESULTS-app-doctor.txt
+++ b/scripts/mutation/RESULTS-app-doctor.txt
@@ -1,5 +1,5 @@
-BASELINE: {'PASS': 3063, 'FAIL': 0, 'SKIP': 1, 'PANIC': 0} total=3064
-M1-exit-gate: KILLED ({'PASS': 3036, 'FAIL': 27, 'SKIP': 1, 'PANIC': 0})
+BASELINE: {'PASS': 3070, 'FAIL': 0, 'SKIP': 1, 'PANIC': 0} total=3071
+M1-exit-gate: KILLED ({'PASS': 3041, 'FAIL': 29, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -7,52 +7,46 @@ M1-exit-gate: KILLED ({'PASS': 3036, 'FAIL': 27, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorJSONIsTheWholeOfStdout
-       app_doctor_test.go:411: expected a non-zero verdict
-M2-severity-compare: KILLED ({'PASS': 766, 'FAIL': 31, 'SKIP': 1, 'PANIC': 1})
-  ⚠ TRUNCATED RUN: 798 verdicts vs baseline 3064 (2266 missing, panics=1) — the verdict below is about a run that did not finish; treat the KILL as unattributed.
-    <- TestDoctorExitsNonZeroOnABlockingProblem
-       app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
-    <- TestDoctorExitsZeroOnAdvisoryOnly
-       app_doctor_test.go:168: advisories alone must exit 0, got listing not ready to publish: 2 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout was:
-    <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
-       app_doctor_test.go:198: summary line is wrong; got:
-    <- TestDoctorReportsAllEightCodesInTheRightGroup
-       app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
-M3-ok-field: KILLED ({'PASS': 3051, 'FAIL': 12, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:418: expected a non-zero verdict
+M2-severity-compare: KILLED (TRUNCATED) ({'PASS': 766, 'FAIL': 32, 'SKIP': 1, 'PANIC': 1})
+  ⚠ TRUNCATED RUN: 799 verdicts vs baseline 3071 (2272 missing, panics=1) — the verdict below is about a run that did not finish; treat the KILL as unattributed.
+M3-ok-field: KILLED ({'PASS': 3058, 'FAIL': 12, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorReportsAllEightCodesInTheRightGroup
        app_doctor_test.go:254: ok must be false when anything is blocking
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
+       app_doctor_test.go:1008: ok = true with gating = 1 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1
-       app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
-M4-icon-remedy: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1008: ok = true with gating = 1 — `ok` must follow gating, not blocking
+M4-icon-remedy: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M5-slug-predicate: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
+M5-slug-predicate: KILLED ({'PASS': 3068, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorSlugSelectionNormalises
-       app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+       app_doctor_test.go:650: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
     <- TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA
-       app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
-M6-unknown-slug: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:650: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+M6-unknown-slug: KILLED ({'PASS': 3064, 'FAIL': 6, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownSlugIsNotFoundNotAPass
-       app_doctor_test.go:643: an unknown slug must NOT read as a clean run; stdout:
+       app_doctor_test.go:669: an unknown slug must NOT read as a clean run; stdout:
+    <- TestDoctorNotFoundOnACappedPageIsNotConclusive
+       app_doctor_test.go:1501: expected a not-found
+    <- TestDoctorVerdictSentinelIsDistinguishable
+       app_doctor_test.go:1584: control: expected a not-found error
     <- TestDoctorProcessExitStatusEndToEnd
        doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
-    <- TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass
-       doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
-M7-edit-url-id-space: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
+M7-edit-url-id-space: KILLED ({'PASS': 3067, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
-       app_doctor_test.go:538: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:39599/apps/listing/doctor-alpha/edit"
+       app_doctor_test.go:564: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:33557/apps/listing/doctor-alpha/edit"
     <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
-       app_doctor_test.go:1171: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:41743/apps/listing/doctor-bravo/edit"
-M8-empty-sentence: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1197: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:34955/apps/listing/doctor-bravo/edit"
+M8-empty-sentence: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorNoListingsIsASentenceAndExitsZero
-       app_doctor_test.go:669: an empty run printed NOTHING — that is indistinguishable from a swallowed read
-M9-clean-sentence: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:695: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+M9-clean-sentence: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsZeroOnACleanListing
        app_doctor_test.go:155: a clean listing must SAY it is complete, got:
     <- TestDoctorProcessExitStatusEndToEnd
@@ -61,10 +55,10 @@ M9-clean-sentence: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
        doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
     <- TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0
        doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
-M10-trpc-input: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+M10-trpc-input: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorSendsNoInputParameter
-       app_doctor_test.go:736: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
-M11-extra-request: KILLED ({'PASS': 2995, 'FAIL': 68, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:762: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+M11-extra-request: KILLED ({'PASS': 2997, 'FAIL': 73, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
     <- TestDoctorExitsZeroOnACleanListing
@@ -73,15 +67,15 @@ M11-extra-request: KILLED ({'PASS': 2995, 'FAIL': 68, 'SKIP': 1, 'PANIC': 0})
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
        app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
-M12-scanning-remedy: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+M12-scanning-remedy: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorScanningMediaOffersNoAction
-       app_doctor_test.go:552: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
-M13-unknown-severity: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:578: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+M13-unknown-severity: KILLED ({'PASS': 3068, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownSeverityIsNotBlocking
-       app_doctor_test.go:583: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:609: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorSeverityIsNormalised
-       app_doctor_test.go:1367: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
-M14-summary-count: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1405: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
+M14-summary-count: KILLED ({'PASS': 3065, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorReportsAllEightCodesInTheRightGroup
        app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
     <- TestDoctorPositiveControlOnTheFindingCount
@@ -89,8 +83,8 @@ M14-summary-count: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:974: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
-M15-exit-tag: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1000: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+M15-exit-tag: KILLED ({'PASS': 3064, 'FAIL': 6, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorProcessExitStatusEndToEnd
        doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
     <- TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build
@@ -99,10 +93,10 @@ M15-exit-tag: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
        doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
     <- TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes
        doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
-M16-metrics-403-claim: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+M16-metrics-403-claim: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestAppMetricsNoTokenNamesTheRouteThatWorks
        app_metrics_credential_test.go:73: the no-token error still claims an OAuth login is refused ("full-scope-refused") — civitai/civitai#3572 annotated the proc with AppBlocksSubmit and it is not: no token configured — app analytics need an OAuth login (`civitai login`) carrying the Apps submit scope, 
-M17-gates-inverted: KILLED ({'PASS': 3025, 'FAIL': 38, 'SKIP': 1, 'PANIC': 0})
+M17-gates-inverted: KILLED ({'PASS': 3030, 'FAIL': 40, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -111,16 +105,16 @@ M17-gates-inverted: KILLED ({'PASS': 3025, 'FAIL': 38, 'SKIP': 1, 'PANIC': 0})
        (no assertion line captured)
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M18-gates-always-true: KILLED ({'PASS': 3046, 'FAIL': 17, 'SKIP': 1, 'PANIC': 0})
+M18-gates-always-true: KILLED ({'PASS': 3053, 'FAIL': 17, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
-M19-gates-always-false: KILLED ({'PASS': 3034, 'FAIL': 29, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M19-gates-always-false: KILLED ({'PASS': 3039, 'FAIL': 31, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorExitsNonZeroOnABlockingProblem
        app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:
     <- TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp
@@ -129,170 +123,208 @@ M19-gates-always-false: KILLED ({'PASS': 3034, 'FAIL': 29, 'SKIP': 1, 'PANIC': 0
        (no assertion line captured)
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
-M20-exit-reads-blocking: KILLED ({'PASS': 3049, 'FAIL': 14, 'SKIP': 1, 'PANIC': 0})
+M20-exit-reads-blocking: KILLED ({'PASS': 3056, 'FAIL': 14, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:997: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
-M21-ok-reads-blocking: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1023: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M21-ok-reads-blocking: KILLED ({'PASS': 3067, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
+       app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
+       app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0
-       app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
-M22-gating-tally-unconditional: KILLED ({'PASS': 3047, 'FAIL': 16, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking
+M22-gating-tally-unconditional: KILLED ({'PASS': 3054, 'FAIL': 16, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
-M23-delisted-rows-hidden: KILLED ({'PASS': 3054, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M23-delisted-rows-hidden: KILLED ({'PASS': 3061, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
-M24-delisted-status-not-normalised: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M24-delisted-status-not-normalised: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedStatusMatchIsNormalised
-       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/REMOVED
-       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/Removed
-       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+       app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
     <- TestDoctorDelistedStatusMatchIsNormalised/removed#01
-       app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
-M25-ordering-dropped: KILLED ({'PASS': 3054, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+M25-ordering-dropped: KILLED ({'PASS': 3061, 'FAIL': 9, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorDelistedListingsDoNotSetTheExitCode
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
     <- TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1
-       app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
-M26-delisted-heading-dropped: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+M26-delisted-heading-dropped: KILLED ({'PASS': 3067, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:1008: a delisted app must still be fully reported (missing "do NOT set the exit code"):
+       app_doctor_test.go:1034: a delisted app must still be fully reported (missing "do NOT set the exit code"):
     <- TestDoctorProcessExitStatusEndToEnd
        doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
     <- TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0
        doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
-M27-summary-explanation-dropped: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+M27-summary-explanation-dropped: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorDelistedRowsAreStillVisible
-       app_doctor_test.go:1013: the summary must explain why the exit code disagrees with the blocking count:
-M28-onsite-arm-dropped: KILLED ({'PASS': 3056, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1039: the summary must explain why the exit code disagrees with the blocking count:
+M28-onsite-arm-dropped: KILLED ({'PASS': 3063, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorOnsiteTextRemedyNamesTheManifest
-       app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:37571/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1177: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:34067/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:44909/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+       app_doctor_test.go:1256: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:33603/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39693/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
-M29-onsite-arm-always: KILLED ({'PASS': 3057, 'FAIL': 6, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39693/apps/listing/apl_ALPHA111/edit"
+M29-onsite-arm-always: KILLED ({'PASS': 3064, 'FAIL': 6, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
     <- TestDoctorTextFixesPointAtTheListingEditorNotTheSlug
-       app_doctor_test.go:533: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:36531/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:559: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:45959/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorOffsiteTextRemedyStillPointsAtTheEditor
-       app_doctor_test.go:1174: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1200: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
-M30-kind-not-normalised: KILLED ({'PASS': 3059, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M30-kind-not-normalised: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/ONSITE
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/Onsite
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite#01
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
-M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3060, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"
+M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3067, 'FAIL': 3, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=
-       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+       app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
     <- TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future
-       app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
-M32-kind-not-passed-through: KILLED ({'PASS': 3056, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+M32-kind-not-passed-through: KILLED ({'PASS': 3063, 'FAIL': 7, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorOnsiteTextRemedyNamesTheManifest
-       app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:33229/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1177: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:40009/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorUnknownKindTakesTheRecoverableArm
-       app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:35035/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
+       app_doctor_test.go:1256: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:39037/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing
     <- TestDoctorKindMatchIsNormalised
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44749/apps/listing/apl_ALPHA111/edit"
     <- TestDoctorKindMatchIsNormalised/onsite
-       app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
-M33-screenshot-advice-appends: KILLED ({'PASS': 3061, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44749/apps/listing/apl_ALPHA111/edit"
+M33-screenshot-advice-appends: KILLED ({'PASS': 3068, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
     <- TestBlockedMediaRemedyIsSufficientPerSlot
-       app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+       app_doctor_test.go:1336: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha. On an approved 
     <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish
-       app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
-M34-blocked-kind-always-empty: KILLED ({'PASS': 3058, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1336: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha. On an approved 
+M34-blocked-kind-always-empty: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
     <- TestBlockedMediaRemedyIsSufficientPerSlot
-       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+       app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing
     <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_icon_before_it_can_publish
-       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+       app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing
     <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_cover_before_it_can_publish
-       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
-    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish
-       app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
-M35-fallback-drops-removal: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing
+    <- TestBlockedMediaKindExtractionIsWordBased
+       app_doctor_test.go:1371: blockedMediaKind("replace the blocked Screenshot before it can publish") = "", want "screenshot"
+M35-fallback-drops-removal: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestBlockedMediaUnknownLabelKeepsTheRemoval
-       app_doctor_test.go:1319: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot
-M36-truncation-never-reported: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
-    <- TestDoctorReportsTruncationAtThePageCap
-       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
-M37-truncation-off-by-one: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
-    <- TestDoctorReportsTruncationAtThePageCap
-       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
-M38-truncation-caveat-silent: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
-    <- TestDoctorReportsTruncationAtThePageCap
-       app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
-M39-json-drops-kind: KILLED ({'PASS': 3062, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+       app_doctor_test.go:1357: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing add-screenshot (find the alsc_ id with ci
+M36-truncation-never-reported: KILLED ({'PASS': 3065, 'FAIL': 5, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorTruncationBoundary
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationBoundary/n=200
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationBoundary/n=201
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationIsReportedOnTheBySlugPathToo
+       app_doctor_test.go:1476: the caveat must print on the by-slug path:
+M37-truncation-off-by-one: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorTruncationBoundary
+       app_doctor_test.go:1449: n=200 caveat presence = false, want true
+    <- TestDoctorTruncationBoundary/n=200
+       app_doctor_test.go:1449: n=200 caveat presence = false, want true
+    <- TestDoctorTruncationIsReportedOnTheBySlugPathToo
+       app_doctor_test.go:1476: the caveat must print on the by-slug path:
+    <- TestDoctorNotFoundOnACappedPageIsNotConclusive
+       app_doctor_test.go:1508: a not-found off a capped page must say it is uncertain (missing "not conclusive"): no listing of yours is called "an-app-past-the-cap" — you can work on: bulk-app-000, bulk-app-001, bulk-app-002, bulk-app-003, bulk-app-004, bulk-app-005, bulk-app-006, bulk-app-007, bulk-app-
+M38-truncation-caveat-silent: KILLED ({'PASS': 3066, 'FAIL': 4, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorTruncationBoundary
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationBoundary/n=200
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationBoundary/n=201
+       app_doctor_test.go:1449: n=201 caveat presence = false, want true
+    <- TestDoctorTruncationIsReportedOnTheBySlugPathToo
+       app_doctor_test.go:1476: the caveat must print on the by-slug path:
+M39-json-drops-kind: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
     <- TestDoctorJSONShapeIsPinnedWhole
        (no assertion line captured)
+M40-error-prefix-restored: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorVerdictPrintsNoErrorPrefix
+       doctor_e2e_exitcode_test.go:297: the verdict line still leads with "Error:" — a CI scraper watching stderr for it flags a run that worked exactly as designed.
+M41-error-prefix-dropped-everywhere: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorVerdictPrintsNoErrorPrefix
+       doctor_e2e_exitcode_test.go:311: a genuine failure must still lead with "Error:" — suppressing it everywhere would hide real errors from the same scraper.
+M42-truncation-from-filtered-slice: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorTruncationIsReportedOnTheBySlugPathToo
+       app_doctor_test.go:1476: the caveat must print on the by-slug path:
+M43-notfound-hides-the-cap: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorNotFoundOnACappedPageIsNotConclusive
+       app_doctor_test.go:1508: a not-found off a capped page must say it is uncertain (missing "not conclusive"): no listing of yours is called "an-app-past-the-cap" — you can work on: bulk-app-000, bulk-app-001, bulk-app-002, bulk-app-003, bulk-app-004, bulk-app-005, bulk-app-006, bulk-app-007, bulk-app-
+M44-json-kind-hardcoded: KILLED ({'PASS': 3069, 'FAIL': 1, 'SKIP': 1, 'PANIC': 0})
+    <- TestDoctorJSONShapeIsPinnedWhole
+       (no assertion line captured)
+M45-screenshot-omits-submit: KILLED ({'PASS': 3068, 'FAIL': 2, 'SKIP': 1, 'PANIC': 0})
+    <- TestBlockedMediaRemedyIsSufficientPerSlot
+       app_doctor_test.go:1331: missing "submit-revision" in: REMOVE the blocked screenshot — adding another does not clear it: civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+    <- TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish
+       app_doctor_test.go:1331: missing "submit-revision" in: REMOVE the blocked screenshot — adding another does not clear it: civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
 
 ==== TABLE ====
 M1-exit-gate	KILLED	off-by-one on the exit gate: one blocking problem stops failing the build
-	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorJSONIsTheWholeOfStdout :: app_doctor_test.go:411: expected a non-zero verdict
-M2-severity-compare	KILLED	the severity split is inverted
+	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorJSONIsTheWholeOfStdout :: app_doctor_test.go:418: expected a non-zero verdict
+M2-severity-compare	KILLED (TRUNCATED)	the severity split is inverted
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:168: advisories alone must exit 0, got listing not ready to publish: 2 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:198: summary line is wrong; got:; TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:5 Advisory:3 Gating:5 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}
 M3-ok-field	KILLED	--json `ok` always says the listing is fine
-	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:254: ok must be false when anything is blocking; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1 :: app_doctor_test.go:982: ok = true with gating = 1 — `ok` must follow gating, not blocking
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:254: ok must be false when anything is blocking; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:1008: ok = true with gating = 1 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_live_listing_with_blocking_problems_exits_1 :: app_doctor_test.go:1008: ok = true with gating = 1 — `ok` must follow gating, not blocking
 M4-icon-remedy	KILLED	missing-icon advises the cover command
 	TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M5-slug-predicate	KILLED	the typed slug is compared byte-for-byte instead of through the shared predicate
-	TestDoctorSlugSelectionNormalises :: app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:; TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA :: app_doctor_test.go:624: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
+	TestDoctorSlugSelectionNormalises :: app_doctor_test.go:650: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:; TestDoctorSlugSelectionNormalises/DOCTOR-ALPHA :: app_doctor_test.go:650: "DOCTOR-ALPHA" should resolve to "doctor-alpha", got no listing of yours is called "DOCTOR-ALPHA" — you can work on: doctor-alpha; stdout:
 M6-unknown-slug	KILLED	an unknown slug reads as a clean run
-	TestDoctorUnknownSlugIsNotFoundNotAPass :: app_doctor_test.go:643: an unknown slug must NOT read as a clean run; stdout:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.; TestDoctorProcessExitStatusEndToEnd/an_unknown_slug_is_NOT_FOUND,_not_a_pass :: doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
+	TestDoctorUnknownSlugIsNotFoundNotAPass :: app_doctor_test.go:669: an unknown slug must NOT read as a clean run; stdout:; TestDoctorNotFoundOnACappedPageIsNotConclusive :: app_doctor_test.go:1501: expected a not-found; TestDoctorVerdictSentinelIsDistinguishable :: app_doctor_test.go:1584: control: expected a not-found error; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:231: `civitai app doctor not-an-app-of-mine` exited 0, want 4 — `you own no app called that` and `that app is fine` are opposite answers.
 M7-edit-url-id-space	KILLED	the listing editor URL is built from the slug, so it 404s
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:538: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:39599/apps/listing/doctor-alpha/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1171: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:41743/apps/listing/doctor-bravo/edit"
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:564: code "empty-category" built the editor URL from the SLUG, which 404s: "edit the listing in the browser: http://127.0.0.1:33557/apps/listing/doctor-alpha/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1197: offsite "empty-category" must point at the listing editor, got "edit the listing in the browser: http://127.0.0.1:34955/apps/listing/doctor-bravo/edit"
 M8-empty-sentence	KILLED	an empty run prints nothing at all
-	TestDoctorNoListingsIsASentenceAndExitsZero :: app_doctor_test.go:669: an empty run printed NOTHING — that is indistinguishable from a swallowed read
+	TestDoctorNoListingsIsASentenceAndExitsZero :: app_doctor_test.go:695: an empty run printed NOTHING — that is indistinguishable from a swallowed read
 M9-clean-sentence	KILLED	a clean app renders as a gap instead of a verdict
 	TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:155: a clean listing must SAY it is complete, got:; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_complete_listing_exits_clean :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":; TestDoctorProcessExitStatusEndToEnd/a_removed_listing_next_to_a_CLEAN_live_one_exits_0 :: doctor_e2e_exitcode_test.go:235: stdout does not carry "No problems":
 M10-trpc-input	KILLED	an input-less tRPC query is sent with ?input={"json":null}
-	TestDoctorSendsNoInputParameter :: app_doctor_test.go:736: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
+	TestDoctorSendsNoInputParameter :: app_doctor_test.go:762: listMine was sent with a query string "input=%7B%22json%22%3Anull%7D" — it takes no input, so none should be sent
 M11-extra-request	KILLED	doctor starts asking getAssetScanStatuses (the owner-filtered proc)
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnACleanListing :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorExitsZeroOnAdvisoryOnly :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:110: unexpected request to /api/trpc/appListings.getAssetScanStatuses — `app doctor` speaks only /api/trpc/appListings.listMine
 M12-scanning-remedy	KILLED	scanning-media advises re-attaching, which restarts the scan
-	TestDoctorScanningMediaOffersNoAction :: app_doctor_test.go:552: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
+	TestDoctorScanningMediaOffersNoAction :: app_doctor_test.go:578: scanning-media must not advise "set-icon" — re-attaching restarts the scan; got "civitai app listing set-icon <file> --slug doctor-alpha"
 M13-unknown-severity	KILLED	an unrecognised severity is promoted to blocking
-	TestDoctorUnknownSeverityIsNotBlocking :: app_doctor_test.go:583: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorSeverityIsNormalised :: app_doctor_test.go:1367: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
+	TestDoctorUnknownSeverityIsNotBlocking :: app_doctor_test.go:609: an unrecognised severity must not block a release, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorSeverityIsNormalised :: app_doctor_test.go:1405: control: an unrecognised severity word must NOT gate, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command
 M14-summary-count	KILLED	the summary counts blocked APPS instead of blocking PROBLEMS
-	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}; TestDoctorPositiveControlOnTheFindingCount :: app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
+	TestDoctorReportsAllEightCodesInTheRightGroup :: app_doctor_test.go:251: summary = {Apps:1 Blocking:1 Advisory:5 Gating:3 Delisted:0 Truncated:false}, want {apps:1 blocking:3 advisory:5}; TestDoctorPositiveControlOnTheFindingCount :: app_doctor_test.go:269: POSITIVE CONTROL FAILED: a payload carrying 8 problems produced 6 findings. Every zero this file reports is a fact about a probe wired to nothing until this passes.; TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:1000: summary.blocking = 2, want 1 — every blocking problem must still be COUNTED
 M15-exit-tag	KILLED	the verdict is tagged ErrBadRequest, moving its exit code from 1 to 2
 	TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/a_blocking_problem_fails_the_build :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/blocked-media_is_blocking_too :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.; TestDoctorProcessExitStatusEndToEnd/--json_uses_the_same_codes :: doctor_e2e_exitcode_test.go:231: `civitai app doctor` exited 2, want 1 — a delisted app must not MASK a real one — this is the arm a naive filter gets wrong.
 M16-metrics-403-claim	KILLED	the corrected D2 claim drifts back to the false one
@@ -300,48 +332,60 @@ M16-metrics-403-claim	KILLED	the corrected D2 claim drifts back to the false one
 M17-gates-inverted	KILLED	the predicate is inverted: ONLY delisted listings gate
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M18-gates-always-true	KILLED	delisted listings gate again — the defect this rule exists to remove
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M19-gates-always-false	KILLED	NOTHING gates — the exit code can never be 1
 	TestDoctorExitsNonZeroOnABlockingProblem :: app_doctor_test.go:134: a blocking problem must exit non-zero; stdout was:; TestDoctorBlockingWinsOverAdvisoriesOnTheSameApp :: app_doctor_test.go:193: a mixed app with one blocking problem must exit non-zero; stdout:; TestDoctorReportsAllEightCodesInTheRightGroup :: (no line); TestDoctorJSONShapeIsPinnedWhole :: (no line)
 M20-exit-reads-blocking	KILLED	the exit gate reads the total instead of the gating subset
-	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:997: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1023: a delisted-only run must exit 0, got listing not ready to publish: 0 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M21-ok-reads-blocking	KILLED	--json `ok` disagrees with the exit code on a delisted-only run
-	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:982: ok = false with gating = 0 — `ok` must follow gating, not blocking
+	TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_next_to_a_CLEAN_live_one_still_exits_0 :: app_doctor_test.go:1008: ok = false with gating = 0 — `ok` must follow gating, not blocking
 M22-gating-tally-unconditional	KILLED	every app's blocking problems are tallied as gating
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:967: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:993: expected exit 0 — nothing publishable is blocked; got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M23-delisted-rows-hidden	KILLED	delisted apps are DROPPED from the report — the population-becomes-unreachable failure
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
 M24-delisted-status-not-normalised	KILLED	a padded or mis-cased `removed` silently gates again
-	TestDoctorDelistedStatusMatchIsNormalised :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/REMOVED :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/Removed :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/removed#01 :: app_doctor_test.go:1079: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
+	TestDoctorDelistedStatusMatchIsNormalised :: app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/REMOVED :: app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/Removed :: app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:; TestDoctorDelistedStatusMatchIsNormalised/removed#01 :: app_doctor_test.go:1105: status " removed " must read as delisted, got listing not ready to publish: 1 blocking problem(s) on publishable listing(s) — the report above lists them; this exit code is the verdict, not a failure of the command; stdout:
 M25-ordering-dropped	KILLED	delisted apps are dropped from the ordering pass, so they no longer sort last
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:974: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorDelistedListingsDoNotSetTheExitCode :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/a_removed_listing_with_blocking_problems_exits_0 :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED; TestDoctorDelistedListingsDoNotSetTheExitCode/BOTH_present_exits_1 :: app_doctor_test.go:1000: summary.blocking = 0, want 1 — every blocking problem must still be COUNTED
 M26-delisted-heading-dropped	KILLED	the delisted section loses its heading, so a 0 exit beside BLOCKING findings is unexplained
-	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1008: a delisted app must still be fully reported (missing "do NOT set the exit code"):; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":; TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0 :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1034: a delisted app must still be fully reported (missing "do NOT set the exit code"):; TestDoctorProcessExitStatusEndToEnd :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":; TestDoctorProcessExitStatusEndToEnd/a_REMOVED_listing_with_blocking_problems_exits_0 :: doctor_e2e_exitcode_test.go:235: stdout does not carry "Delisted":
 M27-summary-explanation-dropped	KILLED	the summary stops explaining why blocking and the exit code disagree
-	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1013: the summary must explain why the exit code disagrees with the blocking count:
+	TestDoctorDelistedRowsAreStillVisible :: app_doctor_test.go:1039: the summary must explain why the exit code disagrees with the blocking count:
 M28-onsite-arm-dropped	KILLED	an onsite app is told to edit the browser, whose edit (3b-sync) reverts
-	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:37571/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:44909/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:37165/apps/listing/apl_ALPHA111/edit"
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1177: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:34067/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1256: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:33603/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39693/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:39693/apps/listing/apl_ALPHA111/edit"
 M29-onsite-arm-always	KILLED	an offsite app is told to edit a block.manifest.json it does not have
-	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:533: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:36531/apps/listing/apl_ALPHA111/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1174: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+	TestDoctorJSONShapeIsPinnedWhole :: (no line); TestDoctorTextFixesPointAtTheListingEditorNotTheSlug :: app_doctor_test.go:559: code "empty-category" fix = "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version", want it to name "http://127.0.0.1:45959/apps/listing/apl_ALPHA111/edit"; TestDoctorOffsiteTextRemedyStillPointsAtTheEditor :: app_doctor_test.go:1200: offsite "empty-category" names a manifest an off-site app does not have: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M30-kind-not-normalised	KILLED	a padded or mis-cased kind silently re-routes the text advice
-	TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/ONSITE :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/Onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite#01 :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:38739/apps/listing/apl_ALPHA111/edit"
+	TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/ONSITE :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/Onsite :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite#01 :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:32901/apps/listing/apl_ALPHA111/edit"
 M31-kind-unknown-takes-manifest	KILLED	an absent/unknown kind takes the manifest arm instead of the recoverable one
-	TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind= :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future :: app_doctor_test.go:1220: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
+	TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind= :: app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"; TestDoctorUnknownKindTakesTheRecoverableArm/kind=a-kind-from-the-future :: app_doctor_test.go:1246: kind "a-kind-from-the-future" must not take the manifest arm: "these fields come from block.manifest.json on an on-site app — edit `name` / `tagline` / `description` there, then `civitai app submit` a new version"
 M32-kind-not-passed-through	KILLED	the row's kind never reaches the remedy, so every app gets the offsite arm
-	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1151: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:33229/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1230: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:35035/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1243: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:35639/apps/listing/apl_ALPHA111/edit"
+	TestDoctorOnsiteTextRemedyNamesTheManifest :: app_doctor_test.go:1177: onsite "empty-category" still points at the browser editor, whose edit `(3b-sync)` reverts: "edit the listing in the browser: http://127.0.0.1:40009/apps/listing/apl_ALPHA111/edit"; TestDoctorUnknownKindTakesTheRecoverableArm :: app_doctor_test.go:1256: control: `onsite` did not take the manifest arm ("edit the listing in the browser: http://127.0.0.1:39037/apps/listing/apl_ALPHA111/edit") — the negatives prove nothing; TestDoctorKindMatchIsNormalised :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44749/apps/listing/apl_ALPHA111/edit"; TestDoctorKindMatchIsNormalised/onsite :: app_doctor_test.go:1269: kind " onsite " must read as onsite, got fix "edit the listing in the browser: http://127.0.0.1:44749/apps/listing/apl_ALPHA111/edit"
 M33-screenshot-advice-appends	KILLED	a blocked SCREENSHOT is answered with add-screenshot, which appends and leaves it blocked
-	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1301: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
+	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1336: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha. On an approved ; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1336: must not advise "add-screenshot" — it does not clear this slot: civitai app listing add-screenshot <file> --slug doctor-alpha civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha. On an approved 
 M34-blocked-kind-always-empty	KILLED	the slot is never extracted, so every blocked asset gets the generic arm
-	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_icon_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_cover_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1296: missing "civitai app listing status" in: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot
+	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_icon_before_it_can_publish :: app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_cover_before_it_can_publish :: app_doctor_test.go:1336: must not advise "set-icon" — it does not clear this slot: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing rm-screenshot (find the alsc_ id with civitai app listing; TestBlockedMediaKindExtractionIsWordBased :: app_doctor_test.go:1371: blockedMediaKind("replace the blocked Screenshot before it can publish") = "", want "screenshot"
 M35-fallback-drops-removal	KILLED	the unknown-label fallback loses the REMOVAL, which is the only sufficient screenshot fix
-	TestBlockedMediaUnknownLabelKeepsTheRemoval :: app_doctor_test.go:1319: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot
+	TestBlockedMediaUnknownLabelKeepsTheRemoval :: app_doctor_test.go:1357: the fallback must not advise appending, which never clears a blocked row: replace or remove the blocked asset named above, with --slug doctor-alpha — civitai app listing set-icon, civitai app listing set-cover, or civitai app listing add-screenshot (find the alsc_ id with ci
 M36-truncation-never-reported	KILLED	a truncated page reports ok:true indistinguishably from a complete one
-	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+	TestDoctorTruncationBoundary :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationBoundary/n=200 :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationBoundary/n=201 :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationIsReportedOnTheBySlugPathToo :: app_doctor_test.go:1476: the caveat must print on the by-slug path:
 M37-truncation-off-by-one	KILLED	an exactly-at-cap page is called complete, though it is the commonest truncated case
-	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+	TestDoctorTruncationBoundary :: app_doctor_test.go:1449: n=200 caveat presence = false, want true; TestDoctorTruncationBoundary/n=200 :: app_doctor_test.go:1449: n=200 caveat presence = false, want true; TestDoctorTruncationIsReportedOnTheBySlugPathToo :: app_doctor_test.go:1476: the caveat must print on the by-slug path:; TestDoctorNotFoundOnACappedPageIsNotConclusive :: app_doctor_test.go:1508: a not-found off a capped page must say it is uncertain (missing "not conclusive"): no listing of yours is called "an-app-past-the-cap" — you can work on: bulk-app-000, bulk-app-001, bulk-app-002, bulk-app-003, bulk-app-004, bulk-app-005, bulk-app-006, bulk-app-007, bulk-app-
 M38-truncation-caveat-silent	KILLED	the stderr caveat never prints, so only a JSON reader can learn the page was capped
-	TestDoctorReportsTruncationAtThePageCap :: app_doctor_test.go:1397: the caveat must reach stderr (missing "would not change the exit code"):
+	TestDoctorTruncationBoundary :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationBoundary/n=200 :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationBoundary/n=201 :: app_doctor_test.go:1449: n=201 caveat presence = false, want true; TestDoctorTruncationIsReportedOnTheBySlugPathToo :: app_doctor_test.go:1476: the caveat must print on the by-slug path:
 M39-json-drops-kind	KILLED	--json omits the field that decides `fix`, so a consumer cannot reproduce the branch
 	TestDoctorJSONShapeIsPinnedWhole :: (no line)
+M40-error-prefix-restored	KILLED	the verdict line leads with `Error:` again, which a CI scraper flags as a failure
+	TestDoctorVerdictPrintsNoErrorPrefix :: doctor_e2e_exitcode_test.go:297: the verdict line still leads with "Error:" — a CI scraper watching stderr for it flags a run that worked exactly as designed.
+M41-error-prefix-dropped-everywhere	KILLED	the prefix is suppressed for REAL failures too, hiding them from the same scraper
+	TestDoctorVerdictPrintsNoErrorPrefix :: doctor_e2e_exitcode_test.go:311: a genuine failure must still lead with "Error:" — suppressing it everywhere would hide real errors from the same scraper.
+M42-truncation-from-filtered-slice	KILLED	truncation is computed from the filtered slice again, so a by-slug run is dead-false
+	TestDoctorTruncationIsReportedOnTheBySlugPathToo :: app_doctor_test.go:1476: the caveat must print on the by-slug path:
+M43-notfound-hides-the-cap	KILLED	a not-found off a capped page is reported as conclusive about an app the caller may own
+	TestDoctorNotFoundOnACappedPageIsNotConclusive :: app_doctor_test.go:1508: a not-found off a capped page must say it is uncertain (missing "not conclusive"): no listing of yours is called "an-app-past-the-cap" — you can work on: bulk-app-000, bulk-app-001, bulk-app-002, bulk-app-003, bulk-app-004, bulk-app-005, bulk-app-006, bulk-app-007, bulk-app-
+M44-json-kind-hardcoded	KILLED	the kind is HARDCODED rather than nulled — the mutant M39 could not see
+	TestDoctorJSONShapeIsPinnedWhole :: (no line)
+M45-screenshot-omits-submit	KILLED	the screenshot remedy omits submit-revision, so doctor keeps reporting blocked-media
+	TestBlockedMediaRemedyIsSufficientPerSlot :: app_doctor_test.go:1331: missing "submit-revision" in: REMOVE the blocked screenshot — adding another does not clear it: civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha; TestBlockedMediaRemedyIsSufficientPerSlot/Replace_the_blocked_screenshot_before_it_can_publish :: app_doctor_test.go:1331: missing "submit-revision" in: REMOVE the blocked screenshot — adding another does not clear it: civitai app listing status --slug doctor-alpha to find its alsc_ id, then civitai app listing rm-screenshot <id> --slug doctor-alpha
 
-==== VERDICT ==== ran=39 killed=39 survived=0 not_run=0
+==== VERDICT ==== defined=45 ran=45 killed=45 survived=0 build_fail=0 not_run=0 truncated=1

--- a/scripts/mutation/RESULTS-app-doctor.txt
+++ b/scripts/mutation/RESULTS-app-doctor.txt
@@ -1,0 +1,17 @@
+harness_rc=0
+==== VERDICT ==== ran=32 killed=32 survived=0 not_run=0
+--- new mutants ---
+M28-onsite-arm-dropped: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+M29-onsite-arm-always: KILLED ({'PASS': 3043, 'FAIL': 6, 'SKIP': 1})
+M30-kind-not-normalised: KILLED ({'PASS': 3045, 'FAIL': 4, 'SKIP': 1})
+M31-kind-unknown-takes-manifest: KILLED ({'PASS': 3046, 'FAIL': 3, 'SKIP': 1})
+M32-kind-not-passed-through: KILLED ({'PASS': 3042, 'FAIL': 7, 'SKIP': 1})
+M28-onsite-arm-dropped	KILLED	an onsite app is told to edit the browser, whose edit (3b-sync) reverts
+M29-onsite-arm-always	KILLED	an offsite app is told to edit a block.manifest.json it does not have
+M30-kind-not-normalised	KILLED	a padded or mis-cased kind silently re-routes the text advice
+M31-kind-unknown-takes-manifest	KILLED	an absent/unknown kind takes the manifest arm instead of the recoverable one
+M32-kind-not-passed-through	KILLED	the row's kind never reaches the remedy, so every app gets the offsite arm
+--- reconcile ---
+defined=32 verdicts=31
+
+[exited with code 0]

--- a/scripts/mutation/mutate-app-doctor.py
+++ b/scripts/mutation/mutate-app-doctor.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Mutation battery for `civitai app doctor`.
+
+Each mutant is the NARROWEST expression that can be wrong. For each:
+  apply -> run the FULL relevant packages -> record which tests failed and the
+  first assertion line of each -> restore and verify the tree is byte-identical.
+
+Reports SURVIVED loudly. Runs the whole package (never a -run filter that could
+exclude the killing test).
+"""
+import hashlib
+import os
+import re
+import subprocess
+import sys
+
+WT = os.environ.get("MUTATE_TREE", os.getcwd())
+PKGS = ["./internal/cmd/", "./internal/appapi/", "./cmd/civitai/"]
+
+DOCTOR = "internal/cmd/app_doctor.go"
+LISTING = "internal/appapi/listing.go"
+METRICS = "internal/cmd/app_metrics.go"
+
+# (id, file, old, new, why)
+MUTANTS = [
+    ("M1-exit-gate", DOCTOR,
+     "if payload.Summary.Gating > 0 {",
+     "if payload.Summary.Gating > 1 {",
+     "off-by-one on the exit gate: one blocking problem stops failing the build"),
+
+    ("M2-severity-compare", DOCTOR,
+     "return p.Severity == appapi.SeverityBlocking",
+     "return p.Severity == appapi.SeverityAdvisory",
+     "the severity split is inverted"),
+
+    ("M3-ok-field", DOCTOR,
+     "out.OK = out.Summary.Gating == 0",
+     "out.OK = true",
+     "--json `ok` always says the listing is fine"),
+
+    ("M4-icon-remedy", DOCTOR,
+     'return "civitai app listing set-icon <file> --slug " + slug',
+     'return "civitai app listing set-cover <file> --slug " + slug',
+     "missing-icon advises the cover command"),
+
+    ("M5-slug-predicate", DOCTOR,
+     "if appapi.SameSlug(slug, r.Slug) {",
+     "if slug == r.Slug {",
+     "the typed slug is compared byte-for-byte instead of through the shared predicate"),
+
+    ("M6-unknown-slug", DOCTOR,
+     "return doctorNoSuchApp(slug, rows)",
+     "return nil",
+     "an unknown slug reads as a clean run"),
+
+    ("M7-edit-url-id-space", DOCTOR,
+     "editURL := editBase + fmt.Sprintf(listingEditPath, r.AppListingID)",
+     "editURL := editBase + fmt.Sprintf(listingEditPath, r.Slug)",
+     "the listing editor URL is built from the slug, so it 404s"),
+
+    ("M8-empty-sentence", DOCTOR,
+     'fmt.Fprintf(w, "No App listings to check — you own none and hold no collaborator seats. %s creates one.\\n",\n\t\t\tst.Code("civitai app submit"))',
+     '_ = st',
+     "an empty run prints nothing at all"),
+
+    ("M9-clean-sentence", DOCTOR,
+     'fmt.Fprintln(w, "  "+st.Success("No problems — this listing is complete."))',
+     "_ = st",
+     "a clean app renders as a gap instead of a verdict"),
+
+    ("M10-trpc-input", LISTING,
+     "\tif input != nil {",
+     "\tif true {",
+     "an input-less tRPC query is sent with ?input={\"json\":null}"),
+
+    ("M11-extra-request", DOCTOR,
+     "rows, err := client.ListMyListings(cmdCtx(cmd))",
+     "_, _ = client.GetAssetScanStatuses(cmdCtx(cmd), []int{1})\n\t\t\trows, err := client.ListMyListings(cmdCtx(cmd))",
+     "doctor starts asking getAssetScanStatuses (the owner-filtered proc)"),
+
+    ("M12-scanning-remedy", DOCTOR,
+     'return "nothing to do — the scan finishes on its own; re-run `civitai app doctor` in a minute"',
+     'return "civitai app listing set-icon <file> --slug " + slug',
+     "scanning-media advises re-attaching, which restarts the scan"),
+
+    ("M13-unknown-severity", DOCTOR,
+     "return p.Severity == appapi.SeverityBlocking",
+     "return p.Severity != appapi.SeverityAdvisory",
+     "an unrecognised severity is promoted to blocking"),
+
+    ("M14-summary-count", DOCTOR,
+     "out.Summary.Blocking += len(app.Blocking)",
+     "out.Summary.Blocking += 1",
+     "the summary counts blocked APPS instead of blocking PROBLEMS"),
+
+    ("M15-exit-tag", DOCTOR,
+     'return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",\n\t\t\tErrListingBlocked, payload.Summary.Gating)',
+     'return civitai.Tag(civitai.ErrBadRequest, fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",\n\t\t\tErrListingBlocked, payload.Summary.Gating))',
+     "the verdict is tagged ErrBadRequest, moving its exit code from 1 to 2"),
+
+    ("M16-metrics-403-claim", METRICS,
+     '"no token configured — app analytics need %s. Or set CIVITAI_TOKEN to either one"',
+     '"no token configured — app analytics need %s; a browser login (`civitai login`) is full-scope-refused with 403 here"',
+     "the corrected D2 claim drifts back to the false one"),
+
+    # --- delisted-gating battery (coordinator follow-up 1) ---
+    ("M17-gates-inverted", DOCTOR,
+     'return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)',
+     'return strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)',
+     "the predicate is inverted: ONLY delisted listings gate"),
+
+    ("M18-gates-always-true", DOCTOR,
+     'return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)',
+     'return true',
+     "delisted listings gate again — the defect this rule exists to remove"),
+
+    ("M19-gates-always-false", DOCTOR,
+     'return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)',
+     'return false',
+     "NOTHING gates — the exit code can never be 1"),
+
+    ("M20-exit-reads-blocking", DOCTOR,
+     "if payload.Summary.Gating > 0 {",
+     "if payload.Summary.Blocking > 0 {",
+     "the exit gate reads the total instead of the gating subset"),
+
+    ("M21-ok-reads-blocking", DOCTOR,
+     "out.OK = out.Summary.Gating == 0",
+     "out.OK = out.Summary.Blocking == 0",
+     "--json `ok` disagrees with the exit code on a delisted-only run"),
+
+    ("M22-gating-tally-unconditional", DOCTOR,
+     "\t\tif gates {\n\t\t\t// The ONLY place the exit code is accumulated.\n\t\t\tout.Summary.Gating += len(app.Blocking)",
+     "\t\tif true {\n\t\t\t// The ONLY place the exit code is accumulated.\n\t\t\tout.Summary.Gating += len(app.Blocking)",
+     "every app's blocking problems are tallied as gating"),
+
+    ("M23-delisted-rows-hidden", DOCTOR,
+     "\tfor _, r := range ordered {",
+     "\tfor _, r := range ordered {\n\t\tif !doctorGates(r.Status) {\n\t\t\tcontinue\n\t\t}",
+     "delisted apps are DROPPED from the report — the population-becomes-unreachable failure"),
+
+    ("M24-delisted-status-not-normalised", DOCTOR,
+     'return !strings.EqualFold(strings.TrimSpace(status), listingStatusRemoved)',
+     'return status != listingStatusRemoved',
+     "a padded or mis-cased `removed` silently gates again"),
+
+    # 🔴 THE NARROWEST EXPRESSION THAT CAN BE WRONG. Deleting the two grouping
+    # loops would remove the guard TOGETHER WITH its enclosing construction and
+    # leave `ordered` empty, which dies to a dozen unrelated assertions for the
+    # wrong reason. This keeps the ordering machinery and only defeats the SORT,
+    # by making the second pass select the same rows as the first.
+    ("M25-ordering-dropped", DOCTOR,
+     "\tfor _, r := range rows {\n\t\tif !doctorGates(r.Status) {",
+     "\tfor _, r := range rows {\n\t\tif false && !doctorGates(r.Status) {",
+     "delisted apps are dropped from the ordering pass, so they no longer sort last"),
+
+    ("M26-delisted-heading-dropped", DOCTOR,
+     'fmt.Fprintln(w, st.Info("Delisted (status \'removed\') — reported for completeness; these do NOT set the exit code."))',
+     "_ = st",
+     "the delisted section loses its heading, so a 0 exit beside BLOCKING findings is unexplained"),
+
+    ("M27-summary-explanation-dropped", DOCTOR,
+     "\tif payload.Summary.Delisted > 0 {\n\t\tfmt.Fprintf(w, \"%d of them are delisted; %d blocking problem(s) on publishable listings set the exit code.\\n\",\n\t\t\tpayload.Summary.Delisted, payload.Summary.Gating)\n\t}",
+     "",
+     "the summary stops explaining why blocking and the exit code disagree"),
+
+    # --- kind-aware TEXT remedy (audit finding 2 on #489, same defect class here) ---
+    ("M28-onsite-arm-dropped", DOCTOR,
+     "\t\tif listingIsOnsite(kind) {",
+     "\t\tif false {",
+     "an onsite app is told to edit the browser, whose edit (3b-sync) reverts"),
+
+    ("M29-onsite-arm-always", DOCTOR,
+     "\t\tif listingIsOnsite(kind) {",
+     "\t\tif true {",
+     "an offsite app is told to edit a block.manifest.json it does not have"),
+
+    ("M30-kind-not-normalised", DOCTOR,
+     'return strings.EqualFold(strings.TrimSpace(kind), "onsite")',
+     'return kind == "onsite"',
+     "a padded or mis-cased kind silently re-routes the text advice"),
+
+    ("M31-kind-unknown-takes-manifest", DOCTOR,
+     'return strings.EqualFold(strings.TrimSpace(kind), "onsite")',
+     'return !strings.EqualFold(strings.TrimSpace(kind), "offsite")',
+     "an absent/unknown kind takes the manifest arm instead of the recoverable one"),
+
+    ("M32-kind-not-passed-through", DOCTOR,
+     "Fix:      doctorRemedy(p, r.Slug, editURL, r.Kind),",
+     'Fix:      doctorRemedy(p, r.Slug, editURL, ""),',
+     "the row's kind never reaches the remedy, so every app gets the offsite arm"),
+]
+
+
+def sha(path):
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def run_tests():
+    p = subprocess.run(["go", "test", "-count=1", "-v"] + PKGS,
+                       cwd=WT, capture_output=True, text=True)
+    return p.stdout + p.stderr
+
+
+def parse(out):
+    """Return (failed_tests, first assertion line per test)."""
+    fails = re.findall(r"^\s*--- FAIL: (\S+)", out, re.M)
+    detail = {}
+    lines = out.split("\n")
+    for i, line in enumerate(lines):
+        m = re.match(r"^=== RUN\s+(\S+)$", line)
+        if not m:
+            continue
+    # simpler: attribute the first "_test.go:NN:" line following a FAIL header
+    for i, line in enumerate(lines):
+        m = re.match(r"^\s*--- FAIL: (\S+)", line)
+        if not m:
+            continue
+        name = m.group(1)
+        # the assertion lines are printed BEFORE the FAIL header in go test -v
+        for j in range(i - 1, max(0, i - 60), -1):
+            mm = re.search(r"(\w+_test\.go:\d+:\s*.*)", lines[j])
+            if mm:
+                detail[name] = mm.group(1)[:300]
+                break
+    counts = {
+        "PASS": len(re.findall(r"^\s*--- PASS:", out, re.M)),
+        "FAIL": len(fails),
+        "SKIP": len(re.findall(r"^\s*--- SKIP:", out, re.M)),
+    }
+    build_err = "build failed" if "[build failed]" in out or "cannot use" in out else ""
+    return fails, detail, counts, build_err
+
+
+def main():
+    only = sys.argv[1:] if len(sys.argv) > 1 else None
+    base_out = run_tests()
+    _, _, base_counts, _ = parse(base_out)
+    print(f"BASELINE: {base_counts}")
+    if base_counts["FAIL"] != 0:
+        print("!! baseline is not green — every result below is meaningless")
+        return 1
+
+    results = []
+    for mid, rel, old, new, why in MUTANTS:
+        if only and mid not in only:
+            continue
+        path = os.path.join(WT, rel)
+        before = sha(path)
+        src = open(path).read()
+        n = src.count(old)
+        if n != 1:
+            print(f"{mid}: BAD-PATTERN — matched {n} times (want exactly 1), NOT RUN. "
+                  f"The mutant's search text is stale against the current source.")
+            results.append((mid, "BAD-PATTERN", "", why))
+            continue
+        open(path, "w").write(src.replace(old, new, 1))
+        out = run_tests()
+        fails, detail, counts, build_err = parse(out)
+        open(path, "w").write(src)
+        assert sha(path) == before, f"{mid}: tree not restored!"
+        if build_err and not fails:
+            verdict = "BUILD-FAIL"
+        elif fails:
+            verdict = "KILLED"
+        else:
+            verdict = "SURVIVED"
+        killers = "; ".join(f"{f} :: {detail.get(f,'(no line)')}" for f in fails[:4])
+        results.append((mid, verdict, killers, why))
+        print(f"{mid}: {verdict} ({counts})")
+        if verdict == "KILLED":
+            for f in fails[:4]:
+                print(f"    <- {f}\n       {detail.get(f,'(no assertion line captured)')}")
+        elif verdict == "SURVIVED":
+            print(f"    !! SURVIVED: {why}")
+
+    bad = [r for r in results if r[1] == "BAD-PATTERN"]
+    surv = [r for r in results if r[1] == "SURVIVED"]
+    print("\n==== TABLE ====")
+    for mid, verdict, killers, why in results:
+        print(f"{mid}\t{verdict}\t{why}\n\t{killers}")
+    print(f"\n==== VERDICT ==== ran={len(results)-len(bad)} killed="
+          f"{len([r for r in results if r[1]=='KILLED'])} survived={len(surv)} not_run={len(bad)}")
+    if bad:
+        print("!! NOT A CLEAN SWEEP — these mutants NEVER RAN, so they are evidence of nothing:")
+        for mid, _, _, why in bad:
+            print(f"     {mid}: {why}")
+        return 2
+    if surv:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutation/mutate-app-doctor.py
+++ b/scripts/mutation/mutate-app-doctor.py
@@ -8,11 +8,17 @@ Each mutant is the NARROWEST expression that can be wrong. For each:
 Reports SURVIVED loudly. Runs the whole package (never a -run filter that could
 exclude the killing test).
 """
+import atexit
 import hashlib
 import os
 import re
 import subprocess
 import sys
+
+# 🔴 A FULL RUN ASSERTS ITS OWN POPULATION, so a table that quietly emptied
+# cannot report a serene `killed=0` and exit 0. Lower this in the same commit
+# that retires a mutant.
+EXPECTED_MUTANTS = 45
 
 WT = os.environ.get("MUTATE_TREE", os.getcwd())
 PKGS = ["./internal/cmd/", "./internal/appapi/", "./cmd/civitai/"]
@@ -193,28 +199,28 @@ MUTANTS = [
     # --- audit finding 1: blocked-media sufficiency per slot ---
     ("M33-screenshot-advice-appends", DOCTOR,
      '\t\t\treturn "REMOVE the blocked screenshot — adding another does not clear it: " +',
-     '\t\t\treturn "civitai app listing add-screenshot <file> --slug " + slug + " " +',
+     '\t\t\treturn "civitai app listing add-screenshot <file> --slug " + slug + " " + "" +',
      "a blocked SCREENSHOT is answered with add-screenshot, which appends and leaves it blocked"),
 
     ("M34-blocked-kind-always-empty", DOCTOR,
-     '\tl := strings.ToLower(label)',
-     '\tl := ""',
+     '\t\tif blockedKindWord[kind].MatchString(label) {',
+     '\t\tif false {',
      "the slot is never extracted, so every blocked asset gets the generic arm"),
 
     ("M35-fallback-drops-removal", DOCTOR,
-     '\t\t"civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot"',
-     '\t\t"civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot"',
+     '\t\t\t"civitai app listing rm-screenshot (find the alsc_ id with " +',
+     '\t\t\t"civitai app listing add-screenshot (find the alsc_ id with " +',
      "the unknown-label fallback loses the REMOVAL, which is the only sufficient screenshot fix"),
 
     # --- audit finding 3: the page cap ---
     ("M36-truncation-never-reported", DOCTOR,
-     "\tout.Summary.Truncated = len(rows) >= appapi.ListMineCap",
-     "\tout.Summary.Truncated = false",
+     "func doctorPageTruncated(n int) bool { return n >= appapi.ListMineCap }",
+     "func doctorPageTruncated(n int) bool { return false }",
      "a truncated page reports ok:true indistinguishably from a complete one"),
 
     ("M37-truncation-off-by-one", DOCTOR,
-     "\tout.Summary.Truncated = len(rows) >= appapi.ListMineCap",
-     "\tout.Summary.Truncated = len(rows) > appapi.ListMineCap",
+     "func doctorPageTruncated(n int) bool { return n >= appapi.ListMineCap }",
+     "func doctorPageTruncated(n int) bool { return n > appapi.ListMineCap }",
      "an exactly-at-cap page is called complete, though it is the commonest truncated case"),
 
     ("M38-truncation-caveat-silent", DOCTOR,
@@ -227,7 +233,62 @@ MUTANTS = [
      "\t\t\tKind:         r.Kind,",
      '\t\t\tKind:         "",',
      "--json omits the field that decides `fix`, so a consumer cannot reproduce the branch"),
+
+    # --- delta-audit fixes ---
+    ("M40-error-prefix-restored", "cmd/civitai/main.go",
+     "\tif errors.Is(err, cmd.ErrListingBlocked) {\n\t\treturn err.Error()\n\t}",
+     "\tif false {\n\t\treturn err.Error()\n\t}",
+     "the verdict line leads with `Error:` again, which a CI scraper flags as a failure"),
+
+    ("M41-error-prefix-dropped-everywhere", "cmd/civitai/main.go",
+     '\treturn "Error: " + err.Error()',
+     "\treturn err.Error()",
+     "the prefix is suppressed for REAL failures too, hiding them from the same scraper"),
+
+    ("M42-truncation-from-filtered-slice", DOCTOR,
+     "\tpayload.Summary.Truncated = doctorPageTruncated(len(rows))",
+     "\tpayload.Summary.Truncated = doctorPageTruncated(len(selected))",
+     "truncation is computed from the filtered slice again, so a by-slug run is dead-false"),
+
+    ("M43-notfound-hides-the-cap", DOCTOR,
+     "\tif doctorPageTruncated(len(rows)) {",
+     "\tif false {",
+     "a not-found off a capped page is reported as conclusive about an app the caller may own"),
+
+    ("M44-json-kind-hardcoded", DOCTOR,
+     "\t\t\tKind:         r.Kind,",
+     '\t\t\tKind:         "offsite",',
+     "the kind is HARDCODED rather than nulled — the mutant M39 could not see"),
+
+    # 🔴 THE MUTANT MUST SPAN BOTH LINES OR IT CREATES NO DEFECT. The first
+    # version replaced only the PROSE and left `"civitai app listing
+    # submit-revision --slug " + slug` on the next line — so the string still
+    # contained "submit-revision", the assertion still passed, and the sweep
+    # reported SURVIVED for a mutation that had not removed anything. A SURVIVED
+    # verdict from a mutant that does not produce its own defect is a FALSE
+    # ALARM, and is exactly as misleading as a KILLED verdict from a mutant that
+    # never ran. Both clauses are deleted here.
+    ("M45-screenshot-omits-submit", DOCTOR,
+     '\t\t\t\t". On an approved listing that stages a revision, so finish with " +\n'
+     '\t\t\t\t"civitai app listing submit-revision --slug " + slug',
+     '\t\t\t\t""',
+     "the screenshot remedy omits submit-revision, so doctor keeps reporting blocked-media"),
 ]
+
+
+# Files currently mutated, so an abnormal exit can put them back.
+_restore_queue = {}
+
+
+def _restore_all():
+    for path, src in list(_restore_queue.items()):
+        try:
+            open(path, "w").write(src)
+        except OSError:
+            pass
+
+
+atexit.register(_restore_all)
 
 
 def sha(path):
@@ -288,18 +349,43 @@ def parse(out):
 
 
 def main():
+    # 🔴 THE SELECTOR USED TO MATCH FULL IDS ONLY, so the invocation the README
+    # itself taught (`… .py M1 M7`) selected NOTHING, ran nothing, and fell
+    # through to `return 0` — which the README defines as "every mutant ran,
+    # compiled, and was killed". An instrument that reports success having run
+    # nothing is the whole failure class this harness exists to avoid, and it
+    # was in the harness. It now accepts a PREFIX, and refuses a name that
+    # matches no mutant instead of quietly doing nothing.
     only = sys.argv[1:] if len(sys.argv) > 1 else None
+    if only:
+        known = [m[0] for m in MUTANTS]
+        unmatched = [a for a in only
+                     if not any(k == a or k.startswith(a + "-") for k in known)]
+        if unmatched:
+            print(f"!! these selectors match no mutant: {unmatched}")
+            print(f"   known: {known}")
+            return 2
     base_out = run_tests()
     _, _, base_counts, _ = parse(base_out)
     base_total = base_counts["PASS"] + base_counts["FAIL"] + base_counts["SKIP"]
     print(f"BASELINE: {base_counts} total={base_total}")
-    if base_counts["FAIL"] != 0:
-        print("!! baseline is not green — every result below is meaningless")
+    if base_counts["FAIL"] != 0 or "[build failed]" in base_out:
+        # A baseline that does not COMPILE is a bad baseline, not a "mutant that
+        # never ran" — it takes 3 like any other, which is what the README says.
+        print("!! baseline is not green (or does not build) — every result below is meaningless")
         return 3
+
+    # 🔴 A FULL RUN ASSERTS ITS OWN POPULATION. Without this a table that
+    # quietly emptied — or a selector bug like the one above — reports a serene
+    # `killed=0 survived=0` and exits 0.
+    if not only and len(MUTANTS) < EXPECTED_MUTANTS:
+        print(f"!! this battery defines {len(MUTANTS)} mutants, expected at least {EXPECTED_MUTANTS}. "
+              f"If mutants were RETIRED, lower EXPECTED_MUTANTS in the same commit that deletes them.")
+        return 2
 
     results = []
     for mid, rel, old, new, why in MUTANTS:
-        if only and mid not in only:
+        if only and not any(mid == a or mid.startswith(a + "-") for a in only):
             continue
         path = os.path.join(WT, rel)
         before = sha(path)
@@ -315,7 +401,11 @@ def main():
         fails, detail, counts, build_err = parse(out)
         open(path, "w").write(src)
         assert sha(path) == before, f"{mid}: tree not restored!"
-        if build_err and not fails:
+        # 🔴 BUILD ERROR WINS OVER `fails`. This was `build_err and not fails`,
+        # so a mutant that failed to COMPILE while some unrelated test also
+        # reported a failure scored KILLED — a build error is not evidence about
+        # the code under test, whatever else the run printed.
+        if build_err:
             verdict = "BUILD-FAIL"
         elif fails:
             verdict = "KILLED"
@@ -331,6 +421,12 @@ def main():
             note = (f"  ⚠ TRUNCATED RUN: {total} verdicts vs baseline {base_total}"
                     f" ({short} missing, panics={counts['PANIC']}) — the verdict below is about a run"
                     f" that did not finish; treat the KILL as unattributed.")
+        # 🔴 `note` GOES IN THE TUPLE. It used to be a local printed to the
+        # stream only, so the `==== TABLE ====` at the end listed a truncated
+        # run as a plain unmarked KILLED and `ran`/`killed` counted it like any
+        # other. A reader recounting from the committed artifact saw no trace.
+        if note:
+            verdict += " (TRUNCATED)"
         results.append((mid, verdict, killers, why))
         print(f"{mid}: {verdict} ({counts})")
         if note:
@@ -343,12 +439,19 @@ def main():
 
     bad = [r for r in results if r[1] == "BAD-PATTERN"]
     surv = [r for r in results if r[1] == "SURVIVED"]
+    bf = [r for r in results if r[1] == "BUILD-FAIL"]
     print("\n==== TABLE ====")
     for mid, verdict, killers, why in results:
         print(f"{mid}\t{verdict}\t{why}\n\t{killers}")
-    print(f"\n==== VERDICT ==== ran={len(results)-len(bad)} killed="
-          f"{len([r for r in results if r[1]=='KILLED'])} survived={len(surv)} not_run={len(bad)}")
-    bf = [r for r in results if r[1] == "BUILD-FAIL"]
+    # 🔴 `ran` EXCLUDES EVERY TERM THAT IS EVIDENCE OF NOTHING. It used to
+    # subtract only BAD-PATTERN while still counting BUILD-FAILs, so the summary
+    # could print `ran=39 killed=38 build_fail=1` — arithmetic disagreeing with
+    # itself. A mutant that never compiled did not run.
+    killed = len([r for r in results if r[1].startswith("KILLED")])
+    trunc = len([r for r in results if "TRUNCATED" in r[1]])
+    print(f"\n==== VERDICT ==== defined={len(results)} ran={len(results)-len(bad)-len(bf)} "
+          f"killed={killed} survived={len(surv)} build_fail={len(bf)} not_run={len(bad)} "
+          f"truncated={trunc}")
     if bad:
         print("!! NOT A CLEAN SWEEP — these mutants NEVER RAN, so they are evidence of nothing:")
         for mid, _, _, why in bad:

--- a/scripts/mutation/mutate-app-doctor.py
+++ b/scripts/mutation/mutate-app-doctor.py
@@ -29,8 +29,8 @@ MUTANTS = [
      "off-by-one on the exit gate: one blocking problem stops failing the build"),
 
     ("M2-severity-compare", DOCTOR,
-     "return p.Severity == appapi.SeverityBlocking",
-     "return p.Severity == appapi.SeverityAdvisory",
+     "return strings.EqualFold(strings.TrimSpace(p.Severity), appapi.SeverityBlocking)",
+     "return strings.EqualFold(strings.TrimSpace(p.Severity), appapi.SeverityAdvisory)",
      "the severity split is inverted"),
 
     ("M3-ok-field", DOCTOR,
@@ -84,8 +84,8 @@ MUTANTS = [
      "scanning-media advises re-attaching, which restarts the scan"),
 
     ("M13-unknown-severity", DOCTOR,
-     "return p.Severity == appapi.SeverityBlocking",
-     "return p.Severity != appapi.SeverityAdvisory",
+     "return strings.EqualFold(strings.TrimSpace(p.Severity), appapi.SeverityBlocking)",
+     "return !strings.EqualFold(strings.TrimSpace(p.Severity), appapi.SeverityAdvisory)",
      "an unrecognised severity is promoted to blocking"),
 
     ("M14-summary-count", DOCTOR,
@@ -94,8 +94,8 @@ MUTANTS = [
      "the summary counts blocked APPS instead of blocking PROBLEMS"),
 
     ("M15-exit-tag", DOCTOR,
-     'return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",\n\t\t\tErrListingBlocked, payload.Summary.Gating)',
-     'return civitai.Tag(civitai.ErrBadRequest, fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — see the report above",\n\t\t\tErrListingBlocked, payload.Summary.Gating))',
+     'return fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — the report above lists them; "+\n\t\t\t"this exit code is the verdict, not a failure of the command",\n\t\t\tErrListingBlocked, payload.Summary.Gating)',
+     'return civitai.Tag(civitai.ErrBadRequest, fmt.Errorf("%w: %d blocking problem(s) on publishable listing(s) — the report above lists them; "+\n\t\t\t"this exit code is the verdict, not a failure of the command",\n\t\t\tErrListingBlocked, payload.Summary.Gating))',
      "the verdict is tagged ErrBadRequest, moving its exit code from 1 to 2"),
 
     ("M16-metrics-403-claim", METRICS,
@@ -189,6 +189,44 @@ MUTANTS = [
      "Fix:      doctorRemedy(p, r.Slug, editURL, r.Kind),",
      'Fix:      doctorRemedy(p, r.Slug, editURL, ""),',
      "the row's kind never reaches the remedy, so every app gets the offsite arm"),
+
+    # --- audit finding 1: blocked-media sufficiency per slot ---
+    ("M33-screenshot-advice-appends", DOCTOR,
+     '\t\t\treturn "REMOVE the blocked screenshot — adding another does not clear it: " +',
+     '\t\t\treturn "civitai app listing add-screenshot <file> --slug " + slug + " " +',
+     "a blocked SCREENSHOT is answered with add-screenshot, which appends and leaves it blocked"),
+
+    ("M34-blocked-kind-always-empty", DOCTOR,
+     '\tl := strings.ToLower(label)',
+     '\tl := ""',
+     "the slot is never extracted, so every blocked asset gets the generic arm"),
+
+    ("M35-fallback-drops-removal", DOCTOR,
+     '\t\t"civitai app listing set-icon, civitai app listing set-cover, civitai app listing rm-screenshot"',
+     '\t\t"civitai app listing set-icon, civitai app listing set-cover, civitai app listing add-screenshot"',
+     "the unknown-label fallback loses the REMOVAL, which is the only sufficient screenshot fix"),
+
+    # --- audit finding 3: the page cap ---
+    ("M36-truncation-never-reported", DOCTOR,
+     "\tout.Summary.Truncated = len(rows) >= appapi.ListMineCap",
+     "\tout.Summary.Truncated = false",
+     "a truncated page reports ok:true indistinguishably from a complete one"),
+
+    ("M37-truncation-off-by-one", DOCTOR,
+     "\tout.Summary.Truncated = len(rows) >= appapi.ListMineCap",
+     "\tout.Summary.Truncated = len(rows) > appapi.ListMineCap",
+     "an exactly-at-cap page is called complete, though it is the commonest truncated case"),
+
+    ("M38-truncation-caveat-silent", DOCTOR,
+     "\tif !payload.Summary.Truncated {\n\t\treturn\n\t}",
+     "\tif true {\n\t\treturn\n\t}",
+     "the stderr caveat never prints, so only a JSON reader can learn the page was capped"),
+
+    # --- audit finding 5: --json carries kind ---
+    ("M39-json-drops-kind", DOCTOR,
+     "\t\t\tKind:         r.Kind,",
+     '\t\t\tKind:         "",',
+     "--json omits the field that decides `fix`, so a consumer cannot reproduce the branch"),
 ]
 
 
@@ -204,7 +242,16 @@ def run_tests():
 
 
 def parse(out):
-    """Return (failed_tests, first assertion line per test)."""
+    """Return (failed_tests, first assertion line per test).
+
+    🔴 THE ATTRIBUTION IS APPROXIMATE AND THE VERDICTS ARE NOT. This scans
+    BACKWARD up to 60 lines from a `--- FAIL` header for any `_test.go:NN:`,
+    which cross-attributes across subtests — in one real sweep all four of a
+    mutant's reported killers echoed a single subtest's message. Which tests
+    FAILED is exact; the REASON printed beside each is a nearby line, not a
+    proven cause. Do not quote these as "each killed by an assertion naming the
+    specific defect" without reading the run.
+    """
     fails = re.findall(r"^\s*--- FAIL: (\S+)", out, re.M)
     detail = {}
     lines = out.split("\n")
@@ -228,6 +275,13 @@ def parse(out):
         "PASS": len(re.findall(r"^\s*--- PASS:", out, re.M)),
         "FAIL": len(fails),
         "SKIP": len(re.findall(r"^\s*--- SKIP:", out, re.M)),
+        # 🔴 A RUN CAN DIE PART-WAY AND STILL LOOK KILLED. One mutant reported
+        # PASS=766 against a 3049 baseline — ~2280 tests produced no verdict at
+        # all, almost certainly a panic. It was legitimately KILLED (its killers
+        # fire before the death), but nothing here could tell "31 tests failed"
+        # from "the suite stopped a third of the way in", and the second is a
+        # result about the harness rather than about the code.
+        "PANIC": len(re.findall(r"^panic:", out, re.M)),
     }
     build_err = "build failed" if "[build failed]" in out or "cannot use" in out else ""
     return fails, detail, counts, build_err
@@ -237,10 +291,11 @@ def main():
     only = sys.argv[1:] if len(sys.argv) > 1 else None
     base_out = run_tests()
     _, _, base_counts, _ = parse(base_out)
-    print(f"BASELINE: {base_counts}")
+    base_total = base_counts["PASS"] + base_counts["FAIL"] + base_counts["SKIP"]
+    print(f"BASELINE: {base_counts} total={base_total}")
     if base_counts["FAIL"] != 0:
         print("!! baseline is not green — every result below is meaningless")
-        return 1
+        return 3
 
     results = []
     for mid, rel, old, new, why in MUTANTS:
@@ -267,8 +322,19 @@ def main():
         else:
             verdict = "SURVIVED"
         killers = "; ".join(f"{f} :: {detail.get(f,'(no line)')}" for f in fails[:4])
+        # Compare this run's TOTAL against the baseline's. A large shortfall
+        # means tests never ran, which no verdict word conveys on its own.
+        total = counts["PASS"] + counts["FAIL"] + counts["SKIP"]
+        short = base_total - total
+        note = ""
+        if counts["PANIC"] or short > base_total * 0.05:
+            note = (f"  ⚠ TRUNCATED RUN: {total} verdicts vs baseline {base_total}"
+                    f" ({short} missing, panics={counts['PANIC']}) — the verdict below is about a run"
+                    f" that did not finish; treat the KILL as unattributed.")
         results.append((mid, verdict, killers, why))
         print(f"{mid}: {verdict} ({counts})")
+        if note:
+            print(note)
         if verdict == "KILLED":
             for f in fails[:4]:
                 print(f"    <- {f}\n       {detail.get(f,'(no assertion line captured)')}")
@@ -282,9 +348,18 @@ def main():
         print(f"{mid}\t{verdict}\t{why}\n\t{killers}")
     print(f"\n==== VERDICT ==== ran={len(results)-len(bad)} killed="
           f"{len([r for r in results if r[1]=='KILLED'])} survived={len(surv)} not_run={len(bad)}")
+    bf = [r for r in results if r[1] == "BUILD-FAIL"]
     if bad:
         print("!! NOT A CLEAN SWEEP — these mutants NEVER RAN, so they are evidence of nothing:")
         for mid, _, _, why in bad:
+            print(f"     {mid}: {why}")
+        return 2
+    if bf:
+        # A mutant that does not COMPILE tested nothing either. It used to be
+        # counted outside `killed` while the process still exited 0, so the
+        # summary's own arithmetic disagreed with itself.
+        print("!! these mutants did not COMPILE, so they are evidence of nothing:")
+        for mid, _, _, why in bf:
             print(f"     {mid}: {why}")
         return 2
     if surv:


### PR DESCRIPTION
## Merge status: the server gate is SATISFIED — merging awaits explicit approval

civitai/civitai#4341 is **serving in production**. Verified by content, not ancestry alone:

- `origin/release` is `0c84428da3` ("5.1.42") and carries **16** `.meta(listingMediaCliScope)` sites, up from 13. `listMine` sits at `:1026` **with** the meta — it was `:914` bare.
- **Control**: `getAssets` is still `protectedProcedure` on that same ref, so the grep discriminates rather than matching everything.
- dp-prod serves `ghcr.io/civitai/civitai-prod:20260825001134-0c84428` — the short sha matches the release tip.

🔴 **Nothing here treats that as authorization.** The release cut, green CI and a clean mutation sweep are all prerequisites; none is approval. **Do not merge without an explicit go-ahead.**

### Live validation, and what it does NOT prove

`civitai app doctor --json` against `https://civitai.com`, 21 real listings: **exit 0**, `ok=true`, `{apps: 21, blocking: 11, advisory: 49, gating: 0, delisted: 11}`. All 11 blocking problems sit on the 11 `removed` listings, so the delisted rule holds on real data — **this same account exited 1 before that fix**. Both kind arms fired: `radio` (off-site) got the browser editor, `panorama-360` (on-site) got the manifest.

🔴 It ran with a **full-scope personal API key**, which `enforceTokenScope` early-returns on before any `requiredScope` check. So it exercises the procedures, this CLI's decode and the logic — and proves **nothing** about the scoped-token path these PRs exist to open. See the OAuth gap at the bottom, which is the one claim still open.
---

## What this adds

`civitai app doctor [slug]` — the client half of #4341. `computeListingProblems` has emitted eight codes for months and an author driving the CLI could reach none of them.

- **No arg** → every listing you own **or hold an accepted collaborator seat on**. That is a wider set than `app status`, which is scoped to what *you submitted* and therefore cannot see a listing acquired by ownership transfer or held on a seat.
- **A slug** → just that one, resolved through `appapi.SameSlug` (the shared predicate), so a padded or mis-cased spelling still lands. An unknown slug exits **4**, not 0 — "you own no app called that" and "that app is fine" are opposite answers.
- Grouped per app, **BLOCKING first**, then ADVISORY. An app with nothing wrong renders as **explicitly complete**; a blank section is indistinguishable from a read that failed.

### The exit code is the product

| | |
|---|---|
| any BLOCKING problem | `1` |
| advisory-only | `0` |
| clean | `0` |
| no listings at all | `0` |
| unknown slug | `4` |

`1` rather than `2` for the reason `app validate` lands there: every flag and argument is well-formed, and what is wrong is the **listing**. `--json` publishes the same verdict under the same codes.

```bash
civitai app doctor my-app || exit 1
```

### Fix advice names only routes that exist

| Code | Route |
|---|---|
| `missing-icon` / `missing-cover` / `no-screenshots` | `civitai app listing set-icon` / `set-cover` / `add-screenshot`, `--slug` filled in |
| `blocked-media` | the same three — the SERVER's label names the slot, the code is kind-less, so this arm offers all three rather than guessing wrong 2× in 3 |
| `scanning-media` | **no command at all** — the scan resolves itself, and the obvious action (re-attaching) restarts it |
| `empty-description` / `empty-tagline` / `empty-category` | the listing's **web editor URL**, keyed by `appListingId` |
| an unknown 9th code | the editor URL, and it still counts toward the verdict |

**Why the web UI and not CLI flags for the three text fields** (the decision the brief asked me to make and justify): `updateListing` / `updateRevisionDraft` *did* become CLI-reachable in #4341, so a CLI route is now possible. It is deliberately not in this command. `doctor` exits non-zero as a release gate, and a diagnostic that also mutates the thing it is grading is a different command with a different contract. And the write is state-dependent in a way that needs its own tests: on an approved listing a material change stages onto a shadow revision, `updateListing` refuses a shadow id outright and `updateRevisionDraft` refuses a top-level listing — "set the tagline" is two procs and a branch, not a flag. Natural follow-up PR.

### It is a pure read — and that is the D3 answer

`listMine` opens no shadow revision, unlike `app listing status`. A **request ledger** pins that `doctor` issues exactly one request and it is `listMine`.

That ledger is also the measurement the brief asked for. `getAssetScanStatuses` filters `Image.userId = caller` for non-moderators (`app-listing-assets.service.ts:1037`), so a collaborator-attached or transferred asset is omitted. But `listMine`'s own scan batch — `loadListingAssetScansBatch`, `:1140` — applies **no** owner filter, so the diagnosis is complete either way; and `doctor` never asks the filtered proc, so it **cannot trip the gap**. A follow-up PR to that filter is **not** warranted on this command's account. The gap would only bite a command that goes on to ask *which asset row* is blocked — and for the `screenshot` kind, that is where it would bite first.

---

## Two stale claims corrected, not worked around

**1. `app metrics` (the brief's D2).** It told authors an OAuth browser login is "refused with 403" and to go mint a full-scope personal API key. **Stale.** True when issue #260 wrote it — the proc carried no `.meta` and an un-annotated proc implicitly requires `TokenScope.Full` — and false since civitai/civitai#3572 (`7c529f1eea`) annotated `blocks.getMyAppAnalytics` with `AppBlocksSubmit`, the same bit `app submit` and `app status` already require. Verified against `origin/main:src/server/routers/blocks.router.ts:5483`.

The claim lived in **five** places, not the two the brief named: the constant, `--help`, the no-token error, and three README sites. All corrected. The test that *asserted* the false claim is corrected too, and `refused with 403` is now a **prohibition** in that test so it cannot drift back.

**2. The shared listing-READ 400 arm** said "check the app you named (list your apps with `civitai app status`)". `listMine` is the **fourth** route to reach that arm and it sends no input at all — no slug, no listing id, no image id — so the remedy named a value one of its four callers never sends. That is civitai/cli#391's wrong-subject class, regenerated on the read arm. Reworded to a sentence true of all four, with the retired clause banned in `procname_leak_test.go`'s table. (It also corrects the pointer: `app status` reads the submissions route and cannot list a transferred or seat-held app.)

---

## Tests

`go build` ✅ · `go vet` ✅ · `golangci-lint` 0 issues · **4763 PASS / 0 FAIL / 4 SKIP** (counted from `--- PASS`/`--- FAIL` lines, not an exit code; no timeout panic).

**Mutation battery — see `scripts/mutation/` in this PR, which carries the harness AND its full output so the count can be recounted rather than believed.** The number has grown across follow-ups; read the committed `RESULTS-app-doctor.txt`, whose last line is the harness's own reconciliation of *defined* against *produced*.

🔴 **Softened deliberately:** this used to claim each mutant was *"killed by an assertion naming the specific defect"*. The harness cannot substantiate that. Which tests FAILED under a mutant is exact; the reason printed beside each killer comes from a backward scan for a nearby `_test.go:NN:` line, which cross-attributes across subtests. Verdicts are sound; attributions are approximate, and the harness now says so in its own docstring.

Highlights:

| Mutant | Killed by |
|---|---|
| exit gate `> 0` → `> 1` | `TestDoctorExitsNonZeroOnABlockingProblem` |
| severity compare `== blocking` → `== advisory` | `TestDoctorExitsZeroOnAdvisoryOnly` |
| `--json` `ok` → always `true` | `TestDoctorReportsAllEightCodesInTheRightGroup` |
| `missing-icon` advises `set-cover` | `TestDoctorJSONShapeIsPinnedWhole` |
| `SameSlug` → `==` | `TestDoctorSlugSelectionNormalises` |
| unknown slug → `return nil` | `TestDoctorUnknownSlugIsNotFoundNotAPass` |
| editor URL built from the slug | `TestDoctorTextFixesPointAtTheListingEditorNotTheSlug` |
| doctor calls `getAssetScanStatuses` | the request ledger |
| summary counts apps, not problems | the positive control (`8 problems produced 6 findings`) |
| the corrected D2 claim drifts back | `TestAppMetricsNoTokenNamesTheRouteThatWorks` |

🔴 **One mutant SURVIVED the first sweep, and finding it is the reason the battery exists.** Tagging the real verdict with `civitai.ErrBadRequest` inside `runAppDoctor` moves the published exit code **1 → 2**, and the entire suite stayed green — including the unit exit-code test, because that test feeds `exitCode` a **hand-built** error and nothing anywhere took the error the *command* actually returns. Classic seam defect: `internal/cmd` owns the verdict, `cmd/civitai` owns the mapping, both were tested, the seam was owned by nobody. Closed by `TestDoctorProcessExitStatusEndToEnd`, which builds the binary, drives it against a fake `listMine`, and reads the **process status** on all four arms — with a negative control proving the harness can observe a *different* code. Re-run: **KILLED**.

Other bar items:

- **Exit code tested directly, three arms** — blocking (non-zero), clean (zero), advisory-only (zero). Two arms cannot tell "correct" from "always 0" or "always 1".
- **Fixtures emit all eight codes**, `blocked-media` and `scanning-media` included — the two that were structurally unreachable on every pre-#4341 surface.
- **Positive-control pair reported**, never a lone zero: *8 findings on the control, 0 under test*.
- **`--json` pinned WHOLE** against a literal payload, not sampled keys, so a renamed/dropped/reordered field is visible.
- **Fix advice resolved against the real cobra tree**, not spelled out — with a negative control (`civitai app listing set-banner` must fail to resolve) and a positive control on the scan itself (≥5 references found, or the resolutions are vacuous).
- **Hermetic** — every test runs against `httptest`; the fake 500s on any unexpected path.

Three pre-existing ledgers went red when the route and the command were added and were updated deliberately, which is exactly what they are for: `listingRouteCases()` + the spelled op set (`internal/appapi/listing_op_test.go`), the wording table (`procname_leak_test.go`), and `TestREADMECommandTableDocumentsEveryAppSubcommand`.

---

## One deviation from the brief

The brief said the argument accepts "a slug/appBlockId". **Slug only.** Accepting the opaque `apb_…` id would need an `==` comparison on a `*blockId*` identifier, which `TestBlockIDComparisonsUseSameSlug` refuses by design — and evading it with an open-coded `EqualFold` is the documented cheap evasion. It is also the right call independently: `<blockId>` in this CLI's vocabulary *is* the slug everywhere else, and introducing a second id space at the argument is precisely the two-id-space confusion civitai/cli#430 was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## 🔴 Outstanding: the OAuth-path gap

Every live validation on this PR ran with a **full-scope personal API key**, which `enforceTokenScope` early-returns on before any `requiredScope` check. That proves the procedures, this CLI's decode, and the logic — and says **nothing** about the scoped-token path these PRs exist to open.

The stored config carries no OAuth credential (`auth_kind: token`; `access_token` / `refresh_token` empty), and minting one needs an interactive device-flow login that cannot be completed on someone's behalf.

**To close it — about a minute, read-only, spends no Buzz:**

```bash
civitai login                 # device flow; approve in the browser
civitai whoami                # expect: Credential type: OAuth login
civitai app doctor --json | jq '{ok, summary}'
```

A `403` there means the scope path is still shut and the release reading is wrong; anything else closes the gap.

