### PR TITLE
docs(agents): item 4 said the token-scope bitmask is NOT vendored — it has been since #36

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,8 @@ func newWhoAmICmd() *cobra.Command {
 
 ## Intentional decisions that look wrong (read before "fixing")
 
-**Index.** Items 1–3, 10 and 11 are deliberate mirrors of the platform;
-items 4, 8 and 25 are deliberate *non*-mirrors (25 = the store-listing image
+**Index.** Items 1–4, 10 and 11 are deliberate mirrors of the platform;
+items 8 and 25 are deliberate *non*-mirrors (25 = the store-listing image
 dimension/aspect bounds, which stay prose in the README rather than becoming a
 local check). Items 5–9 cover `civitai app metrics`, the CLI's only analytics
 read path. Items 12–17, 19, 21 and 22 cover `civitai generate`, the CLI's only
@@ -283,8 +283,8 @@ whether you are in the situation that item governs.
 change it.** A trigger is deliberately not enough to act on: it names the
 situation, never the conclusion, so "I read the trigger" is not "I know the
 rule". If no trigger matches, you have read the whole list and you are done —
-that is what the list is for. Items with no pointer (2 and 4) are shorter than a
-trigger plus a file read would be, so they are stated here in full; there is
+that is what the list is for. Items with no pointer (2, 4, 30) are shorter than
+a trigger plus a file read would be, so they are stated here in full; there is
 nothing further to open.
 
 The move is verbatim and pinned as such (`agents_split_preserved_test.go`); the
@@ -306,13 +306,14 @@ item must carry a trigger that is a routing question rather than a label
    strip, the 64 MiB cap — or adding a package manager to the build recipe?**
    → evidence: claudedocs/decisions/03-lockfile-check.md
 
-4. **The CLI does NOT vendor the server's token-scope bitmask — and shouldn't.**
-   The `whoami` / `dev-token` "can spend Buzz" capability check decodes the JWT
-   `scopes` (a **string array**) and looks for the `ai:write:budgeted` scope
-   string (see `tokenCanSpend` in `internal/cmd/app_dev_token.go`). It does NOT
-   reproduce the server's numeric scope bit positions — all bit/scope authority
-   stays server-side. Don't "helpfully" add a vendored bitmask; the string check
-   is deliberate.
+4. **The token-scope BITMASK is vendored — the dev-token JWT check is not.**
+   `internal/appapi/appblocks.go` mirrors `civitai/civitai`'s frozen
+   `token-scope.constants.ts` bits, and `whoami`'s `CanSpendBuzz` / `--scopes`
+   decode test that `tokenScope` integer — so a change there is a
+   vendored-mirror edit ("Ask first"). Other credential, other mechanism:
+   `tokenCanSpend` (`internal/cmd/app_dev_token.go`) reads the dev-token JWT's
+   `scopes` **string array** for `ai:write:budgeted`, never a bitmask.
+   #70 claimed the reverse, four days after the bits shipped.
 
 5. **Replacing `app metrics`' slug→id→tRPC two-hop with a REST route, or
    editing `internal/appapi/analytics.go`?**
@@ -440,8 +441,9 @@ the server — `schema/`, the ported Go checks in `internal/validate/` (includin
 the slot registry), the Vite dotenv resolution behind the dev-tunnel parent-origin
 check (item 10), and the block→host ready-ack in `internal/blockproto/` (item 11)
 — and update `examples_test.go` (asserts shipped examples validate clean) + the
-README. `internal/genapi` is deliberately NOT on that list: item 13 explains why
-the generation path mirrors nothing.**
+README. A FIFTH mirror answers to AUTH, not validation: the token-scope bits in
+`internal/appapi/` (item 4). `internal/genapi` is deliberately NOT on that list:
+item 13 explains why the generation path mirrors nothing.**
 
 ## Permission boundaries
 

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -44,6 +44,12 @@ import (
 // went from 26,571 bytes to 6,109 (−77%) and the file from 45,027 to 25,258
 // (−43.9%). The ceiling is 28,758 — 3,500 bytes of headroom.
 //
+// 🔴 "ITEMS 2 AND 4" IS WAVE-4 HISTORY, NOT THE CURRENT INLINE SET. It was the
+// whole set on 2026-08-10 (#317); item 30 arrived inline on 2026-08-16 (#437)
+// and the sentence above kept reading present-tense. Do not re-derive today's
+// set from this paragraph — ask the file: evictionPlaybook computes it, and
+// TestInlineAgentsItemsStayUnderTheBreakEven logs the count.
+//
 // 🔴 THE HEADROOM IS A BUDGET FOR ORDINARY EDITS, AND THE THREE NUMBERS BEFORE
 // IT WERE NOT. 287 bytes, then 300, then 2,500: the first two evaporated on the
 // very next commit touching this file (#308 consumed 94% of the 300, leaving 19)
@@ -271,8 +277,35 @@ func evictionPlaybook(t *testing.T, size int) string {
 		fmt.Fprintf(&b, "  item %-2d %7d bytes  %-36s  %s\n", s.num, s.bytes, state, truncateRunes(s.firstL, 72))
 		shown++
 	}
+	// 🔴 THE INLINE SET IS COMPUTED, NOT SPELLED, AND THAT IS A CORRECTION.
+	// This line read "Every item but 2 and 4" as a literal from wave 4 (#317,
+	// 2026-08-10) until #491 — but item 30 arrived inline six days later in
+	// #437, so for months the advice a maintainer read AT THE CEILING named the
+	// wrong set with full confidence. A comment is a claim; one that reads as
+	// coverage while being wrong is worse than none, because it stops the next
+	// person looking. Deriving the set from the same `→ evidence:` predicate
+	// agentsItems uses means it cannot drift from the count
+	// TestInlineAgentsItemsStayUnderTheBreakEven reports, and
+	// TestPlaybookNamesTheLiveInlineSet cross-checks it against that OTHER
+	// slicer so a future re-hardcoding fails by name.
+	var inline []int
+	for _, s := range sizes {
+		if !s.split {
+			inline = append(inline, s.num)
+		}
+	}
+	sort.Ints(inline)
+	subject := "EVERY item is"
+	if len(inline) > 0 {
+		parts := make([]string, 0, len(inline))
+		for _, n := range inline {
+			parts = append(parts, strconv.Itoa(n))
+		}
+		subject = "Every item but " + strings.Join(parts, ", ") + " is"
+	}
+
 	fmt.Fprintf(&b, "\n🔴 THE LIST IS A TRIGGER INDEX, SO AN ITEM OVER ~%d BYTES IS ALREADY THE BUG.\n"+
-		"Every item but 2 and 4 is one routing question plus a pointer. If the ranking above\n"+
+		"%s one routing question plus a pointer. If the ranking above\n"+
 		"shows a large item, convert it; if it shows only trigger-sized ones, the growth is in\n"+
 		"the PROSE sections and no eviction will fix it — see the note on agentsMaxBytes.\n"+
 		"\nTo convert an item:\n"+
@@ -295,7 +328,7 @@ func evictionPlaybook(t *testing.T, size int) string {
 		"     base is fixed at the moment it was evicted and cannot be re-pointed.\n"+
 		"\nDo NOT raise agentsMaxBytes to make this pass. It is currently %d, the file is\n"+
 		"%d bytes, and agentsMaxBytesCeiling (%d) bounds how far it may ever be raised.\n",
-		maxInlineItemBytes, evidenceDir, evidenceDir, agentsMaxBytes, size, agentsMaxBytesCeiling)
+		maxInlineItemBytes, subject, evidenceDir, evidenceDir, agentsMaxBytes, size, agentsMaxBytesCeiling)
 	return b.String()
 }
 
@@ -459,6 +492,53 @@ func TestAgentsSizeGuardCanStillFire(t *testing.T) {
 	if !utf8.ValidString(pb) {
 		t.Errorf("the eviction playbook is not valid UTF-8 — it is truncating a title mid-rune, and the advice a maintainer reads at the ceiling is mojibake\n---\n%q", pb)
 	}
+}
+
+// TestPlaybookNamesTheLiveInlineSet is the drift guard for the correction in
+// evictionPlaybook's 🔴 note. Computing the set fixes TODAY; this fixes
+// tomorrow, by asserting the rendered advice names exactly the inline set the
+// file actually has — so re-hardcoding it fails here by name rather than going
+// stale in silence, which is what "2 and 4" did for months.
+//
+// 🔴 IT DELIBERATELY CROSSES SLICERS. agentsItemSizes (what the playbook reads)
+// and agentsItems (what agents_trigger_test.go reads to decide which items are
+// exempt from the trigger rule) each answer "is this item inline" from their own
+// parse of the `→ evidence:` pointer. Asserting one against the other is the
+// same seam TestEvictionPlaybookSizesTheLastItemCorrectly pins for item
+// BOUNDARIES; a guard built on the playbook's own slicer alone would agree with
+// itself whatever that slicer decided.
+func TestPlaybookNamesTheLiveInlineSet(t *testing.T) {
+	var want []int
+	for _, it := range agentsItems(t) {
+		if !it.converted {
+			want = append(want, it.num)
+		}
+	}
+	// POSITIVE CONTROL. With no inline items the phrase below never renders and
+	// the assertion would pass having compared nothing.
+	if len(want) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: agentsItems reports no inline items, so the assertion below would " +
+			"check for a phrase the playbook never emits. Either every item is now converted (in which case retire this " +
+			"guard deliberately) or the pointer scan is broken.")
+	}
+	sort.Ints(want)
+	parts := make([]string, 0, len(want))
+	for _, n := range want {
+		parts = append(parts, strconv.Itoa(n))
+	}
+	// Anchored at both ends, so a SUPERSET or a stale SUBSET both fail: the
+	// phrase pins the whole set, not merely that some inline item is mentioned.
+	phrase := "Every item but " + strings.Join(parts, ", ") + " is"
+
+	pb := evictionPlaybook(t, agentsMaxBytes+1)
+	if !strings.Contains(pb, phrase) {
+		t.Errorf("the eviction playbook does not name the live inline set %v.\nwant the phrase: %q\n\n"+
+			"A maintainer reads this message AT THE CEILING, so a wrong set here is advice that reads as coverage while "+
+			"naming the wrong items — \"2 and 4\" was right for the six days between wave 4 (#317) and item 30 landing "+
+			"inline (#437), and wrong for months after. Compute the set from the `→ evidence:` pointer; do not spell it.\n---\n%s",
+			want, phrase, pb)
+	}
+	t.Logf("the playbook names the live inline set %v, agreeing with agentsItems", want)
 }
 
 // TestPlaybookTruncationIsRuneSafe is the negative control for truncateRunes.


### PR DESCRIPTION
## The defect

`AGENTS.md` item 4 asserted the CLI **does not** vendor the server's token-scope bitmask, and that the `whoami` "can spend Buzz" check decodes a JWT `scopes` **string array**. That is false about `whoami`, and was false the day it was written.

Evidence, re-verified against `main`:

- `internal/appapi/appblocks.go` hard-codes **26 numeric bit positions** (`ScopeUserRead = 1 << 0` … `ScopeAppBlocksSubmit = 1 << 25`, plus `ScopeFull`), under a comment reading *"mirrored from @civitai/auth token-scope (civitai/civitai `src/shared/constants/token-scope.constants.ts`). These are STABLE/frozen bit positions in the tokenScope bitmask `GET /api/v1/me` returns."*
- `Identity.CanSpendBuzz()` is `hasScope(ScopeAIServicesWrite)` (`1<<15`); `CanReadBuzz()` is `hasScope(1<<16)`; `--scopes` walks `scopeBits`. **No JWT and no string array is anywhere on the `whoami` path.** `README.md:1175` already prints the raw bitmask `100777985` for `--scopes generate`.
- The half that *was* true describes a **different credential**: `tokenCanSpend` (`internal/cmd/app_dev_token.go:195`) decodes the *minted dev-token JWT*'s `scopes` string array for `ai:write:budgeted`. The item conflated the two.

Chronology (`git log -S`): `ScopeAIServicesWrite` landed **2026-06-25** in `908f981` (#36). Item 4's text landed **2026-06-29** in `b0968d7` (#70), whose subject is `docs(agents): correct false "vendored token-scope bitmask" claim`. The "correction" *introduced* the falsehood, four days after the bits shipped — exactly the failure mode this file exists to prevent, so the new item says so in one clause.

## What changed

**Item 4** now states the true rule: the bit positions are vendored and frozen, `whoami`'s capability answers are bit tests over that integer, so editing them is a **vendored-mirror edit** (already governed by the "⚠️ Ask first" boundary). It preserves the still-load-bearing half — the dev-token JWT path uses the string array and must never grow a bitmask. Two credentials, two mechanisms.

**Cross-references corrected in the same pass**, because correcting item 4 changes what *kind* of item it is:

| Surface | Before | After | Why |
|---|---|---|---|
| Index paragraph | `Items 1–3 … mirrors; items 4, 8 and 25 … non-mirrors` | `Items 1–4 … mirrors; items 8 and 25 … non-mirrors` | item 4 is a mirror |
| Vendored-mirror ledger | enumerates **four** mirrors | names a **FIFTH**, `internal/appapi/`'s token-scope bits (item 4) | its absence was part of the same defect |
| "Items with no pointer **(2 and 4)**" | stale independently — item 30 is inline too | `(2, 4, 30)` | the guard reports **3** inline items |

The ledger's fifth entry is flagged as answering to **AUTH rather than validation**, so the paragraph's "when you change a validation rule" trigger stays true of the four it lists.

## Shape: item 4 stays INLINE, as a statement

`agents_trigger_test.go` exempts pointer-less items from the trigger-question rule — *"an inline item is allowed to be a statement — it IS the rule, and there is nothing to route to"* — and items 2 and 30 are statements for the same reason. A trigger question promises a file to open; there is none here. It is bounded by `maxInlineItemBytes` instead: **580 bytes against the 600-byte break-even** (was 500).

## Byte budget

`AGENTS.md` **28,489 → 28,668**, i.e. **90 bytes under** the 28,758 ceiling. Nothing was evicted. Headroom is now thin — the next prose edit to this file will likely need an eviction, and that is worth knowing before it happens.

## Verification

- `go test . -count=1 -v` (full root package) — **196 RUN / 196 PASS / 0 FAIL / 0 SKIP**, `rc=0`, no panics or timeouts. Counted from the output, not read off the exit code.
- `make ci` — green (21 packages). `make ci-shallow` on the pushed tip — `ok=21/21 failing-tests=0 failing-packages=0 timeouts=0 go-test-rc=0`.
- `make lint` under `nix-shell -p golangci-lint` — **0 issues**, and **validated as a real zero**: a planted `ineffassign` in `agents_size_test.go` made it report `1 issues` and exit 1; clean again after restore.
- Guard log lines: `AGENTS.md is 28668 bytes, 90 under the 28758-byte ceiling`; `all 32 AGENTS.md items are named by the index`; `evidence ledger: 29 pointer(s) and 29 file(s) agree`; `3 inline item(s), all within the 600-byte break-even`; `the playbook names the live inline set [2 4 30], agreeing with agentsItems`.
- **Mutation control on the load-bearing prose edit.** Reverting *only* `Items 1–4` back to `Items 1–3` makes `TestEveryAgentsItemIsNamedByTheIndex` fail with its own specific finding — `item 4 is named by no clause in the index paragraph` — proving that clause is item 4's sole index coverage and that the fix is reached, not decorative. Restored and re-measured (28,668 bytes).
- **Mutation controls on the new guard**, both failing with *its* own error: re-hardcoding `"2 and 4"`, and the subset drift `"2, 4"`. The second is the one that matters — `Every item but 2, 4` is a **prefix** of the correct phrase, so an unanchored `Contains` would have passed it. The `" is"` suffix anchor is load-bearing and catches supersets for the same reason.

## Second commit: the same stale fact, in the guard's own failure message

Folded in rather than left as a follow-up, because it is the fact this PR corrects two lines away in the prose, and the repo's rules treat a comment as a claim.

Two strings in `agents_size_test.go` asserted the same thing and were wrong by one item — `:275`, inside the message a maintainer reads **at the ceiling** (*"Every item but 2 and 4 is one routing question plus a pointer"*), and `:42`, the `agentsMaxBytes` header comment. Both were true when written and went stale six days later: wave 4 landed 2026-08-10 (`5120764`, #317) with 26 items, where 2 and 4 genuinely were the whole inline set; item 30 arrived inline 2026-08-16 (`c27b368`, #437). `TestInlineAgentsItemsStayUnderTheBreakEven` has logged `3 inline item(s)` against prose claiming two ever since.

- `evictionPlaybook` now **computes** the set from the same `→ evidence:` predicate it already uses, so it cannot drift from that logged count. Renders `Every item but 2, 4, 30 is …` today and follows the file from here on. The degenerate case (nothing inline) says `EVERY item is …` rather than emitting a dangling "but".
- New **`TestPlaybookNamesTheLiveInlineSet`** fixes tomorrow. It deliberately **crosses slicers** — the expectation comes from `agentsItems` (`agents_trigger_test.go`'s parse), not from the playbook's own `agentsItemSizes` — so a guard built on one slicer cannot agree with itself. Same seam `TestEvictionPlaybookSizesTheLastItemCorrectly` pins for item boundaries.
- The header comment keeps its wave-4 history (every number around it is a wave-4 measurement) but is now labelled as history, pointing at the computed source of truth.

## Scope

Commit 1 is docs-only. Commit 2 touches one test file — a failure-message string and its header comment, plus one new guard; no assertion was weakened and no production path is involved. Nothing under `internal/`, no `README.md`: behaviour is unchanged, and the README's existing `100777985` bitmask text is already consistent with the corrected item. `AGENTS.md` is untouched by commit 2 and stays at 28,668 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
