### PR TITLE
fix(whoami): `canSubmitApps` was a false negative stated as fact, and the two surfaces disagreed

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ README. For the end-to-end walkthrough, see
 | Command | What it does |
 | --- | --- |
 | `civitai login [--scopes <set>] [--token [<t>]] [--no-browser]` | Browser OAuth device login by default (stores auto-refreshing tokens). The default scope set grants identity + Apps submit + dev-tunnel and **not** Buzz-spend; `--scopes generate` additively grants generation + Buzz **spend** (needed by `civitai generate` and money-path `dev:live`). `--token <t>` stores a personal API key instead (not combinable with `--scopes`). `--token` with **no value** prints where to create a personal key (`civitai.com/user/account`) and how to re-run — handy when you know you want a personal key but haven't minted one yet. Config at `~/.config/civitai/config.yaml`, 0600. Also reads `CIVITAI_TOKEN`. |
-| `civitai whoami [--scopes] [--json]` | Verify the stored token; print the authenticated user **and a Capabilities section** — credential type (**OAuth login** vs **personal API key**), **Read Buzz balance**, and **Spend Buzz** — decoded from the token's scope, so a money-path dead end (a default OAuth login can't spend) is visible before `dev:live` — and when it can't, the output names the fix for that credential (`login --scopes generate` for an OAuth login, a full-scope key otherwise). `--scopes` also lists every granted scope; `--json` emits the user + `credentialType`/`canReadBalance`/`canSpend`/`scopes` (scriptable). |
+| `civitai whoami [--scopes] [--json]` | Verify the stored token; print the authenticated user **and a Capabilities section** of four rows — credential type (**OAuth login** vs **personal API key**), **Read Buzz balance**, **Spend Buzz**, and **Submit Apps** — decoded from the token's scope, so a money-path dead end (a default OAuth login can't spend) is visible before `dev:live` — and when it can't, the output names the fix for that credential (`login --scopes generate` for an OAuth login, a full-scope key otherwise). **Submit Apps is tri-state**: `yes` / `no` / **`unknown`**, because a personal key is never scope-gated for submit while an OAuth token's answer *is* the scope bit — so an absent mask makes it unknowable, and `unknown` must never be read as `no`. `--scopes` also lists every granted scope; `--json` emits a **curated, not raw** identity object — `username`/`id`/`base_url`/`credentialType`/`scopesKnown`/`canReadBalance`/`canSpend`/`canSubmitApps` (`true`/`false`/**`null`**)/`scopes`/`capabilities` (scriptable). See [What `civitai whoami` reports](#submit--auth). |
 | `civitai buzz [--json]` | Show your spendable Buzz balance (**blue / green / yellow**, plus a **total**). Needs the BuzzRead scope — a full-scope personal API key or `civitai login --scopes generate`; a **default** OAuth login token can't read it, and gets a clear message naming both fixes. `--json` emits `{blue,green,yellow,total}` (scriptable — handy for before/after diffing a `dev:live` spend). |
 | `civitai app list [--kind <k>] [--category <c>] [--sort <s>] [--limit <n>] [--cursor <c>] [--json]` | **Discover published Apps in the store** (`GET /api/v1/apps`) — filter-based discovery, not free-text search. **Needs a credential** (`civitai login` or `CIVITAI_TOKEN`): the endpoint keys the visible catalog off your identity, so this is *not* one of the anonymous reads. Cursor-paged. See [Browse the App store](#browse-the-app-store). |
 | `civitai app view <slug> [--json]` | **Show one published App's store detail** (`GET /api/v1/apps/{slug}`) — description, category, rating, gallery, live/external target. **Needs a credential**, same as `app list`. Reads the *public store catalog*, which is a different resource from your own deploy — a not-found here says nothing about `<slug>.civit.ai`. See [Browse the App store](#browse-the-app-store). |
@@ -1204,6 +1204,85 @@ only credential carrying the rest of the Full scope mask.
   `/apps/submit`).
 
 `--package-only` always just writes the `.zip` and stops.
+
+#### What `civitai whoami` reports
+
+`civitai whoami` prints the authenticated user and a **Capabilities** section of
+**four** rows — credential type, **Read Buzz balance**, **Spend Buzz (AI
+Services)** and **Submit Apps**:
+
+```
+Logged in as zach (id 1) at https://civitai.com
+
+Capabilities:
+  Credential type:          personal API key
+  Read Buzz balance:        yes
+  Spend Buzz (AI Services): no
+  Submit Apps:              yes
+```
+
+**Submit Apps is a tri-state — `yes` / `no` / `unknown` — and `unknown` is not
+`no`.** The server scope-gates submit **only** on OAuth tokens (the opt-in
+`AppBlocksSubmit` bit, which `ScopeFull` deliberately excludes); a personal API
+key is not scope-gated for submit at all. So:
+
+| Credential | `tokenScope` reported | Submit Apps |
+| --- | --- | --- |
+| Personal API key | either | **`yes`** — never scope-gated, so the mask is irrelevant |
+| OAuth login | present | `yes` / `no` from the `AppBlocksSubmit` bit |
+| OAuth login | **absent** | **`unknown`** — the bit *is* the answer, and the server did not report it |
+| No `subject` in the response | either | **`unknown`** — we cannot tell which gate applies |
+
+When the server reports no scope mask the output says *"(token scope not
+reported by the server — **Buzz** capabilities unknown)"*. That caveat is scoped
+to Buzz on purpose: the Submit Apps row above it may well be a known answer, and
+a blanket "capabilities unknown" would have been false.
+
+A `yes` means the credential's **scope** permits submit — not that the account
+is in the author cohort. The remaining author-cohort and not-banned gates are
+server-side and are not visible to the CLI.
+
+##### `whoami --json`
+
+🔴 **`--json` is a stable, *curated* identity object — it is not the server's
+raw `/api/v1/me` body.** It is a hand-built projection of ten keys; the server
+sends more (`tier`, `status`, `isMember`, `subscriptions`, `email`,
+`emailVerified`) that deliberately never appear. `email` / `emailVerified` in
+particular are PII this command does not print, so passing the body through
+would be a privacy regression, not a fix
+([#377](https://github.com/civitai/cli/issues/377)).
+
+```json
+{
+  "base_url": "https://civitai.com",
+  "canReadBalance": true,
+  "canSpend": false,
+  "canSubmitApps": true,
+  "capabilities": { "can_read_buzz": true, "can_spend_buzz": false },
+  "credentialType": "personal API key",
+  "id": 1,
+  "scopes": ["UserRead", "BuzzRead"],
+  "scopesKnown": true,
+  "username": "zach"
+}
+```
+
+Two fields carry a **third state a script must branch on**, exactly as
+`app metrics` requires for `views.unavailable`:
+
+- **`canSubmitApps` is `true` / `false` / `null`.** `null` means *unknowable*
+  (the two rows above), and a consumer must not read it as `false`. ⚠️ **This
+  field used to be a plain boolean**; a script doing `if (!j.canSubmitApps)`
+  now treats `null` the same as `false` and will report a dead end that may not
+  exist. Test `j.canSubmitApps === null` first.
+- **`scopes` is a list, `[]`, or `null`.** `null` means the scope mask was not
+  reported (`scopesKnown: false`); `[]` means the mask **was** reported and had
+  no bits set. These used to both serialise as `null`, which no consumer could
+  tell apart.
+
+`scopesKnown` disambiguates `canReadBalance` and `canSpend`, which stay plain
+booleans: when it is `false`, both are `false` because nothing is known, not
+because the capability was denied.
 
 #### How big can a bundle be?
 
@@ -3350,6 +3429,8 @@ credited it to the wrong command.)
 | `not logged in (401)` | The credential is present but invalid or expired. OAuth tokens refresh themselves; when the *refresh* token has also expired, log in again. For a personal key, mint a new one at `civitai.com/user/account`. | [Submit & auth](#submit--auth) |
 | `forbidden (403)` | Usually the invite-only Apps beta rather than a broken token — the same account reads the public API fine. | [Submit & auth](#submit--auth) |
 | `not permitted for your account (403)` | Managing a **store listing** needs Apps-author access, which is a narrower grant than being able to submit. | [Listing media requirements](#listing-media-requirements) |
+| `Submit Apps:` | The `civitai whoami` capability row, and it is **tri-state**: `yes` / `no` / `unknown`. **`unknown` is not `no`** — it is the CLI declining to answer, because the server reported no `tokenScope` for an **OAuth** credential (whose submit answer *is* the `AppBlocksSubmit` bit) or sent no `subject` at all, so which gate applies is itself unknown. Re-run `civitai login` to mint a token whose scope the server reports; a **personal API key** always answers `yes`, since it is not scope-gated for submit. In `--json` this row is `canSubmitApps`, which is `true` / `false` / `null`. | [Submit & auth](#submit--auth) |
+| `(token scope not reported by the server — Buzz capabilities unknown)` | `civitai whoami` got no `tokenScope`, so **Buzz** read/spend are unknowable and are omitted rather than printed as `no`. Scoped to Buzz deliberately: the **Submit Apps** row is still shown above it, because a personal key's submit answer does not depend on the scope mask. | [Submit & auth](#submit--auth) |
 | `not permitted to read this app's analytics (403)` | `app metrics` needs the **Apps submit scope**. An OAuth `civitai login` carries it — unless the token was minted before the scope existed, in which case re-run `civitai login`. A full-scope personal API key also works. | [App metrics](#app-metrics) |
 | `block lacks ai:write:budgeted scope` | Printed by your app at runtime under `dev:live`. The dev token was minted **without** `--spend`, so the CLI filtered the budgeted-spend scope out — it never requests that scope implicitly, even when your manifest declares it. | [Local dev loop](#local-dev-loop-harness-mock-vs-live) |
 | `insufficient Buzz` / `generation disabled` | Not credential problems, which is why they exit `1` rather than `3` — a script must not loop on `civitai login` for either. | [Exit codes specific to `generate`](#exit-codes-specific-to-generate) |

--- a/internal/appapi/api_test.go
+++ b/internal/appapi/api_test.go
@@ -183,6 +183,68 @@ func TestIdentityScopeUnknown(t *testing.T) {
 	}
 }
 
+// TestCanSubmitAppsIsTriState pins the THREE states of the submit predicate at
+// its source, so the rule lives in one place and both `whoami` surfaces read
+// the same answer rather than re-deriving it.
+//
+// 🔴 THE nil CASES ARE THE REGRESSION. The predicate used to return a plain
+// bool, so an OAuth credential with an ABSENT mask reported `false` — a false
+// negative stated as fact, since for OAuth the mask bit IS the answer. Same for
+// a credential with no `subject` at all: the CLI cannot tell whether the OAuth
+// gate applies, so it cannot answer. Neither may ever render as "no".
+func TestCanSubmitAppsIsTriState(t *testing.T) {
+	oauthSubject := &Subject{Type: "oauth", ID: json.RawMessage(`"a"`)}
+	keySubject := &Subject{Type: "apiKey", ID: json.RawMessage(`"k"`)}
+
+	cases := []struct {
+		name string
+		id   *Identity
+		want *bool // nil == unknowable
+	}{
+		{"oauth with the submit bit", &Identity{Subject: oauthSubject, TokenScope: scopePtr(ScopeUserRead | ScopeAppBlocksSubmit)}, boolPtr(true)},
+		// Full scope EXCLUDES bit 25, so this is a real "no", not an unknown.
+		{"oauth, full scope, no submit bit", &Identity{Subject: oauthSubject, TokenScope: scopePtr(ScopeFull)}, boolPtr(false)},
+		{"oauth, mask absent", &Identity{Subject: oauthSubject}, nil},
+		// A personal key is not scope-gated for submit, so the answer holds with
+		// or without a mask — the pair below is what makes that visible.
+		{"personal key, minimal mask", &Identity{Subject: keySubject, TokenScope: scopePtr(ScopeUserRead)}, boolPtr(true)},
+		{"personal key, mask absent", &Identity{Subject: keySubject}, boolPtr(true)},
+		{"no subject, mask present", &Identity{TokenScope: scopePtr(ScopeFull | ScopeAppBlocksSubmit)}, nil},
+		{"no subject, mask absent", &Identity{}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.id.CanSubmitApps()
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("CanSubmitApps = %v, want nil (unknowable) — a bool here is a claim the CLI cannot support", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("CanSubmitApps = nil, want %v — this state IS knowable and must not be withheld", *tc.want)
+			case tc.want != nil && got != nil && *tc.want != *got:
+				t.Errorf("CanSubmitApps = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+// TestDecodeScopesNilVsEmpty: `nil` and `[]` are DIFFERENT answers, because
+// `whoami --json` emitted `"scopes": null` in two unrelated states — scope
+// unreported, and a real credential with no bits set — which no consumer could
+// tell apart. Go callers see len 0 either way; only the JSON encoding differs.
+func TestDecodeScopesNilVsEmpty(t *testing.T) {
+	unknown := (&Identity{}).DecodeScopes()
+	if unknown != nil {
+		t.Errorf("an ABSENT mask must decode to nil (JSON null), got %#v", unknown)
+	}
+	knownEmpty := (&Identity{TokenScope: scopePtr(0)}).DecodeScopes()
+	if knownEmpty == nil {
+		t.Error("a KNOWN mask of 0 must decode to a non-nil empty slice (JSON []), not nil — that is the whole distinction")
+	}
+	if len(knownEmpty) != 0 {
+		t.Errorf("a zero mask decodes to no scope names, got %v", knownEmpty)
+	}
+}
+
 // TestDecodeScopes exercises the bit-decode helper against representative masks.
 func TestDecodeScopes(t *testing.T) {
 	full := &Identity{TokenScope: scopePtr(ScopeFull)}

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -273,21 +273,63 @@ func (id *Identity) CanReadBuzz() bool { return id.hasScope(ScopeBuzzRead) }
 // subject.type == "oauth", so any personal key clears it. (The remaining
 // author-cohort / not-banned gates are server-side and not visible here, so a
 // "yes" means the credential's SCOPE permits submit, not that the account is in
-// the author cohort.) An unknown/absent credential is treated as false.
-func (id *Identity) CanSubmitApps() bool {
-	if id.IsOAuth() {
-		return id.hasScope(ScopeAppBlocksSubmit)
+// the author cohort.)
+//
+// 🔴 THE RESULT IS TRI-STATE, AND THE POINTER IS WHY. There are THREE answers,
+// not two — yes, no, and *we cannot tell* — and this is the same discriminator
+// shape as AGENTS.md item 9's `views.unavailable`
+// (claudedocs/decisions/09-views-unavailable-discriminator.md): read that item
+// for the rationale rather than re-deriving it here. A plain `bool` collapses
+// "cannot tell" into "no", which is a false negative stated as fact — measured
+// on `{"username":…,"id":…,"subject":{"type":"oauth","id":"a"}}` (an OAuth
+// credential whose `tokenScope` the server omitted), where the bool version
+// emitted `"canSubmitApps": false` while the truth was unknowable. The pointer
+// return also makes the third state impossible for a caller to ignore: it
+// cannot be handed to a yes/no renderer without an explicit nil branch, and it
+// marshals straight to JSON `null`.
+//
+// The three states, exactly:
+//
+//   - non-nil true/false — an OAuth credential with a KNOWN mask (the bit
+//     decides), or any personal API key (never scope-gated, so always true).
+//   - nil — an OAuth credential whose scope mask is absent (the bit is the
+//     whole answer and we do not have it), or a credential with no `subject`
+//     at all (CredentialType() == "unknown": we cannot even tell whether the
+//     OAuth gate applies).
+//
+// Callers must branch on nil and say "unknown"; they must never print "no".
+func (id *Identity) CanSubmitApps() *bool {
+	switch {
+	case id.IsOAuth():
+		if !id.ScopeKnown() {
+			return nil // the bit is the whole answer, and it is not reported.
+		}
+		return boolPtr(id.hasScope(ScopeAppBlocksSubmit))
+	case id.CredentialType() == "personal API key":
+		// Not scope-gated for submit at all, so this holds with or without a mask.
+		return boolPtr(true)
+	default:
+		// No subject: we cannot tell which gate applies, let alone its answer.
+		return nil
 	}
-	return id.CredentialType() == "personal API key"
 }
 
-// DecodeScopes returns the names of every set scope bit (low → high). A nil
-// (unknown) mask returns nil.
+func boolPtr(b bool) *bool { return &b }
+
+// DecodeScopes returns the names of every set scope bit (low → high).
+//
+// 🔴 nil AND EMPTY ARE DIFFERENT ANSWERS, so the field is self-describing when
+// it reaches a `--json` surface: a nil (unknown) mask returns nil, while a mask
+// that is KNOWN and zero returns a non-nil empty slice. Collapsing the two made
+// `whoami --json` emit `"scopes": null` in two unrelated states — scope
+// unreported, and a real key with no bits set — which no consumer could tell
+// apart. Go callers see len 0 either way; only the JSON encoding differs
+// (`null` vs `[]`).
 func (id *Identity) DecodeScopes() []string {
 	if id.TokenScope == nil {
 		return nil
 	}
-	var out []string
+	out := []string{}
 	for _, s := range scopeBits {
 		if *id.TokenScope&s.bit != 0 {
 			out = append(out, s.name)

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -363,11 +363,17 @@ func TestWhoAmISuccess(t *testing.T) {
 	}
 }
 
-// TestWhoAmISubmitAppsCapability drives the "Submit Apps: yes/no" capability
-// line. Mirrors submit-version.ts's gate: the ScopeAppBlocksSubmit (bit 25 =
-// 33554432) requirement applies ONLY to OAuth tokens; a personal API key is not
-// scope-gated for submit and always reports "yes". An unknown/absent credential
-// reports "no" (conservative).
+// TestWhoAmISubmitAppsCapability drives the "Submit Apps: yes/no/unknown"
+// capability line. Mirrors submit-version.ts's gate: the ScopeAppBlocksSubmit
+// (bit 25 = 33554432) requirement applies ONLY to OAuth tokens; a personal API
+// key is not scope-gated for submit and always reports "yes".
+//
+// 🔴 THE NO-SUBJECT CASE CHANGED FROM "no" TO "unknown", ON PURPOSE. It used to
+// be documented here as "conservative", but "no" is not conservative — it is a
+// claim, and a false one: with no `subject` the CLI cannot tell whether the
+// OAuth gate even applies, let alone its answer. Conservative would be
+// declining to answer, which is what "unknown" does. See
+// appapi.Identity.CanSubmitApps for the three states.
 func TestWhoAmISubmitAppsCapability(t *testing.T) {
 	const submitBit = 1 << 25       // ScopeAppBlocksSubmit
 	const scopeFull = submitBit - 1 // ScopeFull = bits 0..24 (excludes bit 25)
@@ -381,7 +387,7 @@ func TestWhoAmISubmitAppsCapability(t *testing.T) {
 		{"oauth without submit scope (even full scope)", "oauth", scopeFull, "Submit Apps:              no"},
 		{"personal key, full scope, no submit bit", "apiKey", scopeFull, "Submit Apps:              yes"},
 		{"personal key, minimal scope", "apiKey", 1, "Submit Apps:              yes"},
-		{"unknown credential (no subject)", "", 1, "Submit Apps:              no"},
+		{"unknown credential (no subject)", "", 1, "Submit Apps:              unknown"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -29,7 +29,7 @@ can submit/withdraw but cannot spend Buzz — is surfaced here, before dev:live.
 Reads the token from config or CIVITAI_TOKEN.`,
 		Example: `  civitai whoami
   civitai whoami --scopes   # also list every granted scope
-  civitai whoami --json     # raw JSON (scriptable)`,
+  civitai whoami --json     # a stable, curated identity object (scriptable)`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
@@ -46,6 +46,13 @@ Reads the token from config or CIVITAI_TOKEN.`,
 			}
 			out := cmd.OutOrStdout()
 
+			// 🔴 ONE PREDICATE, ONE PLACE. Both surfaces below read this single
+			// tri-state answer; neither re-derives "can this credential submit?"
+			// from the subject type or the mask. nil means UNKNOWABLE — see
+			// appapi.Identity.CanSubmitApps, which states the three states and
+			// cites AGENTS item 9 for the discriminator rationale.
+			canSubmit := id.CanSubmitApps()
+
 			if jsonOut {
 				payload := map[string]any{
 					"username":       id.Username,
@@ -55,8 +62,9 @@ Reads the token from config or CIVITAI_TOKEN.`,
 					"scopesKnown":    id.ScopeKnown(),
 					"canReadBalance": id.CanReadBuzz(),
 					"canSpend":       id.CanSpendBuzz(),
-					"canSubmitApps":  id.CanSubmitApps(),
-					"scopes":         id.DecodeScopes(),
+					// true / false / null — null means unknowable, never "no".
+					"canSubmitApps": canSubmit,
+					"scopes":        id.DecodeScopes(),
 					// Back-compat: the nested capabilities object earlier releases emit.
 					"capabilities": map[string]bool{
 						"can_spend_buzz": id.CanSpendBuzz(),
@@ -73,16 +81,35 @@ Reads the token from config or CIVITAI_TOKEN.`,
 			// login can't spend) is visible BEFORE a dev:live run.
 			fmt.Fprintln(out, "\n"+ui.Bold("Capabilities:"))
 			fmt.Fprintf(out, "  Credential type:          %s\n", id.CredentialType())
+			// 🔴 THE SUBMIT ROW IS NOT GATED ON ScopeKnown(). A personal API key
+			// is not scope-gated for submit at all, so its answer is KNOWN even
+			// when the server reports no mask — the old early return withheld a
+			// fact the command was holding, while `--json` published it. The row
+			// prints in every branch; only its VALUE degrades, and it degrades to
+			// "unknown", never to "no".
+			submitRow := func() {
+				fmt.Fprintf(out, "  Submit Apps:              %s\n", yesNoUnknown(canSubmit))
+			}
 			if !id.ScopeKnown() {
-				fmt.Fprintln(out, "  "+ui.Dim("(token scope not reported by the server — capabilities unknown)"))
+				submitRow()
+				// Scoped to BUZZ deliberately: the submit row above may well be
+				// known, so "capabilities unknown" would have been false.
+				fmt.Fprintln(out, "  "+ui.Dim("(token scope not reported by the server — Buzz capabilities unknown)"))
 				return nil
 			}
 			fmt.Fprintf(out, "  Read Buzz balance:        %s\n", yesNo(id.CanReadBuzz()))
 			fmt.Fprintf(out, "  Spend Buzz (AI Services): %s\n", yesNo(id.CanSpendBuzz()))
-			fmt.Fprintf(out, "  Submit Apps:              %s\n", yesNo(id.CanSubmitApps()))
+			submitRow()
 
 			if showScopes {
-				fmt.Fprintf(out, "\nScopes (%d): %s\n", len(id.DecodeScopes()), strings.Join(id.DecodeScopes(), ", "))
+				scopes := id.DecodeScopes()
+				list := strings.Join(scopes, ", ")
+				if len(scopes) == 0 {
+					// A known mask with no bits set. An empty trailing list read
+					// as truncated output; say what it means.
+					list = ui.Dim("(none granted)")
+				}
+				fmt.Fprintf(out, "\nScopes (%d): %s\n", len(scopes), list)
 			}
 
 			// The #34 dead end, made visible before dev:live: a credential without
@@ -105,15 +132,32 @@ Reads the token from config or CIVITAI_TOKEN.`,
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON (scriptable)")
+	// 🔴 NOT "raw JSON" (#377). The payload is a hand-built projection of ten
+	// keys; the server demonstrably sends six more — `tier`, `status`,
+	// `isMember`, `subscriptions`, `email`, `emailVerified` — that never appear
+	// (see the real production capture in internal/appapi/api_test.go). Making
+	// it actually raw is NOT the fix: `email`/`emailVerified` are PII this
+	// command does not print today, so passing the body through would be a
+	// privacy regression dressed as a bug fix. The words are what was wrong.
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a stable, curated identity object (scriptable)")
 	cmd.Flags().BoolVar(&showScopes, "scopes", false, "also print the full decoded scope list")
 	return cmd
 }
 
-// yesNo renders a capability bit as "yes"/"no".
+// yesNo renders a KNOWN capability bit as "yes"/"no".
 func yesNo(b bool) string {
 	if b {
 		return "yes"
 	}
 	return "no"
+}
+
+// yesNoUnknown renders a TRI-STATE capability as "yes"/"no"/"unknown". nil is
+// the third state (see appapi.Identity.CanSubmitApps) and must never render as
+// "no" — that is the false-negative-stated-as-fact this exists to prevent.
+func yesNoUnknown(b *bool) string {
+	if b == nil {
+		return ui.Dim("unknown")
+	}
+	return yesNo(*b)
 }

--- a/internal/cmd/whoami_test.go
+++ b/internal/cmd/whoami_test.go
@@ -1,0 +1,371 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// The `--json` contract. Pinned WHOLE, not by a handful of keys.
+// ---------------------------------------------------------------------------
+
+// TestWhoAmIJSONShapeIsPinnedWhole compares the ENTIRE marshalled payload
+// against a literal, for every capability state the command can be in, so an
+// ADDED key, a DROPPED key, a rename, or a changed null-vs-value decision is
+// visible.
+//
+// 🔴 EVERY OTHER `whoami --json` TEST DECODES INTO A PARTIAL STRUCT, WHICH BY
+// CONSTRUCTION CANNOT SEE EITHER FAILURE. `encoding/json` ignores unknown keys
+// and zero-fills missing ones, so a partial-struct assertion agrees with a
+// payload that has quietly grown or lost a sibling. Measured before this guard
+// existed, against a full-package run with no `-run` filter: adding
+// `"zzz_mutant": true` to the payload map SURVIVED, and deleting
+// `"canSubmitApps"` SURVIVED. (The positive control — deleting `"canSpend"` —
+// went red in TestWhoAmIJSONCredentialAndScopes, proving the harness could see
+// a missing key at all, which is what makes the two survivors real findings
+// rather than a broken runner.)
+//
+// 🔴 THE FIXTURES ARE A MATRIX, NOT ONE SAMPLE, AND THAT IS LOAD-BEARING.
+// Three booleans over one payload cannot be pairwise distinct, so a single
+// fixture leaves cross-assignment mutants alive (`"canSubmitApps":
+// id.CanReadBuzz()` and friends). Across the cases below every pair disagrees
+// somewhere: A has read=true/spend=false, C has read=false/spend=true, A has
+// submit=true/spend=false, C has submit=true/read=false, and D has submit=null
+// — which no bool-valued mutant can produce.
+func TestWhoAmIJSONShapeIsPinnedWhole(t *testing.T) {
+	const (
+		scopeUserRead        = 1 << 0
+		scopeAIServicesWrite = 1 << 15
+		scopeBuzzRead        = 1 << 16
+		scopeAppBlocksSubmit = 1 << 25
+	)
+	cases := []struct {
+		name string
+		body string
+		// want is a format string; %s is substituted with the test server's URL.
+		want string
+	}{{
+		// ---- A: personal key + KNOWN mask ------------------------------------
+		name: "personal key, known mask",
+		body: fmt.Sprintf(`{"username":"alma","id":11,"tokenScope":%d,"subject":{"type":"apiKey","id":"k"}}`,
+			scopeUserRead|scopeBuzzRead),
+		want: `{
+  "base_url": "%s",
+  "canReadBalance": true,
+  "canSpend": false,
+  "canSubmitApps": true,
+  "capabilities": {
+    "can_read_buzz": true,
+    "can_spend_buzz": false
+  },
+  "credentialType": "personal API key",
+  "id": 11,
+  "scopes": [
+    "UserRead",
+    "BuzzRead"
+  ],
+  "scopesKnown": true,
+  "username": "alma"
+}
+`,
+	}, {
+		// ---- B: personal key + ABSENT mask -----------------------------------
+		// 🔴 canSubmitApps is TRUE here with scopesKnown FALSE. That pair is the
+		// whole point of the tri-state: a personal key is not scope-gated for
+		// submit, so the answer is KNOWN even though the mask is not.
+		name: "personal key, absent mask",
+		body: `{"username":"bertil","id":22,"subject":{"type":"apiKey","id":"k"}}`,
+		want: `{
+  "base_url": "%s",
+  "canReadBalance": false,
+  "canSpend": false,
+  "canSubmitApps": true,
+  "capabilities": {
+    "can_read_buzz": false,
+    "can_spend_buzz": false
+  },
+  "credentialType": "personal API key",
+  "id": 22,
+  "scopes": null,
+  "scopesKnown": false,
+  "username": "bertil"
+}
+`,
+	}, {
+		// ---- C: OAuth + KNOWN mask -------------------------------------------
+		name: "oauth, known mask",
+		body: fmt.Sprintf(`{"username":"cesar","id":33,"tokenScope":%d,"subject":{"type":"oauth","id":"a"}}`,
+			scopeAIServicesWrite|scopeAppBlocksSubmit),
+		want: `{
+  "base_url": "%s",
+  "canReadBalance": false,
+  "canSpend": true,
+  "canSubmitApps": true,
+  "capabilities": {
+    "can_read_buzz": false,
+    "can_spend_buzz": true
+  },
+  "credentialType": "OAuth login",
+  "id": 33,
+  "scopes": [
+    "AIServicesWrite",
+    "AppBlocksSubmit"
+  ],
+  "scopesKnown": true,
+  "username": "cesar"
+}
+`,
+	}, {
+		// ---- D: OAuth + ABSENT mask — THE REGRESSION -------------------------
+		// 🔴 `"canSubmitApps": null`. Before this change the field was a plain
+		// bool and this exact body emitted `false` — a false negative stated as
+		// fact, since an OAuth credential's submit answer IS the mask bit and
+		// the mask is absent. This literal is what fails on pre-change code.
+		name: "oauth, absent mask",
+		body: `{"username":"david","id":44,"subject":{"type":"oauth","id":"a"}}`,
+		want: `{
+  "base_url": "%s",
+  "canReadBalance": false,
+  "canSpend": false,
+  "canSubmitApps": null,
+  "capabilities": {
+    "can_read_buzz": false,
+    "can_spend_buzz": false
+  },
+  "credentialType": "OAuth login",
+  "id": 44,
+  "scopes": null,
+  "scopesKnown": false,
+  "username": "david"
+}
+`,
+	}, {
+		// ---- E: no subject at all --------------------------------------------
+		// The other unknowable state: we cannot tell whether the OAuth gate even
+		// applies. Note scopesKnown is TRUE here while canSubmitApps is null, so
+		// the two are demonstrably not the same discriminator.
+		name: "no subject, known mask",
+		body: `{"username":"elias","id":55,"tokenScope":0}`,
+		want: `{
+  "base_url": "%s",
+  "canReadBalance": false,
+  "canSpend": false,
+  "canSubmitApps": null,
+  "capabilities": {
+    "can_read_buzz": false,
+    "can_spend_buzz": false
+  },
+  "credentialType": "unknown",
+  "id": 55,
+  "scopes": [],
+  "scopesKnown": true,
+  "username": "elias"
+}
+`,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := setupWhoAmI(t, tc.body)
+			stdout, _, err := run(t, "whoami", "--json")
+			if err != nil {
+				t.Fatalf("whoami --json: %v", err)
+			}
+			want := fmt.Sprintf(tc.want, srv.URL)
+			if stdout != want {
+				t.Errorf("--json payload changed.\n--- got ---\n%s\n--- want ---\n%s", stdout, want)
+			}
+		})
+	}
+}
+
+// TestWhoAmIJSONIsTheWholeOfStdout: `civitai whoami --json | jq -e .` must
+// always parse, and nothing human may contaminate it (internal/ui/CONVENTION.md
+// — `--json` never passes through `ui`). An INVARIANT GUARD: it pins behaviour
+// this change did not alter, so it is not regression coverage for anything here.
+func TestWhoAmIJSONIsTheWholeOfStdout(t *testing.T) {
+	setupWhoAmI(t, `{"username":"frida","id":66,"tokenScope":0,"subject":{"type":"oauth","id":"a"}}`)
+	stdout, _, err := run(t, "whoami", "--json")
+	if err != nil {
+		t.Fatalf("whoami --json: %v", err)
+	}
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		t.Fatalf("stdout is not valid JSON (%v):\n%s", err, stdout)
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		t.Fatalf("stdout carries more than the payload:\n%s", stdout)
+	}
+	for _, glyph := range []string{"Logged in as", "Capabilities:", "\x1b["} {
+		if strings.Contains(stdout, glyph) {
+			t.Errorf("--json stdout carries the human marker %q:\n%s", glyph, stdout)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The two surfaces must agree about what is KNOWABLE.
+// ---------------------------------------------------------------------------
+
+// TestWhoAmICapabilityMatrixHumanSurface drives the same four states as the
+// `--json` pin above through the HUMAN surface, because the defect was
+// precisely that the two surfaces disagreed.
+//
+// 🔴 THE REGRESSION IS THE personal-key-with-ABSENT-mask ROW. The old code
+// returned early on `!ScopeKnown()` and printed no Submit Apps row at all,
+// while `--json` published `canSubmitApps: true` for the same body — the human
+// surface withholding a fact the command was holding. The early return was
+// keyed on scope, but a personal key's submit answer does not depend on scope.
+func TestWhoAmICapabilityMatrixHumanSurface(t *testing.T) {
+	const (
+		scopeUserRead        = 1 << 0
+		scopeAIServicesWrite = 1 << 15
+		scopeBuzzRead        = 1 << 16
+		scopeAppBlocksSubmit = 1 << 25
+	)
+	cases := []struct {
+		name    string
+		body    string
+		want    []string
+		notWant []string
+	}{{
+		name: "personal key, known mask",
+		body: fmt.Sprintf(`{"username":"alma","id":11,"tokenScope":%d,"subject":{"type":"apiKey","id":"k"}}`,
+			scopeUserRead|scopeBuzzRead),
+		want: []string{
+			"Credential type:          personal API key",
+			"Read Buzz balance:        yes",
+			"Spend Buzz (AI Services): no",
+			"Submit Apps:              yes",
+		},
+		notWant: []string{"Submit Apps:              unknown", "not reported by the server"},
+	}, {
+		// 🔴 THE ROW MUST APPEAR EVEN THOUGH THE BUZZ CAPABILITIES ARE UNKNOWN.
+		name: "personal key, absent mask",
+		body: `{"username":"bertil","id":22,"subject":{"type":"apiKey","id":"k"}}`,
+		want: []string{
+			"Credential type:          personal API key",
+			"Submit Apps:              yes",
+			"(token scope not reported by the server — Buzz capabilities unknown)",
+		},
+		// The Buzz rows are genuinely unknowable here, so they must NOT print a
+		// "no" — that is the pre-existing behaviour this change preserves.
+		notWant: []string{"Read Buzz balance:", "Spend Buzz (AI Services):"},
+	}, {
+		name: "oauth, known mask",
+		body: fmt.Sprintf(`{"username":"cesar","id":33,"tokenScope":%d,"subject":{"type":"oauth","id":"a"}}`,
+			scopeAIServicesWrite|scopeAppBlocksSubmit),
+		want: []string{
+			"Credential type:          OAuth login",
+			"Read Buzz balance:        no",
+			"Spend Buzz (AI Services): yes",
+			"Submit Apps:              yes",
+		},
+		notWant: []string{"Submit Apps:              unknown"},
+	}, {
+		// 🔴 "unknown", NEVER "no". The mask IS the answer for an OAuth
+		// credential, and the server did not report it.
+		name: "oauth, absent mask",
+		body: `{"username":"david","id":44,"subject":{"type":"oauth","id":"a"}}`,
+		want: []string{
+			"Credential type:          OAuth login",
+			"Submit Apps:              unknown",
+			"(token scope not reported by the server — Buzz capabilities unknown)",
+		},
+		notWant: []string{"Submit Apps:              no"},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupWhoAmI(t, tc.body)
+			stdout, _, err := run(t, "whoami")
+			if err != nil {
+				t.Fatalf("whoami: %v", err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(stdout, w) {
+					t.Errorf("human output missing %q:\n%s", w, stdout)
+				}
+			}
+			for _, n := range tc.notWant {
+				if strings.Contains(stdout, n) {
+					t.Errorf("human output must NOT contain %q:\n%s", n, stdout)
+				}
+			}
+		})
+	}
+}
+
+// TestWhoAmICaveatIsScopedToBuzz: the degraded-scope caveat used to say
+// "capabilities unknown", full stop. With the Submit Apps row now printing
+// under that same caveat, the old wording contradicted the line right above it.
+func TestWhoAmICaveatIsScopedToBuzz(t *testing.T) {
+	setupWhoAmI(t, `{"username":"bertil","id":22,"subject":{"type":"apiKey","id":"k"}}`)
+	stdout, _, err := run(t, "whoami")
+	if err != nil {
+		t.Fatalf("whoami: %v", err)
+	}
+	if strings.Contains(stdout, "— capabilities unknown)") {
+		t.Errorf("the caveat must not claim EVERY capability is unknown while Submit Apps prints a known answer:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Buzz capabilities unknown") {
+		t.Errorf("the caveat must name the capabilities it actually covers:\n%s", stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #377 — the help must not call a curated projection "raw".
+// ---------------------------------------------------------------------------
+
+// TestWhoAmIJSONHelpDoesNotClaimRaw pins BOTH help surfaces, separately.
+//
+// 🔴 TWO SURFACES, EACH GOES STALE ALONE — the `Example` block and the `--json`
+// flag's usage string are different strings in different places, and #377 found
+// the same false claim in both. Asserting once, on the rendered `--help`, would
+// pass with one of them still wrong if the other happened to shadow it.
+//
+// The output is a hand-built projection of ten keys; the server demonstrably
+// sends six more (`tier`, `status`, `isMember`, `subscriptions`, `email`,
+// `emailVerified` — see the production capture in internal/appapi/api_test.go).
+// Making it truly raw is NOT the fix: `email`/`emailVerified` are PII this
+// command does not print.
+func TestWhoAmIJSONHelpDoesNotClaimRaw(t *testing.T) {
+	cmd := newWhoAmICmd()
+	flag := cmd.Flags().Lookup("json")
+	if flag == nil {
+		t.Fatal("whoami has no --json flag")
+	}
+	surfaces := map[string]string{
+		"Example block":     cmd.Example,
+		"--json flag usage": flag.Usage,
+	}
+	for name, text := range surfaces {
+		if strings.Contains(strings.ToLower(text), "raw") {
+			t.Errorf("%s still calls the curated projection raw (#377): %q", name, text)
+		}
+		if !strings.Contains(text, "curated") {
+			t.Errorf("%s should say what the output IS — a curated identity object: %q", name, text)
+		}
+	}
+}
+
+// TestWhoAmIScopesEmptyListIsNotBlank: a KNOWN mask with no bits set rendered
+// as `Scopes (0): ` with an empty trailing list, which reads as truncated
+// output rather than as a measurement.
+func TestWhoAmIScopesEmptyListIsNotBlank(t *testing.T) {
+	setupWhoAmI(t, `{"username":"frida","id":66,"tokenScope":0,"subject":{"type":"apiKey","id":"k"}}`)
+	stdout, _, err := run(t, "whoami", "--scopes")
+	if err != nil {
+		t.Fatalf("whoami --scopes: %v", err)
+	}
+	if strings.Contains(stdout, "Scopes (0): \n") {
+		t.Errorf("a zero mask must not render as a blank trailing list:\n%q", stdout)
+	}
+	if !strings.Contains(stdout, "Scopes (0): (none granted)") {
+		t.Errorf("a zero mask should say so explicitly:\n%s", stdout)
+	}
+}


### PR DESCRIPTION
## 🔴 Breaking change to a published `--json` contract

**`civitai whoami --json` → `canSubmitApps` is now `true` / `false` / `null`.**
It was a plain boolean. `null` means *unknowable*, and a consumer must not read
it as `false`. A script doing `if (!j.canSubmitApps)` will now treat `null` the
same as `false` and report a submit dead end that may not exist — test
`j.canSubmitApps === null` first.

**Also `--json` → `scopes` can now be `[]`.** It was `null` in two unrelated
states (mask unreported, *and* a known mask of `0`); a known-empty mask now
emits `[]` so the field is self-describing. `null` still means "the server did
not report a scope mask" (`scopesKnown: false`).

Nothing else in the object changed — same ten keys, same names.

**In-repo consumers checked.** `find … | xargs grep -l canSubmitApps` (not
`grep -r`, which honours `.gitignore` here) over the whole tree: only
`README.md`, `internal/appapi/appblocks.go`, `internal/cmd/whoami.go`, the new
test, and the built `bin/civitai`. Nothing in `npm/`, `scripts/`, or any
`.ts`/`.js`/`.sh` reads it. Same for `credentialType` / `canReadBalance` /
`scopesKnown`.

---

## Defect 1 — `--json` was unpinned against key addition AND removal

Every existing `whoami --json` test decoded into a **partial struct**, which by
construction ignores unknown keys and zero-fills missing ones.

Measured by mutation on full-package runs (`go test ./internal/cmd/
./internal/appapi/ -count=1 -v`, **no `-run` filter**, 3043 tests each run):

| mutant | before | after this PR | killed by |
| --- | --- | --- | --- |
| add `"zzz_mutant": true` to the payload map | 🟢 survived | 🔴 **KILLED** | `TestWhoAmIJSONShapeIsPinnedWhole` (all 5 subtests), and nothing else |
| delete `"canSubmitApps"` from the payload map | 🟢 survived | 🔴 **KILLED** | `TestWhoAmIJSONShapeIsPinnedWhole` (all 5 subtests), and nothing else |
| **positive control:** delete `"canSpend"` | 🔴 killed (`TestWhoAmIJSONCredentialAndScopes`) | 🔴 killed | that test **plus** the new pin — control still behaves as measured |

The positive control proves the harness can observe a missing key at all, which
is what makes the two survivors real findings rather than a broken runner. Each
mutant was applied to the real source, `go build` confirmed, and the full
package run counted (`RUN=3043` every time) rather than read off an exit code.

`TestWhoAmIJSONShapeIsPinnedWhole` follows `TestDoctorJSONShapeIsPinnedWhole` /
`TestSetTextJSONShapeIsPinnedWhole`, but pins **five** capability states rather
than one. That is load-bearing: three booleans over a single payload cannot be
pairwise distinct, so one fixture leaves cross-assignment mutants
(`"canSubmitApps": id.CanReadBuzz()`) alive. Across the cases every pair
disagrees somewhere, and one case emits `null` — which no bool-valued mutant
can produce.

## Defect 2 — the two surfaces disagreed about what is KNOWABLE

Both directions were wrong, inside one command:

- **Human withheld a known fact.** A personal key with an absent mask printed
  *no* `Submit Apps` row at all — the `!ScopeKnown()` early return suppressed a
  row that does not depend on scope — while `--json` published
  `canSubmitApps: true` for the same body.
- **`--json` stated a false negative as fact.** An OAuth credential with an
  absent mask emitted `canSubmitApps: false`. For OAuth the `AppBlocksSubmit`
  bit *is* the answer, so the truth was unknowable, and `scopesKnown` did not
  disambiguate it the way it does for `canSpend` / `canReadBalance`.

`appapi.Identity.CanSubmitApps` now returns **`*bool`** — one predicate, one
place. `nil` is unknowable; a caller cannot hand it to a yes/no renderer without
an explicit nil branch, and it marshals straight to JSON `null`. Same
discriminator shape as **AGENTS item 9**'s `views.unavailable`, cited by number
in the doc comment; the pointer also matches that item's own precedent
(`AppAnalytics.Views` is a pointer for exactly this reason).

**A third state changed with it.** A response with no `subject` used to report
`no`, documented in the test as *"conservative"*. It is not conservative, it is
a claim — with no subject the CLI cannot tell whether the OAuth gate even
applies. It is now `unknown` / `null`. That test's comment was updated to say so
rather than silently re-pinned.

### Verified on the REAL binary (`make build`, driven at a local fake `/api/v1/me`)

<details><summary><b>A. personal key + KNOWN mask</b> — <code>{"username":"zach","id":1,"tokenScope":65537,"subject":{"type":"apiKey","id":"k"}}</code></summary>

```
$ civitai whoami
Logged in as zach (id 1) at http://127.0.0.1:44797

Capabilities:
  Credential type:          personal API key
  Read Buzz balance:        yes
  Spend Buzz (AI Services): no
  Submit Apps:              yes

⚠ This credential can't spend Buzz — `civitai generate` and money-path `dev:live`
generation both need the AI Services scope. To get it:
  civitai login --token <key>      # a FULL-SCOPE personal API key: create one at https://civitai.com/user/account
  civitai login --scopes generate  # or a browser login that opts into generation
(exit 0)

$ civitai whoami --json
{
  "base_url": "http://127.0.0.1:44797",
  "canReadBalance": true,
  "canSpend": false,
  "canSubmitApps": true,
  "capabilities": {
    "can_read_buzz": true,
    "can_spend_buzz": false
  },
  "credentialType": "personal API key",
  "id": 1,
  "scopes": [
    "UserRead",
    "BuzzRead"
  ],
  "scopesKnown": true,
  "username": "zach"
}
(exit 0)
```
</details>

<details open><summary><b>B. personal key + ABSENT mask</b> — the row the human surface used to withhold — <code>{"username":"zach","id":1,"subject":{"type":"apiKey","id":"k"}}</code></summary>

```
$ civitai whoami
Logged in as zach (id 1) at http://127.0.0.1:44495

Capabilities:
  Credential type:          personal API key
  Submit Apps:              yes
  (token scope not reported by the server — Buzz capabilities unknown)
(exit 0)

$ civitai whoami --json
{
  "base_url": "http://127.0.0.1:44495",
  "canReadBalance": false,
  "canSpend": false,
  "canSubmitApps": true,
  "capabilities": {
    "can_read_buzz": false,
    "can_spend_buzz": false
  },
  "credentialType": "personal API key",
  "id": 1,
  "scopes": null,
  "scopesKnown": false,
  "username": "zach"
}
(exit 0)
```
</details>

<details><summary><b>C. OAuth + KNOWN mask</b> — <code>{"username":"zach","id":1,"tokenScope":33587200,"subject":{"type":"oauth","id":"a"}}</code></summary>

```
$ civitai whoami
Logged in as zach (id 1) at http://127.0.0.1:45483

Capabilities:
  Credential type:          OAuth login
  Read Buzz balance:        no
  Spend Buzz (AI Services): yes
  Submit Apps:              yes
(exit 0)

$ civitai whoami --json
{
  "base_url": "http://127.0.0.1:45483",
  "canReadBalance": false,
  "canSpend": true,
  "canSubmitApps": true,
  "capabilities": {
    "can_read_buzz": false,
    "can_spend_buzz": true
  },
  "credentialType": "OAuth login",
  "id": 1,
  "scopes": [
    "AIServicesWrite",
    "AppBlocksSubmit"
  ],
  "scopesKnown": true,
  "username": "zach"
}
(exit 0)
```
</details>

<details open><summary><b>D. OAuth + ABSENT mask</b> — the false negative — <code>{"username":"zach","id":1,"subject":{"type":"oauth","id":"a"}}</code></summary>

```
$ civitai whoami
Logged in as zach (id 1) at http://127.0.0.1:40355

Capabilities:
  Credential type:          OAuth login
  Submit Apps:              unknown
  (token scope not reported by the server — Buzz capabilities unknown)
(exit 0)

$ civitai whoami --json
{
  "base_url": "http://127.0.0.1:40355",
  "canReadBalance": false,
  "canSpend": false,
  "canSubmitApps": null,
  "capabilities": {
    "can_read_buzz": false,
    "can_spend_buzz": false
  },
  "credentialType": "OAuth login",
  "id": 1,
  "scopes": null,
  "scopesKnown": false,
  "username": "zach"
}
(exit 0)
```

Was `"canSubmitApps": false` before this PR, with no `Submit Apps` row on the
human side at all.
</details>

The caveat line is now scoped to **Buzz** — `(token scope not reported by the
server — Buzz capabilities unknown)` — because the `Submit Apps` row printed
directly above it may well be a known answer, which the old blanket
"capabilities unknown" contradicted.

## Defect 3 — `--json`'s own help called a curated projection "raw JSON" (#377, option a)

Both surfaces said it, and each goes stale alone, so both are pinned separately
by `TestWhoAmIJSONHelpDoesNotClaimRaw`:

```
  civitai whoami --json     # a stable, curated identity object (scriptable)
      --json     emit a stable, curated identity object (scriptable)
```

**Deliberately NOT made actually raw.** It is a hand-built projection of ten
keys and the server demonstrably sends six more (`tier`, `status`, `isMember`,
`subscriptions`, `email`, `emailVerified` — confirmed against the real
production capture in `internal/appapi/api_test.go`). `email` /
`emailVerified` are PII this command does not print today, so passing the body
through would be a privacy regression dressed as a bug fix. #377 option (b)
(modelling `tier`/`status`/`isMember`/`subscriptions`) is explicitly **out of
scope** here; #377 stays open for it.

## Defect 4 — README

`Submit Apps` / `canSubmitApps` / `scopesKnown` had **zero** hits in `README.md`.
`CanSubmitApps` shipped 2026-07-29 (#184) and the README never moved. Every
surface naming whoami's output was grepped and updated:

1. **Command table row** (`civitai whoami …`) — said three capability rows and
   four `--json` keys; now four rows, all ten keys, the tri-state, "curated not
   raw", and a link into the detail.
2. **New `#### What `civitai whoami` reports`** under *Submit & auth* (with a
   `##### whoami --json` sub-block) — the four-row sample output, a
   credential × mask table for the tri-state, the full JSON sample, the
   `canSubmitApps` **and** `scopes` third states with the breaking-change
   warning, and why `scopesKnown` does not disambiguate `canSubmitApps` the way
   it does the Buzz pair. Kept at `####` deliberately: `###` is TOC-governed by
   `TestREADMETableOfContentsCoversEverySection`, and this sits alongside the
   existing `#### How big can a bundle be?` style.
3. **Troubleshooting index** — two new rows in *Credentials and access*:
   `Submit Apps:` (the tri-state, "unknown is not no") and `(token scope not
   reported by the server — Buzz capabilities unknown)`.

The other four `whoami` mentions (lines ~487, 548, 2361, 2503) all say
*"`civitai whoami` shows the capability as **Spend Buzz (AI Services)**"* —
still accurate, deliberately untouched.

**Nothing generated or fixture-frozen was fought.** No `exitcodes_doc.go` prose
and no provenanced fixture covers whoami. One README guard did fire honestly and
is worth recording: `TestREADMETroubleshootingSymptomsExistInTheSource` rejected
a row quoting `Submit Apps:              unknown`, because the CLI builds that
line with `%s` and no such contiguous literal exists in source. The row was
reworded to quote `Submit Apps:` (a real literal) rather than the guard being
worked around.

## The two smaller things — both done

- **`scopes` was `null` in two states.** A known mask of `0` now decodes to a
  non-nil empty slice, so `--json` emits `[]`; `null` is reserved for "mask not
  reported". Pinned by `TestDecodeScopesNilVsEmpty` and by the `no subject,
  known mask` case of the whole-shape pin. Included in the breaking-change note
  above.
- **`Scopes (0): ` printed a blank trailing list**, which read as truncated
  output. Now `Scopes (0): (none granted)`. Verified on the real binary.

## Tests

**Red-at-base matrix.** Every new regression test was run against `origin/main`
(`git checkout origin/main -- internal/cmd/whoami.go internal/appapi/appblocks.go
internal/cmd/cmd_test.go`, keeping the new test file) and watched to fail:

| test | at `origin/main` | at HEAD |
| --- | --- | --- |
| `TestWhoAmIJSONShapeIsPinnedWhole/oauth,_absent_mask` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmIJSONShapeIsPinnedWhole/no_subject,_known_mask` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmICapabilityMatrixHumanSurface/personal_key,_absent_mask` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmICapabilityMatrixHumanSurface/oauth,_absent_mask` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmICaveatIsScopedToBuzz` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmIJSONHelpDoesNotClaimRaw` | 🔴 FAIL | 🟢 PASS |
| `TestWhoAmIScopesEmptyListIsNotBlank` | 🔴 FAIL | 🟢 PASS |
| `TestCanSubmitAppsIsTriState`, `TestDecodeScopesNilVsEmpty` (appapi) | would not compile at base (signature change) — covered by the cmd-level rows above | 🟢 PASS |

The three whole-shape subtests that **pass** at base (`personal key, known
mask`, `personal key, absent mask`, `oauth, known mask`) are the states that
were already correct on the `--json` side. That pin's add/remove value is
demonstrated by the mutation matrix at the top, not by this run.

🔴 **`TestWhoAmIJSONIsTheWholeOfStdout` is an INVARIANT GUARD, not regression
coverage.** It pins `--json` staying free of `ui` output
(`internal/ui/CONVENTION.md`), which this change did not alter — it is green at
base and is labelled as such in its own doc comment.

## Verification

- **`make ci`: PASS** (tidy + vet + test + build; all 20 packages ok).
- **`make lint`: PASS, 0 issues** — run as
  `nix-shell -p golangci-lint --run "make lint"`. It is **not** a formality
  here: it caught a real `gofmt` misalignment in `internal/cmd/whoami.go` that
  `make ci` was green on, exactly the gap AGENTS documents. Fixed, re-run, 0
  issues; `gofmt -s -l .` also reports 0 files.
- **Real binary**, not inferred from the code: `make build`, then all four
  Defect-2 states on both surfaces (pasted above), plus the zero-mask `--scopes`
  and `--json` cases and both help surfaces.

Not touched: `AGENTS.md` (owned by a concurrent session this run). Based
directly on `main`, not stacked.

Closes #377 partially — option (a) only; (b) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
