### PR TITLE
docs: CLAUDE.md is the `@AGENTS.md` import and nothing else — one doc to keep up to date

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,18 @@
 Guidance for AI coding agents (Cursor, Codex, Copilot, Gemini, Claude Code, …)
 and human contributors. This is the **single source of truth** for stack,
 conventions, the release process, and the few decisions that look wrong but are
-intentional. For user-facing docs see [`README.md`](README.md); for the
-contributor checklist see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+intentional. For the contributor checklist see
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+🔴 **[`README.md`](README.md) IS THE PUBLISHED USER CONTRACT, AND IT IS NOT ONE
+PLACE.** This file holds the decisions and rationale; the README states the
+contract — exit codes, `--json` shapes, the command reference (don't re-derive
+it here) — so **any** behaviour change is incomplete until it moves too, not
+only the ones an item below cites. Its command section, exit-code table and
+Troubleshooting index each state that contract and each goes stale ALONE: #371
+shipped having updated two of three (#378). Grep every surface naming what you
+changed: some of that prose is GENERATED (`internal/cmd/exitcodes_doc.go`) or
+frozen verbatim by a provenanced fixture, so it cannot be fixed in place.
 
 ## Stack (exact versions — don't assume training-data defaults)
 
@@ -29,7 +39,7 @@ contributor checklist see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 `civitai` is the Apps authoring CLI. `civitai app` scaffolds a correct
 project, validates the manifest against the platform contract, packages it, and
-submits it for review. See the README command reference — don't re-derive it.
+submits it for review.
 
 ## Build / test / lint / run (exact commands)
 
@@ -283,8 +293,8 @@ whether you are in the situation that item governs.
 change it.** A trigger is deliberately not enough to act on: it names the
 situation, never the conclusion, so "I read the trigger" is not "I know the
 rule". If no trigger matches, you have read the whole list and you are done —
-that is what the list is for. Items with no pointer (2, 4, 30) are shorter than
-a trigger plus a file read would be, so they are stated here in full; there is
+that is what the list is for. Item 2 has no pointer — it is shorter than a
+trigger plus a file read would be, so it is stated here in full; there is
 nothing further to open.
 
 The move is verbatim and pinned as such (`agents_split_preserved_test.go`); the
@@ -306,14 +316,10 @@ item must carry a trigger that is a routing question rather than a label
    strip, the 64 MiB cap — or adding a package manager to the build recipe?**
    → evidence: claudedocs/decisions/03-lockfile-check.md
 
-4. **The token-scope BITMASK is vendored — the dev-token JWT check is not.**
-   `internal/appapi/appblocks.go` mirrors `civitai/civitai`'s frozen
-   `token-scope.constants.ts` bits, and `whoami`'s `CanSpendBuzz` / `--scopes`
-   decode test that `tokenScope` integer — so a change there is a
-   vendored-mirror edit ("Ask first"). Other credential, other mechanism:
-   `tokenCanSpend` (`internal/cmd/app_dev_token.go`) reads the dev-token JWT's
-   `scopes` **string array** for `ai:write:budgeted`, never a bitmask.
-   #70 claimed the reverse, four days after the bits shipped.
+4. **Deciding where a token's scope authority lives — adding or removing a
+   vendored `tokenScope` bitmask, `whoami`'s `CanSpendBuzz` / `--scopes`, or the
+   dev-token JWT's `scopes` array?**
+   → evidence: claudedocs/decisions/04-token-scope-bitmask-is-vendored.md
 
 5. **Replacing `app metrics`' slug→id→tRPC two-hop with a REST route, or
    editing `internal/appapi/analytics.go`?**
@@ -420,13 +426,9 @@ item must carry a trigger that is a routing question rather than a label
     by-slug fallback, the narrowed refusal behind it, or `app status`'s?**
     → evidence: claudedocs/decisions/29-offsite-refusal.md
 
-30. **A live-listing change may be STAGED and left unpublished, on purpose.**
-    `rm-screenshot` writes into the shadow revision and does NOT submit it: it
-    says so and names `app listing submit-revision`, because curation is N
-    removals and the first must not open a review cycle (#436 — the bare
-    `✓ Screenshot removed` was true of the revision, false of the listing).
-    That command's below-floor refusal therefore FAILS where the attach path
-    exits 0: there the job was the attach; here the submit IS the job.
+30. **Staging a live-listing change without publishing it — `rm-screenshot`'s
+    shadow revision, or a refusal that must FAIL where the attach path exits 0?**
+    → evidence: claudedocs/decisions/30-listing-change-may-be-staged.md
 
 31. **Changing a `pkgzip` size cap, vendoring or naming the server's bundle
     ceiling, or wording what `app submit` reports about a bundle's size?**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,1 @@
 @AGENTS.md
-
-## Claude-specific
-
-- This is a single-binary Go project. Use the `make` targets — never reach for a
-  non-Go package manager. `make ci` does **not** mirror CI (it omits lint); run
-  `make lint` too. #287 removed that same false claim from `AGENTS.md`.
-- `AGENTS.md` is the single source of truth for **agent guidance**; keep curated
-  guidance there, not here.
-- The split: `AGENTS.md` holds **decisions and rationale**; `README.md` is the
-  **published user contract** — exit codes, `--json` shapes, the command
-  reference. **Any** behaviour change is incomplete until `README.md` moves with
-  it; this is not scoped to the AGENTS items that happen to cite it today.
-- 🔴 **"README" is not one place.** The command's own section, the exit-code
-  table and the Troubleshooting index each state the contract and each goes stale
-  ALONE — #371 shipped having updated two of the three (#378). Grep the whole
-  file for every surface that names the behaviour you changed, and note that some
-  of that prose is generated (`internal/cmd/exitcodes_doc.go`) or frozen verbatim
-  by a provenanced fixture, so it cannot be corrected in place.

--- a/agents_evidence_test.go
+++ b/agents_evidence_test.go
@@ -55,13 +55,19 @@ const evidenceDir = "claudedocs/decisions"
 // directory — finds zero pointers, compares the empty set with an empty
 // expectation and reports a serene pass while the ledger checks nothing.
 //
-// It rises with each wave, or it stops being a control. TWENTY-SIX items are
-// split today — every item but 2 and 4, which are smaller than a trigger plus a
-// file read would cost. A floor of 5 was set when nine were and 10 when sixteen
-// were; against twenty-six, 10 would let a regex that had lost SIXTY PERCENT of
-// the corpus through — the "comfortable margin" the sibling xrefs guard warns is
-// not evidence of a healthy scan. 16 leaves room to re-inline ten without
-// weakening the control that far.
+// It rises with each wave, or it stops being a control. A floor of 5 was set
+// when nine items were split and 10 when sixteen were; against the corpus wave 4
+// produced, 10 would let a regex that had lost SIXTY PERCENT of the corpus
+// through — the "comfortable margin" the sibling xrefs guard warns is not
+// evidence of a healthy scan. 16 leaves room to re-inline ten without weakening
+// the control that far.
+//
+// 🔴 THE COUNT AND THE INLINE SET ARE NOT SPELLED HERE, ON PURPOSE. This comment
+// used to read "TWENTY-SIX items are split today — every item but 2 and 4", and
+// both halves outlived their truth: item 30 landed inline in #437, item 29 was
+// converted in wave 5, 32 in wave 6, 31 in wave 7, and 4 and 30 in wave 8. Ask
+// the file — TestEvidencePointersAndFilesAreTheSameSet logs the live count and
+// TestPlaybookNamesTheLiveInlineSet names the inline members.
 const minEvidencePointers = 16
 
 // evidencePointerRe matches the pointer line a stub ends with. The path is

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -37,6 +37,14 @@ import (
 
 // agentsMaxBytes is the ceiling on AGENTS.md.
 //
+// 🔴 EVERY MEASUREMENT BELOW IS WAVE-4 HISTORY (2026-08-10, #317), NOT TODAY'S
+// FILE — including "3,500 bytes of headroom", which has not been true for
+// months: the file has run at 12–145 bytes under this ceiling since #471, and
+// that is what forced waves 6, 7 and 8. The numbers are kept because the
+// DERIVATION is what justifies the constant; do not read any of them as the
+// current size. TestAgentsMDStaysUnderItsCeiling logs the live figure on every
+// run, which is the copy that cannot rot.
+//
 // Achieved size: 25,258 bytes, after wave 4 turned the numbered list into a
 // TRIGGER INDEX — twenty-six items reduced to a one-line routing question plus a
 // pointer, ten bodies evicted in the process, items 2 and 4 left inline because

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 )
 
-// The evidence split has moved TWENTY-SIX item BODIES out of AGENTS.md, over
-// four waves, and left first stubs and now TRIGGER LINES behind. The whole value
+// The evidence split has moved item BODIES out of AGENTS.md over EIGHT waves —
+// the count is splitItems' own length, deliberately not restated in prose here,
+// because every earlier attempt to state it went stale within two waves — and
+// left first stubs and now TRIGGER LINES behind. The whole value
 // of the split rests on one claim: the move was VERBATIM. Every measured RSS
 // table, every mutation matrix, every retraction and every enumerated residual
 // is still there, byte for byte, in the file the pointer names.
@@ -174,6 +176,32 @@ const agentsSplitBaseWave6 = "8e51494c8549cdb838d3861de0dcc63c38d294d5"
 // restore it, rather than by spending the last of it.
 const agentsSplitBaseWave7 = "87a147cc00cd930632948d66a992f2506e1f10e3"
 
+// agentsSplitBaseWave8 is the commit items 4 and 30 were moved from — the tip
+// after #492, i.e. the state of the file before CLAUDE.md was collapsed to its
+// bare `@AGENTS.md` import.
+//
+// 🔴 WHAT FORCED IT: collapsing CLAUDE.md meant RELOCATING the two rules it
+// carried that AGENTS.md did not — that `README.md` is the published user
+// contract, and that "README" is three surfaces which go stale independently.
+// That text is ~650 bytes and there were NINETY under agentsMaxBytes. Merging it
+// into the existing prose (the cheapest option, and the one tried first) closes
+// none of that gap: the content is irreducible, so the budget had to come from
+// eviction, which is what this file's playbook says to do.
+//
+// Items 4 (580 bytes) and 30 (532) were the two largest remaining inline bodies
+// and the playbook ranked them first and second. Item 2 (301) is deliberately
+// left inline: TestInlineAgentsItemsStayUnderTheBreakEven needs at least one
+// inline item or its own control fires.
+//
+// 🔴 AND THE JUSTIFICATION FOR KEEPING THEM INLINE HAD ALREADY EXPIRED.
+// maxInlineItemBytes' comment said the inline items "carry nothing to defer: no
+// measurement, no mutation matrix, no retraction". That is no longer true of
+// either: item 4 records a RETRACTION (#70 claimed the reverse of the vendoring,
+// four days after the bits shipped) and item 30 records a worked incident (#436)
+// plus an enumerated exit-code asymmetry. Both now have a body worth opening a
+// file for, which is exactly the condition the break-even describes.
+const agentsSplitBaseWave8 = "c3af4cad891091183836f94a920895c1c28e1cd6"
+
 type splitItem struct {
 	num      int
 	file     string
@@ -216,6 +244,8 @@ var splitItems = []splitItem{
 	{num: 29, file: "claudedocs/decisions/29-offsite-refusal.md", base: agentsSplitBaseWave5, nonBlank: 8, sha: "df86c7a851e2397db48eebd2f4b9d17e91565128ec4550510a62b785f552828d"},
 	{num: 32, file: "claudedocs/decisions/32-submit-provenance-claim.md", base: agentsSplitBaseWave6, nonBlank: 5, sha: "45d00151610d87af805502b0113bd6195417ec26ae5c4a4b0d797e0ef7ca5ad9"},
 	{num: 31, file: "claudedocs/decisions/31-pkgzip-caps-are-not-a-server-mirror.md", base: agentsSplitBaseWave7, nonBlank: 7, sha: "3ee77946d738161963e26167b2de2c12a56b01b8262e257708ab713bbd020c8d"},
+	{num: 4, file: "claudedocs/decisions/04-token-scope-bitmask-is-vendored.md", base: agentsSplitBaseWave8, nonBlank: 8, sha: "63c66afe0ad72780f451645f63474c3877c316e5ab193d7046077fdd4e7a3b7e"},
+	{num: 30, file: "claudedocs/decisions/30-listing-change-may-be-staged.md", base: agentsSplitBaseWave8, nonBlank: 7, sha: "3fbea5dc77a22e8d567b8340b1022915434fc68e2a21a13ab204c5f8b325d722"},
 }
 
 // --- the one deliberate delta, item 3 ---------------------------------------

--- a/agents_trigger_test.go
+++ b/agents_trigger_test.go
@@ -64,10 +64,14 @@ import (
 //  6. A CONVERTED ITEM IS THE TRIGGER AND THE POINTER, NOTHING ELSE. Any other
 //     line in the block is a body creeping back inline.
 //
-//  7. AN INLINE ITEM STAYS UNDER THE BREAK-EVEN. Two items (2 and 4) are stated
-//     in full because a trigger plus a file read costs more than they do; see
+//  7. AN INLINE ITEM STAYS UNDER THE BREAK-EVEN. An item may be stated in full
+//     when a trigger plus a file read costs more than it does; see
 //     maxInlineItemBytes. Without this rule the next item is written inline
 //     "just this once" and the index silently reverts to a list of bodies.
+//     🔴 Do not re-derive today's inline SET from any comment in this package —
+//     "2 and 4" was wave-4 history that outlived its truth twice over. Ask the
+//     file: TestInlineAgentsItemsStayUnderTheBreakEven logs the count and
+//     TestPlaybookNamesTheLiveInlineSet names the members.
 //
 // # 🔴 WHAT THIS FILE SUPERSEDES, AND THE PROPERTY THAT MOVED
 //
@@ -113,17 +117,25 @@ const (
 // A trigger block (the wrapped question plus its pointer line) measures 162–265
 // bytes in AGENTS.md today, mean 204. So converting an item recovers
 // (its size − ~204) bytes and costs one file read whenever its subject comes up.
-// The two items left inline are 301 and 500 bytes — they would recover 97 and
-// 296 — and they are also the only two whose bodies carry nothing to defer: no
-// measurement, no mutation matrix, no retraction, no enumerated residual, no
-// second sub-rule. Their evidence files would hold exactly the text the list
-// already shows, so the trigger would promise something to open and deliver a
-// restatement.
+// An item under the break-even is one that recovers little AND has nothing to
+// defer — no measurement, no mutation matrix, no retraction, no enumerated
+// residual, no second sub-rule — so its evidence file would hold exactly the
+// text the list already shows, and the trigger would promise something to open
+// and deliver a restatement.
 //
-// 600 sits above item 4 (500) and below the smallest converted body (item 11's
-// 638-byte stub, which recovered 441). The two tests agree at this line, which
-// is why it is drawn here: everything under it saves less than 300 bytes AND has
-// nothing to defer; everything over it fails both ways.
+// 600 was drawn above the largest inline body of the day and below the smallest
+// converted one (item 11's 638-byte stub, which recovered 441): everything under
+// it saves less than ~300 bytes AND has nothing to defer; everything over it
+// fails both ways.
+//
+// 🔴 UNDER THE BREAK-EVEN IS NOT A PROHIBITION ON CONVERTING, AND WAVE 8 IS THE
+// CASE. Items 4 (580 bytes) and 30 (532) were both under 600 and both were
+// converted, because the SECOND half of the test had stopped holding: item 4
+// carries a retraction (#70) and item 30 a worked incident (#436) plus an
+// enumerated exit-code asymmetry, so each had a body worth opening a file for.
+// This constant is a CEILING on what may sit inline. It has never been a floor
+// on what may be evicted, and the budget in agents_size_test.go is a legitimate
+// reason to evict — that is what its playbook is for.
 //
 // 🔴 THIS IS THE RULE THAT KEEPS THE INDEX AN INDEX. A new item written inline
 // as a full body fails here by name, and the fix is to write the trigger and

--- a/claude_md_import_only_test.go
+++ b/claude_md_import_only_test.go
@@ -1,0 +1,152 @@
+package cli_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// CLAUDE.md IS AN IMPORT SHIM. IT IS NOT A SECOND PLACE TO PUT GUIDANCE.
+//
+// AGENTS.md is the canonical agent doc because it is the cross-tool one: Cursor,
+// Codex, Copilot and Gemini all read `AGENTS.md`, and none of them resolve
+// Claude Code's `@file` import syntax. So a rule written into CLAUDE.md reaches
+// exactly one tool, while reading — to the person who wrote it — as guidance the
+// project has.
+//
+// 🔴 TWO DOCS DRIFT, AND THE ONE THAT IS NOT CANONICAL IS THE ONE THAT GOES
+// STALE. That is not a prediction; it is what this repo measured before the
+// files were collapsed. CLAUDE.md carried four bullets. One
+// (`make ci` omits lint) was a THIRD copy of a rule AGENTS.md already states
+// twice, so it had three places to rot in. Two more were load-bearing rules
+// AGENTS.md did not state AT ALL — that `README.md` is the published user
+// contract, and that "README" is three surfaces which go stale independently —
+// so every agent that is not Claude Code shipped behaviour changes without them.
+// The fourth ("AGENTS.md is the single source of truth; keep guidance there")
+// was a rule the file itself was violating in the three bullets around it.
+//
+// Prose asking the next maintainer to keep CLAUDE.md empty is what failed the
+// first time, so this is the deterministic version: the file's whole content is
+// pinned, not merely its size or a keyword. A new bullet fails here by name, and
+// the fix is to write it in AGENTS.md — where every tool reads it, and where
+// agents_size_test.go's ceiling prices it.
+
+// claudeMDImport is the ONE line CLAUDE.md may carry. It is the Claude-Code
+// import that makes AGENTS.md load into a session; without it the collapse
+// would have silently removed AGENTS.md from every Claude Code session, which
+// is why its presence is a CONTROL below rather than just another line.
+const claudeMDImport = "@AGENTS.md"
+
+// claudeMDResidue returns every line that is neither blank nor the import —
+// i.e. guidance CLAUDE.md has grown of its own.
+//
+// It is the ONE classifier: the live check and the negative-control corpus both
+// call it, so narrowing what it reports fails the corpus by name instead of
+// quietly widening what CLAUDE.md may contain.
+func claudeMDResidue(body string) []string {
+	var out []string
+	for _, l := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(l)
+		if s == "" || s == claudeMDImport {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestClaudeMDIsTheImportAndNothingElse is the guard nothing provided before:
+// `grep CLAUDE.md *_test.go` returned zero hits, so the file could regrow a
+// second copy of the project's guidance with the whole suite green.
+func TestClaudeMDIsTheImportAndNothingElse(t *testing.T) {
+	raw, err := os.ReadFile("CLAUDE.md")
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v (CONTROL failure — the file this guard measures was not found, so nothing below checked anything)", err)
+	}
+	body := string(raw)
+
+	// POSITIVE CONTROL, and it is the load-bearing half. An EMPTY or deleted
+	// CLAUDE.md trivially satisfies "carries no guidance of its own" while
+	// having removed AGENTS.md from every Claude Code session — the reassuring
+	// zero. So the import must be present as its own line before the residue
+	// check below is allowed to mean anything.
+	found := false
+	for _, l := range strings.Split(body, "\n") {
+		if strings.TrimSpace(l) == claudeMDImport {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CONTROL failure, not a finding: CLAUDE.md does not contain the line %q.\n"+
+			"That import is the only thing loading AGENTS.md into a Claude Code session. Without it this guard would report "+
+			"a serene pass over a file that has stopped doing its one job — and every rule in AGENTS.md would silently "+
+			"stop reaching Claude Code while still reaching Cursor, Codex, Copilot and Gemini.\nfile content:\n%s", claudeMDImport, body)
+	}
+
+	if residue := claudeMDResidue(body); len(residue) > 0 {
+		t.Fatalf("CLAUDE.md carries %d line(s) of guidance of its own:\n  %s\n\n"+
+			"🔴 PUT IT IN AGENTS.md INSTEAD. AGENTS.md is canonical because it is the CROSS-TOOL doc — Cursor, Codex, Copilot and "+
+			"Gemini read it, and none of them resolve the `@file` import syntax, so a rule written here reaches Claude Code alone "+
+			"while reading like a project rule.\n"+
+			"And two docs drift: the one that is not canonical is the one that goes stale, because nobody edits it when the "+
+			"behaviour changes. That is measured, not feared — the bullets this file used to carry were one THIRD copy of a rule "+
+			"AGENTS.md already stated twice, plus two rules AGENTS.md did not state at all.\n"+
+			"If the rule is worth keeping it is worth its bytes in AGENTS.md, where agents_size_test.go prices it and every tool "+
+			"reads it. This file is the import and nothing else.",
+			len(residue), strings.Join(residue, "\n  "))
+	}
+	t.Logf("CLAUDE.md is %d bytes and carries only the %q import", len(raw), claudeMDImport)
+}
+
+// TestClaudeMDResidueClassifierCanGoRed is the NEGATIVE CONTROL. Without it,
+// "CLAUDE.md has no residue" is satisfiable by a classifier that reports nothing
+// — and the live file is, by construction, the one input on which a
+// wired-to-nothing classifier and a correct one agree.
+//
+// The reject corpus is built from the ACTUAL bullets this file used to carry,
+// not from a textbook fixture, because a scanner allowlisting its own canonical
+// examples is how a clean scan gets believed.
+func TestClaudeMDResidueClassifierCanGoRed(t *testing.T) {
+	accept := []struct{ name, in string }{
+		{"the collapsed file", "@AGENTS.md\n"},
+		{"no trailing newline", "@AGENTS.md"},
+		{"surrounded by blank lines", "\n\n@AGENTS.md\n\n"},
+		{"CRLF line endings", "@AGENTS.md\r\n"},
+		{"indented import", "  @AGENTS.md\n"},
+	}
+	for _, tc := range accept {
+		t.Run("accept/"+tc.name, func(t *testing.T) {
+			if got := claudeMDResidue(tc.in); len(got) > 0 {
+				t.Errorf("claudeMDResidue(%q) reported %v — a bare import is the one shape this file may have", tc.in, got)
+			}
+		})
+	}
+
+	reject := []struct{ name, in string }{
+		{"a heading", "@AGENTS.md\n\n## Claude-specific\n"},
+		{"the make-targets bullet that was a third copy",
+			"@AGENTS.md\n\n- This is a single-binary Go project. Use the `make` targets — never reach for a\n  non-Go package manager.\n"},
+		{"the self-referential single-source-of-truth bullet",
+			"@AGENTS.md\n\n- `AGENTS.md` is the single source of truth for **agent guidance**; keep curated\n  guidance there, not here.\n"},
+		{"the README-contract bullet that AGENTS.md did not have",
+			"@AGENTS.md\n\n- The split: `AGENTS.md` holds **decisions and rationale**; `README.md` is the\n  **published user contract**.\n"},
+		{"a lone sentence with no bullet or heading", "@AGENTS.md\n\nAlways run make lint before claiming done.\n"},
+		{"an HTML comment, which is still content to maintain", "@AGENTS.md\n\n<!-- remember to run make lint -->\n"},
+		{"a second import, which is a second doc to keep in step", "@AGENTS.md\n@README.md\n"},
+	}
+	for _, tc := range reject {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if got := claudeMDResidue(tc.in); len(got) == 0 {
+				t.Errorf("claudeMDResidue(%q) reported nothing — this is guidance living outside the canonical doc and the guard cannot see it", tc.in)
+			}
+		})
+	}
+
+	// POSITIVE CONTROL for the corpus itself: both halves must be non-trivial,
+	// or "the classifier agreed with every case" is a claim about an empty table.
+	if len(accept) < 3 || len(reject) < 5 {
+		t.Fatalf("CONTROL failure: the corpus is %d accept / %d reject case(s); a table this small cannot pin the classifier",
+			len(accept), len(reject))
+	}
+}

--- a/claudedocs/decisions/04-token-scope-bitmask-is-vendored.md
+++ b/claudedocs/decisions/04-token-scope-bitmask-is-vendored.md
@@ -1,0 +1,54 @@
+# AGENTS.md item 4 — the token-scope bitmask IS vendored; the dev-token JWT check is not
+
+Evidence for item 4 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements and the residuals, consulted when editing the code they are
+about rather than on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## Two credentials, two mechanisms, one easily-confused word
+
+"Scopes" names two different things in this CLI, carried by two different
+credentials, and the whole item exists because they were once written up as one:
+
+- **The API token** carries a numeric `tokenScope` **bitmask**. Those bit
+  positions are the server's, frozen in `civitai/civitai`'s
+  `token-scope.constants.ts`, and `internal/appapi/appblocks.go` **vendors**
+  them. `whoami`'s `CanSpendBuzz` and `--scopes` decode that integer. A change
+  there is therefore a vendored-mirror edit and falls under "⚠️ Ask first" —
+  confirm it against the server constants before touching it.
+- **The dev token** is a JWT whose `scopes` claim is a **string array**.
+  `tokenCanSpend` (`internal/cmd/app_dev_token.go`) looks for the
+  `ai:write:budgeted` string in it. There is no bitmask on this path, and none
+  should be added: bit authority stays server-side for this credential.
+
+## The retraction this item records
+
+#70 claimed the reverse — that the CLI does not vendor the server's numeric
+scope bits at all — and it said so **four days after the bits shipped**. The
+claim read as a deliberate design decision ("all bit/scope authority stays
+server-side") while a vendored copy of the bit positions was already in
+`internal/appapi/`. A reader acting on it would have "helpfully" deleted a
+mirror the code depends on, or skipped the "Ask first" gate when editing it.
+
+The generalisation: a doc that names ONE of two similar mechanisms and
+generalises to both is wrong about the one it did not look at. Both credentials
+are named above for exactly that reason.
+
+---
+
+4. **The token-scope BITMASK is vendored — the dev-token JWT check is not.**
+   `internal/appapi/appblocks.go` mirrors `civitai/civitai`'s frozen
+   `token-scope.constants.ts` bits, and `whoami`'s `CanSpendBuzz` / `--scopes`
+   decode test that `tokenScope` integer — so a change there is a
+   vendored-mirror edit ("Ask first"). Other credential, other mechanism:
+   `tokenCanSpend` (`internal/cmd/app_dev_token.go`) reads the dev-token JWT's
+   `scopes` **string array** for `ai:write:budgeted`, never a bitmask.
+   #70 claimed the reverse, four days after the bits shipped.

--- a/claudedocs/decisions/30-listing-change-may-be-staged.md
+++ b/claudedocs/decisions/30-listing-change-may-be-staged.md
@@ -1,0 +1,54 @@
+# AGENTS.md item 30 — a live-listing change may be staged and left unpublished
+
+Evidence for item 30 of the *Intentional decisions that look wrong* list in
+[`AGENTS.md`](../../AGENTS.md). AGENTS.md carries only this item's TRIGGER —
+one line naming the situations that mean you should be reading this file.
+Everything below the rule is the item itself, moved here VERBATIM: the thesis,
+the measurements and the residuals, consulted when editing the code they are
+about rather than on every session.
+
+The list is append-only and never renumbered, so this file's number is stable.
+Edit the body here, not in AGENTS.md; `agents_evidence_test.go` asserts the
+pointer and the file agree, `agents_trigger_test.go` asserts the trigger is a
+routing question rather than a label, and `agents_split_preserved_test.go` pins
+the body against the text it was moved from.
+
+## Why staging is the correct default for a removal
+
+Curating a store listing is **N removals**, not one. If the first
+`app listing rm-screenshot` submitted the shadow revision, it would open a
+review cycle the author is not finished preparing — and every subsequent removal
+would open another. So `rm-screenshot` writes into the shadow revision and stops
+there, saying so, and naming `app listing submit-revision` as the command that
+publishes.
+
+#436 is the incident: the command printed a bare `✓ Screenshot removed`. That
+sentence was **true of the revision and false of the listing** — the screenshot
+was still live to every visitor. A success line that names the wrong object is
+not a wording nit; it is a claim about what the user's site now looks like.
+
+## Why the refusals differ between the two commands, on purpose
+
+The below-floor refusal (a listing dropping under its required media minimum)
+**FAILS** — exits non-zero — on `submit-revision`, where the attach path exits
+0 for what looks like the same condition. That asymmetry is the point, and it
+follows from what the job was:
+
+- On the **attach** path the job was the attach. It succeeded. A listing that is
+  not yet publishable is an expected intermediate state while curating, and
+  reporting it as progress is honest.
+- On **`submit-revision`** the submit IS the job. A revision that cannot be
+  published has not been published, so exiting 0 would report a publish that did
+  not happen — the #436 shape again, one command over.
+
+Read a change to either exit code against that split before "harmonising" them.
+
+---
+
+30. **A live-listing change may be STAGED and left unpublished, on purpose.**
+    `rm-screenshot` writes into the shadow revision and does NOT submit it: it
+    says so and names `app listing submit-revision`, because curation is N
+    removals and the first must not open a review cycle (#436 — the bare
+    `✓ Screenshot removed` was true of the revision, false of the listing).
+    That command's below-floor refusal therefore FAILS where the attach path
+    exits 0: there the job was the attach; here the submit IS the job.


### PR DESCRIPTION
`CLAUDE.md` is now the single line `@AGENTS.md`. AGENTS.md stays canonical — it is the cross-tool doc (Cursor, Codex, Copilot and Gemini all read `AGENTS.md`, and none of them resolve Claude Code's `@file` import syntax), so a rule written in CLAUDE.md reached exactly one tool while reading, to whoever wrote it, like a project rule.

## What happened to each of the four bullets

| bullet | verdict | evidence |
| --- | --- | --- |
| `make` targets / `make ci` omits lint / run `make lint` | **deleted** — a THIRD copy | AGENTS.md states it twice (the 🔴 block in Build, the ✅ Always bullet in Permission boundaries). Its one extra clause — that #287 removed the same false claim — is independently recorded in `internal/cmd/app_newest_submission_test.go:359`. Nothing added. |
| "AGENTS.md is the single source of truth; keep guidance there" | **deleted** — vacuous, and self-violating | It was a rule the three bullets around it were breaking. Once CLAUDE.md is one line there is nothing to route, and the new guard enforces it deterministically instead of asking. |
| the `README.md`-is-the-published-contract split | **relocated at full scope** | `grep` found it nowhere in AGENTS.md, so every non-Claude-Code agent has been shipping behaviour changes without it. |
| 🔴 "README is not one place" | **relocated at full scope** | Same — all three surfaces, #371/#378, the generated prose and the provenanced fixture are kept, not summarised. |

The two relocated bullets are folded into AGENTS.md's intro (rather than bolted on as a section), and they absorb the two README-sync spots that were already there.

## The byte budget — strategy (b), and the arithmetic

`agentsMaxBytes` is **UNCHANGED at 28,758**.

Strategy **(a), merge**, was tried first and does not fit. The relocated content is ~700 bytes and there were **90**. It is irreducible — twelve distinct claims, and the brief was explicit that dropping the enumeration is the "description claims coverage the implementation does not have" failure this repo keeps hitting. The two absorbable spots (the intro's *user-facing docs* clause, and *What this is*'s command-reference sentence) return only **100 bytes** between them. Gap: ~510.

So **(b), eviction**, per `agents_size_test.go`'s own playbook, which ranked these two first and second:

| | before | after | freed |
| --- | ---: | ---: | ---: |
| item 4 (token-scope bitmask) | 580 B inline | 270 B trigger + pointer | 310 |
| item 30 (staged listing change) | 532 B inline | 235 B trigger + pointer | 297 |
| intro `README.md` clause | 45 B | — | 45 |
| *What this is* command-ref sentence | 55 B | — | 55 |
| relocated README rule | — | ~707 B | −707 |
| **AGENTS.md** | **28,668** | **28,650** | **108 under the ceiling** (was 90) |

Both bodies moved **VERBATIM** into `claudedocs/decisions/` and are sha256-pinned at their base commit (`agentsSplitBaseWave8` = `c3af4ca`). Item 2 (301 B) stays inline — `TestInlineAgentsItemsStayUnderTheBreakEven` fires its own control at zero inline items.

**The stated reason for keeping 4 and 30 inline had expired.** `maxInlineItemBytes`' comment said the inline items "carry nothing to defer — no measurement, no mutation matrix, no retraction". Item 4 records a retraction (#70 claimed the reverse of the vendoring, four days after the bits shipped); item 30 records a worked incident (#436) plus an enumerated exit-code asymmetry. That constant is a **ceiling on what may sit inline**; it has never been a floor on what may be evicted. The comment is corrected in this PR rather than left to mislead.

**Reach, judged not assumed:** both items are subsystem-scoped. Item 4 fires for someone editing scope constants or `whoami`'s capability output; item 30 for someone touching listing staging. Neither is an always-on warning for a passer-by, so a trigger + file read is the right shape.

Across both files the per-session cost falls **29,823 → 28,661 bytes**.

🔴 **Headroom is still only 108 bytes, and that is the honest bottom line.** Converting the two largest inline bodies bought ~600 bytes and the relocated rule spent ~700 of them. The file has run at 12–145 bytes under this ceiling since #471, and that is what forced waves 6, 7 and 8. If you want real headroom, the remaining levers are `agentsMaxBytes` itself (bounded at 30,600) or the prose sections — **your call, deliberately not taken here.**

## The guard

Nothing pinned CLAUDE.md before: `grep CLAUDE.md *_test.go` returned zero hits, so it could regrow a second copy of the guidance with the whole suite green. `claude_md_import_only_test.go` pins the file's **whole normalised content** — not a keyword, not a size — so a rewording cannot walk around it.

Mutation matrix, every row run:

| mutant | result |
| --- | --- |
| restore a guidance bullet to CLAUDE.md | **RED** — 1 of 216, `TestClaudeMDIsTheImportAndNothingElse`, with **its own** message |
| empty CLAUDE.md (the reassuring zero) | **RED** — the positive control fires: the `@AGENTS.md` import is gone, so the file has stopped doing its one job |
| `claudeMDResidue` wired to report nothing | **RED** — 7 of 7 reject rows in the negative-control corpus |
| edit item 4's evidence body | **RED** — the new wave-8 digest row *and* the line-level differ name the line |

The reject corpus is built from the bullets this file actually carried, not textbook fixtures.

## Verification

- `make ci` — **exit 0**, 21 packages ok, 0 FAIL.
- `make lint` — **exit 0**, `0 issues` (golangci-lint via `nix-shell -p golangci-lint`; it is not on this host's PATH). Stated separately because `make ci` does not run it.
- `gofmt -s -l .` — clean, over **432** Go files found (positive control: it saw files).
- Root package, counted from output rather than an exit code: **216 RUN / 216 PASS / 0 FAIL / 0 SKIP**.
- `./scripts/ci-shallow.sh` on the committed tree — **21/21 ok, 0 failures, 0 timeouts**, i.e. green in the depth-1 environment CI actually uses, where the git-backed digest cross-checks skip.

No behaviour change, so no README surface moves with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
