### PR TITLE
docs(release): v0.1.100 shipped, and v0.1.101 leads with a breaking `--json` tri-state

### DIFF
--- a/claudedocs/release-v0.1.100-draft.md
+++ b/claudedocs/release-v0.1.100-draft.md
@@ -1,20 +1,45 @@
-# v0.1.100 — DRAFT
+# v0.1.100 — SHIPPED
 
-**Not yet tagged.** Cut from `main` at `c97c29c`, which is the commit this draft
-sits on top of. Publishing the draft GitHub Release is what fires **npm and the
-Homebrew tap** (both trigger on `release: published`), and npm unpublish is
-restricted — so the tag is the recoverable step and the publish is not.
+**Tagged and published 2026-08-25T19:08:17Z.** `gh release view v0.1.100`
+reports `isDraft: false` with **14/14** expected assets. The tag sits on
+`d5a9943`, the `docs(release)` commit this draft was merged as — the convention
+`v0.1.99` established. All three channels fired and all three succeeded; npm
+`dist-tags.latest` is `0.1.100` and the tap cask reads `version "0.1.100"`.
+
+Everything below was written *before* the tag and is kept as the record. Where a
+section made a prediction, the measured outcome is folded in and marked
+**MEASURED**; the reasoning that made the release safe is preserved unchanged,
+because it is the part worth re-reading next time.
+
+**What shipped, verified against the published artifact:**
+
+| Claim | Measured |
+| --- | --- |
+| Release is published, not draft | `isDraft: false`, `publishedAt: 2026-08-25T19:08:17Z` |
+| Assets | **14**, exactly the predicted list |
+| `Release` workflow (tag push) | `success` |
+| `Release npm` (on `published`) | `success` |
+| `Release Homebrew cask` (on `published`) | `success` |
+| npm | `dist-tags.latest = 0.1.100` |
+| Homebrew tap | `cask "civitai" … version "0.1.100"` |
+| Changelog entries in the body | **5**, matching the prediction exactly |
+| Stale `[DO NOT MERGE …]` bracket | **absent** — edited out before publishing |
+| `civitai app doctor` present in the artifact | **yes** — first line of help, not `rc` |
+| `civitai app listing set-text` present | **yes** — same method |
 
 ## The version number is `0.1.100`, and that is not a typo
 
-This is the **first three-digit patch** in the repo's history, so it deserves
-the paragraph the previous 99 releases did not need.
+This was the **first three-digit patch** in the repo's history, so it deserved
+the paragraph the previous 99 releases did not need. **The analysis held: no
+comparison site mis-ordered it, and nothing downstream broke.** It is kept in
+full because the next three-digit boundary (`0.1.1000`, a minor bump, a `1.0.0`)
+will want it.
 
-The scheme is not ambiguous. There are **100 tags, `v0.1.0` through `v0.1.99`,
+The scheme is not ambiguous. There were **100 tags, `v0.1.0` through `v0.1.99`,
 with no gaps and no minor bump ever** — every release this project has cut is a
 single patch increment. `0.1.99 + 1 patch = 0.1.100`. Semver puts no ceiling on
 a numeric identifier, and rolling to `0.2.0` instead would assert a minor-level
-change this release does not contain.
+change this release did not contain.
 
 The failure this invites is the classic one: a **lexicographic** comparison puts
 `"0.1.100"` *below* `"0.1.99"`, so an update check silently stops advertising
@@ -45,8 +70,9 @@ not assumed:
 **There is no CI gate on tag or version monotonicity.** `release.yml`'s only tag
 validation is an *identity* check on the dispatch path (tag exists, `HEAD` is
 that tag, goreleaser would pick that name); nothing compares against the
-previous release. So a wrong version would not be caught by CI — which is why it
-is settled here, before tagging, rather than left to a gate that does not exist.
+previous release. So a wrong version would not have been caught by CI — which is
+why it was settled here, before tagging, rather than left to a gate that does
+not exist.
 
 🔴 **The green above is only as good as its negative control.** The numeric
 ordering was exercised against the real `internal/cmd` package —
@@ -55,26 +81,30 @@ ordering was exercised against the real `internal/cmd` package —
 does hold. Without that second half, a passing test says nothing: it would look
 identical if the implementation were the broken one.
 
-🔴 **What this section still cannot settle is the published artifact.** Reading
-`install.js` proves it *would* interpolate `0.1.100` correctly; only a real
-release proves it *did*. Confirm the asset names carry `0.1.100` on the draft —
-see *Verification*.
+**MEASURED — the residual this section could not settle is now closed.** The
+open item read: *"Reading `install.js` proves it would interpolate `0.1.100`
+correctly; only a real release proves it did."* A real release now has. Every
+published asset name carries `0.1.100` (list below, 14/14), npm resolved and
+published `0.1.100` as `latest`, and the rendered cask pins `version "0.1.100"`
+with `civitai_#{version}_*` URLs. The string-interpolation path is confirmed on
+a three-digit patch end to end.
 
-## Predicted contents
+## Contents — predicted, then confirmed
 
-**12 commits** (`v0.1.99..HEAD` including this draft commit): **7 excluded**
-(`docs(`/`test(`/`chore(`), **5 in the notes**, **0 leaking** — the changelog
-filter's optional-scope anchors have now held for four consecutive releases and
-are expected to hold here.
+**12 commits** (`v0.1.99..v0.1.100`): **7 excluded** (`docs(`/`test(`/`chore(`),
+**5 in the notes**, **0 leaking**.
 
-🔴 **The count has moved between drafting and tagging on every recent release.**
-Re-derive it at tag time rather than trusting this number:
+🔴 **The count has moved between drafting and tagging on every recent release**,
+which is why it was re-derived at the tag:
 
 ```
 git log v0.1.99..v0.1.100 --pretty='%s' | grep -cvE '^(docs|test|chore)(\(.*\))?:'
 ```
 
-### The 5 that should appear
+**MEASURED: 12 total, 5 passing the filter — and the published body carries
+exactly 5 entries.** The prediction was exact.
+
+### The 5, as published
 
 | # | commit | thread |
 |---|---|---|
@@ -92,18 +122,30 @@ re-vendor thread.
 ⚠️ **#485 is CI-internal**, the same shape as v0.1.99's #467. It changes a cron
 interval and nothing an author can observe. Note *why* it appears: the exclude
 list is `docs(`/`test(`/`chore(` only — **`ci(` is not filtered at all**, and
-never has been. This is not the scoped-anchor bug that `changelog_filter_ledger_test.go`
-pins; it is a scope the filter was never asked to cover. Left alone deliberately
-rather than widened at tag time, which would be an untested change to the one
-file whose failure mode is invisible until a release ships.
+never has been. This is not the scoped-anchor bug that
+`changelog_filter_ledger_test.go` pins; it is a scope the filter was never asked
+to cover. Left alone deliberately rather than widened at tag time, which would
+be an untested change to the one file whose failure mode is invisible until a
+release ships.
 
-🔴 **Both feature subjects carry a bracketed `[DO NOT MERGE until #4341 is on
-release]` note, and the changelog will publish it verbatim.** The gate it names
-is satisfied — both PRs merged — but the text is a stale instruction to a
-reviewer that will read to a user as a warning about the release they are
-installing. Rewriting it means rewriting a merged subject on `main`, which costs
-more than it saves; **edit it out of the release body in the GitHub UI before
-publishing**, where the notes are still a draft and editing them is free.
+🔴 **MEASURED — a second, unrelated claim closed by this body.**
+`changelog_filter_ledger_test.go` says outright what it *cannot* check: "that
+goreleaser applies these patterns to the subject line the way this test assumes,
+or anything about a real release body … the honest place to confirm it is the
+NEXT release's published notes." This is that body. It carries `ci(revendor)`
+and **no** `docs(`- or `chore(`-scoped subject, so goreleaser did apply the
+optional-scope anchors to the real subjects. That deferred claim is now
+evidenced, not assumed.
+
+🔴 **The stale bracket was removed, as instructed.** Both feature subjects
+carried a `[DO NOT MERGE until #4341 is on release]` note on `main`, and the
+generated changelog would have published it verbatim — a stale instruction to a
+reviewer that reads to a user as a warning about the release they are
+installing. Rewriting a merged subject on `main` costs more than it saves, so
+the fix was to edit the release body in the GitHub UI before publishing, where
+the notes are still a draft and editing them is free. **MEASURED: the published
+body contains zero occurrences of `DO NOT MERGE`.** The 5 entries are otherwise
+verbatim.
 
 ## What actually changes for an author
 
@@ -168,42 +210,63 @@ population it was built for.
 **`repository` is now a glossed manifest pattern** (#487), with the vendored
 schema re-vendored to carry it.
 
-## Verification before tagging
+## Verification — what was run, and what it found
 
-Re-run at the tag, do not trust this section:
+Pre-tag, at `c97c29c`: build + vet clean, `gofmt -s -l` silent, **21 packages
+ok, 0 FAIL, 0 timeout panics** — the same package count v0.1.99 recorded.
 
 ```
 git worktree add --detach /tmp/rel100 v0.1.100
 (cd /tmp/rel100 && go build ./... && go vet ./... && go test ./... -count=1)
 ```
 
-At `c97c29c` this was: build + vet clean, `gofmt -s -l` silent, **21 packages
-ok, 0 FAIL, 0 timeout panics** — the same package count v0.1.99 recorded.
+### 🔴 The feature probe that reads an EXIT CODE reports a false PRESENT — CONFIRMED, and now used correctly
 
-🔴 **A feature probe that reads an EXIT CODE reports a false PRESENT on this
-CLI.** Measured against the installed v0.1.99 binary while checking this
-release's premise: `civitai app doctor --help` and `civitai app listing
-set-text --help` both **exit 0** on a build where neither command exists —
-Cobra falls back to the *parent* command's help rather than erroring on an
-unknown subcommand. `rc=0` therefore says nothing. Read the first line of
-output: the real `doctor` help opens "Report what is missing or blocked on your
-App store listings"; the fallback opens "Browse, author, and ship Civitai
-Apps." Confirmed against the released artifact, not a local build —
-`go version -m` on it reports goreleaser's ldflags and
-`vcs.revision=42002af` (the v0.1.99 tag commit), and neither
-`internal/cmd/app_doctor.go` nor `internal/cmd/app_listing_set_text.go` exists
-in that tree.
+This is the trap this release was written around, and it reproduces on the
+**published** artifact. `civitai app doctor --help` exits **0** whether or not
+the command exists, because Cobra falls back to the *parent* command's help
+rather than erroring on an unknown subcommand. `rc=0` therefore says nothing.
 
-🔴 **Verify the published artifact, not the tag.** Prior releases in this repo
-were caught by two instruments lying in the reassuring direction:
-`raw.githubusercontent.com` served a stale Homebrew cask for five minutes after
-the tap updated (poll `gh api repos/civitai/homebrew-tap/commits` instead), and a
-URL check that *constructed* release URLs answered 200 for a cask still pointing
-at the previous version — a check must read the URLs **out of** the cask.
+**MEASURED against the published `civitai_0.1.100_linux_amd64`**, downloaded
+from the release, sha256 matched against the published `checksums.txt`
+(`038fc428…d3cf4b`), and confirmed genuine by
+`go version -m` → `vcs.revision=d5a99430c345e9817e46d578e4b9d96d995263af`
+(the v0.1.100 tag commit), `vcs.modified=false`, `--version` → `civitai 0.1.100`:
 
-**Expected assets on the draft — 14, the same shape as v0.1.99.** The full
-cross product, windows/arm64 included, twice (archive + bare binary), plus the
-checksums and the rendered cask:
+| probe | rc | first line of output | reading |
+| --- | --- | --- | --- |
+| `app doctor --help` | 0 | `Report what is missing or blocked on your App store listings, and how to fix it.` | **real** |
+| `app listing set-text --help` | 0 | `Set the store listing's TEXT fields — tagline, description and category.` | **real** |
+| `app definitelynotacommand --help` (control) | 0 | `Browse, author, and ship Civitai Apps.` | **fallback** |
+
+The third row is the control that makes the first two mean anything. All three
+exit 0, so the exit code cannot discriminate; only the first line can, and it
+does. **The draft's open residual — "only a real release proves it" — is
+closed: both commands are present and reachable in the shipped binary.**
+
+Keep the control. A probe that reports only rows 1 and 2 is indistinguishable
+from a probe run against a binary where neither command exists.
+
+### 🔴 Two instruments that lie in the reassuring direction
+
+Kept in full — both were caught on prior releases in this repo, and both would
+have reported success while the user-visible install was broken:
+
+- `raw.githubusercontent.com` served a **stale Homebrew cask for five minutes**
+  after the tap updated. Poll `gh api repos/civitai/homebrew-tap/commits`
+  instead of the raw CDN.
+- A URL check that **constructed** release URLs answered 200 for a cask still
+  pointing at the previous version. A check must read the URLs **out of** the
+  cask, never rebuild them from the version it expects.
+
+For this release the tap was read through the API
+(`gh api repos/civitai/homebrew-tap/contents/Casks/civitai.rb`), not the raw
+CDN, and the cask's own `version "0.1.100"` and `civitai_#{version}_*` URL
+templates were read out of the file.
+
+**Assets on the published release — 14, as predicted.** The full cross product,
+windows/arm64 included, twice (archive + bare binary), plus the checksums and
+the rendered cask:
 
 ```
 checksums.txt
@@ -221,12 +284,16 @@ A missing raw binary is the one that breaks silently and durably:
 and `checksums.txt`, but it only checks those two — the npm wrapper resolves
 the rest per platform at postinstall time.
 
-## Release mechanics
+## Release mechanics — as executed
 
-1. Merge this draft. Tag **that** commit (the convention: `v0.1.99` sits on its
-   own `docs(release)` commit, not on the last feature commit).
-2. `git tag v0.1.100 <sha> && git push origin v0.1.100` → goreleaser → **draft**
-   GitHub Release + assets.
-3. **Publishing the draft is a separate maintainer decision** (`AGENTS.md`
-   → Permission boundaries → 🚫 Never): it fires npm and the Homebrew tap, and
-   npm unpublish is restricted.
+1. The draft was merged as `d5a9943` and **that** commit was tagged, per the
+   convention (`v0.1.99` likewise sits on its own `docs(release)` commit).
+2. `v0.1.100` pushed → goreleaser → **draft** GitHub Release + 14 assets.
+   The `Release` workflow run: **success**.
+3. The stale `[DO NOT MERGE …]` bracket was edited out of the draft body.
+4. **Publishing the draft was a separate maintainer decision** (`AGENTS.md`
+   → Permission boundaries → 🚫 Never), taken at 2026-08-25T19:08:17Z. It fired
+   both downstream channels within two seconds — `Release npm` and
+   `Release Homebrew cask` both **success** — which is exactly why it is a
+   separate consent: npm unpublish is restricted, so a bad version is fixed by
+   publishing another, not by taking it back.

--- a/claudedocs/release-v0.1.101-draft.md
+++ b/claudedocs/release-v0.1.101-draft.md
@@ -1,0 +1,242 @@
+# v0.1.101 — DRAFT
+
+**Not yet tagged.** Cut from `main` at `af5e98f`, which is the commit this draft
+sits on top of. Publishing the draft GitHub Release is what fires **npm and the
+Homebrew tap** (both trigger on `release: published`), and npm unpublish is
+restricted — so the tag is the recoverable step and the publish is not.
+
+The version is a plain patch increment on `0.1.100`. The three-digit-ordering
+question was settled in `release-v0.1.100-draft.md` (every comparison site read,
+`parseSemver` numeric, no `\d{1,2}` in the repo, `--sort=-version:refname`) and
+then confirmed end to end by that release's published assets, npm `latest` and
+the tap cask; `0.1.101` raises nothing new.
+
+## 🔴 THE HEADLINE IS A BREAKING `--json` CHANGE
+
+**`civitai whoami --json`'s `canSubmitApps` is no longer a boolean.** It is now
+`true` / `false` / **`null`**, and `null` means *unknowable* — it never means
+"no". Read this before shipping the release, because it is the one thing in
+v0.1.101 that can silently break a consumer that is working today.
+
+⚠️ **The trap, in exactly the terms a script author will hit it:**
+
+```js
+if (!j.canSubmitApps) { … }   // ← now takes the false branch on null
+```
+
+`null` is falsy. A script written against the old boolean now treats **"the CLI
+cannot tell"** as **"this credential cannot submit"** — a dead end reported as
+fact, which may not exist at all. The correct form tests the third state first:
+
+```js
+if (j.canSubmitApps === null) { /* unknown — do not conclude */ }
+else if (!j.canSubmitApps)    { /* genuinely cannot submit */ }
+```
+
+**When is it `null`?** Two states, both documented on
+`appapi.Identity.CanSubmitApps`:
+
+- an **OAuth** credential whose `tokenScope` the server did not report — the
+  `AppBlocksSubmit` bit *is* the whole answer and it was not sent; or
+- a response with **no `subject`** at all — the CLI cannot tell which gate even
+  applies, let alone its answer.
+
+A **personal API key** is never `null`: the backend does not scope-gate submit
+for personal keys, so the mask is irrelevant and the answer is always `true`.
+
+**Second `--json` change, same class:** **`scopes` is now `[]` for a known-empty
+mask**, with `null` reserved for "the mask was not reported". Previously *both*
+states serialised as `null` and no consumer could tell them apart. Go callers
+see `len 0` either way; only the JSON encoding differs.
+
+`scopesKnown` is unchanged and still disambiguates `canReadBalance` and
+`canSpend`, which stay plain booleans: when it is `false`, both are `false`
+because nothing is known, not because the capability was denied.
+
+**Human output changed shape too** (#494), so anything screen-scraping the old
+single `Capabilities:` block breaks. The section is now two:
+
+```
+Logged in as zach (id 1) at https://civitai.com
+
+Credential:
+  Type:                     personal API key
+
+Capabilities:
+  Read Buzz balance:        yes
+  Spend Buzz (AI Services): yes
+  Submit Apps:              yes
+```
+
+The split is by **kind of claim**: `Credential` carries the one identity
+*attribute* (what the token *is*); `Capabilities` carries three *verdicts* (what
+it may *do*). Renaming the header to "Granted Capabilities" was considered and
+rejected, and the reason is the interesting one — **a personal key's
+`Submit Apps: yes` is not a grant at all.** Nothing was granted; the backend
+simply does not scope-gate submit for personal keys, so the gate does not apply.
+For an OAuth token it genuinely *is* the `ScopeAppBlocksSubmit` bit. Grantedness
+would have been the wrong axis to split on.
+
+The degraded-scope caveat stays **inside `Capabilities:` and below the rows**,
+and is scoped to Buzz on purpose — `Submit Apps` above it may well be a known
+answer, so a blanket "capabilities unknown" would be false:
+
+```
+Credential:
+  Type:                     OAuth login
+
+Capabilities:
+  Submit Apps:              unknown
+  (token scope not reported by the server — Buzz capabilities unknown)
+```
+
+The human surface prints the `Submit Apps` row in **every** branch now,
+degrading to `unknown` and never to `no`. Before #492 the two surfaces
+disagreed about what is knowable, in both directions: a personal key with an
+absent mask printed **no** `Submit Apps` row at all while `--json` published
+`canSubmitApps: true` for the same body; and an OAuth credential with an absent
+mask emitted `canSubmitApps: false` when the truth was unknowable.
+
+## Predicted contents
+
+**5 commits** (`v0.1.100..HEAD` including this draft commit): **3 excluded**
+(`docs(`/`test(`/`chore(`), **2 in the notes**, **0 leaking**.
+
+🔴 **The count has moved between drafting and tagging on every recent release.**
+Re-derive it at tag time rather than trusting this number:
+
+```
+git log v0.1.100..v0.1.101 --pretty='%s' | grep -cvE '^(docs|test|chore)(\(.*\))?:'
+```
+
+At `af5e98f` that command returns **2**.
+
+### The 2 that should appear
+
+| # | commit | thread |
+|---|---|---|
+| 1 | `fix(whoami)`: `canSubmitApps` was a false negative stated as fact, and the two surfaces disagreed (#492) | whoami contract |
+| 2 | `refactor(whoami)`: the credential TYPE is not a capability — split the section in two (#494) | whoami contract |
+
+**This release is one thread.** #492 fixes the contract and #494 fixes the
+presentation of the same four rows; they are the reason this release exists and
+neither is gated behind a flag.
+
+⚠️ **`refactor(` is not filtered either — and that is correct here.** The
+exclude list is `docs(` / `test(` / `chore(` only (three patterns in
+`.goreleaser.yaml`, pinned by `changelog_filter_ledger_test.go`), so
+`refactor(whoami)` will appear in the published notes. This is the same shape as
+v0.1.100's `ci(revendor)` and v0.1.99's `fix(ci)`: a scope the filter was never
+asked to cover, **not** the scoped-anchor bug that ledger test pins.
+
+The difference from those two is that this one **should** appear. #485 and #467
+were CI-internal and changed nothing an author could observe, so their presence
+in the notes was noise worth flagging. #494 is a **user-visible output change**
+— it restructures what `civitai whoami` prints — and a user scraping that output
+needs to see it in the changelog. The conventional-commit type says how the
+change was made; the changelog's job is to say what a user will notice. Leaving
+it in is the deliberate call, recorded here so it does not surprise anyone
+reading the published body.
+
+Widening the filter to exclude `refactor(` was considered and rejected: it would
+suppress exactly this kind of user-visible change, and it would be an untested
+edit to the one file whose failure mode is invisible until a release ships.
+
+## What actually changes for a maintainer
+
+Neither of these belongs in the user-facing notes — both are `docs(` and both
+are correctly filtered out — but both matter to the next agent or contributor
+who reads the repo's own guidance:
+
+- **#491 — AGENTS.md item 4 was stating the opposite of the truth.** It read
+  that the CLI does **not** vendor the server's token-scope bitmask; it has
+  vendored it since #36. The item is now a trigger pointing at
+  `claudedocs/decisions/04-token-scope-bitmask-is-vendored.md`, and item 4 has
+  moved from the "deliberate non-mirror" list to the mirror list — the
+  four-mirrors paragraph now names a **fifth** mirror that answers to auth
+  rather than validation. A wrong item here is worse than a missing one: it
+  reads as coverage while pointing the reader away from the real rule.
+- **#493 — `CLAUDE.md` is now the `@AGENTS.md` import and nothing else.** The
+  Claude-specific section had accumulated guidance that duplicated `AGENTS.md`
+  and drifted from it; there is now one doc to keep up to date. #495 re-baselined
+  `agentsMaxBytes` to 29,600 for the consolidated file, which is why a `chore(`
+  commit trails the docs pair.
+
+## Verification before tagging
+
+Re-run at the tag, do not trust this section:
+
+```
+git worktree add --detach /tmp/rel101 v0.1.101
+(cd /tmp/rel101 && go build ./... && go vet ./... && go test ./... -count=1)
+```
+
+Assert a **minimum expected count** as the positive control — 21 packages ok is
+what v0.1.99 and v0.1.100 each recorded — and read the *output*, not the exit
+code: a tool missing from PATH exits 127 and `gofmt -s -l .` checking zero files
+prints nothing and exits 0, which is indistinguishable from clean.
+
+🔴 **A feature probe that reads an EXIT CODE reports a false PRESENT on this
+CLI.** Re-confirmed on the published v0.1.100 artifact while closing that
+release's residual: `civitai app definitelynotacommand --help` **exits 0** and
+prints the *parent* command's help, because Cobra falls back rather than
+erroring on an unknown subcommand. Every probe — present or absent — exits 0, so
+`rc` cannot discriminate. **Read the first line of output instead**, and keep a
+known-absent control in the same run; without it, a green probe is
+indistinguishable from a probe against a binary where nothing exists.
+
+For this release the probe is `whoami`, which has always existed, so presence is
+not the question — **shape** is. The check that matters is the tri-state:
+
+```
+civitai whoami --json | jq 'has("canSubmitApps"), .canSubmitApps, .scopes'
+```
+
+Confirm on the released binary that `canSubmitApps` is **present** and that the
+key can hold `null` (`has()` is the discriminator — a missing key and a `null`
+key are different failures, and `jq .canSubmitApps` prints `null` for both).
+Confirm the human surface prints **both** `Credential:` and `Capabilities:`.
+
+🔴 **Verify the published artifact, not the tag.** Two instruments in this repo
+lie in the reassuring direction: `raw.githubusercontent.com` served a stale
+Homebrew cask for five minutes after the tap updated (poll
+`gh api repos/civitai/homebrew-tap/commits`, or read the cask through
+`gh api …/contents/Casks/civitai.rb`, instead), and a URL check that
+*constructed* release URLs answered 200 for a cask still pointing at the
+previous version — a check must read the URLs **out of** the cask.
+
+**Expected assets on the draft — 14, the same shape as v0.1.99 and v0.1.100.**
+The full cross product, windows/arm64 included, twice (archive + bare binary),
+plus the checksums and the rendered cask:
+
+```
+checksums.txt
+civitai.rb
+civitai_0.1.101_darwin_amd64        civitai_0.1.101_darwin_amd64.tar.gz
+civitai_0.1.101_darwin_arm64        civitai_0.1.101_darwin_arm64.tar.gz
+civitai_0.1.101_linux_amd64         civitai_0.1.101_linux_amd64.tar.gz
+civitai_0.1.101_linux_arm64         civitai_0.1.101_linux_arm64.tar.gz
+civitai_0.1.101_windows_amd64.exe   civitai_0.1.101_windows_amd64.zip
+civitai_0.1.101_windows_arm64.exe   civitai_0.1.101_windows_arm64.zip
+```
+
+A missing raw binary is the one that breaks silently and durably:
+`release-npm.yml` refuses to publish without `civitai_<version>_linux_amd64`
+and `checksums.txt`, but it only checks those two — the npm wrapper resolves
+the rest per platform at postinstall time.
+
+## Release mechanics
+
+1. Merge this draft. Tag **that** commit (the convention: `v0.1.99` and
+   `v0.1.100` each sit on their own `docs(release)` commit, not on the last
+   feature commit).
+2. `git tag v0.1.101 <sha> && git push origin v0.1.101` → goreleaser → **draft**
+   GitHub Release + assets.
+3. Read the generated body before publishing. Both entries should be there,
+   `refactor(whoami)` included — see above for why that is deliberate.
+4. 🔴 **Publishing the draft is a separate maintainer decision** (`AGENTS.md`
+   → Permission boundaries → 🚫 Never): it fires npm and the Homebrew tap, and
+   npm unpublish is restricted, so a bad version is fixed by publishing another
+   rather than by taking it back. On v0.1.100 both downstream workflows started
+   within two seconds of the publish — there is no window to reconsider after
+   the click.


### PR DESCRIPTION
Docs only. Touches `claudedocs/` and nothing else. **No tag was pushed, no release created or published, no workflow dispatched** — tagging is the maintainer's call after this merges.

## 1. `release-v0.1.100-draft.md` was false — it is now a shipped record

Line 3 read `**Not yet tagged.**` after the release had shipped. Every fact below was re-measured, not copied from the brief:

| Claim | Measured | Reproduces? |
| --- | --- | --- |
| Published, not draft | `isDraft: false`, `publishedAt: 2026-08-25T19:08:17Z` | ✅ |
| Assets | **14**, exactly the predicted list | ✅ |
| `Release` / `Release npm` / `Release Homebrew cask` | all `success` | ✅ |
| npm | `dist-tags.latest = 0.1.100` | ✅ |
| Tap cask | `version "0.1.100"` | ✅ |
| `[DO NOT MERGE …]` bracket edited out | **0 occurrences** in the body | ✅ |
| Changelog prediction (12 commits → 5 in notes) | body carries **exactly 5** | ✅ |

**Nothing failed to reproduce.**

### The open residual is closed

The draft said only a real release could prove `app doctor` and `app listing set-text` shipped, and warned that a probe reading `rc` cannot answer it. I downloaded the published `civitai_0.1.100_linux_amd64`, matched its sha256 against the published `checksums.txt`, and confirmed it genuine via `go version -m` → `vcs.revision=d5a99430…` (the tag commit), `vcs.modified=false`.

| probe | rc | first line | reading |
| --- | --- | --- | --- |
| `app doctor --help` | 0 | `Report what is missing or blocked on your App store listings…` | **real** |
| `app listing set-text --help` | 0 | `Set the store listing's TEXT fields…` | **real** |
| `app definitelynotacommand --help` | 0 | `Browse, author, and ship Civitai Apps.` | **fallback** |

The third row is the control that makes the first two mean anything — all three exit 0, so `rc` cannot discriminate and only the first line can. Recorded as a triple, not as two green rows.

### A second claim closed for free

`changelog_filter_ledger_test.go` says outright what it *cannot* check: whether goreleaser applies its optional-scope anchors to real subjects, deferring that to "the NEXT release's published notes". This is that body — it carries `ci(revendor)` and no scoped `docs(`/`chore(`. That deferred claim is now evidenced.

The three-digit-version analysis is **kept in full** (every comparison site, `parseSemver` numeric, no `\d{1,2}`, `--sort=-version:refname`), plus both instruments that lie in the reassuring direction. That analysis is why the release was safe.

## 2. `release-v0.1.101-draft.md` — new

Structure matched to `v0.1.99` and `v0.1.100`'s drafts.

**Changelog arithmetic re-derived, not trusted:** 5 commits, **3 excluded**, **2 in the notes** — #492 (`fix(whoami)`) and #494 (`refactor(whoami)`).

### The headline is a breaking `--json` change, and it leads the document

`canSubmitApps` is now `true`/`false`/`null`. `null` means *unknowable*, never "no" — so `if (!j.canSubmitApps)` now takes the false branch on `null` and reports a dead end that may not exist. `scopes` is now `[]` for a known-empty mask, with `null` reserved for "not reported"; both used to be `null`. The human surface split into `Credential:` and `Capabilities:`, breaking anything scraping the old single block.

### `refactor(` — handled deliberately

Not in the exclude list, so #494 **will** publish. Unlike v0.1.100's `ci(` and v0.1.99's `fix(ci)` — both CI-internal noise — this one *should* appear: it is a user-visible output change, and the changelog's job is what a user notices, not how the change was made. Widening the filter was considered and rejected (it would suppress exactly this class, and it is an untested edit to a file whose failure mode is invisible until a release ships).

## Verification

- `make ci` — **green**, 21 packages ok, 0 FAIL.
- `make lint` — **green**, 0 issues (via `nix-shell -p golangci-lint`; not on PATH here).

Stated separately because `make ci` does not run lint. **Both are weak signals on a docs-only change** — neither tool reads Markdown. The check that actually mattered was confirming no guard covers `claudedocs/` release drafts: `agents_evidence_test.go` scopes itself to `claudedocs/decisions` via a named constant, with a comment stating that non-decisions docs must not be swept into the ledger. The only Go reference to a release draft is a prose comment citing v0.1.95, not a ledger entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
