### PR TITLE
docs(release): v0.1.101 is SHIPPED, and #498's notes belong to v0.1.102

### DIFF
--- a/claudedocs/release-v0.1.101-draft.md
+++ b/claudedocs/release-v0.1.101-draft.md
@@ -1,9 +1,56 @@
-# v0.1.101 — DRAFT
+# v0.1.101 — SHIPPED
 
-**Not yet tagged.** Cut from `main` at `af5e98f`, which is the commit this draft
-sits on top of. Publishing the draft GitHub Release is what fires **npm and the
-Homebrew tap** (both trigger on `release: published`), and npm unpublish is
-restricted — so the tag is the recoverable step and the publish is not.
+**Tagged and published 2026-08-26T03:56:29Z.** `gh release view v0.1.101`
+reports `isDraft: false` with **14/14** expected assets. The tag sits on
+`edc1299`, the `docs(release)` commit this draft was merged as — the convention
+`v0.1.99` and `v0.1.100` established. All three channels fired and all three
+succeeded; npm `dist-tags.latest` is `0.1.101` and the tap cask reads
+`version "0.1.101"`.
+
+Everything below was written *before* the tag and is kept as the record. Where a
+section made a prediction, the measured outcome is folded in and marked
+**MEASURED**; the reasoning that made the release safe is preserved unchanged,
+because it is the part worth re-reading next time.
+
+🔴 **THIS PAGE IS CLOSED. A LATER SESSION EDITED IT ANYWAY, AND EVERY WORD IT
+ADDED WAS FALSE.** On 2026-08-26 an audit reported that the release notes were
+stale about **#498**, and the fix went into *this* file — a third table row, a
+prose section, an extra `jq` probe — without anyone asking whether v0.1.101 had
+already shipped. It had, **20 hours earlier**: the tag published
+`2026-08-26T03:56:29Z` and `79ed55d` merged `2026-08-27T00:03:20Z`. The edit was
+reverted here and the content moved to `release-v0.1.102-draft.md`, where it is
+true. The one-command discriminator, before editing any release page:
+
+```bash
+gh release view v0.1.101 --json isDraft,publishedAt   # isDraft:false ⇒ CLOSED
+git merge-base --is-ancestor <pr-sha> v0.1.101        # non-zero ⇒ NOT in the tag
+```
+
+A draft page and a shipped page look identical in an editor. The heading is the
+only marker, so **a draft that ships and keeps saying `DRAFT` is a trap armed for
+the next reader** — that is why this one now says `SHIPPED` in the first line.
+
+**What shipped, verified against the published artifact:**
+
+| Claim | Measured |
+| --- | --- |
+| Release is published, not draft | `isDraft: false`, `publishedAt: 2026-08-26T03:56:29Z` |
+| Assets | **14**, exactly the predicted list |
+| `Release` workflow (tag push) | `success` |
+| `Release npm` (on `published`) | `success` |
+| `Release Homebrew cask` (on `published`) | `success` |
+| npm | `dist-tags.latest = 0.1.101` |
+| Homebrew tap | `cask "civitai" … version "0.1.101"` |
+| Changelog entries in the body | **2** — `#492` and `#494`, matching the prediction exactly |
+| `refactor(whoami)` (#494) in the notes | **present**, as predicted and as intended |
+| #498 in the notes | **absent** — it merged after the tag and ships in v0.1.102 |
+
+---
+
+**Cut from `main` at `af5e98f`**, which is the commit this draft sat on top of.
+Publishing the draft GitHub Release is what fires **npm and the Homebrew tap**
+(both trigger on `release: published`), and npm unpublish is restricted — so the
+tag is the recoverable step and the publish is not.
 
 The version is a plain patch increment on `0.1.100`. The three-digit-ordering
 question was settled in `release-v0.1.100-draft.md` (every comparison site read,
@@ -53,30 +100,6 @@ see `len 0` either way; only the JSON encoding differs.
 `canSpend`, which stay plain booleans: when it is `false`, both are `false`
 because nothing is known, not because the capability was denied.
 
-**Third `--json` change, and this one is ADDITIVE, not breaking (#498).**
-`whoami --json` now carries the account profile the server was already sending
-and the CLI was discarding: **`tier`, `status`, `isMember`, `subscriptions`**.
-Four keys added, none removed, none retyped — every pre-existing key's value is
-byte-identical. The only consumers that can notice are strict-schema ones
-(`DisallowUnknownFields`, `additionalProperties: false`).
-
-Two things a script author needs:
-
-- **Each is `null` when the server did not report it**, never a fabricated
-  `""` / `false` / `[]`. Same rule as `canSubmitApps` — test for `null` first.
-- **They degrade as a group.** If any one of them arrives in an unexpected
-  shape, all four become `null`; `whoami` still prints identity and
-  capabilities normally. The CLI publishes only fields it models, so an
-  unrecognised shape is withheld rather than passed to your terminal.
-
-`isMember` is the one worth branching on: a member and a free account do not
-see the same usable generation ecosystems, so it predicts whether
-`civitai generate`'s defaults are available to the credential in hand.
-
-**Still withheld on purpose:** `email` and `emailVerified`. The server sends
-both; `whoami` does not print them and `--json` does not carry them, which is
-why the CLI does not describe this output as "raw" (#377).
-
 **Human output changed shape too** (#494), so anything screen-scraping the old
 single `Capabilities:` block breaks. The section is now two:
 
@@ -123,11 +146,8 @@ mask emitted `canSubmitApps: false` when the truth was unknowable.
 
 ## Predicted contents
 
-🔴 **No totals here on purpose.** Every fixed number this section carried has
-gone stale — "2 in the notes" survived #498 adding a third row to the table
-below, three lines under a sentence telling the reader not to trust a total.
-The split is `docs(`/`test(`/`chore(` excluded, everything else in the notes,
-**0 leaking**; for the counts, run the command below and count the table rows.
+**5 commits** (`v0.1.100..HEAD` including this draft commit): **3 excluded**
+(`docs(`/`test(`/`chore(`), **2 in the notes**, **0 leaking**.
 
 🔴 **The count has moved between drafting and tagging on every recent release.**
 Re-derive it at tag time rather than trusting this number:
@@ -136,29 +156,23 @@ Re-derive it at tag time rather than trusting this number:
 git log v0.1.100..v0.1.101 --pretty='%s' | grep -cvE '^(docs|test|chore)(\(.*\))?:'
 ```
 
-At `af5e98f` that command returned **2**. #498 is open and will make it 3 once
-merged, so re-run it at the tag rather than reusing either number.
+At `af5e98f` that command returns **2**.
 
-### The ones that should appear
+✅ **MEASURED at the tag: 2.** The prediction held — the published body carries
+exactly the two rows below and nothing else. Note that the same command run
+against `origin/main` **today** returns 3, because `#498` merged after the tag;
+that third commit belongs to v0.1.102 and is not evidence this section is stale.
 
-Count the numbered rows below rather than trusting a total written anywhere — a
-count maintained beside the list it counts drifts the first time the list grows.
-It happened twice on this page while #498 was open: a heading that said "the 2",
-and a "**2 in the notes**" nine lines above that outlived the fix to the heading.
+### The 2 that should appear
 
 | # | commit | thread |
 |---|---|---|
 | 1 | `fix(whoami)`: `canSubmitApps` was a false negative stated as fact, and the two surfaces disagreed (#492) | whoami contract |
 | 2 | `refactor(whoami)`: the credential TYPE is not a capability — split the section in two (#494) | whoami contract |
-| 3 | `feat(whoami)`: `--json` carries the account profile, and still withholds the PII (#498) | whoami contract |
 
-**This release is one thread.** #492 fixes the contract, #494 fixes the
-presentation of the same four rows, and #498 closes the second half of #377 on
-the same `--json` payload; they are the reason this release exists and none is
-gated behind a flag.
-
-⚠️ **Re-derive the count at tag time**, as the command above the table says —
-this list is written before the tag and any further merge changes it.
+**This release is one thread.** #492 fixes the contract and #494 fixes the
+presentation of the same four rows; they are the reason this release exists and
+neither is gated behind a flag.
 
 ⚠️ **`refactor(` is not filtered either — and that is correct here.** The
 exclude list is `docs(` / `test(` / `chore(` only (three patterns in
@@ -228,13 +242,7 @@ not the question — **shape** is. The check that matters is the tri-state:
 
 ```
 civitai whoami --json | jq 'has("canSubmitApps"), .canSubmitApps, .scopes'
-civitai whoami --json | jq 'has("tier"), has("isMember"), has("email")'
 ```
-
-The second line covers #498: the first two must be `true` (the profile keys are
-present, `null` or not) and **`has("email")` must be `false`** — the PII is
-withheld by design, and `has()` is the only discriminator that distinguishes
-"absent" from "present and null".
 
 Confirm on the released binary that `canSubmitApps` is **present** and that the
 key can hold `null` (`has()` is the discriminator — a missing key and a `null`
@@ -263,6 +271,11 @@ civitai_0.1.101_linux_arm64         civitai_0.1.101_linux_arm64.tar.gz
 civitai_0.1.101_windows_amd64.exe   civitai_0.1.101_windows_amd64.zip
 civitai_0.1.101_windows_arm64.exe   civitai_0.1.101_windows_arm64.zip
 ```
+
+✅ **MEASURED on the published release: 14 assets, this exact list.** Third
+consecutive release at 14/14; windows/arm64 shipped in both forms again, so the
+"no `ignore:` rule exists" claim in `AGENTS.md` is confirmed on an artifact
+rather than on the config for the third time.
 
 A missing raw binary is the one that breaks silently and durably:
 `release-npm.yml` refuses to publish without `civitai_<version>_linux_amd64`

--- a/claudedocs/release-v0.1.102-draft.md
+++ b/claudedocs/release-v0.1.102-draft.md
@@ -1,0 +1,220 @@
+# v0.1.102 — DRAFT
+
+**Not yet tagged.** Cut from `main` at `0db9382`, which is the commit this draft
+sits on top of. Publishing the draft GitHub Release is what fires **npm and the
+Homebrew tap** (both trigger on `release: published`), and npm unpublish is
+restricted — so the tag is the recoverable step and the publish is not.
+
+The version is a plain patch increment on `0.1.101`. The three-digit-ordering
+question was settled in `release-v0.1.100-draft.md` and has now been confirmed
+end to end by two published releases; `0.1.102` raises nothing new.
+
+🔴 **This page exists because the #498 notes were first written into
+`release-v0.1.101-draft.md`, which had already shipped.** The tag published
+`2026-08-26T03:56:29Z`; `79ed55d` merged `2026-08-27T00:03:20Z`, **20 hours
+later**. Nothing about #498 was ever in the v0.1.101 notes, and the discriminator
+is one command:
+
+```bash
+git merge-base --is-ancestor 79ed55d v0.1.101   # non-zero ⇒ NOT in that tag
+```
+
+Before writing a PR into any release page, check whether that release is closed
+(`gh release view vX.Y.Z --json isDraft,publishedAt`). A shipped page and an open
+one are indistinguishable in an editor.
+
+## THE HEADLINE IS AN ADDITIVE `--json` CHANGE — the opposite of last release
+
+v0.1.101 led with a **breaking** `--json` change (`canSubmitApps` became a
+tri-state). v0.1.102 leads with the additive completion of the same payload, and
+the distinction is the whole story for a script author: **nothing that worked
+against v0.1.101 stops working.**
+
+**`civitai whoami --json` now carries the account profile the server was already
+sending and the CLI was discarding: `tier`, `status`, `isMember`,
+`subscriptions` (#498).** Four keys added, none removed, none retyped — every
+pre-existing key's value is byte-identical. The only consumers that can notice
+are strict-schema ones (`DisallowUnknownFields`,
+`additionalProperties: false`).
+
+Two things a script author needs:
+
+- **Each is `null` when the server did not report it**, never a fabricated
+  `""` / `false` / `[]`. Same rule as `canSubmitApps` — test for `null` first.
+- **They degrade as a group.** If any one of them arrives in an unexpected
+  shape, all four become `null`; `whoami` still prints identity and
+  capabilities normally. The CLI publishes only fields it models, so an
+  unrecognised shape is withheld rather than passed to your terminal.
+
+`isMember` is the one worth branching on: a member and a free account do not see
+the same usable generation ecosystems (`AGENTS.md` item 13), so it predicts
+whether `civitai generate`'s defaults are available to the credential in hand.
+
+**Still withheld on purpose:** `email` and `emailVerified`. The server sends
+both; `whoami` does not print them and `--json` does not carry them. That is why
+the CLI stopped describing this output as "raw" in v0.1.101 (#377 option a, PR
+#492) — and it is why option (b) here modelled four fields rather than passing
+the body through. The rationale sits on the `appapi.Identity` struct at the
+field an editor must touch, with two tests that go red.
+
+**`subscriptions` is `[]string`, and that is measured, not inferred.** A
+`json.RawMessage` was tried first and was wrong twice: it would republish server
+bytes verbatim (an object-shaped element carrying a billing address would ship
+with no code change), and it did not buy the drift-resilience it was chosen for,
+because drift in any one of the four blanks all four regardless. Do not "restore"
+it.
+
+**Nothing else in this release is user-visible.** The human `whoami` output is
+byte-identical to v0.1.101's; the `Credential:` / `Capabilities:` split that
+landed in #494 is unchanged.
+
+## Predicted contents
+
+**3 commits** (`v0.1.101..0db9382`), **4 including this draft commit**:
+**3 excluded** (`docs(`), **1 in the notes**, **0 leaking**.
+
+🔴 **The count has moved between drafting and tagging on every recent release.**
+Re-derive it at tag time rather than trusting this number:
+
+```
+git log v0.1.101..v0.1.102 --pretty='%s' | grep -cvE '^(docs|test|chore)(\(.*\))?:'
+```
+
+At `0db9382` that command returns **1**.
+
+### The 1 that should appear
+
+| # | commit | thread |
+|---|---|---|
+| 1 | `feat(whoami)`: `--json` carries the account profile, and still withholds the PII (#498) | whoami contract |
+
+**This is a one-commit release**, and that is the honest description of it: the
+v0.1.101 thread had a second half (#377 option b) that was deliberately not
+rushed into the breaking release, and this ships it. If more merges before the
+tag, re-derive the table from the command above rather than appending here.
+
+The other two commits are `docs(handoff):` (#497, #499) and are correctly
+filtered out — including #499, which is the commit that first recorded that
+v0.1.101 had shipped without #498.
+
+## What actually changes for a maintainer
+
+- **`claudedocs/release-v0.1.101-draft.md` is now headed `SHIPPED`**, with the
+  measured outcome table the `v0.1.100` page established. It had kept saying
+  `DRAFT` / "Not yet tagged" for a release that was live on all three channels,
+  which is what made it look editable. The heading is the only marker
+  distinguishing an open release page from a closed one.
+- **`#377` is closed for real.** #492 shipped option (a) with a body reading
+  `Closes #377 partially — option (a) only`. **GitHub has no partial-close
+  keyword**: it saw `Closes #377`, closed the whole issue one second after the
+  merge, and option (b) was nearly lost. For a half-fix, reference the issue
+  **without** a closing keyword.
+
+## Verification before tagging
+
+Re-run at the tag, do not trust this section:
+
+```
+git worktree add --detach /tmp/rel102 v0.1.102
+(cd /tmp/rel102 && go build ./... && go vet ./... && go test ./... -count=1)
+```
+
+Assert a **minimum expected count** as the positive control — **21 `ok` lines,
+0 `FAIL`, measured on this draft's branch** (`tools/credscan-corpus` reports
+`no test files` and is the 22nd line; it is not a failure), the same 21 that
+v0.1.99 and v0.1.100 each recorded — and read the *output*, not the exit code: a tool missing from PATH exits 127 and `gofmt -s -l .` checking
+zero files prints nothing and exits 0, which is indistinguishable from clean.
+`make ci` is **not** a superset of CI — run `make lint` separately.
+
+🔴 **A feature probe that reads an EXIT CODE reports a false PRESENT on this
+CLI.** `civitai app definitelynotacommand --help` **exits 0** and prints the
+*parent* command's help, because Cobra falls back rather than erroring on an
+unknown subcommand. Every probe — present or absent — exits 0, so `rc` cannot
+discriminate. **Read the first line of output instead**, and keep a known-absent
+control in the same run.
+
+For this release the probe is `whoami`, which has always existed, so presence is
+not the question — **shape** is:
+
+```
+civitai whoami --json | jq 'has("tier"), has("isMember"), has("email")'
+```
+
+`has()` is the only discriminator that separates **absent** from **present and
+`null`**; `jq .tier` prints `null` for both, so it cannot answer this.
+
+- The first two must be **`true`** — the profile keys are present whether or not
+  the server populated them.
+- **`has("email")` must be `false`.** The PII is withheld by design, and this is
+  the check that would catch a regression toward passing the body through.
+
+Also confirm the v0.1.101 contract still holds on the same binary, since this
+release touches the same payload:
+
+```
+civitai whoami --json | jq 'has("canSubmitApps"), .canSubmitApps, .scopes'
+```
+
+**Measured pre-tag on a local build of `main`, against the LIVE production API**
+(not a fixture, not a `curl` of `/api/v1/me`): `tier:"silver"`,
+`status:"active"`, `isMember:true`, `subscriptions:["yellow"]`,
+`has("email") == false`. That is what settled `[]string` as measured rather than
+inferred. **Re-run it on the released binary** — a local build is evidence about
+the working tree, never about the artifact.
+
+For the degraded paths, serve a fixed `/api/v1/me` on loopback:
+
+| body | `--json` must show |
+|---|---|
+| no profile keys | all four `null` |
+| `"subscriptions":[{"billingEmail":"…"}]` | all four `null`, no PII anywhere |
+| `"tier":3` (drift in ONE field) | all four `null`, command still succeeds |
+
+🔴 **Verify the published artifact, not the tag.** Two instruments in this repo
+lie in the reassuring direction: `raw.githubusercontent.com` served a stale
+Homebrew cask for five minutes after the tap updated (poll
+`gh api repos/civitai/homebrew-tap/commits`, or read the cask through
+`gh api …/contents/Casks/civitai.rb`, instead), and a URL check that
+*constructed* release URLs answered 200 for a cask still pointing at the
+previous version — a check must read the URLs **out of** the cask.
+
+**Expected assets on the draft — 14, the same shape as v0.1.99, v0.1.100 and
+v0.1.101.** The full cross product, windows/arm64 included, twice (archive +
+bare binary), plus the checksums and the rendered cask:
+
+```
+checksums.txt
+civitai.rb
+civitai_0.1.102_darwin_amd64        civitai_0.1.102_darwin_amd64.tar.gz
+civitai_0.1.102_darwin_arm64        civitai_0.1.102_darwin_arm64.tar.gz
+civitai_0.1.102_linux_amd64         civitai_0.1.102_linux_amd64.tar.gz
+civitai_0.1.102_linux_arm64         civitai_0.1.102_linux_arm64.tar.gz
+civitai_0.1.102_windows_amd64.exe   civitai_0.1.102_windows_amd64.zip
+civitai_0.1.102_windows_arm64.exe   civitai_0.1.102_windows_arm64.zip
+```
+
+A missing raw binary is the one that breaks silently and durably:
+`release-npm.yml` refuses to publish without `civitai_<version>_linux_amd64`
+and `checksums.txt`, but it only checks those two — the npm wrapper resolves the
+rest per platform at postinstall time.
+
+## Release mechanics
+
+1. Merge this draft. Tag **that** commit (the convention: `v0.1.99`, `v0.1.100`
+   and `v0.1.101` each sit on their own `docs(release)` commit, not on the last
+   feature commit).
+2. `git tag v0.1.102 <sha> && git push origin v0.1.102` → goreleaser → **draft**
+   GitHub Release + assets.
+3. Read the generated body before publishing. One entry — `feat(whoami)` (#498)
+   — and nothing else.
+4. 🔴 **Publishing the draft is a separate maintainer decision** (`AGENTS.md`
+   → Permission boundaries → 🚫 Never): it fires npm and the Homebrew tap, and
+   npm unpublish is restricted, so a bad version is fixed by publishing another
+   rather than by taking it back. On v0.1.100 and v0.1.101 both downstream
+   workflows started within two seconds of the publish — there is no window to
+   reconsider after the click.
+5. **When it ships, change this file's first line to `# v0.1.102 — SHIPPED`**
+   and fold in the measured table, the way `release-v0.1.100-draft.md` and
+   `release-v0.1.101-draft.md` do. A page that keeps saying `DRAFT` after the
+   tag is what caused this release to have its own notes written into the
+   previous one.


### PR DESCRIPTION
`claudedocs/release-v0.1.101-draft.md` described **#498** as part of a release that was tagged and published **20 hours before #498 merged**. This corrects that and gives #498's notes a page where they are true.

Referencing #377 and #498 without a closing keyword — nothing here closes an issue.

## The error, measured

```bash
git rev-list -n1 v0.1.101 | cut -c1-7          # edc1299
git merge-base --is-ancestor 79ed55d v0.1.101  # non-zero -> NOT in the tag
```

| | |
|---|---|
| `v0.1.101` published | `2026-08-26T03:56:29Z` |
| `79ed55d` (#498) merged | `2026-08-27T00:03:20Z` |
| Changelog entries in the **published** body | **2** — #492, #494. No #498. |

The cause was mechanical, and worth recording: an audit reported that the release notes were stale about #498, the fix went into the v0.1.101 page, and **nobody asked whether that release had already closed**. #498's own commit message says "plus the in-flight v0.1.101 release draft" — it was not in flight.

## What changed

**`release-v0.1.101-draft.md` — restored, then closed.**

Restored with `git checkout edc1299 -- <path>`. Only two commits ever touched the file (`edc1299`, `79ed55d`), so #497 is not a factor and the revert is exact rather than a best-effort untangle.

Then headed **`SHIPPED`** with the measured-outcome table the `v0.1.100` page established. It had kept saying `DRAFT` / "Not yet tagged" about a release live on all three channels — which is precisely what made it look editable. **The heading is the only thing distinguishing an open release page from a closed one**, so a draft that ships and keeps saying `DRAFT` is a trap armed for the next reader. Predictions that held are marked `MEASURED` rather than deleted.

**`release-v0.1.102-draft.md` — new.** Carries the #498 content where it is true: the additive `--json` section (`tier`, `status`, `isMember`, `subscriptions`), the table row, and the `jq 'has("tier"), has("isMember"), has("email")'` probe — `has()` being the only discriminator that separates *absent* from *present-and-null*. Its release-mechanics step 5 is "when it ships, flip this heading to SHIPPED", so the loop closes itself next time.

## Verification

Live state, re-measured rather than taken from the previous handoff's record of it:

- `gh release view v0.1.101` → `isDraft: false`, 14/14 assets
- all three release workflows (`release`, `release-npm`, `release-homebrew`) → `success`
- npm `dist-tags.latest` = `0.1.101`; tap cask `version "0.1.101"`
- 14 assets on **each** of v0.1.99 / v0.1.100 / v0.1.101, windows/arm64 present in both forms — so "third consecutive release at 14/14" is counted, not assumed

The v0.1.102 page claims human `whoami` output is byte-identical to v0.1.101's. That is read off the diff: #498 touched `internal/cmd/whoami.go` in exactly two hunks — the `--json` map and the flag's doc comment. The "member vs free ecosystem set" line is `claudedocs/decisions/13-…md`, not memory.

Gates — docs-only, no behaviour change, but all three run:

- `make ci` → **21 ok, 0 FAIL**
- `make lint` (separate CI job; `make ci` does not run it) → **0 issues**
- `./scripts/ci-shallow.sh` → **21/21 ok** at the committed tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)