### PR TITLE
test(cmd): two assertions passed on digits that appeared, not on values rendered

### DIFF
--- a/internal/cmd/app_listing_status_json_test.go
+++ b/internal/cmd/app_listing_status_json_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -630,7 +631,44 @@ func TestREADMEPinsTheListingStatusWriteWarning(t *testing.T) {
 // is precisely what "documented in the help, dropped from the README" looks like.
 // This ledger fails when a surface stops carrying the citation, so adding a third
 // surface means adding a row here.
+// citationRe matches a reference to issue 389 as a CITATION — `#389` with no
+// digit either side — rather than the bare digit run "389".
+//
+// 🔴 THE BARE SUBSTRING WAS A SPELLED GUARD. `Contains(text, "389")` is
+// satisfied by any three consecutive digits: a byte count like "3891", a
+// timestamp, a different issue number. It claimed "this surface cites
+// civitai/cli#389" while testing "these digits appear somewhere", so the
+// citation could be deleted and the test stay green as long as some unrelated
+// number spelled it. Both surfaces really do write `#389` (the Long says
+// "civitai/cli#389 settled that…"; the README links "[#389](…/issues/389)"),
+// so the stronger form costs nothing. The digit guards on either side stop
+// "#3890" — a plausible future issue number — from satisfying it.
+var citationRe = regexp.MustCompile(`(^|[^0-9])#389([^0-9]|$)`)
+
 func TestTheShadowWriteWarningIsOnBothPublishedSurfaces(t *testing.T) {
+	// NEGATIVE CONTROL on the pattern itself, before it is trusted to judge the
+	// real surfaces. A guard whose matcher cannot fail is not a guard, and the
+	// decoys below are exactly the strings the old bare-substring form accepted.
+	for _, decoy := range []string{
+		"a bundle of 3891 bytes",  // digit run containing 389
+		"see civitai/cli#3890",    // a longer issue number
+		"389",                     // the old assertion's entire requirement
+		"no citation here at all", // nothing
+	} {
+		if citationRe.MatchString(decoy) {
+			t.Fatalf("NEGATIVE CONTROL FAILED: citationRe matched %q, which is not a citation of #389. "+
+				"The pattern is too loose to distinguish a real reference from stray digits, so every "+
+				"assertion below is unreliable.", decoy)
+		}
+	}
+	// POSITIVE CONTROL: it must match the forms the surfaces actually use.
+	for _, real := range []string{"civitai/cli#389 settled that", "[#389](https://x/issues/389)", "and #389."} {
+		if !citationRe.MatchString(real) {
+			t.Fatalf("POSITIVE CONTROL FAILED: citationRe did not match %q, a form the published "+
+				"surfaces use. The pattern is too strict and would fail on correct docs.", real)
+		}
+	}
+
 	md := readREADME(t)
 	for _, s := range []struct {
 		surface string
@@ -639,7 +677,7 @@ func TestTheShadowWriteWarningIsOnBothPublishedSurfaces(t *testing.T) {
 		{"`civitai app listing status --help` (the command's Long)", newAppListingStatusCmd().Long},
 		{"README.md", md},
 	} {
-		if !strings.Contains(s.text, "389") {
+		if !citationRe.MatchString(s.text) {
 			t.Errorf("%s no longer cites civitai/cli#389 — every surface that documents this command as a "+
 				"read must also say it opens a revision draft on a live listing", s.surface)
 		}

--- a/internal/cmd/generate_charge_seam_test.go
+++ b/internal/cmd/generate_charge_seam_test.go
@@ -51,11 +51,23 @@ func TestGenerate_WaitingPathPrintsTheRealizedCharge(t *testing.T) {
 	if polls == 0 {
 		t.Fatal("POSITIVE CONTROL FAILED: the poll seam was never reached, so the ordering assertion below is vacuous")
 	}
-	if !strings.Contains(errOut.String(), "137") {
-		t.Errorf("waiting path must print the realized charge 137 via runGenerate.\nstderr:\n%s", errOut.String())
-	}
-	if !strings.Contains(errOut.String(), "Charged") {
-		t.Errorf("waiting path must label the charge.\nstderr:\n%s", errOut.String())
+	// 🔴 PIN THE WHOLE RENDERED CLAIM, NOT THE BARE NUMBER. This assertion used
+	// to read `Contains(errOut, "137")`, and that is a SILENT GREEN at a
+	// measured 0.40%: the same stderr carries a random external-ID UUID, whose
+	// hex digits spell "137" about 1 run in 250. Measured 2026-08-27 by mutating
+	// the charge to 999 — which must make this assertion impossible to satisfy —
+	// and running the test 2000 times: 8 PASSED. The number was being supplied
+	// by the UUID, not by the charge line, and no amount of re-running a green
+	// suite would have shown it.
+	//
+	// "Charged 137 Buzz" cannot be spelled by a UUID (it is not hex), so the
+	// assertion now fails when the charge is wrong instead of coin-flipping.
+	// Generalises: a short numeric literal asserted over command output is a
+	// claim about DIGITS APPEARING SOMEWHERE, never about the value rendered.
+	const wantCharge = "Charged 137 Buzz"
+	if !strings.Contains(errOut.String(), wantCharge) {
+		t.Errorf("waiting path must print the realized charge as %q via runGenerate.\nstderr:\n%s",
+			wantCharge, errOut.String())
 	}
 	if !strings.Contains(stderrAtFirstPoll, "Charged") {
 		t.Errorf("the charge must be printed BEFORE the wait begins; stderr at the first poll was:\n%s", stderrAtFirstPoll)


### PR DESCRIPTION
Two short-literal assertions over command output, both found by sweeping `internal/cmd`, both now **measured** rather than argued.

## 1. `generate_charge_seam_test.go` — a silent green at a measured **0.40%**

`Contains(errOut, "137")` asserted the realized charge. The same stderr carries a **random external-ID UUID**, and its hex digits spell `137` roughly 1 run in 250.

Measured by mutating the charge to `999` — which must make that assertion impossible to satisfy — and running 2000 times:

| | survivals / 2000 |
|---|---|
| before the fix | **8 PASSED** — the UUID supplied the digits |
| after the fix | **0 PASSED** |

Fixed by pinning the whole rendered claim, `"Charged 137 Buzz"`, which a hex UUID cannot spell.

**My predicted mechanism was wrong, and measuring corrected it.** I expected `t.TempDir()`'s path to leak into stderr. It does not — I probed and confirmed stderr carries no temp path. The carrier is the UUID. The hazard was real; my theory of it was not.

## 2. `app_listing_status_json_test.go` — a spelled guard

`Contains(text, "389")` claimed each surface *"cites civitai/cli#389"* while actually testing *"three consecutive digits appear somewhere"*.

Demonstrated: replace the Long's citation with `"a payload of 3891 bytes"` and

```
old  Contains(text,'389')  -> True   <-- SURVIVES, guard green, citation GONE
new  regex #389 boundary   -> False  <-- KILLED
```

Both surfaces really write `#389`, so the stronger form costs nothing, and the digit guards on either side reject `#3890` — a plausible future issue number.

The test now carries **its own controls**, run before it judges anything:
- **negative** — four decoys the old form accepted, including the bare `"389"`
- **positive** — three citation forms the real surfaces use

so a pattern that cannot fail, or one too strict to match correct docs, is caught rather than trusted.

## Gates

`make ci` **21 ok / 0 FAIL** · `make lint` **0 issues** · `./scripts/ci-shallow.sh` **21/21**

🤖 Generated with [Claude Code](https://claude.com/claude-code)