### PR TITLE
fix(listing): a moderator takedown 403 no longer blames the caller's access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2047,7 +2047,11 @@ exit code.** Read the code, not the word "refused":
 
 The first is `2` because the server answers `MATERIAL_CHANGE_BLOCKED` as an HTTP
 `400`, which this CLI classifies as a malformed request — see
-[Exit code 2](#exit-code-2). The message in each case is the server's.
+[Exit code 2](#exit-code-2). In each case the server's own sentence is what names
+the state, and the CLI echoes it verbatim. On the **moderator takedown** the CLI
+adds what that sentence leaves out — that your account's access is not the
+problem, and that asking a moderator to relist the listing is the only step that
+helps.
 
 **If a revision was already open** — because you staged an `rm-screenshot`, or
 one of the attach commands minted one — then *when this edit is material* it
@@ -3523,6 +3527,7 @@ fi
 ### Exit code 3
 
 - Authentication/authorization — login required, token invalid/expired, or the credential lacks the needed scope (HTTP 401/403, or no token configured).
+- **Not every `403` here is about your credential.** `civitai app listing …` against a listing a **moderator removed** answers `403` and so exits `3`, and nothing about the account is wrong: no login, grant or scope changes it. The message says so rather than sending you to fix access that is already fine, and names asking a moderator to relist the listing as the next step. Look the message itself up under [Troubleshooting](#troubleshooting).
 - **`civitai generate` refines this**: several of its failures are *not* credential problems but would otherwise land here or on `2`, so they exit `1` instead and a script never loops on `civitai login`. A **muted account or incomplete onboarding** arrives as a bare `403` that is byte-identical to a missing scope; **out of Buzz** and **generation disabled** arrive as `400` (the upstream 403 is re-thrown server-side as a tRPC `BAD_REQUEST`), which would otherwise read as "bad flags". See [Generate](#exit-codes-specific-to-generate).
 
 ### Exit code 4
@@ -3557,7 +3562,8 @@ credited it to the wrong command.)
 | `no token configured` | Nothing is logged in. Run `civitai login`, or set `CIVITAI_TOKEN`. This includes `civitai app list` / `app view`: the App **store** is not an anonymous read. | [Submit & auth](#submit--auth), [Browse the App store](#browse-the-app-store) |
 | `not logged in (401)` | The credential is present but invalid or expired. OAuth tokens refresh themselves; when the *refresh* token has also expired, log in again. For a personal key, mint a new one at `civitai.com/user/account`. | [Submit & auth](#submit--auth) |
 | `forbidden (403)` | Usually the invite-only Apps beta rather than a broken token — the same account reads the public API fine. | [Submit & auth](#submit--auth) |
-| `not permitted for your account (403)` | Managing a **store listing** needs Apps-author access, which is a narrower grant than being able to submit. | [Listing media requirements](#listing-media-requirements) |
+| `not permitted for your account (403)` | The **catch-all** listing `403`: managing a **store listing** needs Apps-author access, which is a narrower grant than being able to submit. It is not what a **moderator takedown** prints — that has its own message, the row below. | [Listing media requirements](#listing-media-requirements) |
+| `under a moderator takedown (403)` | A moderator removed this **store listing**, so the platform refuses to edit it. **Your account's access is not the problem** — this is the listing `403` that is *not* about your credential — and no login, grant or CLI command reverses it: ask a Civitai moderator to relist it. The server's own sentence follows the code, and it is what names the state. Exit `3`. **Not** the same as unpublishing the listing yourself: that refuses a *material* change as a `400` and exits `2`. | [Exit code 3](#exit-code-3) |
 | `Submit Apps:` | The `civitai whoami` capability row, and it is **tri-state**: `yes` / `no` / `unknown`. **`unknown` is not `no`** — it is the CLI declining to answer, because the server reported no `tokenScope` for an **OAuth** credential (whose submit answer *is* the `AppBlocksSubmit` bit) or sent no `subject` at all, so which gate applies is itself unknown. Re-run `civitai login` to mint a token whose scope the server reports; a **personal API key** always answers `yes`, since it is not scope-gated for submit. In `--json` this row is `canSubmitApps`, which is `true` / `false` / `null`. | [Submit & auth](#submit--auth) |
 | `(token scope not reported by the server — Buzz capabilities unknown)` | `civitai whoami` got no `tokenScope`, so **Buzz** read/spend are unknowable and are omitted rather than printed as `no`. Scoped to Buzz deliberately: the **Submit Apps** row is still shown above it, because a personal key's submit answer does not depend on the scope mask. | [Submit & auth](#submit--auth) |
 | `not permitted to read this app's analytics (403)` | `app metrics` needs the **Apps submit scope**. An OAuth `civitai login` carries it — unless the token was minted before the scope existed, in which case re-run `civitai login`. A full-scope personal API key also works. | [App metrics](#app-metrics) |

--- a/claudedocs/handoff-listing-source-repo.md
+++ b/claudedocs/handoff-listing-source-repo.md
@@ -40,12 +40,20 @@ the gap, then set the link on every app that has a public repo.
 
 ## Open investigations — live diagnosis state
 
-### `listingError`'s 403 arm appends a remedy that is false for a moderator takedown
+### ✅ FIXED — `listingError`'s 403 arm appended a remedy that was false for a moderator takedown
 
-Not mid-diagnosis — root cause and evidence are below and nothing is unknown.
-Recorded because it is unfixed, it now has a **documented destination** (the new
-README exit-code table publishes `a moderator removed the listing → 3`), and the
-next person to hit it will be told to fix access that is already fine.
+**CLOSED by `fix/listing-403-moderator-takedown` (PR #509).** `listingError`'s
+403 arm now branches on `isModeratorTakedownMsg` (declared beside
+`isInsufficientScopeMsg` in `internal/appapi/appblocks.go`) before the
+Apps-author-access fallback, and says the account's access is not the problem
+while naming "ask a Civitai moderator to relist it". Exit code unchanged at `3`.
+`README.md`'s Troubleshooting row was split in two, the source-repo section's
+"the message in each case is the server's" sentence corrected, and a bullet added
+to exit code 3's generated `Detail` (`internal/cmd/exitcodes_doc.go`) saying not
+every `403` there is about the credential. Regression:
+`internal/appapi/listing_forbidden_test.go` — red at `d2a635c`, green at HEAD.
+
+The diagnosis below is kept as the record of what was wrong and why.
 
 - **Symptom + exact repro:** any `civitai app listing` write against a listing a
   moderator removed. The server's own sentence is correct; the CLI appends a
@@ -74,10 +82,8 @@ next person to hit it will be told to fix access that is already fine.
 
 ## Next steps (ranked)
 
-1. **Narrow `listingError`'s 403 arm** — repo `civitai/cli`, files
-   `internal/appapi/listing.go:999-1003` and `README.md:3560`. Evidence and the
-   exact change are in the open investigation above. Pre-existing; deliberately
-   not folded into a listing-feature branch.
+1. ~~**Narrow `listingError`'s 403 arm**~~ — **DONE**, PR #509
+   (`fix/listing-403-moderator-takedown`). See the closed investigation above.
 2. **Set the remaining 3 offsite links, IF their repos go public** — `comfy`,
    `radio`, `cosmetic-studio`. Blocked, not forgotten: `civitai/ai-radio`,
    `civitai/Cosmetic-Studio` and every `comfy` candidate are **private**

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -1859,6 +1859,33 @@ func isInsufficientScopeMsg(msg string) bool {
 	return strings.Contains(strings.ToLower(msg), "required scope")
 }
 
+// isModeratorTakedownMsg detects the server's moderator-TAKEDOWN refusal, for
+// exactly the reason isInsufficientScopeMsg exists: the wire carries no distinct
+// code for it either — both are a TRPCError FORBIDDEN — so the server message is
+// the only signal separating it from the author/cohort 403s. It is therefore
+// classified on the stable CORE of that message rather than on a whole sentence.
+//
+// Two spellings ship upstream and the core is what they share, which is why the
+// match is neither exact nor case-sensitive (`civitai/civitai@origin/main`):
+//
+//   - the edit refusal, lower-case — "this listing has been removed by a
+//     moderator and can no longer be edited"
+//     (src/server/services/blocks/offsite-listing.service.ts:1242 on the
+//     updateListing write path, :1888 on the prefill read path);
+//   - the republish refusal, capitalised — "This listing was removed by a
+//     moderator and cannot be restored by its owner."
+//     (src/server/services/blocks/offsite-moderation.service.ts:1638).
+//
+// 🔴 It means a moderator DELIST and never an owner-initiated unpublish. The
+// same helper that produces the first string returns `null` when the listing was
+// owner-unpublished instead (offsite-listing.service.ts:2320), so the string
+// cannot be reached for a listing its owner took down. That case is a different
+// refusal entirely — MATERIAL_CHANGE_BLOCKED, answered as HTTP 400, classified
+// here as a bad request (exit 2) — and must not be folded into this one.
+func isModeratorTakedownMsg(msg string) bool {
+	return strings.Contains(strings.ToLower(msg), "removed by a moderator")
+}
+
 // devTunnelError maps a non-200 dev-tunnel tRPC response to an actionable CLI
 // error. tRPC error bodies are {error:{json:{message,code,...}}}; the HTTP
 // status carries the mapped code (403 flag-off/not-author, 404 not-your-app).

--- a/internal/appapi/listing.go
+++ b/internal/appapi/listing.go
@@ -1000,6 +1000,22 @@ func listingError(status int, raw []byte, route listingRoute) (err error) {
 		if isInsufficientScopeMsg(msg) {
 			return fmt.Errorf("listing media needs the Apps submit scope (403): %s — re-run `civitai login` (an old token may predate the scope), or use a full-scope personal API key", msg)
 		}
+		// 🔴 A MODERATOR TAKEDOWN IS NOT AN ACCESS PROBLEM, and the fallback
+		// below says it is. That arm answers for every non-scope 403, so it used
+		// to append "managing store listings needs Apps-author access" to a
+		// refusal where the caller's Apps-author access is fine and nothing
+		// about access is what failed — the wrong-subject class (#374/#391) one
+		// level out, on the 403 arm instead of the 400 one. The remedy it named
+		// was unreachable too: no grant, no re-login and no CLI command puts a
+		// delisted listing back.
+		//
+		// So this arm claims nothing about the account and names the only step
+		// that can work. It is deliberately NOT a new exit code: 403 is tagged
+		// by the deferred TagStatus above, so this stays exit 3, which is what
+		// README publishes for "a moderator removed the listing".
+		if isModeratorTakedownMsg(msg) {
+			return fmt.Errorf("this listing is under a moderator takedown (403): %s — your account's access is not the problem and no CLI command reverses this; ask a Civitai moderator to relist it", msg)
+		}
 		return fmt.Errorf("not permitted for your account (403): %s — managing store listings needs Apps-author access (invite-only beta)", msg)
 	case http.StatusNotFound:
 		return fmt.Errorf("no store listing found for this app (404): %s — a store listing is created when you run `civitai app submit` and is settable while the app is pending review; submit the app first, then these commands will work", msg)

--- a/internal/appapi/listing_forbidden_test.go
+++ b/internal/appapi/listing_forbidden_test.go
@@ -1,0 +1,153 @@
+package appapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// THE 403 ARM ANSWERS FOR MORE THAN ONE CAUSE, AND ONLY SOME OF THEM ARE ABOUT
+// THE CALLER'S ACCESS.
+//
+// `listingError`'s forbidden arm used to be two branches: the token-SCOPE
+// refusal, and a fallback that appended "managing store listings needs
+// Apps-author access (invite-only beta)" to everything else. One common
+// "everything else" is a moderator TAKEDOWN — the server's
+// `OffsiteRequestError('FORBIDDEN', 'this listing has been removed by a
+// moderator and can no longer be edited')` — where the caller's Apps-author
+// access is fine, the remedy named is unreachable, and the CLI's sentence
+// contradicts the server's own sentence printed two words earlier.
+//
+// That is the wrong-subject class this package already catalogs on the 400 arm
+// (civitai/cli#374, #391), regenerated one arm over: an arm answering for N
+// causes may only claim what is true of all N.
+//
+// 🔴 WHAT THIS TABLE PINS, and why each row is here rather than folded into
+// `TestListingErrorMapping`:
+//
+//   - the takedown rows are the REGRESSION — measured red at `origin/main`
+//     (d2a635c), where both fail on `wantAccessClaim` because the fallback
+//     claimed the account's access was the problem;
+//   - the cohort row keeps the fallback ALIVE. Deleting the false advice
+//     everywhere would pass a test that only asserted its absence, and would
+//     lose the one 403 the advice is actually true of;
+//   - the scope row pins that the takedown branch was inserted BELOW it, not
+//     in front of it;
+//   - every row asserts the classification with `errors.Is`, never on text
+//     (AGENTS.md item 7): `Error()` is byte-identical with the sentinel
+//     stripped, so a message assertion says nothing about the exit code. 403 →
+//     `ErrUnauthorized` → exit 3, which is what README publishes for "a
+//     moderator removed the listing".
+func TestListingForbiddenTakedownDoesNotBlameTheAccount(t *testing.T) {
+	// The false diagnosis, spelled once. It is the whole subject of the
+	// regression: the takedown rows must not carry it, the cohort row must.
+	const accessClaim = "Apps-author access"
+
+	rows := []struct {
+		name string
+		// msg is the server's own message, verbatim from the source that
+		// throws it wherever the row cites one.
+		msg string
+		// wantSubstr is what the arm the CLI chose must say.
+		wantSubstr string
+		// wantAccessClaim is whether the Apps-author-access diagnosis belongs
+		// on this 403 at all.
+		wantAccessClaim bool
+	}{
+		{
+			// civitai/civitai@origin/main,
+			// src/server/services/blocks/offsite-listing.service.ts:1242 (the
+			// updateListing write path) and :1888 (the prefill read path).
+			name:            "moderator takedown, the edit refusal",
+			msg:             "this listing has been removed by a moderator and can no longer be edited",
+			wantSubstr:      "ask a Civitai moderator to relist it",
+			wantAccessClaim: false,
+		},
+		{
+			// The SECOND spelling, from a different service:
+			// src/server/services/blocks/offsite-moderation.service.ts:1638,
+			// the republish refusal. It shares only the core the predicate
+			// matches — a predicate keyed on the first sentence would answer
+			// this one with the false advice.
+			name:            "moderator takedown, the republish refusal",
+			msg:             "This listing was removed by a moderator and cannot be restored by its owner.",
+			wantSubstr:      "ask a Civitai moderator to relist it",
+			wantAccessClaim: false,
+		},
+		{
+			// 🔴 INVARIANT GUARD, not regression coverage, and labelled as one:
+			// no server message is MEASURED to capitalise the core today. It is
+			// here because the predicate folds case deliberately — the two
+			// measured spellings above already disagree on the sentence's first
+			// letter — so a "simplification" that drops the fold is a real
+			// hazard even though no shipped string exercises it yet.
+			name:            "invariant: the core is matched case-insensitively",
+			msg:             "Removed By A Moderator, pending appeal",
+			wantSubstr:      "ask a Civitai moderator to relist it",
+			wantAccessClaim: false,
+		},
+		{
+			// The 403 the fallback is TRUE of — the invite-gated cohort. Same
+			// string TestListingErrorMapping uses, kept here so a fix that
+			// emptied the fallback cannot pass this file.
+			name:            "a cohort 403 keeps the Apps-author-access advice",
+			msg:             "Apps authoring is not enabled",
+			wantSubstr:      accessClaim,
+			wantAccessClaim: true,
+		},
+		{
+			// The scope arm is tested above the takedown branch; a takedown
+			// branch inserted in front of it would steal nothing today, but a
+			// scope message that ever mentions a moderator would.
+			name:            "the scope 403 still gets its own arm",
+			msg:             "Your API key does not have the required scope for this action",
+			wantSubstr:      "Apps submit scope",
+			wantAccessClaim: false,
+		},
+	}
+
+	for _, tc := range rows {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]any{
+				"error": map[string]any{"json": map[string]any{"message": tc.msg}},
+			})
+			err := listingError(http.StatusForbidden, body, trpcSetIcon)
+			if err == nil {
+				t.Fatalf("expected an error for a 403 carrying %q", tc.msg)
+			}
+			got := err.Error()
+
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Errorf("the 403 for %q must say %q.\ngot: %s", tc.msg, tc.wantSubstr, got)
+			}
+
+			// Every 403 arm surfaces the server's own sentence — the server is
+			// the authority on WHICH 403 this is, and TestListingErrorMapping
+			// pins the same property for the arms it covers.
+			if !strings.Contains(got, tc.msg) {
+				t.Errorf("the 403 for %q must echo the server's own message.\ngot: %s", tc.msg, got)
+			}
+
+			if has := strings.Contains(got, accessClaim); has != tc.wantAccessClaim {
+				if tc.wantAccessClaim {
+					t.Errorf("the 403 for %q dropped the %q advice, which is the one 403 it is TRUE of — "+
+						"the fallback has been emptied, not narrowed.\ngot: %s", tc.msg, accessClaim, got)
+				} else {
+					t.Errorf("the 403 for %q still blames the caller's %q. Nothing about the account's "+
+						"access is the problem here, and no grant, re-login or CLI command reverses this "+
+						"state — the user is sent to fix something that is already fine.\ngot: %s",
+						tc.msg, accessClaim, got)
+				}
+			}
+
+			// AGENTS.md item 7: the exit code is the sentinel, never the text.
+			if !errors.Is(err, civitai.ErrUnauthorized) {
+				t.Errorf("a listing 403 must stay tagged ErrUnauthorized (→ exit 3); got %T: %v", err, err)
+			}
+		})
+	}
+}

--- a/internal/cmd/exitcodes_doc.go
+++ b/internal/cmd/exitcodes_doc.go
@@ -171,6 +171,7 @@ var exitCodeDocs = []ExitCodeDoc{
 		Summary: "Not authorized — login required, token invalid/expired, or the credential lacks the needed scope (HTTP 401/403).",
 		Detail: []string{
 			"Authentication/authorization — login required, token invalid/expired, or the credential lacks the needed scope (HTTP 401/403, or no token configured).",
+			"**Not every `403` here is about your credential.** `civitai app listing …` against a listing a **moderator removed** answers `403` and so exits `3`, and nothing about the account is wrong: no login, grant or scope changes it. The message says so rather than sending you to fix access that is already fine, and names asking a moderator to relist the listing as the next step. Look the message itself up under [Troubleshooting](#troubleshooting).",
 			"**`civitai generate` refines this**: several of its failures are *not* credential problems but would otherwise land here or on `2`, so they exit `1` instead and a script never loops on `civitai login`. A **muted account or incomplete onboarding** arrives as a bare `403` that is byte-identical to a missing scope; **out of Buzz** and **generation disabled** arrive as `400` (the upstream 403 is re-thrown server-side as a tRPC `BAD_REQUEST`), which would otherwise read as \"bad flags\". See [Generate](#exit-codes-specific-to-generate).",
 		},
 	},


### PR DESCRIPTION
## The false diagnosis

`internal/appapi/listing.go`'s `listingError` 403 arm had two branches: the
token-SCOPE refusal, and a fallback that answered **every** other 403 with

```
not permitted for your account (403): <server message> — managing store listings needs Apps-author access (invite-only beta)
```

One common "every other 403" is a **moderator takedown**. There the caller's
Apps-author access is fine, nothing about access is what failed, and the remedy
named is unreachable — no grant, no re-login and no CLI command puts a delisted
listing back. What the user saw was two sentences that contradict each other:

```
not permitted for your account (403): this listing has been removed by a moderator
and can no longer be edited — managing store listings needs Apps-author access (invite-only beta)
```

This is the wrong-subject class this repo already catalogs on the 400 arm
(#374 / #391), one arm over: an arm answering for N causes may only claim what
is true of all N.

## Server evidence

`civitai/civitai` @ `origin/main`:

| where | string |
|---|---|
| `src/server/services/blocks/offsite-listing.service.ts:1242` (the `updateListing` write path) | `OffsiteRequestError('FORBIDDEN', 'this listing has been removed by a moderator and can no longer be edited')` |
| `src/server/services/blocks/offsite-listing.service.ts:1888` (the prefill read path) | the same string |
| `src/server/services/blocks/offsite-listing.service.ts:2320` | the same string — and `null` when the listing was **owner-unpublished** instead, so the string means a genuine mod delist, never an owner-initiated unpublish |
| `src/server/services/blocks/offsite-moderation.service.ts:1638` (the republish refusal) | `'This listing was removed by a moderator and cannot be restored by its owner.'` |
| `src/server/services/blocks/publish-request.service.ts:1518` | the platform's own remedy wording for the state: "ask a moderator to relist" |

`FORBIDDEN` maps to HTTP 403, and the wire carries no distinct code — exactly
the situation `isInsufficientScopeMsg` already exists for — so the message text
is the only available signal.

## What changed

**One predicate, declared beside `isInsufficientScopeMsg`**
(`internal/appapi/appblocks.go`), matching the stable core the two spellings
share, case-insensitively, exactly as its sibling matches `required scope`:

```go
func isModeratorTakedownMsg(msg string) bool {
	return strings.Contains(strings.ToLower(msg), "removed by a moderator")
}
```

Its doc comment states why classification is on message text, cites both server
spellings by file:line, and records that the owner-unpublish case is a
*different* refusal (`MATERIAL_CHANGE_BLOCKED` → HTTP 400 → exit 2) that must
not be folded in.

**The 403 arm branches on it before the fallback.** The new error:

```
this listing is under a moderator takedown (403): <server message> — your account's access is not the problem and no CLI command reverses this; ask a Civitai moderator to relist it
```

It still echoes the server's own sentence (as every other arm does, and as
`TestListingErrorMapping` requires for 403s), claims nothing about the caller's
access, and names the only step that works. No CLI command is invented — none
fixes this.

**The exit code is unchanged at 3.** 403 is still tagged by the existing
`defer civitai.TagStatus(status, err)`; no classification moved. `README.md`
already publishes `a moderator removed the listing → 3` and stays true.

## README rows touched

- **Troubleshooting, "Credentials and access"** — the `not permitted for your
  account (403)` row is **split in two**: it keeps the access diagnosis for the
  genuine cohort case and now names itself the catch-all, and a new row keyed on
  `under a moderator takedown (403)` (the string a user actually sees) states
  what it means, that the account's access is *not* the problem, the remedy,
  exit `3`, and how it differs from unpublishing the listing yourself.
- **`### Link your source code`** — "The message in each case is the server's."
  is now false as written on the 403 arm, so it says instead that the server's
  sentence names the state and the CLI echoes it verbatim, adding on the
  takedown what that sentence leaves out.
- **`### Exit code 3`** — this block is GENERATED, so it was fixed at its source
  in `internal/cmd/exitcodes_doc.go` and the rendered block pasted back: a bullet
  saying not every 403 there is about the credential, since the new
  Troubleshooting row links here and the old text contradicted it in one hop.

`claudedocs/handoff-listing-source-repo.md` recorded this as an open
investigation and ranked next step 1; both are marked closed so the next session
does not re-do it.

## Test matrix — red at `d2a635c`, green at HEAD

New regression: `internal/appapi/listing_forbidden_test.go`
(`TestListingForbiddenTakedownDoesNotBlameTheAccount`). Measured by copying the
new test file into a detached worktree at `origin/main` (`d2a635c`) — no stash —
and running it there:

```
--- FAIL: .../moderator_takedown,_the_edit_refusal
    the 403 for "this listing has been removed by a moderator and can no longer be edited" must say "ask a Civitai moderator to relist it".
        got: not permitted for your account (403): this listing has been removed by a moderator and can no longer be edited — managing store listings needs Apps-author access (invite-only beta)
    the 403 for "this listing has been removed by a moderator and can no longer be edited" still blames the caller's "Apps-author access". Nothing about the account's access is the problem here, and no grant, re-login or CLI command reverses this state — the user is sent to fix something that is already fine.
--- FAIL: .../moderator_takedown,_the_republish_refusal          (same two assertions)
--- FAIL: .../invariant:_the_core_is_matched_case-insensitively  (same two assertions)
--- PASS: .../a_cohort_403_keeps_the_Apps-author-access_advice
--- PASS: .../the_scope_403_still_gets_its_own_arm
```

The two PASSing rows are controls, not regression coverage, and they pass at
both refs on purpose: the cohort row keeps the fallback **alive** (a fix that
deleted the advice everywhere would pass a test that only asserted its absence),
and the scope row pins that the new branch went in **below** the scope branch.
Every row asserts the classification with `errors.Is(err,
civitai.ErrUnauthorized)` rather than on text — AGENTS.md item 7 — so the exit-3
claim is really pinned.

All five rows green at HEAD.

## Mutation results

Applied to the fixed source, one at a time, restoring from a byte-identical copy
between each (checksums re-verified after the last restore). Each died with
**this test's own assertion messages**, not another guard's:

| mutant | outcome | killed by |
|---|---|---|
| invert the branch → `if !isModeratorTakedownMsg(msg)` | **DIED** | all three takedown rows *and* the cohort control (which then wrongly got the takedown message: "dropped the `Apps-author access` advice … the fallback has been emptied, not narrowed") |
| narrow the match to the first spelling's full tail (`removed by a moderator and can no longer be edited`) | **DIED** | the republish-spelling row + the case-fold row |
| drop `strings.ToLower` | **DIED** | the case-fold row only — which is why that row is labelled in the source as an **invariant guard**, not regression coverage: no shipped server string capitalises the core today, and the fold exists because the two measured spellings disagree on the sentence's first letter |
| delete the branch entirely | **DIED** | this is the base-ref run above |

## Gates

- `make ci` — green; 21 packages reported `ok` (read from the output, not the exit code).
- `nix-shell -p golangci-lint --run "make lint"` — `0 issues.` (`make ci` does not run lint.)
- `make ci-shallow` — green in a depth-1 clone at `8adfd14`: `ok=21/21 failing-tests=0 failing-packages=0 timeouts=0`.

## Not fixed, stated rather than narrowed

- `internal/appapi/appblocks.go`'s **other** 403 arms (`submissionsError`'s
  `apps access required — invite-only beta`, `devTunnelError`'s) are untouched.
  A listing takedown does not reach them — those are the submissions and
  dev-tunnel routes — but neither was audited for the same one-arm-N-causes
  shape.
- The new arm is not exercised end-to-end through the built binary. The
  classification is pinned with `errors.Is`, and
  `cmd/civitai/app_listing_lookup_exitcode_test.go` already measures a listing
  403 → exit 3 through the real process; no row was added there because that
  file's fixtures are about *which lookup failed*, not about which 403 arm was
  chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
