### PR TITLE
test: five count floors become membership floors over stable identities

### DIFF
--- a/cmd/civitai/fs_not_network_test.go
+++ b/cmd/civitai/fs_not_network_test.go
@@ -196,14 +196,84 @@ func realFilesystemErrors(t *testing.T) []fsFixture {
 	return out
 }
 
+// fsFixtureFloor is the KEEPER for realFilesystemErrors: the fixture NAMES that
+// must always be produced, whatever else the table gains.
+//
+// 🔴 A COUNT WAS NOT ENOUGH, AND THE FIXTURES IT PROTECTS ARE NOT
+// INTERCHANGEABLE. This started as `len(fixtures) < 8`, reasoning that the table
+// only grows so any deletion drops below the floor. Add-one/delete-one defeats
+// it in one move: delete `os.Symlink EEXIST (*os.LinkError)` and add any
+// unrelated row — a fifth bare errno, say — and the count is still above 8, the
+// guard is green, and `*os.LinkError` has lost half its coverage.
+//
+// The trade matters here more than a row count suggests, because the fixtures
+// are not samples of one thing: each pins a distinct WRAPPING SHAPE
+// (`*fs.PathError`, `*os.LinkError`, `*os.SyscallError`, bare `syscall.Errno`),
+// and the defect in issue #241 was precisely that `errors.As` unwrapped PAST
+// some wrappers and not others. A table that keeps its size while collapsing
+// onto one wrapper still reports "12 fixtures, all green" while the shape that
+// actually regressed is no longer represented. Membership cannot be traded that
+// way: removing a NAME from this list, or its `add(...)` call, is red by name.
+//
+// 🔴 THREE RESIDUALS, STATED RATHER THAN GLOSSED. (1) The two EACCES fixtures
+// are DELIBERATELY ABSENT from this floor: realFilesystemErrors skips them under
+// `os.Geteuid() == 0` because root defeats mode 000, so naming them here would
+// make the guard red in a root container rather than catching anything. Their
+// wrapping shape (`*fs.PathError`) is held by three other named fixtures, so the
+// omission costs no shape coverage — but it does mean the EACCES rows themselves
+// stay tradeable. (2) Protection is OPT-IN PER FIXTURE: the loop iterates THIS
+// list, so a fixture added and not named here is permanently tradeable, and
+// nothing goes red at the moment of the omission. Append the name in the same
+// commit. (3) The two-line bypass is still open: delete the floor entry AND the
+// `add(...)` call together. What this stops is the ONE-line trade — a deletion
+// paid for by an unrelated addition; it does not stop a deliberate two-line
+// removal, and no in-tree check can. That is review's job.
+//
+// The bare-errno names are BUILT the way realFilesystemErrors builds them rather
+// than typed out, because `%s` on a syscall.Errno renders the OS's message text
+// ("no such file or directory"), which is not portable across GOOS. The identity
+// being pinned is the ERRNO, not the English string.
+var fsFixtureFloor = []string{
+	// *fs.PathError, from three unconditional os entry points.
+	"os.Open ENOENT (*fs.PathError)",
+	"os.Stat ENOTDIR (*fs.PathError)",
+	"os.ReadFile EISDIR (*fs.PathError)",
+	// *os.LinkError, from two.
+	"os.Rename ENOENT (*os.LinkError)",
+	"os.Symlink EEXIST (*os.LinkError)",
+	// *os.SyscallError.
+	"os.NewSyscallError EACCES (*os.SyscallError)",
+	// Bare errnos — nothing wrapping them at all.
+	fmt.Sprintf("bare syscall.Errno %s", syscall.ENOENT),
+	fmt.Sprintf("bare syscall.Errno %s", syscall.EACCES),
+	fmt.Sprintf("bare syscall.Errno %s", syscall.ENOTDIR),
+	fmt.Sprintf("bare syscall.Errno %s", syscall.EISDIR),
+}
+
 // TestFilesystemErrorsAreNotNetworkErrors is the regression coverage.
 //
 // RED AT BASE (origin/main): every subtest fails with exit 5.
 // GREEN AT HEAD: every subtest gets exit 1.
 func TestFilesystemErrorsAreNotNetworkErrors(t *testing.T) {
 	fixtures := realFilesystemErrors(t)
-	if len(fixtures) < 8 {
-		t.Fatalf("only %d fixtures were produced — a shrunken table is a guard wired to less than it claims", len(fixtures))
+
+	have := map[string]bool{}
+	for _, f := range fixtures {
+		have[f.name] = true
+	}
+	// POSITIVE CONTROL: an empty floor would make every check below vacuous.
+	if len(fsFixtureFloor) == 0 {
+		t.Fatal("CONTROL failure: fsFixtureFloor is empty, so this test asserts nothing")
+	}
+	for _, name := range fsFixtureFloor {
+		if !have[name] {
+			t.Errorf("the %q fixture is gone.\n"+
+				"Each fixture pins a distinct WRAPPING SHAPE that must not be classified as a network "+
+				"error (AGENTS.md items 7 and 24); deleting one drops that shape's coverage. The old "+
+				"guard was a COUNT (`len(fixtures) < 8`), so deleting this fixture while adding any "+
+				"unrelated one kept the count above 8 and stayed green.\n"+
+				"Adding fixtures is free; this list only forbids REMOVING one.", name)
+		}
 	}
 
 	for _, f := range fixtures {

--- a/internal/cmd/exitcodes_claims_test.go
+++ b/internal/cmd/exitcodes_claims_test.go
@@ -42,6 +42,51 @@ type contractClaim struct {
 	pinnedBy string
 }
 
+// exitCodeClaimsFloor is the KEEPER for exitCodeContractClaims: the row NAMES
+// that must be in the ledger, whatever else it gains.
+//
+// 🔴 A COUNT WAS NOT ENOUGH, AND IT HAD FIVE ROWS OF SLACK. This started as
+// `len(claims) < 5` against a ten-row ledger, which means five rows could be
+// deleted with no addition at all and the guard stayed green. Add-one/delete-one
+// defeats even a tight version of it: delete "a filesystem failure is 1, not 2
+// and not 5" — the issue #241 row, the one that stops a script retrying a
+// permissions error forever — add a row about some other code, count unchanged,
+// green, and the README is free to drop the sentence.
+//
+// The per-row assertions in TestPublishedExitCodeClaims cannot cover this,
+// because they iterate the rows that EXIST. A deleted row takes its own
+// assertion with it, which is what makes row existence a separate question from
+// row content, and the reason this file's header calls a row "a claim someone
+// measured and someone else must not silently drop".
+//
+// Keyed on NAME, not on code: four rows share code 1 and four share code 2, so
+// the code is not an identity. The names are the stable identities and are
+// already the subtest names.
+//
+// 🔴 THREE RESIDUALS, STATED RATHER THAN GLOSSED. (1) Protection is OPT-IN PER
+// ROW: the loop iterates THIS list, so a row added to the ledger and not named
+// here is permanently tradeable, and nothing goes red at the moment of the
+// omission. Append the name in the same commit as the row. (2) The two-line
+// bypass is still open: delete the floor entry AND the row together. What this
+// stops is the ONE-line trade; it does not stop a deliberate two-line removal,
+// and no in-tree check can — that is what review is for. (3) It pins NAMES, not
+// PHRASES: a row keeping its name while its `phrases` are watered down to
+// something the contract trivially satisfies is not caught here. The phrases are
+// asserted against both rendered surfaces, but nothing pins how load-bearing
+// they are.
+var exitCodeClaimsFloor = []string{
+	"a filesystem failure is 1, not 2 and not 5",
+	"a resource that EXISTS but is not READY is 1, not 4",
+	`the not-ready 1 is not always "wait for approval"`,
+	"a local image is refused at 2 for the enumerated reasons",
+	"an unreadable-but-present file is NOT 2",
+	"the missing-vs-unreadable split holds for a flag's value and a positional alike",
+	"a project path that does not exist, or is not a directory, is 2",
+	"a validation VERDICT is 1, and a manifest-less directory is a verdict",
+	"`app validate --json` publishes a result only when it produced one",
+	"5 is the retry code and a filesystem failure never lands there",
+}
+
 func exitCodeContractClaims() []contractClaim {
 	return []contractClaim{
 		{
@@ -190,8 +235,32 @@ func readmeExitCodePublished() string {
 // carry every code and to say where the rest is, which is what it now promises.
 func TestPublishedExitCodeClaims(t *testing.T) {
 	claims := exitCodeContractClaims()
-	if len(claims) < 5 {
-		t.Fatalf("only %d claims in the ledger — a shrunken ledger is a guard wired to less than it says", len(claims))
+
+	have := map[string]bool{}
+	for _, c := range claims {
+		if have[c.name] {
+			// Two rows sharing a name would let one be deleted while its twin
+			// satisfies the floor below, which is the trade this floor exists
+			// to stop.
+			t.Fatalf("two ledger rows are both named %q — the floor keys on the name, so a duplicate "+
+				"lets one of them be deleted silently", c.name)
+		}
+		have[c.name] = true
+	}
+	// POSITIVE CONTROL: an empty floor would make every check below vacuous.
+	if len(exitCodeClaimsFloor) == 0 {
+		t.Fatal("CONTROL failure: exitCodeClaimsFloor is empty, so this test asserts nothing")
+	}
+	for _, name := range exitCodeClaimsFloor {
+		if !have[name] {
+			t.Errorf("the ledger row %q is gone.\n"+
+				"A row is a decision someone MEASURED and someone else must not silently drop; the "+
+				"per-row assertions below only check rows that still exist, so a deleted row takes its "+
+				"own coverage with it. The old guard was a COUNT (`len(claims) < 5`) against ten rows, "+
+				"so five could be deleted outright — and deleting this one while adding any unrelated "+
+				"row kept the count and stayed green.\n"+
+				"Adding rows is free; this list only forbids REMOVING one.", name)
+		}
 	}
 
 	byCode := make(map[int]ExitCodeDoc, len(exitCodeDocs))

--- a/internal/cmd/humanbytes_test.go
+++ b/internal/cmd/humanbytes_test.go
@@ -5,31 +5,6 @@ import (
 	"testing"
 )
 
-// TestHumanBytesLabelsItsOwnArithmetic pins the unit SUFFIX to the divisor the
-// function actually uses.
-//
-// The regression it exists for: humanBytes divided by 1024 and labelled the
-// result with the SI suffixes (KB/MB/GB), so 2 MiB rendered as "2.0 MB" — a
-// figure 4.9% below the bytes it described. That was invisible while the string
-// only ever reached download progress, and #275 put it in `--help`: the
-// set-icon / set-cover one-liners interpolate listingSourceRule(kind), which
-// renders the cap through this function, so two commands advertised "at most
-// 2.0 MB" / "at most 4.0 MB" for caps the README documents as 2 MiB / 4 MiB.
-//
-// 🔴 The table has to pin the DIVISOR as well as the LABEL, because "relabel"
-// and "re-base the arithmetic" are two different fixes and only one of them was
-// wanted. Both mutants were run against this table rather than reasoned about:
-//
-//	SI labels over a 1024 divisor (the bug)  -> every prefixed row reddens.
-//	IEC labels over a 1000 divisor           -> 1023, 1,000,000, all three cap
-//	                                            rows, 1.5 MiB and every rung
-//	                                            from GiB up redden; only the
-//	                                            1024 row survives, because
-//	                                            %.1f rounds 1.024 back to "1.0".
-//
-// The 1,000,000 row is the loudest of those and is here on purpose: it is the
-// value where the two systems disagree about which RUNG to use at all
-// ("976.6 KiB" vs "1.0 MiB"), so it fails legibly rather than by a last digit.
 // humanBytesLadderFloor is the KEEPER for the case table in
 // TestHumanBytesLabelsItsOwnArithmetic: the set of case NAMES that must have a
 // row, whatever else the table gains.
@@ -77,6 +52,31 @@ var humanBytesLadderFloor = []string{
 	"EiB",
 }
 
+// TestHumanBytesLabelsItsOwnArithmetic pins the unit SUFFIX to the divisor the
+// function actually uses.
+//
+// The regression it exists for: humanBytes divided by 1024 and labelled the
+// result with the SI suffixes (KB/MB/GB), so 2 MiB rendered as "2.0 MB" — a
+// figure 4.9% below the bytes it described. That was invisible while the string
+// only ever reached download progress, and #275 put it in `--help`: the
+// set-icon / set-cover one-liners interpolate listingSourceRule(kind), which
+// renders the cap through this function, so two commands advertised "at most
+// 2.0 MB" / "at most 4.0 MB" for caps the README documents as 2 MiB / 4 MiB.
+//
+// 🔴 The table has to pin the DIVISOR as well as the LABEL, because "relabel"
+// and "re-base the arithmetic" are two different fixes and only one of them was
+// wanted. Both mutants were run against this table rather than reasoned about:
+//
+//	SI labels over a 1024 divisor (the bug)  -> every prefixed row reddens.
+//	IEC labels over a 1000 divisor           -> 1023, 1,000,000, all three cap
+//	                                            rows, 1.5 MiB and every rung
+//	                                            from GiB up redden; only the
+//	                                            1024 row survives, because
+//	                                            %.1f rounds 1.024 back to "1.0".
+//
+// The 1,000,000 row is the loudest of those and is here on purpose: it is the
+// value where the two systems disagree about which RUNG to use at all
+// ("976.6 KiB" vs "1.0 MiB"), so it fails legibly rather than by a last digit.
 func TestHumanBytesLabelsItsOwnArithmetic(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/cmd/humanbytes_test.go
+++ b/internal/cmd/humanbytes_test.go
@@ -30,6 +30,53 @@ import (
 // The 1,000,000 row is the loudest of those and is here on purpose: it is the
 // value where the two systems disagree about which RUNG to use at all
 // ("976.6 KiB" vs "1.0 MiB"), so it fails legibly rather than by a last digit.
+// humanBytesLadderFloor is the KEEPER for the case table in
+// TestHumanBytesLabelsItsOwnArithmetic: the set of case NAMES that must have a
+// row, whatever else the table gains.
+//
+// 🔴 A COUNT WAS NOT ENOUGH, AND THE ROWS IT PROTECTS ARE NOT INTERCHANGEABLE.
+// This started as `len(cases) < 13`, reasoning that the table only grows so any
+// deletion drops below the floor. Add-one/delete-one defeats it in one move:
+// delete "one decimal MB" and add any unrelated row — "two bytes", say — and the
+// count is still 13, the guard is green, and the rung is uncovered.
+//
+// That trade is not hypothetical bookkeeping, because this table's rows are
+// individually load-bearing and the doc comment above says which: the IEC-labels
+// -over-a-1000-divisor mutant is survived by the 1024 row alone, so "one decimal
+// MB" is the row that fails LEGIBLY (976.6 KiB vs 1.0 MiB — a disagreement about
+// which RUNG applies, not a last digit). Trading it for a row that only re-pins
+// an already-covered rung keeps the count and silently downgrades the mutation
+// matrix this test's credibility rests on. Membership cannot be traded that way:
+// removing a NAME from this list, or a row from the table, is red by name.
+//
+// 🔴 TWO RESIDUALS, STATED RATHER THAN GLOSSED. (1) Protection is OPT-IN PER
+// ROW: the loop iterates THIS list, so a row added to the table and not named
+// here is permanently tradeable, and nothing goes red at the moment of the
+// omission. Append the name in the same commit as the row. (2) The two-line
+// bypass is still open: delete the floor entry AND the row together. What this
+// stops is the ONE-line trade — a deletion paid for by an unrelated addition,
+// which is exactly the shape a "widen the table" commit takes; it does not stop
+// a deliberate two-line removal, and no in-tree check can. That is review's job.
+//
+// It pins NAMES, not values. A row keeping its name while its `want` is edited
+// to match a regression is not caught here — TestHumanBytesNeverPrintsAnSILabel
+// is the property half that covers the ladder independently of any row.
+var humanBytesLadderFloor = []string{
+	"zero",
+	"one",
+	"just under a KiB",
+	"exactly a KiB",
+	"one decimal MB",
+	"icon cap",
+	"cover cap",
+	"screenshot cap",
+	"a MiB and a half",
+	"GiB",
+	"TiB",
+	"PiB",
+	"EiB",
+}
+
 func TestHumanBytesLabelsItsOwnArithmetic(t *testing.T) {
 	cases := []struct {
 		name string
@@ -51,10 +98,24 @@ func TestHumanBytesLabelsItsOwnArithmetic(t *testing.T) {
 		{"PiB", 1 << 50, "1.0 PiB"},
 		{"EiB", 1 << 60, "1.0 EiB"},
 	}
-	if len(cases) < 13 {
-		t.Fatalf("the table lost rows (%d) — a shrunken table is how this guard stops "+
-			"covering the unit ladder without anything going red", len(cases))
+	have := map[string]bool{}
+	for _, tc := range cases {
+		have[tc.name] = true
 	}
+	// POSITIVE CONTROL: an empty floor would make every check below vacuous.
+	if len(humanBytesLadderFloor) == 0 {
+		t.Fatal("CONTROL failure: humanBytesLadderFloor is empty, so this test asserts nothing")
+	}
+	for _, name := range humanBytesLadderFloor {
+		if !have[name] {
+			t.Errorf("the %q row is gone from the unit-ladder table.\n"+
+				"Rows are only ever ADDED; deleting one stops this guard covering that rung — and "+
+				"because the old guard was a COUNT (`len(cases) < 13`), deleting this row while "+
+				"adding any unrelated one kept the count at 13 and stayed green.\n"+
+				"Adding rows is free; this list only forbids REMOVING one.", name)
+		}
+	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := humanBytes(tc.in); got != tc.want {

--- a/internal/cmd/read_help_test.go
+++ b/internal/cmd/read_help_test.go
@@ -703,6 +703,30 @@ var authRequiringCommands = map[string][]string{
 	"app view": {"app", "view", "some-slug"},
 }
 
+// authRequiringCommandsFloor is the KEEPER for that ledger: the command names
+// that must have a row, whatever else it gains.
+//
+// 🔴 A COUNT WAS NOT ENOUGH — AND `len(...) == 0` IS A COUNT WITH MAXIMAL SLACK.
+// The old guard only refused an EMPTY ledger. Add-one/delete-one defeats it
+// trivially: delete the `app view` row and add `app pull`, the ledger is still
+// non-empty, the measurement loop above runs happily over the two rows that
+// exist, and readAnonNote is then free to drop `app view` from its exception
+// clause — restoring for that command exactly the false blanket claim #268
+// removed. Unlike readAPILimitLedger and readAPIInvocations, this ledger is
+// cross-checked against NO derived set (there is no structural "commands that
+// require auth" walk to diff it against), so nothing else in the suite notices.
+//
+// 🔴 TWO RESIDUALS, STATED RATHER THAN GLOSSED. (1) Protection is OPT-IN PER
+// ROW: a command added to the ledger and not named here is tradeable, and
+// nothing goes red at the moment of the omission. (2) The two-line bypass is
+// open, and here it is a LEGITIMATE edit more often than elsewhere: if a command
+// really does go anonymous, its row SHOULD go, and this floor must go with it in
+// the same commit. That is the intended cost — the deletion becomes visible and
+// reviewable instead of silent. This floor is not a claim that these two
+// commands must require auth forever; it is a claim that dropping one must be
+// deliberate.
+var authRequiringCommandsFloor = []string{"app list", "app view"}
+
 // blanketAuthClaims is the CONTROL CORPUS for the universal-quantifier check:
 // phrasings of the claim #268 had to remove. It is asserted below that the
 // checker FIRES on each of them, so the denylist cannot rot into a filter that
@@ -746,8 +770,21 @@ func TestReadAnonNoteKeepsItsException(t *testing.T) {
 			}
 		})
 	}
-	if len(authRequiringCommands) == 0 {
-		t.Fatal("no auth-requiring commands ledgered — the exception clause would have no basis")
+	// POSITIVE CONTROL: an empty floor would make every check below vacuous.
+	if len(authRequiringCommandsFloor) == 0 {
+		t.Fatal("CONTROL failure: authRequiringCommandsFloor is empty, so this test asserts nothing")
+	}
+	for _, name := range authRequiringCommandsFloor {
+		if _, ok := authRequiringCommands[name]; !ok {
+			t.Errorf("`%s` is gone from the auth-requiring ledger.\n"+
+				"Every row here is an exception that readAnonNote must NAME; the measurement and the "+
+				"naming rule below both iterate the rows that still exist, so a deleted row stops "+
+				"requiring its own mention and #268's false blanket claim comes back for that command. "+
+				"The old guard was `len(...) == 0`, so deleting this row while adding any other one "+
+				"kept the ledger non-empty and stayed green.\n"+
+				"If this command genuinely went ANONYMOUS, that is a real product change: remove it "+
+				"here and from the ledger in the same commit, and say so in the message.", name)
+		}
 	}
 
 	// (2) readAnonNote must NAME every one of them. This is what a blanket

--- a/internal/cmd/readme_troubleshooting_test.go
+++ b/internal/cmd/readme_troubleshooting_test.go
@@ -264,6 +264,35 @@ type symptomAttribution struct {
 	why          string
 }
 
+// symptomAttributionsFloor is the KEEPER for symptomAttributions: the row
+// FRAGMENTS that must be ledgered, whatever else it gains.
+//
+// 🔴 A COUNT WAS NOT ENOUGH, AND THE OLD GUARD'S OWN MESSAGE GAVE IT AWAY. It
+// was `len(ledger) < 2` with the message "it must at least cover the confusable
+// pair from #361" — a MEMBERSHIP claim asserted as a COUNT. Add-one/delete-one
+// defeats it in one move: delete the `is this an App project?` row, which is the
+// #361 row and the one carrying the `notEmittedBy` invariant, add any new row,
+// count still 2, guard green, #361 unprotected.
+//
+// Membership cannot be traded that way: removing a FRAGMENT from this list, or
+// its row from the ledger, is red by name.
+//
+// 🔴 THREE RESIDUALS, STATED RATHER THAN GLOSSED. (1) Protection is OPT-IN PER
+// ROW: a row added and not named here is permanently tradeable, and nothing goes
+// red at the moment of the omission. Append the fragment in the same commit as
+// the row. (2) The two-line bypass is still open: delete the floor entry AND the
+// row together; no in-tree check can stop that, and that is review's job.
+// (3) IT DOES NOT PIN ORDER, and three fixtures below reach rows POSITIONALLY —
+// `symptomAttributions()[0]` and `[1]` at the prose-parser tests. Reordering the
+// ledger silently retargets those fixtures at a different row while this floor
+// stays green. Converting those call sites to look a row up BY FRAGMENT is the
+// obvious follow-up; it is deliberately not done here so this change stays a
+// count→membership port and nothing else.
+var symptomAttributionsFloor = []string{
+	"not found at project root",
+	"is this an App project?",
+}
+
 func symptomAttributions() []symptomAttribution {
 	appValidate := func() attributionRun {
 		return attributionRun{
@@ -424,10 +453,24 @@ func TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand(t *testing.T
 	ledger := symptomAttributions()
 	paths := knownCommandPaths(t)
 
-	// Positive control on the ledger itself: an empty (or accidentally emptied)
-	// ledger passes every assertion below while checking nothing.
-	if len(ledger) < 2 {
-		t.Fatalf("the attribution ledger holds %d rows — it must at least cover the confusable pair from #361", len(ledger))
+	// The ledger's rows are named, not counted — see symptomAttributionsFloor.
+	have := map[string]bool{}
+	for _, a := range ledger {
+		have[a.fragment] = true
+	}
+	// POSITIVE CONTROL: an empty floor would make every check below vacuous.
+	if len(symptomAttributionsFloor) == 0 {
+		t.Fatal("CONTROL failure: symptomAttributionsFloor is empty, so this test asserts nothing")
+	}
+	for _, fragment := range symptomAttributionsFloor {
+		if !have[fragment] {
+			t.Errorf("the attribution ledger no longer holds a row for %q.\n"+
+				"This pair is the confusable pair from #361, and the assertions below only run for rows "+
+				"that still exist. The old guard was a COUNT (`len(ledger) < 2`) whose own message "+
+				"claimed MEMBERSHIP (\"it must at least cover the confusable pair\") — so deleting this "+
+				"row while adding any unrelated one kept the count at 2 and stayed green.\n"+
+				"Adding rows is free; this list only forbids REMOVING one.", fragment)
+		}
 	}
 
 	for _, a := range ledger {


### PR DESCRIPTION
`agents_split_preserved_test.go:422-473` documents a defect an audit found: a guard whose PURPOSE is *"this protected set must never shrink"* but which asserts that purpose as a **COUNT** is defeated by **add-one/delete-one** — delete a protected entry, add an unrelated one, count preserved, guard green, protection gone. The fix was `minSplitRows = 31` → `splitItemsFloor = []int{...}`, membership over stable identities.

This PR sweeps the repo for every other guard with that shape and ports the membership form to the five that genuinely have the hole.

## The discrimination applied

A `len(x) <op> N` is in scope only when **all three** hold: (1) the collection is a preservation ledger — it exists so entries are never removed; (2) the guard is the **keeper** for that protection; (3) **identity matters** — losing A and gaining B is a real loss.

Deliberately **out**: error accumulators (`len(problems) > 0`); walker/corpus positive controls that assert the *instrument ran* (a count question by nature); ordinary behavioural assertions about a computed result; and fixture-table size minimums that only guard against an empty corpus.

## Method and instrument validation

The first sweep pattern was **broken and silently under-reporting**: `len\([A-Za-z0-9_.\[\]]*\)` — in POSIX ERE a backslash inside a bracket expression is literal, so the class closed early and the regex demanded a trailing `]`. Its "positive control" was a fixed string that never exercised the pattern, so it passed while the pattern matched almost nothing. Caught by testing against a hit named in the brief (`neterr_ledger_test.go:131`), which the sweep had missed. Corrected pattern: **945 raw hits → 130 ordering comparisons against a non-zero literal**, plus separate sweeps for non-`len` counters (`count`/`n`/`seen`/`total`) and `min*` const floors. `grep -r` here is a ugrep wrapper honouring `.gitignore`, so every sweep ran as `find … -print0 | xargs -0 grep`.

## Survey

**Non-test code: zero in-scope guards.** All 34 hits under `internal/`, `pkg/` and `cmd/` are runtime parsing/validation (`len(data) < 16` in `imageinfo.go`, `len(parts) < 2` in `app_dev_token.go`, …). No preservation ledger lives in non-test code.

### IN SCOPE — converted (5)

| file:line | collection | why in scope |
|---|---|---|
| `internal/cmd/humanbytes_test.go:54` | the unit-ladder case table (13 literal rows) | Its own comment stated preservation intent — *"the table lost rows … a shrunken table is how this guard stops covering the unit ladder"*. Rows are individually load-bearing: the file's mutation matrix says the IEC-labels-over-1000 mutant is survived by the 1024 row alone, so `one decimal MB` is the row that fails legibly. |
| `cmd/civitai/fs_not_network_test.go:205` | the errno fixture table (12 rows) | Each fixture pins a distinct **wrapping shape** (`*fs.PathError` / `*os.LinkError` / `*os.SyscallError` / bare errno) — and issue #241 was precisely that `errors.As` unwrapped past some wrappers and not others. A table that keeps its size while collapsing onto one wrapper reports "12 fixtures, all green". |
| `internal/cmd/exitcodes_claims_test.go:194` | `exitCodeContractClaims()` (10 literal rows) | The file header: *"A row here is a claim someone measured and someone else must not silently drop."* Floor of 5 against 10 rows — **five deletable with no addition at all**. Per-row assertions only iterate rows that exist, so a deleted row takes its own assertion with it. |
| `internal/cmd/readme_troubleshooting_test.go:429` | `symptomAttributions()` (2 literal rows) | The old message asserted **membership** — *"it must at least cover the confusable pair from #361"* — as a **count**. |
| `internal/cmd/read_help_test.go:749` | `authRequiringCommands` (2 literal rows) | The exception ledger that makes `readAnonNote`'s non-blanket claim true. Guarded only by `len(...) == 0` — a count with maximal slack — and cross-checked against **no** derived set, unlike its two siblings in the same file. |

### OUT OF SCOPE — surveyed, deliberately unchanged

| file:line | collection | verdict |
|---|---|---|
| `neterr_ledger_test.go:131` | `len(files) < 60` | Walker positive control; real protection is bidirectional membership (`grown` :171 / `gone` :191). The reference shape. |
| `internal/cmd/floor_predicate_ledger_test.go:142,162` | module-wide floor-question scan | **Deliberately** a count, not a list — doc comment: *"A list covers the sites somebody thought of. The rule here is structural."* Converting would be a regression. |
| `agents_xrefs_test.go:100` `minAgentsItems=23` | parsed AGENTS.md items | Positive control on a **derived** count; explicitly disclaimed in place as *"a floor against a dead scan, NOT a pin"*. |
| `agents_index_test.go:119,132` | parsed items / index clauses | Same — derived; real keeper is membership over parsed item numbers (`:251-256`). |
| `agents_evidence_test.go:147,327` | evidence pointers / citations | Controls; keeper is bidirectional membership (`:173-205`, `:207-223`). |
| `agents_size_test.go:375,410,629` | AGENTS.md bytes, sizes, rune fixtures | Thresholds + controls; keeper is the phrase list at `:489-516` (already membership). |
| `layout_ledger_test.go:232,237` | `layoutMinPackages` | Controls; keeper is bidirectional membership (`:243-249`, `:251-257`). |
| `changelog_filter_ledger_test.go:71` | goreleaser exclude patterns | Control; the `docs`/`test`/`chore` identities are held behaviourally by table rows. |
| `internal/appapi/listing_patch_ledger_test.go:188` | text/repo wire keys | Field names pinned by `reflect.DeepEqual`; impl ledger is bidirectional (`:162`/`:170`). |
| `internal/appapi/listing_op_test.go:335,731` | route cases / declared routes | Controls; keeper is `TestEveryListingRouteHasAReachabilityCase`, bidirectional. |
| `internal/cmd/app_offsite_ledger_test.go:216,268` | request ledger, `// LEDGER` lines | Already membership, bidirectional, cross-guarded against source comments. |
| `internal/cmd/slug_predicate_ledger_test.go:126,244` | presence checks / `SameSlug` defs | `presenceFloor` documented as deliberately count-shaped; `:244` already pins identity (`!= 1 || != "appapi/slug.go"`). |
| `internal/cmd/exitcodes_clauses_test.go:175` | pre-split sentences | Control; the guard itself is already membership — it names the MISSING clause. |
| `internal/validate/finding_contract_test.go:326` | `minSites=20` | AST-scan positive control; every site is iterated. |
| `internal/cmd/app_doctor_test.go:513` | `seen < 14` | Regex-scan positive control; each ref resolved individually. Its comment already reasons about floor tightness. |
| `internal/cmd/readme_troubleshooting_test.go:166` | `symptoms` | **DERIVED** from README by regex — a `len < 15` here is a parse control, not a floor. Identities live in the README; the real floor is `:1804-1834`, already membership. |
| `internal/cmd/read_help_test.go:439,781` | `byteIdentityClaims`, `blanketAuthClaims` | Classifier **control corpora** ("too few to show the checker fires"), zero slack. Same species as the two below — left for consistency. |
| `agents_trigger_test.go:521`, `claude_md_import_only_test.go:148` | `len(reject) < 8 \|\| len(accept) < 3` | Classifier corpus non-triviality controls, not preservation ledgers. |
| `internal/cmd/app_listing_test.go:818` | `len(subs) < 6` | Read off the **live command tree** ("never a hardcoded list"); the tree is the source of truth. |
| `internal/cmd/whoami_human_block_test.go:642` | `len(all) < 10` | Explicitly *"deliberately loose — a tight number would be a hand-maintained count, which is the thing this design exists to avoid"*. |
| `internal/blockproto/entrygraph_test.go:1087,1160,1171` | `g.Gaps` | Behavioural assertions about a computed result. |
| ~40 further byte/parse/render controls | `len(section) < 500`, `len(links) < 40`, `len(blocks) < 10`, `len(help) < 200`, … | Positive controls over derived text. |

## Proof — the actual trade, per conversion

Each: apply add-one/delete-one, run the **NEW** guard, then swap the **OLD** count guard back in under the *same* edit. All run on committed state; tree reverted and verified clean after each.

**1. `humanBytesLadderFloor`** — delete `one decimal MB`, add `two bytes`; table still 13 rows.

```
NEW: --- FAIL: TestHumanBytesLabelsItsOwnArithmetic
     humanbytes_test.go:111: the "one decimal MB" row is gone from the unit-ladder table.
OLD: ok  github.com/civitai/cli/internal/cmd  0.008s
```

**2. `fsFixtureFloor`** — delete the `os.Symlink EEXIST (*os.LinkError)` fixture, add a 5th bare errno (`EPERM`); count unchanged.

```
NEW: --- FAIL: TestFilesystemErrorsAreNotNetworkErrors
     fs_not_network_test.go:267: the "os.Symlink EEXIST (*os.LinkError)" fixture is gone.
OLD: ok  github.com/civitai/cli/cmd/civitai  0.008s
```

**3. `exitCodeClaimsFloor`** — delete the issue-#241 row, add a filler row that **passes its own checks** (so the membership failure is the only failure); count stays 10.

```
NEW: --- FAIL: TestPublishedExitCodeClaims
     exitcodes_claims_test.go:255: the ledger row "a filesystem failure is 1, not 2 and not 5" is gone.
OLD: ok  github.com/civitai/cli/internal/cmd  0.008s
```

**4. `symptomAttributionsFloor`** — delete the `is this an App project?` row (the #361 row), add a duplicate of the surviving row to pay for it; count stays 2.

```
NEW: --- FAIL: TestREADMETroubleshootingRowsAreAttributedToTheEmittingCommand
     readme_troubleshooting_test.go:434: the attribution ledger no longer holds a row for "is this an App project?".
OLD: ok  github.com/civitai/cli/internal/cmd  0.011s
```

**5. `authRequiringCommandsFloor`** — here the first attempt **corrected the finding**: adding `app pull` as filler made two *other* assertions fail (it is not auth-refused, and `readAnonNote` does not name it). The old `len(...) == 0` has so much slack that **no compensating addition is needed** — a bare deletion (2 → 1) is already green, which is strictly worse than add-one/delete-one. Demonstrated as a delete-one:

```
NEW: --- FAIL: TestReadAnonNoteKeepsItsException
     read_help_test.go:778: `app view` is gone from the auth-requiring ledger.
OLD: ok  github.com/civitai/cli/internal/cmd  0.013s
```

## Mutation results — including what is NOT caught

| floor | empty the floor | drop ONE identity from the floor |
|---|---|---|
| `humanBytesLadderFloor` | **CAUGHT** — `CONTROL failure: humanBytesLadderFloor is empty, so this test asserts nothing` | **NOT caught** (`ok`) |
| `fsFixtureFloor` | **CAUGHT** — same control message | **NOT caught** (`ok`) |
| `exitCodeClaimsFloor` | **CAUGHT** — same control message | **NOT caught** (`ok`) |
| `symptomAttributionsFloor` | **CAUGHT** — same control message | **NOT caught** (`ok`) |
| `authRequiringCommandsFloor` | **CAUGHT** — same control message | **NOT caught** (`ok`) |

The second column is the **documented two-line bypass, reported honestly rather than claimed as coverage**. Also measured on `humanBytesLadderFloor`: dropping the floor entry *and* the table row together (`PiB`) is likewise **not caught** (`ok`). No in-tree check can stop a deliberate two-line removal — that is review's job.

## Residuals, stated rather than glossed

1. **Protection is OPT-IN PER ENTRY.** Each guard iterates its floor, so an entry added to a table and not named in the floor is permanently tradeable — and **nothing goes red at the moment of the omission**. Append the identity in the same commit as the row.
2. **The two-line bypass stays open** (measured above). These guards stop the ONE-line trade an audit actually demonstrated — a deletion paid for by an unrelated addition, which is exactly the shape a "widen the table" commit takes.
3. **Floors pin IDENTITIES, not VALUES.** A row keeping its name while its expectation is edited to match a regression is not caught. For humanbytes, `TestHumanBytesNeverPrintsAnSILabel` is the independent property half.
4. **`fsFixtureFloor` deliberately omits the two EACCES fixtures** — `realFilesystemErrors` skips them under `os.Geteuid() == 0` because root defeats mode 000, so naming them would make the guard red in a root container rather than catch anything. Their wrapping shape is held by three other named fixtures, but those two rows stay tradeable.
5. **`exitCodeClaimsFloor` keys on NAME, not code** — four rows share code 1 and four share code 2, so code is not an identity. A duplicate-name check was added so the key stays honest.
6. **`authRequiringCommandsFloor`'s two-line bypass is a legitimate edit more often than elsewhere**: if a command really goes anonymous its row *should* go, and the floor with it. That is the intended cost — the deletion becomes visible instead of silent.
7. **`symptomAttributions` is still reached POSITIONALLY** by three fixtures (`symptomAttributions()[0]` / `[1]`). Reordering silently retargets them while the floor stays green. Left unfixed on purpose so this change stays a count→membership port.

## Deliberately left unfixed (different defects, not this hazard)

Found during the survey and **not** touched, because none is a count-guard-with-a-hole:

- `internal/cmd/app_listing_advice_ledger_test.go:121` — `len(lines) != tc.wantLines` is a per-case magnitude assertion, and the 7-route table has **no** collection guard at all. That is a *missing* guard.
- `changelog_filter_ledger_test.go:94-148` — the subject table (incl. the three sole mutation-discriminating rows) has no size or membership guard.
- `read_help_test.go:721` `universalAuthQuantifiers` (3 of 7 entries untested), `readme_troubleshooting_test.go:644` `attributionNegators` (8 of 15 untested), `contrastConjunctions` (3 of 4 untested) — unexercised denylist entries.
- `agents_xrefs_test.go:471-499` — the 20-row regex-spelling corpus, the only thing pinning `itemRefRe`'s spellings, has no floor.

## Gates

- `make ci` — green, **21/21 packages `ok`** (+1 with no test files); both touched packages present and non-trivial.
- `nix-shell -p golangci-lint --run "make lint"` — **0 issues**. Instrument validated: injecting an unused variable into a touched file produced `internal/cmd/humanbytes_test.go:101:2: declared and not used (typecheck)`, so the zero is a real read of these files, then reverted.
- `./scripts/ci-shallow.sh` — **PASSED**, `ok=21/21`, cloned at `2ed11da` (matching HEAD), confirming green in the depth-1 checkout CI uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
