### PR TITLE
fix(scaffold): repair 27 dead CSS design tokens in page-money, and guard the class

### DIFF
--- a/internal/scaffold/cmd/bump-pins/main.go
+++ b/internal/scaffold/cmd/bump-pins/main.go
@@ -13,6 +13,23 @@
 //  2. templates/page-money/README.md.tmpl       (@civitai/<pkg>@^X.Y.Z prose)
 //  3. scaffold_test.go                          (the mustContain assertion)
 //
+// It also owns a FOURTH site of a different shape:
+//
+//  4. testdata/design-tokens.txt                (the design-token ledger)
+//
+// 🔴 That fourth site is here, and not in a separate command, because the pin
+// and the ledger are the SAME FACT and drift apart silently otherwise. The
+// ledger records the CSS custom properties `@civitai/blocks-react` defines, and
+// the offline guard (design_tokens_guard_test.go) checks every token the
+// templates reference for membership in it. Bump the pin without regenerating
+// the ledger and that guard is checking references against the token set of a
+// version the scaffold no longer installs — so it can pass over a token the
+// newly-pinned pack dropped, which is precisely the failure the guard exists to
+// catch (an undefined CSS variable resolves to nothing: no error, green build,
+// unstyled app). Regenerating in the same run makes them agree by construction.
+// If the token fetch fails, that package's pin bump is SKIPPED too rather than
+// written alone — a half-applied bump is the drift state.
+//
 // 🔴 It rewrites the LITERAL pins (it does NOT template them): the guard reads
 // the raw `^X.Y.Z` bytes out of the .tmpl, so templating would blind it.
 //
@@ -81,7 +98,7 @@ func main() {
 	check := flag.Bool("check", false, "exit non-zero if a bump is NEEDED; write nothing (for CI)")
 	flag.Parse()
 
-	changes, err := run(*dir, scaffold.FetchNpmLatest, *check, os.Stdout)
+	changes, err := run(*dir, scaffold.FetchNpmLatest, scaffold.FetchNpmTokens, *check, os.Stdout)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "bump-pins:", err)
 		os.Exit(2)
@@ -94,9 +111,19 @@ func main() {
 
 // run discovers the @civitai/* packages pinned in the template, resolves each to
 // its desired pin via fetch, and rewrites every stale literal across the three
-// sites. With check=true it computes the needed changes but writes nothing.
-// It returns the list of applied (or, under --check, needed) changes.
-func run(dir string, fetch func(pkg string) (string, error), check bool, out io.Writer) ([]change, error) {
+// pin sites plus the design-token ledger. With check=true it computes the needed
+// changes but writes nothing. It returns the list of applied (or, under
+// --check, needed) changes.
+//
+// fetchTokens reads the design tokens a published version DEFINES; it is only
+// called for scaffold.DesignTokenPkg.
+func run(
+	dir string,
+	fetch func(pkg string) (string, error),
+	fetchTokens func(pkg, version string) ([]string, error),
+	check bool,
+	out io.Writer,
+) ([]change, error) {
 	// 1. Discover the distinct @civitai/* packages from the canonical source.
 	pkgs, err := discoverPackages(filepath.Join(dir, pkgJSONFile))
 	if err != nil {
@@ -110,6 +137,7 @@ func run(dir string, fetch func(pkg string) (string, error), check bool, out io.
 	//    (or a genuinely-missing package) skips that package without failing —
 	//    the pins-vs-published guard is the loud channel for real drift.
 	desired := map[string]string{} // pkg -> desired bare "X.Y.Z"
+	resolved := map[string]string{}
 	for _, pkg := range pkgs {
 		latest, err := fetch(pkg)
 		if err != nil {
@@ -122,6 +150,24 @@ func run(dir string, fetch func(pkg string) (string, error), check bool, out io.
 			continue
 		}
 		desired[pkg] = pin[1:] // drop the leading caret; the site regexes own the "^"
+		resolved[pkg] = latest
+	}
+
+	// 2b. Read the design tokens the token package's published version defines,
+	//     BEFORE anything is written. On failure the package is dropped from the
+	//     bump entirely: writing the pin without the matching ledger is the drift
+	//     state the ledger exists to prevent, so a half-applied bump is worse
+	//     than no bump.
+	var tokens []string
+	if _, ok := desired[scaffold.DesignTokenPkg]; ok {
+		tokens, err = fetchTokens(scaffold.DesignTokenPkg, resolved[scaffold.DesignTokenPkg])
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"bump-pins: skipping %s ENTIRELY (design-token read failed: %v)\n"+
+					"bump-pins: its pin is deliberately left alone — bumping it without regenerating %s would leave the design-token guard checking against the wrong token set\n",
+				scaffold.DesignTokenPkg, err, scaffold.DesignTokenLedgerFile)
+			delete(desired, scaffold.DesignTokenPkg)
+		}
 	}
 
 	// 3. Rewrite every stale literal across the three sites.
@@ -158,6 +204,20 @@ func run(dir string, fetch func(pkg string) (string, error), check bool, out io.
 		}
 	}
 
+	// 3b. Regenerate the design-token ledger. Rewritten when the pin it records
+	//     has moved OR the published token SET has changed — the two states the
+	//     guard can be wrong about. A published patch that changes neither
+	//     produces no write, so this adds no PR churn of its own.
+	if bare, ok := desired[scaffold.DesignTokenPkg]; ok {
+		ledgerChange, err := syncLedger(dir, scaffold.DesignTokenPkg, "^"+bare, resolved[scaffold.DesignTokenPkg], tokens, check)
+		if err != nil {
+			return nil, err
+		}
+		if ledgerChange != nil {
+			changes = append(changes, *ledgerChange)
+		}
+	}
+
 	// 4. Report.
 	for _, c := range changes {
 		verb := "would bump"
@@ -167,9 +227,87 @@ func run(dir string, fetch func(pkg string) (string, error), check bool, out io.
 		fmt.Fprintf(out, "%s %s: %s -> %s (%s)\n", verb, c.pkg, c.oldPin, c.newPin, c.file)
 	}
 	if len(changes) == 0 {
-		fmt.Fprintln(out, "all @civitai/* pins are current — nothing to do")
+		fmt.Fprintln(out, "all @civitai/* pins are current and the design-token ledger matches — nothing to do")
 	}
 	return changes, nil
+}
+
+// syncLedger rewrites the design-token ledger when it no longer describes what
+// the templates will install: either the caret pin moved, or the published token
+// set changed. It returns the change it made (or, under check, would make), or
+// nil when the ledger is already correct.
+//
+// A MISSING ledger is regenerated, not tolerated — the guard fails closed on
+// one, so leaving it absent would leave the repo permanently red.
+func syncLedger(dir, pkg, pin, version string, tokens []string, check bool) (*change, error) {
+	if len(tokens) == 0 {
+		// FetchNpmTokens already treats an empty read as an error; this is the
+		// belt-and-braces so a future caller cannot write an empty ledger, which
+		// would make the membership guard vacuous.
+		return nil, fmt.Errorf("refusing to write %s with ZERO tokens — that would make the design-token guard pass over everything", scaffold.DesignTokenLedgerFile)
+	}
+
+	path := filepath.Join(dir, scaffold.DesignTokenLedgerFile)
+	want := scaffold.RenderDesignTokenLedger(pkg, pin, version, tokens)
+
+	oldDesc := "(missing)"
+	existing, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if string(existing) == string(want) {
+			return nil, nil // already correct
+		}
+		if l, perr := scaffold.ParseDesignTokenLedger(existing); perr == nil {
+			// Only the provenance line moving (same pin, same tokens) is not
+			// worth a rewrite — it would churn a PR for no behavioural change.
+			if l.Pin == pin && sameTokens(l.Tokens, tokens) {
+				return nil, nil
+			}
+			oldDesc = fmt.Sprintf("%s@%s (%d tokens)", l.Pin, l.Version, len(l.Tokens))
+		} else {
+			oldDesc = "(unparseable)"
+		}
+	case os.IsNotExist(err):
+		// regenerate below
+	default:
+		return nil, fmt.Errorf("reading %s: %w", scaffold.DesignTokenLedgerFile, err)
+	}
+
+	if !check {
+		// The ledger is the one site that can legitimately not exist yet (the
+		// three pin sites are always read before being written), so create its
+		// directory rather than failing on a fresh tree.
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, fmt.Errorf("creating %s: %w", filepath.Dir(scaffold.DesignTokenLedgerFile), err)
+		}
+		if err := os.WriteFile(path, want, 0o644); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", scaffold.DesignTokenLedgerFile, err)
+		}
+	}
+	return &change{
+		pkg:    pkg,
+		oldPin: oldDesc,
+		newPin: fmt.Sprintf("%s@%s (%d tokens)", pin, version, len(tokens)),
+		file:   scaffold.DesignTokenLedgerFile,
+	}, nil
+}
+
+func sameTokens(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// The ledger's tokens are stored sorted+deduped and RenderDesignTokenLedger
+	// sorts+dedupes too, so compare the normalised forms.
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // discoverPackages returns the distinct @civitai/* package names pinned in the

--- a/internal/scaffold/cmd/bump-pins/main_test.go
+++ b/internal/scaffold/cmd/bump-pins/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,6 +113,16 @@ func TestRewritePin(t *testing.T) {
 	})
 }
 
+// fakeTokens is the injected design-token read (no network). It returns a small
+// but non-empty set — non-empty matters, because run() refuses to write an empty
+// ledger and an empty set would make the design-token guard vacuous.
+func fakeTokens(pkg, version string) ([]string, error) {
+	if pkg != scaffold.DesignTokenPkg {
+		return nil, fmt.Errorf("unexpected token fetch for %s", pkg)
+	}
+	return []string{"--civitai-color-text", "--civitai-color-surface", "--civitai-radius"}, nil
+}
+
 // TestRunRewritesAllThreeFilesAndIsIdempotent exercises the full run() against a
 // temp-dir fixture mirroring the three literal sites, with an injected
 // "published" version (no network).
@@ -130,13 +142,26 @@ func TestRunRewritesAllThreeFilesAndIsIdempotent(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	changes, err := run(dir, fetch, false, &buf)
+	changes, err := run(dir, fetch, fakeTokens, false, &buf)
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	// 2 packages × 3 files = 6 rewrites.
-	if len(changes) != 6 {
-		t.Fatalf("expected 6 changes, got %d:\n%s", len(changes), buf.String())
+	// 2 packages × 3 pin sites = 6 rewrites, + the design-token ledger.
+	if len(changes) != 7 {
+		t.Fatalf("expected 7 changes (6 pin sites + the ledger), got %d:\n%s", len(changes), buf.String())
+	}
+
+	// The ledger must have been written, and must record the pin this run set.
+	ledger := readFile(t, dir, scaffold.DesignTokenLedgerFile)
+	l, err := scaffold.ParseDesignTokenLedger([]byte(ledger))
+	if err != nil {
+		t.Fatalf("bump-pins wrote an unparseable ledger: %v\n%s", err, ledger)
+	}
+	if l.Pkg != scaffold.DesignTokenPkg || l.Pin != "^0.30.0" || l.Version != "0.30.1" {
+		t.Errorf("ledger provenance = %+v, want pkg=%s pin=^0.30.0 version=0.30.1", l, scaffold.DesignTokenPkg)
+	}
+	if len(l.Tokens) != 3 {
+		t.Errorf("ledger holds %d token(s), want 3: %v", len(l.Tokens), l.Tokens)
 	}
 
 	pkgJSON := readFile(t, dir, pkgJSONFile)
@@ -154,7 +179,7 @@ func TestRunRewritesAllThreeFilesAndIsIdempotent(t *testing.T) {
 
 	// Second run is a no-op (idempotent).
 	buf.Reset()
-	changes2, err := run(dir, fetch, false, &buf)
+	changes2, err := run(dir, fetch, fakeTokens, false, &buf)
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}
@@ -184,7 +209,7 @@ func TestRunCheckWritesNothing(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	changes, err := run(dir, fetch, true /*check*/, &buf)
+	changes, err := run(dir, fetch, fakeTokens, true /*check*/, &buf)
 	if err != nil {
 		t.Fatalf("run --check: %v", err)
 	}
@@ -211,7 +236,7 @@ func TestRunSkipsOnFetchError(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	changes, err := run(dir, fetch, false, &buf)
+	changes, err := run(dir, fetch, fakeTokens, false, &buf)
 	if err != nil {
 		t.Fatalf("run must not fail on a skipped package: %v", err)
 	}
@@ -221,6 +246,163 @@ func TestRunSkipsOnFetchError(t *testing.T) {
 	if got := readFile(t, dir, pkgJSONFile); got != before {
 		t.Errorf("skipped run must not modify files")
 	}
+}
+
+// TestRunSkipsThePinBumpWhenTheTokenReadFails is the coupling this wiring
+// exists for. Writing the pack's PIN without regenerating the design-token
+// ledger leaves the offline guard checking template references against the token
+// set of a version the scaffold no longer installs — the exact drift state the
+// ledger prevents. So a failed token read must skip that package's pin bump
+// too, not write it alone.
+//
+// The other package must still bump: the failure is scoped to the token package.
+func TestRunSkipsThePinBumpWhenTheTokenReadFails(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir)
+
+	fetch := func(pkg string) (string, error) {
+		switch pkg {
+		case "@civitai/app-sdk":
+			return "0.25.4", nil
+		case "@civitai/blocks-react":
+			return "0.30.1", nil
+		}
+		return "", scaffold.ErrPkgNotFound
+	}
+	failTokens := func(pkg, version string) ([]string, error) {
+		return nil, errors.New("registry unreachable")
+	}
+
+	var buf bytes.Buffer
+	changes, err := run(dir, fetch, failTokens, false, &buf)
+	if err != nil {
+		t.Fatalf("a failed token read must skip, not fail the command: %v", err)
+	}
+	// Only app-sdk's 3 pin sites — blocks-react is skipped entirely, ledger
+	// included.
+	if len(changes) != 3 {
+		t.Fatalf("expected 3 changes (app-sdk only), got %d:\n%s", len(changes), buf.String())
+	}
+	pkgJSON := readFile(t, dir, pkgJSONFile)
+	assertContains(t, pkgJSON, `"@civitai/app-sdk": "^0.25.0"`)
+	// 🔴 The load-bearing assertion: blocks-react's pin is UNCHANGED at the
+	// fixture's value. A bumped pin here would be the half-applied state.
+	assertContains(t, pkgJSON, `"@civitai/blocks-react": "^0.29.0"`)
+	if _, err := os.Stat(filepath.Join(dir, scaffold.DesignTokenLedgerFile)); !os.IsNotExist(err) {
+		t.Errorf("no ledger should have been written when the token read failed (stat err: %v)", err)
+	}
+}
+
+// TestSyncLedgerRewritesOnPinMoveAndOnTokenChange covers the two states the
+// guard can be wrong about, and the one that must NOT churn a PR.
+func TestSyncLedgerRewritesOnPinMoveAndOnTokenChange(t *testing.T) {
+	toks := []string{"--civitai-color-text", "--civitai-color-surface"}
+
+	seed := func(t *testing.T, pin, version string, tokens []string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, scaffold.DesignTokenLedgerFile)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		raw := scaffold.RenderDesignTokenLedger(scaffold.DesignTokenPkg, pin, version, tokens)
+		if err := os.WriteFile(path, raw, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	t.Run("pin moved -> rewrite", func(t *testing.T) {
+		dir := seed(t, "^0.43.0", "0.43.1", toks)
+		c, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.44.0", "0.44.2", toks, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c == nil {
+			t.Fatal("a moved pin must rewrite the ledger — otherwise the guard checks the wrong version's token set")
+		}
+		l, err := scaffold.ParseDesignTokenLedger([]byte(readFile(t, dir, scaffold.DesignTokenLedgerFile)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l.Pin != "^0.44.0" || l.Version != "0.44.2" {
+			t.Errorf("ledger not updated: %+v", l)
+		}
+	})
+
+	t.Run("token set changed -> rewrite", func(t *testing.T) {
+		dir := seed(t, "^0.43.0", "0.43.1", toks)
+		next := []string{"--civitai-color-text", "--civitai-color-surface", "--civitai-color-brand-new"}
+		c, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.43.0", "0.43.2", next, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c == nil {
+			t.Fatal("a changed token set must rewrite the ledger even within one caret range")
+		}
+		l, err := scaffold.ParseDesignTokenLedger([]byte(readFile(t, dir, scaffold.DesignTokenLedgerFile)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(l.Tokens) != 3 {
+			t.Errorf("ledger tokens = %v, want the new 3", l.Tokens)
+		}
+	})
+
+	t.Run("only the version moved -> no churn", func(t *testing.T) {
+		dir := seed(t, "^0.43.0", "0.43.1", toks)
+		before := readFile(t, dir, scaffold.DesignTokenLedgerFile)
+		c, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.43.0", "0.43.2", toks, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c != nil {
+			t.Errorf("same pin + same tokens must not rewrite (it would churn a PR for no behavioural change), got %+v", c)
+		}
+		if got := readFile(t, dir, scaffold.DesignTokenLedgerFile); got != before {
+			t.Error("ledger was rewritten despite no behavioural change")
+		}
+	})
+
+	t.Run("missing ledger is regenerated", func(t *testing.T) {
+		dir := t.TempDir()
+		c, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.43.0", "0.43.1", toks, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c == nil {
+			t.Fatal("a missing ledger must be regenerated — the guard fails closed on one, so leaving it absent leaves the repo permanently red")
+		}
+		if _, err := os.Stat(filepath.Join(dir, scaffold.DesignTokenLedgerFile)); err != nil {
+			t.Errorf("ledger not created: %v", err)
+		}
+	})
+
+	t.Run("refuses to write an empty ledger", func(t *testing.T) {
+		dir := seed(t, "^0.43.0", "0.43.1", toks)
+		before := readFile(t, dir, scaffold.DesignTokenLedgerFile)
+		if _, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.44.0", "0.44.0", nil, false); err == nil {
+			t.Fatal("writing an EMPTY ledger must be an error — it would make the membership guard pass over everything")
+		}
+		if got := readFile(t, dir, scaffold.DesignTokenLedgerFile); got != before {
+			t.Error("the refused write still modified the ledger")
+		}
+	})
+
+	t.Run("check writes nothing", func(t *testing.T) {
+		dir := seed(t, "^0.43.0", "0.43.1", toks)
+		before := readFile(t, dir, scaffold.DesignTokenLedgerFile)
+		c, err := syncLedger(dir, scaffold.DesignTokenPkg, "^0.44.0", "0.44.2", toks, true /*check*/)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c == nil {
+			t.Fatal("--check must still REPORT the needed rewrite")
+		}
+		if got := readFile(t, dir, scaffold.DesignTokenLedgerFile); got != before {
+			t.Error("--check must not write")
+		}
+	})
 }
 
 // --- fixture helpers ---

--- a/internal/scaffold/design_tokens_guard_test.go
+++ b/internal/scaffold/design_tokens_guard_test.go
@@ -1,0 +1,429 @@
+package scaffold
+
+// Structural guard: every design-system custom property the scaffold templates
+// reference must be one the pinned UI pack actually DEFINES.
+//
+// Why this shape, and not a grep. The defect that produced this guard was a
+// namespace rename in `@civitai/blocks-react` (`--ci-color-*` →
+// `--civitai-color-*`, with two names also changing suffix:
+// `text-muted` → `text-dimmed`, `primary-contrast` → `primary-fg`). Every one
+// of the 27 references in page-money went dead at once, and NOTHING went red:
+// an undefined CSS custom property resolves to nothing, so the declaration is
+// dropped, the build is green, and the `template-page-money` CI job (install →
+// typecheck → build) is green — the app just renders with an unset shell
+// background, unset text and an invalid focus outline.
+//
+// A guard that greps for the literal `--ci-color-` would pin a WORD. It passes
+// the moment the dead spelling is gone and says nothing about whether the new
+// spelling is right, so the NEXT rename — the actual recurring hazard — walks
+// straight past it. This guard pins the RELATIONSHIP instead: membership of the
+// referenced set in the defined set. A token dropped or re-spelled upstream
+// stops being a member, so the same class is caught however it is spelled, and
+// even a wholesale namespace rename is caught (the template keeps spelling the
+// old namespace, which the regenerated ledger no longer contains).
+//
+// The defined set is a checked-in ledger (testdata/design-tokens.txt) because CI
+// cannot reach npm reliably and this guard gates every PR. Its provenance header
+// records the package, the caret pin and the concrete version the tokens were
+// read from; `TestDesignTokenLedgerMatchesTemplatePin` fails when that pin no
+// longer matches the template, and `bump-pins` regenerates the ledger in the
+// same run in which it bumps the pin so the two cannot drift.
+//
+// RESIDUAL, stated rather than papered over: the ledger is only as fresh as the
+// last regeneration. Within one caret range (`^0.43.0` admits every `0.43.x`) a
+// patch release could add a token — a template using it would red, which is a
+// false failure a regeneration fixes — or REMOVE one, which the ledger would
+// still list, and that direction is a false PASS. Closing it would need a
+// network read at test time, which is the thing this guard deliberately does not
+// do. Measured across the whole range this pin admits and the next minor
+// (0.43.0, 0.43.1, 0.44.0, 0.44.1, 0.44.2) the defined set is byte-identical, so
+// the residual is small today; it is not zero.
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// loadLedger reads and parses the checked-in ledger, failing closed.
+func loadLedger(t *testing.T) *DesignTokenLedger {
+	t.Helper()
+	raw, err := os.ReadFile(DesignTokenLedgerFile)
+	if err != nil {
+		t.Fatalf(
+			"cannot read the design-token ledger %s: %v\n"+
+				"  The ledger is the DEFINED set this guard checks references against. Without it\n"+
+				"  the membership test would be vacuous — every dead token would pass — so a missing\n"+
+				"  ledger is a hard failure, not a skip.\n"+
+				"  fix: go run ./internal/scaffold/cmd/bump-pins",
+			DesignTokenLedgerFile, err)
+	}
+	l, err := ParseDesignTokenLedger(raw)
+	if err != nil {
+		t.Fatalf("design-token ledger %s is unusable: %v\n  fix: go run ./internal/scaffold/cmd/bump-pins", DesignTokenLedgerFile, err)
+	}
+	return l
+}
+
+// TestScaffoldTemplatesOnlyUseDefinedDesignTokens is the guard.
+func TestScaffoldTemplatesOnlyUseDefinedDesignTokens(t *testing.T) {
+	ledger := loadLedger(t)
+
+	scan, err := ScanDesignTokenRefs(templatesFS, "templates")
+	if err != nil {
+		t.Fatalf("scanning templates for design-token references: %v", err)
+	}
+
+	// ── POSITIVE CONTROLS ───────────────────────────────────────────────────
+	// This test's reassuring answer is "no dead tokens", which is exactly the
+	// answer a scanner wired to an empty tree also gives. Assert it read this
+	// repo's templates and found real references before believing the zero.
+	t.Logf("scanned %d template file(s); %d file(s) reference design tokens; %d distinct (file,token) pair(s), %d total occurrence(s); ledger holds %d token(s) from %s@%s",
+		scan.FilesRead, scan.FilesWith, len(scan.Refs), scan.Occurrences, len(ledger.Tokens), ledger.Pkg, ledger.Version)
+
+	// Measured on this tree: 3 templates, 53 files. The floor is loose — it
+	// exists to catch "walked nothing / walked the wrong tree", not to track a
+	// count.
+	if scan.FilesRead < 20 {
+		t.Fatalf("read only %d template file(s) — the scanner is not looking at this repo's templates, so a clean verdict here would be a statement about nothing", scan.FilesRead)
+	}
+	// Measured on this tree: 27 occurrences across 3 files of page-money. If a
+	// future change legitimately removes ALL design-token usage, lower these
+	// floors DELIBERATELY — do not let the guard silently become a guard over
+	// nothing.
+	if scan.FilesWith < 3 || scan.Occurrences < 20 {
+		t.Fatalf("found design tokens in only %d file(s) / %d occurrence(s) — expected the page-money chrome to reference the pack's tokens; either the templates stopped using them (lower this floor on purpose) or DesignTokenRefRe stopped matching", scan.FilesWith, scan.Occurrences)
+	}
+
+	// ── THE INVARIANT ───────────────────────────────────────────────────────
+	for _, r := range scan.Refs {
+		if ledger.Has(r.Token) {
+			continue
+		}
+		t.Errorf(
+			"DEAD DESIGN TOKEN — this reference resolves to NOTHING at runtime, silently.\n"+
+				"  file:  %s\n"+
+				"  token: %s  ×%d   (not defined by %s@%s)\n"+
+				"  Undefined CSS custom properties are dropped, so the build stays green and the\n"+
+				"  scaffolded app just renders unstyled at this site. Nothing else will catch it.\n"+
+				"  fix: replace it with the token the pack defines for the same intent — see\n"+
+				"       %s for the full defined set. If the pack renamed it, regenerate the\n"+
+				"       ledger first: go run ./internal/scaffold/cmd/bump-pins",
+			r.File, r.Token, r.Occurrences, ledger.Pkg, ledger.Version, DesignTokenLedgerFile)
+	}
+}
+
+// TestDesignTokenLedgerMatchesTemplatePin closes the drift between the pin and
+// the ledger. bump-pins rewrites the pack's caret pin in the template; if the
+// ledger is not regenerated in the same run, it describes a version the scaffold
+// no longer installs and the membership check above is checking against the
+// wrong set. This is the loud channel for that.
+func TestDesignTokenLedgerMatchesTemplatePin(t *testing.T) {
+	ledger := loadLedger(t)
+
+	pins := collectCivitaiPins(t)
+	if len(pins) == 0 {
+		t.Fatal("no @civitai/* pins found in any template package.json.tmpl — the extractor is broken")
+	}
+	var pin string
+	for _, p := range pins {
+		if p.pkg == ledger.Pkg {
+			pin = p.pin
+			break
+		}
+	}
+	if pin == "" {
+		t.Fatalf("the ledger's package %q is not pinned by any template package.json.tmpl — the ledger describes a package the scaffold does not install", ledger.Pkg)
+	}
+
+	if pin != ledger.Pin {
+		t.Fatalf(
+			"DESIGN-TOKEN LEDGER IS STALE — it describes a version the scaffold no longer installs.\n"+
+				"  package:       %s\n"+
+				"  template pins: %s\n"+
+				"  ledger says:   %s   (tokens read from %s)\n"+
+				"  The membership guard is now checking template references against the WRONG token\n"+
+				"  set, so it can pass over a token the newly-pinned pack dropped.\n"+
+				"  fix: go run ./internal/scaffold/cmd/bump-pins   (rewrites the pins AND this ledger)",
+			ledger.Pkg, pin, ledger.Pin, ledger.Version)
+	}
+
+	// The recorded version must be one the recorded pin actually admits —
+	// otherwise the provenance is internally incoherent even when it matches.
+	ok, err := CaretAdmits(ledger.Pin, ledger.Version)
+	if err != nil {
+		t.Fatalf("ledger provenance is unparseable: pin %q vs version %q: %v", ledger.Pin, ledger.Version, err)
+	}
+	if !ok {
+		t.Fatalf("ledger provenance is incoherent: pin %q does NOT admit the version %q the tokens were read from", ledger.Pin, ledger.Version)
+	}
+}
+
+// TestDesignTokenLedgerNamespace pins the ledger to the namespace
+// DesignTokenRefRe knows how to see. If the pack renames its namespace wholesale
+// the regenerated ledger would hold tokens the reference regex cannot match, and
+// the membership guard would go quietly blind rather than red.
+func TestDesignTokenLedgerNamespace(t *testing.T) {
+	ledger := loadLedger(t)
+	for _, tok := range ledger.Tokens {
+		if !strings.HasPrefix(tok, "--civitai-") {
+			t.Errorf("ledger token %q is outside the --civitai-* namespace DesignTokenRefRe matches — update the regex in designtokens.go, or this guard is blind to references to it", tok)
+		}
+		if DesignTokenRefRe.FindString(tok) != tok {
+			t.Errorf("ledger token %q is not matched WHOLE by DesignTokenRefRe — a reference to it could never be recognised", tok)
+		}
+	}
+}
+
+// ── INSTRUMENT VALIDATION ───────────────────────────────────────────────────
+// Everything above reads a verdict out of ExtractDesignTokenRefs /
+// ScanDesignTokenRefs. Until these two controls have been watched to work, that
+// verdict is a fact about the extractor, not about the templates.
+
+// TestExtractDesignTokenRefs is the POSITIVE control: fed input that MUST
+// produce matches, the extractor produces exactly them.
+func TestExtractDesignTokenRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "css var reference",
+			in:   "outline: 2px solid var(--civitai-color-primary);",
+			want: []string{"--civitai-color-primary"},
+		},
+		{
+			name: "nested var with fallback, both extracted",
+			in:   `color: 'var(--civitai-color-text-dimmed, var(--civitai-color-text))',`,
+			want: []string{"--civitai-color-text", "--civitai-color-text-dimmed"},
+		},
+		{
+			name: "literal fallback is not a token",
+			in:   `color: 'var(--civitai-color-success, #2f9e44)',`,
+			want: []string{"--civitai-color-success"},
+		},
+		{
+			name: "dead legacy namespace is still seen",
+			in:   `background: 'var(--ci-color-surface-2)',`,
+			want: []string{"--ci-color-surface-2"},
+		},
+		{
+			name: "js object key form",
+			in:   `style={{ ['--civitai-color-primary']: accent }}`,
+			want: []string{"--civitai-color-primary"},
+		},
+		{
+			name: "non-colour tokens are in scope too",
+			in:   "border-radius: var(--civitai-radius); font-family: var(--civitai-font-mono);",
+			want: []string{"--civitai-font-mono", "--civitai-radius"},
+		},
+		{
+			name: "an ordinary CLI long flag is NOT a token",
+			in:   "run `civitai app build --ci-mode --civitai=no`",
+			want: nil,
+		},
+		{
+			// Prose naming the namespace is documentation, not a reference. The
+			// guard reported its OWN comment as a dead token on the first run
+			// before this case existed.
+			name: "a globbed namespace in prose is not a reference",
+			in:   "every --civitai-color-* token, and the legacy --ci-color-* ones",
+			want: nil,
+		},
+		{
+			name: "a real token adjacent to a globbed one is still seen",
+			in:   "--civitai-color-* generally; here we use var(--civitai-color-text).",
+			want: []string{"--civitai-color-text"},
+		},
+		{
+			name: "unrelated custom properties are ignored",
+			in:   "--my-app-color: red; --mantine-color-body: blue;",
+			want: nil,
+		},
+		{
+			name: "no tokens at all",
+			in:   "const x = 1;",
+			want: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExtractDesignTokenRefs(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("ExtractDesignTokenRefs(%q) = %v, want %v", c.in, got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("ExtractDesignTokenRefs(%q) = %v, want %v", c.in, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractDesignTokenDefs covers the other half of the instrument: the
+// extraction bump-pins uses to BUILD the ledger. Both declaration forms the pack
+// ships, and the shapes that must NOT count as a definition.
+func TestExtractDesignTokenDefs(t *testing.T) {
+	// Both forms appear in the real pack: `@property` blocks in the generated
+	// token sheet, `--x: value` pairs in the :root rule.
+	src := "@property --civitai-color-text {\n  syntax: '<color>';\n}\n" +
+		":root{--civitai-color-text:#222;--civitai-radius:8px;}\n" +
+		"a{color:var(--civitai-color-primary)}\n" + // a REFERENCE, not a definition
+		"--mantine-color-body: #fff;\n" // another design system's token
+	got := ExtractDesignTokenDefs(src)
+	want := []string{"--civitai-color-text", "--civitai-radius"}
+	if len(got) != len(want) {
+		t.Fatalf("ExtractDesignTokenDefs = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("ExtractDesignTokenDefs = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestScanDesignTokenRefsNegativeControl is the NEGATIVE control: the scanner
+// must be able to REPORT a dead token. A scanner that returns nothing whatever
+// you feed it is indistinguishable from a clean tree, so the clean verdict the
+// real guard reports would mean nothing without this.
+//
+// It drives the same ScanDesignTokenRefs the guard uses, over a synthetic FS
+// holding one live token and one dead one, and asserts the membership check
+// separates them.
+func TestScanDesignTokenRefsNegativeControl(t *testing.T) {
+	ledger := loadLedger(t)
+
+	fsys := fstest.MapFS{
+		"templates/fake/src/live.css.tmpl": {Data: []byte("a{color:var(--civitai-color-text)}")},
+		"templates/fake/src/dead.css.tmpl": {Data: []byte("a{color:var(--civitai-color-text-muted)}")},
+		"templates/fake/src/legacy.css.tmpl": {
+			Data: []byte("a{color:var(--ci-color-primary)}"),
+		},
+	}
+	scan, err := ScanDesignTokenRefs(fsys, "templates")
+	if err != nil {
+		t.Fatalf("scanning synthetic FS: %v", err)
+	}
+	if scan.FilesRead != 3 || scan.FilesWith != 3 {
+		t.Fatalf("read %d file(s) / %d with tokens from the synthetic FS, want 3/3", scan.FilesRead, scan.FilesWith)
+	}
+	if len(scan.Refs) != 3 || scan.Occurrences != 3 {
+		t.Fatalf("found %d reference(s) / %d occurrence(s) in the synthetic FS, want 3/3: %v", len(scan.Refs), scan.Occurrences, scan.Refs)
+	}
+
+	var dead []string
+	for _, r := range scan.Refs {
+		if !ledger.Has(r.Token) {
+			dead = append(dead, r.Token)
+		}
+	}
+	// `--civitai-color-text-muted` is the suffix the pack RENAMED away
+	// (→ text-dimmed) and `--ci-color-primary` is the dead namespace. Both must
+	// be reported; the live one must not be.
+	if len(dead) != 2 {
+		t.Fatalf("membership check reported %d dead token(s) %v, want exactly 2 (--civitai-color-text-muted, --ci-color-primary) — the control did not separate live from dead", len(dead), dead)
+	}
+	for _, want := range []string{"--civitai-color-text-muted", "--ci-color-primary"} {
+		found := false
+		for _, d := range dead {
+			if d == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("negative control: %q was NOT reported dead (reported: %v)", want, dead)
+		}
+	}
+	// And the sanity half: the token that IS defined must not be flagged.
+	if ledger.Has("--civitai-color-text") == false {
+		t.Error("--civitai-color-text is missing from the ledger — the live arm of the control is broken")
+	}
+}
+
+// TestParseDesignTokenLedgerFailsClosed pins the fail-closed contract: a
+// missing/empty/provenance-less ledger must be an ERROR, never a usable empty
+// set. An empty set would make the membership guard pass over everything.
+func TestParseDesignTokenLedgerFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty file", ""},
+		{"only whitespace", "\n\n   \n"},
+		{"comments only, no tokens", "# package: p\n# pin: ^1.0.0\n# version: 1.0.0\n"},
+		{"tokens but no provenance", "--civitai-color-text\n--civitai-color-body\n"},
+		{"missing version", "# package: p\n# pin: ^1.0.0\n--civitai-color-text\n"},
+		{"missing pin", "# package: p\n# version: 1.0.0\n--civitai-color-text\n"},
+		{"missing package", "# pin: ^1.0.0\n# version: 1.0.0\n--civitai-color-text\n"},
+		{"garbage body line", "# package: p\n# pin: ^1.0.0\n# version: 1.0.0\nnot-a-token\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			l, err := ParseDesignTokenLedger([]byte(c.in))
+			if err == nil {
+				t.Fatalf("expected an error, got a usable ledger with %d token(s) — this parses OPEN and would make the guard vacuous", len(l.Tokens))
+			}
+		})
+	}
+
+	// Positive half: a well-formed ledger parses.
+	l, err := ParseDesignTokenLedger([]byte("# package: @civitai/blocks-react\n# pin: ^0.43.0\n# version: 0.43.1\n\n--civitai-color-text\n--civitai-color-body\n"))
+	if err != nil {
+		t.Fatalf("well-formed ledger failed to parse: %v", err)
+	}
+	if l.Pkg != "@civitai/blocks-react" || l.Pin != "^0.43.0" || l.Version != "0.43.1" || len(l.Tokens) != 2 {
+		t.Fatalf("well-formed ledger parsed wrong: %+v", l)
+	}
+	if !l.Has("--civitai-color-text") || l.Has("--civitai-color-nope") {
+		t.Fatal("Has() is wrong on a well-formed ledger")
+	}
+}
+
+// TestRenderDesignTokenLedgerRoundTrips pins the render→parse contract bump-pins
+// depends on: what the bumper writes is what the guard reads back.
+func TestRenderDesignTokenLedgerRoundTrips(t *testing.T) {
+	in := []string{"--civitai-color-text", "--civitai-radius", "--civitai-color-body", "--civitai-color-text"}
+	raw := RenderDesignTokenLedger("@civitai/blocks-react", "^0.43.0", "0.43.1", in)
+	l, err := ParseDesignTokenLedger(raw)
+	if err != nil {
+		t.Fatalf("rendered ledger does not parse: %v\n%s", err, raw)
+	}
+	if l.Pkg != "@civitai/blocks-react" || l.Pin != "^0.43.0" || l.Version != "0.43.1" {
+		t.Fatalf("provenance did not round-trip: %+v", l)
+	}
+	// deduped + sorted
+	want := []string{"--civitai-color-body", "--civitai-color-text", "--civitai-radius"}
+	if len(l.Tokens) != len(want) {
+		t.Fatalf("tokens = %v, want %v", l.Tokens, want)
+	}
+	for i := range want {
+		if l.Tokens[i] != want[i] {
+			t.Fatalf("tokens = %v, want %v", l.Tokens, want)
+		}
+	}
+}
+
+// TestCheckedInLedgerIsWhatTheRendererWouldWrite proves the checked-in bytes
+// were produced by RenderDesignTokenLedger and not hand-edited — the ledger's
+// own header says DO NOT HAND-EDIT, and this is what makes that enforceable.
+func TestCheckedInLedgerIsWhatTheRendererWouldWrite(t *testing.T) {
+	raw, err := os.ReadFile(DesignTokenLedgerFile)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", DesignTokenLedgerFile, err)
+	}
+	l, err := ParseDesignTokenLedger(raw)
+	if err != nil {
+		t.Fatalf("cannot parse %s: %v", DesignTokenLedgerFile, err)
+	}
+	want := RenderDesignTokenLedger(l.Pkg, l.Pin, l.Version, l.Tokens)
+	if string(raw) != string(want) {
+		t.Errorf(
+			"%s is not byte-identical to what RenderDesignTokenLedger emits for its own contents —\n"+
+				"  it has been hand-edited, or the renderer changed without the ledger being regenerated.\n"+
+				"  fix: go run ./internal/scaffold/cmd/bump-pins",
+			DesignTokenLedgerFile)
+	}
+}

--- a/internal/scaffold/designtokens.go
+++ b/internal/scaffold/designtokens.go
@@ -1,0 +1,409 @@
+// Shared design-token logic for the scaffold templates.
+//
+// The page-money template styles its own chrome with the CSS custom properties
+// the `@civitai/blocks-react` UI pack injects (`--civitai-color-surface`,
+// `--civitai-color-text`, …). A reference to a token the pack does NOT define is
+// silently inert: CSS resolves an undefined custom property to nothing, so the
+// declaration is dropped and the element falls back to the UA default. Nothing
+// errors, `npm run build` is green, and the template-page-money CI job (install →
+// typecheck → build) is green too — a scaffolded app just ships an unset shell
+// background, unset text colour and an invalid focus outline.
+//
+// That is not hypothetical. The pack renamed the whole token namespace
+// `--ci-color-*` → `--civitai-color-*` and, for two names, changed the SUFFIX as
+// well (`text-muted` → `text-dimmed`, `primary-contrast` → `primary-fg`); the
+// templates kept the old spellings and every app created from them was born
+// unthemed. The pack's own `dist/ui/Badge.js` still carries a comment recording
+// the rename.
+//
+// So the invariant this file exists to make checkable is a RELATIONSHIP, not a
+// word: every design-system custom property referenced anywhere under
+// `templates/` must be a MEMBER of the set the pinned pack DEFINES. Grepping for
+// the literal string `--ci-color-` would only ever catch the rename that already
+// happened; membership catches the next one too, because a token that is dropped
+// or re-spelled upstream stops being in the set.
+//
+// Two consumers keep that honest and MUST agree by construction, so — exactly as
+// with the `@civitai/*` pins in pins.go — the logic lives here in production
+// code rather than in a `_test.go`:
+//
+//   - the offline structural guard (design_tokens_guard_test.go), which runs in
+//     the default `go test ./...` and checks every template reference against the
+//     checked-in ledger at testdata/design-tokens.txt.
+//   - the bump-pins command (internal/scaffold/cmd/bump-pins), which REGENERATES
+//     that ledger from the newly published version whenever it bumps the pack's
+//     pin — so the pin and the ledger cannot drift apart.
+//
+// 🔴 The ledger is checked in on purpose. CI cannot reach npm reliably and the
+// offline guard is the one that gates every PR, so the guard never fetches; it
+// reads bytes a human (or the daily bumper) committed, and records which package
+// version they came from.
+package scaffold
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DesignTokenPkg is the npm package that DEFINES the design tokens the scaffold
+// templates reference. It is one of the `@civitai/*` packages page-money pins,
+// so its version is whatever that pin currently resolves to.
+const DesignTokenPkg = "@civitai/blocks-react"
+
+// DesignTokenLedgerFile is the checked-in ledger, relative to this package dir.
+const DesignTokenLedgerFile = "testdata/design-tokens.txt"
+
+// DesignTokenRefRe matches a design-system custom-property REFERENCE as it
+// appears in a template — inside `var(--x)`, inside a JS string, or as an object
+// key. Two namespaces are matched:
+//
+//   - `--civitai-*`  the live namespace. Matching the whole namespace (not just
+//     `--civitai-color-*`) is what makes a WHOLESALE upstream rename detectable:
+//     the template keeps spelling the old namespace, the regenerated ledger no
+//     longer contains it, and membership fails.
+//   - `--ci-color-*` the dead namespace this guard was written for. Kept
+//     explicitly so a reintroduction is caught by membership rather than by a
+//     string match, and so it names the token in the failure.
+//
+// Deliberately NOT `--ci-*`: that would match an ordinary CLI long flag
+// (`--ci-mode`) appearing in template prose.
+//
+// The trailing `[a-z0-9]` anchor means an interpolated reference
+// (`var(--civitai-color-${intent})`) yields the truncated stem `--civitai-color`,
+// which is not in the ledger and therefore reds. No template builds a token name
+// dynamically today; if one ever needs to, that is a deliberate decision to make
+// here, not something to discover from a confusing failure.
+//
+// A template DEFINING its own `--civitai-…` property is caught the same way and
+// that is intended: the namespace belongs to the pack, so a template minting a
+// name in it either shadows a real token or invents one the pack will never
+// theme. Overriding an EXISTING token is fine — that name is in the ledger.
+var DesignTokenRefRe = regexp.MustCompile(`--(?:civitai|ci-color)-[a-z0-9-]*[a-z0-9]`)
+
+// designTokenDefColonRe matches a token DEFINITION in the published pack's
+// stylesheet: `--civitai-color-text: #222`, including inside the JS string
+// literal the pack ships the stylesheet as.
+var designTokenDefColonRe = regexp.MustCompile(`(--civitai-[a-z0-9-]*[a-z0-9])\s*:`)
+
+// designTokenDefPropertyRe matches the `@property --civitai-color-text {` form
+// the pack's token block is generated as. Measured on 0.43.1 the `@property`
+// set (24) is a strict SUBSET of the colon set (27, the three non-colour
+// `--civitai-font` / `--civitai-font-mono` / `--civitai-radius` tokens being
+// colon-only), but relying on that containment is a guess about a generator we
+// do not own, so both forms are extracted and unioned.
+var designTokenDefPropertyRe = regexp.MustCompile(`@property\s+(--civitai-[a-z0-9-]*[a-z0-9])`)
+
+// ExtractDesignTokenRefs returns the distinct design-system custom properties
+// referenced in src, sorted. It never returns nil for a hit-free input — an
+// empty slice is a real answer ("this file references none").
+//
+// A GLOB in prose is not a reference. Template comments and READMEs legitimately
+// name the namespace as `--civitai-color-*`, which the regex would otherwise
+// see as the stem `--civitai-color` — a token no pack defines, so the guard
+// would red on its own documentation. (Found by the guard, on the first run,
+// against a comment written in the same change.) Matches trailed by `*` or `-*`
+// are therefore dropped: RE2 has no lookahead, so it is done here.
+func ExtractDesignTokenRefs(src string) []string {
+	counts := countDesignTokenRefs(src)
+	out := make([]string, 0, len(counts))
+	for tok := range counts {
+		out = append(out, tok)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// countDesignTokenRefs returns each referenced token and how many times it
+// occurs. Counting from the MATCH LIST is load-bearing: a naive
+// strings.Count(src, tok) overcounts, because `--civitai-color-text` is a
+// substring of `--civitai-color-text-dimmed`.
+func countDesignTokenRefs(src string) map[string]int {
+	counts := map[string]int{}
+	for _, loc := range DesignTokenRefRe.FindAllStringIndex(src, -1) {
+		if isGlobbedNamespace(src[loc[1]:]) {
+			continue
+		}
+		counts[src[loc[0]:loc[1]]]++
+	}
+	return counts
+}
+
+// isGlobbedNamespace reports whether the text immediately following a match
+// makes it a prose wildcard (`--civitai-color-*`, `--civitai-color*`) rather
+// than a real token reference.
+func isGlobbedNamespace(tail string) bool {
+	return strings.HasPrefix(tail, "*") || strings.HasPrefix(tail, "-*")
+}
+
+// ExtractDesignTokenDefs returns the distinct design-system custom properties
+// DEFINED in src, sorted. src is the raw text of a file shipped in the pack.
+func ExtractDesignTokenDefs(src string) []string {
+	var all []string
+	for _, m := range designTokenDefColonRe.FindAllStringSubmatch(src, -1) {
+		all = append(all, m[1])
+	}
+	for _, m := range designTokenDefPropertyRe.FindAllStringSubmatch(src, -1) {
+		all = append(all, m[1])
+	}
+	return dedupeSorted(all)
+}
+
+func dedupeSorted(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DesignTokenLedger is the parsed testdata/design-tokens.txt: the token set plus
+// the provenance that says which published package version it was derived from.
+type DesignTokenLedger struct {
+	Pkg     string   // e.g. @civitai/blocks-react
+	Pin     string   // the template's caret pin at generation time, e.g. ^0.43.0
+	Version string   // the concrete published version the tokens came from, e.g. 0.43.1
+	Tokens  []string // sorted, deduped
+}
+
+// Has reports whether tok is a member of the ledger.
+func (l *DesignTokenLedger) Has(tok string) bool {
+	for _, t := range l.Tokens {
+		if t == tok {
+			return true
+		}
+	}
+	return false
+}
+
+// ledgerHeaderRe matches a `# key: value` provenance line.
+var ledgerHeaderRe = regexp.MustCompile(`^#\s*(package|pin|version)\s*:\s*(\S+)\s*$`)
+
+// ParseDesignTokenLedger parses the ledger file's bytes.
+//
+// It FAILS CLOSED. A ledger that is missing, empty, all-comments, or missing any
+// provenance field is an error, never an empty-but-usable set — an empty set
+// would make the membership check vacuous and every dead token would pass.
+func ParseDesignTokenLedger(raw []byte) (*DesignTokenLedger, error) {
+	l := &DesignTokenLedger{}
+	sc := bufio.NewScanner(strings.NewReader(string(raw)))
+	var toks []string
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			if m := ledgerHeaderRe.FindStringSubmatch(line); m != nil {
+				switch m[1] {
+				case "package":
+					l.Pkg = m[2]
+				case "pin":
+					l.Pin = m[2]
+				case "version":
+					l.Version = m[2]
+				}
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "--") {
+			return nil, fmt.Errorf("ledger line %q is neither a `# key: value` header nor a `--token`", line)
+		}
+		toks = append(toks, line)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("reading ledger: %w", err)
+	}
+	if l.Pkg == "" || l.Pin == "" || l.Version == "" {
+		return nil, fmt.Errorf(
+			"ledger is missing provenance (package=%q pin=%q version=%q) — it must record which published package the tokens came from, or nobody can tell whether it is stale",
+			l.Pkg, l.Pin, l.Version)
+	}
+	if len(toks) == 0 {
+		return nil, fmt.Errorf("ledger lists ZERO tokens — an empty set makes the membership check vacuous, so this is a hard error, not an empty pass")
+	}
+	l.Tokens = dedupeSorted(toks)
+	return l, nil
+}
+
+// RenderDesignTokenLedger produces the ledger file's bytes for a token set.
+// bump-pins writes this; the header it emits is what ParseDesignTokenLedger
+// reads back, so the two round-trip by construction.
+func RenderDesignTokenLedger(pkg, pin, version string, tokens []string) []byte {
+	var b strings.Builder
+	b.WriteString("# Design tokens DEFINED by the pinned UI pack — the membership ledger for\n")
+	b.WriteString("# internal/scaffold/design_tokens_guard_test.go.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Every `--civitai-*` (and any legacy `--ci-color-*`) custom property referenced\n")
+	b.WriteString("# anywhere under internal/scaffold/templates/ must appear below. A reference to a\n")
+	b.WriteString("# token the pack does not define resolves to nothing at runtime: no error, a\n")
+	b.WriteString("# green build, and an app scaffolded with unset colours.\n")
+	b.WriteString("#\n")
+	b.WriteString("# 🔴 DO NOT HAND-EDIT. Regenerate, which also re-reads the pin:\n")
+	b.WriteString("#     go run ./internal/scaffold/cmd/bump-pins\n")
+	b.WriteString("# The bumper rewrites this file in the SAME run in which it bumps the pack's pin,\n")
+	b.WriteString("# so the pin and this ledger cannot drift apart. `--check` reports without writing.\n")
+	b.WriteString("#\n")
+	b.WriteString("# `pin` is the caret literal in templates/page-money/package.json.tmpl at\n")
+	b.WriteString("# generation time; `version` is the concrete version those tokens were read from.\n")
+	b.WriteString("# The guard fails when `pin` no longer matches the template.\n")
+	b.WriteString("#\n")
+	fmt.Fprintf(&b, "# package: %s\n", pkg)
+	fmt.Fprintf(&b, "# pin: %s\n", pin)
+	fmt.Fprintf(&b, "# version: %s\n", version)
+	b.WriteString("\n")
+	for _, t := range dedupeSorted(tokens) {
+		b.WriteString(t)
+		b.WriteString("\n")
+	}
+	return []byte(b.String())
+}
+
+// npmTarballURL builds the registry tarball URL for a scoped or unscoped package.
+// npm serves `@scope/name` at `/@scope/name/-/name-<version>.tgz` — the basename
+// drops the scope, which is the easy thing to get wrong.
+func npmTarballURL(pkg, version string) string {
+	base := pkg
+	if i := strings.LastIndex(pkg, "/"); i >= 0 {
+		base = pkg[i+1:]
+	}
+	return npmRegistryBase + "/" + pkg + "/-/" + base + "-" + version + ".tgz"
+}
+
+// maxTarballBytes caps what FetchNpmTokens will read from the registry. The
+// 0.43.1 tarball is ~313 KiB unpacked-per-file; 64 MiB is far above any
+// plausible UI pack and far below anything that could exhaust a CI runner.
+const maxTarballBytes = 64 << 20
+
+// FetchNpmTokens downloads the published tarball for pkg@version and returns the
+// design tokens it DEFINES, sorted.
+//
+// It is used by bump-pins to regenerate the ledger. The offline guard never
+// calls it — see this file's header for why the ledger is checked in.
+//
+// An empty result is an ERROR, not an empty set: the pack has defined tokens in
+// every published version, so zero means the extractor stopped matching (most
+// likely because the namespace was renamed again) and the caller must not write
+// an empty ledger on the strength of it.
+func FetchNpmTokens(pkg, version string) ([]string, error) {
+	url := npmTarballURL(pkg, version)
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		return nil, fmt.Errorf("GET %s: %s: %w", url, resp.Status, ErrPkgNotFound)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+
+	gz, err := gzip.NewReader(io.LimitReader(resp.Body, maxTarballBytes))
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: gunzip: %w", url, err)
+	}
+	defer gz.Close()
+
+	var all []string
+	tr := tar.NewReader(gz)
+	files := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("GET %s: tar: %w", url, err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		body, err := io.ReadAll(io.LimitReader(tr, maxTarballBytes))
+		if err != nil {
+			return nil, fmt.Errorf("GET %s: reading %s: %w", url, hdr.Name, err)
+		}
+		files++
+		all = append(all, ExtractDesignTokenDefs(string(body))...)
+	}
+	if files == 0 {
+		return nil, fmt.Errorf("GET %s: tarball contained no regular files", url)
+	}
+	tokens := dedupeSorted(all)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf(
+			"GET %s: read %d file(s) but found NO --civitai-* token definitions — the pack's token namespace was probably renamed again; update designTokenDefColonRe/designTokenDefPropertyRe and DesignTokenRefRe in internal/scaffold/designtokens.go before regenerating",
+			url, files)
+	}
+	return tokens, nil
+}
+
+// TemplateDesignTokenRef is one design-token reference found in a template file:
+// a distinct (file, token) pair, with how many times it occurs in that file.
+type TemplateDesignTokenRef struct {
+	File        string // template-relative path, e.g. templates/page-money/src/App.tsx.tmpl
+	Token       string
+	Occurrences int
+}
+
+// DesignTokenScan is the result of walking a template tree, carrying the counts
+// a caller needs to assert a POSITIVE CONTROL. This scanner's reassuring answer
+// is an empty finding list — exactly what a scanner pointed at an empty tree
+// also produces — so the counts are part of the result, not a debug aside.
+type DesignTokenScan struct {
+	Refs        []TemplateDesignTokenRef // distinct (file, token) pairs
+	FilesRead   int                      // every file walked
+	FilesWith   int                      // files holding at least one reference
+	Occurrences int                      // total textual occurrences
+}
+
+// ScanDesignTokenRefs walks fsys from root and returns every distinct
+// (file, token) design-token reference plus the scan's coverage counts.
+func ScanDesignTokenRefs(fsys fs.FS, root string) (DesignTokenScan, error) {
+	var s DesignTokenScan
+	err := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		raw, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return err
+		}
+		s.FilesRead++
+		counts := countDesignTokenRefs(string(raw))
+		if len(counts) > 0 {
+			s.FilesWith++
+		}
+		toks := make([]string, 0, len(counts))
+		for tok := range counts {
+			toks = append(toks, tok)
+		}
+		sort.Strings(toks)
+		for _, tok := range toks {
+			s.Occurrences += counts[tok]
+			s.Refs = append(s.Refs, TemplateDesignTokenRef{File: p, Token: tok, Occurrences: counts[tok]})
+		}
+		return nil
+	})
+	if err != nil {
+		return DesignTokenScan{FilesRead: s.FilesRead}, err
+	}
+	return s, nil
+}

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -864,8 +864,8 @@ const shell: React.CSSProperties = {
   alignItems: 'flex-start',
   padding: 24,
   boxSizing: 'border-box',
-  background: 'var(--ci-color-surface-2)',
-  color: 'var(--ci-color-text)',
+  background: 'var(--civitai-color-surface-2)',
+  color: 'var(--civitai-color-text)',
 };
 
 const cardStyle: React.CSSProperties = { width: '100%', maxWidth: 640 };
@@ -878,7 +878,7 @@ const fieldStyle: React.CSSProperties = { display: 'grid', gap: 4 };
 const fieldLabelStyle: React.CSSProperties = { fontSize: 14, fontWeight: 600 };
 const fieldDescStyle: React.CSSProperties = {
   fontSize: 12,
-  color: 'var(--ci-color-text-muted, var(--ci-color-text))',
+  color: 'var(--civitai-color-text-dimmed, var(--civitai-color-text))',
   opacity: 0.8,
 };
 const currentModelStyle: React.CSSProperties = {
@@ -886,9 +886,9 @@ const currentModelStyle: React.CSSProperties = {
   minWidth: 0,
   padding: '10px 12px',
   borderRadius: 8,
-  border: '1px solid var(--ci-color-border)',
-  background: 'var(--ci-color-surface)',
-  color: 'var(--ci-color-text)',
+  border: '1px solid var(--civitai-color-border)',
+  background: 'var(--civitai-color-surface)',
+  color: 'var(--civitai-color-text)',
   fontSize: 14,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
@@ -907,9 +907,9 @@ function pickerBtnStyle(selected: boolean, disabled: boolean): React.CSSProperti
   return {
     padding: '6px 14px',
     borderRadius: 999,
-    border: '1px solid ' + (selected ? 'var(--ci-color-primary)' : 'var(--ci-color-border)'),
-    background: selected ? 'var(--ci-color-primary)' : 'var(--ci-color-surface)',
-    color: selected ? 'var(--ci-color-primary-contrast, #fff)' : 'var(--ci-color-text)',
+    border: '1px solid ' + (selected ? 'var(--civitai-color-primary)' : 'var(--civitai-color-border)'),
+    background: selected ? 'var(--civitai-color-primary)' : 'var(--civitai-color-surface)',
+    color: selected ? 'var(--civitai-color-primary-fg, #fff)' : 'var(--civitai-color-text)',
     fontSize: 13,
     fontWeight: 600,
     cursor: disabled ? 'not-allowed' : 'pointer',
@@ -925,8 +925,8 @@ const loraRowStyle: React.CSSProperties = {
   gap: 6,
   padding: '8px 10px',
   borderRadius: 8,
-  border: '1px solid var(--ci-color-border)',
-  background: 'var(--ci-color-surface)',
+  border: '1px solid var(--civitai-color-border)',
+  background: 'var(--civitai-color-surface)',
 };
 const loraRowHeadStyle: React.CSSProperties = {
   display: 'flex',
@@ -943,7 +943,7 @@ const loraNameStyle: React.CSSProperties = {
 };
 const loraWeightRowStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
 const loraWeightLabelStyle: React.CSSProperties = { fontSize: 12, opacity: 0.8, minWidth: 44 };
-const loraRangeStyle: React.CSSProperties = { flex: 1, accentColor: 'var(--ci-color-primary)' };
+const loraRangeStyle: React.CSSProperties = { flex: 1, accentColor: 'var(--civitai-color-primary)' };
 const loraWeightValueStyle: React.CSSProperties = {
   fontSize: 12,
   fontVariantNumeric: 'tabular-nums',

--- a/internal/scaffold/templates/page-money/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-money/src/index.css.tmpl
@@ -21,9 +21,12 @@ body {
 
 /* Focus affordance for any raw textarea/button (the W6 /ui pack styles its own
    controls). Use the pack's brand accent so the outline matches, not a clashing
-   gold; --ci-color-primary is defined by the pack's injected stylesheet. */
+   gold; --civitai-color-primary is defined by the stylesheet
+   @civitai/blocks-react/ui injects. Every --civitai-color-* token referenced
+   anywhere under templates/ is checked against that pack's published token set
+   by internal/scaffold/design_tokens_guard_test.go — see its testdata ledger. */
 textarea:focus-visible,
 button:focus-visible {
-  outline: 2px solid var(--ci-color-primary);
+  outline: 2px solid var(--civitai-color-primary);
   outline-offset: 2px;
 }

--- a/internal/scaffold/templates/page-money/src/main.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/main.tsx.tmpl
@@ -592,22 +592,22 @@ const liveScreenStyle: CSSProperties = {
   alignItems: 'flex-start',
   padding: 24,
   boxSizing: 'border-box',
-  background: 'var(--ci-color-surface-2)',
-  color: 'var(--ci-color-text)',
+  background: 'var(--civitai-color-surface-2)',
+  color: 'var(--civitai-color-text)',
 };
 const liveCardStyle: CSSProperties = { width: '100%', maxWidth: 640 };
 const liveCardTitleStyle: CSSProperties = { fontSize: 20 };
 const stepLabelStyle: CSSProperties = { lineHeight: 1.5 };
-const linkStyle: CSSProperties = { color: 'var(--ci-color-primary)', fontWeight: 600 };
-const setupDoneStyle: CSSProperties = { color: 'var(--ci-color-success, #2f9e44)', fontWeight: 600 };
+const linkStyle: CSSProperties = { color: 'var(--civitai-color-primary)', fontWeight: 600 };
+const setupDoneStyle: CSSProperties = { color: 'var(--civitai-color-success, #2f9e44)', fontWeight: 600 };
 // The manual fallback is a quiet disclosure beneath the one-click path.
 const manualDetailsStyle: CSSProperties = {
-  borderTop: '1px solid var(--ci-color-border)',
+  borderTop: '1px solid var(--civitai-color-border)',
   paddingTop: 12,
 };
 const manualSummaryStyle: CSSProperties = {
   cursor: 'pointer',
-  color: 'var(--ci-color-text-muted, #868e96)',
+  color: 'var(--civitai-color-text-dimmed, #868e96)',
   fontSize: 13,
   userSelect: 'none',
 };
@@ -616,10 +616,10 @@ const cmdStyle: CSSProperties = {
   flex: 1,
   margin: 0,
   padding: '10px 12px',
-  background: 'var(--ci-color-surface)',
-  border: '1px solid var(--ci-color-border)',
+  background: 'var(--civitai-color-surface)',
+  border: '1px solid var(--civitai-color-border)',
   borderRadius: 6,
-  color: 'var(--ci-color-text)',
+  color: 'var(--civitai-color-text)',
   fontFamily: 'ui-monospace, SFMono-Regular, monospace',
   fontSize: 13,
   whiteSpace: 'pre-wrap',

--- a/internal/scaffold/testdata/design-tokens.txt
+++ b/internal/scaffold/testdata/design-tokens.txt
@@ -1,0 +1,48 @@
+# Design tokens DEFINED by the pinned UI pack — the membership ledger for
+# internal/scaffold/design_tokens_guard_test.go.
+#
+# Every `--civitai-*` (and any legacy `--ci-color-*`) custom property referenced
+# anywhere under internal/scaffold/templates/ must appear below. A reference to a
+# token the pack does not define resolves to nothing at runtime: no error, a
+# green build, and an app scaffolded with unset colours.
+#
+# 🔴 DO NOT HAND-EDIT. Regenerate, which also re-reads the pin:
+#     go run ./internal/scaffold/cmd/bump-pins
+# The bumper rewrites this file in the SAME run in which it bumps the pack's pin,
+# so the pin and this ledger cannot drift apart. `--check` reports without writing.
+#
+# `pin` is the caret literal in templates/page-money/package.json.tmpl at
+# generation time; `version` is the concrete version those tokens were read from.
+# The guard fails when `pin` no longer matches the template.
+#
+# package: @civitai/blocks-react
+# pin: ^0.43.0
+# version: 0.43.1
+
+--civitai-color-body
+--civitai-color-border
+--civitai-color-error
+--civitai-color-gray-0
+--civitai-color-gray-1
+--civitai-color-gray-2
+--civitai-color-gray-3
+--civitai-color-gray-4
+--civitai-color-gray-5
+--civitai-color-gray-6
+--civitai-color-gray-7
+--civitai-color-gray-8
+--civitai-color-gray-9
+--civitai-color-info
+--civitai-color-primary
+--civitai-color-primary-fg
+--civitai-color-primary-hover
+--civitai-color-primary-light
+--civitai-color-success
+--civitai-color-surface
+--civitai-color-surface-2
+--civitai-color-text
+--civitai-color-text-dimmed
+--civitai-color-warning
+--civitai-font
+--civitai-font-mono
+--civitai-radius

--- a/internal/scaffold/testdata/design-tokens.txt
+++ b/internal/scaffold/testdata/design-tokens.txt
@@ -16,8 +16,8 @@
 # The guard fails when `pin` no longer matches the template.
 #
 # package: @civitai/blocks-react
-# pin: ^0.43.0
-# version: 0.43.1
+# pin: ^0.44.0
+# version: 0.44.2
 
 --civitai-color-body
 --civitai-color-border


### PR DESCRIPTION
## The defect

`page-money` is the **default** template for `civitai app create`. Every app scaffolded from it since the UI pack's token rename has shipped an unset shell background, unset text colour and an invalid focus outline.

`@civitai/blocks-react` renamed its custom-property namespace `--ci-color-*` → `--civitai-color-*`, and for **two** names also changed the *suffix*:

| dead token | occurrences | correct replacement |
|---|---|---|
| `--ci-color-text` | 6 | `--civitai-color-text` |
| `--ci-color-primary` | 6 | `--civitai-color-primary` |
| `--ci-color-border` | 5 | `--civitai-color-border` |
| `--ci-color-surface` | 4 | `--civitai-color-surface` |
| `--ci-color-text-muted` | 2 | `--civitai-color-text-dimmed` ← **suffix changed** |
| `--ci-color-surface-2` | 2 | `--civitai-color-surface-2` |
| `--ci-color-success` | 1 | `--civitai-color-success` |
| `--ci-color-primary-contrast` | 1 | `--civitai-color-primary-fg` ← **suffix changed** |

A blanket `s/--ci-color-/--civitai-color-/` would have left 3 of the 27 still dead.

**Nothing went red.** An undefined CSS custom property resolves to nothing, so the declaration is dropped: no error, green `npm run build`, and the `template-page-money` CI job (install → typecheck → build) green too. The pack's own `dist/ui/Badge.js` still carries a comment recording the rename.

Fixed, preserving intent at each site — the two muted-text sites take `text-dimmed`, the on-primary foreground site takes `primary-fg`. Literal fallbacks are untouched (`#868e96` in `main.tsx.tmpl` is in fact byte-equal to the pack's `--civitai-color-text-dimmed` initial value).

| file | before | after |
|---|---|---|
| `src/App.tsx.tmpl` | 16 | 0 |
| `src/main.tsx.tmpl` | 9 | 0 |
| `src/index.css.tmpl` | 2 | 0 |

`index.css.tmpl`'s comment — which asserted the dead token was defined by the pack — is corrected too. `page-vite` and `static` were clean; the defect was confined to `page-money`.

## The guard

A grep for the literal `--ci-color-` would pin a **word**: it passes the moment the dead spelling is gone and says nothing about whether the new one is *right*, so the next rename — the actual recurring hazard — walks straight past it.

This guard pins the **relationship**: every `--civitai-*` (and any legacy `--ci-color-*`) property referenced anywhere under `templates/**` must be a **member** of the set the pinned pack **defines**. A token dropped or re-spelled upstream stops being a member, so the class is caught however it is spelled — including a wholesale namespace rename, since the template keeps spelling the old namespace and the regenerated ledger no longer contains it.

- **`internal/scaffold/designtokens.go`** — production extractor + the npm token read, shared by the guard and the bumper. Same idiom as `pins.go`: two consumers that must agree by construction, so the logic is not in a `_test.go`.
- **`internal/scaffold/testdata/design-tokens.txt`** — the checked-in ledger. 27 tokens (24 colour + `--civitai-font`, `--civitai-font-mono`, `--civitai-radius`), with a provenance header recording package / pin / version. CI cannot reach npm reliably, so the guard never fetches. **Fails closed**: missing, empty, or provenance-less is a hard error, never an empty-but-usable set — an empty set would make the membership check vacuous.
- **`internal/scaffold/design_tokens_guard_test.go`** — the guard, plus its own instrument validation.

### Pin ⇄ ledger drift

`bump-pins` now owns the ledger as a **fourth site** and regenerates it in the same run in which it bumps the pack's pin, so the two cannot drift. If the token read fails, that package's pin bump is **skipped too** rather than written alone — a half-applied bump *is* the drift state, and there is a test asserting the pin is left untouched in that case. It rewrites only when the pin moved or the token set changed, so a patch release that changes neither produces no PR churn. `TestDesignTokenLedgerMatchesTemplatePin` is the loud channel if they ever do drift.

Verified end-to-end against the live registry: `bump-pins --dir <scratch>` bumps `^0.43.0 → ^0.44.0` **and** regenerates the ledger to `^0.44.0@0.44.2`, and a second run is a clean no-op.

## Evidence

**Red → green.** Restoring `origin/main`'s templates into the branch (`git checkout origin/main -- .../page-money/`) and re-running:

```
--- FAIL: TestScaffoldTemplatesOnlyUseDefinedDesignTokens
    scanned 53 template file(s); 3 file(s) reference design tokens;
    15 distinct (file,token) pair(s), 27 total occurrence(s)
    DEAD DESIGN TOKEN — this reference resolves to NOTHING at runtime, silently.
      file:  templates/page-money/src/App.tsx.tmpl
      token: --ci-color-text  ×4   (not defined by @civitai/blocks-react@0.43.1)
    … 15 findings covering all 27 occurrences
```

At HEAD: `--- PASS`, same 27-occurrence positive-control line.

**Mutation-tested four ways.** Each killed **exactly one** test, with *this* guard's own message — not a bystander's:

| mutation | result |
|---|---|
| reintroduce `--civitai-color-text-muted` at one site | `DEAD DESIGN TOKEN … --civitai-color-text-muted ×1`; 1 of 2407 tests fails |
| ledger records `^0.44.0`, template pins `^0.43.0` | `DESIGN-TOKEN LEDGER IS STALE` from `TestDesignTokenLedgerMatchesTemplatePin` |
| ledger emptied / deleted | fails closed — `ledger lists ZERO tokens` / `cannot read … hard failure, not a skip` |
| drop `--civitai-color-text-dimmed` from the ledger (the *next rename* simulation) | `DEAD DESIGN TOKEN … --civitai-color-text-dimmed` |

**Reachability:** under the first mutation the positive-control log line prints *before* the finding, and `TestDesignTokenLedgerMatchesTemplatePin` / `…Namespace` both still PASS — so no earlier check short-circuits the membership loop.

**Positive control on the scanner:** 53 template files read, 3 contain tokens, 15 distinct (file, token) pairs, **27 total occurrences** — independently reproducing a GNU-grep count of the same tree. Floors on files-read and occurrences fail the test if the scan ever silently covers nothing.

**Full suite:** 21 packages `ok`, 0 `FAIL`, 1 `[no test files]`; **2407 top-level tests pass** (5049 including subtests), 0 fail, 4 skips — all four pre-existing network-gated guards. `gofmt -s -l .` clean over 442 `.go` files; `go vet ./...` clean; `golangci-lint run ./...` → `0 issues.` (negative-control checked: it goes red on a deliberately broken file).

## 🔴 Interaction with #512

**No file conflict** — #512 touches `package.json.tmpl`, `README.md.tmpl` and `scaffold_test.go`; this PR touches `src/*.tmpl` and new files. But there is a **semantic** one, and it is this guard doing its job:

#512 bumps `@civitai/blocks-react` `^0.43.0 → ^0.44.0` **without** regenerating the ledger (it predates it), so whichever lands second goes red on `TestDesignTokenLedgerMatchesTemplatePin`.

The fix is one command — `go run ./internal/scaffold/cmd/bump-pins` — and after this PR merges, the daily `bump-scaffold-pins` bot produces it automatically. Suggested order: **merge this, then let the bot supersede #512** (or re-run the bumper on that branch).

For what it's worth the bump is safe: the defined token set is byte-identical across `0.43.0`, `0.43.1`, `0.44.0`, `0.44.1` and `0.44.2`, so only the ledger's provenance header actually moves.

## Notes / deviations from the brief

- **27 ledger tokens, not 24.** The brief scoped the ledger to `--civitai-color-*`. The pack also defines `--civitai-font`, `--civitai-font-mono` and `--civitai-radius`, and the reference regex matches the whole `--civitai-*` namespace (deliberately — that is what makes a wholesale rename detectable). Ledgering only the 24 would false-red the first legitimate `var(--civitai-radius)`.
- **The `index.css.tmpl` comment was wrong only in the token it named**, so the mechanical rename already corrected the assertion. I extended it to name the injecting package and point at the guard.
- **The guard found a false-positive class on its first run** — prose naming the namespace as `--civitai-color-*` extracted as the stem `--civitai-color`, which reds. It flagged the comment written in this same change. Fixed in the extractor (glob-trailed matches are dropped) rather than by rewording, with test cases both ways.
- **A network freshness check is not included.** Re-deriving the ledger from npm at test time would need a new CI job, and AGENTS.md puts `.github/workflows/*` behind ask-first. The residual is documented in the guard's header: within one caret range a patch could *add* a token (false red, one regeneration fixes it) or *remove* one (false pass). Say the word and I will add the job.
- **No AGENTS.md item added.** The rationale lives in the code's doc comments; the sibling `pins`/`antipattern` guards have no item of their own either, and AGENTS.md is under a byte ceiling. Easy to add if you would rather it be a trigger.
