### PR TITLE
fix(scaffold): bump @civitai/* pins, and repair the disallowed-pool path they break

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -150,8 +150,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.43.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.35.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.44.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.36.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -372,7 +372,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.35.0` + `@civitai/blocks-react@^0.43.0` (already pinned in
+`@civitai/app-sdk@^0.36.0` + `@civitai/blocks-react@^0.44.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.35.0",
-    "@civitai/blocks-react": "^0.43.0",
+    "@civitai/app-sdk": "^0.36.0",
+    "@civitai/blocks-react": "^0.44.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -36,6 +36,7 @@ import {
   phaseForSnapshot,
   phaseForSubmitError,
   spentAccountLabel,
+  submitErrorReason,
   isTerminalStatus,
   type AccountChoice,
   type GenPhase,
@@ -352,7 +353,9 @@ export function App() {
     try {
       snap = await submit(body);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'submit failed';
+      // NOT `err.message` — under blocks-react ^0.44 that is a generic template
+      // and the server's reason rides on `.snapshot.error`. See submitErrorReason.
+      const msg = submitErrorReason(err);
       const failPhase = classifyError(msg);
       setPhase(failPhase);
       if (failPhase === 'account-rejected') handleAccountRejected();

--- a/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.test.ts.tmpl
@@ -19,6 +19,7 @@ import {
   phaseForSnapshot,
   phaseForSubmitError,
   spentAccountLabel,
+  submitErrorReason,
 } from './generation.js';
 import { DEFAULT_CHECKPOINT, type LoraOption } from './models.js';
 
@@ -321,6 +322,58 @@ describe('phaseForSnapshot', () => {
     expect(phaseForSnapshot(snap({ status: 'expired', error: 'Insufficient Buzz' }))).toBe(
       'insufficient',
     );
+  });
+});
+
+describe('submitErrorReason', () => {
+  // Faithful to the real shape: blocks-react ^0.44 throws an Error SUBCLASS whose
+  // `.message` is a generic template and whose `.snapshot.error` holds the server
+  // reason. The three strings below are pairwise distinct and none equals the
+  // 'submit failed' fallback, so every assertion can see WHICH source was read.
+  class FakeWorkflowSubmitError extends Error {
+    snapshot: { error?: string };
+    constructor(message: string, snapshotError?: string) {
+      super(message);
+      this.name = 'WorkflowSubmitError';
+      this.snapshot = { error: snapshotError };
+    }
+  }
+
+  const GENERIC = 'submit did not return a usable workflow (exception) — reason on .snapshot.error';
+  const SERVER_REASON = "buzz account 'green' is not spendable for this app's content rating";
+
+  it('prefers .snapshot.error over the generic .message (blocks-react ^0.44)', () => {
+    // THE REGRESSION: reading `.message` here classifies as `failed` and renders a
+    // hard "Generation failed" instead of the friendly switched-back-to-Auto note.
+    expect(submitErrorReason(new FakeWorkflowSubmitError(GENERIC, SERVER_REASON))).toBe(
+      SERVER_REASON,
+    );
+  });
+
+  it('falls back to .message when there is no snapshot (blocks-react ^0.43)', () => {
+    expect(submitErrorReason(new Error(SERVER_REASON))).toBe(SERVER_REASON);
+  });
+
+  it('falls back to .message when .snapshot.error is absent, empty or whitespace', () => {
+    expect(submitErrorReason(new FakeWorkflowSubmitError(GENERIC))).toBe(GENERIC);
+    expect(submitErrorReason(new FakeWorkflowSubmitError(GENERIC, ''))).toBe(GENERIC);
+    expect(submitErrorReason(new FakeWorkflowSubmitError(GENERIC, '   '))).toBe(GENERIC);
+  });
+
+  it('falls back to the caller default for a non-Error throw or an empty message', () => {
+    expect(submitErrorReason('a bare string')).toBe('submit failed');
+    expect(submitErrorReason(null)).toBe('submit failed');
+    expect(submitErrorReason(undefined)).toBe('submit failed');
+    expect(submitErrorReason(new Error(''))).toBe('submit failed');
+    expect(submitErrorReason(new Error(''), 'estimate failed')).toBe('estimate failed');
+  });
+
+  it('end-to-end: a ^0.44 disallowed-pool rejection still classifies as account-rejected', () => {
+    // The behavioural claim the structural one exists to serve. Reading `.message`
+    // would yield 'failed' here — that is the mutation this case kills.
+    const err = new FakeWorkflowSubmitError(GENERIC, SERVER_REASON);
+    expect(phaseForError(submitErrorReason(err))).toBe('account-rejected');
+    expect(phaseForError(GENERIC)).toBe('failed');
   });
 });
 

--- a/internal/scaffold/templates/page-money/src/generation.ts.tmpl
+++ b/internal/scaffold/templates/page-money/src/generation.ts.tmpl
@@ -135,6 +135,35 @@ export function isDisallowedAccountError(message: string | null | undefined): bo
 }
 
 /**
+ * The reason string to CLASSIFY and DISPLAY for a rejected submit.
+ *
+ * `@civitai/blocks-react@^0.44` throws a `WorkflowSubmitError` whose `.message`
+ * is a deliberately GENERIC template — it carries no server text, so a raw
+ * server string never lands on the default-printed surface of code that merely
+ * awaited the promise. The server's actual reason, the one
+ * {@link isDisallowedAccountError} and {@link isInsufficientBuzz} sniff for,
+ * rides on `.snapshot.error` instead. Under `^0.43` the reason was on `.message`
+ * and there was no snapshot.
+ *
+ * So read the snapshot reason FIRST and fall back to `.message`: that classifies
+ * correctly on BOTH sides of the change, and it is what keeps a disallowed-pool
+ * rejection rendering the friendly "switched back to Auto" note rather than a
+ * hard "Generation failed".
+ *
+ * 🔴 STRUCTURAL ON PURPOSE — it keys on WHERE the reason lives, never on the
+ * wording of the generic template. Sniffing for that wording would be a spelled
+ * guard: the next upstream reword would silently restore the misclassification,
+ * which is exactly the defect this replaces.
+ */
+export function submitErrorReason(err: unknown, fallback = 'submit failed'): string {
+  const snapshotError = (err as { snapshot?: { error?: unknown } } | null | undefined)?.snapshot
+    ?.error;
+  if (typeof snapshotError === 'string' && snapshotError.trim() !== '') return snapshotError;
+  if (err instanceof Error && err.message.trim() !== '') return err.message;
+  return fallback;
+}
+
+/**
  * The Comfy on Civitai recipe id this sample sends. MIRRORED from comfy.ts's
  * `STARTER_COMFY_RECIPE` (kept as a literal here to avoid a generation.ts ⇄
  * comfy.ts import cycle) — the enum-rejection sniff below keys on it. If you


### PR DESCRIPTION
Supersedes #512. Close that one when this merges.

## Why this exists

`pins-vs-published` is a **required** status check with `enforce_admins: true`, and it is red on **any** branch off current `main` (main pins `^0.35.0`/`^0.43.0` against npm's published 0.36.0/0.44.2). So the repo's merge path is frozen — #514 is `BLOCKED` and cannot green that check, because it touches no pin file.

#512 bumped the pins alone and went red on `template-page-money`. That red is a **real regression in the scaffolded app**, not a test artifact — so shipping the bump without the fix would hand a broken money path to every app scaffolded afterwards. Hence one commit.

## The regression

`@civitai/blocks-react@^0.44` throws a `WorkflowSubmitError` whose `.message` is now a deliberately generic template:

> `submit did not return a usable workflow (<code>) — reason on .snapshot.error`

so a raw server string never lands on the default-printed surface of code that merely awaited the promise (the change is intentional — the reasoning is in the package's own source comment). The server's actual reason moved to `.snapshot.error`. Under `^0.43` it was on `.message`.

`App.tsx` classified the submit rejection on `err.message`. Against `^0.44` that string matches neither `isDisallowedAccountError` nor `isInsufficientBuzz`, so a **disallowed Buzz pool falls through to `failed`**: the user gets a hard "Generation failed" alert carrying SDK-internal text instead of the friendly "Buzz account not available" note and the reset to Auto.

Note this is *not* the package the earlier diagnosis suspected — it is `blocks-react` 0.44, not an `app-sdk` 0.35→0.36 change.

## The fix

A new `submitErrorReason(err, fallback?)` in `generation.ts`: read `.snapshot.error` first, fall back to `.message`. Correct on **both** sides of the change, so it does not become the next pin bump's problem.

**Structural on purpose.** Sniffing for the generic template's wording would be a spelled guard, and the next upstream reword would silently restore the misclassification — which is exactly how this defect arrived. Keying on *where* the reason lives cannot be walked by a reword.

## Verification

Ran the `template-page-money` CI job locally at the versions the carets actually resolve to (**app-sdk 0.36.0 / blocks-react 0.44.2**):

| | result |
|---|---|
| scaffold → install → typecheck → test → build → `app validate` | all clean |
| test suite with the fix | **11/11 files, 153/153 tests** |
| pre-fix state, reproduced first | **1 failed \| 147 passed** — `Unable to find an element by: [data-testid="pm-account-rejected"]` |
| full Go suite | **21 ok / 0 FAIL / 1 no-test** (counted from result lines, not an exit code) |
| `go build ./...`, `go vet ./...` | clean |

**Red→green watched, not assumed.** Reverting `submitErrorReason` to the old `.message`-only read kills exactly **3** tests, each with its own message:

- snapshot-preference unit case — got the generic template back
- end-to-end classification case — `expected 'failed' to be 'account-rejected'`
- the original e2e case — no friendly note in the DOM

Restoring returns 153/153. The three *fallback* unit cases correctly **survive** that mutant; they pin the `^0.43` path, which it does not change.

**Negative control:** reverting the pin alone turns `TestRenderPageMoney` red, so the lockstep assertion in `scaffold_test.go` is load-bearing rather than decorative.

## After this merges

1. Close #512 as superseded.
2. Rebase #514 onto the new `main` and regenerate its token ledger — `go run ./internal/scaffold/cmd/bump-pins`. The `--civitai-*` token set is byte-identical across 0.43.1 → 0.44.2 (27 vs 27), so only the ledger's provenance header moves.
