### PR TITLE
feat(scaffold): adopt manifest.bootSkeleton across all three templates

### DIFF
--- a/internal/scaffold/bootskeleton.go
+++ b/internal/scaffold/bootskeleton.go
@@ -1,0 +1,251 @@
+package scaffold
+
+// The `bootSkeleton-not-empty` gate, implemented over a real HTML parse.
+//
+// WHY THIS EXISTS AS CODE RATHER THAN A CONVENTION. `bootSkeleton: true` in a
+// block manifest tells the Civitai run host to stand down THREE things at once:
+// the opaque branded veil, the iframe's `opacity: 0 → 1` reveal, and the
+// `translateY(8px)` settle. The iframe is therefore opaque and unveiled from
+// mount, and whatever the block's entry document paints IS the loading state.
+// Declare the flag over an EMPTY mount container and the viewer gets a blank
+// iframe for the entire load — strictly worse than never opting in.
+//
+// So the manifest key and the markup are ONE change with two halves, and the
+// hazard is that a future template (or a future edit to an existing one) ships
+// one half. That is what this function is for: `TestEveryScaffoldTemplate
+// PassesTheBootSkeletonGate` runs it over every template's real rendered output,
+// so a template declaring the key without painting anything fails the build
+// rather than shipping to an author.
+//
+// The rules below are the platform's `bootSkeleton-not-empty` gate verbatim, so
+// the CLI's verdict and the platform's cannot drift by construction. The gate
+// keys on EMPTINESS — the actual hazard — and treats `data-boot-skeleton` as the
+// affordance that makes the non-empty case unambiguous, plus one placement rule
+// (a marker outside the container is never replaced by the app's own render, so
+// it stays on screen after mount).
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// BootSkeletonMarkerAttr is the marker attribute a boot skeleton's outermost
+// element carries.
+//
+// An ATTRIBUTE and not a class, deliberately: a class name is fair game for
+// CSS-modules hashing or a purge pass, while an attribute survives the bundler
+// and is deterministically greppable out of the BUILT html.
+const BootSkeletonMarkerAttr = "data-boot-skeleton"
+
+// bootSkeletonContainerIDs are the mount-container ids the gate recognises,
+// alongside the `data-app-root` attribute. Matches the platform gate's
+// `#root, #app, [data-app-root]`.
+var bootSkeletonContainerIDs = map[string]bool{"root": true, "app": true}
+
+// bootSkeletonInertTags are the tags that cannot satisfy the non-emptiness rule.
+//
+// 🔴 THEIR SUBTREES ARE SKIPPED WHOLESALE, not just the elements themselves, and
+// that reading is forced by the contract's own worked case rather than chosen.
+// The rule is "at least one descendant element whose tag is not one of these, OR
+// at least one non-whitespace text node" — and a `#root` holding only a
+// `<script>` MUST fail it. A `<script>` almost always contains a non-whitespace
+// TEXT node (its source), so counting text found anywhere in the subtree would
+// pass that case and make the gate vacuous for the one shape it most needs to
+// catch. The same argument covers `<template>`, whose children parse as real
+// element nodes here yet paint nothing.
+var bootSkeletonInertTags = map[string]bool{
+	"script":   true,
+	"template": true,
+	"style":    true,
+	"link":     true,
+	"noscript": true,
+}
+
+// ErrBootSkeletonEmptyContainer and ErrBootSkeletonMarkerOutsideContainer let a
+// caller (and the table test) distinguish the two failure modes without matching
+// on message text.
+var (
+	// ErrBootSkeletonEmptyContainer is returned when the manifest declares
+	// bootSkeleton over a mount container that paints nothing.
+	ErrBootSkeletonEmptyContainer = errors.New("bootSkeleton declared over an empty mount container")
+	// ErrBootSkeletonMarkerOutsideContainer is returned when a
+	// [data-boot-skeleton] element exists but sits outside every mount
+	// container, where the app's own render can never replace it.
+	ErrBootSkeletonMarkerOutsideContainer = errors.New("[data-boot-skeleton] is outside the mount container")
+)
+
+// BootSkeletonGateOK applies the platform's blocking `bootSkeleton-not-empty`
+// gate to one app: `manifestJSON` is the block manifest, `htmlDoc` is the entry
+// document the platform would serve (the BUILT `<outputDir>/index.html`, or the
+// shipped `index.html` for a no-build app).
+//
+// It returns nil when the gate passes and a wrapped
+// ErrBootSkeletonEmptyContainer / ErrBootSkeletonMarkerOutsideContainer
+// carrying the platform's own message when it does not.
+//
+// PASSES VACUOUSLY, on purpose, in two cases the platform also passes:
+//   - the manifest does not set `bootSkeleton: true` (the gate does not apply);
+//   - the document has no recognisable mount container (`#root`, `#app`,
+//     `[data-app-root]`), so there is no empty-container hazard to detect and
+//     the gate does not guess.
+//
+// Callers that need a non-vacuous answer should assert a container exists
+// separately — see `TestReactTemplatesPaintABootSkeletonInsideTheMountContainer`,
+// which pins the container AND the marker's placement rather than relying on
+// this returning nil.
+func BootSkeletonGateOK(manifestJSON, htmlDoc []byte) error {
+	declared, err := bootSkeletonDeclared(manifestJSON)
+	if err != nil {
+		return err
+	}
+	if !declared {
+		return nil
+	}
+
+	doc, err := html.Parse(strings.NewReader(string(htmlDoc)))
+	if err != nil {
+		return fmt.Errorf("parse entry document: %w", err)
+	}
+
+	containers := findBootSkeletonContainers(doc)
+	if len(containers) == 0 {
+		// Rule 2 — nothing identifiable to mount into, so nothing to claim.
+		return nil
+	}
+
+	// Rule 3 — every container must paint something.
+	for _, c := range containers {
+		if !bootSkeletonContainerPaints(c) {
+			return fmt.Errorf(
+				"%w: manifest declares bootSkeleton: true but %s is empty in the built index.html — "+
+					"the run host stands down its loading veil for this app, so the viewer would see a blank "+
+					"iframe for the whole load. Either paint a boot state inside the container, or remove "+
+					"bootSkeleton from the manifest",
+				ErrBootSkeletonEmptyContainer, bootSkeletonContainerLabel(c))
+		}
+	}
+
+	// Rule 4 — a marker outside every container is never replaced on mount.
+	for _, m := range findAllWithAttr(doc, BootSkeletonMarkerAttr) {
+		inside := false
+		for _, c := range containers {
+			if isDescendantOf(m, c) {
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			return fmt.Errorf(
+				"%w: the [data-boot-skeleton] element is outside the mount container, so the app's own "+
+					"render will not replace it and it will stay on screen after mount",
+				ErrBootSkeletonMarkerOutsideContainer)
+		}
+	}
+
+	return nil
+}
+
+// bootSkeletonDeclared reports whether the manifest sets `bootSkeleton` to the
+// boolean true. Any other value — absent, false, or a non-boolean — is "not
+// declared"; the gate is about the opt-in, not about type-checking the manifest
+// (the JSON-Schema validator owns that).
+func bootSkeletonDeclared(manifestJSON []byte) (bool, error) {
+	var m map[string]any
+	if err := json.Unmarshal(manifestJSON, &m); err != nil {
+		return false, fmt.Errorf("parse block manifest: %w", err)
+	}
+	b, ok := m["bootSkeleton"].(bool)
+	return ok && b, nil
+}
+
+// findBootSkeletonContainers returns every element matching
+// `#root, #app, [data-app-root]`, in document order.
+func findBootSkeletonContainers(root *html.Node) []*html.Node {
+	var out []*html.Node
+	walkElements(root, func(n *html.Node) {
+		for _, a := range n.Attr {
+			if a.Key == "id" && bootSkeletonContainerIDs[a.Val] {
+				out = append(out, n)
+				return
+			}
+			if a.Key == "data-app-root" {
+				out = append(out, n)
+				return
+			}
+		}
+	})
+	return out
+}
+
+// bootSkeletonContainerPaints implements rule 3 for one container. See
+// bootSkeletonInertTags for why inert subtrees are skipped wholesale.
+// DEPTH IS NOT SCANNED, and that is a consequence rather than a shortcut: a
+// non-inert element at ANY depth necessarily has a non-inert ANCESTOR chain up
+// to the container (an inert tag's subtree is skipped wholesale, and the only
+// way to reach depth 2 is through a depth-1 element), so the direct children
+// decide the answer. Text is likewise only counted where it can paint —
+// directly in the container, never inside an inert element.
+func bootSkeletonContainerPaints(container *html.Node) bool {
+	for c := container.FirstChild; c != nil; c = c.NextSibling {
+		switch c.Type {
+		case html.ElementNode:
+			if !bootSkeletonInertTags[strings.ToLower(c.Data)] {
+				return true
+			}
+		case html.TextNode:
+			if strings.TrimSpace(c.Data) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bootSkeletonContainerLabel renders a container the way the platform's message
+// names it: `#root` for an id, `[data-app-root]` for the attribute form.
+func bootSkeletonContainerLabel(n *html.Node) string {
+	for _, a := range n.Attr {
+		if a.Key == "id" && bootSkeletonContainerIDs[a.Val] {
+			return "#" + a.Val
+		}
+	}
+	return "[data-app-root]"
+}
+
+// findAllWithAttr returns every element carrying the named attribute.
+func findAllWithAttr(root *html.Node, attr string) []*html.Node {
+	var out []*html.Node
+	walkElements(root, func(n *html.Node) {
+		for _, a := range n.Attr {
+			if a.Key == attr {
+				out = append(out, n)
+				return
+			}
+		}
+	})
+	return out
+}
+
+// isDescendantOf reports whether n is a strict descendant of anc.
+func isDescendantOf(n, anc *html.Node) bool {
+	for p := n.Parent; p != nil; p = p.Parent {
+		if p == anc {
+			return true
+		}
+	}
+	return false
+}
+
+// walkElements calls fn for every element node under root, in document order.
+func walkElements(root *html.Node, fn func(*html.Node)) {
+	if root.Type == html.ElementNode {
+		fn(root)
+	}
+	for c := root.FirstChild; c != nil; c = c.NextSibling {
+		walkElements(c, fn)
+	}
+}

--- a/internal/scaffold/bootskeleton_test.go
+++ b/internal/scaffold/bootskeleton_test.go
@@ -1,0 +1,511 @@
+package scaffold
+
+// Guards for the `manifest.bootSkeleton` opt-in.
+//
+// THE WHOLE HAZARD IS THAT THE TWO HALVES SEPARATE. `bootSkeleton: true` makes
+// the Civitai run host stand down its loading veil, so the block's own entry
+// document becomes the loading state. The manifest key and the markup inside the
+// mount container are therefore ONE change, and shipping either half alone is a
+// regression the other half's absence makes invisible:
+//
+//   - key without markup  -> a BLANK iframe for the entire load, worse than not
+//     opting in, and nothing about the app looks broken to the author;
+//   - markup without key  -> harmless but pointless (the veil still covers it).
+//
+// So these tests do not just assert "the templates contain the right strings".
+// TestEveryScaffoldTemplatePassesTheBootSkeletonGate runs the real platform gate
+// (BootSkeletonGateOK) over every template's rendered output, which is what
+// makes a FUTURE template that declares the key without painting anything fail
+// the build.
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// renderTemplate renders one template into a fresh temp dir and returns it.
+func renderTemplate(t *testing.T, tmpl Template) string {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), string(tmpl))
+	if _, err := Render(tmpl, dest, Data{Slug: "boot-block", Name: "Boot Block"}); err != nil {
+		t.Fatalf("render %s: %v", tmpl, err)
+	}
+	return dest
+}
+
+// readRendered reads one file out of a rendered template tree.
+func readRendered(t *testing.T, dest, rel string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return b
+}
+
+// reactTemplates are the templates that mount a React root and therefore ship
+// skeleton MARKUP. `static` deliberately does not — see
+// TestStaticTemplateDeclaresBootSkeletonWithoutSkeletonMarkup.
+var reactTemplates = []Template{PageVite, PageMoney}
+
+// TestEveryScaffoldTemplateDeclaresBootSkeleton pins the manifest half for all
+// three templates, by PARSING the manifest rather than grepping it — a grep for
+// `"bootSkeleton": true` passes on the string appearing in a comment or in prose
+// and says nothing about the value the platform will read.
+func TestEveryScaffoldTemplateDeclaresBootSkeleton(t *testing.T) {
+	examined := 0
+	for _, tmpl := range AllTemplates() {
+		examined++
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := renderTemplate(t, tmpl)
+			var m map[string]any
+			if err := json.Unmarshal(readRendered(t, dest, "block.manifest.json"), &m); err != nil {
+				t.Fatalf("manifest is not valid JSON: %v", err)
+			}
+			v, present := m["bootSkeleton"]
+			if !present {
+				t.Fatalf("template %q renders a manifest with no `bootSkeleton` key.\n"+
+					"  Every scaffold template opts in: a static app's real content is already on\n"+
+					"  screen at first paint, and the two React templates paint a skeleton inside\n"+
+					"  #root. Without the key the host keeps its veil and that work is invisible.", tmpl)
+			}
+			b, ok := v.(bool)
+			if !ok || !b {
+				t.Fatalf("template %q renders `bootSkeleton: %#v`, want the boolean true", tmpl, v)
+			}
+		})
+	}
+	// COUNT POSITIVE CONTROL. The reassuring answer here is "every subtest
+	// passed", which is also what an empty AllTemplates() produces.
+	if examined < len(AllTemplates()) || examined < 3 {
+		t.Fatalf("examined only %d template(s), expected at least 3 — the enumeration stopped OBSERVING", examined)
+	}
+}
+
+// TestReactTemplatesPaintABootSkeletonInsideTheMountContainer pins the markup
+// half for the two React templates, and pins it POSITIONALLY: the marker must be
+// a DESCENDANT of #root, because a skeleton painted as a sibling of the mount
+// container is never replaced by the app's render and stays on screen forever.
+//
+// This is the non-vacuous companion to the gate test below — the gate passes
+// when a document has no container at all, this one fails.
+func TestReactTemplatesPaintABootSkeletonInsideTheMountContainer(t *testing.T) {
+	examined := 0
+	for _, tmpl := range reactTemplates {
+		examined++
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := renderTemplate(t, tmpl)
+			doc, err := html.Parse(strings.NewReader(string(readRendered(t, dest, "index.html"))))
+			if err != nil {
+				t.Fatalf("parse index.html: %v", err)
+			}
+
+			containers := findBootSkeletonContainers(doc)
+			if len(containers) == 0 {
+				t.Fatalf("template %q renders an index.html with no #root / #app / [data-app-root] "+
+					"mount container — the gate would pass VACUOUSLY on it", tmpl)
+			}
+
+			markers := findAllWithAttr(doc, BootSkeletonMarkerAttr)
+			if len(markers) != 1 {
+				t.Fatalf("template %q renders %d [%s] element(s), want exactly 1 "+
+					"(the marker goes on the OUTERMOST element of the boot content)",
+					tmpl, len(markers), BootSkeletonMarkerAttr)
+			}
+			m := markers[0]
+
+			insideSome := false
+			for _, c := range containers {
+				if isDescendantOf(m, c) {
+					insideSome = true
+					break
+				}
+			}
+			if !insideSome {
+				t.Fatalf("template %q paints [%s] OUTSIDE the mount container — React's render "+
+					"clears the container's children, so a skeleton outside it is never removed",
+					tmpl, BootSkeletonMarkerAttr)
+			}
+
+			// The skeleton is decorative; the host already publishes aria-busy
+			// on the iframe, so a second announcement in here talks over it.
+			ariaHidden := ""
+			for _, a := range m.Attr {
+				if a.Key == "aria-hidden" {
+					ariaHidden = a.Val
+				}
+			}
+			if ariaHidden != "true" {
+				t.Errorf("template %q: [%s] carries aria-hidden=%q, want \"true\"",
+					tmpl, BootSkeletonMarkerAttr, ariaHidden)
+			}
+
+			// And it must actually paint SHAPES, not be an empty marker div —
+			// an empty [data-boot-skeleton] satisfies the gate's non-emptiness
+			// rule (it is a non-inert element) while painting nothing.
+			if m.FirstChild == nil || !bootSkeletonContainerPaints(m) {
+				t.Errorf("template %q: [%s] has no painted content of its own",
+					tmpl, BootSkeletonMarkerAttr)
+			}
+		})
+	}
+	if examined != len(reactTemplates) || examined < 2 {
+		t.Fatalf("examined only %d template(s), expected %d", examined, len(reactTemplates))
+	}
+}
+
+// TestStaticTemplateDeclaresBootSkeletonWithoutSkeletonMarkup is an INVARIANT
+// GUARD, not regression coverage: it pins a decision rather than a bug that
+// happened. The `static` template opts in (its real content paints at first
+// paint, so standing down the veil is pure win) and deliberately ships NO
+// skeleton. A skeleton there would need explicit JS removal — there is no
+// framework render to clear the container — and would buy a skeleton→content
+// flash for nothing.
+func TestStaticTemplateDeclaresBootSkeletonWithoutSkeletonMarkup(t *testing.T) {
+	dest := renderTemplate(t, Static)
+	raw := readRendered(t, dest, "index.html")
+
+	doc, err := html.Parse(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("parse index.html: %v", err)
+	}
+	if got := len(findAllWithAttr(doc, BootSkeletonMarkerAttr)); got != 0 {
+		t.Fatalf("the static template ships %d [%s] element(s); it must ship none — "+
+			"nothing removes a skeleton in a no-build app", got, BootSkeletonMarkerAttr)
+	}
+
+	// The manifest key is only honest if the container really does paint on its
+	// own. This is the fact that makes "no skeleton" correct rather than lazy.
+	containers := findBootSkeletonContainers(doc)
+	if len(containers) == 0 {
+		t.Fatal("the static template renders no mount container — the claim that its own content " +
+			"satisfies the gate would be untestable")
+	}
+	for _, c := range containers {
+		if !bootSkeletonContainerPaints(c) {
+			t.Fatalf("the static template's %s paints nothing, so `bootSkeleton: true` would leave "+
+				"the viewer with a blank iframe", bootSkeletonContainerLabel(c))
+		}
+	}
+}
+
+// TestBootSkeletonGateOK table-tests the gate itself against hand-built
+// documents, including the three shapes that MUST fail. Without these the gate
+// could be a function that returns nil unconditionally and every other test in
+// this file would still pass.
+func TestBootSkeletonGateOK(t *testing.T) {
+	const declared = `{"blockId":"x","bootSkeleton":true}`
+	const notDeclared = `{"blockId":"x"}`
+
+	cases := []struct {
+		name     string
+		manifest string
+		doc      string
+		wantErr  error
+	}{
+		{
+			name:     "passes: skeleton inside #root",
+			manifest: declared,
+			doc: `<!doctype html><html><body><div id="root">` +
+				`<div data-boot-skeleton aria-hidden="true"><div></div></div>` +
+				`</div><script src="/m.js"></script></body></html>`,
+			wantErr: nil,
+		},
+		{
+			name:     "passes: static app, real content and no marker",
+			manifest: declared,
+			doc:      `<!doctype html><html><body><main id="app"><h1>Hi</h1></main></body></html>`,
+			wantErr:  nil,
+		},
+		{
+			name:     "fails (a): bootSkeleton true over an EMPTY #root",
+			manifest: declared,
+			doc:      `<!doctype html><html><body><div id="root"></div><script src="/m.js"></script></body></html>`,
+			wantErr:  ErrBootSkeletonEmptyContainer,
+		},
+		{
+			name:     "fails (b): marker OUTSIDE the mount container",
+			manifest: declared,
+			doc: `<!doctype html><html><body>` +
+				`<div data-boot-skeleton aria-hidden="true"><div></div></div>` +
+				`<div id="root"><span>content</span></div>` +
+				`</body></html>`,
+			wantErr: ErrBootSkeletonMarkerOutsideContainer,
+		},
+		{
+			name:     "fails (c1): #root holds only a <script>",
+			manifest: declared,
+			doc:      `<!doctype html><html><body><div id="root"><script>var a = 1;</script></div></body></html>`,
+			wantErr:  ErrBootSkeletonEmptyContainer,
+		},
+		{
+			name:     "fails (c2): #root holds only whitespace",
+			manifest: declared,
+			doc:      "<!doctype html><html><body><div id=\"root\">\n   \n\t</div></body></html>",
+			wantErr:  ErrBootSkeletonEmptyContainer,
+		},
+		{
+			name:     "fails (c3): #root holds only a comment",
+			manifest: declared,
+			doc:      `<!doctype html><html><body><div id="root"><!-- mounted at runtime --></div></body></html>`,
+			wantErr:  ErrBootSkeletonEmptyContainer,
+		},
+		{
+			name:     "fails: one of TWO containers is empty",
+			manifest: declared,
+			doc: `<!doctype html><html><body><div id="root"><span>x</span></div>` +
+				`<div data-app-root></div></body></html>`,
+			wantErr: ErrBootSkeletonEmptyContainer,
+		},
+		{
+			name:     "passes: gate does not apply when bootSkeleton is absent",
+			manifest: notDeclared,
+			doc:      `<!doctype html><html><body><div id="root"></div></body></html>`,
+			wantErr:  nil,
+		},
+		{
+			name:     "passes: no recognisable container, the gate does not guess",
+			manifest: declared,
+			doc:      `<!doctype html><html><body><div id="mount"></div></body></html>`,
+			wantErr:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := BootSkeletonGateOK([]byte(tc.manifest), []byte(tc.doc))
+			switch {
+			case tc.wantErr == nil && err != nil:
+				t.Fatalf("want pass, got: %v", err)
+			case tc.wantErr != nil && err == nil:
+				t.Fatalf("want %v, got a PASS — the gate did not fire on a document it must reject", tc.wantErr)
+			case tc.wantErr != nil && !errors.Is(err, tc.wantErr):
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+
+	// COUNT POSITIVE CONTROL: an empty table is a serene green.
+	failing := 0
+	for _, tc := range cases {
+		if tc.wantErr != nil {
+			failing++
+		}
+	}
+	if len(cases) < 10 || failing < 6 {
+		t.Fatalf("table shrank to %d case(s) / %d failing — this test's whole value is the failing arms",
+			len(cases), failing)
+	}
+}
+
+// TestEveryScaffoldTemplatePassesTheBootSkeletonGate is the guard that makes the
+// two halves inseparable GOING FORWARD. It runs the real gate over every
+// template's real rendered entry document, so a future template that declares
+// `bootSkeleton: true` without painting anything inside its mount container
+// fails the build here rather than shipping to an author.
+//
+// It reads the SOURCE index.html rather than a built bundle. Stated rather than
+// hidden: the platform gate operates on the BUILT artifact, and vite copies
+// index.html through while rewriting only the script src, so the container and
+// the skeleton survive. The template-page-vite / template-page-money CI jobs
+// build the scaffolded apps for real; this offline guard is about the templates.
+func TestEveryScaffoldTemplatePassesTheBootSkeletonGate(t *testing.T) {
+	examined := 0
+	for _, tmpl := range AllTemplates() {
+		examined++
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := renderTemplate(t, tmpl)
+			manifestJSON := readRendered(t, dest, "block.manifest.json")
+			doc := readRendered(t, dest, "index.html")
+			if err := BootSkeletonGateOK(manifestJSON, doc); err != nil {
+				t.Fatalf("template %q FAILS the platform's bootSkeleton gate:\n  %v", tmpl, err)
+			}
+		})
+	}
+	if examined < len(AllTemplates()) || examined < 3 {
+		t.Fatalf("examined only %d template(s), expected at least 3 — the enumeration stopped OBSERVING", examined)
+	}
+}
+
+var (
+	// A `<style>` element's text content, non-greedy.
+	styleBlockRe = regexp.MustCompile(`(?s)<style[^>]*>(.*?)</style>`)
+	// Any `prefers-color-scheme: dark` media query, however spaced.
+	prefersDarkRe = regexp.MustCompile(`@media[^{]*prefers-color-scheme\s*:\s*dark`)
+	// Any `prefers-color-scheme: light` media query, however spaced.
+	prefersLightRe = regexp.MustCompile(`@media[^{]*prefers-color-scheme\s*:\s*light`)
+	// `<meta name="color-scheme" content="...">`, attribute order-insensitive
+	// enough for the templates we control.
+	metaColorSchemeRe = regexp.MustCompile(`<meta\s+name="color-scheme"\s+content="([^"]*)"`)
+	// An `html { … }` rule and its body. The leading delimiter class includes
+	// `{` so the rule is also found when it is NESTED inside an @media block —
+	// which is exactly where the light override lives.
+	htmlRuleRe = regexp.MustCompile(`(?s)(^|[};{])\s*html\s*\{([^}]*)\}`)
+	// A hex colour.
+	hexColourRe = regexp.MustCompile(`#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b`)
+)
+
+// TestBootSkeletonPaintsDarkByDefault pins the theme rule STRUCTURALLY.
+//
+// The rule is not "the CSS mentions a dark colour somewhere" — that is a word a
+// reword walks past. It is a relationship between where values live:
+//
+//  1. the BASE (unconditioned) rules carry the dark values, specifically an
+//     `html { background: <dark> }`;
+//  2. there is NO `@media (prefers-color-scheme: dark)` block anywhere in the
+//     inline style. That block is the actual defect this guards: it looks
+//     correct and inverts the default, because a UA reporting `no-preference`
+//     — or one without the query at all — matches neither branch and falls
+//     through to the base rules;
+//  3. light IS present, and only inside `@media (prefers-color-scheme: light)`;
+//  4. `<meta name="color-scheme">` reads `dark light`, dark FIRST.
+//
+// Point 4 is asserted for ALL THREE templates. The static one has no inline
+// style, so points 1–3 apply to the two React templates.
+func TestBootSkeletonPaintsDarkByDefault(t *testing.T) {
+	// A colour is "dark" here if every channel is below this. Both palettes in
+	// the templates sit far from the boundary in both directions, so this
+	// threshold is not load-bearing to a few units either way.
+	const darkChannelMax = 0x60
+
+	t.Run("meta color-scheme is dark-first in every template", func(t *testing.T) {
+		examined := 0
+		for _, tmpl := range AllTemplates() {
+			examined++
+			dest := renderTemplate(t, tmpl)
+			doc := string(readRendered(t, dest, "index.html"))
+			m := metaColorSchemeRe.FindStringSubmatch(doc)
+			if m == nil {
+				t.Errorf("template %q renders no <meta name=\"color-scheme\">; the UA canvas is the "+
+					"FIRST thing an iframe paints and without this it defaults light", tmpl)
+				continue
+			}
+			fields := strings.Fields(m[1])
+			if len(fields) == 0 || fields[0] != "dark" {
+				t.Errorf("template %q: <meta name=\"color-scheme\" content=%q> — the FIRST token must "+
+					"be `dark`; `light dark` defaults the canvas to LIGHT", tmpl, m[1])
+			}
+		}
+		if examined < len(AllTemplates()) || examined < 3 {
+			t.Fatalf("examined only %d template(s), expected at least 3", examined)
+		}
+	})
+
+	examined := 0
+	for _, tmpl := range reactTemplates {
+		examined++
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := renderTemplate(t, tmpl)
+			doc := string(readRendered(t, dest, "index.html"))
+
+			blocks := styleBlockRe.FindAllStringSubmatch(doc, -1)
+			if len(blocks) != 1 {
+				t.Fatalf("template %q has %d inline <style> block(s) in index.html, want exactly 1 — "+
+					"the skeleton must be styled inline or it waits on a second round-trip",
+					tmpl, len(blocks))
+			}
+			css := blocks[0][1]
+			if !strings.Contains(css, BootSkeletonMarkerAttr) {
+				t.Fatalf("template %q: the inline <style> never mentions [%s], so it is not the "+
+					"skeleton's stylesheet", tmpl, BootSkeletonMarkerAttr)
+			}
+
+			// (2) — the inverting block must not exist.
+			if loc := prefersDarkRe.FindString(css); loc != "" {
+				t.Errorf("template %q: the inline style contains %q.\n"+
+					"  DARK MUST BE THE BASE, not a media query. A UA reporting `no-preference`, or one\n"+
+					"  without the query, matches neither branch and falls through to the base rules —\n"+
+					"  so putting the dark values behind this block inverts the default.", tmpl, loc)
+			}
+			// (3) — light must be present, and behind the light query.
+			if !prefersLightRe.MatchString(css) {
+				t.Errorf("template %q: no `@media (prefers-color-scheme: light)` block — light is the "+
+					"only theme that belongs behind a query", tmpl)
+			}
+
+			// (1) — the base `html { … }` rule carries a dark background. "Base"
+			// = the first html rule, which must sit before any @media block.
+			firstMedia := strings.Index(css, "@media")
+			hm := htmlRuleRe.FindStringSubmatchIndex(css)
+			if hm == nil {
+				t.Fatalf("template %q: the inline style has no `html { … }` rule. That rule is the "+
+					"STRONG guarantee — unlike `color-scheme` it does not depend on UA support", tmpl)
+			}
+			if firstMedia >= 0 && hm[0] > firstMedia {
+				t.Fatalf("template %q: the first `html { … }` rule sits inside/after an @media block; "+
+					"the base rules must carry the dark values", tmpl)
+			}
+			body := css[hm[4]:hm[5]]
+			if !strings.Contains(body, "background") {
+				t.Fatalf("template %q: the base `html { … }` rule sets no background: %q", tmpl, body)
+			}
+			hex := hexColourRe.FindString(body)
+			if hex == "" {
+				t.Fatalf("template %q: the base `html` background is not a literal colour (%q). It must "+
+					"not be a custom property — nothing has defined one this early", tmpl, body)
+			}
+			if !isDarkHex(t, hex, darkChannelMax) {
+				t.Errorf("template %q: the BASE `html` background is %s, which is not dark. The base "+
+					"rules are what a `no-preference` UA gets.", tmpl, hex)
+			}
+
+			// And the LIGHT override must genuinely be lighter, or the "light
+			// lives behind the query" structure would be decorative.
+			lightIdx := prefersLightRe.FindStringIndex(css)
+			lightCSS := css[lightIdx[0]:]
+			lm := htmlRuleRe.FindStringSubmatch(lightCSS)
+			if lm == nil {
+				t.Fatalf("template %q: the light media block has no `html { … }` override, so the base "+
+					"dark background survives in light mode", tmpl)
+			}
+			lightHex := hexColourRe.FindString(lm[2])
+			if lightHex == "" || isDarkHex(t, lightHex, darkChannelMax) {
+				t.Errorf("template %q: the light override sets `html` background to %q, which is not "+
+					"lighter than the dark base", tmpl, lightHex)
+			}
+		})
+	}
+	if examined != len(reactTemplates) || examined < 2 {
+		t.Fatalf("examined only %d template(s), expected %d", examined, len(reactTemplates))
+	}
+}
+
+// isDarkHex reports whether every channel of a #rgb / #rrggbb colour is below
+// max.
+func isDarkHex(t *testing.T, hex string, max int) bool {
+	t.Helper()
+	h := strings.TrimPrefix(hex, "#")
+	if len(h) == 3 {
+		h = string([]byte{h[0], h[0], h[1], h[1], h[2], h[2]})
+	}
+	if len(h) != 6 {
+		t.Fatalf("unparseable colour %q", hex)
+	}
+	for i := 0; i < 6; i += 2 {
+		var v int
+		for _, c := range h[i : i+2] {
+			v <<= 4
+			switch {
+			case c >= '0' && c <= '9':
+				v |= int(c - '0')
+			case c >= 'a' && c <= 'f':
+				v |= int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				v |= int(c-'A') + 10
+			default:
+				t.Fatalf("unparseable colour %q", hex)
+			}
+		}
+		if v >= max {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/scaffold/bootskeleton_validate_test.go
+++ b/internal/scaffold/bootskeleton_validate_test.go
@@ -1,0 +1,58 @@
+package scaffold_test
+
+// The most likely way the bootSkeleton change breaks something is NOT the
+// markup — it is the CLI refusing its own scaffold output.
+//
+// `civitai app validate` compiles the go:embedded mirror of the platform's
+// canonical manifest schema and validates block.manifest.json against it. Adding
+// a key the mirror does not know is only safe because the canonical schema's
+// ROOT object does not set `additionalProperties: false` (it does set it on the
+// `iframe` and `page` sub-objects, which is why this is worth pinning rather
+// than assuming). If that ever changes — or if the mirror is re-vendored from a
+// canonical that tightens the root — every scaffolded app starts failing the
+// CLI's own validate the moment it is created, and the schema re-vendor stops
+// being optional.
+//
+// This test is the tripwire for that. It is deliberately an END-TO-END read
+// through validate.Dir rather than an inspection of the schema file: the
+// question is whether the CLI accepts the manifest, and only running the
+// validator answers it.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+	"github.com/civitai/cli/internal/validate"
+)
+
+func TestScaffoldedManifestsWithBootSkeletonStillValidate(t *testing.T) {
+	examined := 0
+	for _, tmpl := range scaffold.AllTemplates() {
+		examined++
+		t.Run(string(tmpl), func(t *testing.T) {
+			dest := filepath.Join(t.TempDir(), string(tmpl))
+			if _, err := scaffold.Render(tmpl, dest, scaffold.Data{Slug: "boot-block", Name: "Boot Block"}); err != nil {
+				t.Fatalf("render %s: %v", tmpl, err)
+			}
+
+			res, err := validate.ManifestOnly(dest)
+			if err != nil {
+				t.Fatalf("validate.ManifestOnly(%s): %v", tmpl, err)
+			}
+			if !res.OK() {
+				t.Fatalf("the scaffolded %q manifest FAILS the CLI's own validate:\n  %v\n\n"+
+					"  If the failure names `bootSkeleton`, the vendored schema mirror\n"+
+					"  (schema/app-block.manifest.schema.json) does not know the key AND the canonical\n"+
+					"  root has been tightened to additionalProperties:false. The re-vendor is then\n"+
+					"  NOT optional — run ./scripts/revendor-canonical-schema.sh (or wait for the\n"+
+					"  revendor-canonical-schema workflow's PR) before this can ship.",
+					tmpl, res.Errors)
+			}
+		})
+	}
+	// COUNT POSITIVE CONTROL — an empty AllTemplates() makes this pass serenely.
+	if examined < len(scaffold.AllTemplates()) || examined < 3 {
+		t.Fatalf("examined only %d template(s), expected at least 3 — the enumeration stopped OBSERVING", examined)
+	}
+}

--- a/internal/scaffold/templates/page-money/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/page-money/block.manifest.json.tmpl
@@ -21,6 +21,7 @@
     "sandbox": "allow-scripts allow-forms"
   },
   "contentRating": "g",
+  "bootSkeleton": true,
   "minApiVersion": "1.0",
   "buildCommand": "npm run build",
   "outputDir": "dist"

--- a/internal/scaffold/templates/page-money/index.html.tmpl
+++ b/internal/scaffold/templates/page-money/index.html.tmpl
@@ -3,12 +3,123 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light dark" />
+    <!-- DARK FIRST, deliberately. The first thing an iframe paints is the UA
+         canvas, and the host sends this block no theme hint before it boots, so
+         the boot theme is a GUESS and the platform's guess is dark. `light dark`
+         here would default the canvas to LIGHT and flash white. -->
+    <meta name="color-scheme" content="dark light" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <title>{{ .Name }} — Civitai App</title>
+    <!-- BOOT SKELETON styles. Paired with `"bootSkeleton": true` in
+         block.manifest.json — THE TWO CANNOT BE SEPARATED. When the manifest
+         declares bootSkeleton the Civitai run host stands down its own loading
+         veil (no branded overlay, iframe opaque from mount, no reveal settle),
+         so whatever this document paints IS the loading state. Declare the flag
+         over an empty #root and the viewer stares at a blank iframe for the
+         whole load — strictly worse than not opting in.
+
+         INLINE, and no JS: an external stylesheet is a second round-trip, which
+         is exactly the window this exists to cover. These rules must paint
+         before anything is fetched — including before the W6 pack's stylesheet,
+         so the literal colours below are stand-ins for the pack's surface /
+         border tokens rather than `var(--civitai-color-*)` reads, which resolve
+         to nothing this early.
+
+         DARK IS THE BASE. Light lives in a `prefers-color-scheme: light` block
+         and nowhere else. There is deliberately NO `prefers-color-scheme: dark`
+         block: a UA reporting `no-preference`, or one that does not support the
+         query at all, matches neither branch and would fall through to whatever
+         the base rules say — so the base rules have to be the dark ones. -->
+    <style>
+      html {
+        /* The strong guarantee. Unlike `color-scheme` this does not depend on
+           UA support for anything. */
+        background: #101113;
+      }
+      body {
+        margin: 0;
+      }
+      /* Mirrors the `shell` style in src/App.tsx. */
+      [data-boot-skeleton] {
+        min-height: 100dvh;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+      /* Attribute selectors, not classes: a class is fair game for CSS-modules
+         hashing or a purge pass, an attribute survives the bundler. */
+      [data-boot-skeleton] [data-boot-shape='card'] {
+        width: 100%;
+        max-width: 640px;
+        padding: 24px;
+        border-radius: 8px;
+        background: #1a1b1e;
+        border: 1px solid #2c2e33;
+        box-sizing: border-box;
+      }
+      [data-boot-skeleton] [data-boot-shape='card'] > [data-boot-shape] {
+        background: #2c2e33;
+        border-radius: 6px;
+        margin-bottom: 16px;
+      }
+      [data-boot-skeleton] [data-boot-shape='title'] {
+        height: 24px;
+        width: 45%;
+      }
+      [data-boot-skeleton] [data-boot-shape='control'] {
+        height: 34px;
+      }
+      [data-boot-skeleton] [data-boot-shape='field'] {
+        height: 96px;
+      }
+      [data-boot-skeleton] [data-boot-shape='button'] {
+        height: 36px;
+        margin-bottom: 0;
+      }
+      @media (prefers-color-scheme: light) {
+        html {
+          background: #f8f9fa;
+        }
+        [data-boot-skeleton] [data-boot-shape='card'] {
+          background: #ffffff;
+          border-color: #dee2e6;
+        }
+        [data-boot-skeleton] [data-boot-shape='card'] > [data-boot-shape] {
+          background: #e9ecef;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- The skeleton MUST live inside #root. One painted as a sibling of the
+           mount container is never replaced by the app's render and stays on
+           screen after mount.
+
+           NO REMOVAL CODE IS NEEDED HERE, AND THAT IS REACT-SPECIFIC.
+           `createRoot(container).render(...)` in src/main.tsx clears the
+           container's existing children before its first commit, so this
+           skeleton removes itself. A framework that APPENDS instead of clearing
+           (Svelte 5's `mount(App, { target })`, for one) leaves it on screen
+           and needs an explicit
+           `document.querySelector('[data-boot-skeleton]')?.remove()` straight
+           after the mount call. Assume APPEND for anything you have not
+           measured.
+
+           aria-hidden because this is decoration: the host already publishes
+           `aria-busy` on the iframe while the block is loading, and a second
+           announcement in here would just talk over it. -->
+      <div data-boot-skeleton aria-hidden="true">
+        <div data-boot-shape="card">
+          <div data-boot-shape="title"></div>
+          <div data-boot-shape="control"></div>
+          <div data-boot-shape="field"></div>
+          <div data-boot-shape="button"></div>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/internal/scaffold/templates/page-money/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-money/src/index.css.tmpl
@@ -1,5 +1,9 @@
 :root {
-  color-scheme: light dark;
+  /* DARK FIRST, matching `<meta name="color-scheme" content="dark light">` in
+     index.html. This property OVERRIDES the meta once the bundle lands, so the
+     two orders have to agree — `light dark` here would quietly undo the boot
+     skeleton's dark default at exactly the moment the app takes over. */
+  color-scheme: dark light;
 }
 
 * {

--- a/internal/scaffold/templates/page-vite/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/page-vite/block.manifest.json.tmpl
@@ -17,6 +17,7 @@
     "sandbox": "allow-scripts allow-forms"
   },
   "contentRating": "g",
+  "bootSkeleton": true,
   "minApiVersion": "1.0",
   "buildCommand": "npm run build",
   "outputDir": "dist"

--- a/internal/scaffold/templates/page-vite/index.html.tmpl
+++ b/internal/scaffold/templates/page-vite/index.html.tmpl
@@ -3,11 +3,101 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- DARK FIRST, deliberately. The first thing an iframe paints is the UA
+         canvas, and the host sends this block no theme hint before it boots, so
+         the boot theme is a GUESS and the platform's guess is dark. `light dark`
+         here would default the canvas to LIGHT and flash white. -->
+    <meta name="color-scheme" content="dark light" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <title>{{ .Name }}</title>
+    <!-- BOOT SKELETON styles. Paired with `"bootSkeleton": true` in
+         block.manifest.json — THE TWO CANNOT BE SEPARATED. When the manifest
+         declares bootSkeleton the Civitai run host stands down its own loading
+         veil (no branded overlay, iframe opaque from mount, no reveal settle),
+         so whatever this document paints IS the loading state. Declare the flag
+         over an empty #root and the viewer stares at a blank iframe for the
+         whole load — strictly worse than not opting in.
+
+         INLINE, and no JS: an external stylesheet is a second round-trip, which
+         is exactly the window this exists to cover. These rules must paint
+         before anything is fetched.
+
+         DARK IS THE BASE. Light lives in a `prefers-color-scheme: light` block
+         and nowhere else. There is deliberately NO `prefers-color-scheme: dark`
+         block: a UA reporting `no-preference`, or one that does not support the
+         query at all, matches neither branch and would fall through to whatever
+         the base rules say — so the base rules have to be the dark ones. -->
+    <style>
+      html {
+        /* The strong guarantee. Unlike `color-scheme` this does not depend on
+           UA support for anything. */
+        background: #101113;
+      }
+      body {
+        margin: 0;
+      }
+      /* Mirrors `.app` in src/index.css so the skeleton occupies the same box
+         the real first render does. */
+      [data-boot-skeleton] {
+        max-width: 40rem;
+        margin: 0 auto;
+        padding: 2rem 1.5rem;
+      }
+      /* Attribute selectors, not classes: a class is fair game for CSS-modules
+         hashing or a purge pass, an attribute survives the bundler. */
+      [data-boot-skeleton] [data-boot-shape] {
+        background: #2c2e33;
+        border-radius: 6px;
+      }
+      [data-boot-skeleton] [data-boot-shape='title'] {
+        height: 2.25rem;
+        width: 60%;
+        margin-bottom: 1.25rem;
+      }
+      [data-boot-skeleton] [data-boot-shape='line'] {
+        height: 1rem;
+        width: 85%;
+        margin-bottom: 1.5rem;
+      }
+      [data-boot-skeleton] [data-boot-shape='button'] {
+        height: 2.25rem;
+        width: 9rem;
+      }
+      @media (prefers-color-scheme: light) {
+        html {
+          background: #ffffff;
+        }
+        [data-boot-skeleton] [data-boot-shape] {
+          background: #e9ecef;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- The skeleton MUST live inside #root. One painted as a sibling of the
+           mount container is never replaced by the app's render and stays on
+           screen after mount.
+
+           NO REMOVAL CODE IS NEEDED HERE, AND THAT IS REACT-SPECIFIC.
+           `createRoot(container).render(...)` in src/main.jsx clears the
+           container's existing children before its first commit, so this
+           skeleton removes itself. A framework that APPENDS instead of clearing
+           (Svelte 5's `mount(App, { target })`, for one) leaves it on screen
+           and needs an explicit
+           `document.querySelector('[data-boot-skeleton]')?.remove()` straight
+           after the mount call. Assume APPEND for anything you have not
+           measured.
+
+           aria-hidden because this is decoration: the host already publishes
+           `aria-busy` on the iframe while the block is loading, and a second
+           announcement in here would just talk over it. -->
+      <div data-boot-skeleton aria-hidden="true">
+        <div data-boot-shape="title"></div>
+        <div data-boot-shape="line"></div>
+        <div data-boot-shape="button"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/internal/scaffold/templates/page-vite/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-vite/src/index.css.tmpl
@@ -1,5 +1,9 @@
 :root {
-  color-scheme: light dark;
+  /* DARK FIRST, matching `<meta name="color-scheme" content="dark light">` in
+     index.html. This property OVERRIDES the meta once the bundle lands, so the
+     two orders have to agree — `light dark` here would quietly undo the boot
+     skeleton's dark default at exactly the moment the app takes over. */
+  color-scheme: dark light;
   font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 

--- a/internal/scaffold/templates/static/block.manifest.json.tmpl
+++ b/internal/scaffold/templates/static/block.manifest.json.tmpl
@@ -17,5 +17,6 @@
     "sandbox": "allow-scripts allow-forms"
   },
   "contentRating": "g",
+  "bootSkeleton": true,
   "minApiVersion": "1.0"
 }

--- a/internal/scaffold/templates/static/index.html.tmpl
+++ b/internal/scaffold/templates/static/index.html.tmpl
@@ -3,11 +3,33 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- DARK FIRST, deliberately. The first thing an iframe paints is the UA
+         canvas, and the host sends this block no theme hint before it boots, so
+         the boot theme is a GUESS and the platform's guess is dark. `light dark`
+         here would default the canvas to LIGHT and flash white. `style.css`
+         re-states the same order in its `color-scheme` property, so the two
+         cannot disagree once the stylesheet lands. -->
+    <meta name="color-scheme" content="dark light" />
     <title>{{ .Name }}</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231971c2'/></svg>" />
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <!-- NO BOOT SKELETON HERE, ON PURPOSE — and the manifest still declares
+         `"bootSkeleton": true`. Both halves are deliberate.
+
+         A static app has no bundle to wait for: this document IS the app, and
+         everything below paints at first paint. Declaring bootSkeleton tells the
+         Civitai run host to stand down its loading veil, which for this template
+         is pure delay over content that is already on screen. That is the flag
+         doing exactly what it is for.
+
+         A *skeleton* here would be inert at best. There is no framework render
+         to clear the container, so a skeleton would need explicit JS removal and
+         would buy a skeleton→content flash in exchange for nothing. The
+         platform's `bootSkeleton-not-empty` gate keys on the container being
+         non-empty, not on the presence of a `[data-boot-skeleton]` marker, and
+         the real content below satisfies it on its own. -->
     <main id="app">
       <h1>{{ .Name }}</h1>
       <p>This is a Civitai App (static template). Edit <code>app.js</code> to build your app.</p>

--- a/internal/scaffold/templates/static/style.css.tmpl
+++ b/internal/scaffold/templates/static/style.css.tmpl
@@ -1,5 +1,9 @@
 :root {
-  color-scheme: light dark;
+  /* DARK FIRST, matching `<meta name="color-scheme" content="dark light">` in
+     index.html. This property OVERRIDES the meta once the stylesheet lands, so
+     the two orders have to agree — `light dark` here would quietly undo the
+     meta's dark default the moment this file loads. */
+  color-scheme: dark light;
   font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 


### PR DESCRIPTION
Adopts the App Blocks `manifest.bootSkeleton` opt-in in all three scaffold templates.

## Why the manifest key and the markup are ONE change

When a manifest declares `bootSkeleton: true` the Civitai run host stands down three things at once: the opaque branded veil, the iframe's `opacity: 0 → 1` reveal, and the `translateY(8px)` settle. The iframe is therefore opaque and unveiled from mount, and **whatever the block's entry document paints IS the loading state**.

So declaring the flag over an empty mount container is a blank iframe for the entire load — strictly worse than never opting in — and it looks fine to the author who shipped it. Shipping either half alone is the whole hazard, which is why this PR ships a guard rather than just the templates.

## What changed

**`page-vite` / `page-money`** — `"bootSkeleton": true` **plus** a `[data-boot-skeleton] aria-hidden="true"` element inside `#root`, shaped to roughly match each template's own first render (page-vite mirrors `.app`'s 40rem / `2rem 1.5rem` box; page-money mirrors the centred 640px card). Styled by an inline `<style>` in `<head>` so it paints before anything is fetched. An **attribute** marker rather than a class: a class is fair game for CSS-modules hashing or a purge pass, an attribute survives the bundler.

**Dark is the base.** Light lives only inside `@media (prefers-color-scheme: light)`. There is deliberately **no** `prefers-color-scheme: dark` block — a UA reporting `no-preference`, or one without the query, matches neither branch and falls through to the base rules, so putting the dark values behind a query inverts the default. Plus the two belt-and-braces guards: `<meta name="color-scheme" content="dark light">` (dark **first**) and an unconditioned `html { background }`, which does not depend on `color-scheme` support at all.

**No removal code, and the templates say so in-band.** React's `createRoot(container).render()` clears the container's existing children before its first commit, so the skeleton removes itself. That is **React-specific** — a framework that appends (Svelte 5's `mount(App, { target })`) needs an explicit `document.querySelector('[data-boot-skeleton]')?.remove()`. Re-measured for this PR against React 19.2.8 + jsdom, with a positive control asserting the app really rendered in the same test.

**`static`** — `"bootSkeleton": true` and **no** skeleton markup, both deliberate. A no-build app has no bundle to wait for: its real content is in the shipped `index.html` and paints at first paint, so standing down the veil is pure win, and `<main id="app">` satisfies the gate's non-emptiness rule on its own. A skeleton there would need explicit JS removal — there is no framework render to clear the container — and would buy a skeleton→content flash for nothing. Both decisions are written into the template as a comment and pinned by a test.

**The three stylesheets' `color-scheme` property is flipped to `dark light`** to match the meta. That property *overrides* the meta once the stylesheet lands, so leaving `light dark` there would have quietly undone the dark default at exactly the moment the app takes over — the change would have contradicted itself.

## The guard

`internal/scaffold/bootskeleton.go` implements the platform's blocking `bootSkeleton-not-empty` gate over a real HTML parse (`golang.org/x/net/html`, already a direct dependency), verbatim from the contract:

- containers = `#root, #app, [data-app-root]`; no container → pass (the gate does not guess);
- every container must hold a non-inert descendant element or non-whitespace text;
- a `[data-boot-skeleton]` outside every container → fail (the app's render never replaces it).

`TestEveryScaffoldTemplatePassesTheBootSkeletonGate` runs it over **every** template's real rendered entry document, so a future template that declares the key without painting anything fails the build here instead of shipping an author a blank iframe.

## Verification

Watched-fail matrix, taken by reverting `internal/scaffold/templates/` to `origin/main` and re-running (`-count=1`):

| test | at `origin/main` | at HEAD |
|---|---|---|
| `TestEveryScaffoldTemplateDeclaresBootSkeleton` | **RED** (3/3 subtests) | green |
| `TestReactTemplatesPaintABootSkeletonInsideTheMountContainer` | **RED** (2/2 subtests) | green |
| `TestBootSkeletonPaintsDarkByDefault` | **RED** (3/3 subtests) | green |
| `TestStaticTemplateDeclaresBootSkeletonWithoutSkeletonMarkup` | green — **invariant guard**, pins a decision | green |
| `TestBootSkeletonGateOK` | green — unit coverage of new code | green |
| `TestEveryScaffoldTemplatePassesTheBootSkeletonGate` | green — **vacuous at base** (no template declares the key) | green |
| `TestScaffoldedManifestsWithBootSkeletonStillValidate` | green — **tripwire**, not regression coverage | green |

The four that pass at base are labelled as such rather than counted as regression coverage. The two that matter were proved reachable by mutation instead:

- **the separation guard**: adding `"bootSkeleton": true` to `origin/main`'s `page-vite` manifest (empty `#root`, no markup — exactly the hazard) turns `TestEveryScaffoldTemplatePassesTheBootSkeletonGate/page-vite` **RED** with the gate's own message, while `static` and `page-money` stay green. Isolated mutation, dying for its own reason.
- **the gate itself**: making `BootSkeletonGateOK` return `nil` unconditionally turns all **6** failing table arms red and leaves all 4 passing arms green — so none of them was dying for the wrong reason.

Runner positive control: a deliberately-wrong assertion (`fields[0] != "chartreuse"`) goes red quoting the real rendered value `content="dark light"`, proving the test reads template output rather than a fixture. Counts, not "ok": `go test -count=1 -v -run BootSkeleton ./internal/scaffold/...` → **7 top-level `--- PASS`, 31 `--- PASS` lines including subtests, 0 FAIL**. Full suite `go test -count=1 ./...` → **21 packages ok, 0 FAIL** (CI's floor is 15). `gofmt -l`, `go vet ./...`, `go build ./...` all clean.

Dogfooded end-to-end, not just unit-tested: `civitai app init` → `npm install` → `npm run build` for **both** React templates, then the gate run over the real `dist/index.html`. The skeleton, the single inline `<style>` and `content="dark light"` all survive the vite build, and the gate passes on the built artifact — which is what the platform actually inspects.

## The vendored schema mirror — deliberately untouched

`schema/app-block.manifest.schema.json` has **not** drifted. Measured: it is byte-identical (`cmp`) to both civitai `origin/release` and the live `https://civitai.com/schemas/app-block/v1.json`. `bootSkeleton` exists only on civitai `main`, which is not what dp-prod serves, so **hand-syncing the mirror to `main`'s bytes would turn `schema-drift` red** — the drift job byte-compares against the live URL, not against `main`. The `revendor-canonical-schema` workflow re-vendors it automatically within ~6h of the `main` → `release` cut and opens its own PR.

Nothing here waits on that: the canonical root sets no `additionalProperties: false` (only `iframe` and `page` do), so the new key validates against today's mirror. `TestScaffoldedManifestsWithBootSkeletonStillValidate` runs `validate.ManifestOnly` over all three scaffolded manifests and is the tripwire that fires — with the re-vendor command in its failure message — if the canonical root is ever tightened.

## Residuals, stated rather than hidden

- **`static` trips the contract's ADVISORY check, not the blocking gate.** Its content is styled by `./style.css`, an external stylesheet, so `bootSkeleton-paints-without-network` would warn: the first paint can be unstyled for one round-trip. That warning is not implemented here (only the blocking gate is), and the fix — inlining the static template's CSS — is a separate call.
- `TestEveryScaffoldTemplatePassesTheBootSkeletonGate` reads the **source** `index.html`, while the platform gate reads the built one. The dogfood above closes that for both React templates by hand; the `template-page-vite` / `template-page-money` CI jobs build them on every PR.
- The gate treats `<template>` subtrees as inert. The contract's literal wording ("a descendant element whose tag name is not …") would count a `<div>` inside a `<template>`; that reading also makes a `#root` holding only a `<script>` **pass** (a script's source is a non-whitespace text node), which the contract's own worked case says must fail. Skipping inert subtrees wholesale is the reading that makes the rule self-consistent, and it is documented at the constant.

## CI tiers

Every guard in this PR lands in `build-test` (`go test ./...`), which runs on **every `pull_request`** — a PR gate, not scheduled or advisory. `lint`, `schema-drift`, `template-page-vite` and `template-page-money` are also per-PR; `template-page-*` install, typecheck, build and `validate` the scaffolded apps, so the built-artifact half is covered there. `revendor-canonical-schema` is the only scheduled job in play (every 6h) and it is remediation, not a gate.
