### PR TITLE
fix(scaffold): bump @civitai/* pins to 0.37.0 / 0.45.0 — unblock pins-vs-published

### DIFF
--- a/internal/scaffold/design_tokens_guard_test.go
+++ b/internal/scaffold/design_tokens_guard_test.go
@@ -30,14 +30,23 @@ package scaffold
 // same run in which it bumps the pin so the two cannot drift.
 //
 // RESIDUAL, stated rather than papered over: the ledger is only as fresh as the
-// last regeneration. Within one caret range (`^0.43.0` admits every `0.43.x`) a
+// last regeneration. Within one caret range (`^0.45.0` admits every `0.45.x`) a
 // patch release could add a token — a template using it would red, which is a
 // false failure a regeneration fixes — or REMOVE one, which the ledger would
 // still list, and that direction is a false PASS. Closing it would need a
 // network read at test time, which is the thing this guard deliberately does not
-// do. Measured across the whole range this pin admits and the next minor
-// (0.43.0, 0.43.1, 0.44.0, 0.44.1, 0.44.2) the defined set is byte-identical, so
-// the residual is small today; it is not zero.
+// do.
+//
+// Scope of the residual, re-measured 2026-09-02 at the ^0.44.0 → ^0.45.0 bump.
+// The PATCH axis has stayed quiet: across 0.43.0, 0.43.1, 0.44.0, 0.44.1 and
+// 0.44.2 the defined set is byte-identical, so drift WITHIN a caret range — the
+// only drift this guard cannot see — remains unobserved. The MINOR axis is not
+// quiet, and that is the correction: 0.44.2 → 0.45.0 ADDED five tokens
+// (`--civitai-bp-{xs,sm,md,lg,xl}`, the breakpoint scale behind the new
+// `useBlockBreakpoint` hook), 27 → 32. Nothing was removed, so no reference went
+// dead — but a minor bump demonstrably DOES move the set, which is precisely why
+// `bump-pins` regenerates this ledger in the same run that moves the pin rather
+// than trusting the sets to agree.
 
 import (
 	"os"

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -150,8 +150,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.44.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.36.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.45.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.37.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -372,7 +372,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.36.0` + `@civitai/blocks-react@^0.44.0` (already pinned in
+`@civitai/app-sdk@^0.37.0` + `@civitai/blocks-react@^0.45.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.36.0",
-    "@civitai/blocks-react": "^0.44.0",
+    "@civitai/app-sdk": "^0.37.0",
+    "@civitai/blocks-react": "^0.45.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/testdata/design-tokens.txt
+++ b/internal/scaffold/testdata/design-tokens.txt
@@ -16,9 +16,14 @@
 # The guard fails when `pin` no longer matches the template.
 #
 # package: @civitai/blocks-react
-# pin: ^0.44.0
-# version: 0.44.2
+# pin: ^0.45.0
+# version: 0.45.0
 
+--civitai-bp-lg
+--civitai-bp-md
+--civitai-bp-sm
+--civitai-bp-xl
+--civitai-bp-xs
 --civitai-color-body
 --civitai-color-border
 --civitai-color-error


### PR DESCRIPTION
Unblocks the red `pins-vs-published` gate. Deliberately its own PR, separate from #516 — an SDK boundary change should not ride inside a feature PR.

## Why

`@civitai/app-sdk@0.37.0` and `@civitai/blocks-react@0.45.0` both published 2026-09-02T19:13Z. The pre-1.0 caret locks the minor, so `^0.36.0` genuinely does not admit `0.37.0` and `^0.44.0` does not admit `0.45.0`. The guard has been red on every PR in this repo since, and it is telling the truth — every app scaffolded from `page-money` is born a minor behind.

## What actually changed upstream

Neither package ships a CHANGELOG, so this was established by diffing the **published tarballs** (`npm pack` of each version, full recursive diff of `dist/`).

**`@civitai/app-sdk` 0.36.0 → 0.37.0** — purely additive. Two new orchestrator step types in the step-kind map (`webScrape`, `webSearch`). The only other changed file is the `version` field.

**`@civitai/blocks-react` 0.44.2 → 0.45.0** — additive plus one strictly-*more*-CSS fix.
- New `useBlockBreakpoint` hook (+ `resolveBlockTier`, `BlockBreakpoint`, `BlockSizeTier`).
- `BlockGate` now calls `useBlocksStyles()` unconditionally on both branches, so a block that wraps its root in `BlockGate` but renders no `/ui` component finally gets the design-system CSS on the happy path.
- Transitive exact-pinned deps move with it: `@civitai/theme` 0.2.1 → 0.3.0, `@civitai/components` 0.3.1 → 0.4.0.

(0.44.2 is the right baseline — `^0.44.0` already resolves there today, so this is exactly the delta the bump introduces.)

## The named hazard is not present

`blocks-react` 0.44 inverted the workflow error contract: `estimate()`/`submit()` went from *resolving* a failure snapshot to *throwing* `WorkflowEstimateError` / `WorkflowSubmitError`, whose `.message` is developer-facing and must never reach a viewer. That change generated a ten-round audit ladder on a sibling repo.

**This bump crosses no such boundary.** Every `.d.ts` **and** `.js` under `dist/` mentioning the error contract or the workflow verbs is **byte-identical** between 0.44.2 and 0.45.0 — `useAppWorkflows`, `useBuzzWorkflow`, `internal/transport`, `internal/liveHost`, `internal/mockHost`, `internal/catalog`, `ui/Button`, `ui/SettingsForm` and the rest. The sole differing barrel, `dist/index.js`, differs by exactly one added export line.

So the templates' existing `.snapshot.error` handling — and the comments in `generation.ts.tmpl` / `App.tsx.tmpl` explaining why it must not read `.message` — remain correct. They still say `^0.44`, which is accurate as the version the contract *arrived in*, so they are **left alone on purpose** rather than churned.

## The change

`go run ./internal/scaffold/cmd/bump-pins`, which owns all four literal sites (`package.json.tmpl`, `README.md.tmpl`, the `scaffold_test.go` assertions, the design-token ledger).

The ledger went **27 → 32 tokens**. All five additions are `--civitai-bp-{xs,sm,md,lg,xl}` — the breakpoint scale behind the new hook — and **nothing was removed**, so no template reference went dead.

That last fact falsified a comment in `design_tokens_guard_test.go`, which claimed the defined set was byte-identical "across the whole range this pin admits and the next minor". The patch axis is still quiet; the minor axis is not — this very bump moved the set. Corrected in place with the re-measured numbers rather than left standing, since it is the argument for regenerating the ledger in the same run that moves the pin.

## Verification

Run in a clean worktree off `origin/main`.

**The guard — PASS, not SKIP:**
```
=== RUN   TestScaffoldPinsSatisfyPublished
--- PASS: TestScaffoldPinsSatisfyPublished (0.37s)
ok  	github.com/civitai/cli/internal/scaffold	0.373s
```
The guard SKIPs by design when npm is unreachable, and a skip is a green that says nothing. This is a real PASS. **Instrument validated both ways** — reverting the `blocks-react` pin to `^0.44.0` reproduces the exact original failure (`STALE SCAFFOLD PIN … pinned: ^0.44.0 … published: 0.45.0`), and restoring it goes green again.

**Full Go suite:** 21 packages `ok`, **0 failures**, 1 with no test files.

**End-to-end, mirroring the `template-page-money` CI job** — the only check that proves the bump does not mint broken apps:

| step | result |
|---|---|
| `civitai app init --template page-money` | 36 files |
| `npm install` | resolved app-sdk **0.37.0**, blocks-react **0.45.0**, theme **0.3.0**, components **0.4.0** |
| `npm run typecheck` | rc=0 |
| `npm test` | **11 files / 153 tests passed** |
| `npm run build` | vite build ok, 110 modules |
| `civitai app validate` | `✓ . is valid` |

**`scaffold-currency` offline anti-pattern scan** against that scaffolded app: `--- PASS: TestScanDirFromEnv`, no anti-patterns found.

## Not verified / caveats

- The local end-to-end ran on **Node v26.8.0-alpha**, which npm warns is unsupported; CI pins Node 22. Everything passed regardless, but CI's run on 22 is the authoritative one.
- The design-token guard's residual is unchanged and still real: it cannot see a token **removed** by a patch release inside `^0.45.0`. Stated in the comment, not closed here.

## Collision with #516

**None.** #516 touches `index.html.tmpl`, the manifest templates, `src/index.css.tmpl` / `style.css.tmpl`, and adds `bootskeleton.go` + tests. This PR touches `package.json.tmpl`, `README.md.tmpl`, `scaffold_test.go`, `design_tokens_guard_test.go` and the token ledger. **Zero overlapping files**, so no merge order is required. Based on `origin/main`, not stacked.
