### PR TITLE
chore(schema): re-vendor embedded manifest schema from canonical

### DIFF
--- a/schema/app-block.manifest.schema.json
+++ b/schema/app-block.manifest.schema.json
@@ -178,6 +178,12 @@
         }
       }
     },
+    "bootSkeleton": {
+      "type": "boolean",
+      "default": false,
+      "description": "The app's shipped index.html paints its own loading state inside #root. The full-page run host then stands down its own branded overlay and shows the iframe from mount, so the app's boot state is visible at first paint and its own render replaces it in place with no cross-fade and no reveal transform. Omit (or false) unless the app really ships one: with the overlay stood down, an empty #root is a blank iframe for the whole load. To paint in the HOST's theme rather than guessing from prefers-color-scheme, the app must also be enabled for the BLOCK_INIT URL fragment and read it before first paint; without that the theme is a guess that can disagree with the host and be corrected on BLOCK_INIT.",
+      "$comment": "Honoured by the full-page run host. Other block surfaces ignore it."
+    },
     "page": {
       "type": "object",
       "description": "Full-page surface descriptor (W10). Page apps mount at /apps/run/<slug>.",


### PR DESCRIPTION
Automated by the `revendor-canonical-schema` workflow
(`scripts/revendor-canonical-schema.sh`).

The canonical block-manifest schema published at
https://civitai.com/schemas/app-block/v1.json changed, so the CLI's
go:embedded mirror (`schema/app-block.manifest.schema.json`) drifted
and `check-canonical-schema` would go red. This PR re-vendors the
embedded copy from the canonical.

Validated in the job before opening: the re-vendored schema compiles
under the CLI's jsonschema engine and the bundled example manifests
still validate against it (`go test ./...`).

**Reviewer heads-up:** this bot only re-vendors the schema *bytes*.
If the canonical change added a field with author-facing semantics
(e.g. a new manifest key), consider whether `internal/validate/` (the
Go semantic checks / friendly messages) should track it too — that
part is a deliberate human call.