### PR TITLE
feat(scaffold): ship a width-adaptive example in page-money and page-vite

### DIFF
--- a/internal/scaffold/query_prelude_guard_test.go
+++ b/internal/scaffold/query_prelude_guard_test.go
@@ -1,0 +1,275 @@
+package scaffold
+
+// Structural guard: no scaffold template may put a `var()` inside a media or
+// container query PRELUDE.
+//
+// Why this exists at all. Both width-adaptive examples the scaffold now ships
+// sit right next to the `--civitai-bp-*` tokens, and putting one of those tokens
+// in the query condition is the FIRST thing a reader tries. It does not work,
+// and — this is the whole problem — it does not fail either. The prelude is
+// evaluated before custom properties are substituted, so the at-rule is inert:
+// green build, no console warning, no test failure, and a layout silently frozen
+// on one branch. Measured in Chromium with a literal-value control in the same
+// document (`--bp-sm` = 768px, 1000px window): the literal form applied, the
+// `var()` form did not.
+//
+// Why it is a CLASS guard and not a grep. `grep -F 'var(--civitai-bp-'` pins a
+// SPELLING: it passes the moment the tokens are renamed, says nothing about a
+// `var()` naming some other property, and would have to be re-derived for every
+// future token namespace. This asserts the RELATIONSHIP the browser actually
+// enforces — a prelude may not depend on the cascade — so it holds however the
+// property is named, including for properties that do not exist yet.
+//
+// `@supports` is deliberately out of scope: its condition tests DECLARATIONS,
+// where `var()` is legitimate. See queryprelude.go.
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// TestScaffoldTemplatesHaveNoVarInQueryPreludes is the guard.
+func TestScaffoldTemplatesHaveNoVarInQueryPreludes(t *testing.T) {
+	scan, err := ScanQueryPreludes(templatesFS, "templates")
+	if err != nil {
+		t.Fatalf("scanning templates for query preludes: %v", err)
+	}
+
+	// ── POSITIVE CONTROLS ───────────────────────────────────────────────────
+	// The reassuring answer here is "no violations", which is also what a
+	// scanner wired to an empty tree, or one whose regex stopped matching,
+	// returns. Assert it read this repo's templates AND found real preludes
+	// before believing the zero.
+	t.Logf("scanned %d template file(s); %d media/container prelude(s) survived comment-stripping; %d violation(s)",
+		scan.FilesRead, scan.Preludes, len(scan.Violations))
+
+	if scan.FilesRead < 20 {
+		t.Fatalf("read only %d template file(s) — the scanner is not looking at this repo's templates, so a clean verdict here would be a statement about nothing", scan.FilesRead)
+	}
+	// Measured on this tree: 4 real preludes — the two boot-skeleton
+	// `prefers-color-scheme` blocks (page-money + page-vite index.html),
+	// page-vite's `@container` responsive rule, and the fenced copy of that rule
+	// in page-vite's README. Every other textual occurrence is either inside a
+	// comment (stripped) or prose that opens no block (not a prelude).
+	//
+	// This floor is what makes the comment-stripper's failure visible: a
+	// stripper that ate too much would leave 0 here rather than reporting a
+	// clean tree. If a change legitimately removes a query, lower this
+	// DELIBERATELY — do not let the guard become a guard over nothing.
+	if scan.Preludes < 3 {
+		t.Fatalf("found only %d media/container prelude(s) in the templates — expected at least 3 (two boot-skeleton prefers-color-scheme blocks + page-vite's @container responsive rule). Either the templates lost their queries (lower this floor on purpose), QueryPreludeRe stopped matching, or StripCommentsForQueryScan is eating real code", scan.Preludes)
+	}
+
+	// ── THE INVARIANT ───────────────────────────────────────────────────────
+	for _, v := range scan.Violations {
+		t.Errorf(
+			"DEAD QUERY CONDITION — this at-rule can NEVER match, silently.\n"+
+				"  file:    %s\n"+
+				"  prelude: %s\n"+
+				"  A media/container query prelude is evaluated BEFORE custom properties are\n"+
+				"  substituted, so the var() never resolves and the whole block is inert. There is\n"+
+				"  no error, no warning and no build failure — the scaffolded app just renders one\n"+
+				"  branch of the layout forever.\n"+
+				"  fix: write the pixel value out (the block breakpoint scale is\n"+
+				"       xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440), or make the decision in JS\n"+
+				"       with useBlockBreakpoint() from @civitai/blocks-react.",
+			v.File, v.Prelude)
+	}
+}
+
+// ── INSTRUMENT VALIDATION ───────────────────────────────────────────────────
+// Everything above reads a verdict out of ExtractQueryPreludes /
+// StripCommentsForQueryScan / ScanQueryPreludes. Until these controls have been
+// watched to work, that verdict is a fact about the extractor.
+
+// TestExtractQueryPreludes is the POSITIVE control on the extractor: fed input
+// that MUST produce preludes, it produces exactly them — and fed the shapes that
+// must NOT count, it produces none.
+func TestExtractQueryPreludes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "a literal media query",
+			in:   "@media (min-width: 768px) { .a { color: red } }",
+			want: []string{"@media (min-width: 768px)"},
+		},
+		{
+			name: "a named container query",
+			in:   "@container block (min-width: 480px) {\n  .a { display: flex }\n}",
+			want: []string{"@container block (min-width: 480px)"},
+		},
+		{
+			name: "the DEAD form is extracted, so the guard can see it",
+			in:   "@media (min-width: var(--civitai-bp-sm)) { .a { color: red } }",
+			want: []string{"@media (min-width: var(--civitai-bp-sm))"},
+		},
+		{
+			name: "@supports is NOT a query prelude — var() is legitimate there",
+			in:   "@supports (color: var(--civitai-color-text)) { .a { color: red } }",
+			want: nil,
+		},
+		{
+			name: "a multi-line prelude is one prelude, whitespace collapsed",
+			in:   "@media\n  (min-width: 768px)\n  and (orientation: landscape) {\n}",
+			want: []string{"@media (min-width: 768px) and (orientation: landscape)"},
+		},
+		{
+			name: "two preludes in one file",
+			in:   "@media (min-width: 768px){}\n@container (min-width: 480px){}",
+			want: []string{"@media (min-width: 768px)", "@container (min-width: 480px)"},
+		},
+		{
+			name: "no at-rules at all",
+			in:   ".a { color: var(--civitai-color-text) }",
+			want: nil,
+		},
+		{
+			// The narrowing that keeps README prose out. A sentence naming the
+			// at-rule opens no block, so it is not a prelude — otherwise the
+			// scanner would run 200 characters into the surrounding paragraph
+			// hunting for a brace and could pick up an unrelated var() there.
+			name: "prose naming an at-rule is not a prelude",
+			in:   "a browser without `@container` support falls back to var(--civitai-color-text).",
+			want: nil,
+		},
+		{
+			// ...but a fenced CSS example in a README IS code, and a dead one
+			// there teaches the mistake. It must still be checked.
+			name: "a markdown-fenced rule is still a prelude",
+			in:   "```css\n@container block (min-width: 480px) {\n  .a { color: red }\n}\n```",
+			want: []string{"@container block (min-width: 480px)"},
+		},
+		{
+			// `var()` in an ordinary declaration is the CORRECT use and must not
+			// be confused with a prelude.
+			name: "a declaration using var() is not a prelude",
+			in:   "@media (min-width: 768px) { .a { color: var(--civitai-color-text) } }",
+			want: []string{"@media (min-width: 768px)"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExtractQueryPreludes(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("ExtractQueryPreludes(%q) = %v, want %v", c.in, got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("ExtractQueryPreludes(%q) = %v, want %v", c.in, got, c.want)
+				}
+			}
+		})
+	}
+}
+
+// TestPreludeUsesVar covers the predicate the guard branches on, in both
+// directions, so a mutant that always answers one way dies here.
+func TestPreludeUsesVar(t *testing.T) {
+	if !PreludeUsesVar("@media (min-width: var(--civitai-bp-sm))") {
+		t.Error("the dead form was not recognised as using var() — the guard would pass over every real violation")
+	}
+	if PreludeUsesVar("@container block (min-width: 480px)") {
+		t.Error("a literal-value prelude was reported as using var() — the guard would red on correct code")
+	}
+}
+
+// TestStripCommentsForQueryScan pins the stripper's contract in BOTH directions.
+// It exists because the guard and its own documentation share a file: the
+// templates deliberately spell the dead form out as a warning, so a stripper
+// that under-strips reds on correct prose, and one that over-strips goes blind
+// to real code.
+func TestStripCommentsForQueryScan(t *testing.T) {
+	t.Run("a whole-line // comment naming the dead form is stripped", func(t *testing.T) {
+		src := "// never write @media (min-width: var(--civitai-bp-sm))\n.a { color: red }\n"
+		if got := ExtractQueryPreludes(src); len(got) != 0 {
+			t.Errorf("prose in a // comment was read as code: %v", got)
+		}
+	})
+
+	t.Run("a /* */ block naming the dead form is stripped", func(t *testing.T) {
+		src := "/* never write\n   @container block (min-width: var(--civitai-bp-xs))\n   here */\n.a { color: red }\n"
+		if got := ExtractQueryPreludes(src); len(got) != 0 {
+			t.Errorf("prose in a block comment was read as code: %v", got)
+		}
+	})
+
+	t.Run("a JSX {/* */} comment is stripped", func(t *testing.T) {
+		src := "{/* see the @container rule; never @media (min-width: var(--x)) */}\n"
+		if got := ExtractQueryPreludes(src); len(got) != 0 {
+			t.Errorf("prose in a JSX comment was read as code: %v", got)
+		}
+	})
+
+	t.Run("REAL code after a stripped comment survives", func(t *testing.T) {
+		// The over-stripping direction. If this ever returns nothing, the guard
+		// has gone silently blind and its clean verdict means nothing.
+		src := "/* a note about @media */\n@media (min-width: var(--civitai-bp-sm)) { .a { color: red } }\n"
+		got := ExtractQueryPreludes(src)
+		if len(got) != 1 || !PreludeUsesVar(got[0]) {
+			t.Fatalf("real code following a comment was lost or misread: %v", got)
+		}
+	})
+
+	t.Run("a URL is not a comment start", func(t *testing.T) {
+		// `//` inside `https://` must not eat the rest of the line — that is the
+		// exact over-strip that would hide a violation written after a URL.
+		src := "/* https://developer.civitai.com/apps/responsive */\n" +
+			"a { background: url(https://x/y.png) } @media (min-width: var(--x)) { .b { color: red } }\n"
+		got := ExtractQueryPreludes(src)
+		if len(got) != 1 || !PreludeUsesVar(got[0]) {
+			t.Fatalf("a violation on the same line as a URL was lost: %v", got)
+		}
+	})
+
+	t.Run("newlines are preserved through a stripped block", func(t *testing.T) {
+		src := "a{}\n/* one\ntwo\nthree */\nb{}\n"
+		if got, want := strings.Count(StripCommentsForQueryScan(src), "\n"), strings.Count(src, "\n"); got != want {
+			t.Errorf("stripper changed the line count: %d, want %d", got, want)
+		}
+	})
+}
+
+// TestScanQueryPreludesNegativeControl is the NEGATIVE control: the scanner must
+// be able to REPORT a violation. A scanner that returns nothing whatever you
+// feed it is indistinguishable from a clean tree, so the clean verdict the real
+// guard reports would mean nothing without this.
+//
+// It drives the same ScanQueryPreludes the guard uses, over a synthetic FS
+// holding one correct rule, one dead one, and one comment that merely NAMES the
+// dead one — and asserts it separates all three.
+func TestScanQueryPreludesNegativeControl(t *testing.T) {
+	fsys := fstest.MapFS{
+		"templates/fake/ok.css.tmpl": {
+			Data: []byte("@container block (min-width: 480px) { .a { color: var(--civitai-color-text) } }"),
+		},
+		"templates/fake/dead.css.tmpl": {
+			Data: []byte("@media (min-width: var(--civitai-bp-sm)) { .a { color: red } }"),
+		},
+		"templates/fake/documented.css.tmpl": {
+			Data: []byte("/* never write @media (min-width: var(--civitai-bp-sm)) */\n@media (min-width: 768px) { .a { color: red } }"),
+		},
+	}
+	scan, err := ScanQueryPreludes(fsys, "templates")
+	if err != nil {
+		t.Fatalf("scanning synthetic FS: %v", err)
+	}
+	if scan.FilesRead != 3 {
+		t.Fatalf("read %d file(s) from the synthetic FS, want 3", scan.FilesRead)
+	}
+	if scan.Preludes != 3 {
+		t.Fatalf("found %d prelude(s) in the synthetic FS, want exactly 3 (one per file; the commented one must not count): %+v", scan.Preludes, scan.Violations)
+	}
+	if len(scan.Violations) != 1 {
+		t.Fatalf("reported %d violation(s), want exactly 1 (only dead.css.tmpl) — the control did not separate live from dead: %+v", len(scan.Violations), scan.Violations)
+	}
+	if scan.Violations[0].File != "templates/fake/dead.css.tmpl" {
+		t.Errorf("violation attributed to %q, want templates/fake/dead.css.tmpl", scan.Violations[0].File)
+	}
+	if !strings.Contains(scan.Violations[0].Prelude, "var(--civitai-bp-sm)") {
+		t.Errorf("violation does not report the offending prelude: %q", scan.Violations[0].Prelude)
+	}
+}

--- a/internal/scaffold/queryprelude.go
+++ b/internal/scaffold/queryprelude.go
@@ -1,0 +1,189 @@
+// Shared logic for the "a custom property in a query condition is silently
+// dead" guard.
+//
+// A CSS media/container query PRELUDE is not a declaration. It is evaluated
+// against the environment before custom properties are substituted, so a
+// `var()` inside one never resolves and the whole at-rule simply never applies:
+//
+//	@media (min-width: var(--civitai-bp-sm)) { … }   ← the block NEVER matches
+//
+// Nothing errors. No console warning, no build failure, no red test — the rule
+// is just inert, and the layout is quietly stuck on whichever branch is outside
+// the at-rule. Measured in Chromium against a literal-value control in the same
+// document: with `--bp-sm` resolving to `768px` and a 1000px window, the literal
+// `@media (min-width: 768px)` applied and the `var()` form did not.
+//
+// That makes it the same defect CLASS as a dead design token (designtokens.go):
+// a plausible-looking reference that produces no signal at all. And it is the
+// mistake a reader makes FIRST, because the `--civitai-bp-*` tokens exist and
+// look exactly like the thing to put there. The scaffold now ships width-adaptive
+// examples in two templates, so the wrong form is one copy-paste away.
+//
+// The invariant is therefore structural, not spelled: NO `var()` may appear in
+// any `@media`/`@container` prelude anywhere under templates/. That catches the
+// hazard however the token is named — including a token that does not exist yet,
+// and including `--civitai-bp-*`'s eventual replacement — which a grep for the
+// literal `var(--civitai-bp-` would not.
+//
+// Scope, stated rather than implied:
+//   - `@supports` is deliberately NOT covered. Its condition tests DECLARATIONS,
+//     where `var()` is legitimate (`@supports (color: var(--x))`).
+//   - Comments are stripped before scanning, so documentation may spell the dead
+//     form out — the examples in the templates do exactly that. See
+//     StripCommentsForQueryScan for the one shape it does not strip.
+package scaffold
+
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+)
+
+// QueryPreludeRe matches a media/container query PRELUDE: the at-keyword up to
+// the `{` that opens its block, which is captured in group 1.
+//
+// Two deliberate narrowings, both aimed at the same failure — a stray `@media`
+// or `@container` in PROSE (a README sentence, a markdown mention) being read as
+// code and swallowing an unrelated `var()` on its way to some distant brace:
+//
+//   - The trailing `\{` is REQUIRED. An at-rule always opens a block; a sentence
+//     naming one almost never does. Measured on this tree, requiring it drops a
+//     prose mention of "`@container` support" that was otherwise counted as a
+//     prelude, without losing any real rule — including the one inside a
+//     markdown ```css fence, which IS code and is checked.
+//   - The length cap bounds the damage if a prose mention does happen to be
+//     followed by a brace. A genuine prelude is a few dozen characters; 200 is
+//     far above any of them and far below a runaway.
+var QueryPreludeRe = regexp.MustCompile(`(?s)(@(?:media|container)\b[^{;]{0,200})\{`)
+
+// QueryPreludeViolation is one prelude that carries a var() reference.
+type QueryPreludeViolation struct {
+	File    string // template-relative path
+	Prelude string // the offending prelude, whitespace-collapsed for reporting
+}
+
+// QueryPreludeScan carries the coverage counts a caller needs to assert a
+// POSITIVE CONTROL. This scanner's reassuring answer is an empty violation list
+// — exactly what a scanner pointed at an empty tree, or one whose regex stopped
+// matching, also produces. So "how many preludes did you actually see?" is part
+// of the result, not a debug aside.
+type QueryPreludeScan struct {
+	Violations []QueryPreludeViolation
+	FilesRead  int // every file walked
+	Preludes   int // total @media/@container preludes seen, post-comment-strip
+}
+
+// ExtractQueryPreludes returns every media/container query prelude in src, with
+// comments stripped first and whitespace collapsed. Order is source order.
+func ExtractQueryPreludes(src string) []string {
+	var out []string
+	for _, m := range QueryPreludeRe.FindAllStringSubmatch(StripCommentsForQueryScan(src), -1) {
+		out = append(out, collapseSpace(m[1]))
+	}
+	return out
+}
+
+// PreludeUsesVar reports whether a prelude references a custom property — the
+// inert form.
+func PreludeUsesVar(prelude string) bool {
+	return strings.Contains(prelude, "var(")
+}
+
+// StripCommentsForQueryScan removes comment text so the prelude scan reads CODE,
+// not prose. Without it this guard could not coexist with its own documentation:
+// the templates deliberately spell the dead form out as a warning, and a scanner
+// that could not tell a warning from a use would red on the very comment telling
+// you not to do it.
+//
+// Two forms, chosen to strip LESS rather than more — an over-eager stripper
+// creates false NEGATIVES, which is the failure direction that matters here:
+//
+//   - `/* … */` block comments, wherever they appear. This is the CSS form and
+//     also the multi-line JS form.
+//   - `// … EOL`, but ONLY when the line's first non-space characters are `//`.
+//     A whole-line comment is unambiguous; a TRAILING `//` is not, because
+//     `url(https://…)` and a string literal both contain one, and treating those
+//     as comment starts would blind the scanner to the rest of that line.
+//
+// The residual, stated rather than papered over: a violation written as a
+// TRAILING comment (`foo; // @media (min-width: var(--x))`) is NOT stripped and
+// will be reported. That is fail-closed and the fix is to move the note onto its
+// own line — the opposite bias to hiding a real one.
+//
+// Newlines inside a stripped block are preserved so line-based reasoning about
+// the remaining text stays meaningful.
+func StripCommentsForQueryScan(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for _, line := range strings.SplitAfter(src, "\n") {
+		if strings.HasPrefix(strings.TrimLeft(line, " \t"), "//") {
+			// Drop the comment, keep the line break.
+			if strings.HasSuffix(line, "\n") {
+				b.WriteByte('\n')
+			}
+			continue
+		}
+		b.WriteString(line)
+	}
+	return stripBlockComments(b.String())
+}
+
+// stripBlockComments removes `/* … */` spans, preserving newlines. An unclosed
+// `/*` swallows the remainder, which matches how a CSS parser reads it.
+func stripBlockComments(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for {
+		i := strings.Index(s, "/*")
+		if i < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:i])
+		rest := s[i+2:]
+		j := strings.Index(rest, "*/")
+		if j < 0 {
+			// Unclosed: keep the newlines, drop the text.
+			b.WriteString(strings.Repeat("\n", strings.Count(rest, "\n")))
+			return b.String()
+		}
+		b.WriteString(strings.Repeat("\n", strings.Count(rest[:j], "\n")))
+		s = rest[j+2:]
+	}
+}
+
+var spaceRunRe = regexp.MustCompile(`\s+`)
+
+func collapseSpace(s string) string {
+	return strings.TrimSpace(spaceRunRe.ReplaceAllString(s, " "))
+}
+
+// ScanQueryPreludes walks fsys from root and reports every media/container query
+// prelude that references a custom property, plus the scan's coverage counts.
+func ScanQueryPreludes(fsys fs.FS, root string) (QueryPreludeScan, error) {
+	var s QueryPreludeScan
+	err := fs.WalkDir(fsys, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		raw, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return err
+		}
+		s.FilesRead++
+		for _, prelude := range ExtractQueryPreludes(string(raw)) {
+			s.Preludes++
+			if PreludeUsesVar(prelude) {
+				s.Violations = append(s.Violations, QueryPreludeViolation{File: p, Prelude: prelude})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return QueryPreludeScan{FilesRead: s.FilesRead}, err
+	}
+	return s, nil
+}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -76,6 +76,45 @@ func TestRenderPageVite(t *testing.T) {
 	if !json.Valid([]byte(pkg)) {
 		t.Errorf("page-vite package.json is not valid JSON:\n%s", pkg)
 	}
+
+	// page-vite ships NO @civitai/* dependency and that is load-bearing, not an
+	// oversight: it is the SDK-free template, its ready-ack is the vendored
+	// src/civitai-host.js (Template.ReadyAckPath), and its README tells the author
+	// to delete that file in the same change that adopts the SDK. Adding an
+	// @civitai/* pin here would also come under `pins-vs-published` — which reads
+	// EVERY template's package.json.tmpl — while `bump-pins` only ever rewrites
+	// templates/page-money/. A pin here would therefore be unbumpable, and would
+	// freeze this repo's required merge gate at the next published minor.
+	if strings.Contains(pkg, "@civitai/") {
+		t.Errorf("page-vite package.json pins an @civitai/* package:\n%s\n"+
+			"  page-vite is the SDK-FREE template. Two things break if it stops being one:\n"+
+			"    1. `pins-vs-published` (a REQUIRED check) reads every template's\n"+
+			"       package.json.tmpl, but `bump-pins` rewrites only page-money's three\n"+
+			"       literal sites — so this pin can never be auto-bumped and goes\n"+
+			"       permanently red on the next @civitai/* minor publish.\n"+
+			"    2. The README tells the author to delete src/civitai-host.js when they\n"+
+			"       adopt the SDK. With the SDK already in package.json but no transport\n"+
+			"       mounted, following that instruction leaves the app with NO handshake.\n"+
+			"  If this is deliberate, extend bump-pins' `sites` list and rewrite that\n"+
+			"  README section in the SAME change.", pkg)
+	}
+
+	// WIDTH-ADAPTIVE example, done with a CSS container query because this
+	// template has no SDK to ask. `container-type` is what makes `.app` a query
+	// container; without it the @container rule silently never matches.
+	css := readFile(t, filepath.Join(dest, "src", "index.css"))
+	mustContain(t, css, "container-type: inline-size")
+	mustContain(t, css, "@container block (min-width: 480px)")
+	mustContain(t, css, ".app-actions")
+	// A VIEWPORT media query is the wrong question inside a block iframe (slot
+	// width is not monotonic in viewport width), so the responsive rule must not
+	// be one. The boot skeleton's prefers-color-scheme block lives in index.html,
+	// not here, so this file legitimately has no @media at all.
+	mustNotContain(t, css, "@media")
+	// And the markup must actually use it — a container query over a class
+	// nothing renders is inert.
+	appJSX := readFile(t, filepath.Join(dest, "src", "App.jsx"))
+	mustContain(t, appJSX, `className="app-actions"`)
 }
 
 func TestRenderPageMoney(t *testing.T) {
@@ -95,7 +134,7 @@ func TestRenderPageMoney(t *testing.T) {
 		"src/generation.test.ts", "src/models.test.ts", "src/nav.test.ts",
 		"src/comfy.test.ts",
 		"src/setup-dev-live.test.ts", "src/setup-plugin.test.ts",
-		"src/App.pollretry.test.tsx", "src/index.css",
+		"src/App.pollretry.test.tsx", "src/responsive.test.tsx", "src/index.css",
 		"README.md", ".gitignore", ".env.development", ".env.production", ".env.example",
 		"assets/README.md",
 	} {
@@ -168,6 +207,39 @@ func TestRenderPageMoney(t *testing.T) {
 	mustContain(t, app, "useRequestConsent")
 	mustContain(t, app, "useBuzzWorkflow")
 	mustContain(t, app, "useBlockResize")
+
+	// WIDTH-ADAPTIVE example. The block branches on ITS OWN width tier
+	// (useBlockBreakpoint — a container query over the slot the host gave it),
+	// never on the viewport, and renders a different container for the Model row.
+	//
+	// 🔴 THESE ARE PRESENCE FLOORS, NOT BEHAVIOURAL GUARDS. This is a substring
+	// match over a rendered template, so a comment satisfies every line below;
+	// they exist so DELETING the example is loud, not to prove it works. The
+	// behavioural guard ships in the generated project — src/responsive.test.tsx
+	// renders <App/> at 361px and 900px against a stubbed ResizeObserver and
+	// asserts the layout actually swaps — and CI runs it via `template-page-money`
+	// (`npm test`). The separate CLASS guard against the silently-dead
+	// `var()`-in-a-query-prelude form is
+	// TestScaffoldTemplatesHaveNoVarInQueryPreludes.
+	mustContain(t, app, "useBlockBreakpoint")
+	mustContain(t, app, "bp.below('sm')")
+	mustContain(t, app, `data-testid="pm-model-row"`)
+	mustContain(t, app, `data-layout="stacked"`)
+	mustContain(t, app, `data-layout="row"`)
+	mustContain(t, app, "data-block-tier")
+	// The example must not reach for the viewport instead — that is the wrong
+	// question inside a block iframe, and it is what a reader writes by reflex.
+	mustNotContain(t, app, "matchMedia")
+	mustNotContain(t, app, "window.innerWidth")
+	// And the generated test must actually exercise it at BOTH widths — an
+	// unreferenced example rots (same reasoning as the inline-Comfy sample below).
+	responsiveTest := readFile(t, filepath.Join(dest, "src", "responsive.test.tsx"))
+	mustContain(t, responsiveTest, "pm-model-row")
+	mustContain(t, responsiveTest, "resolveBlockTier")
+	for _, w := range []string{"361", "900"} {
+		mustContain(t, responsiveTest, w)
+	}
+
 	// The model + LoRA controls drive the HOST's native pickers via the SDK hooks
 	// (the in-block catalog browser is gone).
 	mustContain(t, app, "useCheckpointPicker")

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -46,6 +46,8 @@ The money path uses the SDK hooks — never raw `window.parent.postMessage`:
   consent-gated, so the token mints WITHOUT it; the grant arrives as a
   `TOKEN_REFRESH` and the app auto-resumes the click.
 - `useBlockResize()` — the SDK reports height to the host safely.
+- `useBlockBreakpoint()` — the width tier of your block's own box, for layout
+  decisions. See below.
 
 Page constraints: a page is `entity=none` — it carries no HOST model context (a
 model slot would deliver `modelId`/`modelVersionId` via `BLOCK_INIT`; a page does
@@ -55,6 +57,45 @@ paint) — and lets the user CHANGE it via the host picker. The viewer's Buzz
 balance is read in-block via `useBuzzBalance()` (host-mediated, no scope) — an
 insufficient-Buzz `failed` snapshot is still handled as a backstop. The budget
 comes from `page.buzzBudgetPerGen` in the manifest.
+
+### Width-adaptive layout (`useBlockBreakpoint`)
+
+Your app renders inside whatever slot the host gave it, and **slot width is not
+monotonic in viewport width** — the `model.sidebar_top` slot is about 360px next
+to a 360px phone and only about 430px next to a 1440px desktop. So the useful
+question is "how wide am **I**?", not "how wide is the browser window?".
+
+`useBlockBreakpoint()` answers that. It observes your element with a
+`ResizeObserver` (a container query, effectively) and returns the width **tier**:
+
+```ts
+const bp = useBlockBreakpoint(rootRef); // or no ref → the sandbox document
+bp.tier;            // 'base' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+bp.below('sm');     // true when narrower than 768px
+bp.atLeast('md');   // true at 1024px and up
+bp.measured;        // false until the first measurement lands
+```
+
+The scale is **CSS pixels**: `xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440`.
+That is Civitai's own scale, and it is deliberately **not** Mantine's stock `em`
+scale (576 / 768 / 992 / 1200 / 1408) — the two agree on `sm` and nowhere else,
+so a check that only ever exercises 768 tells you nothing about the rest.
+
+It re-renders you on a **tier change only**, never per pixel, so branching on it
+is cheap. `src/App.tsx` uses it for exactly one decision — the Model row is a
+`Group` when there is room and a `Stack` when there is not — and
+`src/responsive.test.tsx` drives that at two widths. Keep the rest of your layout
+in fluid CSS; reach for the hook when you need a genuinely **different element
+tree**, not a different size.
+
+> 🔴 **`--civitai-bp-*` cannot be used in a query condition.** The tokens exist,
+> and putting one in the condition of a media or container query is the first
+> thing most people try — but a query's condition is evaluated before custom
+> properties are substituted, so the rule never matches. Nothing errors, nothing
+> warns, the build stays green, and your layout is silently stuck on one branch.
+> In CSS, write the pixel number out. In JS, use this hook.
+
+Full guide: <https://developer.civitai.com/apps/responsive>
 
 ### Model picker (host-served, server-revalidated)
 

--- a/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.pollretry.test.tsx.tmpl
@@ -22,6 +22,19 @@ const estimateFn = vi.fn<() => Promise<BlockWorkflowSnapshot>>();
 vi.mock('@civitai/blocks-react', () => ({
   useBlockContext: () => ({ ready: true, viewer: { id: 2, username: 'dev' }, theme: 'dark' }),
   useBlockResize: () => {},
+  // Width tier is inert here (this test is about the poll loop, not layout), but
+  // it must be returned in FULL SHAPE — App calls `.below()` on it, so a partial
+  // stub throws. 🔴 This whole `vi.mock` is WHOLESALE: every hook App imports has
+  // to be listed, and vitest fails the test the moment App uses one that isn't.
+  // That is the right failure direction — a silently-missing export would render
+  // a different component than the one that ships — but it does mean this object
+  // is a second place to update when App adopts a new SDK hook.
+  useBlockBreakpoint: () => ({
+    tier: 'base',
+    measured: false,
+    atLeast: () => false,
+    below: () => true,
+  }),
   useBlockToken: () => ({ scopes: ['ai:write:budgeted'], raw: 't', expiresAt: '' }),
   useBuzzWorkflow: () => ({ estimate: estimateFn, submit: submitFn, poll: pollFn }),
   // Balance read is inert here (this test is about the poll loop, not balance).

--- a/internal/scaffold/templates/page-money/src/App.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/App.tsx.tmpl
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
+  useBlockBreakpoint,
   useBlockContext,
   useBlockResize,
   useBlockToken,
@@ -141,6 +142,37 @@ export function App() {
 
   const rootRef = useRef<HTMLDivElement>(null);
   useBlockResize(rootRef);
+
+  // WIDTH-ADAPTIVE LAYOUT. `useBlockBreakpoint` reports the width tier of THIS
+  // BLOCK'S OWN BOX — a container query, not a viewport media query — because a
+  // block renders inside whatever slot the host gave it and SLOT WIDTH IS NOT
+  // MONOTONIC IN VIEWPORT WIDTH (the `model.sidebar_top` slot is ~360px on a
+  // phone and only ~430px on a 1440px desktop). Any viewport-based test —
+  // a viewport media query, or the window's own width read from JS — asks about
+  // the browser window, which is a question nobody here needed answered.
+  //
+  // Scale (CSS px, Civitai's own — NOT Mantine's stock em scale, which agrees on
+  // `sm` alone): xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440. The same numbers
+  // are published as the `--civitai-bp-*` custom properties.
+  //
+  // 🔴 THOSE TOKENS CANNOT BE USED IN A QUERY CONDITION. `@media (min-width:
+  // var(--civitai-bp-sm))` is silently DEAD — a media/container query prelude is
+  // evaluated before custom properties are substituted, so the rule simply never
+  // applies: no error, no warning, no console noise. Write the pixel value out,
+  // or branch in JS the way this component does. (An `internal/scaffold` guard in
+  // the CLI repo fails on a `var()` inside any `@media`/`@container` prelude in
+  // these templates, for exactly this reason.)
+  //
+  // Re-render safety: the hook stores the resolved TIER, not the width, so
+  // dragging a window edge 200px inside one tier re-renders this block zero
+  // times. Full guide: https://developer.civitai.com/apps/responsive
+  const bp = useBlockBreakpoint(rootRef);
+  // ONE structural decision, deliberately. `below('sm')` is the "am I in a narrow
+  // slot?" question every block eventually asks; everything else here is fluid
+  // CSS already. `measured` is not gated on because the fallback (`'base'`, i.e.
+  // narrow) is the safe branch for a block — see the hook's own docs for when to
+  // gate on it instead.
+  const narrow = bp.below('sm');
 
   const [mode, setMode] = useState<GenMode>('txt2img');
   const [prompt, setPrompt] = useState('');
@@ -478,12 +510,32 @@ export function App() {
   const busy = isBusyPhase(phase);
   const isComfy = mode === 'comfy';
 
+  // The Model row's CONTENT, hoisted so the two layouts below share one copy of
+  // it. Only the container differs between the wide and narrow branches.
+  const modelRow = (
+    <>
+      <span style={currentModelStyle} title={checkpoint.label} data-testid="pm-model-label">
+        {checkpoint.label}
+        {checkpoint.baseModel ? ` (${checkpoint.baseModel})` : ''}
+      </span>
+      <Button
+        variant="light"
+        size="sm"
+        loading={pickerBusy}
+        onClick={() => void onChangeModel()}
+        data-testid="pm-change-model"
+      >
+        Change model
+      </Button>
+    </>
+  );
+
   // ---- Render ----
 
   if (!ready) {
     return (
       // Theme the block's OWN root; that's what the pack's CSS reads.
-      <div ref={rootRef} data-theme={theme} style={shell}>
+      <div ref={rootRef} data-theme={theme} data-block-tier={bp.tier} style={shell}>
         <Card padding="lg">
           <Group gap={10}>
             <Badge color="info" variant="light">
@@ -506,7 +558,9 @@ export function App() {
   };
 
   return (
-    <div ref={rootRef} data-theme={theme} style={shell}>
+    // `data-block-tier` is not required by anything — it is here so you can see
+    // the tier in devtools (and assert it in a test) while you build a layout.
+    <div ref={rootRef} data-theme={theme} data-block-tier={bp.tier} style={shell}>
       <Card padding="lg" style={cardStyle}>
         <Stack gap={16}>
           <strong style={titleStyle}>{{ .Name }}</strong>
@@ -570,25 +624,27 @@ export function App() {
                 <span style={fieldDescStyle}>
                   The checkpoint to generate with. The server validates + prices every generation.
                 </span>
-                <Group justify="space-between" align="center" gap={8} wrap={false}>
-                  <span
-                    style={currentModelStyle}
-                    title={checkpoint.label}
-                    data-testid="pm-model-label"
+                {/* THE RESPONSIVE EXAMPLE. Side by side when the block has room;
+                    stacked, with a full-width button, when it doesn't. This is a
+                    STRUCTURAL swap (a different element), which is the kind of
+                    change CSS alone handles badly and `useBlockBreakpoint` is
+                    for — pure sizing/spacing should stay in fluid CSS. */}
+                {narrow ? (
+                  <Stack gap={8} align="stretch" data-testid="pm-model-row" data-layout="stacked">
+                    {modelRow}
+                  </Stack>
+                ) : (
+                  <Group
+                    justify="space-between"
+                    align="center"
+                    gap={8}
+                    wrap={false}
+                    data-testid="pm-model-row"
+                    data-layout="row"
                   >
-                    {checkpoint.label}
-                    {checkpoint.baseModel ? ` (${checkpoint.baseModel})` : ''}
-                  </span>
-                  <Button
-                    variant="light"
-                    size="sm"
-                    loading={pickerBusy}
-                    onClick={() => void onChangeModel()}
-                    data-testid="pm-change-model"
-                  >
-                    Change model
-                  </Button>
-                </Group>
+                    {modelRow}
+                  </Group>
+                )}
               </div>
 
               {/* LoRA control. Add up to MAX_LORAS LoRAs on top of the checkpoint

--- a/internal/scaffold/templates/page-money/src/responsive.test.tsx.tmpl
+++ b/internal/scaffold/templates/page-money/src/responsive.test.tsx.tmpl
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveBlockTier } from '@civitai/blocks-react';
+
+import { App } from './App.js';
+import { installMockMoneyHost } from './mock-buzz.js';
+
+// The width-adaptive layout, tested at its actual widths.
+//
+// This is the BEHAVIOURAL half of the responsive example. `App.tsx` asks
+// `useBlockBreakpoint` for the block's own width tier and renders a DIFFERENT
+// container for the Model row depending on the answer; the tests below drive
+// that at two widths and assert the swap really happens.
+//
+// 🔴 THE STUB IS THE WHOLE TEST, so read it before trusting a green.
+// jsdom implements no `ResizeObserver` and lays nothing out, so out of the box
+// `useBlockBreakpoint` bails on its own `typeof ResizeObserver === 'undefined'`
+// guard, never measures, and reports `'base'` — the NARROW branch — at every
+// width. A test written without the stub would pass the narrow assertion for a
+// reason that has nothing to do with the code under test, and could never
+// observe the wide one at all. Two things are therefore faked:
+//
+//   1. `ResizeObserver`, as an inert class, purely so the hook's effect runs.
+//      It never needs to fire: the hook seeds itself synchronously from
+//      `element.clientWidth` right after `observe()`, which is the path these
+//      tests exercise.
+//   2. `clientWidth`, which jsdom always reports as 0.
+//
+// Both are restored after each test.
+
+/** The width every element reports for the duration of one test. */
+let blockWidth = 0;
+let restoreClientWidth: (() => void) | undefined;
+let restoreResizeObserver: (() => void) | undefined;
+
+class InertResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function setBlockWidth(px: number) {
+  blockWidth = px;
+
+  const original = Object.getOwnPropertyDescriptor(Element.prototype, 'clientWidth');
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => blockWidth,
+  });
+  restoreClientWidth = () => {
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+    if (original) Object.defineProperty(Element.prototype, 'clientWidth', original);
+  };
+
+  const priorRO = (globalThis as unknown as Record<string, unknown>).ResizeObserver;
+  (globalThis as unknown as Record<string, unknown>).ResizeObserver = InertResizeObserver;
+  restoreResizeObserver = () => {
+    (globalThis as unknown as Record<string, unknown>).ResizeObserver = priorRO;
+  };
+}
+
+describe('width-adaptive layout', () => {
+  let uninstall: (() => void) | undefined;
+
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+    restoreClientWidth?.();
+    restoreClientWidth = undefined;
+    restoreResizeObserver?.();
+    restoreResizeObserver = undefined;
+  });
+
+  // 🔴 THE FIXTURE WIDTHS ARE DELIBERATE. 361 and 900 are distinct from each
+  // other and from EVERY breakpoint constant the assertions name (480 / 768 /
+  // 1024 / 1184 / 1440), and each sits strictly INSIDE its tier rather than on a
+  // boundary. A fixture that lands on a boundary — or that happens to equal a
+  // constant — can pass while the comparison it is meant to exercise is wrong.
+  //
+  // 361 also is not arbitrary: it is roughly the `model.sidebar_top` slot, the
+  // narrow case a block actually meets in production.
+
+  it('a NARROW block stacks the Model row', async () => {
+    setBlockWidth(361);
+    uninstall = installMockMoneyHost({ viewer: { id: 2, username: 'dev', status: 'active' } });
+    render(<App />);
+
+    const row = await screen.findByTestId('pm-model-row');
+    await waitFor(() => expect(row).toHaveAttribute('data-layout', 'stacked'));
+    // The tier the decision was made from, so a failure says WHY.
+    expect(document.querySelector('[data-block-tier]')).toHaveAttribute('data-block-tier', 'base');
+  });
+
+  it('a WIDE block puts the Model row side by side', async () => {
+    setBlockWidth(900);
+    uninstall = installMockMoneyHost({ viewer: { id: 2, username: 'dev', status: 'active' } });
+    render(<App />);
+
+    const row = await screen.findByTestId('pm-model-row');
+    await waitFor(() => expect(row).toHaveAttribute('data-layout', 'row'));
+    expect(document.querySelector('[data-block-tier]')).toHaveAttribute('data-block-tier', 'sm');
+  });
+
+  it('the Model row keeps its contents in BOTH layouts', async () => {
+    // The layout swaps the container, not the content. Without this, deleting
+    // the button on one branch would still satisfy the two tests above.
+    setBlockWidth(361);
+    uninstall = installMockMoneyHost({ viewer: { id: 2, username: 'dev', status: 'active' } });
+    render(<App />);
+
+    expect(await screen.findByTestId('pm-change-model')).toBeInTheDocument();
+    expect(screen.getByTestId('pm-model-label')).toHaveTextContent(/SD XL 1\.0/);
+  });
+});
+
+describe('the block breakpoint scale', () => {
+  // 🔴 Civitai's block scale is CSS px — xs 480 · sm 768 · md 1024 · lg 1184 ·
+  // xl 1440 — and it is NOT Mantine's stock em scale (576 / 768 / 992 / 1200 /
+  // 1408). The two agree on `sm` (768) and NOWHERE else, so a test that pins
+  // `sm` alone passes against the entirely wrong scale. Every case below is one
+  // of the four values that DISCRIMINATE, plus the pixel underneath it.
+  //
+  // Why assert a scale you do not own: your layout's thresholds are chosen
+  // against these numbers, and they are also what you must write out by hand in
+  // CSS (a query prelude cannot read `--civitai-bp-*` — see index.css). If the
+  // pack ever moves them, this is the line that says so.
+  it.each([
+    [1, 'base'],
+    [479, 'base'],
+    [480, 'xs'],
+    [767, 'xs'],
+    [768, 'sm'],
+    [1023, 'sm'],
+    [1024, 'md'],
+    [1183, 'md'],
+    [1184, 'lg'],
+    [1439, 'lg'],
+    [1440, 'xl'],
+  ])('%ipx resolves to %s', (width, tier) => {
+    expect(resolveBlockTier(width as number)).toBe(tier);
+  });
+
+  it('an unmeasured width resolves to the conservative tier', () => {
+    // 0 / NaN mean "not measured yet", not "very narrow" — but `base` is the
+    // right answer for both, and it is why the App does not need to gate on
+    // `measured`.
+    expect(resolveBlockTier(0)).toBe('base');
+    expect(resolveBlockTier(Number.NaN)).toBe('base');
+  });
+});

--- a/internal/scaffold/templates/page-vite/README.md.tmpl
+++ b/internal/scaffold/templates/page-vite/README.md.tmpl
@@ -61,6 +61,48 @@ internally.
 > an init: it gives up after 10s while the host sits "ready", showing an app
 > that never started, with no retry and no error card.
 
+## Width-adaptive layout (`src/index.css`)
+
+Your app renders inside whatever slot the host gave it, and **slot width is not
+monotonic in viewport width** — the `model.sidebar_top` slot is about 360px next
+to a 360px phone and only about 430px next to a 1440px desktop. A viewport-based
+media query inside the frame therefore answers a question nobody asked, which is
+why this template ships none.
+
+`src/index.css` makes `.app` a **query container** (`container-type:
+inline-size`) and adapts `.app-actions` against the container's own width:
+
+```css
+.app-actions { flex-direction: column; }          /* narrow — the base state */
+
+@container block (min-width: 480px) {
+  .app-actions { flex-direction: row; }           /* wider */
+}
+```
+
+Narrow is the base state and widening is the override, on purpose: a block is
+narrow far more often than not, and that is also what a browser without
+`@container` support falls back to.
+
+The thresholds are Civitai's block breakpoint scale, in **CSS pixels**:
+`xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440`. (Not Mantine's stock `em`
+scale — the two agree on `sm` and nowhere else.) 480 is the step this layout can
+actually cross, since `.app` is capped at `40rem`.
+
+> 🔴 **Write the pixel number out.** The design system publishes these as
+> `--civitai-bp-*` custom properties, and reaching for one in the condition of a
+> media or container query is the first thing most people try. It does not work:
+> a query's condition is evaluated before custom properties are substituted, so
+> the rule never matches — no error, no warning, green build, and a layout
+> silently stuck on one branch.
+
+Adopting `@civitai/blocks-react` later? Its `useBlockBreakpoint()` hook reports
+the same scale in JS, for decisions CSS cannot make — rendering a genuinely
+*different* element tree rather than restyling the same one. The `page-money`
+template (`civitai app init "…" --template page-money`) shows that form.
+
+Full guide: <https://developer.civitai.com/apps/responsive>
+
 ## Develop
 
 ```bash

--- a/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
+++ b/internal/scaffold/templates/page-vite/src/App.jsx.tmpl
@@ -17,7 +17,14 @@ export default function App() {
     <main className="app">
       <h1>{{ .Name }}</h1>
       <p>A Civitai App built with Vite + React.</p>
-      <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
+      {/* THE RESPONSIVE EXAMPLE. These two buttons stack on a narrow block and
+          sit side by side once there is room. The switch lives in
+          src/index.css (`.app-actions` + the `@container` rule) — read the
+          comments there before adding a `@media` query of your own. */}
+      <div className="app-actions">
+        <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
+        <button onClick={() => setCount(0)}>reset</button>
+      </div>
     </main>
   );
 }

--- a/internal/scaffold/templates/page-vite/src/index.css.tmpl
+++ b/internal/scaffold/templates/page-vite/src/index.css.tmpl
@@ -15,6 +15,49 @@ body {
   max-width: 40rem;
   margin: 0 auto;
   padding: 2rem 1.5rem;
+
+  /* WIDTH-ADAPTIVE LAYOUT — a CONTAINER query, not a viewport media query.
+     Your block renders inside whatever slot the host gave it, and SLOT WIDTH IS
+     NOT MONOTONIC IN VIEWPORT WIDTH: the `model.sidebar_top` slot is ~360px on a
+     phone and only ~430px on a 1440px desktop. A viewport-based media query
+     inside the frame therefore answers a question nobody asked, which is why
+     this file has none. `container-type: inline-size` makes this element a query
+     container, so the `@container` rule below asks about the real box. */
+  container-type: inline-size;
+  container-name: block;
+}
+
+/* Narrow is the BASE state, and widening is the override. A block is narrow far
+   more often than not, so the mobile-ish layout is what you get with no query
+   matched at all — including in a browser that does not support `@container`. */
+.app-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+/* 480px is `xs` on Civitai's block breakpoint scale, in CSS px:
+     xs 480 · sm 768 · md 1024 · lg 1184 · xl 1440
+   (Civitai's own scale — NOT Mantine's stock em scale, which agrees on `sm`
+   alone.) `xs` is the step this template can actually cross, since `.app` is
+   capped at 40rem; a threshold the layout can never reach teaches nothing.
+
+   🔴 WRITE THE PIXEL VALUE OUT. `@container block (min-width: var(--civitai-bp-xs))`
+   is silently DEAD: a media/container query prelude is evaluated before custom
+   properties are substituted, so the rule simply never applies — no error, no
+   warning, no console noise, and the layout is quietly stuck on one branch. The
+   `--civitai-bp-*` tokens exist for use in ordinary declarations, not here.
+
+   Adopting `@civitai/blocks-react`? `useBlockBreakpoint()` reports the same
+   scale in JS, for the decisions CSS cannot make — rendering a DIFFERENT element
+   tree rather than restyling the same one. See the `page-money` template.
+   Guide: https://developer.civitai.com/apps/responsive */
+@container block (min-width: 480px) {
+  .app-actions {
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 button {


### PR DESCRIPTION
A freshly scaffolded App Block starts on the responsive system instead of having to discover it.

**Measured before this change**, across all three templates: `useBlockBreakpoint` 0, `--civitai-bp-*` 0. (`useBlockResize` was *not* 0 — page-money already called it; that hook reports height to the host and is unrelated to layout.) `static` is untouched — it is the CDN `<link>` route and its stylesheet has no `--civitai-bp-*` tokens.

## What the example demonstrates

**page-money — branch on your own width tier.**
`useBlockBreakpoint(rootRef)` is a container query over the slot the host gave the block, not a viewport media query, because **slot width is not monotonic in viewport width**: `model.sidebar_top` is ~360px next to a 360px phone and only ~430px next to a 1440px desktop. One structural decision is wired to it — the Model row renders as a `Group` when there is room and a `Stack` (full-width button) when there is not — plus `data-block-tier` on the block root so the tier is visible in devtools and assertable in a test. The row's *content* is hoisted so only the container differs.

**page-vite — the same lesson without an SDK.**
`container-type: inline-size` on `.app`, `@container block (min-width: 480px)` for `.app-actions`. Narrow is the base state and widening is the override, so a browser without `@container` gets the narrow layout rather than a broken wide one. `480` (`xs`) is the step this template can actually cross — `.app` is capped at `40rem`, so a `768` threshold would never fire and an example that can never fire teaches nothing.

Both READMEs gained a section, including the warning below.

## Packages newly pinned: **none**

`@civitai/blocks-react ^0.45.0` was already pinned in page-money and exports `useBlockBreakpoint` from the package root. `@civitai/theme` and `@civitai/components` are exact-pinned *dependencies* of it (`0.3.0` / `0.4.0`), so they install transitively and did not need pinning.

### 🔴 page-vite deliberately stays SDK-free, and I recommend keeping it that way

Adding `@civitai/*` to `page-vite/package.json.tmpl` was in scope, and I measured two reasons not to:

1. **It would freeze this repo's required merge gate.** `pins_guard_test.go`'s `collectCivitaiPins` walks **every** `package.json.tmpl` under `templates/` (`fs.WalkDir` on `d.Name() != "package.json.tmpl"`). `bump-pins` writes only three hardcoded sites, all page-money (`templates/page-money/package.json.tmpl`, that template's README, `scaffold_test.go`), and `discoverPackages` reads page-money's package.json alone. So a pin in page-vite is **read by the gate and unreachable by the bumper**: at the next `@civitai/*` minor publish, `bump-pins` moves page-money to `^0.46.0`, page-vite stays at `^0.45.0`, and `pins-vs-published` — required, `enforce_admins: true` — goes red for every open PR with no automated remedy. Measured publish cadence for app-sdk minors is ~3.6 days.
2. **It would make the template's own README dangerous.** page-vite's `ReadyAckPath()` is `src/civitai-host.js`, and its README says to delete that file *in the same change* that adopts the SDK. With `@civitai/blocks-react` in `package.json` but no transport mounted, following that instruction leaves the app with **no handshake at all** — the host never reveals it.

`TestRenderPageVite` now asserts page-vite pins no `@civitai/*`, and the failure message states both reasons and what to change if it is ever done deliberately (extend `bump-pins`' `sites`, rewrite that README section, same PR).

## New class guard: no `var()` in a query prelude

`internal/scaffold/queryprelude.go` + `query_prelude_guard_test.go`.

A media/container query **condition** is evaluated before custom properties are substituted, so `@media (min-width: var(--civitai-bp-sm))` never matches. No error, no warning, green build, layout silently frozen on one branch. The `--civitai-bp-*` tokens exist and sit right next to both new examples, so this is the first thing a reader will try.

The guard asserts the **relationship the browser enforces** — a prelude may not depend on the cascade — rather than the spelling `var(--civitai-bp-`, so it holds through a token rename and covers properties that do not exist yet. `@supports` is excluded on purpose (its condition tests declarations, where `var()` is legitimate).

Two design points worth reviewing:
- **Comments are stripped first**, so the templates can spell the dead form out as a warning without the guard reporting its own documentation. The stripper takes `/* … */` anywhere and `// … EOL` **only on a line whose first non-space characters are `//`** — a trailing `//` is ambiguous (`url(https://…)`), and blinding the rest of that line is the failure direction that matters. A violation written as a trailing comment is therefore still reported: fail-closed, fix by moving the note to its own line.
- **A trailing `{` is required.** Prose naming an at-rule opens no block. Without this, `` a browser without `@container` support `` was counted as a prelude and would scan 200 characters into the paragraph hunting for a brace. A fenced ```css example in a README still *is* code and is still checked (test case included).

Ledger untouched: `--civitai-bp-{xs,sm,md,lg,xl}` entered `testdata/design-tokens.txt` at the 0.45.0 bump. `go run ./internal/scaffold/cmd/bump-pins --check` → `all @civitai/* pins are current and the design-token ledger matches — nothing to do`, rc=0.

## Per-gate results (local)

| Gate | Result |
|---|---|
| `build-test` (`go test ./...`, `go vet`, `gofmt -s -l`) | rc=0 · **21** packages `ok` · 0 `FAIL` · gofmt lists 0 files |
| `pins-vs-published` (`CIVITAI_CHECK_PUBLISHED_PINS=1`, `-count=1`) | `--- PASS: TestScaffoldPinsSatisfyPublished (0.37s)` |
| `ready-ack-runtime` (`CIVITAI_CHECK_SCAFFOLD_RUNTIME=1`, `-count=1`) | `--- PASS: TestScaffoldedReadyAckActuallyFires (0.92s)` |
| `scaffold-currency` (a) anti-pattern scan | `--- PASS: TestScanDirFromEnv` · `no anti-patterns found` |
| `scaffold-currency` (b) `@latest` SDK | npm HTTP 200 · installed blocks-react **0.45.0** / app-sdk **0.37.0** · typecheck rc=0 · build rc=0 |
| design-tokens (8 tests) | all PASS · `54 files; 4 with tokens; 17 pairs, 29 occurrences; ledger 32 @0.45.0` |
| new query-prelude guard | PASS · `54 files; 4 preludes; 0 violations` |
| `template-page-vite` | scaffold → install → build rc=0 → `BLOCK_INIT: 1 file(s)`, `BLOCK_READY: 1 file(s)`, control `CI Vite Block: 1 file(s)` → `✓ . is valid` |
| `template-page-money` | scaffold → install → typecheck rc=0 → **168 passed (12 files)** → build rc=0 → `✓ . is valid` |
| `lint` (golangci-lint) | `0 issues.` |

The `@container` rule survives esbuild minification intact in the built page-vite CSS.

## Red / green matrix

Base ref **`22cb38d`** (`origin/main`). The new `src/responsive.test.tsx` was scaffolded from base and dropped into that app unchanged:

| | base `22cb38d` | HEAD |
|---|---|---|
| `src/responsive.test.tsx` | **2 failed**, 13 passed (15) — `Unable to find an element by: [data-testid="pm-model-row"]` | **15 passed** |

Honest scope: only the 2 layout tests are regression coverage. The 13 that pass at base are invariant guards — 11 pin the SDK's px scale and 2 pin content presence.

Also caught and fixed as part of this: `App.pollretry.test.tsx`'s wholesale `vi.mock('@civitai/blocks-react')` went stale the moment `App.tsx` imported a new hook (`No "useBlockBreakpoint" export is defined on the mock`, 2 tests red). Loud failure, correct direction — noted inline that the mock is a second place to update.

## Mutation results

Every mutant was killed by the **guard's own** assertion, on an input no earlier check rejects, and the control was re-run green after each restore.

| Mutation | Killed by | Message |
|---|---|---|
| `const narrow = false` (branch dead) | `responsive.test.tsx` NARROW | `expect(element).toHaveAttribute("data-layout", "stacked")` … `Received: data-layout="row"` |
| `bp.below('sm')` → `bp.below('md')` (wrong threshold) | `responsive.test.tsx` WIDE | `expect(element).toHaveAttribute("data-layout", "row")` … `Received: data-layout="stacked"` |
| `var(--civitai-bp-xs)` into the live `@container` rule | new class guard | `DEAD QUERY CONDITION` naming `templates/page-vite/src/index.css.tmpl`; still `4 preludes`, so the coverage floor was **not** the killer |
| same, in the README's fenced example | new class guard | `DEAD QUERY CONDITION` naming `templates/page-vite/README.md.tmpl` (fenced CSS is checked) |
| replace the hook call + `narrow` in `App.tsx.tmpl` | `TestRenderPageMoney` floor | `expected to contain "bp.below('sm')"` |

Fixture widths are **361** and **900** — pairwise distinct, distinct from every constant the assertions name (480 / 768 / 1024 / 1184 / 1440), and each strictly *inside* its tier rather than on a boundary. 900 is what discriminates `sm` from `md`; 361 is roughly the real `model.sidebar_top` slot.

The scale assertions pin `xs`=480, `md`=1024, `lg`=1184, `xl`=1440 plus the pixel below each — the values that separate Civitai's px scale from Mantine's stock em scale (576/768/992/1200/1408), which agree on `sm` alone.

## Not verified

- **No browser run.** jsdom lays nothing out and ships no `ResizeObserver`, so `responsive.test.tsx` stubs both (an inert `ResizeObserver` purely so the hook's effect runs, plus a `clientWidth` getter — the hook seeds itself synchronously from `clientWidth` right after `observe()`). That exercises the *decision*, not real layout. The `@container` rule in page-vite is verified only as far as "it survives the build byte-correct" — it was not rendered in a browser at two widths.
- The `@media (min-width: var(--x))` inertness is taken from the brief's Chromium measurement, not re-measured here.
- CI itself has not run yet; every result above is local.

**Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
