### PR TITLE
ci: node 22 -> 24 so npm 11 installs the scaffolded app, unfreezing the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,9 +270,17 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # node 24 (npm 11), NOT 22 (npm 10). npm 10's arborist crashes with
+      # `Cannot read properties of null (reading 'edgesOut')` while walking
+      # vitest -> its optional `jsdom@*` peer -> canvas, during `npm install`
+      # of a scaffolded page-money app. That froze EVERY PR in this repo
+      # (scaffold-currency is required + enforce_admins) with no code change,
+      # the moment vitest@5.0.0 published upstream. Measured: npm 10.9.9 fails
+      # on the unmodified template, npm 11.19.0 succeeds; overriding jsdom or
+      # pinning vitest does NOT fix it. Do not drop back to 22.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: scaffolded ready-ack actually fires
         env:
@@ -334,9 +342,17 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # node 24 (npm 11), NOT 22 (npm 10). npm 10's arborist crashes with
+      # `Cannot read properties of null (reading 'edgesOut')` while walking
+      # vitest -> its optional `jsdom@*` peer -> canvas, during `npm install`
+      # of a scaffolded page-money app. That froze EVERY PR in this repo
+      # (scaffold-currency is required + enforce_admins) with no code change,
+      # the moment vitest@5.0.0 published upstream. Measured: npm 10.9.9 fails
+      # on the unmodified template, npm 11.19.0 succeeds; overriding jsdom or
+      # pinning vitest does NOT fix it. Do not drop back to 22.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: scaffold page-vite
         run: go run ./cmd/civitai app init "CI Vite Block" --dir ./_ci-page-vite --template page-vite
@@ -413,9 +429,17 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # node 24 (npm 11), NOT 22 (npm 10). npm 10's arborist crashes with
+      # `Cannot read properties of null (reading 'edgesOut')` while walking
+      # vitest -> its optional `jsdom@*` peer -> canvas, during `npm install`
+      # of a scaffolded page-money app. That froze EVERY PR in this repo
+      # (scaffold-currency is required + enforce_admins) with no code change,
+      # the moment vitest@5.0.0 published upstream. Measured: npm 10.9.9 fails
+      # on the unmodified template, npm 11.19.0 succeeds; overriding jsdom or
+      # pinning vitest does NOT fix it. Do not drop back to 22.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: scaffold page-money
         run: go run ./cmd/civitai app init "CI Money Block" --dir ./_ci-page-money --template page-money
@@ -477,9 +501,17 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # node 24 (npm 11), NOT 22 (npm 10). npm 10's arborist crashes with
+      # `Cannot read properties of null (reading 'edgesOut')` while walking
+      # vitest -> its optional `jsdom@*` peer -> canvas, during `npm install`
+      # of a scaffolded page-money app. That froze EVERY PR in this repo
+      # (scaffold-currency is required + enforce_admins) with no code change,
+      # the moment vitest@5.0.0 published upstream. Measured: npm 10.9.9 fails
+      # on the unmodified template, npm 11.19.0 succeeds; overriding jsdom or
+      # pinning vitest does NOT fix it. Do not drop back to 22.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: scaffold page-money
         run: go run ./cmd/civitai app init "CI Currency Block" --dir "$GITHUB_WORKSPACE/_ci-currency" --template page-money


### PR DESCRIPTION
ci: node 22 -> 24 so npm 11 installs the scaffolded app, unfreezing the repo

Every PR in this repo is currently unmergeable, and no diff caused it.

scaffold-currency is a REQUIRED check with enforce_admins: true, and it is
red on unmodified main. Control run both ways: a workflow_dispatch of ci.yml
on untouched main (run 33783729351) fails scaffold-currency,
template-page-money and schema-drift and passes the other five; PR #519 fails
and passes exactly the same set, zero jobs differ.

Cause: npm 10's arborist crashes with

    Cannot read properties of null (reading 'edgesOut')

while walking vitest -> its optional jsdom@* peer -> canvas@^3.2.3 during
npm install of a scaffolded page-money app. The template pins vitest ^4.1.0,
which does not admit 5.0.0 -- npm 10 fetches candidate peer manifests anyway.
vitest@5.0.0 published after main's last green run, so the repo froze with no
code change.

Measured locally against the unmodified page-money template:

    npm 11, template unmodified              rc=0   works
    npm 10, template unmodified              rc=1   edgesOut crash
    npm 10, overrides jsdom ^25.0.0          rc=1   edgesOut crash
    npm 10, overrides jsdom 25.0.1           rc=1   EOVERRIDE conflict
    npm 10, vitest pinned exact 4.1.11       rc=1   edgesOut crash

Every dependency-graph workaround either fails to fix the crash or trades it
for a different error, so the remedy is the package manager, not the template.

Node 22 bundles npm 10.9.8; Node 24 (LTS Krypton) bundles npm 11.19.0 -- the
exact version measured working. Both figures read from the nodejs.org release
index, not assumed.

This change validates itself: a pull_request run uses the workflow from the
PR branch, so if scaffold-currency and template-page-money go green here while
they are red on main, that is the fix demonstrated rather than asserted.
