### PR TITLE
chore(scaffold): bump @civitai/blocks-react pin to ^0.46.0

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -189,7 +189,7 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.45.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.46.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk": "^0.37.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -413,7 +413,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.37.0` + `@civitai/blocks-react@^0.45.0` (already pinned in
+`@civitai/app-sdk@^0.37.0` + `@civitai/blocks-react@^0.46.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@civitai/app-sdk": "^0.37.0",
-    "@civitai/blocks-react": "^0.45.0",
+    "@civitai/blocks-react": "^0.46.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/testdata/design-tokens.txt
+++ b/internal/scaffold/testdata/design-tokens.txt
@@ -16,8 +16,8 @@
 # The guard fails when `pin` no longer matches the template.
 #
 # package: @civitai/blocks-react
-# pin: ^0.45.0
-# version: 0.45.0
+# pin: ^0.46.0
+# version: 0.46.0
 
 --civitai-bp-lg
 --civitai-bp-md


### PR DESCRIPTION
## Why this is urgent

`pins-vs-published` is a **required** check and is currently **red on every open PR in this repo**. npm published `@civitai/blocks-react@0.46.0`; the `page-money` template pins `^0.45.0`, and a pre-1.0 caret locks the minor — so the pin no longer admits published latest and every app scaffolded from the template is born stale.

The automation that normally handles this, `bump-scaffold-pins`, is **itself failing on main** (`bf4db4b`), which is why the bump did not land on its own. That is a separate problem and is not addressed here.

## What this is

Output of the repo's own tool, `go run ./internal/scaffold/cmd/bump-pins`. Only `@civitai/blocks-react` moved, across the four places that mirror the pin — template, its README, the `scaffold_test` assertion, and the design-tokens fixture header. Token count unchanged at **32**.

## 🔴 Not a rubber stamp — this package has form

**0.44 inverted the workflow error contract**: `estimate()`/`submit()` went from *resolving* a failure snapshot to **throwing** `WorkflowEstimateError`/`WorkflowSubmitError`, whose `.message` the SDK documents as developer-facing and never for a viewer. Blocks that bumped across it silently began rendering internal text to users, and fixtures mocking a *resolved* failure kept passing straight through the change. 0.45 was cleared only by a tarball diff, so 0.46 got the same treatment.

`npm pack`ed both versions and diffed `dist/` recursively:

| surface | 0.45.0 → 0.46.0 |
|---|---|
| `internal/transport.js` | **byte-identical** |
| `internal/liveHost.js` | **byte-identical** |
| `internal/mockHost.js` | **byte-identical** |
| `hooks/useBuzzWorkflow.js` | **byte-identical** |
| `hooks/useAppWorkflows.js` | **byte-identical** |
| every dist file mentioning `WorkflowEstimateError` / `WorkflowSubmitError` | **byte-identical** |

The **entire** delta is additive: four new files (`ui/ReportButton.*`) and one re-export line in `ui/index.js`. Nothing else in `dist` changed, in either direction.

## Verification

- `TestScaffoldPinsSatisfyPublished` passes locally with `CIVITAI_CHECK_PUBLISHED_PINS=1` armed — and reports **PASS, not SKIP**, so it actually reached npm rather than skipping on an unreachable registry (the workflow itself notes a skip would be a green that says nothing).
- Red-before is evidenced by #522's CI, which failed on the unmodified base with exactly this message: `pinned ^0.45.0 (does NOT admit the published version) / published 0.46.0`.
- Full suite: **21/21 packages ok**.

## Follow-on

This unblocks #522, which is otherwise green (12 of 13 checks passing) and blocked solely by this gate.
