### PR TITLE
chore(scaffold): bump @civitai/* pins to 0.39.0 / 0.49.0 — unfreeze the repo

### DIFF
--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -189,8 +189,8 @@ func TestRenderPageMoney(t *testing.T) {
 	// @civitai/app-sdk@0.14.0+. The pins track the CURRENT published minors — the
 	// pins-vs-published guard (TestScaffoldPinsSatisfyPublished) fails CI if they
 	// fall behind npm, so bump BOTH assertions here in lockstep with the .tmpl.
-	mustContain(t, pkg, `"@civitai/blocks-react": "^0.46.0"`)
-	mustContain(t, pkg, `"@civitai/app-sdk": "^0.37.0"`)
+	mustContain(t, pkg, `"@civitai/blocks-react": "^0.49.0"`)
+	mustContain(t, pkg, `"@civitai/app-sdk": "^0.39.0"`)
 	mustContain(t, pkg, `"@civitai/app-sdk"`)
 	mustContain(t, pkg, `"dev:harness"`)
 	mustContain(t, pkg, `"build"`)

--- a/internal/scaffold/templates/page-money/README.md.tmpl
+++ b/internal/scaffold/templates/page-money/README.md.tmpl
@@ -413,7 +413,7 @@ debit). Note this can be **blue** even when you paid: a gen covered mostly by
 free/earned Buzz reports `blue`. It's informational only.
 
 `accountType` / `spentAccountType` / `useBuzzBalance` require
-`@civitai/app-sdk@^0.37.0` + `@civitai/blocks-react@^0.46.0` (already pinned in
+`@civitai/app-sdk@^0.39.0` + `@civitai/blocks-react@^0.49.0` (already pinned in
 `package.json`).
 
 ## Develop

--- a/internal/scaffold/templates/page-money/package.json.tmpl
+++ b/internal/scaffold/templates/page-money/package.json.tmpl
@@ -17,8 +17,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@civitai/app-sdk": "^0.37.0",
-    "@civitai/blocks-react": "^0.46.0",
+    "@civitai/app-sdk": "^0.39.0",
+    "@civitai/blocks-react": "^0.49.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/internal/scaffold/testdata/design-tokens.txt
+++ b/internal/scaffold/testdata/design-tokens.txt
@@ -16,8 +16,8 @@
 # The guard fails when `pin` no longer matches the template.
 #
 # package: @civitai/blocks-react
-# pin: ^0.46.0
-# version: 0.46.0
+# pin: ^0.49.0
+# version: 0.49.0
 
 --civitai-bp-lg
 --civitai-bp-md


### PR DESCRIPTION
chore(scaffold): bump @civitai/* pins to 0.39.0 / 0.49.0 — unfreeze the repo

`pins-vs-published` is a required check with `enforce_admins: true` and has
been red on `main` since upstream published past the pins, so nothing in the
repo could merge. Four PRs were queued behind it.

Generated by `go run ./internal/scaffold/cmd/bump-pins`, which moves all four
surfaces together — the template, its README, the scaffold_test assertion and
the provenanced design-token ledger. A bump that moves one without the others
is the drift state #514 shipped.

The nightly `bump-scaffold-pins` could not land this itself: its step 9
crashes with `npm error Cannot read properties of null (reading 'edgesOut')`,
which skips step 10 "open PR if pins changed", so no bump PR is ever opened.
Filed separately.

Verified, because a pin bump here is not mechanical:

- Scaffolded page-money, hand-bumped, `npm install` -> 142 packages, rc 0;
  `npm run typecheck` clean; `npm run build` clean. Resolved 0.39.0 / 0.49.0.
  So issue #524's "removed/renamed SDK export" classification is wrong — the
  SDK builds fine and the crash is npm-side.
- `npm pack` both blocks-react versions and diffed dist/ recursively, reading
  the verdict off the five error-contract files by name. useBuzzWorkflow and
  useAppWorkflows — where 0.44's contract inversion lived — are BYTE-IDENTICAL.
  transport/liveHost/mockHost differ by ZERO removed lines; the delta is purely
  additive (effectiveBrowsingLevel, a structural timeout type replacing a
  spelled guard, the collection-follow bridge).
- Design-token NAMES are unchanged (32, identical set); only the provenance
  stamp moved. No rename, so none of #514's dead-CSS class.
- `CIVITAI_CHECK_PUBLISHED_PINS=1` guard now passes; `make ci` 21/21;
  `golangci-lint` 0 issues.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A7RUfuWWYUVrLRTmvzgDGF

