### PR TITLE
fix(agent-setup): the AGENTS.md block told a `static` project to run npm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,8 @@ Item 34 is `agent-setup`'s absolute no-credential-on-disk rule, the vendor
 syntaxes that replace it, and what a header-less config actually reaches.
 Item 35 is the OTHER half of that command: what it may do to a config file the
 USER owns — the merge, the parsers, and which rows fail `--check`.
+Item 36 is its THIRD: what the managed block may claim about the project it was
+written into.
 The durable fix for the mirroring is a server-side `civitai app validate` endpoint
 calling the real `BlockManifestValidator`; until that exists, vendoring is on
 purpose.
@@ -458,6 +460,10 @@ item must carry a trigger that is a routing question rather than a label
     about the result — JSONC leniency, keys on OUR entries, the TOML parser,
     symlinks, config roots, `--check`'s verdict, `--json`'s shapes?**
     → evidence: claudedocs/decisions/35-agent-setup-merges-a-users-file.md
+
+36. **Editing what `agent-setup`'s block says a project can RUN — its local-dev
+    branch, script table or lockfile rule — or flattening it to one list?**
+    → evidence: claudedocs/decisions/36-agents-block-per-project.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/README.md
+++ b/README.md
@@ -301,11 +301,24 @@ It does three things, and **it never authenticates**:
 1. Writes an `AGENTS.md` **managed block** into the project — the commands and
    the gotchas an agent cannot infer by reading your code (Buzz is the *viewer's*,
    a newly declared scope is consent-gated, a hung hook is usually a missing HOST
-   handler, `useSharedStorage()` has no REST route, commit the lockfile).
+   handler, `useSharedStorage()` has no REST route).
 2. Writes a one-line `CLAUDE.md` containing `@AGENTS.md`, **only when there is
    no `CLAUDE.md` already**. Claude Code does not read `AGENTS.md` on its own.
 3. Registers the **two Civitai MCP servers** in the detected agent's own config
    file.
+
+🔴 **The block's "Local development" section is READ FROM THE DIRECTORY, not
+fixed.** The `civitai` commands it lists are true in every App project; how you
+run the app locally is not, because the templates differ — `page-money` defines
+`dev:harness`, `dev:live` and `dev:tunnel`, `page-vite` defines `dev` and neither
+of the first two, and `static` (the **default** for `civitai app init`) ships no
+`package.json` at all. So that section is rendered per project: in an npm project
+it names only the scripts that are in **that** project's `package.json` and
+carries the lockfile rule; in a `static` project it says there is no
+`package.json` and points at `index.html` / serving the directory, exactly as
+`civitai app init`'s own next steps do; and in a directory where nothing has been
+scaffolded yet it says so rather than guessing. **Re-run `civitai agent-setup`
+after changing your scripts** and the section is rewritten from the file.
 
 | Server | URL | What it reaches | Anonymous? |
 | --- | --- | --- | --- |
@@ -437,10 +450,20 @@ civitai agent-setup --check --json
     {"name": "claude-md",     "ok": true,  "detail": "/home/u/proj/CLAUDE.md"},
     {"name": "mcp-site",      "ok": true,  "detail": "/home/u/proj/.mcp.json"},
     {"name": "mcp-orch",      "ok": true,  "detail": "/home/u/proj/.mcp.json"},
-    {"name": "authenticated", "ok": false, "detail": "no token — run `civitai login`"}
+    {"name": "authenticated", "ok": false, "detail": "no token in this CLI's config and no CIVITAI_TOKEN in this environment — run `civitai login` for this CLI, and `export CIVITAI_TOKEN` for claude"}
   ]
 }
 ```
+
+🔴 **The `authenticated` row names WHICH STORE it looked in, because there are
+two and your agent reads only one.** `civitai login` writes this CLI's config;
+the MCP entries reference `CIVITAI_TOKEN` and your agent resolves it from the
+**environment**. So the row has three details, not two: `CIVITAI_TOKEN` is
+exported (the setup an agent can use); a token is configured for **this CLI** but
+`CIVITAI_TOKEN` is not exported (this CLI works, your agent gets `401` from
+`orchestration.civitai.com`); or neither. The row's `ok` is `true` for both of
+the first two and it never fails the verdict either way — what it reports is a
+value being **present**, never that a server accepted it.
 
 A config file `--check` cannot **read** is reported the same way an unknown agent
 and an unresolvable home already were: as `mcp-site`/`mcp-orch` rows carrying the

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -160,7 +160,28 @@ import (
 // leaves 210 bytes — room for roughly ONE more trigger line, not a licence to
 // grow. Do not raise it again without doing this arithmetic in a comment of your
 // own, and re-measure the file rather than inheriting this number.
-const agentsMaxBytes = 30_200
+//
+// 🔴 RAISED FROM 30,200 TO 30,500 FOR ITEM 36, AND THIS IS THE LAST SUCH RAISE
+// THAT FITS. The change adding it fixed the managed block asserting `npm run …`
+// in a project scaffolded from the DEFAULT template, which ships no
+// `package.json` — a third `agent-setup` subject, separate from item 34's
+// credential rule and item 35's merge rules, and one a reader "simplifying" the
+// per-project branch away must be routed to. Same two ways out as the raise
+// above; (b) again, for the same reason.
+//
+// MEASURED, not rounded, and re-measured rather than inherited: AGENTS.md is
+// 30,317 bytes with item 36 in it, so 30,500 leaves 183 bytes. That is under one
+// trigger line (162–265 bytes, mean 204) and it is deliberately being reported
+// as the end of the budget rather than as room.
+//
+// 🔴 THE NEXT ITEM CANNOT BE PAID FOR FROM HERE — agentsMaxBytesCeiling (30,600)
+// is UNCHANGED and now bounds this constant at 100 bytes of further slack. Its
+// own property still holds (re-inlining the three largest evicted bodies costs
+// 5,381 bytes net and lands well past it), so nothing was weakened to make this
+// pass; but whoever adds the NEXT item re-derives THAT constant from the
+// achieved size in the same commit, or evicts prose. Raising this one first is the
+// "ceiling nobody bounds" failure this file already records twice.
+const agentsMaxBytes = 30_500
 
 // agentsMaxBytesCeiling bounds agentsMaxBytes itself, so the budget above cannot
 // be turned into unlimited slack by editing one number.

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -424,6 +424,11 @@ var bornSplitItems = []string{
 	// in the numbered list even briefly would have blown the ceiling on the same
 	// commit that raised it.
 	"claudedocs/decisions/35-agent-setup-merges-a-users-file.md",
+	// Item 36 was likewise written straight into claudedocs/decisions/: its body
+	// is the three-template measurement, the per-shape table, the guard ledger
+	// and the enumerated residuals, and AGENTS.md had 183 bytes of headroom under
+	// a ceiling with 100 of its own left. There was nowhere to park it.
+	"claudedocs/decisions/36-agents-block-per-project.md",
 }
 
 // splitItemsFloor is the CI-SIDE KEEPER for bornSplitItems: the set of item

--- a/claudedocs/decisions/36-agents-block-per-project.md
+++ b/claudedocs/decisions/36-agents-block-per-project.md
@@ -1,0 +1,143 @@
+# The `AGENTS.md` managed block is RENDERED PER PROJECT, not a fixed document
+
+`civitai agent-setup` writes a managed block into a project's `AGENTS.md`. That
+block is a document telling somebody else's coding agent which commands to run.
+Its `civitai …` commands are the same everywhere; **its local-dev commands are
+not**, because the three `civitai app init` templates produce three different
+project shapes. So the local-dev section is rendered from the directory the
+block is being written into, and the code that renders it lives in
+`internal/cmd/agent_setup_project.go`.
+
+## The defect this records — measured, on the shipped binary
+
+At `a6a36f6` the block was a single static file. Its command table said, in
+every project it was ever written into:
+
+| Task | Command |
+|---|---|
+| Local dev, mock host, no Buzz spent | `npm run dev:harness` |
+| Local app inside the REAL host | `civitai app dev-tunnel` (with `npm run dev:tunnel` in another terminal) |
+
+and its gotchas said *"Commit the lockfile. The platform builds with `npm ci`…"*.
+
+Measured against the three templates the binary actually ships, by scaffolding
+each one and reading its `package.json`:
+
+| Template | `package.json`? | Scripts it defines |
+|---|---|---|
+| `static` (**the default for `civitai app init`**) | **no** | — the tree is `app.js`, `assets/`, `block.manifest.json`, `civitai-host.js`, `.gitignore`, `index.html`, `README.md`, `style.css` |
+| `page-vite` | yes | `postinstall`, `dev`, `build`, `preview` |
+| `page-money` | yes | `postinstall`, `dev`, `dev:harness`, `dev:live`, `dev:tunnel`, `build`, `typecheck`, `test`, `preview` |
+
+So `dev:harness` and `dev:tunnel` exist in **one** template of three. The block
+was wrong for `page-vite`, which defines neither, and wrong in the worst
+direction for `static`, which has no package manager to run at all — and
+`static` is what `civitai app init` gives you when you do not pass `--template`.
+
+**It also contradicted this CLI's own output.** `civitai app init`'s next-steps
+block is already template-aware (`printScaffoldResult` in
+`internal/cmd/app_init.go` branches on `Template.NeedsHarness()` /
+`NeedsInstall()`), and for `static` it prints:
+
+```
+  1. cd <dir>              # then open index.html or serve the directory
+  2. civitai app submit       # validate + submit for review
+```
+
+A blind dogfood of the onboarding flow found no `package.json`, saw `AGENTS.md`
+and `app init` disagreeing, and had to work out which of two Civitai-authored
+documents to believe. That is the failure: not a wrong command, but two shipped
+surfaces stating different things with equal confidence.
+
+## The rule
+
+**The block may not name a local-dev command it did not read out of the
+project.** `detectProjectShape` classifies the directory into one of three
+kinds, and the template has a branch per kind:
+
+| Kind | Detected by | What the section says |
+|---|---|---|
+| `npm` | a `package.json` is present | a table of the `knownDevScripts` **that project's own `package.json` defines**, plus the lockfile and pin rules |
+| `no-build` | a `block.manifest.json` and no `package.json` | there is no `package.json`; preview with `index.html` or by serving the directory; `civitai app dev-tunnel --port <port>` against a server you start yourself |
+| `none` | neither | nothing has been scaffolded here; run `civitai app init` and re-run `agent-setup` |
+
+Three properties are load-bearing, and each is the reason a simpler version was
+rejected:
+
+1. **`package.json` is tested FIRST.** `page-vite` and `page-money` carry both
+   files, so a classifier that looks for the manifest first calls every npm
+   template no-build.
+2. **The script names come out of the file, never out of a list.** There is no
+   code path that emits a script name from anywhere but the project's
+   `package.json`, which is what makes "the block cannot name a script the
+   project does not define" a property rather than an intention.
+   `knownDevScripts` supplies ORDER and WORDING only: a row is emitted only when
+   the project defines that exact key, so the table can never introduce a
+   command. Its descriptions come from the scaffolds' own generated READMEs
+   (`dev:harness` = the SDK mock host, "no real Buzz, no compute, no network";
+   `dev:live` = the live host against the real backend, "Spends REAL Buzz"; no
+   host behind `npm run dev`), and the rendered section says so, so a project
+   that redefines one of those names under its own meaning is covered by a
+   stated condition rather than by a guess.
+3. **The `none` branch enumerates the templates from `scaffold.AllTemplates()`
+   and `Template.NeedsInstall()`, not from prose.** `agent-setup` is a top-level
+   command that may legitimately run before any app exists (see the header of
+   `internal/cmd/agent_setup.go`), and the honest answer there is that it does
+   not know. The sentence naming which templates ship a `package.json` is
+   generated, so a fourth template appears in it without anyone editing markdown.
+
+## What is guarded, and what is not
+
+`internal/cmd/agent_setup_project_test.go` scaffolds each shipped template with
+`scaffold.Render` and drives the real command, which is the check the dogfood ran
+by hand:
+
+- `TestAStaticProjectIsNeverToldToRunNPM` — the regression guard. Watched fail at
+  `a6a36f6`, where it reported `[npm npm npm]` (`npm run dev:harness`,
+  `npm run dev:tunnel`, and the `npm ci` in the lockfile gotcha) plus all three
+  of its positive-half assertions. The scan bans the WORD, not a code span: a
+  block written for a project with no package manager has no reason to mention
+  one even in prose, and a guard matching only `` `npm …` `` would pass a
+  sentence telling the agent to run npm install without backticks.
+- `TestTheNPMScanCanSeeAnNPMCommand` — the positive control for that scan.
+- `TestTheBlockNeverNamesAScriptTheProjectDoesNotDefine` — the RELATIONSHIP, not
+  a word list: every `npm run X` printed is looked up in that project's own
+  `package.json`, for every shipped template that has one, so the guard holds for
+  a template nobody has written yet.
+- `TestPageViteIsNotToldAboutPageMoneysScripts` — the discriminating case
+  between the two npm templates. Branching only on "is there a `package.json`"
+  passes the static guard while leaving `page-vite` reading page-money's
+  commands, and this is the test that says so.
+- `TestDetectProjectShapeClassifiesEveryShippedTemplate` — the classifier in both
+  directions, including the both-files ordering case and an unparseable
+  `package.json`.
+- `TestAgentsTemplateRendersForEveryShape` — what makes the package-scope
+  `template.Must` safe to read as "cannot fail at runtime": parse errors die at
+  init, execution errors are caught here for every shape.
+
+**What is NOT established, stated so it is not assumed:**
+
+- The `knownDevScripts` set is an **open enumeration**. A project defining a dev
+  script under some other name gets no row for it; the rendered section says
+  `npm run` lists every script, which is the honest fallback, not a claim that
+  the four are all there are.
+- Only **npm** is named in the lockfile rule, because that is what the scaffolds
+  and the platform build use. The pnpm/yarn case is handled the way it already
+  was: by telling the author to set `buildCommand` and `outputDir`. Nothing here
+  detects which package manager an author actually used.
+- The `no-build` row for `civitai app dev-tunnel` says to serve the directory on
+  a port and pass `--port`. That the tunnel then WORKS against an arbitrary
+  static server was **not** measured; what is established is that `--port` exists
+  and defaults to 5186 (`internal/cmd/app_dev_tunnel.go`), and that the tunnel's
+  own embeddability preflight (`internal/devtunnel/embedcheck.go`, item 10)
+  reports a server it cannot frame. Do not upgrade that row into a claim that the
+  static path is a supported dev loop.
+
+## Do not collapse it back
+
+The tempting simplification is one fixed block again, "documented" by saying it
+covers every template. That is exactly what was there, and it is what a
+description-wider-than-its-implementation looks like from the inside: the file
+read as authoritative in a project where two thirds of it was false. If the
+branch has to go, the replacement is a table that states BOTH cases with the
+condition attached — never one case asserted for all of them.

--- a/internal/cmd/agent_setup.go
+++ b/internal/cmd/agent_setup.go
@@ -661,12 +661,38 @@ func agentSetupChecks(env agentEnv, agent, token string) []agentCheckJSON {
 
 	checks = append(checks, agentSetupMCPChecks(env, agent)...)
 
-	if token != "" {
+	// 🔴 THE ROW NAMES *WHICH STORE* IT LOOKED IN, BECAUSE THERE ARE TWO AND THE
+	// AGENT ONLY READS ONE. `config.Load()` merges ~/.config/civitai/config.yaml
+	// with the CIVITAI_TOKEN environment variable, so a `civitai login` alone
+	// satisfies `token != ""` — while every MCP entry this command writes
+	// REFERENCES CIVITAI_TOKEN and the agent resolves it from the PROCESS
+	// ENVIRONMENT. The old detail read "token configured — `civitai whoami`
+	// verifies it", which is a true claim about this CLI and reads as a claim
+	// about the setup: `--check` came back fully green on a machine where the
+	// orchestration server 401s every request. The write path already says this
+	// (printAgentSetupWrite's export step, and the per-server 401 warning);
+	// `--check` was the surface that did not.
+	//
+	// 🔴 `ok` DOES NOT MOVE, AND THAT IS DELIBERATE. This row is excluded from the
+	// verdict on purpose (agentSetupVerdict), and flipping `ok` for the
+	// logged-in-but-not-exported case would change a PUBLISHED row's value for a
+	// setup that is exactly as finished as the one before it. What was wrong was
+	// the sentence, so the sentence is what changed.
+	switch {
+	case token != "" && tokenIsExported(env):
 		checks = append(checks, agentCheckJSON{Name: checkAuthenticated, OK: true,
-			Detail: "token configured — `civitai whoami` verifies it"})
-	} else {
+			Detail: tokenEnvVar + " is set in this environment, which is where " + agent + " resolves it from — " +
+				"`civitai whoami` verifies the value; this row only checks that one is present"})
+	case token != "":
+		checks = append(checks, agentCheckJSON{Name: checkAuthenticated, OK: true,
+			Detail: "a token is configured for THIS CLI (`civitai login` or the config file), but " + tokenEnvVar +
+				" is NOT set in this environment — the MCP entries reference it by name, so " + agent +
+				" resolves it to an empty string and https://orchestration.civitai.com/mcp 401s until you " +
+				"`export " + tokenEnvVar + "`"})
+	default:
 		checks = append(checks, agentCheckJSON{Name: checkAuthenticated, OK: false,
-			Detail: "no token — run `civitai login`"})
+			Detail: "no token in this CLI's config and no " + tokenEnvVar + " in this environment — " +
+				"run `civitai login` for this CLI, and `export " + tokenEnvVar + "` for " + agent})
 	}
 	return checks
 }

--- a/internal/cmd/agent_setup_files.go
+++ b/internal/cmd/agent_setup_files.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
 // The two instruction files `agent-setup` writes into the project, and the rule
@@ -70,11 +71,27 @@ const (
 	actionKeep fileAction = "keep-existing"
 )
 
+// agentsTemplate is the embedded file parsed once. A parse failure is a defect
+// in a file that ships inside the binary, not a condition a run can be in, so it
+// panics at init rather than turning every `agent-setup` into a runtime error
+// about a file the user cannot see. TestAgentsTemplateRendersForEveryShape is
+// what makes that safe: it executes the template for all three shapes.
+var agentsTemplate = template.Must(template.New(agentsFilename).Parse(agentsAppTemplate))
+
 // agentsManagedBlock is the block as it is written into a file: the embedded
-// template with no leading or trailing blank lines, so the three cases below can
-// each control their own spacing.
-func agentsManagedBlock() string {
-	return strings.TrimSpace(agentsAppTemplate)
+// template rendered for THIS project, with no leading or trailing blank lines,
+// so the three merge cases below can each control their own spacing.
+//
+// 🔴 IT TAKES THE PROJECT SHAPE, AND THAT IS THE WHOLE FIX. The block names
+// local-dev commands, and which of those exist depends on what was scaffolded
+// here — see agent_setup_project.go for the measurement. A rendering that
+// ignores the argument is a rendering that tells a `static` project to run npm.
+func agentsManagedBlock(shape projectShape) (string, error) {
+	var b strings.Builder
+	if err := agentsTemplate.Execute(&b, shape); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(b.String()), nil
 }
 
 // mergeAgentsMD applies the three-case AGENTS.md rule to `existing` and returns
@@ -93,8 +110,11 @@ func agentsManagedBlock() string {
 // the new block": the prose above and below the block is untouched, including
 // its whitespace, because a normalising rewrite of somebody's document is a
 // change they did not ask for and cannot review.
-func mergeAgentsMD(path, existing string) (string, fileAction, error) {
-	block := agentsManagedBlock()
+func mergeAgentsMD(path, existing string, shape projectShape) (string, fileAction, error) {
+	block, err := agentsManagedBlock(shape)
+	if err != nil {
+		return "", "", err
+	}
 	if existing == "" {
 		return block + "\n", actionCreate, nil
 	}
@@ -229,7 +249,10 @@ func planAgentsMD(dir string) (path, content string, action fileAction, err erro
 	if rerr != nil {
 		return path, "", "", rerr
 	}
-	content, action, err = mergeAgentsMD(path, string(raw))
+	// 🔴 THE SHAPE IS READ FROM THE SAME `dir` THE FILE IS WRITTEN INTO, AT PLAN
+	// TIME, so `--dry-run` and the real run render byte-identical blocks over one
+	// tree state — the agreement runAgentSetupWrite documents.
+	content, action, err = mergeAgentsMD(path, string(raw), detectProjectShape(dir))
 	return path, content, action, err
 }
 

--- a/internal/cmd/agent_setup_project.go
+++ b/internal/cmd/agent_setup_project.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/civitai/cli/internal/manifest"
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// What `agent-setup` is allowed to say about running THIS project locally.
+//
+// 🔴 THE MANAGED BLOCK USED TO NAME npm SCRIPTS UNCONDITIONALLY, AND `civitai
+// app init` DEFAULTS TO A TEMPLATE THAT HAS NO package.json. The block's command
+// table said "Local dev, mock host, no Buzz spent | `npm run dev:harness`" and
+// its gotchas said "Commit the lockfile. The platform builds with `npm ci`" in
+// EVERY project it was written into. Measured on the three shipped templates:
+// `dev:harness` and `dev:tunnel` exist only in page-money's package.json;
+// page-vite defines `dev`, `build` and `preview` and neither of those two; and
+// `static` — the DEFAULT — scaffolds app.js, assets/, block.manifest.json,
+// civitai-host.js, .gitignore, index.html, README.md, style.css and no
+// package.json at all. So the block was wrong for two templates of three, and
+// wrong in the worst direction for the default one: it told an agent to run a
+// package manager in a project that has nothing to run it on, while `civitai app
+// init`'s own next-steps output for that same template says "then open
+// index.html or serve the directory". A blind dogfood hit exactly that and had
+// to work out which of two Civitai-authored documents to believe.
+//
+// 🔴 SO THE SECTION IS DERIVED, NOT ASSERTED. detectProjectShape READS the
+// directory the block is being written into, and the npm branch names only
+// scripts that are in that project's own package.json — a command it cannot read
+// out of the file is a command it does not print. That is the property: the
+// document cannot name a script the project does not define, because there is no
+// code path that emits a script name from anywhere but the file.
+//
+// 🔴 AND THE "NO PROJECT HERE YET" BRANCH ENUMERATES THE TEMPLATES FROM
+// `scaffold`, NOT FROM PROSE. `agent-setup` is a top-level command that may
+// legitimately run in an empty directory, before any app exists (see the header
+// of agent_setup.go), and there the honest answer is that it does not know. The
+// sentence naming which templates are npm projects is built from
+// scaffold.AllTemplates() and Template.NeedsInstall(), so a fourth template
+// appears there without anybody remembering to edit a markdown file.
+//
+// AGENTS.md item 36 — evidence: claudedocs/decisions/36-agents-block-per-project.md
+// carries the full measurement, the rejected alternatives and the enumerated
+// residuals (what the knownDevScripts table does NOT close, and what was not
+// measured about tunnelling a static project).
+
+// projectKind is what the directory receiving AGENTS.md looks like. Three
+// values, because the three have genuinely different answers and collapsing any
+// two of them is how the defect above got written.
+type projectKind string
+
+const (
+	// projectNPM: a package.json is present. Whatever else is here, npm commands
+	// are meaningful and the lockfile rule applies.
+	projectNPM projectKind = "npm"
+	// projectNoBuild: a block.manifest.json and no package.json — the shape
+	// `civitai app init --template static` produces. No npm command applies.
+	projectNoBuild projectKind = "no-build"
+	// projectNone: neither. `agent-setup` ran somewhere no app has been
+	// scaffolded, which is a supported and documented way to run it.
+	projectNone projectKind = "none"
+)
+
+// devScriptRow is one npm script the project defines, with what the scaffolds
+// mean by that name.
+type devScriptRow struct {
+	Script string
+	Task   string
+}
+
+// templateRow is one `civitai app init` template, for the "no project here"
+// branch. Derived from the scaffold package so it cannot go stale.
+type templateRow struct {
+	Name string
+	NPM  bool
+}
+
+// projectShape is the render input for the managed block.
+type projectShape struct {
+	Kind      projectKind
+	Scripts   []devScriptRow
+	Templates []templateRow
+}
+
+// knownDevScripts is the ORDER and the WORDING for the script names the shipped
+// scaffolds use. A row is emitted only when the project's own package.json
+// defines that exact key, so this table can never introduce a command — it can
+// only describe one that is already there.
+//
+// 🔴 THE DESCRIPTIONS ARE THE SCAFFOLDS' MEANING, AND THE TEMPLATE SAYS SO. They
+// are taken from the generated READMEs rather than invented here: page-money's
+// README states `dev:harness` mounts the SDK mock host ("no real Buzz, no
+// compute, no network") and `dev:live` mounts the live host against the real
+// backend ("Spends REAL Buzz / real compute"); page-vite's states there is no
+// host behind `npm run dev`. A project that redefines one of these names under
+// its own meaning is covered by the sentence the template prints under the
+// table, not by silently guessing.
+//
+// The safe one is first on purpose: an agent reading top-down reaches the
+// no-Buzz command before the one that spends the user's money.
+var knownDevScripts = []devScriptRow{
+	{"dev:harness", "Local dev against a MOCK host — synthetic replies, no real Buzz, no compute, no network"},
+	{"dev", "Plain local preview — there is no host behind it, so nothing sends BLOCK_INIT"},
+	{"dev:live", "Local dev against the REAL Civitai backend with a dev token — spends REAL Buzz"},
+	{"dev:tunnel", "Serve this app so `civitai app dev-tunnel` can reach it (run it in another terminal)"},
+}
+
+// scaffoldTemplateRows is the template enumeration, read from the scaffold
+// package rather than restated.
+func scaffoldTemplateRows() []templateRow {
+	all := scaffold.AllTemplates()
+	rows := make([]templateRow, 0, len(all))
+	for _, t := range all {
+		rows = append(rows, templateRow{Name: string(t), NPM: t.NeedsInstall()})
+	}
+	return rows
+}
+
+// detectProjectShape classifies dir. It is a pure read and never fails: a
+// package.json this process cannot read or cannot parse is still a package.json,
+// so the kind stays `npm` and the script list is simply empty — the template's
+// npm branch has wording for that, and refusing the whole run because a file is
+// malformed would be a much worse answer than a narrower section.
+//
+// 🔴 THE ORDER IS package.json FIRST. page-vite and page-money carry BOTH a
+// package.json and a block.manifest.json, so testing the manifest first would
+// classify every npm template as no-build.
+func detectProjectShape(dir string) projectShape {
+	shape := projectShape{Templates: scaffoldTemplateRows()}
+
+	pkgPath := filepath.Join(dir, "package.json")
+	if _, err := os.Stat(pkgPath); err == nil {
+		shape.Kind = projectNPM
+		shape.Scripts = devScriptsIn(pkgPath)
+		return shape
+	}
+	if _, err := os.Stat(filepath.Join(dir, manifest.Filename)); err == nil {
+		shape.Kind = projectNoBuild
+		return shape
+	}
+	shape.Kind = projectNone
+	return shape
+}
+
+// devScriptsIn returns the knownDevScripts the file at path defines, in
+// knownDevScripts order. An unreadable or unparseable package.json yields none,
+// which the template reports as "no dev script this CLI recognises" rather than
+// as an error — see detectProjectShape.
+func devScriptsIn(path string) []devScriptRow {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		return nil
+	}
+	var rows []devScriptRow
+	for _, candidate := range knownDevScripts {
+		if _, ok := pkg.Scripts[candidate.Script]; ok {
+			rows = append(rows, candidate)
+		}
+	}
+	return rows
+}

--- a/internal/cmd/agent_setup_project_test.go
+++ b/internal/cmd/agent_setup_project_test.go
@@ -1,0 +1,306 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/scaffold"
+)
+
+// The regression guards for the defect agent_setup_project.go records: the
+// managed block naming npm commands in a project that has no package.json.
+//
+// 🔴 THESE RUN OVER THE REAL SCAFFOLDS, NOT OVER A HAND-BUILT FIXTURE. The
+// defect was a disagreement between two shipped artefacts — `civitai app init`'s
+// tree and the block `civitai agent-setup` writes into it — so a fixture that
+// asserts what a static project "looks like" would have re-encoded the same
+// assumption that produced the bug. Every case below scaffolds with
+// scaffold.Render and then drives the real command, which is the check the blind
+// dogfood ran by hand.
+
+// allProjectShapesForTest enumerates the shapes the template must render for.
+// It is derived from the projectKind constants' own list rather than from a
+// literal, so a fourth kind cannot be added without a rendering test for it.
+func allProjectShapesForTest() []projectShape {
+	kinds := []projectKind{projectNPM, projectNoBuild, projectNone}
+	shapes := make([]projectShape, 0, len(kinds)+1)
+	for _, k := range kinds {
+		shapes = append(shapes, projectShape{Kind: k, Templates: scaffoldTemplateRows()})
+	}
+	// The npm kind has two renderings — with and without recognised scripts —
+	// and the second one is the unreadable/unrecognised package.json path.
+	shapes = append(shapes, projectShape{
+		Kind:      projectNPM,
+		Scripts:   knownDevScripts,
+		Templates: scaffoldTemplateRows(),
+	})
+	return shapes
+}
+
+// scaffoldInto renders one shipped template into a fresh directory and returns
+// it, so a case cannot accidentally assert against a directory somebody built by
+// hand.
+func scaffoldInto(t *testing.T, tmpl scaffold.Template) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, err := scaffold.Render(tmpl, dir, scaffold.Data{Slug: "demo-app", Name: "Demo App"}); err != nil {
+		t.Fatalf("scaffold %s: %v", tmpl, err)
+	}
+	return dir
+}
+
+// managedBlockIn extracts what `agent-setup` wrote between its markers. Asserting
+// against the whole file would also read whatever the author already had there.
+func managedBlockIn(t *testing.T, dir string) string {
+	t.Helper()
+	raw := readFile(t, filepath.Join(dir, agentsFilename))
+	begin := strings.Index(raw, agentsBeginMarker)
+	end := strings.Index(raw, agentsEndMarker)
+	if begin < 0 || end <= begin {
+		t.Fatalf("no well-formed managed block in %s:\n%s", filepath.Join(dir, agentsFilename), raw)
+	}
+	return raw[begin : end+len(agentsEndMarker)]
+}
+
+// setupInto runs the real command into dir with a neutralised environment.
+func setupInto(t *testing.T, dir string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CIVITAI_TOKEN", "")
+	t.Setenv("CIVITAI_NO_UPDATE_CHECK", "1")
+	for _, s := range agentEnvSignals {
+		t.Setenv(s.Var, "")
+	}
+	out, errOut, err := run(t, "agent-setup", "--dir", dir, "--agent", "claude")
+	if err != nil {
+		t.Fatalf("agent-setup into %s: %v\n%s\n%s", dir, err, out, errOut)
+	}
+	return managedBlockIn(t, dir)
+}
+
+// npmCommandRe matches any npm/pnpm/yarn invocation the block might name.
+var npmCommandRe = regexp.MustCompile(`\b(npm|pnpm|yarn)\b`)
+
+// TestAStaticProjectIsNeverToldToRunNPM is THE regression guard.
+//
+// 🔴 IT WAS WATCHED FAIL ON origin/main, AND THE MEASUREMENT IS THE EXACT ONE.
+// Run at a6a36f6 against a `--template static` scaffold, it reported
+// `[npm npm npm]` — `npm run dev:harness`, `npm run dev:tunnel` and the `npm ci`
+// in the lockfile gotcha — plus all three of the positive-half assertions below
+// ("no `package.json`", "index.html", "serve the directory"), because the block
+// had nothing to say to a project that ships no package.json at all (`app.js`,
+// `assets/`, `block.manifest.json`, `civitai-host.js`, `.gitignore`,
+// `index.html`, `README.md`, `style.css`).
+//
+// 🔴 THE SCAN IS DELIBERATELY BLUNT: it bans the WORD, not a code span. A block
+// written for a project with no package manager has no reason to mention one
+// even in prose, and a guard that only matched a backticked code span would pass
+// a sentence telling the agent to run npm install without backticks.
+//
+// 🔴 AND IT ASSERTS THE POSITIVE HALF IN THE SAME RUN, so a fix that empties the
+// section instead of branching it does not pass: the block must still tell a
+// static author how to preview the app, in the words `civitai app init` uses.
+func TestAStaticProjectIsNeverToldToRunNPM(t *testing.T) {
+	dir := scaffoldInto(t, scaffold.Static)
+
+	// PREMISE, checked rather than assumed: this really is a project with no
+	// package.json. If the static template ever gains one, this test is measuring
+	// something else and must say so instead of passing.
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err == nil {
+		t.Fatalf("PREMISE BROKEN: the static scaffold now ships a package.json, so this guard is not "+
+			"exercising the no-build case (%s)", dir)
+	}
+
+	block := setupInto(t, dir)
+	if hits := npmCommandRe.FindAllString(block, -1); len(hits) > 0 {
+		t.Errorf("the managed block written into a static project names a package manager %v — that project "+
+			"has no package.json, so every one of those commands fails. Block:\n%s", hits, block)
+	}
+	// The section has to say something true, not nothing.
+	for _, want := range []string{"no `package.json`", "index.html", "serve the directory"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("the static project's block never mentions %q — it dropped the npm rows without "+
+				"replacing them:\n%s", want, block)
+		}
+	}
+}
+
+// TestTheNPMScanCanSeeAnNPMCommand is the POSITIVE CONTROL for the scan above. A
+// regex wired to nothing reports a clean static project and a clean page-money
+// one identically, and only one of those is correct.
+func TestTheNPMScanCanSeeAnNPMCommand(t *testing.T) {
+	dir := scaffoldInto(t, scaffold.PageMoney)
+	block := setupInto(t, dir)
+	if hits := npmCommandRe.FindAllString(block, -1); len(hits) == 0 {
+		t.Fatalf("the npm scan found nothing in a page-money project, which IS an npm project — the scan in "+
+			"TestAStaticProjectIsNeverToldToRunNPM observes nothing. Block:\n%s", block)
+	}
+}
+
+// TestTheBlockNeverNamesAScriptTheProjectDoesNotDefine is the RELATIONSHIP the
+// fix actually establishes, asserted as a relationship rather than as a word
+// list.
+//
+// 🔴 A LIST OF EXPECTED SCRIPT NAMES WOULD BE THE SAME MISTAKE ONE LEVEL UP: it
+// would pass for a template that hardcodes the names this test happens to
+// expect. So every `npm run X` the block prints is looked up in THAT project's
+// own package.json, for every shipped template that has one. The guard therefore
+// holds for a template nobody has written yet.
+func TestTheBlockNeverNamesAScriptTheProjectDoesNotDefine(t *testing.T) {
+	runScriptRe := regexp.MustCompile("`npm run ([a-z0-9:._-]+)`")
+	checked := 0
+	for _, tmpl := range scaffold.AllTemplates() {
+		if !tmpl.NeedsInstall() {
+			continue
+		}
+		t.Run(string(tmpl), func(t *testing.T) {
+			dir := scaffoldInto(t, tmpl)
+			block := setupInto(t, dir)
+
+			var pkg struct {
+				Scripts map[string]string `json:"scripts"`
+			}
+			if err := json.Unmarshal([]byte(readFile(t, filepath.Join(dir, "package.json"))), &pkg); err != nil {
+				t.Fatalf("%s's package.json does not parse: %v", tmpl, err)
+			}
+			named := runScriptRe.FindAllStringSubmatch(block, -1)
+			if len(named) == 0 {
+				t.Fatalf("the block for %s names no `npm run` script at all, so this test asserts nothing "+
+					"about it:\n%s", tmpl, block)
+			}
+			for _, m := range named {
+				if _, ok := pkg.Scripts[m[1]]; !ok {
+					t.Errorf("the block tells a %s project to run `npm run %s`, which is not in its "+
+						"package.json (it defines %v)", tmpl, m[1], scriptNames(pkg.Scripts))
+				}
+				checked++
+			}
+		})
+	}
+	if checked == 0 {
+		t.Fatal("no npm template was exercised — the loop found nothing to check")
+	}
+}
+
+// TestPageViteIsNotToldAboutPageMoneysScripts is the discriminating case between
+// the two npm templates. Branching only on "is there a package.json" would leave
+// page-vite — which defines `dev`, `build` and `preview` and neither of the two
+// the old block named — reading instructions written for page-money.
+func TestPageViteIsNotToldAboutPageMoneysScripts(t *testing.T) {
+	dir := scaffoldInto(t, scaffold.PageVite)
+	block := setupInto(t, dir)
+	if !strings.Contains(block, "`npm run dev`") {
+		t.Errorf("the page-vite block never names `npm run dev`, which is the script it does define:\n%s", block)
+	}
+	for _, absent := range []string{"dev:harness", "dev:live", "dev:tunnel"} {
+		if strings.Contains(block, absent) {
+			t.Errorf("the page-vite block names %q, which only page-money's package.json defines:\n%s", absent, block)
+		}
+	}
+}
+
+// TestAnEmptyDirectoryIsToldThatNothingIsScaffoldedHere covers the third shape.
+// `agent-setup` is a top-level command that legitimately runs before any app
+// exists, and there the honest answer is that it does not know — not a guess,
+// and not page-money's commands.
+func TestAnEmptyDirectoryIsToldThatNothingIsScaffoldedHere(t *testing.T) {
+	dir := t.TempDir()
+	block := setupInto(t, dir)
+	if hits := npmCommandRe.FindAllString(block, -1); len(hits) > 0 {
+		t.Errorf("the block written into a directory holding no app names a package manager %v:\n%s", hits, block)
+	}
+	if !strings.Contains(block, "No Civitai App has been scaffolded in this directory") {
+		t.Errorf("the empty-directory block does not say the directory holds no app:\n%s", block)
+	}
+	// The template enumeration is DERIVED from scaffold.AllTemplates(), so every
+	// shipped template must appear in it — including one added after this test.
+	for _, tmpl := range scaffold.AllTemplates() {
+		if !strings.Contains(block, "`"+string(tmpl)+"`") {
+			t.Errorf("the empty-directory block does not name the %q template:\n%s", tmpl, block)
+		}
+	}
+}
+
+// TestDetectProjectShapeClassifiesEveryShippedTemplate pins the classifier
+// itself against the trees `civitai app init` really produces, in BOTH
+// directions: an npm template must not read as no-build, and the no-build one
+// must not read as npm.
+func TestDetectProjectShapeClassifiesEveryShippedTemplate(t *testing.T) {
+	for _, tmpl := range scaffold.AllTemplates() {
+		t.Run(string(tmpl), func(t *testing.T) {
+			dir := scaffoldInto(t, tmpl)
+			got := detectProjectShape(dir)
+			want := projectNoBuild
+			if tmpl.NeedsInstall() {
+				want = projectNPM
+			}
+			if got.Kind != want {
+				t.Fatalf("detectProjectShape(%s scaffold) = %q, want %q", tmpl, got.Kind, want)
+			}
+			if want == projectNPM && len(got.Scripts) == 0 {
+				t.Errorf("%s is an npm template but no recognised dev script was read out of its "+
+					"package.json — the block would tell its author there is none", tmpl)
+			}
+		})
+	}
+	t.Run("empty", func(t *testing.T) {
+		if got := detectProjectShape(t.TempDir()); got.Kind != projectNone {
+			t.Errorf("detectProjectShape(empty dir) = %q, want %q", got.Kind, projectNone)
+		}
+	})
+	t.Run("manifest-and-package-json", func(t *testing.T) {
+		// The order matters: page-vite and page-money carry BOTH files, so a
+		// classifier testing the manifest first calls every npm template no-build.
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "block.manifest.json"), "{}\n")
+		writeFile(t, filepath.Join(dir, "package.json"), `{"scripts":{"dev":"vite"}}`)
+		if got := detectProjectShape(dir); got.Kind != projectNPM {
+			t.Errorf("a directory with both files classified as %q, want %q", got.Kind, projectNPM)
+		}
+	})
+	t.Run("unparseable-package-json", func(t *testing.T) {
+		// Still an npm project; just one this command cannot read scripts out of.
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "package.json"), "{not json")
+		got := detectProjectShape(dir)
+		if got.Kind != projectNPM {
+			t.Errorf("kind = %q, want %q", got.Kind, projectNPM)
+		}
+		if len(got.Scripts) != 0 {
+			t.Errorf("scripts = %v, want none from a file that does not parse", got.Scripts)
+		}
+	})
+}
+
+// TestAgentsTemplateRendersForEveryShape is what makes the template.Must at
+// package scope safe to read as "this cannot fail at runtime": a parse error is
+// caught at init, and an EXECUTION error (a field that does not exist, a bad
+// range) is caught here, for every shape the command can produce.
+func TestAgentsTemplateRendersForEveryShape(t *testing.T) {
+	for _, shape := range allProjectShapesForTest() {
+		block, err := agentsManagedBlock(shape)
+		if err != nil {
+			t.Fatalf("rendering for kind %q: %v", shape.Kind, err)
+		}
+		if strings.Contains(block, "<no value>") || strings.Contains(block, "{{") {
+			t.Errorf("the rendered block for kind %q still holds template syntax or an unresolved "+
+				"field:\n%s", shape.Kind, block)
+		}
+	}
+}
+
+func scriptNames(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cmd/agent_setup_test.go
+++ b/internal/cmd/agent_setup_test.go
@@ -1027,9 +1027,17 @@ func TestAgentsMarkersAreInTheTemplate(t *testing.T) {
 	if !strings.Contains(agentsBeginMarker, "—") {
 		t.Error("the BEGIN marker lost its em dash — an existing file's marker would no longer match")
 	}
-	block := agentsManagedBlock()
-	if !strings.HasPrefix(block, agentsBeginMarker) || !strings.HasSuffix(block, agentsEndMarker) {
-		t.Errorf("the managed block does not start and end with its markers:\n%q", block)
+	// EVERY shape, not one: the markers now sit either side of a branch, so a
+	// template edit that closes an `{{ if }}` in the wrong place can lose them for
+	// one project shape while the other two stay green.
+	for _, shape := range allProjectShapesForTest() {
+		block, err := agentsManagedBlock(shape)
+		if err != nil {
+			t.Fatalf("rendering the managed block for kind %q: %v", shape.Kind, err)
+		}
+		if !strings.HasPrefix(block, agentsBeginMarker) || !strings.HasSuffix(block, agentsEndMarker) {
+			t.Errorf("the managed block for kind %q does not start and end with its markers:\n%q", shape.Kind, block)
+		}
 	}
 }
 

--- a/internal/cmd/templates/agents-app.md
+++ b/internal/cmd/templates/agents-app.md
@@ -6,14 +6,76 @@ inside civitai.com. The host page and your app talk over `postMessage`.
 
 ### Commands
 
+Every row below is a `civitai` CLI command and is true in any Civitai App
+project. How you RUN this app locally is not — it depends on what was scaffolded
+here — so it has its own section, written from what is actually in this
+directory.
+
 | Task | Command |
 |---|---|
 | Scaffold a new app | `civitai app init <name>` |
-| Local dev, mock host, no Buzz spent | `npm run dev:harness` |
-| Local app inside the REAL host | `civitai app dev-tunnel` (with `npm run dev:tunnel` in another terminal) |
 | Check the manifest | `civitai app validate` |
 | Package and submit for review | `civitai app submit` |
 | Diagnose an incomplete store listing | `civitai app doctor` |
+| Your local app inside the REAL host (needs a local dev server already running — see below) | `civitai app dev-tunnel` |
+
+### Local development
+{{ if eq .Kind "npm" }}
+`civitai agent-setup` read `package.json` in this directory.
+{{- if .Scripts }} These are the
+scripts it actually defines — no command outside this table is claimed to exist
+here:
+
+| Task | Command |
+|---|---|
+{{- range .Scripts }}
+| {{ .Task }} | `npm run {{ .Script }}` |
+{{- end }}
+
+`npm run` lists every script, including any this CLI does not recognise. The
+descriptions are the meaning `civitai app init` gives those names; if you wrote
+your own script under one of them, yours is what runs.
+{{- else }} It defines no
+`dev` script this CLI recognises, so there is no local-dev command to name here.
+Run `npm run` to list what this project does define.
+{{- end }}
+
+- **Commit the lockfile.** The platform builds with `npm ci` and will not build
+  without one. If you switch package manager, set `buildCommand` and `outputDir`
+  in the manifest and commit that lockfile instead.
+- **Do not hand-edit the `@civitai/*` versions.** `civitai app init` carries the
+  pins that are known to work together; a hand-picked version is how the money
+  path breaks silently.
+{{- else if eq .Kind "no-build" }}
+**This project has no `package.json`.** `civitai agent-setup` looked: this
+directory holds a `block.manifest.json` and no `package.json`, which is the
+no-build shape `civitai app init --template static` produces. So there is
+nothing to install, no build step, no package-manager script to run, no lockfile
+to commit and no `@civitai/*` dependency to pin — the platform serves these
+files as they are.
+
+| Task | How |
+|---|---|
+| Preview it | open `index.html` in a browser, or serve the directory (`python3 -m http.server 8080`) |
+| Reach it from `civitai app dev-tunnel` | serve the directory on a port yourself, then `civitai app dev-tunnel --port 8080` |
+
+If you later add a `package.json`, re-run `civitai agent-setup` here — this
+section is rewritten from the directory each time.
+{{- else }}
+**No Civitai App has been scaffolded in this directory.** `civitai agent-setup`
+found neither a `package.json` nor a `block.manifest.json` here, so it cannot
+name a command for running one, and anything it named would be a guess.
+
+Run `civitai app init <name>` — it prints the next steps for the template you
+pick — then re-run `civitai agent-setup` in that directory and this section is
+rewritten to match the project.
+
+The templates differ in exactly this respect, which is why this section is not a
+fixed list. As of this CLI version:
+{{ range .Templates }}
+- `{{ .Name }}` — {{ if .NPM }}ships a `package.json` with its own build and dev scripts{{ else }}no `package.json`, no build step, nothing to install{{ end }}
+{{- end }}
+{{- end }}
 
 ### Gotchas — these defy reasonable assumptions
 
@@ -30,12 +92,6 @@ inside civitai.com. The host page and your app talk over `postMessage`.
   it cannot be scripted, seeded or written from a server.
 - **`civitai app validate` is a local mirror. The server is authoritative.** A
   clean local validate is necessary, never sufficient.
-- **Commit the lockfile.** The platform builds with `npm ci` and will not build
-  without one. If you switch package manager, set `buildCommand` and `outputDir`
-  in the manifest and commit that lockfile instead.
-- **Do not hand-edit the `@civitai/*` versions.** `civitai app init` carries the
-  pins that are known to work together; a hand-picked version is how the money
-  path breaks silently.
 
 ### Docs
 


### PR DESCRIPTION
## The defect

`civitai app init` defaults to `--template static`, which scaffolds **no `package.json` at all** — the tree is `app.js`, `assets/`, `block.manifest.json`, `civitai-host.js`, `.gitignore`, `index.html`, `README.md`, `style.css`.

The managed block `civitai agent-setup` writes into `AGENTS.md` was a single fixed document. In *every* project it was written into, it said:

| Task | Command |
|---|---|
| Local dev, mock host, no Buzz spent | `npm run dev:harness` |
| Local app inside the REAL host | `civitai app dev-tunnel` (with `npm run dev:tunnel` in another terminal) |

and, in its gotchas, *"Commit the lockfile. The platform builds with `npm ci`…"*.

Measured against the three templates the binary actually ships:

| Template | `package.json`? | scripts |
|---|---|---|
| `static` (**the default**) | **no** | — |
| `page-vite` | yes | `postinstall`, `dev`, `build`, `preview` |
| `page-money` | yes | `postinstall`, `dev`, `dev:harness`, `dev:live`, `dev:tunnel`, `build`, `typecheck`, `test`, `preview` |

`dev:harness` and `dev:tunnel` exist in **one template of three**. The block was wrong for `page-vite`, which defines neither, and wrong in the worst direction for `static`, which has no package manager to run at all.

It also **contradicted this CLI's own output**: `civitai app init`'s next steps are already template-aware and for `static` print `1. cd <dir>              # then open index.html or serve the directory`.

## How it was found

A blind dogfood of the agent-onboarding flow. It found no `package.json`, saw `AGENTS.md` and `app init` disagreeing, and had to work out which of two Civitai-authored documents to believe. That is the failure: two shipped surfaces stating different things with equal confidence.

## The fix

The local-dev commands are now **read from the directory**, not from a constant. `detectProjectShape` (new `internal/cmd/agent_setup_project.go`) classifies three ways and the embedded template branches:

| Kind | Detected by | What the section says |
|---|---|---|
| `npm` | a `package.json` is present | a table of the dev scripts **that project's own `package.json` defines**, plus the lockfile and pin rules |
| `no-build` | a `block.manifest.json` and no `package.json` | there is no `package.json`; `index.html` / serve the directory, matching `app init` word for word |
| `none` | neither | nothing is scaffolded here; templates enumerated from `scaffold.AllTemplates()` |

Three properties are load-bearing:

1. **`package.json` is tested first** — `page-vite`/`page-money` carry both files, so manifest-first calls every npm template no-build.
2. **Script names come out of the file, never out of a list.** `knownDevScripts` supplies order and wording only; a row is emitted only when the project defines that exact key. So "the block cannot name a script the project does not define" is a property, not an intention.
3. **The `none` branch's template enumeration is generated** from `scaffold.AllTemplates()` / `Template.NeedsInstall()`, so a fourth template appears in it without anyone editing markdown.

Full rationale, rejected alternatives and the **enumerated residuals** (what `knownDevScripts` does *not* close, and what was *not* measured about tunnelling a static project) are in `claudedocs/decisions/36-agents-block-per-project.md`, routed by AGENTS.md item 36.

### Second item: `--check`'s `authenticated` row

It read `token configured — \`civitai whoami\` verifies it`. That is a true claim about **this CLI's** config store, and it reads as a claim about the setup — while the MCP entries reference `${CIVITAI_TOKEN}` from the **environment**. Reproduced on this machine: `--check` came back `ok: true` with every row green on a box where the orchestration server would 401.

The wording now names which store it looked in, in three cases (exported / configured-for-this-CLI-only / neither). **`ok` and the row's exclusion from the verdict are unchanged** — that is settled and a test pins it; only the sentence moved.

## Verification — the binary, not the tests

Scaffolded each template, ran `agent-setup` into it, read the result:

| project | package-manager words in the managed block | scripts named |
|---|---|---|
| `static` | **0** | — |
| `page-vite` | 3 (lockfile rule + one row) | `` `npm run dev` `` |
| `page-money` | 6 | `dev:harness`, `dev`, `dev:live`, `dev:tunnel` |
| empty dir | **0** | — |

Every named script is in that project's own `package.json`. Re-run is `unchanged`/`keep-existing`. No literal token and no `"headers": {}` in any of the four `.mcp.json` files.

## The regression guard, red then green

`TestAStaticProjectIsNeverToldToRunNPM` scaffolds `static` with `scaffold.Render` and drives the real command.

**Red at `origin/main` (a6a36f6):**

```
--- FAIL: TestRedStaticProjectIsNeverToldToRunNPM
    the managed block written into a static project names a package manager [npm npm npm]
    the static project's block never mentions "no `package.json`"
    the static project's block never mentions "index.html"
    the static project's block never mentions "serve the directory"
```

(`npm run dev:harness`, `npm run dev:tunnel`, `npm ci`.) **Green on this branch.**

Alongside it: `TestTheNPMScanCanSeeAnNPMCommand` (positive control), `TestTheBlockNeverNamesAScriptTheProjectDoesNotDefine` (the *relationship* — every `npm run X` printed is looked up in that project's `package.json`, so it holds for a template nobody has written yet), `TestPageViteIsNotToldAboutPageMoneysScripts` (the case a `package.json`-only branch would miss), `TestDetectProjectShapeClassifiesEveryShippedTemplate`, `TestAgentsTemplateRendersForEveryShape`.

## Constraints honoured

- No package version pinned in the template — `TestAgentsTemplatePinsNoVersion` green.
- Every `civitai …` the template names resolves in the Cobra tree — `TestAgentsTemplateCommandsResolveInTheTree` green (the walker now scans all branches of the template source).
- Credential invariants re-run and green.
- `AGENTS.md`: item 36 added; `agentsMaxBytes` 30,200 → 30,500 (file measured at 30,317; **183 bytes left**), arithmetic in the constant's comment. `agentsMaxBytesCeiling` (30,600) **unchanged** — it now has 100 bytes of slack, so the next item re-derives *that* constant rather than raising this one again. No item was evicted.

## Gate

- `env CGO_ENABLED=0 make ci` — pass
- `nix-shell -p golangci-lint --run "make lint"` — `0 issues.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7RUfuWWYUVrLRTmvzgDGF
