### PR TITLE
fix(agent-setup): the AGENTS.md block named the wrong scaffolder, and `--check` claimed reachability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,7 +462,8 @@ item must carry a trigger that is a routing question rather than a label
     → evidence: claudedocs/decisions/35-agent-setup-merges-a-users-file.md
 
 36. **Editing what `agent-setup`'s block says a project can RUN — its local-dev
-    branch, script table or lockfile rule — or flattening it to one list?**
+    branch, script table, lockfile rule — flattening it to one list, or naming
+    the SCAFFOLDER an author with no app should run?**
     → evidence: claudedocs/decisions/36-agents-block-per-project.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with

--- a/README.md
+++ b/README.md
@@ -398,8 +398,13 @@ header holding your actual token is a secret headed for version control. Instead
 - Where the vendor **documents** environment-variable interpolation, the header
   **references** `CIVITAI_TOKEN` in that vendor's own spelling (the last column
   above; the four spellings genuinely differ). Export it so the agent resolves
-  it: `export CIVITAI_TOKEN=<your token>` — put it in your shell profile so the
-  agent inherits it.
+  it: `export CIVITAI_TOKEN=<a personal API key>` — put it in your shell profile
+  so the agent inherits it. 🔴 **Mint that key at
+  [civitai.com/user/account](https://civitai.com/user/account) (API Keys); it is
+  not the token `civitai login` stored, and no command prints that one.**
+  Exporting a value makes this CLI treat it as a personal key with **no
+  refresh**, so an OAuth login token exported here works until it expires and
+  then hard-fails.
 - Where the vendor documents **none** — Zed today, and `--agent other`, whose
   target agent is by definition unknown — **no header is written at all**, and the
   output names the exact header to add yourself. Guessing a syntax
@@ -448,8 +453,8 @@ civitai agent-setup --check --json
     {"name": "cli-version",   "ok": true,  "detail": "v0.1.103"},
     {"name": "agents-md",     "ok": true,  "detail": "/home/u/proj/AGENTS.md"},
     {"name": "claude-md",     "ok": true,  "detail": "/home/u/proj/CLAUDE.md"},
-    {"name": "mcp-site",      "ok": true,  "detail": "/home/u/proj/.mcp.json"},
-    {"name": "mcp-orch",      "ok": true,  "detail": "/home/u/proj/.mcp.json"},
+    {"name": "mcp-site",      "ok": true,  "detail": "registered in /home/u/proj/.mcp.json — this row read that file; it does not contact https://mcp.civitai.com/mcp"},
+    {"name": "mcp-orch",      "ok": true,  "detail": "registered in /home/u/proj/.mcp.json — this row read that file; it does not contact https://orchestration.civitai.com/mcp, which returns 401 until an Authorization header is present"},
     {"name": "authenticated", "ok": false, "detail": "no token in this CLI's config and no CIVITAI_TOKEN in this environment — run `civitai login` for this CLI, and `export CIVITAI_TOKEN` for claude"}
   ]
 }
@@ -464,6 +469,14 @@ exported (the setup an agent can use); a token is configured for **this CLI** bu
 `orchestration.civitai.com`); or neither. The row's `ok` is `true` for both of
 the first two and it never fails the verdict either way — what it reports is a
 value being **present**, never that a server accepted it.
+
+🔴 **An `ok: true` `mcp-*` row means an entry is IN THAT FILE — never that the
+server answered.** `--check` is offline and side-effect-free: every one of its
+steps is a file read, and it contacts nothing. So the row names the file it
+inspected and says so, because `ok: true` beside a bare path used to read as
+"this server works" — and `https://orchestration.civitai.com/mcp` returns `401`
+to an unauthenticated request, which a green row said nothing about. Same rule as
+`authenticated` above: presence, not acceptance.
 
 A config file `--check` cannot **read** is reported the same way an unknown agent
 and an unresolvable home already were: as `mcp-site`/`mcp-orch` rows carrying the
@@ -1949,7 +1962,7 @@ manifest to read, so it stops before it builds a request:
 
 ```text
 $ cd /tmp && civitai app listing status
-Error: could not resolve the app — run this from your app directory (with block.manifest.json) or pass --slug: no block.manifest.json found in . — is this an App project? run `civitai app init` to create one
+Error: could not resolve the app — run this from your app directory (with block.manifest.json) or pass --slug: no block.manifest.json found in . — is this an App project? run `civitai app create` to create one
 ```
 
 Two flags name the app instead: **`--slug <blockId>`** skips the manifest

--- a/claudedocs/decisions/34-agent-setup-writes-no-credential.md
+++ b/claudedocs/decisions/34-agent-setup-writes-no-credential.md
@@ -430,3 +430,65 @@ merge path already refuses to do for the same reason.
 The regression guard was watched **red on the pre-fix branch code** for all
 seven agents plus the `--agent other` paste block, and green after. That matrix
 is in the PR that introduced this item.
+
+---
+
+## The `<your token>` placeholder had no source (#534, dogfood 2/3)
+
+`agent-setup`'s Next block printed:
+
+```
+  2. Export the token where claude can see it — the config above references it by name:
+       export CIVITAI_TOKEN=<your token>
+```
+
+and the Zed / `--agent other` branch printed `"Authorization": "Bearer <your
+token>"`. **Nothing in the CLI said where `<your token>` comes from.** A blind
+dogfood checked every subcommand looking for one that prints the stored
+credential and found none — which is correct and is this item's whole invariant
+(no file in `internal/cmd` prints `cfg.Token()` / `AccessToken()` /
+`RefreshToken()`; verified by grep). So the placeholder's only obvious resolution
+was the one thing the CLI must never do, which makes it a dead end by
+construction.
+
+**And the obvious guess is wrong in a way that fails LATER**, which is worse than
+being stuck. Read off `internal/config/config.go`, not remembered:
+
+- `Config.Token()` returns the env-bound `token` key when non-empty, in
+  preference to the stored `access_token` — so an exported value *shadows* the
+  refreshable OAuth pair.
+- `Config.AuthKind()` opens with `if c.v.GetString(keyToken) != "" { return
+  AuthKindToken }`, and `keyToken` is `BindEnv`'d to `CIVITAI_TOKEN`.
+  `AuthKindToken` is documented as "a personal API key (no refresh)".
+
+So a user who dug their `civitai login` token out of `config.yaml` and exported
+it gets a setup that verifies green today and hard-fails at expiry, with nothing
+left to refresh it.
+
+**The fix names the SOURCE, never the VALUE** — surfacing the credential to close
+this would be exactly the leak this item exists to prevent. `tokenPlaceholder`
+is now `<a personal API key>`, and `printTokenSourceNote` follows every
+placeholder with the mint URL, the fact that no command prints the stored
+credential, and the no-refresh consequence. It builds on `accountAPIKeysURL`, the
+constant seven other remedies already use, so it cannot drift from where
+`civitai login --token` sends the same user.
+
+### Guards (`internal/cmd/agent_setup_scaffolder_test.go`)
+
+- `TestEveryCredentialPlaceholderNamesItsSource` — a RELATIONSHIP over BOTH
+  placeholder surfaces (claude's interpolating export step and Zed's manual
+  header block, with a premise check that the two still straddle that branch):
+  output that asks the user to type a credential must name where to get one, must
+  no longer print `<your token>`, and must still not print the configured token.
+- `TestTokenSourceNoteSaysAnExportedTokenIsNotRefreshed` — asserts the
+  `AuthKind()` property the sentence rests on, so the claim cannot outlive the
+  behaviour.
+
+Red on `origin/main` `cbcb992` with a shim reproducing that branch:
+
+```
+the claude run tells the user to type <your token> and never names where one comes
+from — no command prints the stored credential, so a placeholder without a source
+is a dead end
+the claude run still prints the sourceless `<your token>` placeholder
+```

--- a/claudedocs/decisions/35-agent-setup-merges-a-users-file.md
+++ b/claudedocs/decisions/35-agent-setup-merges-a-users-file.md
@@ -871,3 +871,76 @@ source. The tell was that the `grep` verifying the edit printed nothing — only
 visible if you look at it. Re-applied with a Python replace that asserts
 `count(anchor) == 1` first, the mutant dies. Assert the edit landed before
 reading the verdict.
+
+---
+
+## `--check`'s `mcp-*` rows: presence in a file, never reachability (#534, dogfood 2)
+
+A blind dogfood probed both registered servers with a real MCP `initialize`, no
+credential:
+
+```
+POST https://mcp.civitai.com/mcp            -> 200
+POST https://orchestration.civitai.com/mcp  -> 401
+```
+
+and `civitai agent-setup --check --json` reported, for both:
+
+```json
+{"name": "mcp-site", "ok": true, "detail": "/home/u/proj/.mcp.json"},
+{"name": "mcp-orch", "ok": true, "detail": "/home/u/proj/.mcp.json"}
+```
+
+`ok: true` beside a bare filename is indistinguishable from "this server works",
+and one of the two rows was green against a `401`. The command's own PROSE was
+already correct — the write path prints *"⚠ needs an Authorization header — this
+one returns 401 without a credential"*, and the `authenticated` row already says
+*"this row only checks that one is present"* — so what was narrow was the
+machine-readable row, which is the surface `developer.civitai.com`'s hosted
+prompt consumes.
+
+### What was NOT done: a network probe
+
+`--check` is offline and side-effect-free by construction — every call in
+`agentSetupChecks` is a file read — and that property is worth more than a tick
+that has to reach the network to be earned: it works on a plane, in CI, behind a
+proxy, and it can never be why a setup run hangs. `ok` was also left alone: the
+entry IS registered, which is what the row has always meant and what
+`agentSetupVerdict` counts. **The sentence is what changed**, the same fix shape
+the `authenticated` row got.
+
+`mcpRegisteredDetail(path, srv)` (`internal/cmd/agent_setup_mcp.go`) renders it:
+
+```
+registered in <path> — this row read that file; it does not contact <url>[, which
+returns 401 until an Authorization header is present]
+```
+
+The trailing clause is **derived from `mcpServer.Anonymous`**, the same field
+`mcpAnonymityNote` reads, so it cannot be spelled per Check name and drift from
+the table; a third server gets the right sentence the moment it is added.
+
+It deliberately does not claim the entry AUTHENTICATES — whether a header
+present in the file resolves to a credential is `mcpAuthCoverage`'s three-valued
+question, not this row's.
+
+### Guards
+
+`internal/cmd/agent_setup_scaffolder_test.go`:
+
+- `TestRegisteredMCPRowSaysWhatItInspected` — checks the premise (the two shipped
+  servers still disagree on `Anonymous`, else the assertion is vacuous), then
+  MUTATES `Anonymous` on a probe server in both directions and requires the
+  sentence to move with it.
+- `TestCheckJSONDoesNotReportOrchestrationAsReachable` — drives the real
+  `--check --json`, asserts each `ok: true` row is not the bare config path, and
+  that the two rows differ, because the two servers do.
+
+Red on `origin/main` `cbcb992` with a shim reproducing that branch byte-for-byte
+(`Detail: path`):
+
+```
+the mcp-orch row's ok:true detail mentions 401 = false, want true (Anonymous=false): "/home/u/proj/.mcp.json"
+mcp-orch's ok:true detail is the bare config path — presence in a file is not reachability of …
+both mcp rows carry an identical detail … while the servers disagree on anonymous access
+```

--- a/claudedocs/decisions/36-agents-block-per-project.md
+++ b/claudedocs/decisions/36-agents-block-per-project.md
@@ -141,3 +141,84 @@ description-wider-than-its-implementation looks like from the inside: the file
 read as authoritative in a project where two thirds of it was false. If the
 branch has to go, the replacement is a table that states BOTH cases with the
 condition attached — never one case asserted for all of them.
+
+---
+
+## Second defect, same block: it named the WRONG SCAFFOLDER (#534, dogfood 2)
+
+The per-project fix above made the block's *local-dev* section true of the
+directory it is written into. It left the row that tells an author how to CREATE
+that directory pointing at the other scaffolder:
+
+```
+| Scaffold a new app | `civitai app init <name>` |
+```
+
+`app init` and `app create` share one `RunE` (`runAppScaffold`) and differ in
+exactly one thing — the default `--template`. Measured on the shipped binary at
+`cbcb992`:
+
+| command (no `--template`) | template | files | `package.json` | dev scripts |
+| --- | --- | --- | --- | --- |
+| `civitai app init df-init --yes` | `static` | **8** | **none** | none |
+| `civitai app create df-create --yes` | `page-money` | **37** | yes | `dev`, `dev:harness`, `dev:live`, `dev:tunnel` |
+
+So an author following the block's own row got the project shape for which the
+block has the LEAST to say — while four sections later the same block credits the
+scaffolder with `dev:harness`/`dev`/`dev:live`/`dev:tunnel` and with the
+`@civitai/*` pins, none of which exist in a `static` project.
+
+**The binary already had an answer, and the block was the outlier.**
+`civitai app --help`: *"`civitai app create` is the friendly,
+batteries-included scaffolder (defaults to the rich page-money SDK template);
+`civitai app init` is the same scaffolder with a no-build static default
+(back-compat alias)."* `civitai --help`'s "Get started" block, `civitai --help`'s
+`Example`, `app --help`'s `Example` and `agentSetupNoSuchDir` all already said
+`create`. Three surfaces said `init`: this block, `remedyNoSuchDir`
+(`internal/cmd/project_dir.go`) and `manifest.Load`/`LoadRaw`'s
+"run `civitai app …` to create one". All three moved.
+
+### Established answer: `create`, and `init` is not named to a NEW author
+
+`init` is not deprecated and was not touched — it is a documented, tested,
+back-compat alias, and a message that needs the `static` template's artefacts
+still names it deliberately (`readyAckRemedy` in `internal/validate/readyack.go`
+tells an author to scaffold a scratch project and copy its `civitai-host.js`;
+`app create`'s page-money default ships no such file, so `init` is the *correct*
+command there and was left alone). What changed is only the surfaces addressed to
+a reader who has **no app yet**: those name one command, and it is the one this
+CLI's own help recommends.
+
+### Guards
+
+`internal/cmd/agent_setup_scaffolder_test.go`:
+
+- `TestTheBlocksScaffolderProducesAProjectItsOwnCommandsRunIn` — reads the
+  scaffold row out of the shipped template, RUNS it exactly as spelled (no
+  `--template`), and requires the result to be a project the block's own
+  local-dev section can name commands for, then checks every `npm run X` the
+  rendered block prints against that project's `package.json`. It asserts a
+  relationship, never the word "create".
+- `TestBlockScaffoldRowExtractorCanFail` — negative control for the extractor.
+- `TestEveryNewAppRemedyNamesOneScaffolder` — the seven-surface ledger, held to
+  ONE verb, with a per-surface positive control. **The ledger is an open
+  enumeration**: it is not a claim that nothing else in the repo names a
+  scaffolder (`app --help` and the README command table document both on
+  purpose), only that these seven agree.
+
+Red-then-green, run against `origin/main` `cbcb992` with only the test file
+added:
+
+```
+--- FAIL: TestTheBlocksScaffolderProducesAProjectItsOwnCommandsRunIn
+    the block's "Scaffold a new app" row names `civitai app init`, whose default
+    template produced a "no-build" project with 0 recognised dev scripts …
+--- FAIL: TestEveryNewAppRemedyNamesOneScaffolder
+    a new author is told 2 different commands by one binary …
+      `civitai app create`: agent-setup --dir remedy, civitai --help (Example),
+                            civitai --help (Long: Get started), civitai app --help (Example)
+      `civitai app init`:   agent-setup's managed block scaffold row,
+                            manifest.Load remedy, project-path remedy (remedyNoSuchDir)
+```
+
+Both green at HEAD.

--- a/internal/cmd/agent_setup.go
+++ b/internal/cmd/agent_setup.go
@@ -84,6 +84,43 @@ const (
 	agentSetupNotADir   = "%s is not a directory — --dir takes the project ROOT that receives AGENTS.md, not a file"
 )
 
+// tokenPlaceholder is what stands in for the credential in every line this
+// command tells a user to type, and printTokenSourceNote is the sentence that
+// follows it.
+//
+// 🔴 `<your token>` NAMED NO SOURCE, AND A BLIND DOGFOOD GOT STUCK THERE. The
+// next-step block printed `export CIVITAI_TOKEN=<your token>` and nothing — here,
+// in `--help`, or in any other command — said where that value comes from. The
+// dogfood went looking for a command that prints the stored credential and found
+// none, which is correct and deliberate: no file in internal/cmd prints
+// `cfg.Token()` / `AccessToken()` / `RefreshToken()`, and that invariant is the
+// point of this whole path, not an omission. A placeholder whose only resolution
+// would be a leak is a dead end by construction, so it has to name its source.
+//
+// 🔴 AND THE OBVIOUS GUESS IS WRONG IN A WAY THAT FAILS *LATER*. Exporting the
+// token `civitai login` stored is not equivalent to minting a key. `Config.Token`
+// prefers the env-bound `token` key over the stored `access_token`, and
+// `Config.AuthKind` returns AuthKindToken — documented as "a personal API key
+// (no refresh)" — for ANY env-supplied value. So an exported OAuth access token
+// shadows the refreshable pair, works until it expires and then hard-fails, with
+// nothing left to refresh it. That is a worse outcome than being stuck, because
+// it is a setup that verifies green today.
+//
+// 🔴 IT NAMES THE SOURCE, NEVER THE VALUE. Printing, echoing or logging the
+// stored credential to close this would be exactly the leak item 34 forbids.
+// `accountAPIKeysURL` is the one constant seven other remedies already use, so
+// this cannot drift from where `civitai login --token` sends the same user.
+const tokenPlaceholder = "<a personal API key>"
+
+func printTokenSourceNote(w io.Writer, st ui.Styler, indent string) {
+	// The wording is context-NEUTRAL on purpose: this note follows an `export`
+	// line for the interpolating agents and a pasted `Authorization` header for
+	// Zed, so it says "used this way" rather than "exported".
+	fmt.Fprintf(w, "%s%s\n", indent, st.Dim("Mint one at "+accountAPIKeysURL+" (API Keys). No command prints the"))
+	fmt.Fprintf(w, "%s%s\n", indent, st.Dim("credential `civitai login` stored, and that one is the wrong kind here: a"))
+	fmt.Fprintf(w, "%s%s\n", indent, st.Dim("token used this way is never refreshed, so an OAuth login token dies at expiry."))
+}
+
 // resolveAgentSetupDir classifies the directory the user named, BEFORE anything
 // is read or written.
 //
@@ -743,7 +780,10 @@ func agentSetupMCPChecks(env agentEnv, agent string) []agentCheckJSON {
 	rows := make([]agentCheckJSON, 0, len(civitaiMCPServers))
 	for _, srv := range civitaiMCPServers {
 		if registered[srv.Name] {
-			rows = append(rows, agentCheckJSON{Name: srv.Check, OK: true, Detail: path})
+			// 🔴 NOT THE BARE PATH. `ok: true` here means an entry for this server
+			// exists in that file; it has never meant the server answers, and the
+			// path alone read as though it did. See mcpRegisteredDetail.
+			rows = append(rows, agentCheckJSON{Name: srv.Check, OK: true, Detail: mcpRegisteredDetail(path, srv)})
 			continue
 		}
 		rows = append(rows, agentCheckJSON{Name: srv.Check, OK: false,
@@ -1227,7 +1267,8 @@ func printAgentSetupWrite(w io.Writer, env agentEnv, agent, token string, change
 	if token != "" && known && (target.EnvHeaderSyntax != "" || target.EnvBearerKey != "") {
 		n++
 		fmt.Fprintf(w, "  %d. Export the token where %s can see it — the config above references it by name:\n", n, agent)
-		fmt.Fprintf(w, "       %s\n", st.Code("export "+tokenEnvVar+"=<your token>"))
+		fmt.Fprintf(w, "       %s\n", st.Code("export "+tokenEnvVar+"="+tokenPlaceholder))
+		printTokenSourceNote(w, st, "     ")
 		if exported {
 			fmt.Fprintf(w, "     %s\n", st.Dim(tokenEnvVar+" is already set in this shell. Put it in your shell "+
 				"profile so the agent inherits it too."))
@@ -1334,7 +1375,8 @@ func printAgentSetupAuthNote(w io.Writer, st ui.Styler, agent string, t agentTar
 			fmt.Fprintf(w, "  was written. %s\n", st.Warn("Access without one: "+mcpAnonymityNote()+"."))
 		}
 		fmt.Fprintf(w, "  To authenticate, add this yourself to each Civitai entry in that file:\n")
-		fmt.Fprintf(w, "       %s\n", st.Code(`"`+t.HeadersKey+`": {"Authorization": "Bearer <your token>"}`))
+		fmt.Fprintf(w, "       %s\n", st.Code(`"`+t.HeadersKey+`": {"Authorization": "Bearer `+tokenPlaceholder+`"}`))
+		printTokenSourceNote(w, st, "  ")
 		fmt.Fprintf(w, "  %s\n", st.Dim("That file is yours; note that a literal token in it is a credential on disk, "+
 			"so keep it out of version control."))
 	}

--- a/internal/cmd/agent_setup_mcp.go
+++ b/internal/cmd/agent_setup_mcp.go
@@ -105,6 +105,44 @@ func mcpAnonymityNote() string {
 	}
 }
 
+// mcpRegisteredDetail is the `detail` an `ok: true` mcp-* row carries.
+//
+// 🔴 THE ROW ESTABLISHES PRESENCE IN A FILE, NOT REACHABILITY OF A SERVER, AND
+// IT USED TO PRINT ONLY THE PATH — a bare filename beside `ok: true`, which
+// reads as "this server is set up and working". Measured by a blind dogfood, no
+// credential, POST `initialize`: `mcp.civitai.com` answered 200 and
+// `orchestration.civitai.com` answered 401, while `--check --json` reported
+// `{"name": "mcp-orch", "ok": true}` for both. The command's own PROSE was
+// already right — the write path prints "⚠ needs an Authorization header — this
+// one returns 401 without a credential" — so what was narrow was the JSON row a
+// script reads, which is the surface `developer.civitai.com`'s hosted prompt
+// consumes.
+//
+// 🔴 THE FIX IS THE SENTENCE, NOT A PROBE. `--check` is offline and
+// side-effect-free by construction (every call in agentSetupChecks is a file
+// read), and that is a property worth more than a green tick that has to reach
+// the network to be earned: it works on a plane, in CI, behind a proxy, and it
+// can never be the reason a setup run hangs. So the row says WHAT IT
+// INSPECTED — the same move the `authenticated` row already makes ("this row
+// only checks that one is present") and the one the dogfood credited as honest.
+//
+// 🔴 AND THE 401 CLAUSE IS DERIVED FROM `srv.Anonymous`, NOT SPELLED PER ROW.
+// The two servers disagree (see mcpServer.Anonymous), a third would have its own
+// answer, and a hand-written sentence per Check name is how the table and the
+// prose drift apart. TestRegisteredMCPRowSaysWhatItInspected mutates the field
+// and requires the sentence to move with it.
+//
+// What this deliberately does NOT claim: that the entry AUTHENTICATES. Whether
+// the header a config carries resolves to a credential is mcpAuthCoverage's
+// three-valued question, and `--check` does not re-derive it here.
+func mcpRegisteredDetail(path string, srv mcpServer) string {
+	detail := "registered in " + path + " — this row read that file; it does not contact " + srv.URL
+	if !srv.Anonymous {
+		detail += ", which returns 401 until an Authorization header is present"
+	}
+	return detail
+}
+
 // mcpAuthCoverage is which of the Civitai entries in the config a run LEAVES ON
 // DISK carry a credential — whichever hand wrote it.
 //

--- a/internal/cmd/agent_setup_scaffolder_test.go
+++ b/internal/cmd/agent_setup_scaffolder_test.go
@@ -1,0 +1,474 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/internal/config"
+	"github.com/civitai/cli/internal/manifest"
+	"github.com/civitai/cli/internal/ui"
+)
+
+// The regression guards for the SECOND blind dogfood's two findings:
+//
+//   - the managed block's "Scaffold a new app" row named `civitai app init`,
+//     the no-build `static` default, while everything around it — its own
+//     npm-script table, its lockfile rule, its `@civitai/*` pin rule — describes
+//     a page-money project, and `civitai --help`'s "Get started" block names
+//     `civitai app create`. Measured by the dogfood: `app init dogfood2-hello`
+//     produced an 8-file static app with NO package.json; `app create
+//     dogfood2-cmp` produced 37 files, page-money, with `dev:harness`,
+//     `dev:tunnel` and `dev:live` all present.
+//
+//   - `--check --json` returned `ok: true` for `mcp-orch` with the config path
+//     as its whole `detail`, against a server the dogfood measured returning
+//     401 to an unauthenticated `initialize`.
+
+// ---------------------------------------------------------------------------
+// Defect 1 — the block's scaffolder
+// ---------------------------------------------------------------------------
+
+// blockScaffoldRowRe reads the "Scaffold a new app" row out of the SHIPPED
+// document rather than out of a literal here. A guard that hardcodes the command
+// it expects re-encodes the assumption that produced the bug; this one asks the
+// template what it tells an author to run, and then goes and runs it.
+var blockScaffoldRowRe = regexp.MustCompile("(?m)^\\|\\s*Scaffold a new app\\s*\\|\\s*`civitai ([^`]+)`")
+
+// blockScaffoldCommand returns the `civitai …` command path the block's scaffold
+// row names, with placeholder operands (`<name>`) and flags dropped.
+func blockScaffoldCommand(doc string) []string {
+	m := blockScaffoldRowRe.FindStringSubmatch(doc)
+	if m == nil {
+		return nil
+	}
+	var path []string
+	for _, f := range strings.Fields(m[1]) {
+		if strings.HasPrefix(f, "<") || strings.HasPrefix(f, "[") || strings.HasPrefix(f, "-") {
+			continue
+		}
+		path = append(path, f)
+	}
+	return path
+}
+
+// TestTheBlocksScaffolderProducesAProjectItsOwnCommandsRunIn is THE regression
+// guard for defect 1, and it is a RELATIONSHIP rather than a word check: it does
+// not assert that the row says "create". It runs whatever the row says, exactly
+// as the row spells it (no `--template`), and then requires that the block
+// `civitai agent-setup` writes into the result can actually name commands that
+// run there.
+//
+// 🔴 WATCHED FAIL ON origin/main (cbcb992), where the row read
+// `civitai app init <name>`:
+//
+//	agent_setup_scaffolder_test.go:  the block's "Scaffold a new app" row names
+//	`civitai app init`, whose default template produced a "no-build" project
+//	with 0 recognised dev scripts …
+//
+// because `app init` with no flags is the no-build `static` template. That is
+// the whole defect: the block's Local-development branch credits `civitai app
+// create` with `dev:harness` / `dev` / `dev:live` / `dev:tunnel`, and the
+// scaffolder the block named produces a project that defines none of them and
+// has no package.json to define them in.
+//
+// 🔴 WHAT IT DOES NOT CLAIM. It says nothing about `app init`, which is a
+// supported command with a documented purpose ("the same scaffolder with a
+// no-build static default (back-compat alias)"). The claim is only that the
+// command the block hands a NEW author must produce a project the block's own
+// following sections describe.
+func TestTheBlocksScaffolderProducesAProjectItsOwnCommandsRunIn(t *testing.T) {
+	path := blockScaffoldCommand(agentsAppTemplate)
+	if len(path) == 0 {
+		t.Fatal("no `Scaffold a new app` row found in the embedded template — the extractor is reading the " +
+			"wrong text, and every assertion below would be vacuous")
+	}
+	spelling := "civitai " + strings.Join(path, " ")
+
+	// It has to be a real command before it can be a right one. (The walker in
+	// agent_setup_test.go covers every command in the block; this is the same
+	// check on the one command this test is about to execute.)
+	c, _, err := NewRootCmd().Find(path)
+	if err != nil || c.Name() != path[len(path)-1] {
+		t.Fatalf("the block's scaffold row names `%s`, which does not resolve in the command tree (%v)", spelling, err)
+	}
+
+	// Run it the way the row spells it: a name, and NO --template. --dir keeps it
+	// out of the working directory; --yes is only there because the row is meant
+	// to be runnable in a script too.
+	dir := filepath.Join(t.TempDir(), "scaffolded")
+	args := append(append([]string{}, path...), "demo-app", "--dir", dir, "--yes")
+	if out, errOut, err := run(t, args...); err != nil {
+		t.Fatalf("`%s demo-app` failed: %v\n%s\n%s", spelling, err, out, errOut)
+	}
+
+	// 🔴 THE DISCRIMINATING ASSERTION. The block's Local-development section is
+	// rendered from this directory, and its npm branch names `%s` as the
+	// authority for what those script names mean. A scaffolder whose default
+	// output has no package.json cannot be that authority.
+	shape := detectProjectShape(dir)
+	if shape.Kind != projectNPM || len(shape.Scripts) == 0 {
+		t.Fatalf("the block's \"Scaffold a new app\" row names `%s`, whose default template produced a %q "+
+			"project with %d recognised dev scripts — so an author who follows that row gets a project in "+
+			"which the block's own Local-development table can name nothing, while the block credits that "+
+			"same command with `dev:harness`/`dev`/`dev:live`/`dev:tunnel` and with the `@civitai/*` pins. "+
+			"Name the scaffolder whose output the rest of the block describes.",
+			spelling, shape.Kind, len(shape.Scripts))
+	}
+
+	// The "can run" half proper: every command the block prints for THIS project
+	// must exist in it.
+	block := setupInto(t, dir)
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal([]byte(readFile(t, filepath.Join(dir, "package.json"))), &pkg); err != nil {
+		t.Fatalf("the scaffolded package.json does not parse: %v", err)
+	}
+	named := regexp.MustCompile("`npm run ([a-z0-9:._-]+)`").FindAllStringSubmatch(block, -1)
+	if len(named) == 0 {
+		t.Fatalf("the block written into a `%s` project names no `npm run` script at all — the assertion "+
+			"below observes nothing:\n%s", spelling, block)
+	}
+	for _, m := range named {
+		if _, ok := pkg.Scripts[m[1]]; !ok {
+			t.Errorf("the block tells a `%s` project to run `npm run %s`, which that project does not define "+
+				"(it defines %v)", spelling, m[1], scriptNames(pkg.Scripts))
+		}
+	}
+}
+
+// TestBlockScaffoldRowExtractorCanFail is the NEGATIVE CONTROL for the extractor
+// above. An extractor that returns a constant — or that silently returns nothing
+// and lets a `len(path) == 0` guard be the only thing standing — would make the
+// test above a fact about the extractor rather than about the template.
+func TestBlockScaffoldRowExtractorCanFail(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"create", "| Task | Command |\n| Scaffold a new app | `civitai app create <name>` |\n", "app create"},
+		{"init", "| Scaffold a new app | `civitai app init <name>` |\n", "app init"},
+		{"flags dropped", "| Scaffold a new app | `civitai app create <name> --yes` |\n", "app create"},
+		{"a command that does not exist", "| Scaffold a new app | `civitai app frobnicate <name>` |\n", "app frobnicate"},
+		{"no such row", "| Check the manifest | `civitai app validate` |\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(blockScaffoldCommand(tc.doc), " "); got != tc.want {
+				t.Errorf("blockScaffoldCommand(%q) = %q, want %q", tc.doc, got, tc.want)
+			}
+		})
+	}
+	// And the row it extracts must be resolvable-or-not on its own merits: the
+	// control command must NOT resolve, or the resolution check in the guard
+	// above accepts anything.
+	c, _, err := NewRootCmd().Find(blockScaffoldCommand("| Scaffold a new app | `civitai app frobnicate` |\n"))
+	if err == nil && c.Name() == "frobnicate" {
+		t.Error("`civitai app frobnicate` resolved — the resolution check cannot reject a command that does not exist")
+	}
+}
+
+// newAppRemedySurfaces is the ENUMERATED ledger of the places this CLI tells
+// somebody who has NO app which command creates one.
+//
+// 🔴 IT IS AN ENUMERATION AND THE ENUMERATION IS OPEN. This is not a claim that
+// no other string in the repo names a scaffolder — it cannot be, because plenty
+// legitimately do: `civitai app --help` documents BOTH commands on purpose (that
+// is where the alias is defined), the README's command table has a row for each,
+// and `readyAckRemedy` names `civitai app init` deliberately, because it needs
+// the `static` template's `civitai-host.js` and `app create`'s page-money
+// default does not ship one. The claim is only that these SEVEN surfaces, each
+// of which addresses a reader with no project, agree on one answer. A new
+// surface of that kind has to be added here by hand.
+func newAppRemedySurfaces(t *testing.T) map[string]string {
+	t.Helper()
+	root := NewRootCmd()
+	appCmd, _, err := root.Find([]string{"app"})
+	if err != nil {
+		t.Fatalf("app command: %v", err)
+	}
+	_, manifestErr := manifest.Load(t.TempDir())
+	if manifestErr == nil {
+		t.Fatal("manifest.Load on an empty directory returned no error — its remedy cannot be measured")
+	}
+	return map[string]string{
+		"civitai --help (Long: Get started)":       root.Long,
+		"civitai --help (Example)":                 root.Example,
+		"civitai app --help (Example)":             appCmd.Example,
+		"agent-setup's managed block scaffold row": strings.Join(blockScaffoldCommand(agentsAppTemplate), " "),
+		"agent-setup --dir remedy":                 agentSetupNoSuchDir,
+		"project-path remedy (remedyNoSuchDir)":    remedyNoSuchDir,
+		"manifest.Load remedy":                     manifestErr.Error(),
+	}
+}
+
+var scaffolderRe = regexp.MustCompile(`\bapp (create|init)\b`)
+
+// TestEveryNewAppRemedyNamesOneScaffolder is the cross-surface half of defect 1.
+//
+// 🔴 THE DEFECT WAS A DISAGREEMENT, NOT A TYPO. On origin/main this ledger held
+// three surfaces saying `create` (both root-help blocks, `app --help`'s example
+// and `agentSetupNoSuchDir`) and three saying `init` (the managed block,
+// `remedyNoSuchDir`, `manifest.Load`) — so a new author was told two different
+// things by one binary, and the two commands have DIFFERENT defaults. `app
+// --help` settles which is meant: "civitai app create is the friendly,
+// batteries-included scaffolder … civitai app init is the same scaffolder with a
+// no-build static default (back-compat alias)".
+//
+// The test does not name the winner. It requires the union to be a SINGLE verb,
+// so a future change that moves them all together passes and one that moves half
+// of them fails.
+func TestEveryNewAppRemedyNamesOneScaffolder(t *testing.T) {
+	named := map[string][]string{}
+	for surface, text := range newAppRemedySurfaces(t) {
+		hits := scaffolderRe.FindAllStringSubmatch(text, -1)
+		// POSITIVE CONTROL, per surface: a surface that stopped naming a
+		// scaffolder at all would otherwise silently drop out of the union and
+		// leave the remaining ones trivially in agreement.
+		if len(hits) == 0 {
+			t.Errorf("%s names no `app create`/`app init` at all — either it stopped telling a new author "+
+				"how to scaffold, or this ledger is reading the wrong text:\n%s", surface, text)
+			continue
+		}
+		for _, h := range hits {
+			named[h[1]] = appendOnce(named[h[1]], surface)
+		}
+	}
+	if len(named) != 1 {
+		var report []string
+		for verb, surfaces := range named {
+			sort.Strings(surfaces)
+			report = append(report, "`civitai app "+verb+"`: "+strings.Join(surfaces, ", "))
+		}
+		sort.Strings(report)
+		t.Errorf("the surfaces that tell a new author how to scaffold do not agree — a new author is told "+
+			"%d different commands by one binary, and they default to DIFFERENT templates:\n  %s",
+			len(named), strings.Join(report, "\n  "))
+	}
+}
+
+func appendOnce(xs []string, s string) []string {
+	for _, x := range xs {
+		if x == s {
+			return xs
+		}
+	}
+	return append(xs, s)
+}
+
+// ---------------------------------------------------------------------------
+// Defect 2 — what an `ok: true` mcp-* row claims
+// ---------------------------------------------------------------------------
+
+// TestRegisteredMCPRowSaysWhatItInspected pins the sentence an `ok: true`
+// `mcp-*` row carries, and pins the 401 clause to `mcpServer.Anonymous` rather
+// than to a Check name.
+//
+// 🔴 THE PREMISE IS CHECKED, NOT ASSUMED. If the two shipped servers ever agree
+// on Anonymous, the per-server assertion below cannot discriminate and this test
+// says so instead of passing.
+func TestRegisteredMCPRowSaysWhatItInspected(t *testing.T) {
+	const path = "/home/u/proj/.mcp.json"
+
+	anon, auth := anonymousServerNames(), authRequiredServerNames()
+	if len(anon) == 0 || len(auth) == 0 {
+		t.Fatalf("PREMISE BROKEN: the shipped servers no longer disagree on anonymous access (anonymous=%v, "+
+			"auth-required=%v) — the discriminating assertion below is vacuous", anon, auth)
+	}
+
+	for _, srv := range civitaiMCPServers {
+		detail := mcpRegisteredDetail(path, srv)
+		// It has to say WHAT it inspected: the file, by name.
+		if !strings.Contains(detail, path) {
+			t.Errorf("the %s row's ok:true detail does not name the file it read: %q", srv.Check, detail)
+		}
+		// And that inspecting the file is ALL it did.
+		if !strings.Contains(detail, "does not contact "+srv.URL) {
+			t.Errorf("the %s row's ok:true detail does not say it did not contact %s — `ok: true` then reads "+
+				"as a reachability claim: %q", srv.Check, srv.URL, detail)
+		}
+		if got, want := strings.Contains(detail, "401"), !srv.Anonymous; got != want {
+			t.Errorf("the %s row's ok:true detail mentions 401 = %v, want %v (Anonymous=%v): %q",
+				srv.Check, got, want, srv.Anonymous, detail)
+		}
+	}
+
+	// MUTATION: the 401 clause is DERIVED from the field, not spelled per row.
+	// A probe server flipped in both directions must move the sentence.
+	probe := mcpServer{Name: "probe", URL: "https://probe.invalid/mcp", Check: "mcp-probe", Anonymous: true}
+	if strings.Contains(mcpRegisteredDetail(path, probe), "401") {
+		t.Error("an anonymous server's ok:true detail claims a 401 — the clause is not derived from Anonymous")
+	}
+	probe.Anonymous = false
+	if !strings.Contains(mcpRegisteredDetail(path, probe), "401") {
+		t.Error("a non-anonymous server's ok:true detail omits the 401 — the clause is not derived from Anonymous")
+	}
+}
+
+// TestCheckJSONDoesNotReportOrchestrationAsReachable is the same finding at the
+// surface a consumer actually reads: `civitai agent-setup --check --json`.
+//
+// 🔴 MEASURED BY THE DOGFOOD, no credential, POST `initialize`:
+// `mcp.civitai.com` → 200, `orchestration.civitai.com` → 401. Before this fix
+// both rows read `{"ok": true, "detail": "<path>"}`, so the green row for the
+// 401 server was indistinguishable from the green row for the 200 one.
+//
+// 🔴 IT ASSERTS THE DIFFERENCE, NOT A KEYWORD. The two rows must not be
+// interchangeable, because the two servers are not.
+func TestCheckJSONDoesNotReportOrchestrationAsReachable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "block.manifest.json"), "{}\n")
+	setupInto(t, dir) // writes AGENTS.md, CLAUDE.md and .mcp.json; also sets the env
+
+	out, errOut, err := run(t, "agent-setup", "--check", "--json", "--dir", dir, "--agent", "claude")
+	if err != nil {
+		t.Fatalf("agent-setup --check --json: %v\n%s\n%s", err, out, errOut)
+	}
+	var payload struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			OK     bool   `json:"ok"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("--check --json did not emit an object: %v\n%s", err, out)
+	}
+
+	details := map[string]string{}
+	for _, c := range payload.Checks {
+		for _, srv := range civitaiMCPServers {
+			if c.Name != srv.Check {
+				continue
+			}
+			// POSITIVE CONTROL: the row has to be the green one, or this test is
+			// asserting the wording of a failure row.
+			if !c.OK {
+				t.Fatalf("%s is not ok:true after a successful setup (%q) — this test is not exercising the "+
+					"green row it is about", c.Name, c.Detail)
+			}
+			details[srv.Check] = c.Detail
+		}
+	}
+	if len(details) != len(civitaiMCPServers) {
+		t.Fatalf("found %d of %d mcp rows in --check --json: %v", len(details), len(civitaiMCPServers), details)
+	}
+	for _, srv := range civitaiMCPServers {
+		if got, want := details[srv.Check], mcpRegisteredDetail(agentConfigPathForTest(t, dir), srv); got != want {
+			t.Errorf("%s detail = %q, want %q", srv.Check, got, want)
+		}
+		if strings.TrimSpace(details[srv.Check]) == agentConfigPathForTest(t, dir) {
+			t.Errorf("%s's ok:true detail is the bare config path — presence in a file is not reachability of "+
+				"%s, and a consumer reading `ok: true` beside a filename cannot tell the two apart",
+				srv.Check, srv.URL)
+		}
+	}
+	// The two servers differ, so their rows must differ.
+	if len(civitaiMCPServers) > 1 && details[civitaiMCPServers[0].Check] == details[civitaiMCPServers[1].Check] {
+		t.Errorf("both mcp rows carry an identical detail (%q) while the servers disagree on anonymous access",
+			details[civitaiMCPServers[0].Check])
+	}
+}
+
+// agentConfigPathForTest resolves the config path the check rows name.
+func agentConfigPathForTest(t *testing.T, dir string) string {
+	t.Helper()
+	path, ok := agentConfigPath(agentEnv{Dir: dir}, agentClaude)
+	if !ok {
+		t.Fatalf("could not resolve claude's config path under %s", dir)
+	}
+	return path
+}
+
+// ---------------------------------------------------------------------------
+// The `<your token>` placeholder had no source
+// ---------------------------------------------------------------------------
+
+// TestEveryCredentialPlaceholderNamesItsSource is the guard for the third
+// dogfood finding: `agent-setup` printed `export CIVITAI_TOKEN=<your token>` and
+// nothing anywhere in the CLI said where that value comes from. The dogfood went
+// looking for a command that prints the stored credential and found none — which
+// is correct (nothing may print it) and is precisely why the placeholder had to
+// name its own source instead.
+//
+// 🔴 IT IS A RELATIONSHIP, NOT A KEYWORD: wherever the output asks the user to
+// type a credential, the SAME output must name where to get one. It is asserted
+// over BOTH surfaces that print a placeholder — the interpolating agents' export
+// step and the manual `Authorization` block Zed gets — because a fix applied to
+// one of the two is how the other keeps the dead end.
+func TestEveryCredentialPlaceholderNamesItsSource(t *testing.T) {
+	// PREMISE: the two agents below really do take the two different branches.
+	if agentTargets[agentClaude].EnvHeaderSyntax == "" || agentTargets[agentZed].EnvHeaderSyntax != "" {
+		t.Fatalf("PREMISE BROKEN: claude (%q) and zed (%q) no longer straddle the interpolation branch",
+			agentTargets[agentClaude].EnvHeaderSyntax, agentTargets[agentZed].EnvHeaderSyntax)
+	}
+	for _, agent := range []string{agentClaude, agentZed} {
+		t.Run(agent, func(t *testing.T) {
+			dir, _ := agentSetupProject(t)
+			t.Setenv("CIVITAI_TOKEN", credFixtureToken)
+			out, _, err := run(t, "agent-setup", "--dir", dir, "--agent", agent)
+			if err != nil {
+				t.Fatalf("agent-setup --agent %s: %v\n%s", agent, err, out)
+			}
+			// POSITIVE CONTROL: this surface must actually print a placeholder,
+			// or the assertion below is about a branch that did not run.
+			if !strings.Contains(out, tokenPlaceholder) {
+				t.Fatalf("the %s run prints no credential placeholder, so this test asserts nothing about "+
+					"it:\n%s", agent, out)
+			}
+			if !strings.Contains(out, accountAPIKeysURL) {
+				t.Errorf("the %s run tells the user to type %s and never names where one comes from — no "+
+					"command prints the stored credential, so a placeholder without a source is a dead "+
+					"end:\n%s", agent, tokenPlaceholder, out)
+			}
+			// The sourceless spelling must be gone from every surface, not just
+			// the one that was reported.
+			if strings.Contains(out, "<your token>") {
+				t.Errorf("the %s run still prints the sourceless `<your token>` placeholder:\n%s", agent, out)
+			}
+			// 🔴 AND THE CREDENTIAL INVARIANT STILL HOLDS: naming the SOURCE must
+			// never become surfacing the VALUE.
+			if strings.Contains(out, credFixtureToken) {
+				t.Errorf("the %s run printed the configured token itself:\n%s", agent, out)
+			}
+		})
+	}
+}
+
+// TestTokenSourceNoteSaysAnExportedTokenIsNotRefreshed pins the second half of
+// the finding, which is the half that fails LATER.
+//
+// 🔴 THE CLAIM IS READ OFF internal/config, NOT REMEMBERED. `Config.Token`
+// prefers the env-bound `token` key over the stored `access_token`, and
+// `Config.AuthKind` returns AuthKindToken — "a personal API key (no refresh)" —
+// for ANY env-supplied value. So exporting the token `civitai login` stored
+// shadows the refreshable pair and hard-fails at expiry. This test asserts that
+// property directly, so the sentence cannot outlive the behaviour it describes.
+func TestTokenSourceNoteSaysAnExportedTokenIsNotRefreshed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
+	t.Setenv("CIVITAI_TOKEN", credFixtureToken)
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if got := cfg.AuthKind(); got != config.AuthKindToken {
+		t.Fatalf("an env-supplied CIVITAI_TOKEN classifies as %q, want %q — the printed note claims an "+
+			"exported value is never refreshed, and that claim rests on this", got, config.AuthKindToken)
+	}
+
+	var buf bytes.Buffer
+	printTokenSourceNote(&buf, ui.For(&buf), "  ")
+	note := buf.String()
+	for _, want := range []string{accountAPIKeysURL, "never refreshed", "civitai login"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("the token-source note does not mention %q:\n%s", want, note)
+		}
+	}
+}

--- a/internal/cmd/project_dir.go
+++ b/internal/cmd/project_dir.go
@@ -57,7 +57,7 @@ import (
 // settled on.
 // The two exit-2 arms carry DIFFERENT remedies, and which arm gets which is
 // part of the contract rather than cosmetic: "the path is not there" sends you
-// to `app init`, while "you pointed at a file" sends you to the parent
+// to the scaffolder, while "you pointed at a file" sends you to the parent
 // directory. Swapped, the CLI tells someone whose path is simply missing to
 // pass "the ROOT, not a file" — advice about a file that does not exist — and
 // tells someone who pointed at their manifest to scaffold a project they
@@ -74,8 +74,18 @@ import (
 // NOT the other's, and pins that the two are non-empty and distinct — an empty
 // or duplicated remedy would make `strings.Contains` vacuously true and disarm
 // the whole guard.
+//
+// 🔴 THE SCAFFOLDER IT NAMES IS `app create`, NOT `app init`, AND THE TWO ARE
+// NOT INTERCHANGEABLE. They share one RunE but default to different templates —
+// `create` to the batteries-included page-money, `init` to the no-build
+// `static` — and `civitai app --help` calls `init` "a back-compat alias". Every
+// other surface that tells somebody with no app how to get one already named
+// `create` (`civitai --help`'s "Get started" block, `app --help`'s example,
+// agentSetupNoSuchDir in agent_setup.go); this constant said `init` and was the
+// odd one out, alongside the `agent-setup` managed block a blind dogfood caught.
+// TestEveryNewAppRemedyNamesOneScaffolder holds the set to one.
 const (
-	remedyNoSuchDir = "%s: no such directory — pass the path to an App project root, or scaffold one with `civitai app init <name>`"
+	remedyNoSuchDir = "%s: no such directory — pass the path to an App project root, or scaffold one with `civitai app create <name>`"
 	remedyNotADir   = "%s is not a directory — pass the App project ROOT (the directory holding %s), not a file"
 )
 

--- a/internal/cmd/project_dir_gate_test.go
+++ b/internal/cmd/project_dir_gate_test.go
@@ -450,7 +450,7 @@ func TestProjectDirRemediesMatchTheirArm(t *testing.T) {
 		why        string
 	}{
 		{
-			name: "nonexistent path gets the `app init` remedy",
+			name: "nonexistent path gets the `app create` remedy",
 			dir:  missing, want: noSuchAt, deny: notDirAt,
 			why: "the path is not there, so there is no file to have pointed at — telling the user to " +
 				"pass the ROOT rather than a file is advice about something that does not exist",
@@ -459,7 +459,7 @@ func TestProjectDirRemediesMatchTheirArm(t *testing.T) {
 			name: "a regular file gets the project-ROOT remedy",
 			dir:  file, want: notDirAt, deny: noSuchAt,
 			why: "the user has a real project and pointed one level too deep (typically at the manifest) — " +
-				"telling them to scaffold a new one with `app init` sends them to create what they already have",
+				"telling them to scaffold a new one with `app create` sends them to create what they already have",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cmd/templates/agents-app.md
+++ b/internal/cmd/templates/agents-app.md
@@ -13,7 +13,7 @@ directory.
 
 | Task | Command |
 |---|---|
-| Scaffold a new app | `civitai app init <name>` |
+| Scaffold a new app | `civitai app create <name>` |
 | Check the manifest | `civitai app validate` |
 | Package and submit for review | `civitai app submit` |
 | Diagnose an incomplete store listing | `civitai app doctor` |
@@ -33,7 +33,7 @@ here:
 {{- end }}
 
 `npm run` lists every script, including any this CLI does not recognise. The
-descriptions are the meaning `civitai app init` gives those names; if you wrote
+descriptions are the meaning `civitai app create` gives those names; if you wrote
 your own script under one of them, yours is what runs.
 {{- else }} It defines no
 `dev` script this CLI recognises, so there is no local-dev command to name here.
@@ -43,13 +43,13 @@ Run `npm run` to list what this project does define.
 - **Commit the lockfile.** The platform builds with `npm ci` and will not build
   without one. If you switch package manager, set `buildCommand` and `outputDir`
   in the manifest and commit that lockfile instead.
-- **Do not hand-edit the `@civitai/*` versions.** `civitai app init` carries the
-  pins that are known to work together; a hand-picked version is how the money
-  path breaks silently.
+- **Do not hand-edit the `@civitai/*` versions.** `civitai app create` carries
+  the pins that are known to work together; a hand-picked version is how the
+  money path breaks silently.
 {{- else if eq .Kind "no-build" }}
 **This project has no `package.json`.** `civitai agent-setup` looked: this
 directory holds a `block.manifest.json` and no `package.json`, which is the
-no-build shape `civitai app init --template static` produces. So there is
+no-build shape `civitai app create --template static` produces. So there is
 nothing to install, no build step, no package-manager script to run, no lockfile
 to commit and no `@civitai/*` dependency to pin — the platform serves these
 files as they are.
@@ -66,7 +66,7 @@ section is rewritten from the directory each time.
 found neither a `package.json` nor a `block.manifest.json` here, so it cannot
 name a command for running one, and anything it named would be a guess.
 
-Run `civitai app init <name>` — it prints the next steps for the template you
+Run `civitai app create <name>` — it prints the next steps for the template you
 pick — then re-run `civitai agent-setup` in that directory and this section is
 rewritten to match the project.
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -59,7 +59,7 @@ func Load(dir string) (*Manifest, error) {
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app init` to create one", Filename, dir)
+			return nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app create` to create one", Filename, dir)
 		}
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func LoadRaw(dir string) (any, *Manifest, error) {
 	raw, err := os.ReadFile(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app init` to create one", Filename, dir)
+			return nil, nil, fmt.Errorf("no %s found in %s — is this an App project? run `civitai app create` to create one", Filename, dir)
 		}
 		return nil, nil, err
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -45,8 +45,14 @@ func TestLoadMissingFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing manifest")
 	}
-	if !contains(err.Error(), "civitai app init") {
-		t.Errorf("error should hint at init: %v", err)
+	// 🔴 `app create`, NOT `app init`. Both run the same scaffolder, but they
+	// default to different templates and `civitai app --help` calls `init` "a
+	// back-compat alias" — so a reader who has NO app is sent to `create`, the
+	// command `civitai --help`'s "Get started" block also names. The set is held
+	// to one across every such surface by
+	// internal/cmd.TestEveryNewAppRemedyNamesOneScaffolder.
+	if !contains(err.Error(), "civitai app create") {
+		t.Errorf("error should name the scaffolder a reader with no app should run: %v", err)
 	}
 }
 


### PR DESCRIPTION
A **second blind dogfood** of the agent-onboarding flow found three defects. All three are things the CLI *said*, not things it computed wrong — which is why nothing was red.

## 1 🔴 The managed block named the wrong scaffolder

`internal/cmd/templates/agents-app.md` told every new author:

```
| Scaffold a new app | `civitai app init <name>` |
```

`app init` and `app create` share one `RunE` and differ in **exactly one thing** — the default `--template`. Measured on the shipped binary at `cbcb992`:

| command (no `--template`) | template | files | `package.json` | dev scripts |
| --- | --- | --- | --- | --- |
| `civitai app init df-init --yes` | `static` | **8** | **none** | none |
| `civitai app create df-create --yes` | `page-money` | **37** | yes | `dev`, `dev:harness`, `dev:live`, `dev:tunnel` |

So the block handed a new author the project shape it has the **least** to say about — while four sections later crediting *that same command* with `dev:harness`/`dev`/`dev:live`/`dev:tunnel` and with the `@civitai/*` pins, none of which exist in a `static` project. And `civitai --help`'s own "Get started" block already said `civitai app create my-app`.

**Established answer: `create`.** `civitai app --help` settles it — *"`civitai app create` is the friendly, batteries-included scaffolder (defaults to the rich page-money SDK template); `civitai app init` is the same scaffolder with a no-build static default (**back-compat alias**)."* On `main` the binary was split 4–3: `civitai --help` (Long + Example), `app --help`'s example and `agentSetupNoSuchDir` said `create`; the managed block, `remedyNoSuchDir` and `manifest.Load`/`LoadRaw` said `init`.

Every surface addressed to a reader who has **no app yet** now says `create` — the block's five sites, `internal/cmd/project_dir.go`'s `remedyNoSuchDir`, and both `internal/manifest` remedies.

**`init` was not deprecated and was not touched.** `readyAckRemedy` still names it deliberately: it needs the `static` template's `civitai-host.js`, and `create`'s page-money default ships no such file. `app --help` and the README command table still document both.

## 2 🟡 `--check`'s `mcp-*` rows claimed more than they inspected

The dogfood probed both registered servers with a real MCP `initialize`, no credential:

```
POST https://mcp.civitai.com/mcp            -> 200
POST https://orchestration.civitai.com/mcp  -> 401
```

and `--check --json` said, for **both**: `{"ok": true, "detail": "/home/u/proj/.mcp.json"}`. `ok: true` beside a bare filename is indistinguishable from *"this server works"*, and one of the two rows was green against a `401`.

**No network probe was added.** `--check` stays offline and side-effect-free — every one of its steps is a file read — and `ok` still means what it always meant (an entry is registered). The **sentence** changed, the same fix the `authenticated` row already got:

```
mcp-orch  registered in …/.mcp.json — this row read that file; it does not contact
          https://orchestration.civitai.com/mcp, which returns 401 until an
          Authorization header is present
```

The trailing clause is **derived from `mcpServer.Anonymous`**, the field `mcpAnonymityNote` already reads, so it cannot be spelled per Check name and drift from the table.

## 3 🟡 `<your token>` had no source *(routed in from the parallel docs PR — it belongs in the CLI)*

`agent-setup` printed `export CIVITAI_TOKEN=<your token>` and **nothing anywhere said where that value comes from**. The dogfood went looking for a command that prints the stored credential and found none — which is correct and is this feature's whole invariant, so the placeholder's only obvious resolution was the one thing the CLI must never do.

**And the obvious guess fails *later***, which is worse than being stuck. Read off `internal/config/config.go`: `Config.Token()` prefers the env-bound `token` key over the stored `access_token`, and `Config.AuthKind()` returns `AuthKindToken` — documented "a personal API key (**no refresh**)" — for *any* env-supplied value. So an exported `civitai login` token shadows the refreshable pair, verifies green today, and hard-fails at expiry.

The placeholder is now `<a personal API key>`, followed on both surfaces (the `export` step and Zed's hand-pasted header) by the mint URL — built on `accountAPIKeysURL`, the constant seven other remedies already use. **It names the source, never the value.**

## Regression guards — red on `origin/main` first

`internal/cmd/agent_setup_scaffolder_test.go`. Run against `cbcb992` with only the test file added (plus a shim reproducing that branch's `Detail: path` and `<your token>` byte-for-byte):

```
--- FAIL: TestTheBlocksScaffolderProducesAProjectItsOwnCommandsRunIn
    the block's "Scaffold a new app" row names `civitai app init`, whose default
    template produced a "no-build" project with 0 recognised dev scripts — so an
    author who follows that row gets a project in which the block's own
    Local-development table can name nothing …
--- FAIL: TestEveryNewAppRemedyNamesOneScaffolder
    a new author is told 2 different commands by one binary …
      `civitai app create`: agent-setup --dir remedy, civitai --help (Example),
                            civitai --help (Long: Get started), civitai app --help (Example)
      `civitai app init`:   agent-setup's managed block scaffold row,
                            manifest.Load remedy, project-path remedy (remedyNoSuchDir)
--- FAIL: TestRegisteredMCPRowSaysWhatItInspected
    the mcp-orch row's ok:true detail mentions 401 = false, want true (Anonymous=false)
--- FAIL: TestCheckJSONDoesNotReportOrchestrationAsReachable
    both mcp rows carry an identical detail … while the servers disagree on anonymous access
--- FAIL: TestEveryCredentialPlaceholderNamesItsSource/claude
    the claude run tells the user to type <your token> and never names where one
    comes from — no command prints the stored credential, so a placeholder without
    a source is a dead end
```

All green at HEAD.

The primary guard is **a relationship, not a word check**: it reads the scaffold row out of the shipped template, RUNS it exactly as spelled (no `--template`), and requires the result to be a project the block's own local-dev section can name commands for — then checks every `npm run X` the rendered block prints against that project's `package.json`. It never asserts the word "create". `TestBlockScaffoldRowExtractorCanFail` is its negative control; `TestEveryNewAppRemedyNamesOneScaffolder`'s seven-surface ledger has a **per-surface positive control** and states in its own doc comment that **the enumeration is open** — it is not a claim that nothing else in the repo names a scaffolder.

## Verified by running the binary

Scaffolded with **both** commands, ran `agent-setup` into each, read the resulting `AGENTS.md`, and exercised every command each block names:

| | `app init` project (static, 8 files) | `app create` project (page-money, 37 files) |
| --- | --- | --- |
| block's scaffold row | `civitai app create <name>` | `civitai app create <name>` |
| local-dev section | no-build branch: `index.html`, serve the directory | the 4 `npm run` scripts, all present in `package.json` |
| `civitai app validate` | `rc=0  ✓ . is valid` | `rc=1` — the documented pre-`npm install` lockfile error, which `app create`'s own next steps predict |
| `civitai app submit --package-only` | `rc=0`, 11 files packaged | `rc=1`, same lockfile error |
| `civitai app doctor` | `rc=3` no token (auth class, unrelated) | same |
| `app dev-tunnel` / `app create` | resolve | resolve |

Written `.mcp.json` re-checked: no literal token, no `"headers": {}`.

**Not verified:** the four `npm run` scripts were confirmed to exist in `package.json` but not executed — that needs a ~100 MB `npm install`, which is what the block itself tells the author to do first. `app doctor`/`app submit`'s server paths were not reached (no token).

## Gate

```
$ env CGO_ENABLED=0 make ci                       -> rc 0
$ nix-shell -p golangci-lint --run "make lint"    -> 0 issues, rc 0
$ ./scripts/ci-shallow.sh                         -> 21/21 ok
```

The linter was negative-controlled (a deliberate unused variable was reported, then removed). No pin was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7RUfuWWYUVrLRTmvzgDGF
