### PR TITLE
docs(agents): evict the wrong whoami snippet and ledger CONTRIBUTING.md's map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,35 +180,12 @@ These go beyond the global defaults because this repo's release pipeline
   so a dependency change breaks the flake build until `bump-flake-vendorhash.yml`
   updates it; `flake.yml` is what catches that.
 
-## House conventions (with one real snippet)
+## House conventions
 
 Each command is a `newXxxCmd() *cobra.Command` constructor in `internal/cmd`.
-Always set `Short`, a useful `Long`, and an `Example`:
-
-```go
-func newWhoAmICmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "whoami",
-		Short:   "Verify your stored API token",
-		Long:    `Verify the stored API token … Reads the token from config or CIVITAI_TOKEN.`,
-		Example: `  civitai whoami`,
-		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load()
-			if err != nil {
-				return err
-			}
-			if cfg.Token() == "" {
-				// Actionable: tell the user the next command to run.
-				return fmt.Errorf("no token configured — run `civitai login` (or set CIVITAI_TOKEN)")
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Logged in as %s\n", /* … */)
-			return nil
-		},
-	}
-	return cmd
-}
-```
+Always set `Short`, a useful `Long`, and an `Example`. Copy the live one —
+`internal/cmd/whoami.go` — never a snippet: it TAGS the error it returns, and
+item 7 owns why an untagged return unpins a published exit code.
 
 - **Errors:** return `error` from `RunE`; lowercase, no trailing punctuation;
   wrap with `%w` when the cause matters. Root sets `SilenceUsage` +

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,8 @@ command, and the release process. The short version:
 
 - `cmd/civitai` — the binary entrypoint.
 - `internal/cmd` — the Cobra command tree (one file per command).
-- `internal/{scaffold,validate,pkgzip,manifest,api,config}` — the building blocks.
+- `internal/{scaffold,validate,pkgzip,manifest,config,auth}` — the building blocks.
+- `internal/{appapi,genapi}` — the App-Blocks and generation API clients.
 - `schema/` — the vendored App manifest JSON Schema.
 
 ## The validate fidelity caveat

--- a/agents_size_test.go
+++ b/agents_size_test.go
@@ -181,6 +181,51 @@ import (
 // pass; but whoever adds the NEXT item re-derives THAT constant from the
 // achieved size in the same commit, or evicts prose. Raising this one first is the
 // "ceiling nobody bounds" failure this file already records twice.
+//
+// 🔴 THE NEXT ITEM WAS PAID FOR BY EVICTION, AND BOTH CONSTANTS ARE UNCHANGED
+// (2026-09-08). The paragraph above said the budget was spent and told the next
+// author to evict prose. That is what happened, so this entry records a
+// SUBTRACTION rather than a raise: agentsMaxBytes is still 30,500 and
+// agentsMaxBytesCeiling is still 30,600, and neither was touched to make
+// anything fit.
+//
+// WHAT WAS EVICTED, AND WHY IT IS NOT "just the longest thing". The "House
+// conventions" section carried a `newWhoAmICmd` code fence advertised as "one
+// real snippet". It was not one, and the drift was a DEFECT rather than staleness:
+// the fence returned a bare `fmt.Errorf` where internal/cmd/whoami.go returns
+// `civitai.Tag(civitai.ErrUnauthorized, …)`. Item 7 records that stripping
+// exactly that tagging leaves the whole suite green while unpinning a published
+// exit code — and this fence is the template a new command is copied from, so
+// the file's single most-copied 24 lines were teaching the one mistake item 7
+// exists to prevent. Its `Short` was two revisions behind as well, and its
+// `Long` further still. It is replaced by a routing line to the live file naming
+// item 7, and `(with one real snippet)` is dropped from the heading. The bullets
+// under it (errors / output / testability / config) already state every rule the
+// fence illustrated and they stay, so the eviction lost no warning: the fence's
+// only in-band one, "Actionable: tell the user the next command to run", is the
+// Errors bullet's own sentence.
+//
+// MEASURED, not rounded, and re-measured rather than inherited from the entry
+// above (which read 30,317 and was already 58 bytes stale — #533 and #534 landed
+// after it): AGENTS.md was 30,375 bytes at origin/main 3377a3b and is 29,827
+// after the eviction, −548. Headroom under agentsMaxBytes goes from 125 to 673.
+//
+// 🔴 THE POINT IS THE MERGED TREE, NOT THIS BRANCH. PR #532 adds one item — an
+// index clause plus a trigger block, 201 bytes of AGENTS.md. On origin/main that
+// merge lands at 30,576, which is 76 bytes OVER agentsMaxBytes and could not have
+// been raised out of, because agentsMaxBytesCeiling leaves only 100 and its own
+// property would have had to be re-derived for a docs change. MEASURED on a
+// scratch merge of this branch with refs/pull/532/head — resolving the item-36
+// collision the way AGENTS.md's own rule requires, by renumbering the
+// second-merging PR's item to 37 — the merged file is 30,028 bytes, 472 under
+// agentsMaxBytes, with the full root-package suite green. That collision is
+// pre-existing and NOT caused by this change: `git merge-tree --write-tree
+// origin/main refs/pull/532/head` conflicts identically.
+//
+// So the 673 bytes above are a real budget again, not a rounding error. The next
+// author still re-derives rather than raises — but the lever the paragraph above
+// said was gone (evicting prose) has now been shown to work, and the prose
+// sections remain the place to pull it.
 const agentsMaxBytes = 30_500
 
 // agentsMaxBytesCeiling bounds agentsMaxBytes itself, so the budget above cannot

--- a/layout_ledger_test.go
+++ b/layout_ledger_test.go
@@ -118,29 +118,38 @@ func normaliseSpan(span string) string {
 	return afterInternalRe.ReplaceAllString(spanWhitespaceRe.ReplaceAllString(span, " "), "internal/")
 }
 
-func layoutSection(t *testing.T) string {
+// docSection returns the body of one `## ` section of a markdown file, heading to
+// next heading. It is the ONE locator: both ledgers below call it, so a locator
+// that stops matching fails LOUDLY in whichever file it was pointed at rather
+// than returning an empty region that reads as a clean ledger.
+func docSection(t *testing.T, path, heading string) string {
 	t.Helper()
 
-	b, err := os.ReadFile("AGENTS.md")
+	b, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
+		t.Fatalf("read %s: %v", path, err)
 	}
 	doc := string(b)
 
-	start := strings.Index(doc, layoutSectionHeading)
+	start := strings.Index(doc, heading)
 	if start < 0 {
-		t.Fatalf("AGENTS.md no longer contains the heading %q — this guard's locator is broken, "+
+		t.Fatalf("%s no longer contains the heading %q — this guard's locator is broken, "+
 			"which is NOT the same as the ledger being clean. Fix the locator or the heading.",
-			layoutSectionHeading)
+			path, heading)
 	}
-	rest := doc[start+len(layoutSectionHeading):]
+	rest := doc[start+len(heading):]
 
 	end := strings.Index(rest, "\n## ")
 	if end < 0 {
-		t.Fatalf("no heading follows %q — the section is unbounded, so the region would swallow "+
-			"the rest of the file and this guard would stop being scoped", layoutSectionHeading)
+		t.Fatalf("no heading follows %q in %s — the section is unbounded, so the region would swallow "+
+			"the rest of the file and this guard would stop being scoped", heading, path)
 	}
 	return rest[:end]
+}
+
+func layoutSection(t *testing.T) string {
+	t.Helper()
+	return docSection(t, "AGENTS.md", layoutSectionHeading)
 }
 
 // parseInternalRefs pulls the internal/ package names out of one code span. It
@@ -254,6 +263,103 @@ func TestLayoutSectionLedgersEveryInternalPackage(t *testing.T) {
 				"A map pointing at a deleted package is worse than no map: a reader greps for it, "+
 				"finds nothing, and cannot tell a rename from their own mistake.", name)
 		}
+	}
+}
+
+// CONTRIBUTING.md CARRIES THE SAME MAP AND WAS NOT GUARDED, WHICH IS THE EXACT
+// DEFECT THIS FILE WAS WRITTEN FOR. The doc comment above cites `internal/api`
+// — deleted 2026-07-20 by #172 — as the motivating incident. AGENTS.md was
+// fixed and ledgered in the same change; CONTRIBUTING.md's "Architecture" list
+// still said `internal/{scaffold,validate,pkgzip,manifest,api,config}` more than
+// a month later, because this guard read AGENTS.md and nothing else. A ledger
+// scoped to one of two copies of the same map leaves the other one drifting with
+// a green suite over it, which is worse than no ledger: the green is read as
+// covering the contributor docs.
+//
+// # The direction chosen, and why it is ONE direction and not two
+//
+// AGENTS.md's ledger is BIDIRECTIONAL: a named package must exist AND an
+// existing package must be named. This one asserts only the first half — a name
+// in CONTRIBUTING.md must resolve to a real directory — and completeness is
+// deliberately NOT required.
+//
+// CONTRIBUTING.md says so itself: the section links to AGENTS.md "for the full
+// layout" and calls what follows "The short version". Requiring completeness
+// would force all 16 packages into a list whose whole purpose is to be an
+// orienting subset, and it would duplicate the exhaustive map one link away —
+// making the two copies drift *harder*, not less. The completeness half is
+// already enforced, once, on the authoritative map.
+//
+// What is NOT weakened by that choice: a name pointing at a package that does
+// not exist is exactly the `internal/api` failure, and it is caught here. A
+// reader greps for it, finds nothing, and cannot tell a rename from their own
+// mistake — the direction that costs a newcomer time is the direction guarded.
+const contributingArchHeading = "## Architecture"
+
+// contributingMinPackages is the positive control for the parse, in the same
+// shape as layoutMinPackages: the "short version" list spells seven names today,
+// so a floor of four never trips on ordinary churn and exists only to catch a
+// locator or parser that matched nothing at all. Without it, a renamed heading
+// would produce an empty ledgered set, zero names to check, and a serene pass —
+// the reassuring zero this repo's rules name by hand.
+const contributingMinPackages = 4
+
+func TestContributingArchitectureNamesNoDeletedPackage(t *testing.T) {
+	real := realPackages(t)
+	ledgered := map[string]bool{}
+	parseLayoutPackages(docSection(t, "CONTRIBUTING.md", contributingArchHeading), ledgered)
+
+	if len(real) < layoutMinPackages {
+		t.Fatalf("only %d package(s) found under internal/ (%v) — expected at least %d. "+
+			"The filesystem read is broken; a comparison against it would pass for the wrong reason.",
+			len(real), sortedKeys(real), layoutMinPackages)
+	}
+	if len(ledgered) < contributingMinPackages {
+		t.Fatalf("only %d package name(s) parsed out of CONTRIBUTING.md's %q section (%v) — expected at least %d. "+
+			"The parse is broken, so every name in that list is going UNCHECKED and this test's pass means nothing.",
+			len(ledgered), contributingArchHeading, sortedKeys(ledgered), contributingMinPackages)
+	}
+
+	for _, name := range sortedKeys(ledgered) {
+		if !real[name] {
+			t.Errorf("CONTRIBUTING.md's %q section names internal/%s, which does not exist. "+
+				"This is the `internal/api` failure this file's doc comment records, in the OTHER copy of the map: "+
+				"a newcomer greps for it, finds nothing, and cannot tell a rename from their own mistake.",
+				contributingArchHeading, name)
+		}
+	}
+
+	// Completeness is deliberately NOT asserted here — see the block comment
+	// above. Logged so a reader of a green run knows the exact scope of the
+	// claim rather than inferring the stronger one.
+	var unnamed []string
+	for _, name := range sortedKeys(real) {
+		if !ledgered[name] {
+			unnamed = append(unnamed, name)
+		}
+	}
+	t.Logf("%q names %d of %d internal/ packages; the %d it omits (%v) are NOT a failure — "+
+		"that section is the short version and AGENTS.md's ledger owns completeness",
+		contributingArchHeading, len(real)-len(unnamed), len(real), len(unnamed), unnamed)
+}
+
+// TestContributingLedgerCatchesADeletedPackage is the NEGATIVE CONTROL for the
+// guard above: it feeds the parse the exact string CONTRIBUTING.md carried until
+// this change and asserts the deleted package is seen. Without it, a narrowed
+// regex or a wrong heading would leave the guard structurally unable to go red
+// and the suite would stay green while the doc drifted again.
+func TestContributingLedgerCatchesADeletedPackage(t *testing.T) {
+	real := realPackages(t)
+	got := map[string]bool{}
+	parseLayoutPackages("- `internal/{scaffold,validate,pkgzip,manifest,api,config}` — the building blocks.\n", got)
+
+	if !got["api"] {
+		t.Fatalf("the parser did not see `api` in the pre-fix CONTRIBUTING.md line — it can no longer "+
+			"observe the failure it exists for, so a green run above proves nothing. Parsed: %v", sortedKeys(got))
+	}
+	if real["api"] {
+		t.Fatalf("internal/api exists again — this control assumes it does not, and the guard above " +
+			"would now accept the stale line it was written to reject")
 	}
 }
 


### PR DESCRIPTION
## Why

`AGENTS.md` is imported wholesale by `CLAUDE.md` (`@AGENTS.md`), so every byte
is paid on every session. `agents_size_test.go`'s last derivation paragraph
called its raise to 30,500 **"THE LAST SUCH RAISE THAT FITS"** and told the next
author to evict prose or re-derive `agentsMaxBytesCeiling`. This evicts.

The block being evicted is **wrong**, which is the real justification — the byte
win is the side effect.

## 1. The evicted snippet was wrong, not merely long

`## House conventions (with one real snippet)` carried a `newWhoAmICmd` code
fence. Two drifts from `internal/cmd/whoami.go`, one of them a defect:

1. 🔴 **It taught an untagged error return.** The fence had
   `return fmt.Errorf("no token configured — …")`. The real code has
   `return civitai.Tag(civitai.ErrUnauthorized, fmt.Errorf("no token configured — …"))`.
   Same message, different classification.
   `claudedocs/decisions/07-exit-codes-pinned-by-errors-is.md` records that
   stripping exactly this tagging leaves the whole suite green while unpinning a
   published exit code. This fence is the template a new command is copied from,
   so it was the single highest-leverage place in the repo to get that wrong.
2. Its `Short` was two revisions behind — `"Verify your stored API token"` vs the
   live `"Verify your stored API token and its capabilities"`; the `Long` had
   diverged much further.

**What the fence was protecting, and what was lifted.** Checked every line of it.
Its only in-band warning was the comment `// Actionable: tell the user the next
command to run.` — already stated verbatim by the **Errors** bullet directly
below the fence, which survives. `Args: cobra.NoArgs` is in the "Adding a
command" checklist; `cmd.OutOrStdout()` is the **Output** bullet; the
`CIVITAI_TOKEN` override is the **Config** bullet. Nothing was lost. The one
rule the fence did *not* carry — error tagging — is now named by the routing
line that replaces it.

The rule sentence above the fence stays. The fence becomes a routing line to the
live file naming item 7, and `(with one real snippet)` is dropped from the
heading because it is no longer true. The four bullets below it stay untouched
(enforced by `internal/cmd/errors_name_next_command_test.go` and
`internal/cmd/exit_classify_test.go`).

## 2. Bytes — and the merged tree is the point

Both constants are **UNCHANGED**: `agentsMaxBytes = 30_500`,
`agentsMaxBytesCeiling = 30_600`. `agents_size_test.go` gains a dated derivation
paragraph recording the subtraction, re-measured rather than inherited (the
previous entry read 30,317 and was already 58 bytes stale after #533/#534).

| tree | `AGENTS.md` | vs `agentsMaxBytes` (30,500) |
|---|---:|---|
| `origin/main` (3377a3b) | 30,375 | 125 under |
| this branch | **29,827** | **673 under** (−548) |
| **merged with #532** | **30,028** | **472 under** ✅ |
| `origin/main` + #532 (counterfactual) | 30,576 | **76 OVER** ❌ |

#532 adds 201 bytes to `AGENTS.md` (index clause + trigger block). On plain
`main` that merge is 76 bytes over, and it could not have been raised out of:
`agentsMaxBytesCeiling` leaves only 100, and moving it would mean re-deriving an
anti-loosening bound for a docs change.

The merged figure is a real scratch merge with `refs/pull/532/head`, with the
**full root-package suite green** on that tree. #532 collides with `main` on the
item number 36 (both add one); resolved per `AGENTS.md`'s own rule — the PR
merging second renumbers **its own** items — so #532's becomes item 37. That
collision is **pre-existing and not caused by this change**:
`git merge-tree --write-tree origin/main refs/pull/532/head` conflicts
identically.

## 3. `CONTRIBUTING.md` drifted for a month under a guard that could not see it

`CONTRIBUTING.md`'s Architecture list said
`internal/{scaffold,validate,pkgzip,manifest,api,config}`. **`internal/api` does
not exist** — deleted 2026-07-20 by #172. That is precisely the incident
`layout_ledger_test.go`'s own doc comment cites as its reason for existing, but
the ledger read `AGENTS.md` only (`os.ReadFile("AGENTS.md")`), so the *other*
copy of the same map drifted unguarded with a green suite over it.

Fixed, and the ledger extended to that section via a shared `docSection`
locator — one parser, one pipeline, both files.

**Completeness direction, chosen deliberately: ONE direction only.** A name in
`CONTRIBUTING.md` must resolve to a real package; an existing package it omits
is **not** a failure. That section says "The short version" and links to
`AGENTS.md` "for the full layout" — requiring completeness would force all 16
packages into a list whose purpose is to be an orienting subset, and would
duplicate the exhaustive map one link away, making the two copies drift harder.
`AGENTS.md`'s ledger already owns completeness, bidirectionally, once. The
direction that costs a newcomer time — grepping for a package that is not there —
is the one guarded. The test `t.Logf`s the omitted set so a green run states its
own scope rather than implying the stronger claim.

### Red-then-green matrix

Guard extended, `CONTRIBUTING.md` still stale:

```
$ go test -count=1 -run 'TestContributing' -v .
--- FAIL: TestContributingArchitectureNamesNoDeletedPackage
    CONTRIBUTING.md's "## Architecture" section names internal/api, which does not exist.
    "## Architecture" names 6 of 16 internal/ packages; the 10 it omits … are NOT a failure
--- PASS: TestContributingLedgerCatchesADeletedPackage
FAIL
```

After correcting the doc:

```
$ go test -count=1 -run 'TestContributing|TestLayout' -v .
--- PASS: TestLayoutSectionLedgersEveryInternalPackage
--- PASS: TestContributingArchitectureNamesNoDeletedPackage
    "## Architecture" names 9 of 16 internal/ packages; the 7 it omits … are NOT a failure
--- PASS: TestContributingLedgerCatchesADeletedPackage
--- PASS: TestLayoutLedgerParserHandlesEverySpelling
--- PASS: TestLayoutLedgerSeesSpansThatWrap
--- PASS: TestLayoutCodeSpanBoundIsOneNewline
ok  github.com/civitai/cli
```

`TestContributingLedgerCatchesADeletedPackage` is the negative control: it feeds
the parser the exact pre-fix line and asserts `api` is seen, so a narrowed regex
or a wrong heading cannot leave the guard structurally unable to go red.

## Gate

- `make ci` — green, **22 packages `ok`** (non-zero count asserted; `gofmt -s -l .`
  printed nothing over 462 `.go` files found).
- `nix-shell -p golangci-lint --run "make lint"` — `0 issues.`
- `make ci-shallow` — `PASSED in a depth-1 clone: 21 package(s) ok, 0 failures, 0 timeouts.`
- Every named guard green: `agents_size_test.go`, `agents_split_preserved_test.go`,
  `agents_evidence_test.go`, `agents_trigger_test.go`, `agents_index_test.go`,
  `agents_xrefs_test.go`, `layout_ledger_test.go`, and
  `internal/cmd/readme_contributor_links_test.go`
  (`TestREADMEDoesNotLinkContributorDocsRelatively`,
  `TestContributorOnlyDocsAreReallyNotShipped`,
  `TestNormaliseLinkTargetSeesEverySpelling`).
- `README.md` was grepped for `one real snippet` / `newWhoAmICmd` / `House
  conventions` — no references; no README surface goes stale from this change.
