### PR TITLE
docs(readme): lead with the agent-setup one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@
 
 [![Request access](https://img.shields.io/badge/Request%20access-invite--only%20beta-3b82f6?style=for-the-badge&logo=github)](https://github.com/civitai/cli/issues/new?template=request-access.yml)
 
+## Using an AI coding agent? Paste this
+
+```text
+Fetch and execute the appropriate instructions to set me up for Civitai from https://developer.civitai.com/agent-setup/prompt.md
+```
+
+Your agent installs the CLI, configures itself for App development (an
+`AGENTS.md` for your project, plus Civitai's two MCP servers), and verifies the
+result. It stops before authenticating and hands `civitai login` back to you —
+it will not log in on your behalf.
+
+Prefer to read it first? The whole prompt is rendered at
+[developer.civitai.com/agent-setup](https://developer.civitai.com/agent-setup/).
+If a step is refused or an agent goes off-script, the rest of this README is the
+manual path — nothing below depends on having used the prompt.
+
 The command-line interface for [Civitai](https://civitai.com) — a single static
 binary that does two things: it's a thin **read/download client** for Civitai's
 **public** API (browse and fetch models, images, and articles — no account needed
@@ -38,6 +54,7 @@ contract, and **packages/submits** it for review.
 
 **Get started**
 
+- [Using an AI coding agent? Paste this](#using-an-ai-coding-agent-paste-this)
 - [Install](#install)
   - [npm (Node)](#npm-node)
   - [Homebrew (macOS / Linux)](#homebrew-macos--linux)


### PR DESCRIPTION
Devs pasting one string into their coding agent is the fastest path from
nothing to a configured App project, and the README did not mention it existed.

Placed after the invite-only notice rather than above it — the beta caveat is
load-bearing and should not be displaced — and above the prose, so it is still
the first actionable thing.

The pasted string is byte-identical to `SETUP_PROMPT` in
civitai-developer-docs' `.vitepress/agent-setup.mjs`, which is the single source
of truth that repo's guard grades its landing page against. Verified by
comparison, not by retyping.

Also says plainly that the flow stops before authenticating, and that nothing
below it depends on having used the prompt — a reader whose agent refused a
step needs to know the manual path still works.

TOC entry added: `TestREADMETableOfContentsCoversEverySection` caught the
missing line, which is the guard doing its job.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A7RUfuWWYUVrLRTmvzgDGF