### PR TITLE
chore: gitignore /node_modules/ — it was hiding a test private key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,13 @@ coverage.html
 # and all 13 CI checks stayed green).
 /result
 /result-*
+
+# A Go repo has no node_modules of its own, but npm-adjacent tooling run with
+# this directory as cwd leaves one behind — a scaffolded template's harness, the
+# docs-snapshot tooling. What turned up here was
+# `node_modules/.cache/civitai-test-keys/block-token-rsa2048-v1.json`, a test
+# RSA keypair with a `privatePem` in it: nothing in THIS repo writes it, and it
+# sat untracked in the repo root protected only by the discipline of never
+# blind-staging. Ignoring the directory removes that from being one `git add -A`
+# away from a committed private key.
+/node_modules/


### PR DESCRIPTION
`node_modules/` has been untracked in the repo root since 2026-08-17. It is not
an npm install: it holds exactly one thing,

    node_modules/.cache/civitai-test-keys/block-token-rsa2048-v1.json

a test RSA keypair with a `privatePem` field. Nothing in this repo writes it —
`grep` finds no reference in any .go/.mjs/.js file — so it is left behind by
npm-adjacent tooling run with this directory as cwd (a scaffolded template's
harness, the docs-snapshot tooling).

Harmless in itself, and a test key rather than a real credential. The reason to
ignore it is what it was one command away from: an untracked private key in the
repo root is protected only by the discipline of never running `git add -A`,
which is exactly the rule that exists because blind-staging leaks things from a
dirty tree. Ignoring the directory removes the class rather than relying on
nobody making that mistake.

Not deleted — it is a cache, nothing here owns it, and ignoring is the
reversible half.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A7RUfuWWYUVrLRTmvzgDGF