### PR TITLE
fix(read): repair on decode failure, not before it — and strip what the error snippet prints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,11 @@ These go beyond the global defaults because this repo's release pipeline
   less U+FE0F, plus two blank-but-graphic runes. It is NOT applied to what the
   USER typed on the command line — two documented exceptions, `--input` file
   content and `download`'s mixed-origin target path.
-  `cmd`'s `safeTerm` and `genapi`'s `hasPrintableContent` both call
-  it; #393 was two tables that disagreed, and its first fix drew the class on a
-  category instead of the property and was wrong in both directions. Read its
+  `cmd`'s `safeTerm`, `genapi`'s `hasPrintableContent` and `pkg/civitai`'s
+  `snippet` all call it — three questions, one table, ledgered both ways by
+  `TestSaferuneCallersAreLedgered`; #393 was two tables that disagreed, and its
+  first fix drew the class on a category instead of the property and was wrong
+  in both directions. Read its
   doc comment before changing the class: it states the derivation, the one
   exception, what is deliberately KEPT and the nine scripts the strip costs.
 - **Module root** (`package cli`, `main.go` + `schema.go`) exists *only* to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,7 @@ USER owns — the merge, the parsers, and which rows fail `--check`.
 Item 36 is its THIRD: what the managed block may claim about the project it was
 written into.
 Item 37 is a username that arrives as a NUMBER.
+Item 38 is what the read path may CLAIM about the bytes it prints.
 The durable fix for the mirroring is a server-side `civitai app validate` endpoint
 calling the real `BlockManifestValidator`; until that exists, vendoring is on
 purpose.
@@ -447,6 +448,10 @@ item must carry a trigger that is a routing question rather than a label
 37. **Typing a `pkg/civitai` username as `string`, or "fixing" a `FlexString`
     back?**
     → evidence: claudedocs/decisions/37-numeric-username.md
+
+38. **Moving where a read body is repaired, filtering (or unfiltering) what an
+    error snippet prints, or wording what `--json` and `Raw` are made of?**
+    → evidence: claudedocs/decisions/38-read-body-repair-and-snippet.md
 
 **When you change a validation rule, keep all four vendored mirrors in sync with
 the server — `schema/`, the ported Go checks in `internal/validate/` (including

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,16 @@ Two properties make the output safe to pipe:
   exits `4` with `Error: not found (404): Model not found` on stderr and an empty
   stdout.
 
+One thing the CLI does change, and it is not cosmetic: the API intermittently
+emits a **raw control byte** — a carriage return, most often — inside a `prompt`
+or `description` string, which is not legal JSON and used to fail the whole page
+([#525](https://github.com/civitai/cli/issues/525)). When a page will not decode,
+the CLI rewrites those bytes as their JSON escapes (`\r`, `\u0001`) and decodes
+the repaired body, and that repaired body is what `--json` prints. The *document*
+is still the API's — the same strings, the same characters — but the bytes are
+not, which is another reason not to diff or hash `--json` output against the
+wire. A page that decodes as sent is passed through with no such rewrite.
+
 Both properties hold for `civitai generate` and `civitai workflows …` too, but
 their payloads are **not** Site API REST shapes — generation has no REST route,
 so those commands pass through the raw *orchestrator* reply. Read
@@ -3919,7 +3929,7 @@ credited it to the wrong command.)
 | `SHA256 mismatch for` | A download's hash did not match, and the partial file was deleted. Retry — this is integrity checking working, not a bug. | [Download model files](#download-model-files) |
 | `checksum mismatch for` | The same, during `civitai upgrade`. The binary was **not** replaced. | [Upgrading](#upgrading) |
 | ``git is required for `civitai app pull` `` | `app pull` shells out to `git`, which is not on your `PATH`. | [Pull your app's repository](#pull-your-apps-repository-app-pull) |
-| `unexpected response from` | A public read endpoint answered **`200`** with a body this CLI could not decode. Nothing is wrong with your request, your credential or your network — which is why it exits `1` rather than `2` or `3` — and the text after the colon is the server's own body, truncated. One cause is known and is **fixed** as of [#513](https://github.com/civitai/cli/issues/513), reported by Rochet2: a Civitai username can be entirely digits, and such a value was reported arriving as a bare JSON **number** (`"username": 2802169344506`, unquoted) rather than a string. A single such uploader on a page failed the whole page, so `civitai images search` printed nothing at all; the CLI now accepts either shape and keeps the digits exactly as sent. If you still hit this, the body really is a shape the SDK does not model — please open an issue with the snippet. | [Exit code 1](#exit-code-1) |
+| `unexpected response from` | A public read endpoint answered **`200`** with a body this CLI could not decode. Nothing is wrong with your request, your credential or your network — which is why it exits `1` rather than `2` or `3` — and the text after the colon is the server's own body, truncated, with invisible and terminal-controlling characters removed (so a hostile body cannot rewrite what is already on your screen from inside the error line; nothing else is rewritten, and the CLI's own repair below is **not** applied to what you are shown). **Two causes are known and both are fixed.** [#513](https://github.com/civitai/cli/issues/513), reported by Rochet2: a Civitai username can be entirely digits, and such a value was reported arriving as a bare JSON **number** (`"username": 2802169344506`, unquoted) rather than a string. A single such uploader on a page failed the whole page, so `civitai images search` printed nothing at all; the CLI now accepts either shape and keeps the digits exactly as sent. [#525](https://github.com/civitai/cli/issues/525): the API intermittently emits a **raw control byte** (a carriage return, say) inside a `prompt` or `description` string, which is not legal JSON, so the whole page failed to decode; the CLI now rewrites those bytes as their JSON escapes and decodes the page. If you still hit this, the body really is a shape the SDK does not model — please open an issue with the snippet. | [Exit code 1](#exit-code-1) |
 
 Still stuck? Every command takes `--help`, `civitai --help` prints the exit-code
 contract, and failures are differentiated by [exit code](#exit-codes) — so a

--- a/README.md
+++ b/README.md
@@ -1083,13 +1083,19 @@ Behavior:
 
 ## Scripting with `--json`
 
-Every read subcommand takes `--json`, which prints the **raw `/api/v1/...` REST
-response** — a stable passthrough, not a CLI-invented shape. So the field schema
+Every read subcommand takes `--json`, which prints the `/api/v1/...` REST
+response as the API shaped it — not a CLI-invented shape. So the field schema
 is exactly the public Site API's; keep the
 [REST field reference](https://developer.civitai.com/site/reference/) open
 (e.g. [models](https://developer.civitai.com/site/reference/models),
 [model-versions](https://developer.civitai.com/site/reference/model-versions))
 rather than reverse-engineering fields with `jq keys`.
+
+🔴 **It passes through the DOCUMENT, not the BYTES — do not diff or hash
+`--json` output against the wire.** Two things change the bytes without changing
+the document. The first is cosmetic: **the output is re-indented**, so a compact
+API body comes out longer than it went in. The second is not, and it has its own
+paragraph below: **a body that will not parse is repaired first.**
 
 Two properties make the output safe to pipe:
 
@@ -1101,18 +1107,20 @@ Two properties make the output safe to pipe:
   exits `4` with `Error: not found (404): Model not found` on stderr and an empty
   stdout.
 
-One thing the CLI does change, and it is not cosmetic: the API intermittently
+The repair, in full. The API intermittently
 emits a **raw control byte** — a carriage return, most often — inside a `prompt`
 or `description` string, which is not legal JSON and used to fail the whole page
 ([#525](https://github.com/civitai/cli/issues/525)). When a page will not decode,
 the CLI rewrites those bytes as their JSON escapes (`\r`, `\u0001`) and decodes
 the repaired body, and that repaired body is what `--json` prints. The *document*
 is still the API's — the same strings, the same characters — but the bytes are
-not, which is another reason not to diff or hash `--json` output against the
-wire. A page that decodes as sent is passed through with no such rewrite.
+not: this is the second of the two byte changes named above, and the reason the
+warning against diffing or hashing is not just about whitespace. A page that
+decodes as sent is passed through with no such rewrite.
 
-Both properties hold for `civitai generate` and `civitai workflows …` too, but
-their payloads are **not** Site API REST shapes — generation has no REST route,
+Both of the two piping properties above hold for `civitai generate` and
+`civitai workflows …` too, but their payloads are **not** Site API REST
+shapes — generation has no REST route,
 so those commands pass through the raw *orchestrator* reply. Read
 [Generation `--json`](#generation---json) before scripting against them.
 

--- a/README.md
+++ b/README.md
@@ -1120,8 +1120,13 @@ decodes as sent is passed through with no such rewrite.
 
 Both of the two piping properties above hold for `civitai generate` and
 `civitai workflows …` too, but their payloads are **not** Site API REST
-shapes — generation has no REST route,
-so those commands pass through the raw *orchestrator* reply. Read
+shapes — generation has no REST route, so those commands print the
+*orchestrator's* reply. **The two byte changes apply differently there, so take
+them one at a time:** the output is **re-indented** exactly as above, so it is no
+more diffable or hashable than the read group's; but the **repair never runs on
+a generation reply** — it is applied by the read SDK's own decode step, and the
+generation client decodes with plain `encoding/json`, so nothing rewrites a
+control byte there. Read
 [Generation `--json`](#generation---json) before scripting against them.
 
 Two `app` commands emit a shape this **CLI composes**, not a wire payload:

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -435,17 +435,18 @@ var bornSplitItems = []string{
 	"claudedocs/decisions/37-numeric-username.md",
 	// Item 38 was written straight into claudedocs/decisions/ for the same
 	// reason: AGENTS.md had 472 bytes of headroom when it was added, and the
-	// body is five decisions, three tables and the enumerated residuals.
+	// body is five decisions, four tables and the enumerated residuals.
 	//
 	// 🔴 THIS SENTENCE HAS NOW BEEN WRONG TWICE, IN OPPOSITE DIRECTIONS, SO THE
 	// GEOMETRY IS PINNED RATHER THAN COUNTED IN PROSE. Round 2 wrote "measurement
 	// and mutation matrices" — there has never been a mutation matrix, and that
 	// half was right to correct. Round 3 then wrote "one measurement table", in
-	// the same commit that ADDED a second and a third. The tables are: a
-	// clause-by-clause table and a cross-tree measurement table in §3, and a
-	// cross-tree exit-code measurement table in §4. Their placement is asserted
-	// by TestItem38EvidenceTableGeometry below; the adjectives are not, and are
-	// the reader's to check.
+	// the same commit that ADDED a second and a third. Round 5 added a FOURTH,
+	// and this sentence with it. The tables are: a clause-by-clause table and a
+	// cross-tree measurement table in §3, and in §4 a cross-tree exit-code
+	// measurement table plus an allocation table for maxClassifyMessage. Their
+	// placement is asserted by TestItem38EvidenceTableGeometry below; the
+	// adjectives are not, and are the reader's to check.
 	//
 	// Mutation results still live in the PR body and in each guard's own doc
 	// comment, not in this file.
@@ -936,7 +937,7 @@ const item38Doc = "claudedocs/decisions/38-read-body-repair-and-snippet.md"
 // item38TablesPerSection is the LEDGER of where item 38's tables live: section
 // number -> number of Markdown table blocks in it. Sections not listed must
 // carry none.
-var item38TablesPerSection = map[int]int{3: 2, 4: 1}
+var item38TablesPerSection = map[int]int{3: 2, 4: 2}
 
 // TestItem38EvidenceTableGeometry is round 4's finding 5.
 //

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -435,11 +435,20 @@ var bornSplitItems = []string{
 	"claudedocs/decisions/37-numeric-username.md",
 	// Item 38 was written straight into claudedocs/decisions/ for the same
 	// reason: AGENTS.md had 472 bytes of headroom when it was added, and the
-	// body is three decisions, the cross-tree measurement table in §3 and the
-	// enumerated residuals. ("Measurement and mutation matrices" is what this
-	// said in round 2; the file has one measurement table and has never had a
-	// mutation matrix — the mutation results live in the PR body and in each
-	// guard's own doc comment.)
+	// body is five decisions, three tables and the enumerated residuals.
+	//
+	// 🔴 THIS SENTENCE HAS NOW BEEN WRONG TWICE, IN OPPOSITE DIRECTIONS, SO THE
+	// GEOMETRY IS PINNED RATHER THAN COUNTED IN PROSE. Round 2 wrote "measurement
+	// and mutation matrices" — there has never been a mutation matrix, and that
+	// half was right to correct. Round 3 then wrote "one measurement table", in
+	// the same commit that ADDED a second and a third. The tables are: a
+	// clause-by-clause table and a cross-tree measurement table in §3, and a
+	// cross-tree exit-code measurement table in §4. Their placement is asserted
+	// by TestItem38EvidenceTableGeometry below; the adjectives are not, and are
+	// the reader's to check.
+	//
+	// Mutation results still live in the PR body and in each guard's own doc
+	// comment, not in this file.
 	"claudedocs/decisions/38-read-body-repair-and-snippet.md",
 }
 
@@ -918,4 +927,89 @@ func TestEveryBaseBodyLineSurvivedTheMove(t *testing.T) {
 			"The slicer or the evidence reader is broken; this is NOT the shallow-clone case, which is skipped above.")
 	}
 	t.Logf("checked %d non-blank base lines across %d moved items", total, len(splitItems))
+}
+
+// item38Doc is the evidence file whose shape the bornSplitItems comment above
+// describes.
+const item38Doc = "claudedocs/decisions/38-read-body-repair-and-snippet.md"
+
+// item38TablesPerSection is the LEDGER of where item 38's tables live: section
+// number -> number of Markdown table blocks in it. Sections not listed must
+// carry none.
+var item38TablesPerSection = map[int]int{3: 2, 4: 1}
+
+// TestItem38EvidenceTableGeometry is round 4's finding 5.
+//
+// 🔴 A SENTENCE DESCRIBING A FILE'S OWN SHAPE HAS BEEN WRONG TWICE, AND THE
+// SECOND TIME IT WAS FALSIFIED BY THE COMMIT THAT WROTE IT. Round 2's
+// "measurement and mutation matrices" was corrected by round 3 to "one
+// measurement table and no mutation matrix" — in the same commit that added a
+// second and a third table to the file. Nothing asserted on either sentence, in
+// either round, so both survived a full green suite.
+//
+// This is the assertion. It does not check the adjectives ("cross-tree",
+// "measurement", "clause") — those are a reader's judgement — but it pins WHERE
+// the tables are and HOW MANY, which is the half that was retyped and got wrong
+// both times. A table added to §5 or the residuals is red by name.
+func TestItem38EvidenceTableGeometry(t *testing.T) {
+	raw, err := os.ReadFile(item38Doc)
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read %s: %v", item38Doc, err)
+	}
+	sectionRe := regexp.MustCompile(`^## (\d+)\. `)
+	// A GitHub-flavoured Markdown table is identified by its separator row.
+	sepRe := regexp.MustCompile(`^\|[ :|-]+\|$`)
+
+	section := 0
+	got := map[int]int{}
+	sections := 0
+	seps := 0
+	for _, line := range strings.Split(string(raw), "\n") {
+		if m := sectionRe.FindStringSubmatch(line); m != nil {
+			n, _ := strconv.Atoi(m[1])
+			section = n
+			sections++
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			// A non-numbered heading (the residuals) ends the numbered sections.
+			section = 0
+			continue
+		}
+		if sepRe.MatchString(strings.TrimSpace(line)) {
+			seps++
+			got[section]++
+		}
+	}
+	// POSITIVE CONTROLS, before any verdict. A parser that matched no heading or
+	// no table reports a reassuring zero indistinguishable from "as ledgered".
+	if sections < 5 {
+		t.Fatalf("CONTROL failure, not a finding: found only %d numbered sections in %s "+
+			"— the section scanner is not reading the file", sections, item38Doc)
+	}
+	if seps == 0 {
+		t.Fatalf("CONTROL failure, not a finding: found no Markdown table separator row "+
+			"in %s — the table detector is not matching", item38Doc)
+	}
+
+	for sec, want := range item38TablesPerSection {
+		if got[sec] != want {
+			t.Errorf("%s §%d holds %d table(s), ledgered as %d.\n"+
+				"The bornSplitItems comment in this file DESCRIBES this geometry, and that "+
+				"sentence has been retyped wrong twice. Move both together.",
+				item38Doc, sec, got[sec], want)
+		}
+	}
+	for sec, n := range got {
+		if _, ok := item38TablesPerSection[sec]; ok {
+			continue
+		}
+		where := "§" + strconv.Itoa(sec)
+		if sec == 0 {
+			where = "outside the numbered sections (the residuals, or the header)"
+		}
+		t.Errorf("%s holds %d unledgered table(s) %s — add the section to "+
+			"item38TablesPerSection and say so in the bornSplitItems comment.",
+			item38Doc, n, where)
+	}
 }

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -433,6 +433,11 @@ var bornSplitItems = []string{
 	// merging second renumbers its own items) was written straight into
 	// claudedocs/decisions/ for the same reason as 35.
 	"claudedocs/decisions/37-numeric-username.md",
+	// Item 38 was written straight into claudedocs/decisions/ for the same
+	// reason: AGENTS.md had 472 bytes of headroom when it was added, and the
+	// body is three decisions plus their measurement and mutation matrices and
+	// four enumerated residuals.
+	"claudedocs/decisions/38-read-body-repair-and-snippet.md",
 }
 
 // splitItemsFloor is the CI-SIDE KEEPER for bornSplitItems: the set of item

--- a/agents_split_preserved_test.go
+++ b/agents_split_preserved_test.go
@@ -435,8 +435,11 @@ var bornSplitItems = []string{
 	"claudedocs/decisions/37-numeric-username.md",
 	// Item 38 was written straight into claudedocs/decisions/ for the same
 	// reason: AGENTS.md had 472 bytes of headroom when it was added, and the
-	// body is three decisions plus their measurement and mutation matrices and
-	// four enumerated residuals.
+	// body is three decisions, the cross-tree measurement table in §3 and the
+	// enumerated residuals. ("Measurement and mutation matrices" is what this
+	// said in round 2; the file has one measurement table and has never had a
+	// mutation matrix — the mutation results live in the PR body and in each
+	// guard's own doc comment.)
 	"claudedocs/decisions/38-read-body-repair-and-snippet.md",
 }
 

--- a/claudedocs/decisions/38-read-body-repair-and-snippet.md
+++ b/claudedocs/decisions/38-read-body-repair-and-snippet.md
@@ -1,21 +1,34 @@
 # The read path repairs a body only when it must, and strips only what it prints
 
 **Item 38.** Code: `pkg/civitai/read.go` (`getInto`, `decodeBody`, `snippet`,
-`readError`, `isDeepPagingCap`, `EscapeJSONStringControlChars`),
-`pkg/civitai/hashes.go` (`postInto`), `internal/cmd/read_help.go`
-(`readJSONNote`), `internal/saferune` (the class the snippet strip uses),
-`cmd/civitai/main.go` (`errorLine`). Guards:
-`pkg/civitai/read_repair_test.go`, `pkg/civitai/raw_doc_ledger_test.go`,
-`internal/cmd/read_json_note_test.go`,
-`cmd/civitai/read_error_stderr_test.go`, `saferune_callers_ledger_test.go`.
+`readError`, `isDeepPagingCap`, `classifyWindow`,
+`EscapeJSONStringControlChars`), `pkg/civitai/hashes.go` (`postInto`),
+`internal/cmd/read_help.go` (`readJSONNote`), `internal/saferune/saferune.go`
+(the class the snippet strip uses), `cmd/civitai/main.go` (`errorLine`).
+Guards: `pkg/civitai/read_repair_test.go`, `pkg/civitai/raw_doc_ledger_test.go`,
+`internal/cmd/read_json_note_test.go`, `internal/cmd/read_help_test.go`,
+`internal/cmd/read_r2_test.go`, `cmd/civitai/read_error_stderr_test.go`,
+`saferune_callers_ledger_test.go`.
+This list and `item38CommentedFiles` — the set whose comments are checked for
+dangling test citations — are pinned equal by
+`TestItem38FileLedgerMatchesTheDecisionHeader`. They disagreed in both
+directions until round 4: the ledger held four files, two of which this header
+did not name, and none of the `pkg/civitai` or `cmd/civitai` ones.
 
 Born split: written straight into `claudedocs/decisions/` — AGENTS.md had 472
-bytes of headroom when this was added and the body is three decisions, the
-cross-tree measurement table in §3 and the enumerated residuals. See
-`bornSplitItems` in `agents_split_preserved_test.go`. (Round 2 described this
-as "measurement and mutation matrices"; there is one measurement table and no
-mutation matrix — mutation results live in the PR body and in each guard's own
-doc comment.)
+bytes of headroom when this was added, and the body is five decisions, three
+tables and the enumerated residuals. See `bornSplitItems` in
+`agents_split_preserved_test.go`.
+
+🔴 **That sentence has been wrong twice, in opposite directions, so the geometry
+is now pinned.** Round 2 wrote "measurement and mutation matrices"; there has
+never been a mutation matrix here, and that half was right to correct. Round 3
+then wrote "one measurement table" — in the same commit that added the second and
+the third. The three are: a clause-by-clause table and a cross-tree measurement
+table in §3, and a cross-tree exit-code measurement table in §4.
+`TestItem38EvidenceTableGeometry` asserts where they are and how many; the
+adjectives are not asserted and remain a reader's judgement. Mutation results
+live in the PR body and in each guard's own doc comment, never here.
 
 This is the follow-up to the adversarial audit of civitai/cli#526 (squash
 `517fc76`). #526's own change was correct and its regression test was watched
@@ -221,10 +234,18 @@ Contrived for Civitai's own backend, which does not emit soft hyphens; not
 contrived for the proxy, CDN and captive-portal 429s `readError` also handles.
 AGENTS.md items 7 and 24 make the exit code a published contract.
 
-**The fix is to classify on the WIRE message.** `readError` keeps `wireMsg`
+**The fix is to classify on the WIRE message.** `readError` takes `classifyMsg`
 before the `snippet` call; the display still gets the filtered string.
 "Narrow" is a claim about what the SERVER sent, so the classifier is asked
 about what arrived.
+
+🔴 **"ANY TRANSFORMATION CAN ONLY WIDEN IT" WAS FALSE, AND `isDeepPagingCap`'S
+OWN COMMENT SAID IT.** `snippet` applies TWO transformations that pull in
+opposite directions, and this PR knew both: the **strip** can only widen (the
+table above), the **500-byte bound** can only narrow (the paragraph below, and
+half (c) of the guard). Three other sites in this PR stated it correctly; the
+one that generalised was the comment a maintainer reads before feeding the
+classifier a processed string. Corrected in round 4 to name both directions.
 
 🔴 **THAT FIX MOVES A SECOND EXIT CODE, DELIBERATELY, AND IN THE OPPOSITE
 DIRECTION — SAID HERE RATHER THAN DISCOVERED LATER.** `snippet` also truncates
@@ -237,6 +258,31 @@ intended reading — a display budget is not a statement about what the server
 said — and it is pinned as half (c) of the same test rather than left as prose.
 Reachability is not hypothetical (a >500-byte error body is ordinary) but no
 such 429 has been observed from the API; the case is constructed.
+
+🔴 **THE SAME EDIT ALSO UN-BOUNDED THE MATCH AGAINST AN ARBITRARY BODY, WHICH
+ROUND 3 DID NOT SAY.** The paragraph above frames the change as re-widening the
+match for a legitimate cap message. It is also a change in the SIZE of what the
+matcher scans, in the other direction: `readError`'s `msg` is the server's
+`error`/`message` field only when the body is JSON and carries one. When a 429
+body is not JSON, or is JSON without either key, `msg` is the **entire body**,
+bounded only by `maxResponseBody` (64 MiB). Before round 3 the matcher inherited
+`snippet`'s 500 bytes; after it, `strings.ToLower` (a full copy) plus three
+`Contains` ran over whatever arrived.
+
+Round 4 bounds it with `maxClassifyMessage` (8 KiB) via `classifyWindow` — a
+budget deliberately separate from the display budget, since conflating the two
+is the defect this section exists for. **No false positive was demonstrated;
+this is containment, not a fix for an observed defect**, and the number is
+generous rather than derived: the API's own cap message is ~60 bytes, no
+measurement in this repo pins a largest legitimate 429 message, and none of the
+proxy/CDN/captive-portal 429s `readError` also handles has been sampled for
+length. 8 KiB is ~130x that observed message and ~16x the display bound. The
+visible consequence is stated rather than hidden: a 429 whose cap phrase sits
+past 8 KiB is not reclassified and keeps exit 6. Pinned by
+`TestDeepPagingCapClassificationIsBounded`, which is red on an unbounded
+`classifyMsg` and carries a positive control — the same fixture shape with the
+phrase inside the window must still reclassify, or half (a) would pass against a
+classifier that never matches.
 
 This is the ONLY site in `pkg/civitai` where the text of an error picks a
 classification; `readError`'s other branches classify from the status alone
@@ -292,10 +338,26 @@ the numeral cannot drift from the membership.
   - a throttle 429 whose message carries a `Default_Ignorable` rune exits 6, at
     the seam (`TestThrottle429KeepsExitSixThroughTheMessageFilter`) and as a
     sentinel (`TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne`);
-  - the deep-paging cap still exits 2 (same test, half (b)).
+  - the deep-paging cap still exits 2 (same test, half (b));
+  - a cap message whose phrase falls past `snippet`'s 500-byte DISPLAY bound
+    exits 2 (same test, half (c)) — the deliberate move in the opposite
+    direction;
+  - a cap message whose phrase falls past `maxClassifyMessage` (8 KiB) exits 6
+    (`TestDeepPagingCapClassificationIsBounded`), with the same fixture shape
+    inside the window still exiting 2 as its positive control.
   Nothing asserts that the filter cannot move a code the CLI does not yet
   classify from text. Today there is no such code — §4 records the grep — but
   that is a measurement of the tree, not a guard on it.
+- **The README does not document the 429 → exit 2 reclassification at all**, so
+  neither the round-3 change nor round 4's bound has a published counterpart to
+  keep in sync. Its Troubleshooting row reads "`rate limited (429)` | Throttled;
+  exit `6`", and §4 above is the only statement anywhere that some 429s exit 2.
+  This gap PRE-DATES this PR — `isDeepPagingCap` and its reclassification are
+  live at `517fc76` — and is recorded rather than fixed here, because writing the
+  row is a change to the published exit-code contract's wording and belongs with
+  whoever owns AGENTS.md item 7's table, not with a follow-up audit. Closing
+  condition: the Troubleshooting row and the exit-code table both name the
+  deep-paging case, and `readme_troubleshooting_test.go` still passes.
 - **`TestRawDocCommentsDisclaimByteIdentity` covers doc comments on struct
   fields, not prose.** The detail getters (`GetModel`, `GetArticle`,
   `GetCollection`, `GetApp`, `GetModelVersion`, `GetModelVersionByHash`) return
@@ -303,13 +365,71 @@ the numeral cannot drift from the membership.
   find, and narrative comments anywhere in the package are not read. So the
   byte-identity enumeration is OPEN, not closed — which is the whole lesson of
   round 2's count of three.
-- **`TestItem38CommentsCiteTestsThatExist` is scoped to item 38's four files.**
-  Measured across all of `internal/cmd`, 31 comment-cited test names do not
-  resolve: cross-package citations, hypothetical examples (`TestFoo`), and real
-  rot, unseparated. Widening the check to the package is a separate change with
-  31 findings to triage; globbing it now would make the guard permanently red,
-  which trains people to click through.
+- 🔴 **`TestItem38CommentsCiteTestsThatExist` is scoped to item 38's OWN files
+  — twelve of them plus this document since round 4 — and the number that
+  justified the scope limit was measured with an instrument this PR does not
+  ship.** Round 3 wrote "measured across all of `internal/cmd`, 31 comment-cited
+  test names do not resolve", and listed *cross-package citations* as part of the
+  31 — but `repoTestFuncNames` is repo-WIDE precisely so cross-package citations
+  DO resolve. That 31 came from a package-local resolver. Re-measured on this
+  tree with the shipped instruments (`repoTestFuncNames` + `testIdentRe`) over
+  all 471 `.go` files in the module, at this commit: **2096 citations, 23
+  unresolved sites, 20 distinct names.** (A measurement of this tree, not an
+  invariant: the citation total moves with any comment edit.)
+
+  All 20 were triaged. **Sixteen names at nineteen sites are correct prose** in
+  five shapes a regex cannot separate from rot: a name **wrapped across a comment
+  line-break, or elided with an ellipsis**; a **glob** naming a family; a
+  **subtest path** (`Parent_Sub`), which no `func` declares; a **fixture
+  identifier quoted from the test's own source**; and a **deliberate citation of
+  a test that was deleted, renamed or replaced**, which is this repo's own
+  convention for recording what a test used to assert. Globbing the check today
+  reports 23 sites of which 19 are not defects — a permanently-red gate.
+  Widening it needs a suppression convention for those five shapes first, which
+  is a separate change. The per-shape file:line index is in
+  `TestItem38CommentsCiteTestsThatExist`'s doc comment; neither that comment nor
+  this document may quote the identifiers, because both are now scanned and would
+  flag themselves.
+- 🔴 **Four genuine rot findings came out of that triage, and are NOT fixed
+  here.** Each is a doc comment, or a "pinned by" pointer, naming a test nothing
+  declares — the same defect §3 of this document exists for, four more instances
+  of it, in files this PR did not write. Site, then what is actually declared
+  there:
+
+  - `pkg/civitai/download_ssrf_test.go:147` → the function under it is
+    `Test`+`DownloadFileRedirectTargetSchemeChecked`.
+  - `internal/cmd/app_pull_not_approved_test.go:372` → the function under it is
+    `Test`+`AppPullForbiddenIsNotDisambiguated`.
+  - `internal/cmd/update_check_test.go:393` → the function under it is
+    `Test`+`VersionCommandEnvOptOut`.
+  - `internal/appapi/appblocks.go:1261` → the guard it means is
+    `Test`+`SubmissionSelectorPrecedenceAgreesWithTheParse`.
+
+  (The real names are written split across a `+` for the same reason as the dead
+  identifier in §3: this document is scanned, and it must not resolve names for
+  the check by accident.) They are named rather than fixed because a name-only
+  correction leaves a comment that reads truer and may still be wrong — the first
+  row is the proof: its body describes a redirect-to-**loopback** case while the
+  function under it builds a redirect-to-**plain-http** case, so the sentence
+  needs rewriting from the function, not renaming. Doing that for four guards on
+  evidence this PR has not gathered is how a follow-up audit introduces its own
+  false claims. Closing condition: each comment is rewritten from what its
+  function does, and the repo-wide unresolved-name count drops from 20 to 16.
 - **`TestSaferuneCallersAreLedgered` proves membership and naming, not
   CORRECTNESS.** It cannot tell whether a fourth caller is entitled to the
   unconditional strip — that judgement is `saferune`'s package doc (never what
   the user typed), and no test enforces it.
+- 🔴 **And until round 4 it did not prove NAMING in the direction its own
+  comment advertised.** The comment on the ledger's `question` field said
+  "asserting the IDENTIFIER rather than a phrase … the function can be renamed
+  and the texts must move with it". `question` was a plain `string` used as a
+  substring needle; nothing bound it to a declaration. Measured: renaming
+  `safeTerm` across `internal/cmd` at `31d5ba3` left `go test ./...` **fully
+  green** while AGENTS.md's Layout entry and `saferune`'s package doc both named
+  a function that no longer existed. `checkQuestionsResolve` now resolves every
+  ledgered `question` to a top-level `FuncDecl` in its own package before any
+  prose is searched, and all three rows were mutation-tested by an actual rename
+  (`safeTerm`, `hasPrintableContent`, `snippet`), each failing with the ledger's
+  own RENAMED message. It reads top-level, receiver-less funcs only: a question
+  moved onto a method is a change to the class's shape and must widen the
+  resolver deliberately.

--- a/claudedocs/decisions/38-read-body-repair-and-snippet.md
+++ b/claudedocs/decisions/38-read-body-repair-and-snippet.md
@@ -1,0 +1,162 @@
+# The read path repairs a body only when it must, and strips only what it prints
+
+**Item 38.** Code: `pkg/civitai/read.go` (`getInto`, `decodeBody`, `snippet`,
+`EscapeJSONStringControlChars`), `pkg/civitai/hashes.go` (`postInto`),
+`internal/cmd/read_help.go` (`readJSONNote`), `cmd/civitai/main.go`
+(`errorLine`). Guards: `pkg/civitai/read_repair_test.go`,
+`internal/cmd/read_json_note_test.go`,
+`cmd/civitai/read_error_stderr_test.go`.
+
+Born split: written straight into `claudedocs/decisions/` — AGENTS.md had 472
+bytes of headroom when this was added and the body is three decisions plus their
+measurement and mutation matrices. See `bornSplitItems` in
+`agents_split_preserved_test.go`.
+
+This is the follow-up to the adversarial audit of civitai/cli#526 (squash
+`517fc76`). #526's own change was correct and its regression test was watched
+red at base; what this item records is the set of OUR claims that its correct
+change falsified, and the two design choices taken while fixing them.
+
+## 1. The repair is a RETRY on the decode, never a pre-pass
+
+#526 shipped, in `getInto`:
+
+```go
+if !json.Valid(raw) {
+    if fixed := EscapeJSONStringControlChars(raw); json.Valid(fixed) {
+        raw = fixed
+    }
+}
+if out != nil {
+    if err := json.Unmarshal(raw, out); err != nil {
+        return nil, fmt.Errorf("unexpected response from %s (status %d): %s", path, status, snippet(raw))
+    }
+}
+```
+
+It is now unmarshal-first: decode, and only on failure sanitize and decode
+again, keeping the repaired bytes only if the second decode succeeded. Three
+reasons, in descending order of how load-bearing they are.
+
+**(a) The snippet.** `snippet(raw)` is the only thing a user is shown when a
+`200` will not decode, and the pre-pass reassigned `raw` to the repaired bytes
+*before* it ran. So a server that sent one `0x0D` was reported as having sent a
+backslash and an `r`, and README's Troubleshooting row — "the text after the
+colon is the server's own body, truncated" — was false. Under the retry shape
+the reassignment happens only on the branch that succeeded, so a failure
+message still quotes what actually arrived.
+Pinned by `TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes`.
+
+**(b) The unrepairable case.** A body invalid for a reason the sanitizer cannot
+fix must reach the same error with the ORIGINAL bytes. Nothing exercised that:
+a mutant assigning the sanitized bytes unconditionally SURVIVED a full green
+`pkg/civitai` + `internal/cmd` run. Pinned by
+`TestGetIntoUnrepairableBodyReportsTheOriginalBytes`, which is labelled in
+source as an **invariant guard** — it passes at `517fc76` too, so it is not
+regression coverage; its value is the mutant.
+
+**(c) Cost.** The pre-pass scanned every successful body in full, on top of the
+`json.Unmarshal` that walks the same bytes — on the happy path of an importable
+SDK, not a one-shot CLI. The load-bearing half of this is STRUCTURAL: the retry
+shape does no extra work at all on a body that decodes. The size of what was
+removed is one host's measurement and is not portable — a synthetic 1.50 MB /
+2185-item models page, go1.25, `-benchtime 300x -count=5`: `json.Valid`
+4.9–6.4 ms against `json.Unmarshal` 12.9–26.4 ms. The scratch benchmark is not
+in the tree; re-measure rather than quoting this.
+
+`decodeBody` exists so `getInto` and `postInto` cannot answer this differently.
+`postInto`'s doc comment enumerates what it mirrors from `getInto`, and the
+repair was, for one release, a fourth axis on which it silently did not — a
+divergence no test could see, because `HashMatch` is two ints and a 64-char hex
+with no free-text field. Sharing the body makes the enumeration true by
+construction. `TestDecodeBodyIsSharedByGetIntoAndPostInto` is a bidirectional
+ledger of its callers; `TestPostIntoRepairsControlBytesLikeGetInto` is the
+behavioural half.
+
+## 2. `snippet` strips; `errorLine` does not — decision (a), and why not (b)
+
+`cmd/civitai/main.go` prints `Error: <err>` straight to stderr. `internal/cmd`'s
+`safeTerm` sits on the HUMAN RENDERERS, not on the error path, and `snippet`
+embeds up to 500 bytes of a server body verbatim. So a `200` or a `404` body
+carrying `ESC[1A ESC[2K` could erase the CLI's own preceding output from inside
+an error message. That hole PRE-DATES #526; fixing (a) above would have widened
+it back to the 2xx path as well, because restoring the wire bytes to the snippet
+restores the wire's escapes too.
+
+**Chosen: filter inside `snippet`, using `internal/saferune`.** Every argument
+`snippet` is ever given is the server's own bytes — the undecodable 2xx body,
+the API's `{"error":…}`/`{"message":…}` text, a zod issue out of a 400, a
+retry-exhaustion body, a `FlexString` value. None of it is anything the user
+typed, which is what makes an unconditional strip correct at this one function.
+`snippet` was already a terminal-concern helper: its existing job is bounding
+length "so a huge response can't flood the terminal".
+
+**Rejected: filter at the print site (`errorLine`).** It would apply the class
+to EVERY error, including the many that echo what the user typed — a slug, a
+path, a prompt. That is exactly the regression civitai/cli#393 exists to
+prevent, and `TestSafeTermIsNeverAppliedToUserTypedInput` exists because it
+already happened once.
+
+**Rejected: re-derive the class inside `pkg/civitai`.** That is the OTHER half
+of #393 — two tables that disagree. `saferune`'s package doc is emphatic that
+the class is a PROPERTY with one enumerated exception, and that a summary of it
+is a copy of it.
+
+🔴 **THE COST, STATED RATHER THAN HIDDEN.** This makes `pkg/civitai` — the
+public read/download SDK — the first thing under `pkg/` to import `internal/`,
+and it means an SDK consumer that is not a terminal reads an error string with
+those runes already removed. Two things bound that: the strip touches only the
+human-readable tail of an error message, and the byte path an SDK consumer would
+actually parse (`Raw`) is returned unstripped.
+
+Pinned by `TestReadErrorSnippetStripsTerminalControlRunes` (unit) and
+`TestReadErrorReachesStderrWithoutTerminalControlRunes` (the SEAM: a real HTTP
+reply, the real SDK, the real `errorLine`, plus the published exit code for a
+404). The seam test exists because each side was already tested and neither side
+owned the join.
+
+## 3. What `--json` and `Raw` may CLAIM
+
+`readJSONNote`'s doc comment carried a MEASURED claim that #526 falsified in
+every clause — that a raw C0 byte inside a string exits 1 with empty stdout, so
+the repair "is not a behaviour of this group". Re-measured on the same fixture
+shape: exit 0, the table renders, `emitJSON` IS entered.
+
+The measurement across the merge, for the record:
+
+| tree | `models search` over a body with a raw CR in `name` |
+| --- | --- |
+| `5557b6a` (before #526) | exit 1, `unexpected response from /api/v1/models (status 200)`, empty stdout |
+| `517fc76` (#526) and after | exit 0, table renders, `--json` prints the document with `\r` |
+
+The paragraph survived a full green suite because nothing asserted on it: the
+only test touching the constant asked a different question (`claimsByteIdentity`).
+`TestReadJSONNoteDescribesTheRepair` now re-measures the behaviour through the
+real command tree AND pins the constant verbatim against that measurement, so a
+reword fails on purpose; `TestReadJSONNoteCommentNamesItsGuard` keeps the doc
+comment pointing at it.
+
+The same false byte-identity claim was in two result-type doc comments
+(`CollectionSearchResult`, `ArticleSearchResult` — "the raw response body") and
+in `numeric_username_test.go` ("a raw passthrough of the server's own bytes").
+All three now say what is true; the single accurate statement lives on
+`EscapeJSONStringControlChars`, which is exported and therefore visible to a
+godoc reader of the public package.
+
+## Residuals, enumerated
+
+- **The README's prose is not machine-checked against the behaviour.**
+  `readme_troubleshooting_test.go` is a drift detector over symptom STRINGS, and
+  no symptom string changed, which is why it did not catch the false
+  "server's own body" clause. The BEHAVIOUR the row describes is pinned (§1a,
+  §2); that the row still describes it is not. Widening the detector to compare
+  a row's explanation against runtime behaviour is a much larger guard than the
+  one that exists, and was not attempted.
+- **`snippet` still truncates by BYTE at 500**, so it can cut a multi-byte rune
+  in half and emit invalid UTF-8. Pre-existing, unchanged here, and not a
+  terminal-control hazard — the strip runs before the bound.
+- **`saferune` keeps `\n` and `\t` deliberately**, so a server body can still
+  put a newline in an error line. `internal/cmd`'s `indentContinuation` is the
+  answer to that on the renderers it covers; the error path has no equivalent.
+- **The exit-code contract is unchanged** and asserted: a 404 read still exits
+  4 with the filtered message (`TestReadErrorReachesStderrWithoutTerminalControlRunes`).

--- a/claudedocs/decisions/38-read-body-repair-and-snippet.md
+++ b/claudedocs/decisions/38-read-body-repair-and-snippet.md
@@ -1,16 +1,21 @@
 # The read path repairs a body only when it must, and strips only what it prints
 
 **Item 38.** Code: `pkg/civitai/read.go` (`getInto`, `decodeBody`, `snippet`,
-`EscapeJSONStringControlChars`), `pkg/civitai/hashes.go` (`postInto`),
-`internal/cmd/read_help.go` (`readJSONNote`), `cmd/civitai/main.go`
-(`errorLine`). Guards: `pkg/civitai/read_repair_test.go`,
+`readError`, `isDeepPagingCap`, `EscapeJSONStringControlChars`),
+`pkg/civitai/hashes.go` (`postInto`), `internal/cmd/read_help.go`
+(`readJSONNote`), `internal/saferune` (the class the snippet strip uses),
+`cmd/civitai/main.go` (`errorLine`). Guards:
+`pkg/civitai/read_repair_test.go`, `pkg/civitai/raw_doc_ledger_test.go`,
 `internal/cmd/read_json_note_test.go`,
-`cmd/civitai/read_error_stderr_test.go`.
+`cmd/civitai/read_error_stderr_test.go`, `saferune_callers_ledger_test.go`.
 
 Born split: written straight into `claudedocs/decisions/` — AGENTS.md had 472
-bytes of headroom when this was added and the body is three decisions plus their
-measurement and mutation matrices. See `bornSplitItems` in
-`agents_split_preserved_test.go`.
+bytes of headroom when this was added and the body is three decisions, the
+cross-tree measurement table in §3 and the enumerated residuals. See
+`bornSplitItems` in `agents_split_preserved_test.go`. (Round 2 described this
+as "measurement and mutation matrices"; there is one measurement table and no
+mutation matrix — mutation results live in the PR body and in each guard's own
+doc comment.)
 
 This is the follow-up to the adversarial audit of civitai/cli#526 (squash
 `517fc76`). #526's own change was correct and its regression test was watched
@@ -117,10 +122,21 @@ owned the join.
 
 ## 3. What `--json` and `Raw` may CLAIM
 
-`readJSONNote`'s doc comment carried a MEASURED claim that #526 falsified in
-every clause — that a raw C0 byte inside a string exits 1 with empty stdout, so
-the repair "is not a behaviour of this group". Re-measured on the same fixture
-shape: exit 0, the table renders, `emitJSON` IS entered.
+`readJSONNote`'s doc comment carried a MEASURED claim that #526 falsified —
+that a raw C0 byte inside a string exits 1 with empty stdout, so the repair "is
+not a behaviour of this group". Re-measured on the same fixture shape: exit 0,
+the table renders, `emitJSON` IS entered.
+
+**What #526 falsified is the CONCLUSION, not every premise**, and round 2 wrote
+this up as "falsified in every clause" — an over-claim of exactly the kind this
+item exists to close. Clause by clause, measured at HEAD:
+
+| clause | at HEAD |
+| --- | --- |
+| "every read command reaches `emitJSON` only AFTER `getInto` has unmarshalled the same bytes into a typed struct" | **still true** — every `emitJSON` call site in the read group is handed `res.Raw` or the `raw` return of a `getInto`-backed getter |
+| "`encoding/json` rejects a raw C0 byte inside a string literal there first" | **still true** — measured: `invalid character '\r' in string literal`. That rejection is now what TRIGGERS the repair |
+| "a body carrying a literal CR … exits 1 … and an EMPTY stdout — `emitJSON` is never entered" | **false** |
+| "it is not a behaviour of this group, so it is not described as one" | **false**, and it is the conclusion the two true premises stopped supporting |
 
 The measurement across the merge, for the record:
 
@@ -130,18 +146,124 @@ The measurement across the merge, for the record:
 | `517fc76` (#526) and after | exit 0, table renders, `--json` prints the document with `\r` |
 
 The paragraph survived a full green suite because nothing asserted on it: the
-only test touching the constant asked a different question (`claimsByteIdentity`).
+only test touching the constant was `TestReadJSONNoteDoesNotClaimByteIdentity`
+(`internal/cmd/read_help_test.go`, via its `claimsByteIdentity` helper), which
+asks a different question — whether the note promises byte identity, not whether
+it describes the repair.
 `TestReadJSONNoteDescribesTheRepair` now re-measures the behaviour through the
 real command tree AND pins the constant verbatim against that measurement, so a
 reword fails on purpose; `TestReadJSONNoteCommentNamesItsGuard` keeps the doc
 comment pointing at it.
 
-The same false byte-identity claim was in two result-type doc comments
-(`CollectionSearchResult`, `ArticleSearchResult` — "the raw response body") and
-in `numeric_username_test.go` ("a raw passthrough of the server's own bytes").
-All three now say what is true; the single accurate statement lives on
-`EscapeJSONStringControlChars`, which is exported and therefore visible to a
-godoc reader of the public package.
+🔴 **AND THE COMMENT SAYING SO NAMED A TEST THAT HAS NEVER EXISTED.** Round 2
+wrote the sentence above into `read_json_note_test.go` citing
+`Test`+`ReadJSONNoteWordingMatchesEmitJSON` — an identifier that appears nowhere
+in this repository and in no commit of its history. The comment written to stop
+comments going stale was itself unverifiable, and
+`TestReadJSONNoteCommentNamesItsGuard` could not see it: that test pins only the
+FORWARD direction (the doc comment contains the guard's name), so a wrong name
+in the same file is structurally invisible to it. The reverse direction is now
+`TestItem38CommentsCiteTestsThatExist` — every `Test…` identifier in a comment
+in item 38's files must resolve to a test function declared somewhere in the
+module. Resolution is repo-wide on purpose: these comments legitimately cite
+guards in other packages.
+
+The same false byte-identity claim was spread much wider than one commit's
+sweep found.
+
+🔴 **ROUND 2 CLOSED THIS AS A COUNT OF THREE AND THE COUNT WAS WRONG.** It read:
+"the same false claim was in two result-type doc comments … and in
+`numeric_username_test.go`. All three now say what is true." At that point at
+least seven more sites were live, including the two that matter most —
+`ModelSearchResult` and `ImageSearchResult`, the exact types civitai/cli#525
+bites, since the raw byte arrives in a model `name` or an image `prompt`. And
+`getInto`'s own doc comment said "see the note on Raw in the result types",
+pointing at eight referents of which two carried the note.
+
+**A count is the wrong instrument for a sweep**, which is why the fix is not a
+better count. `TestRawDocCommentsDisclaimByteIdentity` is a bidirectional
+ledger of every type with a `Raw []byte` field, and it requires the disclaimer
+on each: a ninth result type cannot be added without it, and a ledgered type
+cannot silently lose the field. Corrected in the same pass, outside what that
+ledger can see: `ArticleDetail.Content`'s "`--json` still returns the raw body
+untouched" (its point is that `--json` does not do the HTML rendering
+`--content` does — that survives; the byte word does not) and
+`flexstring_test.go`'s "Raw … must still be the server's own bytes" / "`--json`
+is a raw passthrough", which is verbatim the comment #526's follow-up corrected
+in `numeric_username_test.go` and missed here.
+
+The single accurate statement lives on `EscapeJSONStringControlChars`, which is
+exported and therefore visible to a godoc reader of the public package.
+
+Deliberately NOT rewritten: "preserved for `--json` via the raw body" on
+`ModelDetail`, `ArticleDetail`, `ImageItem` and their neighbours. That is a
+claim about FIELD preservation — a key the struct does not model survives into
+`--json` — which is true, and which the repair does not touch.
+
+## 4. The strip is a DISPLAY filter and must not become a CLASSIFIER
+
+Round 3, and the only behavioural finding in it. §2 put `internal/saferune`
+inside `snippet`. `readError` then handed `snippet`'s output to
+`isDeepPagingCap`, whose own comment says the match is "deliberately narrow so a
+real rate-limit 429 is never misclassified as a usage error".
+
+Removing runes can only WIDEN a substring match, and it widened it in exactly
+that direction. Same 429 body on both trees — one U+00AD SOFT HYPHEN, which is
+`Cf` and therefore in the class, inside the word "many":
+
+| tree | `{"message":"… too ma<U+00AD>ny pages …"}` on a 429 |
+| --- | --- |
+| `517fc76` | `ErrRateLimited` — **exit 6** |
+| `f936cfc` (round 2) | `ErrBadRequest` — **exit 2** |
+| HEAD | `ErrRateLimited` — **exit 6** |
+
+Contrived for Civitai's own backend, which does not emit soft hyphens; not
+contrived for the proxy, CDN and captive-portal 429s `readError` also handles.
+AGENTS.md items 7 and 24 make the exit code a published contract.
+
+**The fix is to classify on the WIRE message.** `readError` keeps `wireMsg`
+before the `snippet` call; the display still gets the filtered string.
+"Narrow" is a claim about what the SERVER sent, so the classifier is asked
+about what arrived.
+
+🔴 **THAT FIX MOVES A SECOND EXIT CODE, DELIBERATELY, AND IN THE OPPOSITE
+DIRECTION — SAID HERE RATHER THAN DISCOVERED LATER.** `snippet` also truncates
+at 500 bytes, which is the same hazard in a second shape: before this change a
+genuine cap message whose phrase fell past the display budget was invisible to
+the classifier and exited 6, so a scripter's backoff loop span forever on a
+structurally doomed request. Classifying pre-`snippet` removes the truncation
+from the match as well as the strip, so such a message now exits 2. That is the
+intended reading — a display budget is not a statement about what the server
+said — and it is pinned as half (c) of the same test rather than left as prose.
+Reachability is not hypothetical (a >500-byte error body is ordinary) but no
+such 429 has been observed from the API; the case is constructed.
+
+This is the ONLY site in `pkg/civitai` where the text of an error picks a
+classification; `readError`'s other branches classify from the status alone
+(`statusKind`), and `snippet`'s other callers are display-only. Verified by
+grep over every `kind =` assignment and every `snippet(` call site.
+
+Pinned by `TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne` (the
+sentinel, plus a positive control that the cap is still reclassified, plus that
+the display is still filtered) and
+`TestThrottle429KeepsExitSixThroughTheMessageFilter` (the published number, at
+the `cmd/civitai` seam).
+
+## 5. Two prose statements of the caller set, both stale at once
+
+`pkg/civitai`'s `snippet` became the THIRD non-test caller of
+`internal/saferune`. AGENTS.md's Layout entry still said `safeTerm` and
+`hasPrintableContent` "both" call it, and `saferune`'s package doc still opened
+"BECAUSE TWO PACKAGES ASK THE SAME QUESTION". Both survived a green suite, a
+lint run and a round-2 audit of the branch that falsified them.
+
+The third caller asks a THIRD question — "what may an ERROR STRING carry",
+because `cmd/civitai/main.go` prints `Error: <err>` to stderr with no renderer
+in front of it — so the package doc states the question, not just a bigger
+number. `TestSaferuneCallersAreLedgered` is the bidirectional ledger: it fails
+when the importer set grows or shrinks, requires both texts to name every
+ledgered call site, and derives the count WORD from the ledger's own length so
+the numeral cannot drift from the membership.
 
 ## Residuals, enumerated
 
@@ -158,5 +280,36 @@ godoc reader of the public package.
 - **`saferune` keeps `\n` and `\t` deliberately**, so a server body can still
   put a newline in an error line. `internal/cmd`'s `indentContinuation` is the
   answer to that on the renderers it covers; the error path has no equivalent.
-- **The exit-code contract is unchanged** and asserted: a 404 read still exits
-  4 with the filtered message (`TestReadErrorReachesStderrWithoutTerminalControlRunes`).
+- 🔴 **The exit-code contract was NOT unchanged**, and round 2 recorded here
+  that it was — "unchanged and asserted", on the evidence of one 404 test. That
+  is a description wider than its body twice over. A 404 is classified from the
+  STATUS alone, so `TestReadErrorReachesStderrWithoutTerminalControlRunes`
+  cannot see a message filter moving a code no matter what the filter does; and
+  the one code the filter COULD move, it did (§4). What is asserted now, stated
+  at the width actually measured:
+  - a 404 read exits 4 with the filtered message
+    (`TestReadErrorReachesStderrWithoutTerminalControlRunes`);
+  - a throttle 429 whose message carries a `Default_Ignorable` rune exits 6, at
+    the seam (`TestThrottle429KeepsExitSixThroughTheMessageFilter`) and as a
+    sentinel (`TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne`);
+  - the deep-paging cap still exits 2 (same test, half (b)).
+  Nothing asserts that the filter cannot move a code the CLI does not yet
+  classify from text. Today there is no such code — §4 records the grep — but
+  that is a measurement of the tree, not a guard on it.
+- **`TestRawDocCommentsDisclaimByteIdentity` covers doc comments on struct
+  fields, not prose.** The detail getters (`GetModel`, `GetArticle`,
+  `GetCollection`, `GetApp`, `GetModelVersion`, `GetModelVersionByHash`) return
+  raw bytes as a bare second `[]byte`, with no doc-comment slot the ledger can
+  find, and narrative comments anywhere in the package are not read. So the
+  byte-identity enumeration is OPEN, not closed — which is the whole lesson of
+  round 2's count of three.
+- **`TestItem38CommentsCiteTestsThatExist` is scoped to item 38's four files.**
+  Measured across all of `internal/cmd`, 31 comment-cited test names do not
+  resolve: cross-package citations, hypothetical examples (`TestFoo`), and real
+  rot, unseparated. Widening the check to the package is a separate change with
+  31 findings to triage; globbing it now would make the guard permanently red,
+  which trains people to click through.
+- **`TestSaferuneCallersAreLedgered` proves membership and naming, not
+  CORRECTNESS.** It cannot tell whether a fourth caller is entitled to the
+  unconditional strip — that judgement is `saferune`'s package doc (never what
+  the user typed), and no test enforces it.

--- a/claudedocs/decisions/38-read-body-repair-and-snippet.md
+++ b/claudedocs/decisions/38-read-body-repair-and-snippet.md
@@ -272,7 +272,7 @@ bounded only by `maxResponseBody` (64 MiB). Before round 3 the matcher inherited
 Round 4 bounds it with `maxClassifyMessage` (8 KiB) via `classifyWindow` — a
 budget deliberately separate from the display budget, since conflating the two
 is the defect this section exists for. **No false positive was demonstrated;
-this is containment, not a fix for an observed defect**, and the number is
+this is not a fix for an observed defect**, and the number is
 generous rather than derived: the API's own cap message is ~60 bytes, no
 measurement in this repo pins a largest legitimate 429 message, and none of the
 proxy/CDN/captive-portal 429s `readError` also handles has been sampled for
@@ -283,6 +283,38 @@ past 8 KiB is not reclassified and keeps exit 6. Pinned by
 `classifyMsg` and carries a positive control — the same fixture shape with the
 phrase inside the window must still reclassify, or half (a) would pass against a
 classifier that never matches.
+
+🔴 **ROUND 4 CALLED THAT BOUND "CONTAINMENT" AND MEASURED NOTHING; ROUND 5
+MEASURED IT AND THE WORD WAS WRONG.** The bound is **semantic** — it decides
+which bytes may move a published exit code, and that is the whole of what the
+guard above pins. It is **not** a bound on this function's footprint, because
+the statement immediately after the classifier, `msg = snippet([]byte(msg))`,
+converts the whole message and walks every byte of it through
+`saferune.Strip` — unconditionally, and regardless of `maxClassifyMessage` — on
+top of the `string(raw)` copy `readError` already made at entry.
+
+Measured on this tree, `go1.25.14 linux/amd64`, a `readError` benchmark over a
+non-JSON 429 body at `-benchtime=20x -count=3`:
+
+| body | `B/op` with `classifyWindow` | without |
+|---|---|---|
+| 32 MiB, uppercase | 67.12 MB | 100.67 MB |
+| 1 MiB, uppercase | 2.11 MB | 3.15 MB |
+| 32 MiB, lowercase | 67.11 MB | 67.11 MB |
+| 1 MiB, lowercase | 2.10 MB | 2.10 MB |
+
+So peak allocation is **~2x the body either way** — the bound removes a third
+full-body copy, not the first two. The one allocation it does bound is
+`strings.ToLower(msg)` inside `isDeepPagingCap`, and the lowercase rows are the
+reason that has to be said carefully: `strings.ToLower` returns its input
+without allocating when an all-ASCII string has nothing to fold, so an
+all-lowercase fixture measures the two arms as identical and would have
+"confirmed" that the bound buys no memory at all. **No wall-time claim is made
+here**: across those four size/case pairs the median direction was not even
+consistent — at 1 MiB lowercase the unbounded arm measured *faster*.
+
+The benchmark was written to take these numbers and then deleted; it is not in
+the tree. Re-derive rather than inherit the table.
 
 This is the ONLY site in `pkg/civitai` where the text of an error picks a
 classification; `readError`'s other branches classify from the status alone

--- a/cmd/civitai/read_error_stderr_test.go
+++ b/cmd/civitai/read_error_stderr_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/civitai/cli/pkg/civitai"
+)
+
+// TestReadErrorReachesStderrWithoutTerminalControlRunes is the SEAM guard for
+// the civitai/cli#526 follow-up's (a) decision.
+//
+// 🔴 EACH SIDE OF THIS SEAM IS TESTED AND NEITHER SIDE OWNS IT.
+// pkg/civitai proves snippet() strips; internal/cmd proves safeTerm strips on
+// the HUMAN renderers. Nothing joined them, and the join is where the hole was:
+// errorLine below hands err.Error() to fmt.Fprintln(os.Stderr, …) with no
+// filter of its own, so before this a 404 body carrying ESC[1A ESC[2K could
+// erase the CLI's own preceding output from inside an "Error: " line.
+//
+// This test builds the state neither package's fixtures build: a real HTTP
+// reply, decoded by the real SDK, rendered by the real stderr renderer.
+//
+// It also pins the published EXIT CODE across the change (AGENTS.md item 7): a
+// 404 must still classify as exit 4. The strip touches the message, and the
+// message is not what carries the classification — this is the assertion that
+// says so rather than assuming it.
+func TestReadErrorReachesStderrWithoutTerminalControlRunes(t *testing.T) {
+	// ESC[1A is CURSOR UP, ESC[2K is ERASE LINE, U+2066 is an isolate that can
+	// reorder what follows. All three are written as escapes: a literal control
+	// byte in a Go string literal is what staticcheck's ST1018 catches.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(
+			"{\"message\":\"no version 44190\\u001b[1A\\u001b[2K\\u2066 checksum ok\"}"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := civitai.New(srv.URL, "").GetModelVersion(context.Background(), "44190")
+	if err == nil {
+		t.Fatal("a 404 must be an error; without it this test asserts on nothing")
+	}
+	line := errorLine(err)
+
+	// Positive control FIRST: the server's own words must be in the line, or the
+	// absence checks below pass on an empty string.
+	if !strings.Contains(line, "no version 44190") || !strings.Contains(line, "checksum ok") {
+		t.Fatalf("the server's words are missing — the checks below would be vacuous:\n%q", line)
+	}
+	for _, bad := range []struct {
+		r    rune
+		name string
+	}{
+		{'\u001b', "ESC (0x1B), the ANSI/OSC introducer"},
+		{'\u2066', "U+2066 LEFT-TO-RIGHT ISOLATE"},
+	} {
+		if strings.ContainsRune(line, bad.r) {
+			t.Errorf("%s reached the line main() writes to stderr:\n%q", bad.name, line)
+		}
+	}
+	// The published exit code for a 404 read is 4 and must not have moved.
+	if got := exitCode(err); got != exitNotFound {
+		t.Errorf("exit code = %d, want %d (exitNotFound) — a 404 read's published "+
+			"classification must survive the message filter", got, exitNotFound)
+	}
+}

--- a/cmd/civitai/read_error_stderr_test.go
+++ b/cmd/civitai/read_error_stderr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -65,5 +66,47 @@ func TestReadErrorReachesStderrWithoutTerminalControlRunes(t *testing.T) {
 	if got := exitCode(err); got != exitNotFound {
 		t.Errorf("exit code = %d, want %d (exitNotFound) — a 404 read's published "+
 			"classification must survive the message filter", got, exitNotFound)
+	}
+}
+
+// TestThrottle429KeepsExitSixThroughTheMessageFilter is the EXIT-CODE half of
+// round 3's finding 4, at the seam where the code is actually published.
+//
+// 🔴 A 404 IS THE WRONG WITNESS FOR THIS CLAIM, AND IT WAS THE ONLY ONE.
+// The test above pins a 404 at exit 4, and item 38's evidence file cited it for
+// "the exit-code contract is unchanged". But 404 is classified from the STATUS
+// alone — the message filter cannot reach it, so that assertion is vacuous about
+// filtering. The 429 branch is the one place in pkg/civitai where the TEXT of
+// an error picks the exit code, and it is where the filter did move one:
+// snippet() strips Default_Ignorable runes, so a proxy throttle whose message
+// carried a U+00AD inside "many" was reclassified from 6 to 2.
+//
+// pkg/civitai's TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne
+// owns the sentinel; this owns the number a script reads from `$?`.
+func TestThrottle429KeepsExitSixThroughTheMessageFilter(t *testing.T) {
+	// U+00AD SOFT HYPHEN inside "many", written as an escape (ST1018).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(
+			"{\"message\":\"Edge throttle: too ma\\u00adny pages in flight, slow down\"}"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := civitai.New(srv.URL, "").GetModelVersion(context.Background(), "31708")
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it this test asserts on nothing")
+	}
+	// Positive control on the INSTRUMENT: exitCode must be able to return 2, or
+	// "it returned 6" says nothing about whether it discriminates at all.
+	if got := exitCode(civitai.Tag(civitai.ErrBadRequest, errors.New("bad enum"))); got != exitUsage {
+		t.Fatalf("CONTROL failure, not a finding: exitCode(ErrBadRequest) = %d, want %d",
+			got, exitUsage)
+	}
+	if got := exitCode(err); got != exitRateLimited {
+		t.Errorf("a throttle 429 exits %d, want %d (exitRateLimited).\n"+
+			"The deep-paging-cap reclassification is reading the FILTERED message, so "+
+			"the CLI's own strip synthesised the cap phrase and turned a retryable "+
+			"throttle into a usage error:\n%q", got, exitRateLimited, err)
 	}
 }

--- a/internal/cmd/numeric_username_test.go
+++ b/internal/cmd/numeric_username_test.go
@@ -67,10 +67,16 @@ func TestImagesSearchDecodesANumericUsername(t *testing.T) {
 }
 
 // TestImagesSearchJSONKeepsTheUnquotedUsername pins the --json contract across
-// the fix: it is a raw passthrough of the server's own bytes, so the number stays
-// UNQUOTED on stdout. FlexString would re-emit it quoted if anything marshalled
-// the struct — nothing does, and this is the assertion that says so at the
-// published surface rather than in a comment.
+// the fix: the body is passed through undecoded, so the number stays UNQUOTED on
+// stdout. FlexString would re-emit it quoted if anything marshalled the struct —
+// nothing does, and this is the assertion that says so at the published surface
+// rather than in a comment.
+//
+// "Passed through" is not "the server's own bytes", and an earlier revision of
+// this comment said the latter. `--json` re-indents (see readJSONNote), and
+// civitai/cli#525's repair rewrites a raw control byte into its escape when the
+// wire body would not otherwise decode. Neither touches the digits this test is
+// about; both make a byte-identity claim false.
 func TestImagesSearchJSONKeepsTheUnquotedUsername(t *testing.T) {
 	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"items":[{"id":1,"url":"u","username":` + numericUploader + `}],"metadata":{}}`))

--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -95,7 +95,7 @@ func newReader(o *readOpts) (*civitai.Client, string, error) {
 func emitJSON(cmd *cobra.Command, raw []byte) error {
 	src := raw
 	if !json.Valid(src) {
-		if fixed := escapeJSONStringControlChars(src); json.Valid(fixed) {
+		if fixed := civitai.EscapeJSONStringControlChars(src); json.Valid(fixed) {
 			src = fixed
 		}
 	}
@@ -106,12 +106,6 @@ func emitJSON(cmd *cobra.Command, raw []byte) error {
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), strings.TrimRight(buf.String(), "\n"))
 	return nil
-}
-
-// escapeJSONStringControlChars delegates to civitai.EscapeJSONStringControlChars
-// in pkg/civitai.
-func escapeJSONStringControlChars(raw []byte) []byte {
-	return civitai.EscapeJSONStringControlChars(raw)
 }
 
 // nonModelFileMarker returns a short human tag naming a version's PRIMARY file

--- a/internal/cmd/read_help.go
+++ b/internal/cmd/read_help.go
@@ -51,20 +51,35 @@ when you are logged in.`
 // promises "pure JSON — nothing else is written to stdout", never byte-identity.
 //
 // 🔴 THE RAW-CONTROL-BYTE REPAIR IS A BEHAVIOUR OF THIS GROUP, AND THE COMMENT
-// THAT USED TO SIT HERE SAID IT WAS NOT — EVERY CLAUSE OF IT MEASURED FALSE.
-// It read: "every read command reaches emitJSON only AFTER getInto has
-// unmarshalled the same bytes into a typed struct, and encoding/json rejects a
-// raw C0 byte inside a string literal there first. Measured: a body carrying a
-// literal CR inside a description exits 1 … and an EMPTY stdout — emitJSON is
-// never entered. … it is not a behaviour of this group, so it is not described
-// as one."
+// THAT USED TO SIT HERE SAID IT WAS NOT. It read: "every read command reaches
+// emitJSON only AFTER getInto has unmarshalled the same bytes into a typed
+// struct, and encoding/json rejects a raw C0 byte inside a string literal there
+// first. Measured: a body carrying a literal CR inside a description exits 1 …
+// and an EMPTY stdout — emitJSON is never entered. … it is not a behaviour of
+// this group, so it is not described as one."
 //
-// That was true when it was written and civitai/cli#526 falsified it: getInto
-// now repairs the same class of byte before the typed decode, so the decode
-// SUCCEEDS. Re-measured on the same fixture — a literal CR inside a `name` on
-// `models search` — the command exits 0, the table renders, and with `--json`
-// emitJSON is entered and prints a document carrying `\r`. The whole suite was
-// green across that merge, because nothing asserted on this paragraph.
+// 🔴 WHAT #526 FALSIFIED IS THE CONCLUSION, NOT EVERY PREMISE, AND AN EARLIER
+// REVISION OF THIS RETRACTION SAID "EVERY CLAUSE OF IT MEASURED FALSE". That
+// over-claim is the same failure the paragraph it retracts committed. Clause by
+// clause at HEAD:
+//
+//   - "every read command reaches emitJSON only AFTER getInto has unmarshalled
+//     the same bytes into a typed struct" — STILL TRUE. emitJSON is downstream
+//     of getInto in every leaf; #526 changed what getInto does on a failed
+//     decode, not the order.
+//   - "encoding/json rejects a raw C0 byte inside a string literal there first"
+//     — STILL TRUE. That rejection is exactly what now triggers the repair.
+//   - "a body carrying a literal CR … exits 1 … and an EMPTY stdout — emitJSON
+//     is never entered" — FALSE. Re-measured on the same fixture shape, a
+//     literal CR inside a `name` on `models search`: exit 0, the table renders,
+//     and with `--json` emitJSON IS entered and prints a document carrying `\r`.
+//   - "it is not a behaviour of this group, so it is not described as one" —
+//     FALSE, and it is the conclusion the two true premises no longer support:
+//     the rejection is now the trigger for a retry rather than the end of the
+//     call.
+//
+// The whole suite was green across that merge, because nothing asserted on this
+// paragraph.
 //
 // So the repair IS described below, and TestReadJSONNoteDescribesTheRepair is
 // what stops this paragraph going stale a second time: it re-measures the

--- a/internal/cmd/read_help.go
+++ b/internal/cmd/read_help.go
@@ -50,20 +50,33 @@ when you are logged in.`
 // The README's "Scripting with --json" section is careful about exactly this: it
 // promises "pure JSON — nothing else is written to stdout", never byte-identity.
 //
-// It also does NOT mention emitJSON's raw-control-byte repair
-// (escapeJSONStringControlChars), and that omission is measured rather than an
-// oversight: every read command reaches emitJSON only AFTER getInto has
+// 🔴 THE RAW-CONTROL-BYTE REPAIR IS A BEHAVIOUR OF THIS GROUP, AND THE COMMENT
+// THAT USED TO SIT HERE SAID IT WAS NOT — EVERY CLAUSE OF IT MEASURED FALSE.
+// It read: "every read command reaches emitJSON only AFTER getInto has
 // unmarshalled the same bytes into a typed struct, and encoding/json rejects a
 // raw C0 byte inside a string literal there first. Measured: a body carrying a
-// literal CR inside a description exits 1 with "unexpected response from
-// /api/v1/models (status 200)" and an EMPTY stdout — emitJSON is never entered.
-// The repair is real defence-in-depth for any future caller that passes raw
-// bytes through without a typed decode; it is not a behaviour of this group, so
-// it is not described as one.
+// literal CR inside a description exits 1 … and an EMPTY stdout — emitJSON is
+// never entered. … it is not a behaviour of this group, so it is not described
+// as one."
+//
+// That was true when it was written and civitai/cli#526 falsified it: getInto
+// now repairs the same class of byte before the typed decode, so the decode
+// SUCCEEDS. Re-measured on the same fixture — a literal CR inside a `name` on
+// `models search` — the command exits 0, the table renders, and with `--json`
+// emitJSON is entered and prints a document carrying `\r`. The whole suite was
+// green across that merge, because nothing asserted on this paragraph.
+//
+// So the repair IS described below, and TestReadJSONNoteDescribesTheRepair is
+// what stops this paragraph going stale a second time: it re-measures the
+// behaviour through the real command tree and pins this constant's text
+// verbatim against that measurement. A reword fails it on purpose — the note is
+// a measured claim, not prose, and the test's failure message says which
+// measurement to redo.
 const readJSONNote = `--json writes the API response to stdout and nothing else — notes and errors go
 to stderr, so ` + "`… --json | jq -e .`" + ` always parses. The document is the API's,
-the bytes are not: it is re-indented on the way out, so do not diff or hash it
-against the wire.`
+the bytes are not: it is re-indented on the way out, and a raw control byte the
+API emits inside a string (which is not legal JSON) is rewritten as its escape
+so the output still parses. Do not diff or hash it against the wire.`
 
 // limitRule renders one endpoint's --limit bounds.
 //

--- a/internal/cmd/read_json_note_test.go
+++ b/internal/cmd/read_json_note_test.go
@@ -223,7 +223,7 @@ const item38DecisionDoc = "claudedocs/decisions/38-read-body-repair-and-snippet.
 // them — but repoTestFuncNames is repo-WIDE precisely so cross-package citations
 // resolve, so that 31 came from a package-local resolver this guard does not
 // ship. Re-measured with the instruments below (repoTestFuncNames + testIdentRe)
-// over all 471 .go files in the module, at this commit: 2096 citations, 23
+// over all 471 .go files in the module, at this commit: 2103 citations, 23
 // unresolved sites, 20 distinct names. Those are a measurement of this tree, not
 // an invariant — the citation total moves with any comment edit.
 //
@@ -289,7 +289,7 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 
 	root := moduleRoot(t)
 	fset := token.NewFileSet()
-	cited := 0
+	goCited := 0
 	for _, name := range item38CommentedFiles {
 		f, err := parser.ParseFile(fset, filepath.Join(root, name), nil, parser.ParseComments)
 		if err != nil {
@@ -298,7 +298,7 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 		for _, cg := range f.Comments {
 			for _, c := range cg.List {
 				for _, ident := range testIdentRe.FindAllString(c.Text, -1) {
-					cited++
+					goCited++
 					if defined[ident] {
 						continue
 					}
@@ -321,7 +321,6 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 	for i, line := range strings.Split(string(doc), "\n") {
 		for _, ident := range testIdentRe.FindAllString(line, -1) {
 			docCited++
-			cited++
 			if defined[ident] {
 				continue
 			}
@@ -331,16 +330,27 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 				item38DecisionDoc, i+1, ident)
 		}
 	}
-	// POSITIVE CONTROLS on the SCAN: zero citations found is indistinguishable
-	// from zero dangling citations, and the Markdown arm has its own zero.
+	// POSITIVE CONTROLS on the SCAN — one PER ARM, because zero citations found is
+	// indistinguishable from zero dangling citations and the two arms read
+	// different things with different code.
+	//
+	// 🔴 THEY WERE ONE COMBINED FLOOR, AND IT COULD NOT SEE THE .go ARM GO TO ZERO.
+	// Both arms incremented a single counter floored at 20 while the Markdown arm
+	// alone contributes 28, so the .go arm's zero was structurally unobservable:
+	// dropping parser.ParseComments from the ParseFile call above left this test
+	// green while it read no comments at all from the twelve ledgered files.
+	// Measured at this commit: goCited 82, docCited 28. The floors below are
+	// lower bounds well under those, not the measurements themselves — the counts
+	// move with any comment edit, and a floor pinned to today's exact value would
+	// fail on the next one.
 	if docCited < 5 {
 		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
 			"names in %s — the Markdown arm is not reading the file", docCited, item38DecisionDoc)
 	}
-	if cited < 20 {
+	if goCited < 40 {
 		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
-			"names across %v + %s — it is not reading the comments",
-			cited, item38CommentedFiles, item38DecisionDoc)
+			"names across %v — the .go arm is not reading the comments",
+			goCited, item38CommentedFiles)
 	}
 }
 

--- a/internal/cmd/read_json_note_test.go
+++ b/internal/cmd/read_json_note_test.go
@@ -5,13 +5,18 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
 
-// crInAName is a raw carriage return inside a model NAME — the civitai/cli#525
-// class, written as a Go escape rather than a literal control byte (ST1018).
+// crBodyModelName is a raw carriage return inside a model NAME — the
+// civitai/cli#525 class, written as a Go escape rather than a literal control
+// byte (ST1018).
 // The two halves are distinct from every other fixture in this package so a
 // mutant that hardcodes one cannot satisfy an assertion about the other.
 const crBodyModelName = "Speckled\rGrebe"
@@ -33,8 +38,9 @@ const wantReadJSONNote = "--json writes the API response to stdout and nothing e
 // never reaches emitJSON, so the repair "is not a behaviour of this group".
 // civitai/cli#526 moved the repair ahead of the typed decode and every clause of
 // that paragraph became false, with the whole suite green: the only test
-// touching the constant was TestReadJSONNoteWordingMatchesEmitJSON's
-// claimsByteIdentity check, which asks a different question.
+// touching the constant was TestReadJSONNoteDoesNotClaimByteIdentity
+// (read_help_test.go), which asks a different question — whether the note
+// promises byte identity, not whether it describes the repair.
 //
 // So this test does both halves in one place, deliberately:
 //
@@ -143,4 +149,151 @@ func TestReadJSONNoteCommentNamesItsGuard(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: no documented const declaration " +
 			"named readJSONNote was found in read_help.go")
 	}
+}
+
+// item38CommentedFiles are the files item 38 owns. The citation check below
+// runs over exactly these, and it is a LEDGER rather than a glob: a file added
+// to the item must be added here to be covered, and a file removed from the
+// item makes this list fail rather than silently shrink the check.
+var item38CommentedFiles = []string{
+	"read_help.go",
+	"read_help_test.go",
+	"read_json_note_test.go",
+	"read_r2_test.go",
+}
+
+// TestItem38CommentsCiteTestsThatExist is round 3's finding 6.
+//
+// 🔴 THE COMMENT WRITTEN TO STOP COMMENTS GOING STALE CITED A TEST THAT HAS
+// NEVER EXISTED. TestReadJSONNoteDescribesTheRepair's own doc comment above
+// named a guard that appears nowhere in this repository and in no commit of its
+// history; the real test is TestReadJSONNoteDoesNotClaimByteIdentity in
+// read_help_test.go. The suite was green, the lint run was clean, and a round-2
+// audit of this very branch read the sentence without being able to check it.
+//
+// The dead identifier is spelled out ONCE, as a string literal in the third
+// control below and deliberately not in any comment: this test reads comments,
+// so writing it in prose here would make the test flag itself.
+//
+// 🔴 TestReadJSONNoteCommentNamesItsGuard PINS ONLY THE FORWARD DIRECTION —
+// that readJSONNote's doc comment CONTAINS the guard's name. A comment in the
+// same file naming a test that does not exist is structurally invisible to it,
+// which is what happened. This is the reverse direction, and it is the
+// deterministic fix: a name is either resolvable or it is not, so nobody has to
+// notice.
+//
+// Resolution is REPO-WIDE, not package-local: comments here legitimately cite
+// tests in pkg/civitai (read_r2_test.go names
+// TestEscapeJSONStringControlCharsLeavesStructuralWhitespace, which lives
+// there), and a package-local resolver would report those as dangling.
+//
+// 🔴 WHAT IT DOES NOT COVER. The scan is scoped to the files above, not to the
+// tree: measured across all of internal/cmd, 31 comment-cited names do not
+// resolve — a mix of cross-package citations, hypothetical examples
+// (`TestFoo`), and real rot. Widening this to the package is a separate change
+// with 31 findings to triage, and pretending otherwise by globbing would make
+// the guard permanently red, which is worse than no guard.
+func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
+	defined := repoTestFuncNames(t)
+	// POSITIVE CONTROL on the resolver: a walk that collected nothing declares
+	// every citation dangling, and a walk that collected garbage declares none.
+	if len(defined) < 1000 {
+		t.Fatalf("CONTROL failure, not a finding: found only %d Test functions in the "+
+			"module — the resolver is not reading the tree", len(defined))
+	}
+	if !defined["TestReadJSONNoteDescribesTheRepair"] {
+		t.Fatalf("CONTROL failure, not a finding: the resolver cannot see a test " +
+			"defined in this very file")
+	}
+	// NEGATIVE CONTROL: the resolver must NOT resolve the dead name this test
+	// exists because of. If it does, the resolver is matching something other
+	// than a test-function declaration and every verdict below is worthless.
+	const deadCitation = "TestReadJSONNoteWordingMatchesEmitJSON"
+	if defined[deadCitation] {
+		t.Fatalf("CONTROL failure, not a finding: the resolver claims to have found "+
+			"%s, the name this test exists because NOTHING defines. Either it has "+
+			"since been written — in which case delete this control — or the "+
+			"resolver is matching something that is not a test function declaration.",
+			deadCitation)
+	}
+
+	fset := token.NewFileSet()
+	cited := 0
+	for _, name := range item38CommentedFiles {
+		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, err)
+		}
+		for _, cg := range f.Comments {
+			for _, c := range cg.List {
+				for _, ident := range testIdentRe.FindAllString(c.Text, -1) {
+					cited++
+					if defined[ident] {
+						continue
+					}
+					t.Errorf("%s:%d cites %s, which no test function in this module "+
+						"declares.\nA comment naming a guard is a POINTER; an unresolvable "+
+						"one sends the next reader looking for a test that was never "+
+						"written, and reads as coverage while providing none.",
+						name, fset.Position(c.Pos()).Line, ident)
+				}
+			}
+		}
+	}
+	// POSITIVE CONTROL on the SCAN: zero citations found is indistinguishable
+	// from zero dangling citations.
+	if cited < 5 {
+		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
+			"names across %v — it is not reading the comments", cited, item38CommentedFiles)
+	}
+}
+
+// testIdentRe matches a Go test-function identifier as written in prose. The
+// 4-character tail keeps it off the bare word "Test".
+var testIdentRe = regexp.MustCompile(`\bTest[A-Za-z0-9_]{4,}\b`)
+
+// testFuncRe matches a test function DECLARATION at the start of a line.
+var testFuncRe = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]*)\s*\(`)
+
+// repoTestFuncNames returns every Test function declared anywhere in the
+// module, so a comment may cite a guard that lives in another package.
+func repoTestFuncNames(t *testing.T) map[string]bool {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot resolve the module root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("CONTROL failure, not a finding: %s is not the module root "+
+			"(no go.mod): %v", root, err)
+	}
+	out := map[string]bool{}
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			n := d.Name()
+			if path != root && (strings.HasPrefix(n, ".") || n == "node_modules" ||
+				n == "dist" || n == "bin" || n == "testdata") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		for _, m := range testFuncRe.FindAllStringSubmatch(string(src), -1) {
+			out[m[1]] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: walking the module: %v", err)
+	}
+	return out
 }

--- a/internal/cmd/read_json_note_test.go
+++ b/internal/cmd/read_json_note_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -151,16 +152,45 @@ func TestReadJSONNoteCommentNamesItsGuard(t *testing.T) {
 	}
 }
 
-// item38CommentedFiles are the files item 38 owns. The citation check below
-// runs over exactly these, and it is a LEDGER rather than a glob: a file added
-// to the item must be added here to be covered, and a file removed from the
-// item makes this list fail rather than silently shrink the check.
+// item38CommentedFiles are the files item 38 owns, REPO-RELATIVE. The citation
+// check below runs over exactly these, and it is a LEDGER rather than a glob: a
+// file added to the item must be added here to be covered, and a file removed
+// from the item makes this list fail rather than silently shrink the check.
+//
+// 🔴 IT WAS FOUR FILES, ALL IN internal/cmd, AND THE TWO SETS DISAGREED IN BOTH
+// DIRECTIONS. claudedocs/decisions/38's header declares item 38's files; this
+// ledger covered four, of which TWO (read_help_test.go, read_r2_test.go) the
+// header did not name at all, and NONE of pkg/civitai/read.go,
+// pkg/civitai/read_repair_test.go, pkg/civitai/raw_doc_ledger_test.go,
+// cmd/civitai/read_error_stderr_test.go or saferune_callers_ledger_test.go.
+// Measured consequence: renaming
+// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne left
+// `go test ./...` fully green while pkg/civitai/read.go — item 38's PRIMARY code
+// file — and the decision doc both cited a name nothing declared.
+// TestItem38FileLedgerMatchesTheDecisionHeader now pins the two sets together,
+// so this list cannot drift from the header again in either direction.
 var item38CommentedFiles = []string{
-	"read_help.go",
-	"read_help_test.go",
-	"read_json_note_test.go",
-	"read_r2_test.go",
+	"cmd/civitai/main.go",
+	"cmd/civitai/read_error_stderr_test.go",
+	"internal/cmd/read_help.go",
+	"internal/cmd/read_help_test.go",
+	"internal/cmd/read_json_note_test.go",
+	"internal/cmd/read_r2_test.go",
+	"internal/saferune/saferune.go",
+	"pkg/civitai/hashes.go",
+	"pkg/civitai/raw_doc_ledger_test.go",
+	"pkg/civitai/read.go",
+	"pkg/civitai/read_repair_test.go",
+	"saferune_callers_ledger_test.go",
 }
+
+// item38DecisionDoc is item 38's evidence file. It is scanned for citations too
+// — it cites more guards by name than any single source file does, and a
+// dangling name there sends exactly the same reader looking for exactly the same
+// missing test. It is NOT in item38CommentedFiles because that list is compared,
+// element for element, against the file set this document's own header declares
+// — and a document cannot be a member of the list it declares.
+const item38DecisionDoc = "claudedocs/decisions/38-read-body-repair-and-snippet.md"
 
 // TestItem38CommentsCiteTestsThatExist is round 3's finding 6.
 //
@@ -187,12 +217,52 @@ var item38CommentedFiles = []string{
 // TestEscapeJSONStringControlCharsLeavesStructuralWhitespace, which lives
 // there), and a package-local resolver would report those as dangling.
 //
-// 🔴 WHAT IT DOES NOT COVER. The scan is scoped to the files above, not to the
-// tree: measured across all of internal/cmd, 31 comment-cited names do not
-// resolve — a mix of cross-package citations, hypothetical examples
-// (`TestFoo`), and real rot. Widening this to the package is a separate change
-// with 31 findings to triage, and pretending otherwise by globbing would make
-// the guard permanently red, which is worse than no guard.
+// 🔴 WHAT IT DOES NOT COVER, AND THE NUMBER THAT SAYS SO WAS MEASURED WITH THE
+// WRONG INSTRUMENT. Round 3 wrote "measured across all of internal/cmd, 31
+// comment-cited names do not resolve", listing cross-package citations among
+// them — but repoTestFuncNames is repo-WIDE precisely so cross-package citations
+// resolve, so that 31 came from a package-local resolver this guard does not
+// ship. Re-measured with the instruments below (repoTestFuncNames + testIdentRe)
+// over all 471 .go files in the module, at this commit: 2096 citations, 23
+// unresolved sites, 20 distinct names. Those are a measurement of this tree, not
+// an invariant — the citation total moves with any comment edit.
+//
+// All 20 were triaged. Each is cited by FILE AND LINE rather than by name: this
+// scan reads comments — and, since round 4, the evidence file too — so spelling
+// an unresolvable identifier in either would make the guard flag itself. Go and
+// look at the lines.
+//
+// SIXTEEN names at nineteen sites are CORRECT PROSE that this regex cannot tell
+// from rot, in five shapes:
+//
+//   - a name WRAPPED across a comment line-break, or elided with "…", leaving
+//     the regex a truncated identifier (internal/scaffold/bootskeleton.go:15,
+//     internal/validate/pattern.go:63, internal/cmd/agent_setup_round4_test.go:22,
+//     internal/cmd/workflows_list_failure_reason_test.go:217);
+//   - a GLOB naming a family (internal/cmd/app_pull_not_approved_test.go:261);
+//   - a SUBTEST path, Parent_Sub, which no func declares
+//     (internal/genapi/generate_test.go:661);
+//   - a fixture identifier quoted from the test's own source
+//     (internal/cmd/app_newest_submission_test.go:425, two names);
+//   - a deliberate citation of a test that was DELETED, RENAMED or REPLACED —
+//     this repo's own convention for recording what a test used to assert
+//     (internal/cmd/cmd_test.go:446, internal/cmd/app_listing_test.go:471 and
+//     :858, internal/scaffold/slug_test.go:21, internal/cmd/app_status_drift_test.go:522,
+//     internal/cmd/agent_setup_round2_test.go:31, agents_evidence_test.go:394,
+//     agents_trigger_test.go:78, internal/cmd/app_metrics_test.go:864,
+//     internal/cmd/newest_row_pick_test.go:323, internal/appapi/submissions_test.go:114).
+//
+// FOUR names at four sites are GENUINE ROT — a doc comment or a "pinned by"
+// pointer naming something nothing declares. They are listed with their real
+// targets as a residual in
+// claudedocs/decisions/38-read-body-repair-and-snippet.md, and are NOT fixed
+// here: each needs its own function read before its comment can be rewritten,
+// and a name-only fix leaves a truer-looking comment that is still wrong.
+//
+// So the scope limit stays for now, on the corrected number: globbing this check
+// today reports 23 sites of which 19 are correct prose. Widening it needs a
+// suppression convention for those five shapes first — a separate change, with
+// the four rot findings above as its motivation.
 func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 	defined := repoTestFuncNames(t)
 	// POSITIVE CONTROL on the resolver: a walk that collected nothing declares
@@ -217,10 +287,11 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 			deadCitation)
 	}
 
+	root := moduleRoot(t)
 	fset := token.NewFileSet()
 	cited := 0
 	for _, name := range item38CommentedFiles {
-		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		f, err := parser.ParseFile(fset, filepath.Join(root, name), nil, parser.ParseComments)
 		if err != nil {
 			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, err)
 		}
@@ -240,12 +311,154 @@ func TestItem38CommentsCiteTestsThatExist(t *testing.T) {
 			}
 		}
 	}
-	// POSITIVE CONTROL on the SCAN: zero citations found is indistinguishable
-	// from zero dangling citations.
-	if cited < 5 {
-		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
-			"names across %v — it is not reading the comments", cited, item38CommentedFiles)
+	// The evidence file is Markdown, so it is scanned as TEXT rather than parsed.
+	// Same regex, same resolver, same verdict.
+	doc, err := os.ReadFile(filepath.Join(root, item38DecisionDoc))
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read %s: %v", item38DecisionDoc, err)
 	}
+	docCited := 0
+	for i, line := range strings.Split(string(doc), "\n") {
+		for _, ident := range testIdentRe.FindAllString(line, -1) {
+			docCited++
+			cited++
+			if defined[ident] {
+				continue
+			}
+			t.Errorf("%s:%d cites %s, which no test function in this module declares.\n"+
+				"The evidence file names more guards than any source file does; an "+
+				"unresolvable one reads as coverage while providing none.",
+				item38DecisionDoc, i+1, ident)
+		}
+	}
+	// POSITIVE CONTROLS on the SCAN: zero citations found is indistinguishable
+	// from zero dangling citations, and the Markdown arm has its own zero.
+	if docCited < 5 {
+		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
+			"names in %s — the Markdown arm is not reading the file", docCited, item38DecisionDoc)
+	}
+	if cited < 20 {
+		t.Fatalf("CONTROL failure, not a finding: the scan found only %d cited test "+
+			"names across %v + %s — it is not reading the comments",
+			cited, item38CommentedFiles, item38DecisionDoc)
+	}
+}
+
+// item38HeaderPathRe matches a backticked repo-relative .go path in the decision
+// file's header paragraph.
+var item38HeaderPathRe = regexp.MustCompile("`([A-Za-z0-9_./-]+\\.go)`")
+
+// TestItem38FileLedgerMatchesTheDecisionHeader is round 4's finding 4.
+//
+// 🔴 TWO DECLARATIONS OF ONE FILE SET, DISAGREEING IN BOTH DIRECTIONS, NEITHER
+// ASSERTED. claudedocs/decisions/38's header paragraph names item 38's Code and
+// Guards; item38CommentedFiles names the files the citation check reads. The
+// ledger covered four files, two of which the header did not list, and missed
+// item 38's primary code file — so a comment in pkg/civitai/read.go could, and
+// did, cite a test by a name a rename would break, invisibly.
+//
+// This is the bidirectional assertion. Adding a file to the item means adding it
+// in BOTH places or this fails by name.
+func TestItem38FileLedgerMatchesTheDecisionHeader(t *testing.T) {
+	root := moduleRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, item38DecisionDoc))
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read %s: %v", item38DecisionDoc, err)
+	}
+	// The header is the paragraph opening "**Item 38.**", up to the first blank
+	// line after it. Scoping to that paragraph is deliberate: the rest of the
+	// document names plenty of files it does not OWN.
+	lines := strings.Split(string(raw), "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, "**Item 38.**") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("CONTROL failure, not a finding: %s has no line opening "+
+			"\"**Item 38.**\" — this test cannot find the declaration it guards",
+			item38DecisionDoc)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			end = i
+			break
+		}
+	}
+	header := strings.Join(lines[start:end], "\n")
+	// POSITIVE CONTROL on the extraction: a one-line header means the paragraph
+	// scanner is wrong and every path below would be reported missing.
+	if end-start < 3 {
+		t.Fatalf("CONTROL failure, not a finding: the Item 38 header extracted to %d "+
+			"lines:\n%s", end-start, header)
+	}
+
+	declared := map[string]bool{}
+	for _, m := range item38HeaderPathRe.FindAllStringSubmatch(header, -1) {
+		declared[m[1]] = true
+	}
+	// POSITIVE CONTROL on the MATCH: an empty set passes a "does the ledger
+	// contain everything declared?" check silently.
+	if len(declared) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: no backticked .go path in the Item 38 "+
+			"header:\n%s", header)
+	}
+
+	ledgered := map[string]bool{}
+	for _, f := range item38CommentedFiles {
+		ledgered[f] = true
+	}
+	var missingFromLedger, missingFromHeader []string
+	for p := range declared {
+		if !ledgered[p] {
+			missingFromLedger = append(missingFromLedger, p)
+		}
+	}
+	for p := range ledgered {
+		if !declared[p] {
+			missingFromHeader = append(missingFromHeader, p)
+		}
+	}
+	sort.Strings(missingFromLedger)
+	sort.Strings(missingFromHeader)
+	if len(missingFromLedger) > 0 {
+		t.Errorf("%s declares %v as item 38's files, but item38CommentedFiles does not "+
+			"cover them — their comments are not citation-checked, which is how a\n"+
+			"rename left a dangling reference in pkg/civitai/read.go with the suite green.",
+			item38DecisionDoc, missingFromLedger)
+	}
+	if len(missingFromHeader) > 0 {
+		t.Errorf("item38CommentedFiles covers %v, which the Item 38 header in %s does not "+
+			"declare.\nEither the header is missing a file the item owns, or the ledger "+
+			"has grown past the item — say which, in the header.",
+			missingFromHeader, item38DecisionDoc)
+	}
+
+	// Every ledgered file must actually exist: a typo silently narrows the scan.
+	for _, f := range item38CommentedFiles {
+		if _, err := os.Stat(filepath.Join(root, f)); err != nil {
+			t.Errorf("item38CommentedFiles names %s, which does not exist: %v", f, err)
+		}
+	}
+}
+
+// moduleRoot resolves the module root from this package's directory and proves
+// it by finding go.mod there. Every path the item-38 guards read is relative to
+// it, so a wrong root is a broken instrument, not a finding.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot resolve the module root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("CONTROL failure, not a finding: %s is not the module root "+
+			"(no go.mod): %v", root, err)
+	}
+	return root
 }
 
 // testIdentRe matches a Go test-function identifier as written in prose. The
@@ -259,16 +472,9 @@ var testFuncRe = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]*)\s*\(`)
 // module, so a comment may cite a guard that lives in another package.
 func repoTestFuncNames(t *testing.T) map[string]bool {
 	t.Helper()
-	root, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatalf("CONTROL failure, not a finding: cannot resolve the module root: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
-		t.Fatalf("CONTROL failure, not a finding: %s is not the module root "+
-			"(no go.mod): %v", root, err)
-	}
+	root := moduleRoot(t)
 	out := map[string]bool{}
-	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/read_json_note_test.go
+++ b/internal/cmd/read_json_note_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// crInAName is a raw carriage return inside a model NAME — the civitai/cli#525
+// class, written as a Go escape rather than a literal control byte (ST1018).
+// The two halves are distinct from every other fixture in this package so a
+// mutant that hardcodes one cannot satisfy an assertion about the other.
+const crBodyModelName = "Speckled\rGrebe"
+
+// wantReadJSONNote is readJSONNote, typed out. It is a LITERAL expectation,
+// derived from nothing, because a test that rebuilds the note from the same
+// pieces the note is built from moves with it and asserts nothing.
+const wantReadJSONNote = "--json writes the API response to stdout and nothing else — notes and errors go\n" +
+	"to stderr, so `… --json | jq -e .` always parses. The document is the API's,\n" +
+	"the bytes are not: it is re-indented on the way out, and a raw control byte the\n" +
+	"API emits inside a string (which is not legal JSON) is rewritten as its escape\n" +
+	"so the output still parses. Do not diff or hash it against the wire."
+
+// TestReadJSONNoteDescribesTheRepair is the guard finding 1 asked for.
+//
+// 🔴 A CLAIM NOTHING ASSERTS ON IS UNPINNED BY CONSTRUCTION, AND THAT IS EXACTLY
+// HOW THIS ONE WENT FALSE. readJSONNote's doc comment carried a MEASURED claim —
+// that a body with a raw C0 byte inside a string exits 1 with empty stdout and
+// never reaches emitJSON, so the repair "is not a behaviour of this group".
+// civitai/cli#526 moved the repair ahead of the typed decode and every clause of
+// that paragraph became false, with the whole suite green: the only test
+// touching the constant was TestReadJSONNoteWordingMatchesEmitJSON's
+// claimsByteIdentity check, which asks a different question.
+//
+// So this test does both halves in one place, deliberately:
+//
+//   - it RE-MEASURES the behaviour through the real command tree, so a future
+//     change to where the repair happens goes red here; and
+//   - it pins the constant's text VERBATIM against that measurement, so the
+//     sentence cannot be reworded away from what was measured.
+//
+// A cosmetic reword fails this test on purpose. Pay it: when the note changes,
+// re-run the measurement below and re-type wantReadJSONNote from what you saw.
+func TestReadJSONNoteDescribesTheRepair(t *testing.T) {
+	body := "{\"items\":[{\"id\":7714,\"name\":\"" + crBodyModelName + "\",\"type\":\"Checkpoint\"," +
+		"\"creator\":{\"username\":\"lark\"},\"stats\":{}}],\"metadata\":{}}"
+
+	// (a) The HUMAN path. The old comment measured exit 1 and empty stdout here.
+	setupReadServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	out, _, err := run(t, "models", "search")
+	if err != nil {
+		t.Fatalf("a body carrying a raw CR inside a name must now succeed, got: %v", err)
+	}
+	if !strings.Contains(out, "SpeckledGrebe") {
+		t.Errorf("the repaired name should render (the CR removed by safeTerm):\n%s", out)
+	}
+
+	// (b) The --json path. The old comment said emitJSON is never entered.
+	setupReadServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	jsonOut, _, err := run(t, "models", "search", "--json")
+	if err != nil {
+		t.Fatalf("models search --json over the same body: %v", err)
+	}
+	if !json.Valid([]byte(jsonOut)) {
+		t.Fatalf("--json stdout does not parse — the whole note rests on this:\n%q", jsonOut)
+	}
+	// The document keeps the control character; the ENCODING is what changed.
+	var doc struct {
+		Items []struct {
+			Name string `json:"name"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &doc); err != nil {
+		t.Fatalf("decoding --json stdout: %v", err)
+	}
+	if len(doc.Items) != 1 || doc.Items[0].Name != crBodyModelName {
+		t.Fatalf("--json changed the DOCUMENT, not just the encoding: %+v", doc)
+	}
+	if !strings.Contains(jsonOut, `\r`) {
+		t.Errorf("the escape the note promises is absent from stdout:\n%s", jsonOut)
+	}
+
+	// (c) The note, pinned verbatim against what (a) and (b) just measured.
+	if readJSONNote != wantReadJSONNote {
+		t.Errorf("readJSONNote no longer matches the measured behaviour.\n"+
+			"If you changed the WORDING: re-run this test's (a)/(b) measurements and\n"+
+			"re-type wantReadJSONNote from what you saw — do not just paste the new note.\n"+
+			"If you changed the BEHAVIOUR: (a)/(b) above are what the note claims; fix\n"+
+			"the note and its doc comment before this line.\ngot:\n%s\nwant:\n%s",
+			readJSONNote, wantReadJSONNote)
+	}
+}
+
+// TestReadJSONNoteCommentNamesItsGuard keeps the doc comment and the guard
+// attached to each other. It does NOT check that the comment is TRUE — no test
+// can — but it makes the next person to rewrite the paragraph carry the pointer
+// to the thing that re-measures it, which is what was missing when the previous
+// paragraph went stale.
+func TestReadJSONNoteCommentNamesItsGuard(t *testing.T) {
+	const guard = "TestReadJSONNoteDescribesTheRepair"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "read_help.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot parse read_help.go: %v", err)
+	}
+	found := false
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST || gd.Doc == nil {
+			continue
+		}
+		names := ""
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				names += n.Name
+			}
+		}
+		if !strings.Contains(names, "readJSONNote") {
+			continue
+		}
+		found = true
+		if !strings.Contains(gd.Doc.Text(), guard) {
+			t.Errorf("readJSONNote's doc comment does not name %s, the test that\n"+
+				"re-measures what it claims. The previous paragraph named no guard and\n"+
+				"was false in every clause for a full release.", guard)
+		}
+	}
+	// Positive control: a parser that matched nothing must fail, not pass with a
+	// reassuring zero findings.
+	if !found {
+		t.Fatalf("CONTROL failure, not a finding: no documented const declaration " +
+			"named readJSONNote was found in read_help.go")
+	}
+}

--- a/internal/cmd/read_r2_test.go
+++ b/internal/cmd/read_r2_test.go
@@ -104,16 +104,12 @@ func TestEmitJSONValidInputUnchanged(t *testing.T) {
 	}
 }
 
-// TestEscapeJSONStringControlCharsLeavesStructuralWhitespace ensures control
-// bytes OUTSIDE string literals (newlines/tabs between tokens, which are valid
-// JSON whitespace) are not molested.
-func TestEscapeJSONStringControlCharsLeavesStructuralWhitespace(t *testing.T) {
-	raw := []byte("{\n\t\"a\": 1\n}")
-	got := escapeJSONStringControlChars(raw)
-	if !bytes.Equal(got, raw) {
-		t.Fatalf("structural whitespace altered:\n got %q\nwant %q", got, raw)
-	}
-}
+// The structural-whitespace guard that used to sit here was a byte-identical
+// copy of pkg/civitai's TestEscapeJSONStringControlCharsLeavesStructuralWhitespace,
+// reaching the same function through a one-line delegating wrapper that existed
+// only so this file compiled. Both are gone; emitJSON calls
+// civitai.EscapeJSONStringControlChars directly and the guard lives with the
+// implementation it guards.
 
 // TestCheckLimitExplicitZeroRejected drives the bindReadFlags PreRunE guard:
 // an explicit `--limit 0` must be a usage error (exit code 2), while an UNSET

--- a/internal/saferune/saferune.go
+++ b/internal/saferune/saferune.go
@@ -20,17 +20,33 @@
 // (structural, over every call site) and TestSameBytesTypedAndReceived_AreEchoedAndStripped
 // (behavioural, the same bytes typed and received).
 //
-// 🔴 IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE TWO PACKAGES ASK THE SAME
+// 🔴 IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE THREE PACKAGES ASK THE SAME
 // QUESTION AND MUST NOT ANSWER IT DIFFERENTLY. `internal/cmd`'s safeTerm asks
 // "may this rune reach the terminal"; `internal/genapi`'s hasPrintableContent
 // asks "would this string still say anything once a renderer has removed the
-// runes it removes". The second is the first one's complement, and before #393
-// they were answered by two tables that disagreed: safeTerm stripped C0/C1
+// runes it removes"; `pkg/civitai`'s snippet asks "what may an ERROR STRING
+// carry", because cmd/civitai/main.go prints `Error: <err>` to stderr with no
+// renderer in front of it. The second is the first one's complement, and before
+// #393 they were answered by two tables that disagreed: safeTerm stripped C0/C1
 // while hasPrintableContent used unicode.IsControl, which is Cc-only, so a
 // reason made entirely of U+200B counted as content and rendered as
 // `(the server reported: )` — an empty parenthetical. `internal/genapi` cannot
 // import `internal/cmd` (the import runs the other way), so the shared answer
 // lives below them both.
+//
+// The third question arrived with civitai/cli#526's follow-up and this sentence
+// still said TWO for the length of that branch. The count and the call-site set
+// are now a bidirectional ledger — the repo-root TestSaferuneCallersAreLedgered
+// fails when the set grows OR shrinks, and requires this paragraph and
+// AGENTS.md's Layout entry to name every caller in it. Adding a fourth caller is
+// a decision about the class, so it is meant to make you edit this text.
+//
+// 🔴 A CALLER IS NOT AUTOMATICALLY ENTITLED TO THE UNCONDITIONAL STRIP. snippet
+// qualifies because every argument it is ever given is the server's own bytes;
+// the rule at the top of this comment — never what the user typed — binds a new
+// caller exactly as hard. See pkg/civitai's snippet doc comment for the layering
+// cost that answer carries, and claudedocs/decisions/38-read-body-repair-and-snippet.md
+// for the two alternatives that were rejected.
 //
 // # THE CLASS
 //

--- a/pkg/civitai/apps.go
+++ b/pkg/civitai/apps.go
@@ -77,8 +77,10 @@ type AppCard struct {
 	KindData      AppCardKindData     `json:"kindData"`
 }
 
-// AppSearchResult bundles the parsed cards + pagination metadata with the raw
-// response body (for --json passthrough). It uses the shared Metadata type —
+// AppSearchResult bundles the parsed cards + pagination metadata with the body
+// that decoded, for --json passthrough. Raw is NOT promised to be the server's
+// own bytes: see EscapeJSONStringControlChars for the one case where it is the
+// repaired body instead. It uses the shared Metadata type —
 // exactly like every other Search* result — so CursorString + printPageFooter
 // work unchanged; the apps endpoint populates only nextCursor/nextPage on it
 // (keyset cursor pagination, no page/offset).

--- a/pkg/civitai/articles.go
+++ b/pkg/civitai/articles.go
@@ -76,7 +76,9 @@ type ArticleDetail struct {
 }
 
 // ArticleSearchResult bundles the parsed items + pagination metadata with the
-// raw response body (for --json passthrough).
+// body that decoded, for --json passthrough. Raw is NOT promised to be the
+// server's own bytes: see EscapeJSONStringControlChars for the one case where it
+// is the repaired body instead.
 type ArticleSearchResult struct {
 	Items    []ArticleListItem `json:"items"`
 	Metadata Metadata          `json:"metadata"`

--- a/pkg/civitai/articles.go
+++ b/pkg/civitai/articles.go
@@ -71,7 +71,11 @@ type ArticleDetail struct {
 	Stats       *ArticleDetailStats `json:"stats"`
 	// Content is the article body as sanitized HTML (the TipTap/ProseMirror
 	// output). `articles get --content` renders it to readable plain text /
-	// lightweight markdown; --json still returns the raw body untouched.
+	// lightweight markdown; --json does NOT render it — the HTML reaches stdout
+	// as the API wrote it. ("Untouched" is what this used to say and it was a
+	// byte claim, which is a different and false one: --json re-indents the
+	// document, and a body that would not decode is repaired first. Neither
+	// changes the HTML string; both make byte-identity false.)
 	Content string `json:"content"`
 }
 

--- a/pkg/civitai/collections.go
+++ b/pkg/civitai/collections.go
@@ -53,7 +53,9 @@ type CollectionDetail struct {
 }
 
 // CollectionSearchResult bundles the parsed items + pagination metadata with the
-// raw response body (for --json passthrough).
+// body that decoded, for --json passthrough. Raw is NOT promised to be the
+// server's own bytes: see EscapeJSONStringControlChars for the one case where it
+// is the repaired body instead.
 type CollectionSearchResult struct {
 	Items    []CollectionListItem `json:"items"`
 	Metadata Metadata             `json:"metadata"`

--- a/pkg/civitai/flexstring_test.go
+++ b/pkg/civitai/flexstring_test.go
@@ -285,9 +285,19 @@ func TestSearchImagesDecodesANumericUsername(t *testing.T) {
 	if got := string(res.Items[1].Username); got != "quilted-heron" {
 		t.Errorf("string username decoded to %q, want %q", got, "quilted-heron")
 	}
-	// Raw is what --json emits, and it must still be the server's own bytes.
+	// Raw is what --json emits, and it must still carry the number UNQUOTED.
+	//
+	// This is a claim about the DOCUMENT, not about the bytes: an earlier
+	// revision said "it must still be the server's own bytes" and "--json is a
+	// raw passthrough", which is the same false byte-identity claim this branch
+	// corrected in internal/cmd/numeric_username_test.go and on every Raw field's
+	// doc comment. Raw is the body that DECODED — a body the API sent with a raw
+	// control byte inside a string is repaired first (EscapeJSONStringControlChars),
+	// and emitJSON re-indents on the way to stdout. Neither touches the digits
+	// below; both make byte-identity false.
 	if !strings.Contains(string(res.Raw), `"username":`+reportedUsername) {
-		t.Errorf("Raw no longer carries the server's unquoted username — --json is a raw passthrough:\n%s", res.Raw)
+		t.Errorf("Raw no longer carries the server's unquoted username — FlexString "+
+			"re-quoted it, or something marshalled the struct:\n%s", res.Raw)
 	}
 }
 

--- a/pkg/civitai/hashes.go
+++ b/pkg/civitai/hashes.go
@@ -92,11 +92,18 @@ func isSHA256Hex(s string) bool {
 }
 
 // postInto POSTs body (JSON-encoded) to path and, on a 2xx, unmarshals the
-// response into out (when non-nil), returning the raw body. It mirrors getInto:
-// the same readError status classification, the same maxBody cap, and the same
-// bounded transient-failure retry/backoff via getWithRetry. Retry is safe here
-// because the by-hash lookup is idempotent and the build closure re-creates the
-// body reader on every attempt.
+// response into out (when non-nil), returning the body. It mirrors getInto: the
+// same readError status classification, the same maxBody cap, the same bounded
+// transient-failure retry/backoff via getWithRetry, and — through the shared
+// decodeBody — the same raw-control-byte repair and the same failure message.
+// Retry is safe here because the by-hash lookup is idempotent and the build
+// closure re-creates the body reader on every attempt.
+//
+// The last of those four is shared CODE rather than a parallel copy on purpose:
+// see decodeBody. It is currently unobservable on this route — a HashMatch is
+// two ints and a 64-char hex, with no free-text field the API could put a
+// control byte in — so mirroring here buys no fix today; it buys that the
+// enumeration above cannot go stale the day this route returns a name.
 func (c *Client) postInto(ctx context.Context, path string, body, out any) ([]byte, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -118,10 +125,5 @@ func (c *Client) postInto(ctx context.Context, path string, body, out any) ([]by
 	if status < 200 || status >= 300 {
 		return nil, readError(status, raw)
 	}
-	if out != nil {
-		if err := json.Unmarshal(raw, out); err != nil {
-			return nil, fmt.Errorf("unexpected response from %s (status %d): %s", path, status, snippet(raw))
-		}
-	}
-	return raw, nil
+	return decodeBody(path, status, raw, out)
 }

--- a/pkg/civitai/images.go
+++ b/pkg/civitai/images.go
@@ -204,8 +204,10 @@ func (im ImageItem) ParseMeta() (ImageMeta, MetaState) {
 	return m, MetaOK
 }
 
-// ImageSearchResult bundles the parsed items + pagination metadata with the raw
-// response body (for --json passthrough).
+// ImageSearchResult bundles the parsed items + pagination metadata with the
+// body that decoded, for --json passthrough. Raw is NOT promised to be the
+// server's own bytes: see EscapeJSONStringControlChars for the one case where it
+// is the repaired body instead.
 type ImageSearchResult struct {
 	Items    []ImageItem `json:"items"`
 	Metadata Metadata    `json:"metadata"`

--- a/pkg/civitai/models.go
+++ b/pkg/civitai/models.go
@@ -54,8 +54,10 @@ type ModelDetail struct {
 	ModelVersions []ModelVersionSummary `json:"modelVersions"`
 }
 
-// ModelSearchResult bundles the parsed items + pagination metadata with the raw
-// response body (for --json passthrough).
+// ModelSearchResult bundles the parsed items + pagination metadata with the
+// body that decoded, for --json passthrough. Raw is NOT promised to be the
+// server's own bytes: see EscapeJSONStringControlChars for the one case where it
+// is the repaired body instead.
 type ModelSearchResult struct {
 	Items    []ModelListItem `json:"items"`
 	Metadata Metadata        `json:"metadata"`

--- a/pkg/civitai/raw_doc_ledger_test.go
+++ b/pkg/civitai/raw_doc_ledger_test.go
@@ -1,0 +1,179 @@
+package civitai
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// rawBearingTypes is the LEDGER of exported result types carrying a `Raw
+// []byte` field. It fails in BOTH directions: a new result type that exposes
+// Raw and is not listed (the set grew — it needs the disclaimer too), and a
+// listed type that no longer has the field (the set shrank — this ledger and
+// getInto's cross-reference have gone stale).
+//
+// It is a ledger and not a count because a count is tradeable: delete one
+// type's row and add another's and the number does not move.
+var rawBearingTypes = []string{
+	"AppSearchResult",
+	"ArticleSearchResult",
+	"CollectionSearchResult",
+	"CreatorSearchResult",
+	"ImageSearchResult",
+	"ModelSearchResult",
+	"TagSearchResult",
+	"UserSearchResult",
+}
+
+// rawDisclaimer is the sentence every one of those types must carry. It is the
+// wording civitai/cli#526's follow-up put on CollectionSearchResult and
+// ArticleSearchResult; this test is what makes the other six say it too.
+const rawDisclaimer = "NOT promised to be the server's own bytes"
+
+// TestRawDocCommentsDisclaimByteIdentity is round 3's finding 1.
+//
+// 🔴 A CROSS-REFERENCE IS ONLY AS TRUE AS ITS REFERENTS, AND THIS ONE WAS TRUE
+// OF TWO OUT OF EIGHT. getInto's doc comment says the bytes it returns are the
+// REPAIRED body and points the reader at "the note on Raw in the result types".
+// That note was written on two of the eight types that have a Raw field; the
+// other six still said Raw was "the raw response body" / "the raw body", which
+// is the byte-identity claim the same branch was correcting everywhere else.
+// The evidence file went further and asserted the sweep was CLOSED at three
+// sites; at least seven more were live.
+//
+// The fix for a claim nothing asserts on is not a better sentence. This is the
+// assertion: every type in the ledger must carry the disclaimer, and the ledger
+// must be exactly the set of types that have the field.
+//
+// 🔴 WHAT THIS DOES **NOT** COVER, STATED SO IT IS NOT READ AS WIDER THAN IT IS:
+//
+//   - The DETAIL getters (GetModel, GetArticle, GetCollection, GetApp,
+//     GetModelVersion, GetModelVersionByHash) return raw bytes as a bare second
+//     `[]byte` return value, not as a struct field. They have no doc-comment
+//     slot this test can find, and they are not checked.
+//   - Narrative prose elsewhere in the package — "preserved for --json via the
+//     raw body" on ModelDetail, ArticleDetail, ImageItem and friends — is a claim
+//     about FIELD preservation (a key the struct does not model survives into
+//     --json), which is true, and is deliberately left alone. A future comment
+//     that phrases a BYTE claim in a place this test does not read is not
+//     caught. That residual is why the enumeration in
+//     claudedocs/decisions/38-read-body-repair-and-snippet.md is written as open
+//     rather than as a closed count.
+func TestRawDocCommentsDisclaimByteIdentity(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	files := 0
+	docs := map[string]string{}
+	var found []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if perr != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, perr)
+		}
+		files++
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
+					continue
+				}
+				if !hasRawBytesField(st) {
+					continue
+				}
+				found = append(found, ts.Name.Name)
+				// A `type ( … )` block shares one doc comment; a lone `type X
+				// struct` carries it on the GenDecl. Accept either.
+				doc := ""
+				if ts.Doc != nil {
+					doc = ts.Doc.Text()
+				} else if gd.Doc != nil {
+					doc = gd.Doc.Text()
+				}
+				docs[ts.Name.Name] = doc
+			}
+		}
+	}
+
+	// POSITIVE CONTROLS, before any verdict. A parser that walked nothing, or
+	// matched no type, reports a reassuring zero that is indistinguishable from
+	// "everything is fine".
+	if files < 5 {
+		t.Fatalf("CONTROL failure, not a finding: parsed only %d non-test source files "+
+			"in pkg/civitai — the scan is not reading the package", files)
+	}
+	if len(found) < len(rawBearingTypes) {
+		t.Fatalf("CONTROL failure, not a finding: found %d types with a `Raw []byte` "+
+			"field, expected at least %d. Either the field detector is broken or a "+
+			"result type stopped exposing Raw.", len(found), len(rawBearingTypes))
+	}
+
+	sort.Strings(found)
+	want := append([]string(nil), rawBearingTypes...)
+	sort.Strings(want)
+	if strings.Join(found, ",") != strings.Join(want, ",") {
+		t.Errorf("types with a `Raw []byte` field are %v, ledgered as %v.\n"+
+			"GREW: a new result type exposes Raw — give it the disclaimer and add it here.\n"+
+			"SHRANK: a type dropped the field — getInto's \"see the note on Raw in the\n"+
+			"        result types\" now points at one fewer referent.",
+			found, want)
+	}
+
+	for _, name := range want {
+		doc, ok := docs[name]
+		if !ok {
+			continue // already reported by the ledger comparison above
+		}
+		// Match on WHITESPACE-NORMALISED text. A doc comment is hard-wrapped, so
+		// the sentence lands with a newline at a different word in every file —
+		// a raw Contains reports "missing" for six comments that carry it, which
+		// is the instrument lying, not a finding. (Measured: it did exactly that
+		// on the first run of this test.)
+		if !strings.Contains(strings.Join(strings.Fields(doc), " "), rawDisclaimer) {
+			t.Errorf("%s's doc comment does not carry %q.\n"+
+				"Raw is the body that DECODED, which is the REPAIRED body when the wire\n"+
+				"body would not decode (EscapeJSONStringControlChars). Six of these eight\n"+
+				"comments claimed byte identity for a full branch while the same branch\n"+
+				"was correcting the claim elsewhere.\ngot:\n%s",
+				name, rawDisclaimer, doc)
+		}
+	}
+}
+
+// hasRawBytesField reports whether st declares a field named Raw of type []byte.
+func hasRawBytesField(st *ast.StructType) bool {
+	for _, fld := range st.Fields.List {
+		at, ok := fld.Type.(*ast.ArrayType)
+		if !ok || at.Len != nil {
+			continue
+		}
+		id, ok := at.Elt.(*ast.Ident)
+		if !ok || id.Name != "byte" {
+			continue
+		}
+		for _, n := range fld.Names {
+			if n.Name == "Raw" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/civitai/raw_doc_ledger_test.go
+++ b/pkg/civitai/raw_doc_ledger_test.go
@@ -120,10 +120,19 @@ func TestRawDocCommentsDisclaimByteIdentity(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: parsed only %d non-test source files "+
 			"in pkg/civitai — the scan is not reading the package", files)
 	}
-	if len(found) < len(rawBearingTypes) {
-		t.Fatalf("CONTROL failure, not a finding: found %d types with a `Raw []byte` "+
-			"field, expected at least %d. Either the field detector is broken or a "+
-			"result type stopped exposing Raw.", len(found), len(rawBearingTypes))
+	// 🔴 THIS IS A HARD FLOOR OF ONE, NOT A FLOOR OF len(rawBearingTypes), AND
+	// THE DIFFERENCE IS THE WHOLE POINT. It used to read
+	// `len(found) < len(rawBearingTypes)`, which fires on EVERY shrink — so a
+	// type that genuinely dropped its Raw field was reported as "CONTROL
+	// failure, not a finding" and the SHRANK guidance below was unreachable.
+	// The label was wrong in the one direction the ledger exists for. A floor of
+	// one still separates a broken detector (matches nothing at all) from a
+	// finding (matches fewer than ledgered), and the comparison below now owns
+	// every shrink.
+	if len(found) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: the `Raw []byte` field detector "+
+			"matched no type at all across %d parsed files — it is broken, or every "+
+			"result type dropped the field at once.", files)
 	}
 
 	sort.Strings(found)

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -257,7 +257,7 @@ func readError(status int, raw []byte) (err error) {
 			msg = wrapped.Message
 		}
 	}
-	// 🔴 THE CLASSIFIER READS wireMsg; ONLY THE DISPLAY READS msg. snippet()
+	// 🔴 THE CLASSIFIER READS classifyMsg; ONLY THE DISPLAY READS msg. snippet()
 	// removes runes (internal/saferune) and bounds length, and BOTH of those can
 	// change which substrings a matcher finds — a strip can JOIN two words into a
 	// phrase the server never sent, and the 500-byte bound can cut one in half.
@@ -265,7 +265,10 @@ func readError(status int, raw []byte) (err error) {
 	// decides a published exit code (item 7), so it is asked about what arrived,
 	// never about what will be printed. Pinned by
 	// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne.
-	wireMsg := msg
+	//
+	// classifyWindow bounds what the classifier scans; it is NOT the display
+	// budget and the two numbers are deliberately separate. See its doc comment.
+	classifyMsg := classifyWindow(msg)
 	msg = snippet([]byte(msg))
 	switch status {
 	case http.StatusUnauthorized:
@@ -290,7 +293,7 @@ func readError(status int, raw []byte) (err error) {
 		// usage error (ErrBadRequest → exit 2) so a scripter's generic 429
 		// backoff-and-retry loop doesn't spin on it, while a real throttle 429
 		// stays ErrRateLimited (exit 6). The visible message is unchanged.
-		if isDeepPagingCap(wireMsg) {
+		if isDeepPagingCap(classifyMsg) {
 			kind = ErrBadRequest
 		}
 		return fmt.Errorf("rate limited (429): %s — for deep paging use --cursor instead of --page", msg)
@@ -308,17 +311,68 @@ func readError(status int, raw []byte) (err error) {
 // 429 carries none of these phrases. The match is deliberately narrow so a real
 // rate-limit 429 is never misclassified as a usage error.
 //
-// 🔴 msg MUST BE THE WIRE MESSAGE, NOT snippet()'s OUTPUT. "Narrow" is a claim
-// about what the SERVER sent, and any transformation applied first can only
-// widen it: snippet strips Default_Ignorable runes, so one U+00AD inside "many"
-// in a proxy's throttle message is enough to synthesise "too many pages" out of
-// bytes the server never sent, and the exit code moves 6 → 2. See readError's
-// comment at the wireMsg assignment.
+// 🔴 msg MUST NOT BE snippet()'s OUTPUT. "Narrow" is a claim about what the
+// SERVER sent, and snippet applies TWO transformations that pull in OPPOSITE
+// directions — so "any transformation can only widen the match" is false, and
+// this comment said it until round 4. Both are wrong here:
+//
+//   - the STRIP can only WIDEN. It removes Default_Ignorable runes, so one
+//     U+00AD inside "many" in a proxy's throttle message is enough to synthesise
+//     "too many pages" out of bytes the server never sent: exit 6 → 2.
+//   - the 500-byte BOUND can only NARROW. A genuine cap message whose phrase
+//     sits past the display budget stops matching: exit 2 → 6, and a scripter's
+//     backoff loop spins on a structurally doomed request.
+//
+// What this function is given is the message readError extracted from the wire
+// body, bounded by classifyWindow — a budget that is NOT snippet's and exists
+// only to cap the scan. See readError's comment at the classifyMsg assignment.
 func isDeepPagingCap(msg string) bool {
 	m := strings.ToLower(msg)
 	return strings.Contains(m, "too many pages") ||
 		strings.Contains(m, "use cursors") ||
 		strings.Contains(m, "deep paging")
+}
+
+// maxClassifyMessage bounds how many bytes of a server-supplied error message
+// may be SCANNED to pick a classification. It is deliberately a different budget
+// from snippet's 500-byte DISPLAY bound: conflating them is what round 3 fixed
+// in the other direction (a display budget silently deciding an exit code).
+//
+// 🔴 WHY A BOUND EXISTS AT ALL. readError's `msg` is the server's `error`/
+// `message` field when the body is JSON and carries one — but when a 429 body is
+// not JSON, or is JSON without either key, `msg` is the ENTIRE body, capped only
+// by maxResponseBody (64 MiB). Classifying pre-snippet removed the 500-byte
+// bound the matcher used to inherit, so without this the ToLower copy and the
+// three Contains scans run over whatever arrived.
+//
+// 🔴 THE NUMBER IS GENEROUS, NOT DERIVED, AND IS STATED AS SUCH. The only cap
+// wording this repo records is the ~60-byte one in isDeepPagingCap's doc comment
+// above — which is that comment's claim, not a fresh measurement of the API. No
+// measurement here pins a largest LEGITIMATE 429 message, and none of the
+// proxy/CDN/captive-portal 429s readError also handles has been sampled for
+// length at all. 8 KiB is ~130x that recorded wording and ~16x the display
+// budget: large enough that no plausible cap message is cut, small enough that
+// an arbitrary body is not scanned in full. That is the whole justification —
+// it is containment, not a fix for an observed false positive, and none was
+// demonstrated.
+//
+// The visible consequence: a 429 whose cap phrase sits past 8 KiB is NOT
+// reclassified and keeps exit 6. Pinned by
+// TestDeepPagingCapClassificationIsBounded.
+const maxClassifyMessage = 8 << 10 // 8 KiB
+
+// classifyWindow returns the prefix of msg that a classifier may scan. It
+// truncates by BYTE and may therefore split a multi-byte rune — which is
+// harmless HERE, and is not the same as snippet's byte bound: this result feeds
+// a substring match and is never printed, so invalid UTF-8 at the cut cannot
+// reach a terminal. It can, in principle, split one of the matched phrases; that
+// is the same truncation effect the bound exists to accept, at 8 KiB instead of
+// 500 bytes.
+func classifyWindow(msg string) string {
+	if len(msg) > maxClassifyMessage {
+		return msg[:maxClassifyMessage]
+	}
+	return msg
 }
 
 // badRequestDetail extracts a concise, human-readable detail from a 400 response

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -97,8 +97,12 @@ func (c *Client) getRaw(ctx context.Context, path string, q url.Values) (int, []
 // strict RFC 8259 JSON syntax but are intermittently emitted by the Civitai API
 // inside prompt/description strings (civitai/cli#525) — are repaired by
 // EscapeJSONStringControlChars so typed decode succeeds. The returned bytes are
-// then the REPAIRED body, not the wire body; see the note on Raw in the result
-// types.
+// then the REPAIRED body, not the wire body — which is why every result type
+// with a `Raw []byte` field disclaims byte identity in its doc comment. That is
+// a cross-reference, so it is asserted rather than asked for:
+// TestRawDocCommentsDisclaimByteIdentity is a bidirectional ledger of those
+// types and requires the disclaimer on each. It was written because this
+// sentence pointed at eight referents and only two of them said it.
 //
 // 🔴 THE REPAIR IS A RETRY ON THE DECODE, NOT A PRE-PASS OVER EVERY BODY, AND
 // THE ORDER IS LOAD-BEARING IN THREE WAYS.
@@ -253,6 +257,15 @@ func readError(status int, raw []byte) (err error) {
 			msg = wrapped.Message
 		}
 	}
+	// 🔴 THE CLASSIFIER READS wireMsg; ONLY THE DISPLAY READS msg. snippet()
+	// removes runes (internal/saferune) and bounds length, and BOTH of those can
+	// change which substrings a matcher finds — a strip can JOIN two words into a
+	// phrase the server never sent, and the 500-byte bound can cut one in half.
+	// isDeepPagingCap is the one place in this package where the text of an error
+	// decides a published exit code (item 7), so it is asked about what arrived,
+	// never about what will be printed. Pinned by
+	// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne.
+	wireMsg := msg
 	msg = snippet([]byte(msg))
 	switch status {
 	case http.StatusUnauthorized:
@@ -277,7 +290,7 @@ func readError(status int, raw []byte) (err error) {
 		// usage error (ErrBadRequest → exit 2) so a scripter's generic 429
 		// backoff-and-retry loop doesn't spin on it, while a real throttle 429
 		// stays ErrRateLimited (exit 6). The visible message is unchanged.
-		if isDeepPagingCap(msg) {
+		if isDeepPagingCap(wireMsg) {
 			kind = ErrBadRequest
 		}
 		return fmt.Errorf("rate limited (429): %s — for deep paging use --cursor instead of --page", msg)
@@ -294,6 +307,13 @@ func readError(status int, raw []byte) (err error) {
 // requested too many pages, please use cursors instead"; a genuine throttle
 // 429 carries none of these phrases. The match is deliberately narrow so a real
 // rate-limit 429 is never misclassified as a usage error.
+//
+// 🔴 msg MUST BE THE WIRE MESSAGE, NOT snippet()'s OUTPUT. "Narrow" is a claim
+// about what the SERVER sent, and any transformation applied first can only
+// widen it: snippet strips Default_Ignorable runes, so one U+00AD inside "many"
+// in a proxy's throttle message is enough to synthesise "too many pages" out of
+// bytes the server never sent, and the exit code moves 6 → 2. See readError's
+// comment at the wireMsg assignment.
 func isDeepPagingCap(msg string) bool {
 	m := strings.ToLower(msg)
 	return strings.Contains(m, "too many pages") ||

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/civitai/cli/internal/saferune"
 )
 
 // Reader is the read surface of the public Civitai REST API (`/api/v1/**`).
@@ -89,11 +91,43 @@ func (c *Client) getRaw(ctx context.Context, path string, q url.Values) (int, []
 }
 
 // getInto GETs path+q, and on a 2xx unmarshals the body into out (when non-nil)
-// and returns the raw body (for --json). A non-2xx returns a readError.
+// and returns the body (for --json). A non-2xx returns a readError.
+//
 // Raw C0 control characters (0x00–0x1F) inside string literals — which violate
 // strict RFC 8259 JSON syntax but are intermittently emitted by the Civitai API
-// inside prompt/description strings — are sanitized via
-// EscapeJSONStringControlChars before unmarshaling so typed decode succeeds.
+// inside prompt/description strings (civitai/cli#525) — are repaired by
+// EscapeJSONStringControlChars so typed decode succeeds. The returned bytes are
+// then the REPAIRED body, not the wire body; see the note on Raw in the result
+// types.
+//
+// 🔴 THE REPAIR IS A RETRY ON THE DECODE, NOT A PRE-PASS OVER EVERY BODY, AND
+// THE ORDER IS LOAD-BEARING IN THREE WAYS.
+//
+//  1. COST. The first cut ran `json.Valid(raw)` over every successful body
+//     before unmarshalling it — a second full scan of bytes Unmarshal is about
+//     to walk anyway, on the happy path of an importable SDK rather than a
+//     one-shot CLI. The load-bearing half of that is STRUCTURAL, not measured:
+//     unmarshal-first does no extra work at all on a body that decodes, which
+//     is every body but the broken ones. The size of what was removed is one
+//     host's measurement and is quoted as such — a synthetic 1.50 MB /
+//     2185-item models page, go1.25, `-benchtime 300x -count=5`: json.Valid
+//     4.9–6.4 ms against json.Unmarshal 12.9–26.4 ms, so roughly a quarter to
+//     a half again on top of the decode. Do not treat that ratio as portable;
+//     the benchmark was scratch and is not in the tree.
+//  2. THE SNIPPET. `snippet(raw)` below is the only thing the user is shown
+//     when decode fails, and the pre-pass reassigned `raw` to the repaired
+//     bytes BEFORE it ran — so a body the server sent with a literal CR was
+//     reported as `Pony\rModel`, two printable characters, and README's
+//     "the text after the colon is the server's own body" was false. Here the
+//     reassignment happens only on the branch that succeeded, so the failure
+//     message still quotes what arrived.
+//  3. THE UNREPAIRABLE CASE. A body that is invalid for a reason the sanitizer
+//     cannot fix (a trailing comma, a truncated object) must reach the same
+//     error as before, with the ORIGINAL bytes in the snippet. That path is
+//     pinned by TestGetIntoUnrepairableBodyReportsTheOriginalBytes.
+//
+// out is non-nil at every call site today; a nil out therefore performs no
+// decode and no repair, and returns the wire bytes unchanged.
 func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any) ([]byte, error) {
 	status, raw, err := c.getRaw(ctx, path, q)
 	if err != nil {
@@ -102,15 +136,29 @@ func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any
 	if status < 200 || status >= 300 {
 		return nil, readError(status, raw)
 	}
-	if !json.Valid(raw) {
-		if fixed := EscapeJSONStringControlChars(raw); json.Valid(fixed) {
-			raw = fixed
-		}
+	return decodeBody(path, status, raw, out)
+}
+
+// decodeBody is the shared 2xx-body decode for getInto and postInto: it
+// unmarshals raw into out (when non-nil) and returns the bytes that decoded.
+//
+// 🔴 IT IS ONE FUNCTION BECAUSE THE TWO CALLERS MUST NOT ANSWER THIS
+// DIFFERENTLY. postInto's doc comment enumerates what it mirrors from getInto
+// (status classification, body cap, retry/backoff) and the control-byte repair
+// was, for one release, a fourth axis on which it silently did NOT — a
+// divergence no test could see because HashMatch carries no free text today.
+// Sharing the body makes the enumeration true by construction instead of by
+// prose. Both call sites are pinned by TestDecodeBodyIsSharedByGetIntoAndPostInto.
+func decodeBody(path string, status int, raw []byte, out any) ([]byte, error) {
+	if out == nil {
+		return raw, nil
 	}
-	if out != nil {
-		if err := json.Unmarshal(raw, out); err != nil {
+	if err := json.Unmarshal(raw, out); err != nil {
+		fixed := EscapeJSONStringControlChars(raw)
+		if json.Unmarshal(fixed, out) != nil {
 			return nil, fmt.Errorf("unexpected response from %s (status %d): %s", path, status, snippet(raw))
 		}
+		return fixed, nil
 	}
 	return raw, nil
 }
@@ -121,7 +169,13 @@ func (c *Client) getInto(ctx context.Context, path string, q url.Values, out any
 // \u00xx). Control bytes outside strings (structural whitespace) and everything
 // already escaped are left byte-for-byte unchanged, so valid input round-trips
 // identically. This does not attempt to repair other kinds of malformed JSON;
-// callers should verify the result with json.Valid before relying on it.
+// callers should verify the result with json.Valid, or by decoding it, before
+// relying on it.
+//
+// This is the ONE case in which a result type's Raw field is not the server's
+// own bytes. getInto applies this repair when — and only when — the wire body
+// fails to decode, so a body that decodes is passed through untouched, and a
+// body that does not is replaced by the repaired one that did.
 func EscapeJSONStringControlChars(raw []byte) []byte {
 	var out bytes.Buffer
 	out.Grow(len(raw))
@@ -425,10 +479,39 @@ func readResponseBody(body io.Reader, limit int64) ([]byte, error) {
 	return raw, nil
 }
 
-// snippet bounds an error/body string so a huge response can't flood the
-// terminal.
+// snippet renders SERVER-SUPPLIED bytes into the human-readable tail of an
+// error message: it removes the runes that must not reach a terminal, then
+// bounds the length so a huge response can't flood it.
+//
+// 🔴 EVERY ARGUMENT THIS FUNCTION IS EVER GIVEN IS THE SERVER'S OWN BYTES — the
+// 2xx body that failed to decode, the API's `{"error":…}`/`{"message":…}` text,
+// a zod issue out of a 400, a retry-exhaustion body, a FlexString value. None of
+// it is anything the user typed, which is what makes an unconditional strip
+// correct here and would make it wrong one layer up (internal/saferune's package
+// doc states that rule and what it costs; do not restate the class here).
+//
+// 🔴 IT STRIPS BECAUSE THE OUTPUT REACHES A RAW TERMINAL WITH NO OTHER GATE.
+// cmd/civitai/main.go prints `Error: <err>` straight to stderr — internal/cmd's
+// safeTerm sits on the HUMAN RENDERERS, not on the error path — so before this,
+// a 200 body containing `\x1b[1A\x1b[2K` could overwrite the CLI's own preceding
+// output from inside an error message. Truncating first would not have helped:
+// the escape needs a dozen bytes and the budget is 500.
+//
+// The strip runs BEFORE the bound so the 500 bytes are 500 bytes the user can
+// actually see, rather than a budget an invisible run can eat.
+//
+// 🔴 THE LAYERING COST, STATED RATHER THAN HIDDEN: this makes pkg/civitai — the
+// public SDK — depend on internal/saferune, and it means an SDK consumer that is
+// not a terminal sees an error string with those runes already removed. That was
+// chosen over the two alternatives. Filtering at the print site in
+// cmd/civitai/main.go would apply the class to EVERY error, including the ones
+// that echo what the user typed, which is exactly the regression civitai/cli#393
+// exists to prevent. Re-deriving the class inside pkg/civitai would be a second
+// table, which is the OTHER half of #393. The unaffected byte path is Raw: it is
+// returned to the caller unstripped, so nothing machine-readable passes through
+// here.
 func snippet(raw []byte) string {
-	s := strings.TrimSpace(string(raw))
+	s := strings.TrimSpace(saferune.Strip(string(raw)))
 	const max = 500
 	if len(s) > max {
 		return s[:max] + "…"

--- a/pkg/civitai/read.go
+++ b/pkg/civitai/read.go
@@ -345,16 +345,38 @@ func isDeepPagingCap(msg string) bool {
 // bound the matcher used to inherit, so without this the ToLower copy and the
 // three Contains scans run over whatever arrived.
 //
+// 🔴 IT IS A SEMANTIC BOUND, NOT RESOURCE CONTAINMENT, AND THIS COMMENT CLAIMED
+// THE SECOND. What it decides is which bytes may move a published exit code: a
+// cap phrase past 8 KiB no longer reclassifies a 429 from exit 6 to exit 2. That
+// is the consequence stated below and pinned by
+// TestDeepPagingCapClassificationIsBounded.
+//
+// It does NOT bound this function's footprint, because the very next statement
+// in readError — msg = snippet([]byte(msg)) — converts the whole message and
+// hands every byte of it to saferune.Strip, unconditionally and regardless of
+// this constant, on top of the string(raw) copy readError already made at entry.
+// Measured on this tree (go1.25.14, linux/amd64, `-bench -benchtime=20x
+// -count=3`, non-JSON 429 body): allocation is ~2x the body WITH the bound in
+// place — 67.1 MB/op for 32 MiB, 2.11 MB/op for 1 MiB.
+//
+// What it does bound is exactly ONE allocation: strings.ToLower(msg) in
+// isDeepPagingCap, which otherwise copies the whole message. Deleting
+// classifyWindow moved that same benchmark to 100.7 MB/op at 32 MiB and
+// 3.15 MB/op at 1 MiB — one extra full-body copy, ~3x rather than ~2x. That
+// difference is invisible to an all-lowercase ASCII fixture, because ToLower
+// returns its input and allocates nothing when there is nothing to fold; the
+// numbers above come from an all-uppercase body. NO WALL-TIME CLAIM IS MADE: the
+// direction was not even consistent across the four size/case pairs measured.
+//
 // 🔴 THE NUMBER IS GENEROUS, NOT DERIVED, AND IS STATED AS SUCH. The only cap
 // wording this repo records is the ~60-byte one in isDeepPagingCap's doc comment
 // above — which is that comment's claim, not a fresh measurement of the API. No
 // measurement here pins a largest LEGITIMATE 429 message, and none of the
 // proxy/CDN/captive-portal 429s readError also handles has been sampled for
 // length at all. 8 KiB is ~130x that recorded wording and ~16x the display
-// budget: large enough that no plausible cap message is cut, small enough that
-// an arbitrary body is not scanned in full. That is the whole justification —
-// it is containment, not a fix for an observed false positive, and none was
-// demonstrated.
+// budget: large enough that no plausible cap message is cut. That is the whole
+// justification — no false positive was ever demonstrated, and the 8192 is a
+// round number chosen above every message length anyone here has written down.
 //
 // The visible consequence: a 429 whose cap phrase sits past 8 KiB is NOT
 // reclassified and keeps exit 6. Pinned by

--- a/pkg/civitai/read_repair_test.go
+++ b/pkg/civitai/read_repair_test.go
@@ -20,37 +20,69 @@ import (
 // hole its shape opened, and — added in round 3 — the exit code the fix for
 // that hole moved.
 //
-// 🔴 THE MATRIX IS HERE, AND IT IS NOT UNIFORM. An earlier revision of this
-// header said "every test here is RED at 517fc76 and green at HEAD" and
-// deferred the matrix to the PR body. Both halves were wrong: one of the five
-// tests below is labelled in its own doc comment as an INVARIANT GUARD that
-// PASSES at 517fc76 — so the header contradicted an accurate label 100 lines
-// under it — and a PR body is not in the tree, so a reader of the file could
-// not check either claim. A test you have not watched fail proves nothing, and
-// a header that says you watched them all fail when you did not is the same
-// error one level up.
+// 🔴 THE MATRIX IS HERE, AND IT IS NOT UNIFORM. An early revision said "every
+// test here is RED at 517fc76 and green at HEAD" while one test below is
+// labelled in its own doc comment as an INVARIANT GUARD that PASSES there.
+// Round 3 replaced that with a matrix — and got the last row wrong in the
+// reassuring direction, by describing a measurement instead of running one.
 //
-// Measured by running this file against a `git archive 517fc76` tree, not
-// reasoned about:
+// 🔴 A COUNT IN THIS HEADER IS A CLAIM LIKE ANY OTHER, AND ROUND 3'S WAS WRONG:
+// it said "one of the FIVE tests below" over a file that already declared six.
+// So this header states no count. What it states instead is a MEMBERSHIP, and
+// TestReadRepairMatrixNamesEveryTestInThisFile enforces it: every test declared
+// in this file must appear by name in this comment. Add a test without a row and
+// that is red by name.
+//
+// The rows below were produced by extracting `git archive <ref>` (517fc76 for
+// the column, f936cfc for the round-3 test's other end) and copying THIS file
+// into it, minus the round-4 test — which names a constant neither tree
+// declares, so the package would not compile — then running
+// `go test ./pkg/civitai/`. Re-run it that way rather than inheriting this:
 //
 //	TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes   RED at 517fc76
+//	                                                              (2 assertions)
 //	TestReadErrorSnippetStripsTerminalControlRunes                RED at 517fc76
+//	                                                              (2 assertions)
 //	TestPostIntoRepairsControlBytesLikeGetInto                    RED at 517fc76
 //	TestDecodeBodyIsSharedByGetIntoAndPostInto                    RED at 517fc76
 //	TestGetIntoUnrepairableBodyReportsTheOriginalBytes            INVARIANT GUARD —
 //	                                                              PASSES at 517fc76;
 //	                                                              its value is the mutant
 //	TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne  see below
+//	TestDeepPagingCapClassificationIsBounded                      NOT RUNNABLE at
+//	                                                              517fc76; see below
+//	TestReadRepairMatrixNamesEveryTestInThisFile                  the guard on THIS
+//	                                                              matrix; no tree row
 //
-// The last one is a round-3 regression against THIS BRANCH, not against
-// 517fc76, and its row does not compress into the column above. Its subject is
-// the exit code that f936cfc — this branch's round-2 head — moved by classifying
-// a 429 on snippet()'s STRIPPED output: RED there, on the two classification
-// assertions. At 517fc76 it is ALSO red, but for the opposite reason and with
-// different assertions: that tree has no strip at all, so the classification
-// half passes and the two assertions that the DISPLAY is still filtered fail.
-// "Red at both ends, for opposite reasons" is the honest row; "red at 517fc76"
-// alone would read as regression coverage for a bug 517fc76 did not have.
+// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne is a round-3
+// regression against THIS BRANCH, not against 517fc76, so its row does not
+// compress into the column above. Round 3 described BOTH of its ends, and got
+// both descriptions wrong in the same way — by naming two failing assertions
+// where three fail. Re-run, per the recipe above:
+//
+//   - at f936cfc (this branch's round-2 head, which classified a 429 on
+//     snippet()'s STRIPPED output): THREE assertions fail — half (a)'s two
+//     CLASSIFICATION assertions, plus half (c)'s classification assertion, which
+//     that tree also fails because it reads snippet()'s TRUNCATED output. Round
+//     3 said "on the two classification assertions of half (a)".
+//   - at 517fc76 (no strip at all): THREE assertions fail — half (a)'s two
+//     DISPLAY assertions (U+00AD survives; the server's own words are absent,
+//     because the strip that would rejoin "ma"+"ny" does not exist there), plus
+//     half (c)'s classification assertion again. Round 3 said "the
+//     classification half passes and the two assertions that the DISPLAY is
+//     still filtered fail" — the second clause holds, the first does not:
+//     halves (a) and (b) classify correctly at 517fc76, half (c) does not.
+//
+// So: red at both ends, three assertions at each, overlapping in half (c) and
+// disjoint in half (a). "Red at 517fc76" alone would still read as regression
+// coverage for a bug 517fc76 did not have.
+//
+// TestDeepPagingCapClassificationIsBounded (round 4) cannot be run at 517fc76 at
+// all: it names maxClassifyMessage, which that tree does not declare, so the
+// package does not compile. Its matrix is against THIS tree instead — RED with
+// classifyWindow removed (the pre-round-4 shape, where the classifier scanned
+// the whole extracted message), green with it. That is stated as what it is: a
+// containment guard measured against a mutant, not against a shipped tree.
 //
 // 🔴 The fixture strings below are pairwise distinct and distinct from every
 // constant asserted on, so a mutant that hardcodes one literal cannot satisfy
@@ -327,6 +359,135 @@ func TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne(t *testing.T) 
 		t.Errorf("a deep-paging cap whose phrase falls past snippet's 500-byte "+
 			"display bound must still be reclassified (exit 2). The classifier is "+
 			"reading the truncated string:\n%q", err)
+	}
+}
+
+// TestDeepPagingCapClassificationIsBounded is round 4's containment guard for
+// the window the round-3 fix opened.
+//
+// 🔴 IT IS NOT A FIX FOR A DEMONSTRATED DEFECT, AND MUST NOT BE READ AS ONE.
+// No false positive was shown. What round 3 changed is the SIZE of the string
+// the matcher scans: before it, isDeepPagingCap saw snippet()'s 500 bytes; after
+// it, it saw readError's `msg`, which is the ENTIRE body whenever a 429 is not
+// JSON or is JSON without `error`/`message` — bounded only by maxResponseBody
+// (64 MiB). maxClassifyMessage is a named, separate budget for that scan.
+//
+// The pair below is the point. (a) alone would pass against a classifier wired
+// to nothing; (b) is the positive control that the same fixture shape, with the
+// phrase moved INSIDE the window, still reclassifies — so (a) is about the
+// BOUND and not about a phrase that never matched.
+//
+// The filler word is distinct from every other fixture in this file and from
+// every phrase isDeepPagingCap matches.
+func TestDeepPagingCapClassificationIsBounded(t *testing.T) {
+	const capPhrase = "you have requested too many pages"
+	body := func(padBytes int) string {
+		pad := strings.Repeat("lattice ", (padBytes/8)+1)
+		return `{"message":"` + pad + capPhrase + `"}`
+	}
+
+	// (a) The phrase sits PAST the classification window.
+	outside := body(maxClassifyMessage + 512)
+	// CONTROL on the fixture: the phrase must genuinely fall past the window, or
+	// this asserts nothing. The window is applied to the extracted message, so
+	// measure the offset inside the message, not inside the body.
+	if idx := strings.Index(outside, capPhrase); idx <= maxClassifyMessage {
+		t.Fatalf("CONTROL failure, not a finding: the cap phrase starts at byte %d, "+
+			"which is inside the %d-byte classification window — (a) would assert "+
+			"nothing", idx, maxClassifyMessage)
+	}
+	c := serveOnce(t, http.StatusTooManyRequests, outside)
+	_, err := c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it half (a) asserts on nothing")
+	}
+	if errors.Is(err, ErrBadRequest) {
+		t.Errorf("a 429 whose cap phrase sits past maxClassifyMessage (%d bytes) was "+
+			"reclassified — the classifier is scanning the whole body, which for a "+
+			"non-JSON 429 is bounded only by maxResponseBody:\n%q", maxClassifyMessage, err)
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("a 429 the classifier cannot see the cap phrase in must keep "+
+			"ErrRateLimited (exit 6):\n%q", err)
+	}
+
+	// (b) POSITIVE CONTROL: the same shape, phrase inside the window.
+	inside := body(64)
+	if idx := strings.Index(inside, capPhrase); idx > maxClassifyMessage {
+		t.Fatalf("CONTROL failure, not a finding: the control fixture's phrase is at "+
+			"byte %d, past the %d-byte window — the two arms are not the same shape",
+			idx, maxClassifyMessage)
+	}
+	c = serveOnce(t, http.StatusTooManyRequests, inside)
+	_, err = c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it half (b) asserts on nothing")
+	}
+	if !errors.Is(err, ErrBadRequest) {
+		t.Errorf("CONTROL failure: the SAME fixture shape with the phrase inside the "+
+			"window is not reclassified, so half (a) proves nothing about the bound — "+
+			"it would pass against a classifier that never matches:\n%q", err)
+	}
+}
+
+// matrixMarker is a phrase from this file's header comment, used to find that
+// comment group rather than the first one in the file.
+const matrixMarker = "THE MATRIX IS HERE"
+
+// TestReadRepairMatrixNamesEveryTestInThisFile is round 4's guard on the header
+// above.
+//
+// 🔴 THE HEADER HAS MISDESCRIBED ITS OWN CONTENTS IN EVERY ROUND SO FAR — "every
+// test here is RED at 517fc76" when one is an invariant guard, then "one of the
+// five tests below" over six, then a row for the round-3 test that disagreed
+// with what running it prints. Two of those three are membership or count
+// errors, and both are mechanical. This makes them red.
+//
+// It asserts MEMBERSHIP, not a count, and not the content of a row: a row can
+// still say something false about a tree (that is what re-running the
+// measurement is for), but a test cannot be added to this file without one.
+func TestReadRepairMatrixNamesEveryTestInThisFile(t *testing.T) {
+	const self = "read_repair_test.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, self, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", self, err)
+	}
+	header := ""
+	for _, cg := range f.Comments {
+		if strings.Contains(cg.Text(), matrixMarker) {
+			header = cg.Text()
+			break
+		}
+	}
+	// POSITIVE CONTROL on the extraction: an empty header makes every name below
+	// "missing" for the wrong reason.
+	if header == "" {
+		t.Fatalf("CONTROL failure, not a finding: no comment in %s contains %q — "+
+			"this test cannot find the matrix it guards", self, matrixMarker)
+	}
+	var names []string
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv != nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+			continue
+		}
+		names = append(names, fd.Name.Name)
+	}
+	// POSITIVE CONTROL on the SCAN: zero test declarations found is
+	// indistinguishable from "every one of them is named".
+	if len(names) < 5 {
+		t.Fatalf("CONTROL failure, not a finding: found only %d test declarations in "+
+			"%s — the scan is not reading the file", len(names), self)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if strings.Contains(header, n) {
+			continue
+		}
+		t.Errorf("%s declares %s, and the matrix in this file's header does not name "+
+			"it.\nA test with no row is a test nobody watched fail: give it a row saying "+
+			"what it is RED against, or say plainly that it is an invariant guard.", self, n)
 	}
 }
 

--- a/pkg/civitai/read_repair_test.go
+++ b/pkg/civitai/read_repair_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -381,22 +382,28 @@ func TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne(t *testing.T) 
 // every phrase isDeepPagingCap matches.
 func TestDeepPagingCapClassificationIsBounded(t *testing.T) {
 	const capPhrase = "you have requested too many pages"
-	body := func(padBytes int) string {
-		pad := strings.Repeat("lattice ", (padBytes/8)+1)
-		return `{"message":"` + pad + capPhrase + `"}`
+	// 🔴 THE TWO STRINGS ARE KEPT APART ON PURPOSE. classifyWindow is applied to
+	// the MESSAGE readError extracts, never to the wire body, so an offset
+	// measured in the body is 12 bytes — the `{"message":"` prefix — larger than
+	// the one the bound acts on. The controls below measured the body while their
+	// own comment said message; the slack happened to point the safe way, which is
+	// how it stayed unnoticed. message() is what the bound sees; body() is only
+	// the envelope that delivers it.
+	message := func(padBytes int) string {
+		return strings.Repeat("lattice ", (padBytes/8)+1) + capPhrase
 	}
+	body := func(msg string) string { return `{"message":"` + msg + `"}` }
 
 	// (a) The phrase sits PAST the classification window.
-	outside := body(maxClassifyMessage + 512)
+	outsideMsg := message(maxClassifyMessage + 512)
 	// CONTROL on the fixture: the phrase must genuinely fall past the window, or
-	// this asserts nothing. The window is applied to the extracted message, so
-	// measure the offset inside the message, not inside the body.
-	if idx := strings.Index(outside, capPhrase); idx <= maxClassifyMessage {
-		t.Fatalf("CONTROL failure, not a finding: the cap phrase starts at byte %d, "+
-			"which is inside the %d-byte classification window — (a) would assert "+
-			"nothing", idx, maxClassifyMessage)
+	// this asserts nothing.
+	if idx := strings.Index(outsideMsg, capPhrase); idx <= maxClassifyMessage {
+		t.Fatalf("CONTROL failure, not a finding: the cap phrase starts at byte %d of "+
+			"the extracted message, which is inside the %d-byte classification window "+
+			"— (a) would assert nothing", idx, maxClassifyMessage)
 	}
-	c := serveOnce(t, http.StatusTooManyRequests, outside)
+	c := serveOnce(t, http.StatusTooManyRequests, body(outsideMsg))
 	_, err := c.SearchModels(context.Background(), url.Values{})
 	if err == nil {
 		t.Fatal("a 429 must be an error; without it half (a) asserts on nothing")
@@ -411,14 +418,17 @@ func TestDeepPagingCapClassificationIsBounded(t *testing.T) {
 			"ErrRateLimited (exit 6):\n%q", err)
 	}
 
-	// (b) POSITIVE CONTROL: the same shape, phrase inside the window.
-	inside := body(64)
-	if idx := strings.Index(inside, capPhrase); idx > maxClassifyMessage {
-		t.Fatalf("CONTROL failure, not a finding: the control fixture's phrase is at "+
-			"byte %d, past the %d-byte window — the two arms are not the same shape",
-			idx, maxClassifyMessage)
+	// (b) POSITIVE CONTROL: the same shape, phrase inside the window. Measured in
+	// the message, for the same reason as (a); the phrase must fit ENTIRELY inside
+	// the window, since classifyWindow cuts by byte and a split phrase matches
+	// nothing.
+	insideMsg := message(64)
+	if idx := strings.Index(insideMsg, capPhrase); idx+len(capPhrase) > maxClassifyMessage {
+		t.Fatalf("CONTROL failure, not a finding: the control fixture's phrase ends at "+
+			"byte %d of the extracted message, past the %d-byte window — the two arms "+
+			"are not the same shape", idx+len(capPhrase), maxClassifyMessage)
 	}
-	c = serveOnce(t, http.StatusTooManyRequests, inside)
+	c = serveOnce(t, http.StatusTooManyRequests, body(insideMsg))
 	_, err = c.SearchModels(context.Background(), url.Values{})
 	if err == nil {
 		t.Fatal("a 429 must be an error; without it half (b) asserts on nothing")
@@ -434,6 +444,12 @@ func TestDeepPagingCapClassificationIsBounded(t *testing.T) {
 // comment group rather than the first one in the file.
 const matrixMarker = "THE MATRIX IS HERE"
 
+// matrixIdentRe matches a Go test-function identifier as written in the header's
+// prose, so the membership check below can compare NAMES rather than substrings.
+// It is the same shape as internal/cmd's testIdentRe, re-declared because that
+// one lives in another package; keep the two in step if either changes.
+var matrixIdentRe = regexp.MustCompile(`\bTest[A-Za-z0-9_]*\b`)
+
 // TestReadRepairMatrixNamesEveryTestInThisFile is round 4's guard on the header
 // above.
 //
@@ -446,6 +462,25 @@ const matrixMarker = "THE MATRIX IS HERE"
 // It asserts MEMBERSHIP, not a count, and not the content of a row: a row can
 // still say something false about a tree (that is what re-running the
 // measurement is for), but a test cannot be added to this file without one.
+//
+// 🔴 MEMBERSHIP WAS A SUBSTRING TEST, WHICH IS NOT A NAME TEST. It asked whether
+// the header CONTAINS each declared name, so any test whose name is a strict
+// PREFIX of a name already in the matrix satisfied it with no row of its own.
+// This file's naming makes that the likely next edit rather than a contrived
+// one: TestDeepPagingCapClassificationIsBounded and
+// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne agree on their
+// first 25 characters, and TestGetIntoUnrepairableBodyReportsTheOriginalBytes
+// and TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes on their
+// first 11. Measured: declaring a test named
+// TestDeepPagingCapClassificationIsBounded with the trailing "IsBounded"
+// removed — a name in the file that nothing in the header names, but that is a
+// strict prefix of one the header does — left this guard green. It now extracts
+// the header's identifiers with matrixIdentRe and compares them EXACTLY, so a
+// prefix is a different name.
+//
+// The mutant is described that way rather than spelled out because
+// internal/cmd's TestItem38CommentsCiteTestsThatExist reads this comment and
+// would, correctly, report a name nothing declares as a dangling citation.
 func TestReadRepairMatrixNamesEveryTestInThisFile(t *testing.T) {
 	const self = "read_repair_test.go"
 	fset := token.NewFileSet()
@@ -466,6 +501,17 @@ func TestReadRepairMatrixNamesEveryTestInThisFile(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: no comment in %s contains %q — "+
 			"this test cannot find the matrix it guards", self, matrixMarker)
 	}
+	named := map[string]bool{}
+	for _, ident := range matrixIdentRe.FindAllString(header, -1) {
+		named[ident] = true
+	}
+	// POSITIVE CONTROL on the EXTRACTION: a header the regex found no identifiers
+	// in makes every name below "missing" for the wrong reason, exactly as an
+	// empty header would.
+	if len(named) < 5 {
+		t.Fatalf("CONTROL failure, not a finding: matrixIdentRe found only %d test "+
+			"names in %s's matrix header — the extraction is not reading it", len(named), self)
+	}
 	var names []string
 	for _, decl := range f.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
@@ -482,7 +528,7 @@ func TestReadRepairMatrixNamesEveryTestInThisFile(t *testing.T) {
 	}
 	sort.Strings(names)
 	for _, n := range names {
-		if strings.Contains(header, n) {
+		if named[n] {
 			continue
 		}
 		t.Errorf("%s declares %s, and the matrix in this file's header does not name "+

--- a/pkg/civitai/read_repair_test.go
+++ b/pkg/civitai/read_repair_test.go
@@ -2,6 +2,7 @@ package civitai
 
 import (
 	"context"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -15,11 +16,41 @@ import (
 )
 
 // This file is the follow-up to civitai/cli#526's audit. #526 added the
-// raw-control-byte repair; these tests cover the three things it left unpinned
-// and the one hole its shape opened.
+// raw-control-byte repair; these tests cover the things it left unpinned, the
+// hole its shape opened, and — added in round 3 — the exit code the fix for
+// that hole moved.
 //
-// Every test here is RED at 517fc76 (the #526 squash, i.e. origin/main before
-// this branch) and green at HEAD. The matrix is in the PR body.
+// 🔴 THE MATRIX IS HERE, AND IT IS NOT UNIFORM. An earlier revision of this
+// header said "every test here is RED at 517fc76 and green at HEAD" and
+// deferred the matrix to the PR body. Both halves were wrong: one of the five
+// tests below is labelled in its own doc comment as an INVARIANT GUARD that
+// PASSES at 517fc76 — so the header contradicted an accurate label 100 lines
+// under it — and a PR body is not in the tree, so a reader of the file could
+// not check either claim. A test you have not watched fail proves nothing, and
+// a header that says you watched them all fail when you did not is the same
+// error one level up.
+//
+// Measured by running this file against a `git archive 517fc76` tree, not
+// reasoned about:
+//
+//	TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes   RED at 517fc76
+//	TestReadErrorSnippetStripsTerminalControlRunes                RED at 517fc76
+//	TestPostIntoRepairsControlBytesLikeGetInto                    RED at 517fc76
+//	TestDecodeBodyIsSharedByGetIntoAndPostInto                    RED at 517fc76
+//	TestGetIntoUnrepairableBodyReportsTheOriginalBytes            INVARIANT GUARD —
+//	                                                              PASSES at 517fc76;
+//	                                                              its value is the mutant
+//	TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne  see below
+//
+// The last one is a round-3 regression against THIS BRANCH, not against
+// 517fc76, and its row does not compress into the column above. Its subject is
+// the exit code that f936cfc — this branch's round-2 head — moved by classifying
+// a 429 on snippet()'s STRIPPED output: RED there, on the two classification
+// assertions. At 517fc76 it is ALSO red, but for the opposite reason and with
+// different assertions: that tree has no strip at all, so the classification
+// half passes and the two assertions that the DISPLAY is still filtered fail.
+// "Red at both ends, for opposite reasons" is the honest row; "red at 517fc76"
+// alone would read as regression coverage for a bug 517fc76 did not have.
 //
 // 🔴 The fixture strings below are pairwise distinct and distinct from every
 // constant asserted on, so a mutant that hardcodes one literal cannot satisfy
@@ -182,6 +213,120 @@ func TestPostIntoRepairsControlBytesLikeGetInto(t *testing.T) {
 	}
 	if got[0].Hash != "\v"+hash {
 		t.Errorf("the repair must not change the DOCUMENT, only its encoding: hash = %q", got[0].Hash)
+	}
+}
+
+// softHyphenIn429 is a 429 body from a THROTTLE, carrying one U+00AD SOFT
+// HYPHEN inside the word "many". U+00AD is Cf, therefore
+// Default_Ignorable_Code_Point, therefore in saferune's class — so the strip
+// joins "ma" and "ny" and produces the cap's own phrase out of bytes the server
+// never sent. Written as a Go escape rather than a literal (ST1018).
+//
+// The surrounding words are distinct from every other fixture in this file and
+// from the phrases isDeepPagingCap matches, so an assertion below cannot be
+// satisfied by a mutant that hardcodes another fixture's literal.
+const softHyphenIn429 = "{\"message\":\"Upstream throttle: too ma\u00adny pages " +
+	"queued on this key, retry in 41s\"}"
+
+// softHyphen is the same rune, for the assertion that the DISPLAY still strips
+// it. Named rather than written inline so the two cannot drift apart.
+const softHyphen = '\u00ad'
+
+// realDeepPagingCap is the server's actual cap message. It carries no ignorable
+// rune, so the strip cannot be what makes it match.
+const realDeepPagingCap = `{"message":"You've requested too many pages; please use cursors instead"}`
+
+// TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne is round 3's
+// finding 4, and it is the only BEHAVIOURAL one: a published exit code moved.
+//
+// 🔴 A DISPLAY FILTER BECAME A CLASSIFIER. readError extracts the server's
+// message, hands it to snippet() — which since this PR routes it through
+// internal/saferune — and then asked isDeepPagingCap() about the STRIPPED
+// string. isDeepPagingCap's own comment says the match is "deliberately narrow
+// so a real rate-limit 429 is never misclassified as a usage error", and
+// removing invisible runes can only WIDEN it, in exactly that direction: a 429
+// whose message carries one Default_Ignorable rune inside "many" was reclassified
+// from ErrRateLimited (exit 6) to ErrBadRequest (exit 2). Contrived for
+// Civitai's own backend; not contrived for the proxy, CDN and captive-portal
+// 429s readError also handles. AGENTS.md items 7 and 24 make that a published
+// contract.
+//
+// Both halves are needed and neither is redundant:
+//
+//   - (a) is the regression. It is RED at f936cfc (this branch before round 3)
+//     and green at HEAD.
+//   - (b) is the POSITIVE CONTROL on the classifier. Without it, `func
+//     isDeepPagingCap(string) bool { return false }` — and any fix that simply
+//     stopped calling it — passes (a) and this test asserts nothing.
+func TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne(t *testing.T) {
+	// (a) A throttle 429 the strip would turn into a cap.
+	c := serveOnce(t, http.StatusTooManyRequests, softHyphenIn429)
+	_, err := c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it this test asserts on nothing")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("a throttle 429 whose message merely CONTAINS an invisible rune lost "+
+			"ErrRateLimited (exit 6). The classifier is reading snippet()'s output, not "+
+			"the wire message — the CLI's own strip is inventing the cap phrase:\n%q", err)
+	}
+	if errors.Is(err, ErrBadRequest) {
+		t.Errorf("a throttle 429 was reclassified as a usage error (exit 2):\n%q", err)
+	}
+	// The DISPLAY must still be stripped. A "fix" that stopped stripping the
+	// message would satisfy both checks above and reopen the stderr hole §2 of
+	// claudedocs/decisions/38-read-body-repair-and-snippet.md closes.
+	if strings.ContainsRune(err.Error(), softHyphen) {
+		t.Errorf("U+00AD survived into the error string — snippet no longer strips "+
+			"what it prints:\n%q", err)
+	}
+	if !strings.Contains(err.Error(), "too many pages queued") {
+		t.Errorf("the server's own words are missing from the message, so the checks "+
+			"above are not about the fixture they name:\n%q", err)
+	}
+
+	// (b) The real cap must still be reclassified.
+	c = serveOnce(t, http.StatusTooManyRequests, realDeepPagingCap)
+	_, err = c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it half (b) asserts on nothing")
+	}
+	if !errors.Is(err, ErrBadRequest) {
+		t.Errorf("the deep-paging cap must still be reclassified as a usage error "+
+			"(exit 2) — otherwise a scripter's 429 backoff loop spins on a request "+
+			"that is structurally doomed:\n%q", err)
+	}
+	if errors.Is(err, ErrRateLimited) {
+		t.Errorf("the deep-paging cap must NOT stay ErrRateLimited:\n%q", err)
+	}
+
+	// (c) The SECOND, deliberate consequence of classifying pre-snippet, pinned
+	// rather than left in a comment: snippet also truncates at 500 BYTES, so
+	// before this change a cap message whose phrase sat past the display budget
+	// was invisible to the classifier and exited 6 — a scripter's backoff loop
+	// spinning forever on a structurally doomed request. The bound is a display
+	// budget, not a statement about what the server said.
+	long := `{"message":"` + strings.Repeat("context, ", 70) +
+		"you have requested too many pages here" + `"}`
+	if len(long) <= 520 {
+		t.Fatalf("CONTROL failure, not a finding: the fixture is %d bytes, which does "+
+			"not exceed snippet's 500-byte bound — half (c) would assert nothing", len(long))
+	}
+	c = serveOnce(t, http.StatusTooManyRequests, long)
+	_, err = c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a 429 must be an error; without it half (c) asserts on nothing")
+	}
+	// Positive control on the FIXTURE: the phrase really is past the bound, so
+	// the assertion below is about truncation and not about the phrase.
+	if strings.Contains(snippet([]byte(long)), "too many pages") {
+		t.Fatal("CONTROL failure, not a finding: the cap phrase survives snippet's " +
+			"truncation, so half (c) is not testing what it says")
+	}
+	if !errors.Is(err, ErrBadRequest) {
+		t.Errorf("a deep-paging cap whose phrase falls past snippet's 500-byte "+
+			"display bound must still be reclassified (exit 2). The classifier is "+
+			"reading the truncated string:\n%q", err)
 	}
 }
 

--- a/pkg/civitai/read_repair_test.go
+++ b/pkg/civitai/read_repair_test.go
@@ -1,0 +1,259 @@
+package civitai
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file is the follow-up to civitai/cli#526's audit. #526 added the
+// raw-control-byte repair; these tests cover the three things it left unpinned
+// and the one hole its shape opened.
+//
+// Every test here is RED at 517fc76 (the #526 squash, i.e. origin/main before
+// this branch) and green at HEAD. The matrix is in the PR body.
+//
+// 🔴 The fixture strings below are pairwise distinct and distinct from every
+// constant asserted on, so a mutant that hardcodes one literal cannot satisfy
+// another assertion.
+
+// escapedCR is the TWO-CHARACTER sequence a repaired body carries where the wire
+// carried one 0x0D byte. It is what the snippet must NOT contain: seeing it
+// means the error message is quoting the CLI's repair rather than the server.
+const escapedCR = `\r`
+
+// serveOnce returns a client pointed at a server that answers every request with
+// status + body.
+func serveOnce(t *testing.T, status int, body string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "")
+}
+
+// TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes is finding 2(b).
+//
+// README's Troubleshooting row promises "the text after the colon is the
+// server's own body, truncated". #526's pre-pass reassigned the body to the
+// REPAIRED bytes before the snippet was taken, so a server that sent one CR was
+// reported as having sent a backslash and an `r` — the CLI quoting itself. The
+// fixture decodes to neither shape: `id` is a string where the SDK wants an int,
+// so the repair succeeds at the JSON level and the typed decode still fails,
+// which is the only way to reach this message with a repairable body.
+func TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes(t *testing.T) {
+	c := serveOnce(t, http.StatusOK,
+		"{\"items\":[{\"id\":\"kestrel-97\",\"name\":\"Marbled\rHeron\"}],\"metadata\":{}}")
+
+	_, err := c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatal("a body whose id is a string must still fail the typed decode; " +
+			"without the failure this test asserts on nothing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected response from /api/v1/models (status 200)") {
+		t.Fatalf("wrong error reached the assertion below: %q", msg)
+	}
+	if strings.Contains(msg, escapedCR) {
+		t.Errorf("the snippet carries the CLI's REPAIR (%s), not the server's bytes — "+
+			"README's \"the server's own body\" is false again:\n%q", escapedCR, msg)
+	}
+	// Positive control: the body really did reach the snippet. Without this a
+	// snippet that dropped the body entirely would satisfy the check above.
+	if !strings.Contains(msg, "MarbledHeron") {
+		t.Errorf("the server's own text is missing from the snippet — "+
+			"expected the CR-joined name with the CR removed by the strip:\n%q", msg)
+	}
+}
+
+// TestGetIntoUnrepairableBodyReportsTheOriginalBytes is finding 4: the
+// retry-fails path. Nothing exercised a body the sanitizer cannot repair
+// through getInto, and a mutant dropping the guard on the repaired bytes
+// survived a full green pkg/civitai + internal/cmd run.
+//
+// 🔴 IT IS AN INVARIANT GUARD, NOT REGRESSION COVERAGE, AND IT IS LABELLED AS
+// ONE. It PASSES at 517fc76 — the pre-pass shape returned the same error for
+// the same body — so it pins no bug that was ever live. Its whole value is
+// mutation: it goes red, with the message above, on a decodeBody that assigns
+// the sanitized bytes without checking they decoded.
+//
+// The fixture is a trailing comma: valid-looking, unrepairable by an in-string
+// control-byte rewriter, and not the shape any other test here uses.
+func TestGetIntoUnrepairableBodyReportsTheOriginalBytes(t *testing.T) {
+	const body = `{"items":[{"id":41,"name":"Sorrel Kite",}],"metadata":{}}`
+	c := serveOnce(t, http.StatusOK, body)
+
+	res, err := c.SearchModels(context.Background(), url.Values{})
+	if err == nil {
+		t.Fatalf("an unrepairable body must be an error, got %+v", res)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unexpected response from /api/v1/models (status 200)") {
+		t.Errorf("the unrepairable body must reach the documented message:\n%q", msg)
+	}
+	if !strings.Contains(msg, "Sorrel Kite") {
+		t.Errorf("the snippet must quote the body that failed:\n%q", msg)
+	}
+	if res != nil {
+		t.Errorf("no result may be returned alongside the error: %+v", res)
+	}
+}
+
+// TestReadErrorSnippetStripsTerminalControlRunes is the (a) half of the
+// stderr-hole decision: snippet() now routes the server's bytes through
+// internal/saferune.
+//
+// 🔴 THE PATH THIS COVERS IS THE ERROR PATH, WHICH HAS NO OTHER GATE.
+// internal/cmd's safeTerm sits on the HUMAN RENDERERS; cmd/civitai/main.go
+// prints `Error: <err>` to stderr with no filter at all. Before this, a 404
+// body could carry a cursor-up + line-erase and overwrite the CLI's own
+// preceding output from inside an error message.
+//
+// The escape arrives JSON-ESCAPED on the wire — which is what a real server
+// emits — so this is not a fixture that only a malformed body could produce.
+func TestReadErrorSnippetStripsTerminalControlRunes(t *testing.T) {
+	// ESC[2K is ERASE LINE; U+200E is an invisible bidi mark. Both are written
+	// as escapes in this source: a literal control byte in a Go string literal
+	// is exactly what staticcheck's ST1018 exists to catch.
+	c := serveOnce(t, http.StatusNotFound,
+		"{\"error\":\"no such widget \\u001b[2K\\u200eSHA256 verified\"}")
+
+	_, _, err := c.GetModel(context.Background(), "9")
+	if err == nil {
+		t.Fatal("a 404 must be an error; without it this test asserts on nothing")
+	}
+	msg := err.Error()
+	// Positive control FIRST: the server's text must be present, or the two
+	// absence checks below are satisfied by an empty snippet.
+	if !strings.Contains(msg, "no such widget") || !strings.Contains(msg, "SHA256 verified") {
+		t.Fatalf("the server's own words are missing — the checks below would be vacuous:\n%q", msg)
+	}
+	for _, bad := range []struct {
+		r    rune
+		name string
+	}{
+		{'\x1b', "ESC (0x1B) — an ANSI/OSC introducer"},
+		{'\u200e', "U+200E LEFT-TO-RIGHT MARK"},
+	} {
+		if strings.ContainsRune(msg, bad.r) {
+			t.Errorf("%s reached the error string, which main.go prints to stderr unfiltered:\n%q",
+				bad.name, msg)
+		}
+	}
+}
+
+// TestPostIntoRepairsControlBytesLikeGetInto is finding 6, behaviourally: the
+// batch by-hash POST claims in its doc comment to mirror getInto, and the
+// control-byte repair was a fourth axis on which it did not.
+//
+// It is unobservable in production today (HashMatch is two ints and a hex
+// string), so this is the guard that makes the CLAIM checkable rather than a
+// fix for a reported bug.
+func TestPostIntoRepairsControlBytesLikeGetInto(t *testing.T) {
+	const hash = "6B1E0F2A9C7D45538E0A1B2C3D4E5F60718293A4B5C6D7E8F90A1B2C3D4E5F60"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A raw 0x0B (vertical tab) inside the echoed hash string: invalid JSON
+		// on the wire, exactly the #525 class.
+		_, _ = w.Write([]byte("[{\"modelVersionId\":8123,\"modelId\":557,\"hash\":\"\v" + hash + "\"}]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := New(srv.URL, "").GetModelVersionsByHashes(context.Background(), []string{hash})
+	if err != nil {
+		t.Fatalf("postInto did not repair a raw control byte the way getInto does: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match, got %d (%+v)", len(got), got)
+	}
+	if got[0].ModelVersionID != 8123 || got[0].ModelID != 557 {
+		t.Errorf("decoded the wrong entry: %+v", got[0])
+	}
+	if got[0].Hash != "\v"+hash {
+		t.Errorf("the repair must not change the DOCUMENT, only its encoding: hash = %q", got[0].Hash)
+	}
+}
+
+// decodeBodyCallers is the LEDGER of functions allowed to reach the shared 2xx
+// decode. It fails in both directions: a third caller (the set grew — decide
+// whether it should mirror) and a named one that no longer calls it (the set
+// shrank — postInto's "it mirrors getInto" comment has gone stale again).
+var decodeBodyCallers = []string{"getInto", "postInto"}
+
+// TestDecodeBodyIsSharedByGetIntoAndPostInto is the structural half of finding
+// 6. The behavioural test above can only see the repair; this sees the SEAM —
+// that the two transports answer the question with one piece of code rather
+// than two that agree today.
+func TestDecodeBodyIsSharedByGetIntoAndPostInto(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	files, calls := 0, 0
+	seen := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, perr)
+		}
+		files++
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fd, func(n ast.Node) bool {
+				ce, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if id, ok := ce.Fun.(*ast.Ident); ok && id.Name == "decodeBody" {
+					calls++
+					seen[fd.Name.Name] = true
+				}
+				return true
+			})
+		}
+	}
+	// Positive controls: a parser that found nothing must fail, not report a
+	// reassuring zero.
+	if files < 5 {
+		t.Fatalf("CONTROL failure, not a finding: parsed only %d source files in pkg/civitai", files)
+	}
+	if calls < len(decodeBodyCallers) {
+		t.Fatalf("found %d decodeBody call sites, expected at least %d — "+
+			"either the scan is broken or a transport stopped sharing the decode",
+			calls, len(decodeBodyCallers))
+	}
+	var got []string
+	for name := range seen {
+		got = append(got, name)
+	}
+	sort.Strings(got)
+	want := append([]string(nil), decodeBodyCallers...)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("decodeBody's callers are %v, ledgered as %v.\n"+
+			"GREW: a new transport now shares the 2xx decode — say so in postInto's\n"+
+			"      mirror comment and add it here.\n"+
+			"SHRANK: a transport went back to its own json.Unmarshal, so the repair,\n"+
+			"      the failure message and the snippet can now disagree between them.",
+			got, want)
+	}
+}

--- a/pkg/civitai/tags_creators_users.go
+++ b/pkg/civitai/tags_creators_users.go
@@ -12,7 +12,10 @@ type TagItem struct {
 	Link string `json:"link"`
 }
 
-// TagSearchResult bundles parsed tags + metadata with the raw body.
+// TagSearchResult bundles parsed tags + metadata with the body that decoded,
+// for --json passthrough. Raw is NOT promised to be the server's own bytes: see
+// EscapeJSONStringControlChars for the one case where it is the repaired body
+// instead.
 type TagSearchResult struct {
 	Items    []TagItem `json:"items"`
 	Metadata Metadata  `json:"metadata"`
@@ -39,7 +42,10 @@ type CreatorItem struct {
 	Link       string     `json:"link"`
 }
 
-// CreatorSearchResult bundles parsed creators + metadata with the raw body.
+// CreatorSearchResult bundles parsed creators + metadata with the body that
+// decoded, for --json passthrough. Raw is NOT promised to be the server's own
+// bytes: see EscapeJSONStringControlChars for the one case where it is the
+// repaired body instead.
 type CreatorSearchResult struct {
 	Items    []CreatorItem `json:"items"`
 	Metadata Metadata      `json:"metadata"`
@@ -74,8 +80,11 @@ type UserItem struct {
 	Image    string     `json:"image"`
 }
 
-// UserSearchResult bundles parsed users with the raw body. The public users
-// endpoint returns only `{ items }` (no pagination metadata).
+// UserSearchResult bundles parsed users with the body that decoded, for --json
+// passthrough. Raw is NOT promised to be the server's own bytes: see
+// EscapeJSONStringControlChars for the one case where it is the repaired body
+// instead. The public users endpoint returns only `{ items }` (no pagination
+// metadata).
 type UserSearchResult struct {
 	Items []UserItem `json:"items"`
 	Raw   []byte     `json:"-"`

--- a/saferune_callers_ledger_test.go
+++ b/saferune_callers_ledger_test.go
@@ -1,0 +1,259 @@
+package cli_test
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// saferune_callers_ledger_test.go pins WHO asks internal/saferune its question,
+// because two separate prose statements of that set went stale on one commit.
+//
+// 🔴 THE SET GREW AND BOTH SENTENCES DESCRIBING IT STAYED AT TWO.
+// civitai/cli#526's follow-up made pkg/civitai's snippet the third non-test
+// caller. AGENTS.md's Layout entry still read "`cmd`'s `safeTerm` and
+// `genapi`'s `hasPrintableContent` BOTH call it", and saferune's own package doc
+// still opened "IT IS A PACKAGE RATHER THAN A FUNCTION BECAUSE TWO PACKAGES ASK
+// THE SAME QUESTION" and then named the two. Both survived a full green suite,
+// a lint run and a round-2 audit of the very branch that falsified them, because
+// nothing asserted on either.
+//
+// This is the assertion. It fails when the caller set GROWS (a fourth package
+// now shares the class — a decision about the class, so both texts must say so)
+// and when it SHRINKS (a caller re-derived the class locally, which is the
+// two-tables-that-disagree defect #393 exists to prevent).
+type saferuneCaller struct {
+	// pkgPath is the import path suffix the caller lives under.
+	pkgPath string
+	// question is the identifier both prose statements must name — the function
+	// that asks. Asserting the IDENTIFIER rather than a phrase is what keeps
+	// this from being a guard on wording: the function can be renamed and the
+	// texts must move with it, but the sentence around it is free.
+	question string
+	// why is the question that call site asks, for a reader of this ledger.
+	why string
+}
+
+var saferuneCallers = []saferuneCaller{
+	{
+		pkgPath:  "internal/cmd",
+		question: "safeTerm",
+		why:      "may this rune reach the terminal — the HUMAN renderers",
+	},
+	{
+		pkgPath:  "internal/genapi",
+		question: "hasPrintableContent",
+		why:      "would this string still say anything once a renderer stripped it",
+	},
+	{
+		pkgPath: "pkg/civitai",
+		// snippet is the FUNCTION that asks; read.go is where the import sits.
+		question: "snippet",
+		why: "what may an ERROR STRING carry — cmd/civitai/main.go prints " +
+			"`Error: <err>` to stderr with no renderer in front of it",
+	},
+}
+
+const saferuneImportPath = "github.com/civitai/cli/internal/saferune"
+
+// countWords renders len(saferuneCallers) as the word the two prose statements
+// must use, so the NUMBER moves with the set rather than being retyped. Growing
+// the ledger past this table is a deliberate stop: a fifth caller is a decision
+// about the class, not a bump.
+var countWords = map[int]string{2: "TWO", 3: "THREE", 4: "FOUR"}
+
+// TestSaferuneCallersAreLedgered is round 3's finding 2.
+func TestSaferuneCallersAreLedgered(t *testing.T) {
+	files := goSourceFiles(t)
+	// POSITIVE CONTROL on the walk itself, before any verdict: a walk that found
+	// nothing reports "no unledgered callers", which is the reassuring zero.
+	if len(files) < 100 {
+		t.Fatalf("CONTROL failure, not a finding: walked only %d non-test .go files "+
+			"in the module — the scan is not reading the tree", len(files))
+	}
+
+	fset := token.NewFileSet()
+	importers := map[string]bool{}
+	for _, path := range files {
+		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", path, err)
+		}
+		for _, imp := range f.Imports {
+			if imp.Path == nil {
+				continue
+			}
+			if strings.Trim(imp.Path.Value, `"`) != saferuneImportPath {
+				continue
+			}
+			importers[filepath.ToSlash(filepath.Dir(path))] = true
+		}
+	}
+	// POSITIVE CONTROL on the MATCH: an import-path typo, or a parser that read
+	// no imports, yields an empty set that would pass a "grew?" check silently.
+	if len(importers) == 0 {
+		t.Fatalf("CONTROL failure, not a finding: no non-test file in the module "+
+			"imports %s. The package has callers; the scan is broken.", saferuneImportPath)
+	}
+
+	var got []string
+	for pkg := range importers {
+		got = append(got, pkg)
+	}
+	sort.Strings(got)
+	var want []string
+	for _, c := range saferuneCallers {
+		want = append(want, c.pkgPath)
+	}
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("packages importing internal/saferune are %v, ledgered as %v.\n"+
+			"GREW: a fourth package now asks the class's question. That is a decision\n"+
+			"      about the class — read saferune's package doc (the strip is\n"+
+			"      unconditional and must never see what the USER typed), add an entry\n"+
+			"      here, and update BOTH prose statements this test checks below.\n"+
+			"SHRANK: a caller stopped importing it, which usually means it re-derived\n"+
+			"      the class locally — the two-tables-that-disagree defect of #393.",
+			got, want)
+	}
+
+	// The two prose statements. Each must name every ledgered question and the
+	// count word derived from the ledger's own length.
+	word, ok := countWords[len(saferuneCallers)]
+	if !ok {
+		t.Fatalf("CONTROL failure, not a finding: countWords has no word for %d "+
+			"callers — extend it, and say in saferune's package doc why the class "+
+			"is now shared that widely", len(saferuneCallers))
+	}
+	// 🔴 EACH TEXT IS NARROWED TO THE PASSAGE THAT MAKES THE CLAIM BEFORE IT IS
+	// SEARCHED. The first cut of this test searched the WHOLE of AGENTS.md, and
+	// a mutant that deleted `snippet` from the Layout entry SURVIVED: the file
+	// also contains "what an error snippet prints" in item 38's trigger, so a
+	// whole-file Contains was green about a sentence that no longer named the
+	// caller. A guard on a document must be scoped to the sentence it guards, or
+	// it is asserting on the document's vocabulary.
+	pkgDoc := saferunePackageDoc(t)
+	layout := agentsSaferuneEntry(t)
+	for _, doc := range []struct {
+		text     string
+		what     string
+		backtick bool
+	}{
+		{pkgDoc, "saferune's package doc", false},
+		{layout, "AGENTS.md's Layout entry for internal/saferune", true},
+	} {
+		for _, c := range saferuneCallers {
+			needle := c.question
+			if doc.backtick {
+				// In AGENTS.md an identifier is a code span. Requiring the
+				// backticks is what stops the prose word "snippet" satisfying a
+				// claim about the FUNCTION snippet.
+				needle = "`" + c.question + "`"
+			}
+			if !strings.Contains(doc.text, needle) {
+				t.Errorf("%s does not name %s (%s), which imports internal/saferune.\n"+
+					"Both statements of this set went stale at once when it grew to %d; "+
+					"this is what stops that happening silently again.\ngot:\n%s",
+					doc.what, needle, c.pkgPath, len(saferuneCallers), doc.text)
+			}
+		}
+	}
+	// The COUNT is a separate claim from the membership and goes stale on its
+	// own: saferune's package doc opens with it in words.
+	if !strings.Contains(pkgDoc, word+" PACKAGES ASK THE SAME") {
+		t.Errorf("saferune's package doc does not say %q — it must state the count "+
+			"the ledger has (%d), and it said TWO for a full branch after the third "+
+			"caller landed.", word+" PACKAGES ASK THE SAME", len(saferuneCallers))
+	}
+}
+
+// saferunePackageDoc returns internal/saferune's package doc comment, parsed
+// rather than grepped so "the package doc" means the package doc and not any
+// comment that happens to be in the file.
+func saferunePackageDoc(t *testing.T) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "internal/saferune/saferune.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot parse saferune.go: %v", err)
+	}
+	if f.Doc == nil {
+		t.Fatalf("CONTROL failure, not a finding: internal/saferune/saferune.go has " +
+			"no package doc comment — the checks below would be vacuous")
+	}
+	return f.Doc.Text()
+}
+
+// agentsSaferuneEntry returns just the `internal/saferune` bullet from
+// AGENTS.md's Layout section: from the line opening it to the next top-level
+// bullet.
+func agentsSaferuneEntry(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("AGENTS.md")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read AGENTS.md: %v", err)
+	}
+	const opener = "- `internal/saferune`"
+	lines := strings.Split(string(raw), "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, opener) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("CONTROL failure, not a finding: AGENTS.md has no Layout bullet "+
+			"starting %q — this test cannot see the sentence it guards", opener)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "- ") || strings.HasPrefix(lines[i], "## ") {
+			end = i
+			break
+		}
+	}
+	entry := strings.Join(lines[start:end], "\n")
+	// POSITIVE CONTROL on the extraction: a one-line slice means the bullet
+	// scanner is wrong, and every Contains below would fail for that reason
+	// rather than for a finding.
+	if end-start < 3 {
+		t.Fatalf("CONTROL failure, not a finding: the internal/saferune bullet "+
+			"extracted to %d lines:\n%s", end-start, entry)
+	}
+	return entry
+}
+
+// goSourceFiles returns every non-test .go file in the module.
+func goSourceFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if path != "." && (strings.HasPrefix(name, ".") || name == "testdata" ||
+				name == "node_modules" || name == "dist" || name == "bin") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/saferune_callers_ledger_test.go
+++ b/saferune_callers_ledger_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
@@ -31,9 +32,18 @@ type saferuneCaller struct {
 	// pkgPath is the import path suffix the caller lives under.
 	pkgPath string
 	// question is the identifier both prose statements must name — the function
-	// that asks. Asserting the IDENTIFIER rather than a phrase is what keeps
-	// this from being a guard on wording: the function can be renamed and the
-	// texts must move with it, but the sentence around it is free.
+	// that asks.
+	//
+	// 🔴 IT IS RESOLVED TO A DECLARATION BEFORE IT IS USED AS A NEEDLE, AND THE
+	// EARLIER VERSION OF THIS COMMENT CLAIMED THE RENAME-SAFETY THAT RESOLUTION
+	// BUYS WITHOUT DOING IT. It read "the function can be renamed and the texts
+	// must move with it"; question was a plain string and nothing bound it to a
+	// declaration, so renaming safeTerm across internal/cmd left the whole suite
+	// green while AGENTS.md and saferune's package doc named a function that no
+	// longer existed. Measured, not reasoned: that rename was performed and
+	// `go test ./...` stayed green. checkQuestionsResolve below is what makes
+	// the sentence true — a rename is now red by name, at this file, before any
+	// prose is searched.
 	question string
 	// why is the question that call site asks, for a reader of this ledger.
 	why string
@@ -122,6 +132,13 @@ func TestSaferuneCallersAreLedgered(t *testing.T) {
 			got, want)
 	}
 
+	// 🔴 RESOLVE EVERY question TO A DECLARATION BEFORE SEARCHING FOR IT AS TEXT.
+	// Until this ran, `question` was a bare string used as a substring needle:
+	// the two prose statements could name a function that no longer existed and
+	// this test stayed green. It runs BEFORE the prose checks so a rename is
+	// reported as a rename rather than as two "does not name" errors.
+	checkQuestionsResolve(t)
+
 	// The two prose statements. Each must name every ledgered question and the
 	// count word derived from the ledger's own length.
 	word, ok := countWords[len(saferuneCallers)]
@@ -170,6 +187,83 @@ func TestSaferuneCallersAreLedgered(t *testing.T) {
 			"the ledger has (%d), and it said TWO for a full branch after the third "+
 			"caller landed.", word+" PACKAGES ASK THE SAME", len(saferuneCallers))
 	}
+}
+
+// checkQuestionsResolve requires every ledgered `question` to be a function
+// DECLARED in its own pkgPath. This is what turns the identifier into a binding
+// rather than a word: rename the function and this fails HERE, naming the
+// package it searched and any near-matching declaration in it, instead of the
+// prose checks failing with "AGENTS.md does not name `safeTerm`" — which is the
+// same red for the opposite cause.
+//
+// It reads top-level FuncDecls with no receiver, which is what all three
+// ledgered questions are today. A caller that moved its question onto a method
+// is a decision about the class, not a rename: extend this deliberately.
+func checkQuestionsResolve(t *testing.T) {
+	t.Helper()
+	for _, c := range saferuneCallers {
+		names, err := pkgFuncDecls(c.pkgPath)
+		if err != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot read %s: %v", c.pkgPath, err)
+		}
+		// POSITIVE CONTROL on the parse: a package that yielded no functions at
+		// all cannot answer the question below, and would report every ledgered
+		// identifier as renamed.
+		if len(names) == 0 {
+			t.Fatalf("CONTROL failure, not a finding: parsed no top-level funcs in %s — "+
+				"the resolver is not reading the package", c.pkgPath)
+		}
+		if names[c.question] {
+			continue
+		}
+		// Report NEAR MATCHES, not the whole package: internal/cmd declares
+		// hundreds of top-level funcs, and dumping them buries the one line a
+		// reader needs. The count is printed instead, as the scan's own control.
+		var near []string
+		for n := range names {
+			if strings.Contains(strings.ToLower(n), strings.ToLower(c.question)) {
+				near = append(near, n)
+			}
+		}
+		sort.Strings(near)
+		t.Fatalf("%s declares no top-level func %s, which this ledger names as the "+
+			"function that asks internal/saferune's question.\n"+
+			"RENAMED: move the new name here and into BOTH prose statements — "+
+			"saferune's package doc and AGENTS.md's Layout entry — in the same commit.\n"+
+			"MOVED ONTO A RECEIVER: that is a change to the class's shape; widen this "+
+			"resolver deliberately rather than deleting the check.\n"+
+			"%d top-level funcs in %s; names containing %q: %v",
+			c.pkgPath, c.question, len(names), c.pkgPath, c.question, near)
+	}
+}
+
+// pkgFuncDecls returns the set of top-level, receiver-less func names declared
+// in the non-test .go files of dir.
+func pkgFuncDecls(dir string) (map[string]bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	out := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if perr != nil {
+			return nil, perr
+		}
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv != nil {
+				continue
+			}
+			out[fd.Name.Name] = true
+		}
+	}
+	return out, nil
 }
 
 // saferunePackageDoc returns internal/saferune's package doc comment, parsed


### PR DESCRIPTION
Follow-up to the adversarial audit of #526. **#526's code is correct and its regression test was watched red at base — nothing here re-audits it.** What this PR fixes is the set of *our* claims that #526's correct change falsified, plus the one pre-existing hole that fixing them would otherwise have widened.

Every finding below was re-verified against the tree before acting on it.

## Findings closed

| # | What | Where |
| --- | --- | --- |
| 1 🔴 | `readJSONNote`'s doc comment asserted the repair "is not a behaviour of this group", with a measurement (exit 1, empty stdout, `emitJSON` never entered). **Re-measured: exit 0, table renders, `emitJSON` IS entered.** Every clause false. Comment rewritten; a guard now pins it. | `internal/cmd/read_help.go`, `internal/cmd/read_json_note_test.go` |
| 2 🟡 | README's Troubleshooting row for `unexpected response from` named one known cause (#513) and claimed the snippet is "the server's own body" — false, because `getInto` reassigned `raw` to the sanitized bytes before `snippet(raw)` ran. Both halves fixed; #525 named as the second known cause. | `README.md` |
| 3 🟡 | `json.Valid` over every successful 2xx body, on top of the `Unmarshal` that walks the same bytes. Replaced by unmarshal-first + sanitize-and-retry. | `pkg/civitai/read.go` |
| 4 🟡 | The inner `json.Valid(fixed)` guard was untested — a mutant assigning unconditionally SURVIVED a full green run. The retry-fails path is now tested. | `pkg/civitai/read_repair_test.go` |
| 5 🟢 | Two result types documented `Raw` as "the raw response body", and `numeric_username_test.go` as "a raw passthrough of the server's own bytes". For a repaired body neither is true. Fixed, with the one accurate statement on the exported `EscapeJSONStringControlChars`. | `pkg/civitai/{collections,articles,read}.go`, `internal/cmd/numeric_username_test.go` |
| 6 🟢 | `postInto`'s comment enumerated what it mirrors from `getInto`; sanitization was a fourth axis on which it did not. **Made to mirror, as shared code** (`decodeBody`) rather than a stated divergence — so the enumeration is true by construction. | `pkg/civitai/hashes.go` |
| 7 🟢 | The one-line delegating wrapper kept only so `read_r2_test.go` compiled, and the byte-identical duplicate test in two packages. Both removed. | `internal/cmd/read.go`, `internal/cmd/read_r2_test.go` |

## The design decision: **(a)** — `snippet()` is filtered, `errorLine` is not

`cmd/civitai/main.go` prints `Error: <err>` to stderr with no filter, and `snippet()` embeds up to 500 bytes of a server body verbatim. That hole **pre-dates #526**; finding 3's fix would have widened it back to the 2xx path, because restoring the wire bytes to the snippet restores the wire's escapes too.

**Chosen (a): `snippet()` routes the server's bytes through `internal/saferune`.** The reason is that every argument `snippet` is ever given is server-supplied — the undecodable 2xx body, the API's `{"error":…}`/`{"message":…}`, a zod issue, a retry-exhaustion body, a `FlexString` value — and none of it is anything the user typed. `snippet` was already a terminal-concern helper; its existing job is bounding length "so a huge response can't flood the terminal".

Two alternatives were rejected for stated reasons, not by preference:

- **Filtering at the print site (`errorLine`)** would apply the class to *every* error, including the many that echo what the user typed. That is exactly the #393 regression `TestSafeTermIsNeverAppliedToUserTypedInput` exists to prevent.
- **Re-deriving the class inside `pkg/civitai`** would be a second table — the other half of #393. No third table was created; `internal/saferune` remains the single owner.

🔴 **The cost, stated rather than hidden:** this makes `pkg/civitai` the first thing under `pkg/` to import `internal/`, and an SDK consumer that is not a terminal now reads an error string with those runes already removed. Two things bound it: the strip touches only the human-readable tail of an error message, and `Raw` — the byte path a consumer would parse — is returned unstripped. That trade is written into the code and into item 38, so the next person can reverse it deliberately.

## Verification

`make ci` green (21 packages). `make lint` **0 issues**, and the gate was negative-controlled: a deliberate raw `ESC` in a string literal produced `ST1018 … (staticcheck)` and `make lint` exited non-zero. `gofmt -s -l .` clean over 469 `.go` files. `./scripts/ci-shallow.sh` PASSED against the committed SHA `f936cfc` (21/21).

**Red at base** (`517fc76`, i.e. `origin/main`), green at HEAD:

| test | at `517fc76` |
| --- | --- |
| `TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes` | RED — snippet carried `Pony\rModel`, the CLI's repair |
| `TestReadErrorSnippetStripsTerminalControlRunes` | RED — `ESC` and U+200E reached the error string |
| `TestPostIntoRepairsControlBytesLikeGetInto` | RED — `postInto` did not repair |
| `TestDecodeBodyIsSharedByGetIntoAndPostInto` | RED — 0 call sites found |
| `TestReadJSONNoteDescribesTheRepair` | RED on the wording pin |
| `TestReadJSONNoteCommentNamesItsGuard` | RED — comment named no guard |
| `TestReadErrorReachesStderrWithoutTerminalControlRunes` (seam) | RED — `ESC[1A ESC[2K` reached the exact line `main()` writes |

Two honest labels:

- `TestGetIntoUnrepairableBodyReportsTheOriginalBytes` **passes at `517fc76`**. It is an **invariant guard**, labelled as one in source, and is not counted as regression coverage. Its value is the mutant it kills.
- `TestReadJSONNoteDescribesTheRepair`'s behavioural halves also pass at `517fc76` — because #526 is what made them pass. Measured one commit earlier at `5557b6a`: RED, `unexpected response from /api/v1/models (status 200)`. So the guard observes the transition in both directions.

**Mutation matrix** — each mutant applied to the real source, run, reverted; each killed by *that guard's own* message:

| mutant | killed by |
| --- | --- |
| `decodeBody`: assign the sanitized bytes unconditionally | `TestGetIntoUnrepairableBodyReportsTheOriginalBytes` |
| `decodeBody`: `snippet(fixed)` instead of `snippet(raw)` | `TestGetIntoErrorSnippetQuotesTheWireBytesNotTheRepairedOnes` |
| `snippet`: drop `saferune.Strip` | `TestReadErrorSnippetStripsTerminalControlRunes` **and** the seam test |
| `postInto`: stop sharing `decodeBody` | `TestPostIntoRepairs…` **and** the ledger ("found 1 … expected at least 2") |
| add a third `decodeBody` caller (ledger GREW) | `TestDecodeBodyIsSharedByGetIntoAndPostInto` |
| reword one word of `readJSONNote` | `TestReadJSONNoteDescribesTheRepair` |
| remove the guard's name from the doc comment | `TestReadJSONNoteCommentNamesItsGuard` |

Both AST-based guards assert a **minimum count** (files parsed, call sites found) so a scan that matches nothing fails instead of passing with a reassuring zero — both controls were watched to fire.

## Known residuals (in item 38, not hidden here)

- **The README's prose is not machine-checked against the behaviour.** `readme_troubleshooting_test.go` is a drift detector over symptom *strings*; no symptom string changed, which is exactly why it did not catch the false clause. The behaviour is now pinned; that the row still *describes* it is not. Widening the detector to compare a row's explanation against runtime behaviour is a much larger, different guard and was **not** attempted rather than attempted badly.
- `snippet` still truncates by **byte** at 500, so it can split a multi-byte rune. Pre-existing, unchanged; not a terminal-control hazard since the strip runs before the bound.
- `saferune` keeps `\n`/`\t` deliberately, so a server body can still put a newline in an error line. `indentContinuation` answers that on the renderers it covers; the error path has no equivalent.

## Also

The perf numbers in the audit were **not** copied into the code. Re-measured here (synthetic 1.50 MB / 2185-item page, go1.25, `-benchtime 300x -count=5`): `json.Valid` 4.9–6.4 ms vs `json.Unmarshal` 12.9–26.4 ms — a quarter to a half again, not the audit's 50–100%. The comment quotes my numbers with their scope and says the ratio is not portable; the load-bearing claim (zero extra work on a body that decodes) is structural, not measured. The scratch benchmark is not in the tree (this repo has no benchmarks and one was not worth introducing for this).

No published exit code moved, and the seam test asserts it: a 404 read still exits `4` with the filtered message (AGENTS.md item 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gx6N59iqHtBT752mc3DnJB


---

# Round 3 (`31d5ba3`) — four findings from the blind audit of round 2

🔴 **Read this section before the one above it: round 2's body contains claims round 3 falsified, and they are corrected here rather than quietly edited out.** Every one of round 2's six findings was *a claim the tree made that the tree did not support* — and round 2 was itself a fix round. That is the measured pattern on this branch, so round 3's rule was: either make the statement true and name the guard enforcing it, or state the enumerated truth and admit the enumeration is open.

## Corrections to the round-2 body above

| round-2 claim | status |
| --- | --- |
| "**No published exit code moved**, and the seam test asserts it" (last line) | 🔴 **FALSE.** One did — see F4 below. And the 404 seam test could never have seen it: a 404 is classified from the *status*, so no message filter can move it. The sentence was both wrong and vacuously supported. |
| Finding 1: "**Every clause false**" | Over-claimed. Two of the four clauses are still true at HEAD; what #526 falsified is the *conclusion*. Corrected clause by clause in `read_help.go`, both premises re-measured. |
| Finding 5: "Two result types … Fixed" | The sweep was **not** complete — 7+ sites were still live, including `ModelSearchResult` and `ImageSearchResult`, the exact types #525 bites. See F1 below. |
| "`gofmt -s -l .` clean over 469 `.go` files" | Now **471** (two new guard files). Still clean, still positive-controlled. |
| "`ci-shallow.sh` PASSED against `f936cfc`" | Re-run at `31d5ba3`: **21/21 ok**, `HEAD=31d5ba3e56c3`, `shallow=true`. |

## F4 🔴 — the strip became a classifier, and exit 6 became exit 2

`readError` handed `snippet()`'s output to `isDeepPagingCap`, whose own comment says the match is *"deliberately narrow so a real rate-limit 429 is never misclassified as a usage error"*. `snippet()` began stripping `Default_Ignorable` runes **on this branch**, and removing runes can only **widen** a substring match — in exactly that direction. Same 429 body, one U+00AD inside "many":

| tree | result |
| --- | --- |
| `517fc76` | `ErrRateLimited` — **exit 6** |
| `f936cfc` (round 2) | `ErrBadRequest` — **exit 2** ← the regression |
| `31d5ba3` (HEAD) | `ErrRateLimited` — **exit 6** |

Contrived for Civitai's own backend; **not** contrived for the proxy, CDN and captive-portal 429s `readError` also handles. AGENTS.md items 7 and 24 make this a published contract.

**Fix:** `readError` keeps `wireMsg` before the `snippet` call and classifies on it. "Narrow" is a claim about what the *server* sent, so the classifier is asked about what arrived. The display is unchanged.

🔴 **This moves a second exit code, deliberately and in the opposite direction, and it is stated rather than discovered later.** `snippet` also truncates at 500 bytes — the same hazard in a second shape. Before this, a genuine cap message whose phrase fell past the display budget was invisible to the classifier and exited 6, spinning a scripter's backoff loop on a structurally doomed request. It now exits 2. Pinned as half (c) of the same test. A >500-byte error body is ordinary, but no such 429 has been observed from the API — the case is constructed.

**Scope, measured not assumed:** `grep` over every `kind =` assignment and every `snippet(` call site in `pkg/civitai` — `read.go:290` is the *only* place where the text of an error picks a classification. Every other branch classifies from the status alone (`statusKind`); every other `snippet` caller is display-only.

## F1 🟡 — a cross-reference true of 2 of its 8 referents, closed as a count of 3

`getInto` said *"see the note on Raw in the result types"*. Two of the eight types with a `Raw []byte` field carried the note; the other six still said "the raw response body" / "the raw body" — the byte-identity claim the same branch was correcting elsewhere. The item file closed the sweep as *"All three now say what is true"*; at least seven more were live.

**A count is the wrong instrument for a sweep**, so the fix is not a better count. All eight now disclaim byte identity, and `TestRawDocCommentsDisclaimByteIdentity` is a **bidirectional ledger** of `Raw`-bearing types that requires the disclaimer on each. Also corrected outside what that ledger can see: `ArticleDetail.Content` (kept its point about HTML rendering, dropped the byte word) and `flexstring_test.go` — verbatim the comment round 2 corrected in `numeric_username_test.go` and missed here.

## F2 🟡 — two prose statements of one set, both stale at once

`pkg/civitai`'s `snippet` became the **third** non-test caller of `internal/saferune`. `AGENTS.md:170` still said the other two "**both**" call it; `saferune.go:23` still said "**TWO PACKAGES** ASK THE SAME QUESTION". Both survived a green suite, a clean lint run *and* a blind audit of the branch that falsified them.

The third caller asks a **third question** — *"what may an error string carry"*, because `main.go` prints `Error: <err>` to stderr with no renderer in front of it — so the package doc states the question, not just a bigger number. `TestSaferuneCallersAreLedgered` fails when the importer set grows **or** shrinks, requires both texts to name every ledgered call site, and derives the count **word** from the ledger's own length so the numeral cannot drift from the membership.

AGENTS.md headroom: **175 → 58 bytes** under the 30,500 ceiling (`agents_size_test.go` green). Verified, as asked.

## F6 🟡 — the comment written to stop comments going stale cited a test that has never existed

`read_json_note_test.go` named a guard that appears nowhere in this repo or in any commit of its history. `TestReadJSONNoteCommentNamesItsGuard` pins only the **forward** direction (the doc comment contains the guard's name), so a wrong name in the same file was structurally invisible.

`TestItem38CommentsCiteTestsThatExist` is the reverse direction: every `Test…` identifier in a comment in item 38's files must resolve to a test function declared **somewhere in the module** (these comments legitimately cite guards in other packages). The dead identifier is kept only as a string literal in a negative control, never in prose — otherwise the test flags its own comment (it did, on first run).

## Also fixed — same class, smaller

- `read_repair_test.go`'s header claimed every test in it was RED at `517fc76`; one is an **invariant guard** the same file labels correctly 100 lines later. It also deferred the matrix to "the PR body", which is not in the tree. **The matrix is now in the file, measured by running it against a `git archive 517fc76` tree** — not reasoned about. That measurement corrected my own first draft, which had guessed the new test PASSES at `517fc76`; it is red there too, on the *opposite* assertions.
- `read_help.go`'s "EVERY CLAUSE OF IT MEASURED FALSE" — corrected clause by clause. Both surviving premises re-measured: `emitJSON` is downstream of `getInto` at all 16 of its call sites, and `encoding/json` returns `invalid character '\r' in string literal`.
- `read_json_note_test.go:13` named the wrong constant (`crInAName` vs `crBodyModelName`).
- `bornSplitItems` claimed "mutation matrices" the item file has never had.
- README: the "another reason" with no first reason, the "raw … a stable passthrough" opening that let a README-only reader still conclude byte identity, and the insertion sitting between the "Two properties" bullets and the sentence referring back to them.

## Round-3 verification

`make ci` green (**21 packages ok**, 1 with no test files). `make lint` **0 issues** — and the instrument was validated by a real failure first: my initial fixture used a literal U+00AD and lint reported `ST1018 … (staticcheck)`, exit non-zero. `gofmt -s -l .` clean over **471** `.go` files, positive-controlled (a deliberately misformatted file was listed, then restored). `./scripts/ci-shallow.sh` **21/21 PASSED** against the committed SHA `31d5ba3e56c3`.

⚠️ **Local golangci-lint is 2.13.2; CI pins v2.12.2** (`.github/workflows/ci.yml:161`). The zero above is my version's, not CI's.

### Red/green

| test | pre-change | at HEAD |
| --- | --- | --- |
| `TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne` (a) | **RED at `f936cfc`** — "lost ErrRateLimited (exit 6)" | green |
| `TestDeepPagingCap…` (c), the 500-byte half | **RED at `f936cfc`** — "the classifier is reading the truncated string" | green |
| `TestThrottle429KeepsExitSixThroughTheMessageFilter` (seam) | **RED at `f936cfc`** — "exits 2, want 6" | green |
| `TestRawDocCommentsDisclaimByteIdentity` | **RED before the sweep** — 6 of 8 types | green |
| `TestSaferuneCallersAreLedgered` | **RED before the doc fixes** | green |
| `TestItem38CommentsCiteTestsThatExist` | **RED before the citation fix** | green |

### Mutation matrix — each applied to real source, run, reverted; each killed by *that guard's own* message

| mutant | killed by |
| --- | --- |
| `wireMsg := snippet([]byte(msg))` (== the pre-fix shape) | `TestDeepPagingCap…` halves (a) and (c) **and** the seam test |
| `isDeepPagingCap` → `return false` | `TestDeepPagingCap…` half (b) — the positive control on the classifier |
| `snippet` drops `saferune.Strip` | `TestDeepPagingCap…`'s display assertions |
| revert `ModelSearchResult`'s comment to the byte claim | `TestRawDocCommentsDisclaimByteIdentity` |
| add a 9th `Raw []byte` type, unledgered (GREW) | same, by name |
| ledger names a type that does not exist (SHRANK) | same, via its minimum-count control |
| delete `` `snippet` `` from AGENTS.md's Layout entry | `TestSaferuneCallersAreLedgered` |
| revert `saferune.go` to "TWO PACKAGES" | same, on the count |
| remove `pkg/civitai` from the ledger (GREW) | same, on membership |
| `pkg/civitai` stops importing `saferune` (SHRANK) | same, on membership |
| reintroduce the original dangling citation | `TestItem38CommentsCiteTestsThatExist` |
| typo a guard name in a *different* file (`read_help.go`) | same — proves reachability beyond its host file |

🔴 **One mutant SURVIVED on the first attempt and the instrument was fixed, not the score.** Deleting `` `snippet` `` from AGENTS.md's Layout entry passed, because the first cut searched the *whole file* and AGENTS.md also contains the prose phrase "what an error **snippet** prints" in item 38's trigger. The check is now scoped to the `internal/saferune` bullet and requires the **backticked** identifier; the mutant then died. The same class bit `TestRawDocCommentsDisclaimByteIdentity`, which reported 8 false "missing" verdicts until the doc text was whitespace-normalised (doc comments hard-wrap, so the sentence lands with a newline at a different word in every file). Both are recorded in the tests' own comments.

## Not in scope, and not made worse

The #393 structural guard's blindness to `pkg/civitai`'s `saferune.Strip` call, and the `--help` rune budget, are untouched — being filed separately. Neither was widened: no `--help` text changed, and no `safeTerm` call site moved.

## What I could not fully establish

- **`saferune`'s "the strip is correct here because every argument is server-supplied" is a judgement no test enforces.** `TestSaferuneCallersAreLedgered` proves membership and naming; it cannot tell whether a fourth caller is *entitled* to the unconditional strip. Stated as a residual in item 38.
- **The byte-identity enumeration is OPEN, not closed** — deliberately, and that is the whole lesson of round 2's count of three. The new ledger reads doc comments on struct fields; the detail getters return raw bytes as a bare `[]byte` with no doc-comment slot, and narrative prose anywhere in the package is not read.
- ~~**`TestItem38CommentsCiteTestsThatExist` is scoped to four files, not the package.** Measured: 31 comment-cited names across `internal/cmd` do not resolve…~~ **Superseded by round 4:** that 31 was measured with a package-local resolver this guard does not ship, and the scan now covers twelve files plus the decision doc. Corrected numbers and the real reason for the scope limit are in the Round 4 section below.

---

# Round 4 — `39389c1` (audited range `31d5ba3..39389c1`)

Numbering follows this tree's own: `f936cfc` = round 2, `31d5ba3` = round 3, this commit = round 4.

The adversarial audit of `31d5ba3` returned **nine findings, zero of them runtime defects**. Every one was a claim the tree made that the tree did not support — which is the same shape as round 3's, and round 3's fixes are where they came from. All nine are addressed. In every case the fix is a guard that pins the claim, not a better sentence.

**Every number below was re-derived on this tree with the instrument that ships, not inherited from the audit brief.**

## Findings closed

| # | Finding | What changed |
| --- | --- | --- |
| 🔴-1 | `saferune_callers_ledger_test.go`'s `question` field advertised rename-safety it did not have — it was a plain `string` used as a substring needle, bound to no declaration. | `checkQuestionsResolve` resolves every ledgered `question` to a top-level receiver-less `FuncDecl` in its own `pkgPath` before any prose is searched. Comment rewritten to say what the code does. Residual in item 38 corrected. |
| 🔴-2 | The "measured, not reasoned" matrix in `read_repair_test.go` disagreed with the measurement, at **both** ends, and said "one of the five tests" over a file declaring six. | Both ends re-run against real `git archive` trees and rewritten from what the run prints. The header now states **no count**; `TestReadRepairMatrixNamesEveryTestInThisFile` pins membership instead. |
| 🟡-1 | `isDeepPagingCap`: "any transformation applied first can only widen it" — false, and contradicted by this PR's own half (c). | Both directions named: the strip can only widen, the 500-byte bound can only narrow, both are wrong to classify on. |
| 🟡-2 | Classifying pre-`snippet` also un-bounded the match: `msg` is the **entire body** for a non-JSON 429, capped only by `maxResponseBody` (64 MiB). | `classifyWindow` + `maxClassifyMessage = 8 KiB`, a budget deliberately separate from the display budget. Pinned red-before/green-after. **No false positive was demonstrated — this is not a fix for an observed defect**, and the number is generous rather than derived (`read.go` says so explicitly). Round 4 called it *containment*; round 5 measured it and that word was wrong — see below. |
| 🟡-3 | The "31 unresolved comment-cited names" justifying a scope limit was measured with a **package-local** resolver this guard does not ship. | Re-measured with the shipped instruments; scope limit kept on a corrected and much better reason (below). |
| 🟡-4 | The evidence header and `item38CommentedFiles` declared different file sets, disagreeing in **both** directions; `pkg/civitai/read.go` — item 38's primary code file — was uncovered. | Ledger widened to 12 repo-relative files **plus the decision doc**, scanned as text. `TestItem38FileLedgerMatchesTheDecisionHeader` pins the two sets equal in both directions. |
| 🟡-5 | "one measurement table and no mutation matrix" was written by the same commit that added the second and third tables. | Corrected in both places, and `TestItem38EvidenceTableGeometry` now asserts table placement and count per section. The "no mutation matrix" half was correct and is kept. |
| 🟢-1 | `raw_doc_ledger_test.go`'s control fired on every SHRINK, so the ledger's own `SHRANK:` guidance was unreachable and a real finding was labelled "not a finding". | Now a **hard floor of one**; the ledger comparison owns every shrink. |
| 🟢-2 | README: `generate` / `workflows list --json` "pass through the raw *orchestrator* reply" — they route through `writeRawJSON`, which `json.Indent`s. | Split into the two byte changes: the re-indent **does** apply; the repair **never runs** there. |

## 🟡-3 re-measured, and why the scope limit stays

With `repoTestFuncNames` + `testIdentRe` — the instruments the guard actually ships — over all **471** `.go` files in the module, at this commit:

| | |
| --- | --- |
| citations in Go comments | **2103** (was 2096 at `39389c1`; round 5's own comments added 7) |
| unresolved sites | **23** |
| distinct unresolved names | **20** |

The 31 came from a package-local resolver; `repoTestFuncNames` is repo-wide precisely so cross-package citations resolve, which is why the old sentence listed them as part of its own count.

**All 20 were triaged.** 16 names at 19 sites are *correct prose* in five shapes a regex cannot separate from rot:

- a name **wrapped across a comment line-break**, or elided with `…`
- a **glob** naming a family (`TestAppPull*`)
- a **subtest path** (`Parent_Sub`), which no `func` declares
- a **fixture identifier** quoted from the test's own source
- a **deliberate citation of a test that was deleted, renamed or replaced** — this repo's own convention for recording what a test used to assert

**Four are genuine rot**, in packages this PR does not own. They are named with their real targets as a residual in item 38 rather than fixed, because a name-only correction leaves a comment that reads truer and may still be wrong — `pkg/civitai/download_ssrf_test.go:147` is the proof: its body describes a redirect-to-*loopback* case while the function under it builds a redirect-to-*plain-http* case.

So: globbing the check today reports 23 sites of which 19 are not defects — a permanently-red gate. Widening needs a suppression convention for those five shapes first, and the four rot findings are its motivation.

## Mutation matrix — round 4

Every mutant applied to real source in a `.git`-free sandbox copy, run, discarded. Each was watched to fail **with that guard's own message**.

| mutant | tree | result |
| --- | --- | --- |
| rename `safeTerm` → `safeTermRenamedByMutant` across `internal/cmd` | `31d5ba3` | `go test ./...` **FULLY GREEN** — the guard was unpinned |
| same rename | this commit | `TestSaferuneCallersAreLedgered` red: *"internal/cmd declares no top-level func safeTerm … RENAMED"* |
| rename `hasPrintableContent` in `internal/genapi` | this commit | same guard, same message, that row |
| rename `snippet` in `pkg/civitai` | this commit | same guard, same message, that row |
| rename `TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne` | `31d5ba3` | `go test ./...` **FULLY GREEN** |
| same rename | this commit | `TestItem38CommentsCiteTestsThatExist` red at **5 sites**, incl. `pkg/civitai/read.go:267` and the decision doc |
| `classifyMsg := msg` (remove the bound — the pre-round-4 shape) | this commit | `TestDeepPagingCapClassificationIsBounded` half (a) red, both assertions |
| `classifyWindow` → `return ""` | this commit | half (b) red — the positive control fires, so (a) is about the bound and not a phrase that never matched |
| rename `TagSearchResult.Raw` → `RawMUT` (a real SHRINK) | `31d5ba3` | red, but mislabelled *"CONTROL failure, not a finding"* |
| same mutant | this commit | red with the ledger's **SHRANK** guidance — the finding is now labelled as one |
| append a table to item 38's residuals | this commit | `TestItem38EvidenceTableGeometry`: *"holds 1 unledgered table(s) outside the numbered sections"* |
| delete one §3 table separator | this commit | same guard: *"§3 holds 1 table(s), ledgered as 2"* |
| add a test to `read_repair_test.go` with no matrix row | this commit | `TestReadRepairMatrixNamesEveryTestInThisFile` red by name |

## Re-measurements that corrected a written claim

`git archive <ref>` extracted to a clean tree, this commit's `read_repair_test.go` copied in minus the round-4 test (which names `maxClassifyMessage`, so neither tree compiles with it), then `go test ./pkg/civitai/`:

| tree | `TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne` | round 3 wrote |
| --- | --- | --- |
| `517fc76` | **3** assertions fail: half (a)'s two DISPLAY assertions + half (c)'s CLASSIFICATION assertion | "the classification half passes and the two DISPLAY assertions fail" — the second clause holds, the first does not |
| `f936cfc` | **3** assertions fail: half (a)'s two CLASSIFICATION assertions + half (c)'s | "RED there, on the two classification assertions" |

The other five rows of the matrix reproduced exactly as written. `read_repair_test.go` declared **six** `func Test`, not five.

## Gate

| gate | result |
| --- | --- |
| `make ci` | green (tidy + vet + test + build) |
| `go test ./...` | green, 21/21 packages |
| `make ci-shallow` | **PASSED** in a depth-1 clone of `5c9fba7d3187` — 21 pkgs ok, 0 failures, 0 timeouts |
| `make lint` | **0 issues**, golangci-lint **2.13.2** locally (CI pins **v2.12.2** — check CI's own `lint` job on this SHA) |
| `gofmt -s -l .` | clean, over **471** `.go` files found by `find` (positive control on the count) |
| lint negative control | a deliberately bad file → **1 issue**, so the zero above is a real zero |

## What round 4 could NOT establish

- **`maxClassifyMessage = 8 KiB` is generous, not derived.** No measurement in this repo pins a largest *legitimate* 429 message, and none of the proxy / CDN / captive-portal 429s `readError` also handles has been sampled for length at all. The only cap wording the repo records is the ~60-byte one in `isDeepPagingCap`'s own doc comment — which is *that comment's* claim, not a fresh measurement of the API. `read.go` states this in place of a justification it does not have.
- **`TestDeepPagingCapClassificationIsBounded` has no shipped-tree red row.** It cannot compile at `517fc76` or `f936cfc`. Its matrix is against a mutant of *this* tree, and the guard's own comment says so.
- **The four rot findings are named, not verified fixed.** Each needs its own function read before its comment can be rewritten; doing that on evidence this PR has not gathered is exactly how a follow-up audit introduces its own false claims. Closing condition is written into item 38.
- **`TestItem38EvidenceTableGeometry` pins placement and count, not adjectives.** "cross-tree measurement table" is a reader's judgement and is unasserted.
- **The README does not document the 429 → exit 2 reclassification at all** — a gap that *pre-dates* this PR (`isDeepPagingCap` is live at `517fc76`). Recorded as a residual with a closing condition, not fixed: writing that row changes the published exit-code contract's wording.
- **`checkQuestionsResolve` reads top-level receiver-less funcs only.** A question moved onto a method fails it as a rename; that is deliberate and the message says so, but it is a limitation, not a proof.
- **The citation totals are a measurement of this tree, not an invariant** — 2103 moves with any comment edit. Only the unresolved counts carry the argument.


---

# Round 5 — `5c9fba7`, the last round

Four fixes. **Zero runtime defects**: every one is a guard that did not guard, or
a sentence the code did not support. The ladder ends here; nothing below was
audited by anyone else.

## 1 — the citation check's `.go` arm had no positive control

At `31d5ba3` the `.go` scan had its own floor. At `39389c1` both arms
incremented one `cited`, and the only floors were `docCited < 5`
(Markdown-specific) and a combined `cited < 20`. The Markdown arm alone
contributes **28**, so the combined floor could never observe a zero from the
twelve-file `.go` scan — while the code's own comment asserted that case was
covered.

Split into `goCited` (floor **40**, measured **82** at this commit) and
`docCited` (floor **5**, measured **28**). Floors are lower bounds well under
the measurements, not the measurements — the counts move with any comment edit.

## 2 — matrix membership was a substring test, not a name test

`TestReadRepairMatrixNamesEveryTestInThisFile` asked whether the header
*contains* each declared name, so any test whose name is a strict **prefix** of
a ledgered one passed with no row. Not contrived: this file's names share
**25**-character (`TestDeepPagingCapClassifi…`) and **11**-character
(`TestGetInto…`) prefixes. The header's identifiers are now extracted with
`matrixIdentRe` and compared **exactly**, with a positive control on the
extraction.

## 3 — a fixture control measured the opposite of what its comment said

`TestDeepPagingCapClassificationIsBounded`'s controls measured
`strings.Index(body, capPhrase)` while their comment said *"measure the offset
inside the message, not inside the body"* — 12 bytes apart (`{"message":"`).
Both arms now measure inside the extracted message, and (b) asserts the phrase
**ends** inside the window rather than merely starting there, since
`classifyWindow` cuts by byte and a split phrase matches nothing.

## 4 — `maxClassifyMessage` was framed as resource containment; it is not

Both `read.go` and item 38 §4 said the bound stops "an arbitrary body" being
"scanned in full". Measured on this tree (`go1.25.14 linux/amd64`, a `readError`
benchmark over a non-JSON 429 at `-benchtime=20x -count=3`, written to take
these numbers and then deleted):

| body | `B/op` **with** `classifyWindow` | **without** |
| --- | --- | --- |
| 32 MiB, uppercase | 67.12 MB | 100.67 MB |
| 1 MiB, uppercase | 2.11 MB | 3.15 MB |
| 32 MiB, lowercase | 67.11 MB | 67.11 MB |
| 1 MiB, lowercase | 2.10 MB | 2.10 MB |

Peak allocation is **~2× the body either way**. The statement immediately after
the classifier — `msg = snippet([]byte(msg))` — converts the whole message and
walks every byte through `saferune.Strip`, unconditionally and regardless of
this constant, on top of the `string(raw)` copy `readError` already made at
entry. The bound removes a *third* full-body copy, not the first two.

What it **does** bound is exactly one allocation: `strings.ToLower(msg)` inside
`isDeepPagingCap`, worth one full-body copy. The lowercase rows are why that has
to be said carefully — `strings.ToLower` returns its input **without
allocating** when an all-ASCII string has nothing to fold, so an all-lowercase
fixture measures the two arms as identical and would have "confirmed" that the
bound buys no memory at all.

Both sites now say the bound is **semantic** — a cap phrase past 8 KiB no longer
moves the exit code, which is the consequence the guard actually pins — name
`saferune.Strip` as the call that walks the whole message, and make **no
wall-time claim**: across the four size/case pairs the median direction was not
even consistent (at 1 MiB lowercase the *unbounded* arm measured faster).

## Mutation matrix — round 5

Applied to real source, run, reverted from a copy. Each watched to fail **with
that guard's own message**.

| mutant | tree | result |
| --- | --- | --- |
| `parser.ParseComments` → `0` in the `.go` loop | `39389c1` | **SURVIVES** — `ok github.com/civitai/cli/internal/cmd`, a green verdict about twelve files it read zero comments from |
| same mutant | `5c9fba7` | **KILLED**: *"the scan found only 0 cited test names across […] — the `.go` arm is not reading the comments"* |
| declare a test named `TestDeepPagingCapClassificationIsBounded` minus `IsBounded` (a strict prefix of a ledgered name, with no row) | `39389c1` | **SURVIVES** — guard green |
| same mutant | `5c9fba7` | **KILLED**: *"read_repair_test.go declares … and the matrix in this file's header does not name it"* |
| `matrixIdentRe` → a pattern matching nothing | `5c9fba7` | **KILLED**: *"matrixIdentRe found only 0 test names in read_repair_test.go's matrix header"* |
| (a) fixture at **message** offset 8184 / **body** offset 8196 — the phrase *split* by the window, which makes half (a) vacuous | `39389c1` (body-measured control) | **SURVIVES** — the old control reads 8196 > 8192 and calls it "outside" |
| same fixture | `5c9fba7` (message-measured control) | **KILLED**: *"the cap phrase starts at byte 8184 of the extracted message, which is inside the 8192-byte classification window — (a) would assert nothing"* |
| (b) fixture pushed to message offset 8200 | `5c9fba7` | **KILLED**: *"the control fixture's phrase ends at byte 8233 … past the 8192-byte window"* |

The `39389c1` rows are the point: the first, third and sixth are guards that
were green while not guarding.

## Gate — round 5

| gate | result |
| --- | --- |
| `make ci` | green (tidy + vet + test + build), 21/21 packages |
| `make ci-shallow` | **PASSED** in a depth-1 clone of `5c9fba7d3187` — 21 pkgs ok, 0 failures, 0 timeouts, `go-test-rc=0` |
| `make lint` | **0 issues**; golangci-lint **2.13.2** (nixpkgs, built with go1.27.1). **CI pins v2.12.2** — read CI's own `lint` job on this SHA, the local zero is a different build |
| lint negative control | a file with an unused func + a misspelling → **2 issues** (`misspell: 1`, `unused: 1`), so the zero above is a real zero |
| `gofmt -s -l .` | **0 listed**, against **471** `.go` files located by `find` — the positive control on the count |

## Collateral the round forced

Adding the allocation table to §4 moved item 38's table geometry to
`{3: 2, 4: 2}`; `TestItem38EvidenceTableGeometry` caught it, and the
`bornSplitItems` prose that describes the geometry ("three tables" → "four
tables", plus the enumeration) moved with it. Round 5's own comments added 7
citations, so the repo-wide total in `read_json_note_test.go` moved 2096 → 2103;
unresolved sites (23) and distinct names (20) are unchanged.

`TestItem38CommentsCiteTestsThatExist` also caught round 5's *own* first draft,
which spelled elided identifiers (`TestGetIntoErrorSnippet…`) and the prefix
mutant's name in prose. Those are now described rather than spelled, and the
comment says why.

## Noticed in round 5, NOT fixed

- **`TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne`'s half (c)
  has the same body-vs-message confusion fix 3 repaired.** `if len(long) <= 520`
  measures the whole wire body against `snippet`'s 500-byte bound, which applies
  to the extracted message (14 bytes smaller: 12 of prefix, 2 of suffix). The
  20-byte margin means it errs loud today, and the `strings.Contains(snippet(…))`
  check directly below it is a real control on the substance — so nothing is
  broken. Left alone because this round was scoped to four named fixes; filed so
  it is not lost.
- Everything under **"What round 4 could NOT establish"** above still stands
  unchanged, except that the 8 KiB number's justification is now stated
  correctly rather than as containment.
