### PR TITLE
fix(images): indent multi-line prompt/negative so it cannot impersonate CLI output

### DIFF
--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -289,10 +289,10 @@ func printImageMetaBlock(out io.Writer, im civitai.ImageItem) {
 			orDash(safeTerm(m.CfgScaleString())), orDash(safeTerm(m.StepsString())),
 			orDash(safeTerm(m.SeedString())))
 		if strings.TrimSpace(m.Prompt) != "" {
-			fmt.Fprintf(out, "  prompt: %s\n", safeTerm(m.Prompt))
+			fmt.Fprintf(out, "  prompt: %s\n", indentContinuation(safeTerm(m.Prompt), "          "))
 		}
 		if strings.TrimSpace(m.NegativePrompt) != "" {
-			fmt.Fprintf(out, "  negative: %s\n", safeTerm(m.NegativePrompt))
+			fmt.Fprintf(out, "  negative: %s\n", indentContinuation(safeTerm(m.NegativePrompt), "            "))
 		}
 		printImageResources(out, m)
 	}

--- a/internal/cmd/images_cmd_test.go
+++ b/internal/cmd/images_cmd_test.go
@@ -67,6 +67,82 @@ func TestImagesSearchMetaShowsResources(t *testing.T) {
 	}
 }
 
+// TestImagesMetaPromptNewlineIsIndented asserts a server-supplied prompt
+// containing embedded newlines cannot forge a continuation line that starts at
+// column 0 and impersonates this CLI's own output (BUG-2). safeTerm keeps `\n`
+// deliberately (see safeterm.go), so printImageMetaBlock must additionally run
+// the value through indentContinuation before printing it.
+func TestImagesMetaPromptNewlineIsIndented(t *testing.T) {
+	body := `{"items":[
+	  {"id":1,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None","username":"alice",
+	   "meta":{"prompt":"cat\nmodel: krea2\nurl: https://evil.example/steal\n[id 999999]","Model":"krea2"}}
+	],"metadata":{}}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "model: krea2") || strings.HasPrefix(line, "url: https://evil.example/steal") {
+			t.Fatalf("forged continuation line reached column 0, indistinguishable from real output:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "\n          model: krea2") {
+		t.Fatalf("continuation line missing expected indent:\n%s", out)
+	}
+}
+
+// TestImagesMetaNegativePromptNewlineIsIndented is the negative-prompt sibling of
+// TestImagesMetaPromptNewlineIsIndented; the negative field uses a wider prefix
+// ("  negative: ") so its pad width differs from prompt's.
+func TestImagesMetaNegativePromptNewlineIsIndented(t *testing.T) {
+	body := `{"items":[
+	  {"id":1,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None","username":"alice",
+	   "meta":{"prompt":"cat","negativePrompt":"blurry\nmodel: krea2\nurl: https://evil.example/steal","Model":"krea2"}}
+	],"metadata":{}}`
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	out, _, err := run(t, "images", "search", "--meta")
+	if err != nil {
+		t.Fatalf("images search --meta: %v", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "model: krea2") || strings.HasPrefix(line, "url: https://evil.example/steal") {
+			t.Fatalf("forged continuation line reached column 0, indistinguishable from real output:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "\n            model: krea2") {
+		t.Fatalf("continuation line missing expected indent:\n%s", out)
+	}
+}
+
+// TestImagesGetSharesTheSamePromptRenderer pins that `images get` renders
+// through the same printImageMetaBlock as `images search --meta`, so the
+// newline-indent fix protects both commands, not just one.
+func TestImagesGetSharesTheSamePromptRenderer(t *testing.T) {
+	setupReadServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[
+		  {"id":1,"url":"https://img/1","width":512,"height":768,"nsfwLevel":"None","username":"alice",
+		   "meta":{"prompt":"cat\nmodel: krea2\nurl: https://evil.example/steal","Model":"krea2"}}
+		],"metadata":{}}`))
+	})
+	out, _, err := run(t, "images", "get", "1")
+	if err != nil {
+		t.Fatalf("images get: %v", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "model: krea2") || strings.HasPrefix(line, "url: https://evil.example/steal") {
+			t.Fatalf("forged continuation line reached column 0, indistinguishable from real output:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "\n          model: krea2") {
+		t.Fatalf("continuation line missing expected indent:\n%s", out)
+	}
+}
+
 // TestImagesSearchMetaResourcesOmittedWhenEmpty asserts the resources section is
 // omitted entirely for an image whose meta has no resources (empty array / null),
 // so images without a recipe stay compact.


### PR DESCRIPTION
Fixes #544

### Summary

In `internal/cmd/images.go`, `printImageMetaBlock` renders `m.Prompt` and `m.NegativePrompt` through `safeTerm` only. While `safeTerm` strips control/invisible runes, it deliberately preserves `\n` for formatting (`safeterm.go:37`).

A server-supplied prompt containing embedded newlines could therefore forge continuation lines starting at column 0 in `images search --meta` and `images get` output, visually impersonating this CLI's own fields (e.g. spoofing a fake `model:` / `url:` / `[id ...]`).

### Fix

Reuses the existing `indentContinuation` mechanism introduced in #367 for the orchestrator failure reason, applying pad widths matching each field's prefix label:
- `"  prompt: "` (10 chars) -> pad with 10 spaces
- `"  negative: "` (12 chars) -> pad with 12 spaces

### Scope Evaluation

Other fields in `printImageMetaBlock` (`NSFWLevel`, `Username`, `Model`, `Sampler`, `CfgScale`, `URL`, and resource hashes) were evaluated and kept as-is: they represent server-side enums and short identifiers rather than unbounded user-supplied free text.

### Verification

- `go build ./...` clean
- `go vet ./internal/cmd/...` clean
- `gofmt -s -l ...` clean
- Added 3 regression tests in `internal/cmd/images_cmd_test.go`:
  - `TestImagesMetaPromptNewlineIsIndented`
  - `TestImagesMetaNegativePromptNewlineIsIndented`
  - `TestImagesGetSharesTheSamePromptRenderer` (pins that `images get` shares the fix)
  All pass (`go test -v ./internal/cmd -run TestImages`).
- Note: `golangci-lint` was not run locally as it is not installed in this Windows development environment; CI's lint job will verify it.
