### PR TITLE
feat(agent-setup): the managed block links example apps, as ONE docs URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,9 +442,9 @@ item must carry a trigger that is a routing question rather than a label
     symlinks, config roots, `--check`'s verdict, `--json`'s shapes?**
     → evidence: claudedocs/decisions/35-agent-setup-merges-a-users-file.md
 
-36. **Editing what `agent-setup`'s block says a project can RUN — its local-dev
-    branch, script table, lockfile rule — flattening it to one list, or naming
-    the SCAFFOLDER an author with no app should run?**
+36. **Editing what `agent-setup`'s block says — its local-dev branch, script
+    table, lockfile rule, flattening it to one list, the SCAFFOLDER an author
+    with no app should run, or what its Docs section links?**
     → evidence: claudedocs/decisions/36-agents-block-per-project.md
 
 37. **Typing a `pkg/civitai` username as `string`, or "fixing" a `FlexString`

--- a/claudedocs/decisions/36-agents-block-per-project.md
+++ b/claudedocs/decisions/36-agents-block-per-project.md
@@ -222,3 +222,125 @@ added:
 ```
 
 Both green at HEAD.
+
+---
+
+## Third: the Docs section links ONE URL, never a list of repositories
+
+The block's `### Docs` section reached the guide, the reference and `llms.txt`,
+and nothing in it reached a **worked example**. An author's agent had four
+sentences of gotchas and no App Block it could read end to end. One line was
+added:
+
+```
+- Example apps you can read end-to-end:
+  https://developer.civitai.com/apps/examples
+```
+
+### The rejected alternative, and why it is not a style preference
+
+The obvious edit is to spell the seven example repositories into the block. It
+is refused for one structural reason:
+
+🔴 **This block is written to disk in somebody else's project, and nothing can
+recall it.** A URL embedded here is copied into every directory `civitai
+agent-setup` has ever run in. The only thing that rewrites it is another
+`agent-setup` run in that same directory, which most authors never do. So a
+literal that rots here rots in every project separately and forever, while a
+docs-site page is corrected once, for every reader, by the people who own the
+list. That asymmetry is the whole argument: **the CLI ships the address, the
+docs repo ships the contents.**
+
+### The measurements behind it
+
+Taken 2026-09-10/11 from this host, anonymously, over real HTTP.
+
+| Probe | Result | What it settles |
+|---|---|---|
+| `developer.civitai.com/apps/guide/` | `200` | positive control — the prober can see a live page |
+| `developer.civitai.com/apps/reference/` | `200` | positive control |
+| `developer.civitai.com/llms.txt` | `200` | positive control |
+| `developer.civitai.com/apps/showcase` | `200` | **no trailing slash** |
+| `developer.civitai.com/apps/showcase/` | `404` | **with one** — the slash is load-bearing per path |
+| `civitai.com/models` | `200` | control: the site answers anonymous GETs |
+| `civitai.com/apps` | `404` | the whole `/apps` route family is unreachable anonymously |
+| `civitai.com/apps/run/gen-matrix` | `404` | …which is why a run-URL is not a readable example |
+
+Three residuals follow from that table, and each killed a different candidate
+line:
+
+1. **A run-URL is not an example.** `civitai.com/apps/run/<slug>` 404s for a
+   logged-out reader — and it does so because `civitai.com/apps` itself 404s,
+   not because that particular slug is wrong. An agent sent there gets a 404 and
+   no way to tell a dead app from a dead route. So the page links **repositories**,
+   which an agent can clone and read, not running instances.
+2. **`/apps/showcase` is the COMPONENT showcase, and was conflated with an
+   example gallery in the handoff this work came from.** It answers `200`, which
+   is exactly what makes the conflation survivable: a link there resolves and
+   sends the reader to the wrong thing. It is not what this line points at.
+3. **GitHub topics are already an unreliable enumeration, so "just query the
+   topic" is not a durable substitute for a curated page.** `topic:civitai-app-block`
+   returned **6** repositories, which is a different set from the seven example
+   apps: two of the seven carry no topics at all, and one repository the query
+   *does* return is not one of the seven. A list nobody maintains is a list that
+   is wrong in both directions.
+
+### The trailing slash is measured, never tidied
+
+`/apps/guide/` is `200` **with** its slash; `/apps/showcase` is `200`
+**without** one. There is no site-wide rule to infer, so the spelling of any URL
+in this section is a measurement, not a convention. Do not normalise them by eye.
+
+### Guards
+
+`internal/cmd/agent_setup_docs_test.go`:
+
+- `TestTheBlocksDocsSectionIsPinnedForEveryProjectKind` — pins the WHOLE
+  normalised `### Docs` section, byte for byte, for every shape
+  `allProjectShapesForTest` produces (`npm` with and without recognised scripts,
+  `no-build`, `none`). Two assertions with different messages: the link **set**
+  (so adding or removing a URL is a named edit) and the **whole string** (so a
+  reword is too — a word-level guard on prose is walkable by rewording, and the
+  wording is the claim about what a reader gets from following the link). It is
+  per-shape because the three `{{ if }}` branches are what a mis-nested template
+  edit can drop the section out of, and the `static` author — the one with the
+  least local code to read — is exactly the reader who needs the examples most.
+- `TestDocsSectionExtractorCanFail` — negative control for `docsSectionOf`, in
+  both directions: it must report *absent* for a block with no section, *present*
+  for one that has it, and must stop at the END marker.
+- `TestBlockDocsLinksResolve` — the liveness probe, **opt-in behind
+  `CIVITAI_CHECK_DOCS_LINKS=1`**, following `internal/scaffold`'s
+  `CIVITAI_CHECK_PUBLISHED_PINS` pattern so an offline `make ci` stays green. It
+  carries its own negative control (a path on the same host that cannot exist
+  must answer `>= 400` or the whole run is declared meaningless), and a transport
+  failure **skips** rather than fails — "the network is down" and "the page is
+  gone" are different findings.
+
+Red-then-green, run at `origin/main` `8e7d2dc` with only the test file added:
+
+```
+--- FAIL: TestTheBlocksDocsSectionIsPinnedForEveryProjectKind
+    the `### Docs` link SET changed for kind "npm".
+      want: …/apps/examples, …/apps/guide/, …/apps/reference/, …/llms.txt
+      got:  …/apps/guide/, …/apps/reference/, …/llms.txt
+    the `### Docs` section for kind "npm" is not what is pinned. …
+```
+
+reported once per shape (`npm`, `no-build`, `none`, `npm`-with-scripts). Green at
+HEAD.
+
+### 🔴 WHAT IS NOT ESTABLISHED
+
+**The page was not live when this shipped.** `developer.civitai.com/apps/examples`
+answered `404` — both with and without a trailing slash — at the time of the
+measurements above, while the other three links in the same section answered
+`200`. The docs page is authored in a separate repository, in parallel. So this
+records a **dead link that was shipped deliberately, on the expectation that the
+page lands**; `TestBlockDocsLinksResolve` is the check that says when it has, and
+it is the check to run before believing any claim that the link works.
+
+**No CI job sets `CIVITAI_CHECK_DOCS_LINKS`.** Adding one means editing
+`.github/workflows/*`, which AGENTS.md puts behind "ask first". Until that
+happens the probe is a manual pre-merge check and nothing runs it on a schedule —
+so a link that dies later dies silently. Saying so is the honest version of "the
+links are verified".

--- a/internal/cmd/agent_setup_docs_test.go
+++ b/internal/cmd/agent_setup_docs_test.go
@@ -1,0 +1,256 @@
+package cmd
+
+// The managed block's `### Docs` section: what it links, and the one rule about
+// how it links it.
+//
+// 🔴 THE SECTION NAMES ONE URL PER RESOURCE, AND NEVER A LIST OF REPOSITORIES.
+// The example App Blocks live in seven separate GitHub repos, and the obvious
+// "helpful" edit is to spell all seven into the block. That edit is refused, and
+// the reason is not taste: this block is WRITTEN TO DISK IN SOMEBODY ELSE'S
+// PROJECT. A repo URL embedded here is copied into every project `agent-setup`
+// has ever run in, and nothing can recall it — only a re-run of `agent-setup`
+// rewrites the block, and most authors never re-run it. A docs-site page can be
+// corrected once for every reader. See AGENTS.md item 36 — evidence:
+// claudedocs/decisions/36-agents-block-per-project.md §"Third: the Docs section
+// links ONE URL" for the measurements (the GitHub topic enumeration is already
+// wrong, and `civitai.com/apps/...` 404s anonymously).
+//
+// 🔴 WHERE THE URL LIVES: `internal/cmd/templates/agents-app.md` holds the
+// literal that ships, and `wantDocsSection` below holds the only other spelling
+// in this repo. Correcting the URL is those two edits and nothing else — verified
+// by grep at the time this was written, and the failure message below names both
+// so the next person does not have to.
+
+import (
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// wantDocsSection is the WHOLE `### Docs` section, byte for byte.
+//
+// 🔴 IT IS PINNED AS A WHOLE STRING, NOT AS A SET OF WORDS, BECAUSE THE ARTIFACT
+// UNDER TEST IS PROSE. A guard that checks "the block mentions
+// developer.civitai.com/apps/examples" is walkable by rewording the line around
+// it into something that no longer tells the reader what they get — and the
+// wording is the point: this line is read by an agent deciding whether to follow
+// the link. Pinning the whole section costs a test edit for a cosmetic reword,
+// which is the price of a machine-readable claim about what the section says.
+const wantDocsSection = `### Docs
+
+- Guide: https://developer.civitai.com/apps/guide/
+- Reference (manifest, scopes, hooks, message bridge, CLI):
+  https://developer.civitai.com/apps/reference/
+- Example apps you can read end-to-end:
+  https://developer.civitai.com/apps/examples
+- Full doc index for agents: https://developer.civitai.com/llms.txt`
+
+// docsLinkRe pulls the link SET out of a section. The expected set is derived
+// from the golden above rather than written out again, so the two cannot
+// disagree. It exists for the failure MESSAGE: a whole-string mismatch reports a
+// diff, while the set reports "a link was added" or "a link was removed", which
+// is the edit somebody actually made.
+var docsLinkRe = regexp.MustCompile(`https?://[^\s)]+`)
+
+// docsSectionOf returns the `### Docs` section of a rendered block, from its
+// heading to the end of the block, with surrounding whitespace trimmed. The
+// second return is false when there is no such section — a distinct answer from
+// "the section is empty", because a guard that cannot tell those apart passes
+// vacuously on a block that lost the section entirely.
+func docsSectionOf(block string) (string, bool) {
+	const heading = "### Docs"
+	i := strings.Index(block, heading)
+	if i < 0 {
+		return "", false
+	}
+	rest := block[i:]
+	if j := strings.Index(rest, agentsEndMarker); j >= 0 {
+		rest = rest[:j]
+	}
+	// A following `### ` heading would end the section too. Today Docs is last;
+	// this is here so the extractor does not silently swallow a section added
+	// after it.
+	if j := strings.Index(rest[len(heading):], "\n### "); j >= 0 {
+		rest = rest[:len(heading)+j]
+	}
+	return strings.TrimSpace(rest), true
+}
+
+// TestTheBlocksDocsSectionIsPinnedForEveryProjectKind is the guard.
+//
+// It is per-SHAPE on purpose. The template branches three ways on the project it
+// is being written into (item 36), and each branch is a `{{ if }}`/`{{ else }}`
+// boundary a mis-nested edit can move — so "the Docs section survived" is a claim
+// about each branch separately, not about the file. An author scaffolding the
+// `static` template is exactly the reader with the most to gain from an example
+// app and the least local code to read.
+func TestTheBlocksDocsSectionIsPinnedForEveryProjectKind(t *testing.T) {
+	wantLinks := docsLinkRe.FindAllString(wantDocsSection, -1)
+	if len(wantLinks) < 4 {
+		t.Fatalf("CONTROL failure, not a finding: the golden section parses to %d link(s), want >= 4. "+
+			"docsLinkRe (%s) has stopped matching, so every comparison below is against an empty set",
+			len(wantLinks), docsLinkRe)
+	}
+	sort.Strings(wantLinks)
+
+	shapes := allProjectShapesForTest()
+	if len(shapes) < 3 {
+		t.Fatalf("CONTROL failure, not a finding: allProjectShapesForTest returned %d shape(s), want >= 3 — "+
+			"the three-branch claim in this test's name is not being exercised", len(shapes))
+	}
+
+	for _, shape := range shapes {
+		block, err := agentsManagedBlock(shape)
+		if err != nil {
+			t.Fatalf("rendering for kind %q: %v", shape.Kind, err)
+		}
+		got, ok := docsSectionOf(block)
+		if !ok {
+			t.Errorf("the rendered block for kind %q (%d recognised script(s)) has NO `### Docs` section at all. "+
+				"Every branch of the template must keep it: the reader of a `static` project has the least local "+
+				"code to learn from and the most to gain from the examples page", shape.Kind, len(shape.Scripts))
+			continue
+		}
+
+		gotLinks := docsLinkRe.FindAllString(got, -1)
+		sort.Strings(gotLinks)
+		if strings.Join(gotLinks, "\n") != strings.Join(wantLinks, "\n") {
+			t.Errorf("the `### Docs` link SET changed for kind %q.\n  want: %s\n  got:  %s\n"+
+				"The set is asserted so that adding or removing a link is a deliberate edit. If the change is "+
+				"intended, update wantDocsSection in internal/cmd/agent_setup_docs_test.go to match "+
+				"internal/cmd/templates/agents-app.md — those are the only two places a docs URL is spelled.",
+				shape.Kind, strings.Join(wantLinks, ", "), strings.Join(gotLinks, ", "))
+		}
+
+		if got != wantDocsSection {
+			t.Errorf("the `### Docs` section for kind %q is not what is pinned.\n--- want ---\n%s\n--- got ---\n%s\n"+
+				"The WHOLE section is pinned, not individual words, because a reworded line is still a changed "+
+				"claim about what a reader gets from following it. Edit internal/cmd/templates/agents-app.md and "+
+				"wantDocsSection together.", shape.Kind, wantDocsSection, got)
+		}
+	}
+}
+
+// TestDocsSectionExtractorCanFail is the negative control for docsSectionOf.
+//
+// Without it, an extractor that has stopped finding the heading returns ("",
+// false) for every shape, the test above reports "no Docs section" for all of
+// them, and a reader "fixes" the template. Worse in the other direction: an
+// extractor returning ("", true) on a block with no section would compare an
+// empty string against an empty expectation if the golden were ever blanked.
+func TestDocsSectionExtractorCanFail(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		block string
+		want  bool
+	}{
+		{"no docs section", "## Building a Civitai App\n\n### Gotchas\n\n- a\n" + agentsEndMarker, false},
+		{"empty block", "", false},
+		{"heading only", "### Docs\n" + agentsEndMarker, true},
+	} {
+		if _, ok := docsSectionOf(tc.block); ok != tc.want {
+			t.Errorf("%s: docsSectionOf reported present=%t, want %t — the extractor cannot tell "+
+				"an absent section from a present one, so the guard above proves nothing", tc.name, ok, tc.want)
+		}
+	}
+
+	// The positive half: it finds the real one, and stops at the END marker.
+	block, err := agentsManagedBlock(allProjectShapesForTest()[0])
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	got, ok := docsSectionOf(block)
+	if !ok {
+		t.Fatal("docsSectionOf found no section in a real rendered block — the extractor is broken, " +
+			"not the template")
+	}
+	if strings.Contains(got, agentsEndMarker) {
+		t.Errorf("the extracted section still carries the END marker, so it is not the section but the "+
+			"rest of the file:\n%s", got)
+	}
+}
+
+// docsLinkProbeEnv gates the ONE network-touching test in this package.
+//
+// 🔴 OPT-IN, NEVER DEFAULT. `make ci` must stay green with no network — a test
+// that fails on a train is a test somebody deletes. This follows the existing
+// pattern in internal/scaffold (CIVITAI_CHECK_PUBLISHED_PINS); no CI job sets
+// this one today, so it is a MANUAL pre-merge check, and saying that out loud is
+// the honest version of "the links are verified".
+const docsLinkProbeEnv = "CIVITAI_CHECK_DOCS_LINKS"
+
+// mustNotResolve is the probe's own negative control: a path on the same host
+// that cannot exist. If THIS comes back < 400 the prober is reading something
+// other than the status of the URL it was given, and every green below is a fact
+// about the prober rather than about the docs site.
+const mustNotResolve = "https://developer.civitai.com/__civitai-cli-link-probe-must-404__"
+
+// TestBlockDocsLinksResolve fetches every URL the block ships and fails on a
+// 4xx/5xx. A transport failure SKIPS rather than fails: "the network is down"
+// and "the page is gone" are different findings and only one of them is this
+// test's.
+func TestBlockDocsLinksResolve(t *testing.T) {
+	if os.Getenv(docsLinkProbeEnv) != "1" {
+		t.Skipf("network guard; set %s=1 to run (no CI job does — this is a manual pre-merge check)", docsLinkProbeEnv)
+	}
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	status := func(url string) (int, error) {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("User-Agent", "civitai-cli-docs-link-probe")
+		resp, err := client.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode, nil
+	}
+
+	if code, err := status(mustNotResolve); err != nil {
+		t.Skipf("%s unreachable (%v) — skipping, not failing; the control could not be run either", mustNotResolve, err)
+	} else if code < 400 {
+		t.Fatalf("CONTROL failure, not a finding: %s answered %d. A URL that cannot exist is reporting OK, "+
+			"so this prober cannot distinguish a live page from a dead one and nothing below it means anything",
+			mustNotResolve, code)
+	}
+
+	block, err := agentsManagedBlock(allProjectShapesForTest()[0])
+	if err != nil {
+		t.Fatalf("rendering: %v", err)
+	}
+	section, ok := docsSectionOf(block)
+	if !ok {
+		t.Fatal("no `### Docs` section to probe")
+	}
+	links := docsLinkRe.FindAllString(section, -1)
+	if len(links) < 4 {
+		t.Fatalf("CONTROL failure, not a finding: %d link(s) extracted, want >= 4", len(links))
+	}
+
+	for _, url := range links {
+		code, err := status(url)
+		switch {
+		case err != nil:
+			t.Skipf("%s unreachable (%v) — skipping, not failing", url, err)
+		case code >= 400:
+			t.Errorf("DEAD LINK IN THE MANAGED BLOCK — this URL is written into every project "+
+				"`civitai agent-setup` runs in, and nothing can recall it.\n  url:    %s\n  status: %d\n"+
+				"  fix:    correct it in internal/cmd/templates/agents-app.md AND wantDocsSection in this file, "+
+				"or publish the page before merging.", url, code)
+		default:
+			t.Logf("%s -> %d", url, code)
+		}
+	}
+}
+
+// 🔴 A TRAILING SLASH IS LOAD-BEARING ON THIS HOST, AND THAT IS MEASURED RATHER
+// THAN ASSUMED. developer.civitai.com serves `/apps/showcase` (200) and 404s
+// `/apps/showcase/`, while `/apps/guide/` is the other way round. So a URL here
+// cannot be "tidied" one way or the other by eye; run the probe above.

--- a/internal/cmd/templates/agents-app.md
+++ b/internal/cmd/templates/agents-app.md
@@ -98,5 +98,7 @@ fixed list. As of this CLI version:
 - Guide: https://developer.civitai.com/apps/guide/
 - Reference (manifest, scopes, hooks, message bridge, CLI):
   https://developer.civitai.com/apps/reference/
+- Example apps you can read end-to-end:
+  https://developer.civitai.com/apps/examples
 - Full doc index for agents: https://developer.civitai.com/llms.txt
 <!-- END civitai agent-setup -->


### PR DESCRIPTION
## 🔴 DO NOT MERGE YET — the link this PR ships does not resolve

`https://developer.civitai.com/apps/examples` answers **404** today, with and
without a trailing slash, while the other three links in the same section answer
**200**. The docs page is authored in a **separate repository, in parallel**, and
is still an open PR there. Merge this only once the page is live, and re-run the
probe below to confirm — **including the exact spelling**, because the trailing
slash is load-bearing on that host (`/apps/showcase` is `200`,
`/apps/showcase/` is `404`). If the docs side lands a different spelling, the URL
is in exactly two places (below) and both must move.

```
CIVITAI_CHECK_DOCS_LINKS=1 go test -count=1 -run TestBlockDocsLinksResolve -v ./internal/cmd/
```

## What this does

`civitai agent-setup`'s managed `AGENTS.md` block reached the guide, the
reference and `llms.txt` in its `### Docs` section, and **nothing in it reached a
worked example**. An author's agent had four sentences of gotchas and no App
Block it could read end to end. One line is added:

```
- Example apps you can read end-to-end:
  https://developer.civitai.com/apps/examples
```

## 🔴 ONE URL, never a list of repositories — and that is structural

The obvious "helpful" edit is to spell the seven example repos into the block.
It is refused because **this block is written to disk in somebody else's
project**: a repo URL embedded here is copied into every directory `agent-setup`
has ever run in, and nothing can recall it — only another `agent-setup` run *in
that same directory* rewrites the block, which most authors never do. A
docs-site page is corrected once, for every reader, by the people who own the
list. **The CLI ships the address; the docs repo ships the contents.**

Measured anonymously over real HTTP and recorded in the decision file:

| Probe | Result |
|---|---|
| `developer.civitai.com/apps/guide/` | `200` (positive control) |
| `developer.civitai.com/apps/reference/` | `200` (positive control) |
| `developer.civitai.com/llms.txt` | `200` (positive control) |
| `developer.civitai.com/apps/examples` | **`404` — not live yet** |
| `developer.civitai.com/apps/showcase` | `200` (no trailing slash) |
| `developer.civitai.com/apps/showcase/` | `404` (with one) |
| `civitai.com/models` | `200` (control: the site answers anonymous GETs) |
| `civitai.com/apps` | `404` |
| `civitai.com/apps/run/gen-matrix` | `404` |

Three residuals follow, each of which killed a different candidate line:

1. **A run-URL is not an example.** `civitai.com/apps/run/<slug>` 404s for a
   logged-out reader — and it does so because the whole `/apps` route family
   does, not because that slug is wrong. So the page links **repositories**, which
   an agent can clone and read, not running instances.
2. **`/apps/showcase` is the COMPONENT showcase**, and was conflated with an
   example gallery in the handoff this came from. It answers `200`, which is
   exactly what makes the conflation survivable — a link there resolves and sends
   the reader to the wrong thing.
3. **GitHub topics are already an unreliable enumeration**, so "just query the
   topic" is not a durable substitute for a curated page: `topic:civitai-app-block`
   returns **6** repos, a different set from the seven example apps — two of the
   seven carry no topics, and one repo the query *does* return is not one of the
   seven.

## Where the URL lives

Exactly two places, verified by grep across the repo:

- `internal/cmd/templates/agents-app.md` — the literal that ships
- `wantDocsSection` in `internal/cmd/agent_setup_docs_test.go` — the golden

Both failure messages name both files, so correcting the URL is those two edits.

## Tests — `internal/cmd/agent_setup_docs_test.go`

- **`TestTheBlocksDocsSectionIsPinnedForEveryProjectKind`** — pins the WHOLE
  normalised `### Docs` section for **every** project shape (`npm` with and
  without recognised scripts, `no-build`, `none`). Per-shape because the
  template's three `{{ if }}` branches are what a mis-nested edit drops the
  section out of. Two assertions with different messages: the link **SET**, and
  the **whole string** — a word-level guard on prose is walkable by rewording,
  and the wording *is* the claim about what a reader gets from following the link.
- **`TestDocsSectionExtractorCanFail`** — negative control for `docsSectionOf`,
  both directions.
- **`TestBlockDocsLinksResolve`** — the liveness probe, **opt-in behind
  `CIVITAI_CHECK_DOCS_LINKS=1`**, following `internal/scaffold`'s
  `CIVITAI_CHECK_PUBLISHED_PINS` pattern so an offline `make ci` stays green. It
  carries its own must-404 negative control and **skips** on transport failure
  ("the network is down" and "the page is gone" are different findings).
  🔴 **No CI job sets it** — editing `.github/workflows/*` is "ask first" in
  `AGENTS.md` — so it is a manual pre-merge check and nothing runs it on a
  schedule. Saying so is the honest version of "the links are verified".

### Red/green matrix — four isolated mutations, each watched fail with its own assertion

| # | Mutation | Red at | Assertion that fired | Isolation it proves |
|---|---|---|---|---|
| 0 | new test file only, template untouched | `origin/main` `8e7d2dc` | `docs_test.go:122` + `:130`, all 4 shapes | the guard sees the missing line |
| A | **reword only** (`Example apps you can read end-to-end:` → `Examples:`), URLs untouched | HEAD | **`:130` only** — `:122` did NOT fire | the whole-string pin is reachable and not shadowed by the set assertion |
| B | **URL spelling only** — one added trailing slash | HEAD | `:122` *and* `:130` | the load-bearing character is caught |
| C | Docs section wrapped in `{{ if ne .Kind "no-build" }}` | HEAD | **`:113`, for `no-build` only** — other 3 shapes green | the per-shape loop genuinely reaches each branch separately |
| D | `docsSectionOf` returns `("", true)` when the heading is absent | HEAD | `:156` ×2 | the extractor's negative control is not vacuous |

Mutation A's exact text:

```
--- FAIL: TestTheBlocksDocsSectionIsPinnedForEveryProjectKind
    agent_setup_docs_test.go:130: the `### Docs` section for kind "npm" is not what is pinned.
        ... - Example apps you can read end-to-end:  (want)
        ... - Examples:                              (got)
        The WHOLE section is pinned, not individual words, because a reworded line
        is still a changed claim about what a reader gets from following it.
```

Mutation C's exact text:

```
--- FAIL: TestTheBlocksDocsSectionIsPinnedForEveryProjectKind
    agent_setup_docs_test.go:113: the rendered block for kind "no-build" (0 recognised script(s))
        has NO `### Docs` section at all. Every branch of the template must keep it ...
```

All four restored; green at HEAD `c2c1b7f`.

## Docs

Extends **`AGENTS.md` item 36**'s trigger with the Docs-section situation rather
than minting item 39: item 36 is the managed block's content record and already
carries two such sections. Net **+1 byte** — `AGENTS.md` is **30,443** of the
**30,500** ceiling (`agents_size_test.go`), leaving **57** bytes of headroom; the
body goes in `claudedocs/decisions/36-agents-block-per-project.md` §"Third", which
costs zero session bytes.

**README**: grepped the three surfaces `AGENTS.md` names — the command table
(line 596), the exit-code table (generated from `exitCodeDocs`) and the
Troubleshooting index — plus every `developer.civitai.com` occurrence. **Nothing
in the README enumerates the block's `### Docs` section or its links**, and this
change adds no error string, exit code or flag, so no surface goes stale. The
narrative at §"Set up your coding agent" summarises the block as "the commands and
the gotchas", which already omitted Docs before this change.

## Gates

- `make ci` — **rc 0**, 21 packages `ok`, build succeeded
- `make lint` (`nix-shell -p golangci-lint`) — **rc 0**, `0 issues`.
  Instrument validated: a deliberately unused func + empty branch made it report
  `2 issues` (staticcheck SA9003 + unused) and exit 1, then was reverted.
- `make ci-shallow` — **rc 0** at `c2c1b7f`, 21/21 in a depth-1 clone (this
  touches `AGENTS.md`, which the git-history tests read)
- `gofmt -s -l .` — clean, with a positive control confirming it still flags a
  malformed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mJg86oQbTwuyPo5zcq3qP
