### PR TITLE
fix(agent-setup): the docs-link gate could report ok without probing the link (#549 audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,7 +444,7 @@ item must carry a trigger that is a routing question rather than a label
 
 36. **Editing what `agent-setup`'s block says — its local-dev branch, script
     table, lockfile rule, flattening it to one list, the SCAFFOLDER an author
-    with no app should run, or what its Docs section links?**
+    with no app should run, or what its Docs section links and where?**
     → evidence: claudedocs/decisions/36-agents-block-per-project.md
 
 37. **Typing a `pkg/civitai` username as `string`, or "fixing" a `FlexString`

--- a/claudedocs/decisions/36-agents-block-per-project.md
+++ b/claudedocs/decisions/36-agents-block-per-project.md
@@ -285,11 +285,42 @@ line:
    *does* return is not one of the seven. A list nobody maintains is a list that
    is wrong in both directions.
 
+### Re-measured 2026-09-11, WITHOUT following redirects
+
+The table above was taken with a redirect-following client, which cannot tell
+"this URL is served" from "this URL redirects somewhere that is". Re-run from the
+same host with the probe's own User-Agent and `CheckRedirect` disabled:
+
+| Probe | Result |
+|---|---|
+| `developer.civitai.com/apps/guide` | `301` → `http://developer.civitai.com/apps/guide/` |
+| `developer.civitai.com/apps/guide/` | `200` |
+| `developer.civitai.com/apps/reference` | `301` → `http://developer.civitai.com/apps/reference/` |
+| `developer.civitai.com/apps/reference/` | `200` |
+| `developer.civitai.com/apps/examples` | `200` |
+| `developer.civitai.com/apps/examples/` | `404` |
+| `developer.civitai.com/apps/showcase` | `200` |
+| `developer.civitai.com/apps/showcase/` | `404` |
+| `developer.civitai.com/llms.txt` | `200` |
+| `developer.civitai.com/__civitai-cli-link-probe-must-404__` | `404` (negative control) |
+
+All four URLs the block ships answer `200` at exactly the spelling they ship,
+with **zero** hops. Note the redirect target's scheme: the hop lands on cleartext
+`http`, so a following probe scores an https→http downgrade as a clean `200`.
+
 ### The trailing slash is measured, never tidied
 
 `/apps/guide/` is `200` **with** its slash; `/apps/showcase` is `200`
 **without** one. There is no site-wide rule to infer, so the spelling of any URL
 in this section is a measurement, not a convention. Do not normalise them by eye.
+
+🔴 **A withdrawn claim, not a replaced one.** `internal/cmd/agent_setup_docs_test.go`
+carried a comment saying `/apps/showcase` is `200` while `/apps/showcase/` `404`s
+— true, and it re-measures true — and then that "`/apps/guide/` is the other way
+round", which reads as `/apps/guide` `404`ing. It does not: it `301`s. Nothing
+narrower is put in its place, because the table above shows four distinct
+behaviours across five paths and there is no rule to state. Each spelling is a
+measurement; run the probe.
 
 ### Guards
 
@@ -305,16 +336,68 @@ in this section is a measurement, not a convention. Do not normalise them by eye
   per-shape because the three `{{ if }}` branches are what a mis-nested template
   edit can drop the section out of, and the `static` author — the one with the
   least local code to read — is exactly the reader who needs the examples most.
+  Its shape control **counts KINDS, not shapes**: the wanted set is read out of
+  `agent_setup_project.go`'s own `projectKind` constants, so three shapes of one
+  kind no longer satisfy it (see the audit repairs below).
 - `TestDocsSectionExtractorCanFail` — negative control for `docsSectionOf`, in
   both directions: it must report *absent* for a block with no section, *present*
   for one that has it, and must stop at the END marker.
+- `TestEveryDocsURLSpellingIsLedgered` — the bidirectional ledger over **where a
+  docs URL is spelled in this repo**. It walks the tree and fails both when a
+  file outside `docsURLSpellingLedger` names one of the block's URLs and when a
+  ledgered file stops naming any. Dated records under `claudedocs/handoff-` are
+  exempt: they record what was true when written and are not corrected.
 - `TestBlockDocsLinksResolve` — the liveness probe, **opt-in behind
   `CIVITAI_CHECK_DOCS_LINKS=1`**, following `internal/scaffold`'s
   `CIVITAI_CHECK_PUBLISHED_PINS` pattern so an offline `make ci` stays green. It
-  carries its own negative control (a path on the same host that cannot exist
-  must answer `>= 400` or the whole run is declared meaningless), and a transport
-  failure **skips** rather than fails — "the network is down" and "the page is
-  gone" are different findings.
+  does **not follow redirects** (the spelling that ships is the claim), probes
+  **every** link before diagnosing anything, and separates four verdicts that
+  lead to four different actions: live (`< 300`), **moved** (`3xx`), **gone**
+  (`404`/`410` — the dead-link finding), and **cannot tell**
+  (`401`/`403`/`429`/`5xx`, which a blocked edge produces as readily as a broken
+  page). A transport failure on one link is collected and the run continues; a
+  run that could not reach every link reports **SKIP with the counts**, never a
+  pass.
+
+#### The audit repairs (#549 follow-up)
+
+An adversarial audit of #549 found the probe's guards, not its conclusion. Each
+was reproduced before it was fixed:
+
+- **The gate could report `ok` without probing the link it existed to check.**
+  The per-link loop did `case err != nil: t.Skipf(...)`, abandoning the whole run
+  on the first transport error. Demonstrated: with only the FIRST link's host
+  made unresolvable and `/apps/examples` pointed at a known-404 path, the
+  pre-change test printed one skip line and exited `ok` — the dead link was never
+  fetched. The same tree at HEAD reports `checked 3 of 4 link(s); 1 unreachable`
+  and fails on the dead link.
+- **Negative control present, positive control absent.** The `mustNotResolve`
+  control is satisfied by an edge that `403`s *everything*, which is also what
+  makes every real link `>= 400`. Demonstrated against a local server answering
+  `403` to every path: the pre-change test emitted four `DEAD LINK IN THE MANAGED
+  BLOCK … fix: correct it in internal/cmd/templates/agents-app.md` errors — the
+  exact wrong instruction. HEAD emits a `CANNOT TELL` message that says in as
+  many words that it is **not** a dead-link finding, and skips when no link in
+  the run answered `< 300` (no positive control ⇒ no verdict).
+- **The probe followed redirects while the comment claimed the spelling was
+  measured.** Demonstrated with a local `301` → `200`: the pre-change test logged
+  `-> 200` and passed; HEAD reports `MOVED LINK`, with the `Location`.
+- **"Correcting the URL is those two edits and nothing else" was false when it
+  was written** — #549 itself added a third spelling, in this file. Measured
+  2026-09-11 over the whole tree, ignored files included: 9 lines in 4 files name
+  `developer.civitai.com/apps/examples`. Replaced by the ledger above rather than
+  by a narrower sentence.
+- **The three-branch control counted shapes, not kinds.** `len(shapes) < 3` is
+  satisfied by three shapes of one kind; `allProjectShapesForTest` returns four
+  shapes over three kinds, so the two numbers were never the same claim.
+  Demonstrated by rewriting its kind list to `{npm, npm, npm}`: the pre-change
+  control passed. The wanted set is now read from `agent_setup_project.go`'s own
+  constants, which also repairs an adjacent comment the audit flagged —
+  `allProjectShapesForTest` claimed to be "derived from the projectKind
+  constants' own list rather than from a literal" while being a literal.
+  `TestAllProjectShapesCoversEveryDeclaredKind` (in
+  `internal/cmd/agent_setup_project_test.go`) is the derivation that makes the
+  sentence true: a fourth `projectKind` constant with no shape now fails.
 
 Red-then-green, run at `origin/main` `8e7d2dc` with only the test file added:
 
@@ -331,13 +414,16 @@ HEAD.
 
 ### 🔴 WHAT IS NOT ESTABLISHED
 
-**The page was not live when this shipped.** `developer.civitai.com/apps/examples`
-answered `404` — both with and without a trailing slash — at the time of the
-measurements above, while the other three links in the same section answered
-`200`. The docs page is authored in a separate repository, in parallel. So this
-records a **dead link that was shipped deliberately, on the expectation that the
-page lands**; `TestBlockDocsLinksResolve` is the check that says when it has, and
-it is the check to run before believing any claim that the link works.
+**The page was not live when this shipped, and IS live now.**
+`developer.civitai.com/apps/examples` answered `404` — both with and without a
+trailing slash — when #549 was written, while the other three links in the same
+section answered `200`: a **dead link shipped deliberately, on the expectation
+that the page lands**. It landed. Re-measured 2026-09-11 with
+`CIVITAI_CHECK_DOCS_LINKS=1`, all four links answer `200` at the spelling that
+ships, with zero redirect hops. That is a measurement of **that day**:
+`TestBlockDocsLinksResolve` is still the check to run before believing any claim
+that the link works, and it is now the only thing that would catch the link dying
+later.
 
 **No CI job sets `CIVITAI_CHECK_DOCS_LINKS`.** Adding one means editing
 `.github/workflows/*`, which AGENTS.md puts behind "ask first". Until that

--- a/internal/cmd/agent_setup_docs_test.go
+++ b/internal/cmd/agent_setup_docs_test.go
@@ -15,15 +15,30 @@ package cmd
 // links ONE URL" for the measurements (the GitHub topic enumeration is already
 // wrong, and `civitai.com/apps/...` 404s anonymously).
 //
-// 🔴 WHERE THE URL LIVES: `internal/cmd/templates/agents-app.md` holds the
-// literal that ships, and `wantDocsSection` below holds the only other spelling
-// in this repo. Correcting the URL is those two edits and nothing else — verified
-// by grep at the time this was written, and the failure message below names both
-// so the next person does not have to.
+// 🔴 WHERE THE URL LIVES: AN ENUMERATION THAT A TEST KEEPS HONEST, NOT AN
+// ABSOLUTE. This comment used to say "`internal/cmd/templates/agents-app.md`
+// holds the literal that ships, and `wantDocsSection` below holds the only other
+// spelling in this repo — correcting the URL is those two edits and nothing
+// else, verified by grep". That was FALSE WHEN IT WAS WRITTEN: the same PR (#549)
+// also wrote the URL into `claudedocs/decisions/36-agents-block-per-project.md`.
+// Re-measured on 2026-09-11 over the whole tree, ignored files included:
+// `developer.civitai.com/apps/examples` appears on 9 lines in 4 files.
+//
+// So the enumeration is not restated in prose here. It is
+// `docsURLSpellingLedger` below, and `TestEveryDocsURLSpellingIsLedgered` walks
+// the repository and fails BOTH when a file outside the ledger spells one of
+// these URLs and when a ledgered file stops spelling any — which is what makes
+// "these are the files you edit" a checked claim rather than a remembered one.
+// Dated records under `claudedocs/handoff-` are exempt on purpose: they record
+// what was true on the day they were written and are not corrected afterwards.
 
 import (
+	"bytes"
+	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -97,10 +112,49 @@ func TestTheBlocksDocsSectionIsPinnedForEveryProjectKind(t *testing.T) {
 	}
 	sort.Strings(wantLinks)
 
+	// 🔴 THE CONTROL COUNTS KINDS, NOT SHAPES. It used to read
+	// `if len(shapes) < 3`, which three shapes of the SAME kind satisfy —
+	// `allProjectShapesForTest` returns four shapes covering three kinds, so the
+	// count and the coverage are different numbers and only the second one is
+	// what "for every project kind" in this test's name claims. The wanted set is
+	// read out of `agent_setup_project.go`'s own `projectKind` constants
+	// (`declaredProjectKinds`), so a fourth kind added there fails HERE until it
+	// is rendered and pinned too.
 	shapes := allProjectShapesForTest()
-	if len(shapes) < 3 {
-		t.Fatalf("CONTROL failure, not a finding: allProjectShapesForTest returned %d shape(s), want >= 3 — "+
-			"the three-branch claim in this test's name is not being exercised", len(shapes))
+	want := declaredProjectKinds(t)
+	seen := map[projectKind]bool{}
+	for _, shape := range shapes {
+		seen[shape.Kind] = true
+	}
+	var missing, extra []string
+	for _, k := range want {
+		if !seen[k] {
+			missing = append(missing, string(k))
+		}
+	}
+	wanted := map[projectKind]bool{}
+	for _, k := range want {
+		wanted[k] = true
+	}
+	for k := range seen {
+		if !wanted[k] {
+			extra = append(extra, string(k))
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 {
+		t.Fatalf("CONTROL failure, not a finding: allProjectShapesForTest returned %d shape(s) covering kind(s) %s, "+
+			"but %s is declared in agent_setup_project.go and never rendered. The `### Docs` section is pinned "+
+			"per-shape because each kind is a different `{{ if }}` branch of the template; an unrendered kind is a "+
+			"branch this guard says nothing about. Add a shape for it to allProjectShapesForTest.",
+			len(shapes), strings.Join(sortedKindNames(seen), ", "), strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		t.Fatalf("CONTROL failure, not a finding: allProjectShapesForTest renders kind(s) %s that "+
+			"agent_setup_project.go does not declare as a projectKind constant. Either the constant was renamed "+
+			"(update the shapes) or declaredProjectKinds has stopped reading the file (the wanted set was %s).",
+			strings.Join(extra, ", "), strings.Join(sortedKindNames(wanted), ", "))
 	}
 
 	for _, shape := range shapes {
@@ -122,7 +176,8 @@ func TestTheBlocksDocsSectionIsPinnedForEveryProjectKind(t *testing.T) {
 			t.Errorf("the `### Docs` link SET changed for kind %q.\n  want: %s\n  got:  %s\n"+
 				"The set is asserted so that adding or removing a link is a deliberate edit. If the change is "+
 				"intended, update wantDocsSection in internal/cmd/agent_setup_docs_test.go to match "+
-				"internal/cmd/templates/agents-app.md — those are the only two places a docs URL is spelled.",
+				"internal/cmd/templates/agents-app.md, then run TestEveryDocsURLSpellingIsLedgered — it names "+
+				"every OTHER file in this repo that spells a docs URL.",
 				shape.Kind, strings.Join(wantLinks, ", "), strings.Join(gotLinks, ", "))
 		}
 
@@ -174,6 +229,155 @@ func TestDocsSectionExtractorCanFail(t *testing.T) {
 	}
 }
 
+// sortedKindNames renders a kind set for a failure message, deterministically.
+func sortedKindNames(set map[projectKind]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, string(k))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// docsURLSpellingLedger is every file in this repository that spells one of the
+// block's docs URLs AND must be reconciled when one of them changes.
+//
+// 🔴 IT IS A LEDGER BECAUSE THE PROSE VERSION WAS FALSE. See the file header:
+// the claim "those two edits and nothing else" shipped in #549 alongside a THIRD
+// file that spells the URL twice. A sentence cannot notice a fourth; the walk
+// below can.
+var docsURLSpellingLedger = map[string]string{
+	"internal/cmd/templates/agents-app.md": "the literal that SHIPS — this is the one that is written into somebody " +
+		"else's project and cannot be recalled",
+	"internal/cmd/agent_setup_docs_test.go": "wantDocsSection, the golden the template is compared against, plus " +
+		"this file's own prose about the URL",
+	"claudedocs/decisions/36-agents-block-per-project.md": "AGENTS.md item 36's evidence file: it quotes the added " +
+		"line verbatim and tabulates each URL's measured status",
+}
+
+// docsURLLedgerExemptPrefix is the ONE exemption, and it is not a convenience.
+// A handoff doc is a DATED RECORD of what was true when it was written — a URL
+// in one is evidence, not a link anybody follows from a shipped artefact, and
+// "correcting" it would falsify the record. Anything else that names a docs URL
+// is a place the URL can rot, so it belongs in the ledger.
+const docsURLLedgerExemptPrefix = "claudedocs/handoff-"
+
+// docsURLLedgerSkipDirs are directories the walk must not descend into. `.claude`
+// is load-bearing on a machine that uses git worktrees: this repo's own
+// `.gitignore` puts `/.claude/worktrees` there, and each worktree is a FULL COPY
+// of the tree, so a walk that entered it would report every ledgered file a
+// second time under a different path.
+var docsURLLedgerSkipDirs = map[string]bool{
+	".git": true, ".claude": true, "bin": true, "dist": true, "node_modules": true, ".venv": true,
+}
+
+// TestEveryDocsURLSpellingIsLedgered is the bidirectional guard behind the file
+// header's enumeration.
+//
+// It fails when a file OUTSIDE the ledger spells one of the block's docs URLs
+// (the enumeration grew and nobody said so) and when a ledgered file no longer
+// spells any (the enumeration shrank and the ledger is now pointing at a file
+// with nothing in it). Both directions matter: the first is how the original
+// claim went stale, the second is how a ledger becomes decoration.
+func TestEveryDocsURLSpellingIsLedgered(t *testing.T) {
+	urls := docsLinkRe.FindAllString(wantDocsSection, -1)
+	if len(urls) < 4 {
+		t.Fatalf("CONTROL failure, not a finding: the golden section parses to %d URL(s), want >= 4 — "+
+			"the walk below would be searching for nothing", len(urls))
+	}
+	// Match on host+path rather than the full URL: the header comment above names
+	// the examples page without a scheme, and that mention rots exactly like a
+	// link does.
+	needles := make([][]byte, 0, len(urls))
+	for _, u := range urls {
+		needles = append(needles, []byte(strings.TrimPrefix(strings.TrimPrefix(u, "https://"), "http://")))
+	}
+
+	root := repoRootDir(t)
+	scanned := 0
+	found := map[string]bool{}
+	exempt := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if rel != "." && docsURLLedgerSkipDirs[d.Name()] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Size() > 2<<20 {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		scanned++
+		for _, needle := range needles {
+			if bytes.Contains(body, needle) {
+				if strings.HasPrefix(rel, docsURLLedgerExemptPrefix) {
+					exempt[rel] = true
+				} else {
+					found[rel] = true
+				}
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	// Positive control: the walk must have READ a real tree. A misrooted walk
+	// reads nothing, finds nothing, and reports the ledger fully satisfied in the
+	// one direction anybody checks.
+	if scanned < 200 {
+		t.Fatalf("CONTROL failure, not a finding: the walk read %d file(s) under %s, want >= 200. "+
+			"This repository had 696 tracked files on 2026-09-11, so a number this low means the walk is "+
+			"rooted somewhere else or is skipping everything — not that the ledger is clean", scanned, root)
+	}
+
+	for rel := range found {
+		if _, ok := docsURLSpellingLedger[rel]; !ok {
+			t.Errorf("%s spells one of the block's docs URLs and is NOT in docsURLSpellingLedger.\n"+
+				"  A docs URL in this repo is a place it can rot: when the URL changes, this file goes stale "+
+				"alone and silently.\n"+
+				"  fix: add it to docsURLSpellingLedger in internal/cmd/agent_setup_docs_test.go with what it "+
+				"is FOR, or take the URL out of it.", rel)
+		}
+	}
+	for rel, why := range docsURLSpellingLedger {
+		if found[rel] {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("docsURLSpellingLedger names %s (%s), which cannot be read: %v. "+
+				"The ledger is pointing at a file that moved or was deleted.", rel, why, err)
+			continue
+		}
+		t.Errorf("docsURLSpellingLedger names %s (%s), but it no longer spells ANY of the block's docs URLs.\n"+
+			"  Either the URL was removed from it — drop the row — or the golden changed and this file was "+
+			"left on the old spelling, which is the exact rot the ledger exists to catch.", rel, why)
+	}
+	t.Logf("scanned %d file(s); %d ledgered spelling(s), %d exempt dated record(s): %s",
+		scanned, len(found), len(exempt), strings.Join(sortedKeys(exempt), ", "))
+}
+
 // docsLinkProbeEnv gates the ONE network-touching test in this package.
 //
 // 🔴 OPT-IN, NEVER DEFAULT. `make ci` must stay green with no network — a test
@@ -183,42 +387,99 @@ func TestDocsSectionExtractorCanFail(t *testing.T) {
 // the honest version of "the links are verified".
 const docsLinkProbeEnv = "CIVITAI_CHECK_DOCS_LINKS"
 
-// mustNotResolve is the probe's own negative control: a path on the same host
-// that cannot exist. If THIS comes back < 400 the prober is reading something
-// other than the status of the URL it was given, and every green below is a fact
-// about the prober rather than about the docs site.
+// mustNotResolve is the probe's NEGATIVE control: a path on the same host that
+// cannot exist. If THIS comes back < 400 the prober is reading something other
+// than the status of the URL it was given, and every green below is a fact about
+// the prober rather than about the docs site.
+//
+// 🔴 IT IS ONLY HALF A CONTROL, AND THE OTHER HALF IS `sawLive` BELOW. An edge
+// that blocks this prober answers `403`/`429`/`503` to EVERY request, which
+// satisfies "the impossible path is >= 400" perfectly while making every real
+// link >= 400 too. This host has form: `developer.civitai.com` hard-blocks
+// `Python-urllib/3.11` with Cloudflare `error code: 1010`, and the probe sends a
+// custom non-browser User-Agent. So a negative control that passes proves the
+// prober is not answering OK to everything; it does NOT prove the prober can see
+// a live page. That needs a positive control, and its absence is why this test
+// must be able to say "cannot tell" as well as "gone".
 const mustNotResolve = "https://developer.civitai.com/__civitai-cli-link-probe-must-404__"
 
-// TestBlockDocsLinksResolve fetches every URL the block ships and fails on a
-// 4xx/5xx. A transport failure SKIPS rather than fails: "the network is down"
-// and "the page is gone" are different findings and only one of them is this
-// test's.
+// docsProbeResult is one URL's answer, kept so the loop can finish before
+// anything is diagnosed. The earlier version diagnosed inside the loop and
+// abandoned the whole run on the first transport error, so one DNS hiccup on the
+// FIRST link reported a pass without ever fetching the others.
+type docsProbeResult struct {
+	url      string
+	code     int
+	location string
+	err      error
+}
+
+// TestBlockDocsLinksResolve fetches every URL the block ships and reports what it
+// found, in four separable verdicts. The split is the point: "gone", "moved",
+// "cannot tell" and "could not reach" lead to four different actions, and the
+// version that printed one message for all of them told a reader to edit the
+// template when the truth was that the prober had been blocked.
+//
+//   - < 300               — live at the spelling that ships.
+//   - 3xx                 — MOVED. The page answers, but not at this spelling.
+//   - 404 / 410           — GONE. This is the dead-link finding.
+//   - other >= 400        — CANNOT TELL: 401/403/429/5xx are what a blocked or
+//     failing edge returns, and are indistinguishable from a
+//     genuinely broken page without a positive control.
+//   - transport error     — COULD NOT REACH. Collected, never fatal, and never a
+//     reason to stop probing the remaining links.
 func TestBlockDocsLinksResolve(t *testing.T) {
 	if os.Getenv(docsLinkProbeEnv) != "1" {
 		t.Skipf("network guard; set %s=1 to run (no CI job does — this is a manual pre-merge check)", docsLinkProbeEnv)
 	}
 
-	client := &http.Client{Timeout: 20 * time.Second}
-	status := func(url string) (int, error) {
+	// 🔴 REDIRECTS ARE NOT FOLLOWED, BECAUSE THE SPELLING IS THE CLAIM. Go's
+	// default CheckRedirect follows up to 10 hops, so a probe that reports 200 is
+	// reporting on wherever it LANDED, not on the URL written into the block.
+	// Measured 2026-09-11: `/apps/guide` answers 301 to
+	// `http://developer.civitai.com/apps/guide/` — a different spelling, and a
+	// downgrade to cleartext http — which a following probe scores as a clean 200.
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	probe := func(url string) docsProbeResult {
+		out := docsProbeResult{url: url}
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
-			return 0, err
+			out.err = err
+			return out
 		}
 		req.Header.Set("User-Agent", "civitai-cli-docs-link-probe")
 		resp, err := client.Do(req)
 		if err != nil {
-			return 0, err
+			out.err = err
+			return out
 		}
 		defer func() { _ = resp.Body.Close() }()
-		return resp.StatusCode, nil
+		out.code = resp.StatusCode
+		out.location = resp.Header.Get("Location")
+		return out
 	}
 
-	if code, err := status(mustNotResolve); err != nil {
-		t.Skipf("%s unreachable (%v) — skipping, not failing; the control could not be run either", mustNotResolve, err)
-	} else if code < 400 {
+	control := probe(mustNotResolve)
+	switch {
+	case control.err != nil:
+		t.Skipf("%s unreachable (%v) — skipping, not failing; the control could not be run either",
+			mustNotResolve, control.err)
+	case control.code < 400:
 		t.Fatalf("CONTROL failure, not a finding: %s answered %d. A URL that cannot exist is reporting OK, "+
 			"so this prober cannot distinguish a live page from a dead one and nothing below it means anything",
-			mustNotResolve, code)
+			mustNotResolve, control.code)
+	case control.code != 404 && control.code != 410:
+		// Still a pass, but worth printing: an impossible path answering 403 or
+		// 503 is what a blocking edge looks like, not what a 404 handler looks
+		// like. It changes how the statuses below should be read.
+		t.Logf("note: the negative control %s answered %d rather than 404/410 — if the links below are also "+
+			">= 400, read that as 'this prober is being blocked' before reading it as 'the pages are gone'",
+			mustNotResolve, control.code)
 	}
 
 	block, err := agentsManagedBlock(allProjectShapesForTest()[0])
@@ -234,23 +495,150 @@ func TestBlockDocsLinksResolve(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: %d link(s) extracted, want >= 4", len(links))
 	}
 
+	// Probe EVERY link first. Nothing in this loop can end the run.
+	results := make([]docsProbeResult, 0, len(links))
 	for _, url := range links {
-		code, err := status(url)
+		results = append(results, probe(url))
+	}
+
+	var (
+		unreachable []docsProbeResult
+		moved       []docsProbeResult
+		gone        []docsProbeResult
+		cannotTell  []docsProbeResult
+		sawLive     bool
+	)
+	for _, r := range results {
 		switch {
-		case err != nil:
-			t.Skipf("%s unreachable (%v) — skipping, not failing", url, err)
-		case code >= 400:
-			t.Errorf("DEAD LINK IN THE MANAGED BLOCK — this URL is written into every project "+
-				"`civitai agent-setup` runs in, and nothing can recall it.\n  url:    %s\n  status: %d\n"+
-				"  fix:    correct it in internal/cmd/templates/agents-app.md AND wantDocsSection in this file, "+
-				"or publish the page before merging.", url, code)
+		case r.err != nil:
+			unreachable = append(unreachable, r)
+		case r.code < 300:
+			sawLive = true
+			t.Logf("%s -> %d", r.url, r.code)
+		case r.code < 400:
+			moved = append(moved, r)
+		case r.code == 404 || r.code == 410:
+			gone = append(gone, r)
 		default:
-			t.Logf("%s -> %d", url, code)
+			cannotTell = append(cannotTell, r)
 		}
+	}
+	checked := len(links) - len(unreachable)
+	for _, r := range unreachable {
+		t.Logf("%s -> transport error: %v (continuing; this run does NOT claim to have checked it)", r.url, r.err)
+	}
+	t.Logf("checked %d of %d link(s); %d unreachable, %d live, %d moved, %d gone, %d undiagnosable",
+		checked, len(links), len(unreachable), checkedLive(results), len(moved), len(gone), len(cannotTell))
+
+	if checked == 0 {
+		t.Skipf("NONE of the %d link(s) could be reached — every one failed at the transport layer. "+
+			"That is a finding about this machine's network, not about the docs site, so it skips rather "+
+			"than fails. Nothing was verified.", len(links))
+	}
+
+	for _, r := range gone {
+		t.Errorf("DEAD LINK IN THE MANAGED BLOCK — this URL is written into every project "+
+			"`civitai agent-setup` runs in, and nothing can recall it.\n  url:    %s\n  status: %d\n"+
+			"  fix:    correct it in internal/cmd/templates/agents-app.md AND wantDocsSection in this file "+
+			"(then run TestEveryDocsURLSpellingIsLedgered for the rest), or publish the page before merging.",
+			r.url, r.code)
+	}
+	for _, r := range moved {
+		t.Errorf("MOVED LINK IN THE MANAGED BLOCK — the page answers, but NOT at the spelling that ships. "+
+			"This is not a dead link and it is not a live one: a browser follows the hop, and the block is "+
+			"left naming a URL the site no longer serves directly.\n  url:      %s\n  status:   %d\n"+
+			"  location: %s\n"+
+			"  fix:      if the target is the intended canonical spelling, write THAT into "+
+			"internal/cmd/templates/agents-app.md and wantDocsSection. Check the scheme before you copy it: "+
+			"this host has been measured redirecting https to cleartext http.",
+			r.url, r.code, orNone(r.location))
+	}
+	if len(cannotTell) > 0 {
+		var lines []string
+		for _, r := range cannotTell {
+			lines = append(lines, fmt.Sprintf("    %s -> %d", r.url, r.code))
+		}
+		msg := fmt.Sprintf("CANNOT TELL whether these links are dead — they answered a status that a BLOCKED "+
+			"or FAILING EDGE produces just as readily as a broken page (401/403/407/429/5xx):\n%s\n"+
+			"  The negative control %s answered %d.\n"+
+			"  🔴 This is NOT a dead-link finding. Do not edit internal/cmd/templates/agents-app.md on the "+
+			"strength of it. Re-run; if it persists, fetch the URL in a browser and check whether the host is "+
+			"refusing this probe's User-Agent (`civitai-cli-docs-link-probe`) — developer.civitai.com is known "+
+			"to hard-block non-browser agents with Cloudflare `error code: 1010`.",
+			strings.Join(lines, "\n"), mustNotResolve, control.code)
+		if sawLive {
+			// A live link in the same run IS the positive control: the prober can
+			// see a live page, so a >= 400 elsewhere is a real anomaly worth
+			// failing on — it is just not diagnosable as "gone".
+			t.Errorf("%s\n  (At least one other link in this run answered < 300, so this prober is not being "+
+				"blocked wholesale — which is what makes this worth failing on rather than skipping.)", msg)
+		} else if !t.Failed() {
+			// No link answered < 300 anywhere. There is no positive control, so
+			// this run cannot separate "the site is down/blocking" from "the
+			// pages are gone", and a failure here would be a guess.
+			t.Skipf("%s\n  NO link in this run answered < 300, so there is no positive control at all: "+
+				"this run cannot distinguish a blocked prober from a dead docs site. Skipping rather than "+
+				"guessing.", msg)
+		} else {
+			t.Errorf("%s\n  (No link in this run answered < 300, so the dead-link finding(s) above are "+
+				"reported WITHOUT a positive control — a site-wide outage or block is not excluded.)", msg)
+		}
+	}
+	if len(gone) > 0 && !sawLive {
+		t.Errorf("POSITIVE CONTROL ABSENT: %d link(s) are reported gone above and NOT ONE link in this run "+
+			"answered < 300. A prober that never saw a live page cannot distinguish 'these pages were removed' "+
+			"from 'this whole host is answering 404 to me'. Confirm one of these URLs in a browser before "+
+			"editing the template.", len(gone))
+	}
+	if !t.Failed() && len(unreachable) > 0 {
+		t.Skipf("PARTIAL RUN: %d of %d link(s) checked, %d unreachable at the transport layer. The links that "+
+			"WERE checked are fine — but this run did not verify the whole set, so it reports SKIP rather than "+
+			"a pass that reads as 'all links verified'.", checked, len(links), len(unreachable))
 	}
 }
 
-// 🔴 A TRAILING SLASH IS LOAD-BEARING ON THIS HOST, AND THAT IS MEASURED RATHER
-// THAN ASSUMED. developer.civitai.com serves `/apps/showcase` (200) and 404s
-// `/apps/showcase/`, while `/apps/guide/` is the other way round. So a URL here
-// cannot be "tidied" one way or the other by eye; run the probe above.
+// checkedLive counts the results that answered < 300, for the summary line.
+func checkedLive(results []docsProbeResult) int {
+	n := 0
+	for _, r := range results {
+		if r.err == nil && r.code < 300 {
+			n++
+		}
+	}
+	return n
+}
+
+// orNone renders an empty header value visibly, so a 3xx with no Location does
+// not print as a blank the reader mistakes for a missing line.
+func orNone(s string) string {
+	if s == "" {
+		return "(none — the response carried no Location header)"
+	}
+	return s
+}
+
+// 🔴 A TRAILING SLASH IS LOAD-BEARING ON THIS HOST, PER PATH, AND THAT IS
+// MEASURED RATHER THAN ASSUMED. Re-measured 2026-09-11 from this host, over real
+// HTTP, with the probe's own User-Agent and WITHOUT following redirects:
+//
+//	/apps/guide       301 -> http://developer.civitai.com/apps/guide/
+//	/apps/guide/      200
+//	/apps/reference   301 -> http://developer.civitai.com/apps/reference/
+//	/apps/reference/  200
+//	/apps/examples    200
+//	/apps/examples/   404
+//	/apps/showcase    200
+//	/apps/showcase/   404
+//	/llms.txt         200
+//
+// All four URLs the block ships answer 200 at exactly the spelling they ship,
+// with zero hops.
+//
+// 🔴 A PREVIOUS VERSION OF THIS COMMENT WAS WRONG AND IS WITHDRAWN, NOT REPLACED
+// WITH A NARROWER CLAIM. It said `/apps/showcase` is 200 while `/apps/showcase/`
+// 404s — that part re-measures true — and then that "`/apps/guide/` is the other
+// way round", which reads as `/apps/guide` 404ing. It does not: it 301s, and the
+// hop lands on cleartext http. There is no site-wide rule here to state in its
+// place, and the two redirecting paths are the reason a probe that FOLLOWS hops
+// cannot tell you whether the spelling you ship is the one the site serves. Each
+// URL's spelling is a measurement. Do not tidy one by eye; run the probe above.

--- a/internal/cmd/agent_setup_project_test.go
+++ b/internal/cmd/agent_setup_project_test.go
@@ -23,9 +23,75 @@ import (
 // scaffold.Render and then drives the real command, which is the check the blind
 // dogfood ran by hand.
 
+// declaredProjectKindRe pulls the `projectKind` constants out of
+// agent_setup_project.go's own source. Go has no way to enumerate the members of
+// a string-constant "enum" at runtime, so the alternative to reading the source
+// is a literal that silently stops being the whole set — which is exactly what
+// the comment on allProjectShapesForTest used to claim it was not.
+var declaredProjectKindRe = regexp.MustCompile(`(?m)^\s*project\w+\s+projectKind\s*=\s*"([^"]+)"`)
+
+// declaredProjectKinds returns every projectKind value declared in
+// agent_setup_project.go, in source order.
+//
+// 🔴 THIS IS THE DERIVATION THE COMMENT BELOW USED TO ASSERT WITHOUT DOING.
+// `allProjectShapesForTest` names its three kinds as a literal; nothing made a
+// fourth constant show up there. Reading the source closes that, and
+// TestAllProjectShapesCoversEveryDeclaredKind is where the two are compared.
+func declaredProjectKinds(t *testing.T) []projectKind {
+	t.Helper()
+	path := filepath.Join(repoRootDir(t), "internal", "cmd", "agent_setup_project.go")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	matches := declaredProjectKindRe.FindAllStringSubmatch(string(src), -1)
+	if len(matches) < 3 {
+		t.Fatalf("CONTROL failure, not a finding: declaredProjectKindRe (%s) matched %d constant(s) in %s, "+
+			"want >= 3. The regex has stopped reading the declarations, so every set comparison built on it "+
+			"is a comparison against an empty set", declaredProjectKindRe, len(matches), path)
+	}
+	kinds := make([]projectKind, 0, len(matches))
+	for _, m := range matches {
+		kinds = append(kinds, projectKind(m[1]))
+	}
+	return kinds
+}
+
+// TestAllProjectShapesCoversEveryDeclaredKind makes the sentence on
+// allProjectShapesForTest true by checking it: every `projectKind` constant
+// declared in agent_setup_project.go is rendered by at least one shape, and no
+// shape carries a kind that is not declared.
+func TestAllProjectShapesCoversEveryDeclaredKind(t *testing.T) {
+	declared := declaredProjectKinds(t)
+	seen := map[projectKind]bool{}
+	for _, shape := range allProjectShapesForTest() {
+		seen[shape.Kind] = true
+	}
+	for _, k := range declared {
+		if !seen[k] {
+			t.Errorf("projectKind %q is declared in internal/cmd/agent_setup_project.go and rendered by NO "+
+				"shape in allProjectShapesForTest. Every guard in this package that loops over the shapes is "+
+				"silent about that branch of the template — add a shape for it.", k)
+		}
+	}
+	declaredSet := map[projectKind]bool{}
+	for _, k := range declared {
+		declaredSet[k] = true
+	}
+	for k := range seen {
+		if !declaredSet[k] {
+			t.Errorf("allProjectShapesForTest renders kind %q, which is not declared as a projectKind constant "+
+				"in internal/cmd/agent_setup_project.go — the constant was renamed or removed and the shapes "+
+				"were left behind.", k)
+		}
+	}
+}
+
 // allProjectShapesForTest enumerates the shapes the template must render for.
-// It is derived from the projectKind constants' own list rather than from a
-// literal, so a fourth kind cannot be added without a rendering test for it.
+// The kind list below is a literal — Go cannot enumerate a string-constant set —
+// and TestAllProjectShapesCoversEveryDeclaredKind is what stops it drifting from
+// the projectKind constants, so a fourth kind cannot be added without a rendering
+// test for it.
 func allProjectShapesForTest() []projectShape {
 	kinds := []projectKind{projectNPM, projectNoBuild, projectNone}
 	shapes := make([]projectShape, 0, len(kinds)+1)


### PR DESCRIPTION
Follow-up to **#549** (already merged as `7b7d5f1`). An adversarial audit found five
defects in the **guards** around the managed block's `### Docs` section, not in the
section itself. Every one was reproduced on merged `main` before it was fixed.

Context that changed since the audit: `https://developer.civitai.com/apps/examples`
now **resolves 200**. Re-verified here — all four links answer 200 at exactly the
spelling that ships, with **zero** redirect hops. The findings are still live,
because they are about the guard, which is now the only thing that would catch the
link dying later.

---

## Red → green matrix

Every row is a real run. "before" = `origin/main`'s `agent_setup_docs_test.go`
restored over the same mutated tree; "after" = this branch.

| # | Mutation | Before | After (exact assertion watched) |
|---|---|---|---|
| 1 | First link's host unresolvable **+** `/apps/examples` → known-404 path | `--- SKIP` → `ok` (the dead link was **never fetched**) | `--- FAIL`: `DEAD LINK IN THE MANAGED BLOCK …  url: …/apps/examples-does-not-exist  status: 404`, preceded by `checked 3 of 4 link(s); 1 unreachable, 2 live, 0 moved, 1 gone, 0 undiagnosable` |
| 1b | First link's host unresolvable only | `--- SKIP` → `ok` | `--- SKIP`: `PARTIAL RUN: 3 of 4 link(s) checked, 1 unreachable at the transport layer. … so it reports SKIP rather than a pass that reads as 'all links verified'.` — and the other three **were** probed |
| 2a | Local server answering **403** to every path, incl. `mustNotResolve` | `--- FAIL` ×4 `DEAD LINK IN THE MANAGED BLOCK … fix: correct it in internal/cmd/templates/agents-app.md` (**the wrong instruction**) | `--- SKIP`: `CANNOT TELL whether these links are dead — they answered a status that a BLOCKED or FAILING EDGE produces just as readily as a broken page (401/403/407/429/5xx)` + `🔴 This is NOT a dead-link finding.` + `NO link in this run answered < 300, so there is no positive control at all` |
| 2b | One link 403, other three live | same `DEAD LINK` text as a genuine 404 | `--- FAIL`: same `CANNOT TELL` message + `(At least one other link in this run answered < 300, so this prober is not being blocked wholesale — which is what makes this worth failing on rather than skipping.)` |
| 2c | All links **404**, no live link anywhere | four `DEAD LINK`s, no caveat | `--- FAIL`: four `DEAD LINK`s **plus** `POSITIVE CONTROL ABSENT: 4 link(s) are reported gone above and NOT ONE link in this run answered < 300.` |
| 3 | One link → local `301` → `200` | `--- PASS`, logging `http://127.0.0.1:18733/apps/guide -> 200` | `--- FAIL`: `MOVED LINK IN THE MANAGED BLOCK — the page answers, but NOT at the spelling that ships.  status: 301  location: http://127.0.0.1:18733/apps/guide/` |
| 4a | New unledgered file spelling the URL | (no such guard) | `--- FAIL`: `claudedocs/zz-mutant-unledgered.md spells one of the block's docs URLs and is NOT in docsURLSpellingLedger.` |
| 4b | Same file renamed to `claudedocs/handoff-zz-mutant.md` | — | `--- PASS`, logging `2 exempt dated record(s)` — the exemption is exercised, not assumed |
| 4c | URL removed from a ledgered file (`decisions/36`) | — | `--- FAIL`: `docsURLSpellingLedger names claudedocs/decisions/36-… but it no longer spells ANY of the block's docs URLs.` |
| 4d | Walk misrooted (`repoRootDir(t)` → `t.TempDir()`) | — | `--- FAIL`: `CONTROL failure, not a finding: the walk read 0 file(s) … want >= 200` — **positive control, count moved 696 → 0** |
| 5a | `allProjectShapesForTest` kind list → `{npm, npm, npm}` | `--- PASS` (4 shapes ≥ 3) | `--- FAIL`: `CONTROL failure, not a finding: allProjectShapesForTest returned 4 shape(s) covering kind(s) npm, but no-build, none is declared in agent_setup_project.go and never rendered.` |
| 5b | Fourth `projectKind` constant added, no shape | (nothing fired) | `--- FAIL` ×2: the control above naming `mutant-4th-kind`, and `projectKind "mutant-4th-kind" is declared … and rendered by NO shape in allProjectShapesForTest.` |
| 5c | Shape with an undeclared kind | — | `--- FAIL`: `allProjectShapesForTest renders kind "bogus-undeclared", which is not declared as a projectKind constant …` |
| 5d | `declaredProjectKindRe` broken | — | `--- FAIL`: `CONTROL failure … matched 0 constant(s) … want >= 3` |

Harness validation for rows 2–3: the local status servers were themselves probed
first (`18731/anything -> 403`, `18732/x -> 404`, `18733/apps/reference -> 301
loc=…/apps/reference/`, `18733/apps/guide/ -> 200`) before any verdict was read
off them.

## Finding 3's other half: a false measured claim, withdrawn

The comment at the foot of the file said `/apps/showcase` is 200 and
`/apps/showcase/` 404s — true — "while `/apps/guide/` is the other way round",
which reads as `/apps/guide` 404ing. It does not. Re-measured 2026-09-11 from this
host, probe User-Agent, **no redirect following**:

```
/apps/guide       301 -> http://developer.civitai.com/apps/guide/
/apps/guide/      200
/apps/reference   301 -> http://developer.civitai.com/apps/reference/
/apps/reference/  200
/apps/examples    200
/apps/examples/   404
/apps/showcase    200
/apps/showcase/   404
/llms.txt         200
/__must-404__     404   (negative control)
```

Note the redirect target's **scheme**: the hop lands on cleartext `http`, so a
following probe scores an https→http downgrade as a clean 200. The claim is
**withdrawn, not replaced with a narrower one** — five paths show four distinct
behaviours and there is no rule to state.

## Finding 4: the grep count

Whole tree, ignored files included (`find … | xargs gnugrep`, not the
`.gitignore`-blind wrapper):

```
claudedocs/handoff-agent-setup-onboarding.md          4
claudedocs/decisions/36-agents-block-per-project.md   2
internal/cmd/agent_setup_docs_test.go                 2
internal/cmd/templates/agents-app.md                  1
```

**9 lines, 4 files** — the auditor's "four places" was a file count and is right;
"two edits and nothing else" was wrong, and was wrong on the day it was written,
since `decisions/36` was added by #549 itself.

The replacement is not a narrower sentence. `TestEveryDocsURLSpellingIsLedgered`
walks the tree and asserts the file set both ways. The one exemption —
`claudedocs/handoff-` — is stated in the code with its reason (dated records are
evidence; correcting them falsifies the record) and is itself exercised by
mutation 4b.

## Out-of-scope neighbour, called out separately

The audit flagged `agent_setup_project_test.go:27-30`: the comment claimed
`allProjectShapesForTest` is "derived from the projectKind constants' own list
rather than from a literal" while the code is a literal. **It is fixed here**,
because finding 5's fix needed the derivation anyway: `declaredProjectKinds` reads
the `projectKind` constants out of `agent_setup_project.go`'s source (Go cannot
enumerate a string-constant set at runtime), and
`TestAllProjectShapesCoversEveryDeclaredKind` compares the two sets both ways.
Mutations 5b/5c/5d are its red-then-green.

## Gates

```
$ make ci
go mod tidy
go vet ./...
go test ./...
ok  	github.com/civitai/cli	1.979s
ok  	github.com/civitai/cli/cmd/civitai	15.902s
…
ok  	github.com/civitai/cli/internal/cmd	33.744s
…
go build -ldflags "…" -o bin/civitai ./cmd/civitai
```

22 packages reported `ok`, 1 `[no test files]` — no package silently compiled to
zero tests.

```
$ nix-shell -p golangci-lint --run "make lint"
golangci-lint run
0 issues.
```

That zero is instrument-validated: with a planted `ineffassign` in the new test it
went red —
`internal/cmd/agent_setup_docs_test.go:283:2: ineffectual assignment to lintProbe (ineffassign)` /
`make: *** [Makefile:30: lint] Error 1` — then back to `0 issues.` once reverted.

`gofmt -s -l .` flagged 0 files, with 472 `.go` files present (so the zero is not a
zero-files zero).

Live probe on this branch:

```
$ CIVITAI_CHECK_DOCS_LINKS=1 go test -run TestBlockDocsLinksResolve -count=1 -v ./internal/cmd/
    https://developer.civitai.com/apps/guide/ -> 200
    https://developer.civitai.com/apps/reference/ -> 200
    https://developer.civitai.com/apps/examples -> 200
    https://developer.civitai.com/llms.txt -> 200
    checked 4 of 4 link(s); 0 unreachable, 4 live, 0 moved, 0 gone, 0 undiagnosable
--- PASS
```

## Docs

- `claudedocs/decisions/36-agents-block-per-project.md`: added the no-redirect
  re-measurement table, the withdrawn-claim note, the new guards, an "audit
  repairs" subsection, and corrected **WHAT IS NOT ESTABLISHED** — the page is
  live now, stated as a measurement of that day rather than a standing fact.
- `AGENTS.md` item 36's trigger now reads "…or what its Docs section links **and
  where**?", so a change to *where* a docs URL is spelled routes to the item.
  +10 bytes: **30,453 / 30,500**. The ceiling was **not** raised.

## Not verified

- CI has not run yet at the time of writing; `make ci` here is a full clone, and
  `make ci-shallow` was not run (no test in this change reads git history).
- The 403/301 cases are simulated with a local status server, not observed against
  `developer.civitai.com`. The Cloudflare `1010` block is quoted from the handoff,
  not re-triggered — deliberately, since re-triggering it means getting this host
  blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mJg86oQbTwuyPo5zcq3qP
