### PR TITLE
fix(read): buy back read --help headroom, and stop the residual note naming a command (#543)

### DIFF
--- a/internal/cmd/read_help.go
+++ b/internal/cmd/read_help.go
@@ -90,8 +90,8 @@ when you are logged in.`
 const readJSONNote = `--json writes the API response to stdout and nothing else — notes and errors go
 to stderr, so ` + "`… --json | jq -e .`" + ` always parses. The document is the API's,
 the bytes are not: it is re-indented on the way out, and a raw control byte the
-API emits inside a string (which is not legal JSON) is rewritten as its escape
-so the output still parses. Do not diff or hash it against the wire.`
+API emits inside a string is rewritten as its escape. Do not diff or hash it
+against the wire.`
 
 // limitRule renders one endpoint's --limit bounds.
 //

--- a/internal/cmd/read_help_test.go
+++ b/internal/cmd/read_help_test.go
@@ -162,14 +162,33 @@ func TestReadAPIHelpBodiesAreComplete(t *testing.T) {
 // line as 81 and reddens prose that renders fine.
 //
 // 🔴 KNOWN SHIPPED RESIDUAL — READ THIS BEFORE ACTING ON A FAILURE HERE.
-// `images search` sits at 1386 of the 1400 runes: about FOURTEEN of headroom.
-// Five of these bodies interpolate shared constants (readAnonNote,
-// readAnonShort, readJSONNote, serverOwnedEnumNote, deepPagingNote), so growing
-// ONE of those by a sentence reddens this test naming `images search` — the
-// longest consumer — rather than naming the constant that actually grew. If that
-// is why you are here, edit the constant or trim `images search`, and do not
-// raise the budget to make a shared sentence fit; the budget is what stops a
-// migration turning into a `--help` nobody reads.
+// These bodies interpolate shared constants (readAnonNote, readAnonShort,
+// readJSONNote, serverOwnedEnumNote, deepPagingNote), so growing ONE of those by
+// a sentence reddens this test naming whichever BODY is longest rather than the
+// constant that actually grew. If that is why you are here, edit the constant or
+// trim the body, and do not raise the budget to make a shared sentence fit; the
+// budget is what stops a migration turning into a `--help` nobody reads.
+//
+// 🔴 "WHICH BODY IS LONGEST" IS NOT A STABLE FACT — DO NOT TRUST A NAME HERE,
+// RE-MEASURE. This comment named `images search` as "the longest consumer" and
+// that went FALSE without anyone touching it: civitai/cli#541 grew readJSONNote
+// by 131 runes (253 → 384), which pushed `users` to 1395 of 1400 — FIVE of
+// headroom — and made it the longest, while `images search` did not move at all.
+// So the note pointed the next person at the wrong command, and the command it
+// named was not the one about to red (civitai/cli#543).
+//
+// The mechanism is the thing worth remembering, because it is what makes the
+// ranking move: `images` (the parent) interpolates readJSONNote and `images
+// search` does NOT, so a change to that one constant re-orders these bodies
+// against each other. Trimming readJSONNote back to 331 runes restored the
+// earlier ordering — which is exactly why a name is the wrong thing to record.
+//
+// Measured on this tree rather than recalled: `images search` 1386 (14 of
+// headroom, the binding constraint and a PRE-EXISTING one — it was 1386 both
+// before and after #541), then `users` 1342 (58), `images` 1303 (97). To
+// re-measure, count utf8.RuneCountInString over each readAPINodes body; there is
+// no committed probe, because a helper that prints the ranking would itself need
+// pinning to stay honest.
 func TestReadAPIHelpStaysWithinTheBudget(t *testing.T) {
 	nodes := readAPINodes(t)
 	var checked int

--- a/internal/cmd/read_json_note_test.go
+++ b/internal/cmd/read_json_note_test.go
@@ -28,8 +28,8 @@ const crBodyModelName = "Speckled\rGrebe"
 const wantReadJSONNote = "--json writes the API response to stdout and nothing else — notes and errors go\n" +
 	"to stderr, so `… --json | jq -e .` always parses. The document is the API's,\n" +
 	"the bytes are not: it is re-indented on the way out, and a raw control byte the\n" +
-	"API emits inside a string (which is not legal JSON) is rewritten as its escape\n" +
-	"so the output still parses. Do not diff or hash it against the wire."
+	"API emits inside a string is rewritten as its escape. Do not diff or hash it\n" +
+	"against the wire."
 
 // TestReadJSONNoteDescribesTheRepair is the guard finding 1 asked for.
 //


### PR DESCRIPTION
Closes #543.

## What was wrong

`civitai/cli#541` grew `readJSONNote` by 131 runes (253 → 384) as an audited
correctness fix. Two consequences, both measured by the blind audit that filed
this:

1. **`users --help` reached 1395 of the 1400-rune budget — 5 of headroom.** By
   this repo's own recorded standard (`agents_size_test.go`: *"A ceiling with 19
   bytes under it is indistinguishable from a frozen file"*) that is frozen, and
   the next person to red it would be someone editing unrelated prose.
2. **The residual note named the wrong command.** It still called `images
   search` *"the longest consumer"* with *"about FOURTEEN of headroom"*. After
   #541 `users` was longest and `images search` had not moved at all.

## Fix 1 — trim the shared constant, not the budget

The guard's own comment says *"do not raise the budget to make a shared sentence
fit"*, and that doctrine is kept. `readJSONNote` loses two pieces that claim
nothing about our output:

- **`(which is not legal JSON)`** — an aside about the **input** the API sent,
  not about what the CLI emits. The README still carries that explanation twice,
  at the two places with room for it.
- **`so the output still parses`** — already claimed by the note's *first*
  sentence (`… --json | jq -e .` always parses), and asserted by the guard's own
  `json.Valid` check.

**384 → 331 runes**, so all eight bodies interpolating it gain 53.

| body | before | after |
|---|---|---|
| `users` | 1395 (5) | **1342 (58)** |
| `images` | 1356 (44) | 1303 (97) |
| `images search` | 1386 (14) | 1386 (14) — does not interpolate it |

Every measured claim survives: stdout-only with notes/errors on stderr, the
**document** unchanged, the control byte arriving as its `\r` escape, and don't
diff or hash against the wire.

**`readJSONNote` is pinned VERBATIM, so the change was made the way that guard
demands** rather than by pasting: the pin was watched **failing** first —

```
read_json_note_test.go:100: readJSONNote no longer matches the measured behaviour.
```

— then (a) and (b) were re-run to confirm the behaviour they assert is unchanged,
then the expectation was re-typed. (a)/(b) passed throughout, which is the point:
they test behaviour, and only a help string moved.

## Fix 2 — the note now records the mechanism, not a ranking

🔴 **The trim moves the binding constraint rather than removing it, and saying so
is the point.** `images search` is longest again at **1386 (14 of headroom)**
because it does **not** interpolate `readJSONNote` — `images`, the *parent*,
does. That asymmetry is what makes the ranking move at all, and it is why a note
naming a command goes stale without anyone touching it.

So the note now states the mechanism, the current measured numbers, and that the
ordering flipped once and flipped back — instead of a name that was false for the
last three weeks.

🔴 **`images search` at 14 is PRE-EXISTING and is NOT closed here.** It was 1386
both before and after #541, so it is untouched by the regression this issue is
about and untouched by this fix. Rather than leave it for the next person to
rediscover, it is now recorded in the note as the binding constraint. If a
maintainer wants that one opened up too, it needs a different lever —
`serverOwnedEnumNote` / `deepPagingNote` / the body itself — and is worth its own
issue.

No probe is committed: a helper that printed the ranking would itself need
pinning to stay honest, which is an instance of exactly the failure this issue
reports.

## Gate

`make ci` rc **0** (21 packages `ok`) · `make lint` rc **0**, `0 issues`.
