### PR TITLE
fix(comments): rewrite four rotted test citations, and correct half (c)'s controls

### DIFF
--- a/claudedocs/decisions/38-read-body-repair-and-snippet.md
+++ b/claudedocs/decisions/38-read-body-repair-and-snippet.md
@@ -400,7 +400,15 @@ the numeral cannot drift from the membership.
   - the deep-paging cap still exits 2 (same test, half (b));
   - a cap message whose phrase falls past `snippet`'s 500-byte DISPLAY bound
     exits 2 (same test, half (c)) — the deliberate move in the opposite
-    direction;
+    direction. ✅ Half (c)'s two CONTROLS were measuring the wrong string and
+    have been corrected: `readError` extracts `message` and only then calls
+    `snippet` on it, so the 500-byte bound applies to the MESSAGE, while both
+    controls were written against the whole `{"message":"…"}` body — a length
+    check against a fudged 520 (500 plus a guess at the envelope) and a
+    truncation check calling `snippet` on the body. They passed only because the
+    body is a superset of the message and this fixture clears the bound either
+    way. A control that is right by accident cannot be relied on when the fixture
+    changes;
   - a cap message whose phrase falls past `maxClassifyMessage` (8 KiB) exits 6
     (`TestDeepPagingCapClassificationIsBounded`), with the same fixture shape
     inside the window still exiting 2 as its positive control.
@@ -449,8 +457,22 @@ the numeral cannot drift from the membership.
   `TestItem38CommentsCiteTestsThatExist`'s doc comment; neither that comment nor
   this document may quote the identifiers, because both are now scanned and would
   flag themselves.
-- 🔴 **Four genuine rot findings came out of that triage, and are NOT fixed
-  here.** Each is a doc comment, or a "pinned by" pointer, naming a test nothing
+- ✅ **RESOLVED — four genuine rot findings came out of that triage.** They were
+  NOT fixed in the PR that found them; they are fixed now. Each comment was
+  rewritten from what its function actually does rather than renamed, and the
+  repo-wide unresolved-name count dropped **20 → 16** (sites 23 → 19), measured
+  with the shipped instruments on both sides of the change. Two carried a SECOND
+  error that a rename alone would have left in place: the `download_ssrf` comment
+  described a redirect-to-loopback case over a function that builds a
+  redirect-to-plain-http one, and the `appblocks.go` comment claimed
+  `submissionsURL` "sends only the id" when the guard's own fake server fails
+  unless BOTH selectors arrive. The dead identifiers are deliberately not quoted
+  in the replacements — citations are scanned repo-wide, so quoting one would
+  keep it in the very count this closes. The original finding follows, kept
+  because a corrected reading is worth more than a deleted one:
+
+- 🔴 **Four genuine rot findings came out of that triage, and were NOT fixed
+  when they were found.** Each is a doc comment, or a "pinned by" pointer, naming a test nothing
   declares — the same defect §3 of this document exists for, four more instances
   of it, in files this PR did not write. Site, then what is actually declared
   there:

--- a/internal/appapi/appblocks.go
+++ b/internal/appapi/appblocks.go
@@ -1257,9 +1257,19 @@ func (c *Client) getSubmissionRows(ctx context.Context, id, blockID string) (*Su
 // submissionSubject names WHICH lookup came back empty, using the selector the
 // caller actually passed (GetSubmission takes either a pubreq id or a slug, and
 // id wins when both are set — mirror that order here or the error names a
-// selector the request did not use). The id-first order is REACHABLE and pinned
-// by TestSubmissionSelectorPrecedenceMirrorsTheRequest: `civitai app status --id
-// <id> <slug>` passes both, and submissionsURL sends only the id.
+// selector the request did not use). The id-first order is REACHABLE — `civitai
+// app status --id <id> <slug>` passes both — and is pinned by
+// TestSubmissionSelectorPrecedenceAgreesWithTheParse, which asserts the
+// behaviour and this function's wording TOGETHER: with both selectors sent and
+// the server answering both shapes, the client resolves the id-shaped reply,
+// and the subject string must then name the id and not the slug.
+//
+// 🔴 THIS COMMENT CITED A TEST NOTHING DECLARES, AND ALSO STATED THE WIRE
+// BEHAVIOUR BACKWARDS. It claimed submissionsURL "sends only the id". Both
+// selectors ARE sent — the guard's own fake server fails the
+// test unless it receives BOTH — and the precedence is applied to the REPLY, not
+// by omitting a query parameter. Fixing only the name would have left the second
+// sentence reading truer while still being false (item 38's residuals).
 func submissionSubject(id, blockID string) string {
 	if s := strings.TrimSpace(id); s != "" {
 		return fmt.Sprintf("submission id %q", s)

--- a/internal/cmd/app_pull_not_approved_test.go
+++ b/internal/cmd/app_pull_not_approved_test.go
@@ -369,8 +369,17 @@ func TestAppPullDisambiguationFailureKeepsTheServerAnswer(t *testing.T) {
 	}
 }
 
-// TestAppPullNotApprovedDoesNotRegressTheHappyPath: the disambiguation must only
-// run on a not-found. A 403 is a different question and keeps its own message.
+// TestAppPullForbiddenIsNotDisambiguated: the disambiguation must only run on a
+// not-found. A 403 is a different question and keeps its own message.
+//
+// Two assertions, and the first is the one worth naming: the fake server FAILS
+// the test if the submissions lookup is reached at all, so this pins that a 403
+// does not even attempt the disambiguation — not merely that its message
+// survives one. The second is that the error still says "not permitted".
+//
+// (The name above previously cited a test nothing declares; the dead identifier
+// is not repeated here, because citations are scanned repo-wide. AGENTS.md
+// item 38's enumerated residuals.)
 func TestAppPullForbiddenIsNotDisambiguated(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/blocks/submissions") {

--- a/internal/cmd/update_check_test.go
+++ b/internal/cmd/update_check_test.go
@@ -390,8 +390,19 @@ func TestUpdateCheckDisabled(t *testing.T) {
 	}
 }
 
-// TestVersionCommandEnvOptOutMakesNoCall asserts the env opt-out path skips the
-// HTTP call entirely (the server must get zero hits).
+// TestVersionCommandEnvOptOut asserts the CIVITAI_NO_UPDATE_CHECK path skips the
+// HTTP call entirely — the server must get zero hits — AND that the notice is
+// absent from the output.
+//
+// Both halves are load-bearing and neither implies the other: a call could be
+// made and its result discarded (zero hits fails, notice absent passes), or the
+// call skipped while a cached notice still prints (zero hits passes, notice
+// absent fails). The server here is primed with v9.9.9, so the notice WOULD
+// appear if the opt-out leaked.
+//
+// (The name above previously cited a test nothing declares, and described only
+// the first half. The dead identifier is not repeated here, because citations
+// are scanned repo-wide. AGENTS.md item 38's enumerated residuals.)
 func TestVersionCommandEnvOptOut(t *testing.T) {
 	srv, hits := newReleaseServer(t, "v9.9.9", http.StatusOK)
 	pointAtServer(t, srv.URL)

--- a/pkg/civitai/download_ssrf_test.go
+++ b/pkg/civitai/download_ssrf_test.go
@@ -144,12 +144,25 @@ func TestDownloadFileRefusesLoopbackIP(t *testing.T) {
 	}
 }
 
-// TestDownloadFileRedirectToLoopbackRefused proves the dial guard also catches a
-// REDIRECT to an internal IP: a public-looking first hop that 302s to loopback
-// is refused when the guard follows the redirect and dials the internal address.
-// (Modeled with the bypass off; the first hop is itself https loopback, which the
-// guard blocks — the same mechanism that would block a redirect target, since
-// CheckRedirect + the dial Control run on every hop.)
+// TestDownloadFileRedirectTargetSchemeChecked asserts the WIRING: the client
+// downloadHTTPClient builds actually carries our redirect policy, and that
+// policy refuses a plain-http target.
+//
+// It is deliberately narrow. The policy's own decision logic is owned by
+// TestCheckDownloadRedirectRejectsHTTP, which calls checkDownloadRedirect
+// directly; what nothing else covers is whether the client ever INSTALLS it —
+// a `CheckRedirect: nil` would leave every redirect unchecked with that other
+// test still green. So this one asserts CheckRedirect is non-nil and then
+// invokes it through the built client.
+//
+// 🔴 THIS COMMENT USED TO NAME A TEST NOTHING DECLARES, AND TO DESCRIBE A
+// DIFFERENT CASE: a public-looking first hop that 302s to loopback — a
+// redirect-to-LOOPBACK story — over a function that builds a
+// redirect-to-PLAIN-HTTP case and never issues a request at all. Both halves
+// were wrong, which is why it was rewritten from the function rather than
+// renamed (AGENTS.md item 38's enumerated residuals). The dead identifier is
+// deliberately not repeated here: citations are scanned repo-wide, and quoting
+// it would keep it in the unresolved count this fix exists to reduce.
 func TestDownloadFileRedirectTargetSchemeChecked(t *testing.T) {
 	// Guard on: a redirect to plain-http is refused by checkDownloadRedirect even
 	// though the dial guard would separately block an internal IP. Verified in

--- a/pkg/civitai/read_repair_test.go
+++ b/pkg/civitai/read_repair_test.go
@@ -339,22 +339,34 @@ func TestDeepPagingCapClassifiesOnTheWireMessageNotTheStrippedOne(t *testing.T) 
 	// was invisible to the classifier and exited 6 — a scripter's backoff loop
 	// spinning forever on a structurally doomed request. The bound is a display
 	// budget, not a statement about what the server said.
-	long := `{"message":"` + strings.Repeat("context, ", 70) +
-		"you have requested too many pages here" + `"}`
-	if len(long) <= 520 {
-		t.Fatalf("CONTROL failure, not a finding: the fixture is %d bytes, which does "+
-			"not exceed snippet's 500-byte bound — half (c) would assert nothing", len(long))
+	// 🔴 BOTH CONTROLS BELOW MEASURE THE MESSAGE, NOT THE BODY, AND THAT
+	// DISTINCTION IS THE POINT. readError extracts `message` out of the envelope
+	// and only then calls snippet on it — `msg = snippet([]byte(msg))` — so
+	// snippet's 500-byte bound applies to the MESSAGE. These controls used to be
+	// written against the whole `{"message":"…"}` body: the length check compared
+	// the body against a fudged 520 (500 plus a guess at the envelope), and the
+	// truncation check called snippet on the body rather than on the string
+	// snippet actually receives. They passed only because the body is a superset
+	// of the message and this fixture clears the bound either way — a control
+	// that is right by accident cannot be relied on when the fixture changes.
+	capPhrase := "you have requested too many pages here"
+	capMsg := strings.Repeat("context, ", 70) + capPhrase
+	long := `{"message":"` + capMsg + `"}`
+	if len(capMsg) <= 500 {
+		t.Fatalf("CONTROL failure, not a finding: the MESSAGE is %d bytes, which does "+
+			"not exceed snippet's 500-byte bound — half (c) would assert nothing", len(capMsg))
 	}
 	c = serveOnce(t, http.StatusTooManyRequests, long)
 	_, err = c.SearchModels(context.Background(), url.Values{})
 	if err == nil {
 		t.Fatal("a 429 must be an error; without it half (c) asserts on nothing")
 	}
-	// Positive control on the FIXTURE: the phrase really is past the bound, so
-	// the assertion below is about truncation and not about the phrase.
-	if strings.Contains(snippet([]byte(long)), "too many pages") {
+	// Positive control on the FIXTURE: the phrase really is past the bound once
+	// snippet has been applied to the MESSAGE, so the assertion below is about
+	// truncation and not about the phrase.
+	if strings.Contains(snippet([]byte(capMsg)), capPhrase) {
 		t.Fatal("CONTROL failure, not a finding: the cap phrase survives snippet's " +
-			"truncation, so half (c) is not testing what it says")
+			"truncation of the message, so half (c) is not testing what it says")
 	}
 	if !errors.Is(err, ErrBadRequest) {
 		t.Errorf("a deep-paging cap whose phrase falls past snippet's 500-byte "+


### PR DESCRIPTION
Clears **two of the three** enumerated residuals of AGENTS.md item 38. The third is left open on purpose — see the end.

## 1. Four comment-citation rot sites

Each is a doc comment or a "pinned by" pointer naming a test nothing declares. The residual list named them and deliberately did **not** fix them, because *"a name-only correction leaves a comment that reads truer and may still be wrong."* That was right, and two of the four prove it:

- **`pkg/civitai/download_ssrf_test.go`** — the comment told a redirect-to-**loopback** story over a function that builds a redirect-to-**plain-http** case and never issues a request at all. Rewritten from the function: it asserts the **wiring** (that `downloadHTTPClient` installs a `CheckRedirect` at all — a `nil` there would leave every redirect unchecked with `TestCheckDownloadRedirectRejectsHTTP` still green), and delegates the policy's own logic to that test.
- **`internal/appapi/appblocks.go`** — the comment claimed `submissionsURL` *"sends only the id"*. Both selectors **are** sent: the guard's own fake server fails the test unless it receives both, and the precedence is applied to the **reply**. Renaming alone would have left that sentence reading truer and still false.

The other two were accurate in body and wrong only in name. Both gained the half of the assertion their comment had omitted: that a 403 never **reaches** the submissions lookup (not merely that its message survives one), and that the env opt-out suppresses the **notice** as well as the call.

🔴 **The dead identifiers are not quoted in the replacements.** Citations are scanned repo-wide, so a "previously called X" note keeps X in the very count this closes. My first draft did exactly that and would have left the count at 20.

### Measured on both sides, not asserted

Using the shipped instruments (`testIdentRe` + `repoTestFuncNames`) over the whole module:

| | files | citations | unresolved sites | **distinct names** |
|---|---|---|---|---|
| `origin/main` | 474 | 2115 | 23 | **20** |
| this branch | 474 | 2116 | 19 | **16** |

The four names that disappear are exactly the four the residual list names, at exactly the `file:line` it gives. **20 → 16 is the closing condition it states.**

## 2. Half (c)'s controls measured the wrong string

`readError` extracts `message` from the envelope and *only then* calls `snippet` on it, so snippet's 500-byte bound applies to the **message**. Both of half (c)'s controls were written against the whole `{"message":"…"}` **body**: a length check against a fudged **520** (500 plus a guess at the envelope), and a truncation check calling `snippet` on the body rather than on the string snippet actually receives.

They passed only because the body is a superset of the message and this fixture clears the bound either way — **right by accident**, and not something to rely on when the fixture changes.

Both now measure `capMsg`, and the assertion reuses the phrase constant instead of re-typing it. Verified by shrinking the fixture below the bound and watching the control fire with the corrected measurement:

```
CONTROL failure, not a finding: the MESSAGE is 83 bytes, which does not
exceed snippet's 500-byte bound — half (c) would assert nothing
```

## 3. NOT done, deliberately — the README's 429 → exit 2 gap

The residual list assigns this to *"whoever owns AGENTS.md item 7's table"*, and inspecting it confirms that is a different kind of change rather than a scoping excuse: **both** README exit-code blocks are **generated** from `exitCodeDocs` in `internal/cmd/exitcodes_doc.go` (pinned by `TestREADMEExitCodeTableIsGenerated` and `TestREADMEExitCodeSectionsAreGenerated`). Documenting the case means editing the generator and republishing the exit-code contract, which is a decision about published wording rather than a comment fix. It stays open and stays recorded.

`decisions/38`'s residual list marks the two closed ones and keeps the original findings rather than deleting them.

## Gate

`make ci` rc **0** (21 packages `ok`) · `make lint` rc **0**, `0 issues`.
