### PR TITLE
fix(safeterm): ledger every call site by enclosing function, and pin 12 that were unpinned

### DIFF
--- a/internal/cmd/read.go
+++ b/internal/cmd/read.go
@@ -123,7 +123,15 @@ func nonModelFileMarker(files []civitai.ModelVersionFile) string {
 	if typ == "" {
 		typ = "Other"
 	}
-	return "[" + typ + "]"
+	// 🔴 SERVER TEXT, SO IT GOES THROUGH THE GATE — civitai/cli#399 found this
+	// one by driving the renderer rather than by reading it. `files[].type` is
+	// uploader-supplied and this marker is INTERPOLATED INTO A HEADER LINE
+	// (`printModelVersionDetail`'s first line, and a row of `printModelDetail`'s
+	// version table), which is precisely where an escape sequence is worth the
+	// most to an attacker. The same field is safeTerm'd in the files table a few
+	// lines further down; here it was not, and nothing could see the difference
+	// until a hostile fixture was fed through this function.
+	return "[" + safeTerm(typ) + "]"
 }
 
 // checkLimit validates a --limit against an endpoint's documented maximum. It

--- a/internal/cmd/safeterm_coverage_test.go
+++ b/internal/cmd/safeterm_coverage_test.go
@@ -1,0 +1,454 @@
+package cmd
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// civitai/cli#399 — safeTerm WAS UNPINNED AT MOST OF ITS CALL SITES, AND
+// NOTHING COULD SAY WHICH.
+//
+// safeTerm is the CLI's ONE gate on server-supplied text reaching a terminal
+// (see internal/saferune's package doc for the class it removes, and
+// safeterm.go for what a hostile field does without it). It is called from 152
+// sites in 60 functions. An adversarial audit of #398 deleted `safeTerm(...)`
+// at each of 25 sampled sites in turn: 20 of them left the WHOLE SUITE GREEN.
+// A refactor could drop the call and CI would say nothing.
+//
+// 🔴 THE PROBLEM WAS NOT A MISSING TEST, IT WAS A MISSING NUMBER. Nobody could
+// answer "which of these sites is pinned?" without re-running that audit by
+// hand, so the answer was never written down and never re-checked. A table of
+// 60 rows beats 152 tests: this is the answer, in a form a compiler keeps
+// honest.
+//
+// It is deliberately NOT a claim that every site is covered. Most rows say
+// notCovered, and that is the point — the absence is now IMPOSSIBLE NOT TO
+// WRITE DOWN, counted by the test, and capped by maxUncoveredSafeTermFuncs so
+// it can only shrink. A ledger that could only record coverage would have been
+// satisfied by deleting the rows nobody had got to.
+//
+// Why the ENCLOSING FUNCTION is the key, and not the call site's argument
+// expression: #398's bareIdentArgs is keyed by argument name and its own
+// comment concedes the weakness — "the same name holds a server-returned id at
+// other call sites". A function is the unit a test actually drives, the unit a
+// refactor moves, and the unit whose row goes stale the moment its last
+// safeTerm call is deleted.
+//
+// 🔴 TWO DIFFERENT CLAIMS LIVE HERE, AND CONFUSING THEM WOULD OVERSTATE WHAT
+// THIS BUYS. Say plainly what each half covers:
+//
+//   - The LEDGER pins that a function still calls safeTerm AT ALL. Deleting a
+//     function's LAST safeTerm call empties its row and fails SHRANK below —
+//     for every row, notCovered ones included. That is the whole set of 60
+//     functions, and it is what #399's headline measurement was about.
+//   - A NAMED TEST pins that the class does not reach the SCREEN. That is
+//     strictly more, and it is the only thing that catches deleting ONE of a
+//     function's twelve calls, or a new field printed without the gate.
+//
+// So a notCovered row is not "unguarded"; it is "guarded against wholesale
+// removal, not against a per-field regression". Do not read the covered count
+// as a coverage percentage of the 151 call sites — it is a count of FUNCTIONS
+// whose output a test actually inspects.
+//
+// The walk is scanSafeTermCallSites in safeterm_userinput_test.go — the same
+// one #398 built for the opposite property (that no site sanitises what the
+// USER typed). #399's own body asked for it there: "the same walk is the
+// natural place to hang a coverage ledger."
+
+// safeTermCoverage is one row: what pins the safeTerm call(s) in one function.
+type safeTermCoverage struct {
+	// test is the name of the test that goes RED when the safeTerm call(s) in
+	// this function are deleted — measured by deleting them, not by reading the
+	// test and believing it. notCovered means no test in this package does.
+	//
+	// 🔴 IT IS RESOLVED TO A DECLARATION, not used as a label. A ledger naming a
+	// test that does not exist is worse than no ledger: it reads as coverage and
+	// stops anyone looking. checkCoveringTestsResolve is what makes the name a
+	// binding, so renaming or deleting the test is red HERE.
+	test string
+	// why is what that test asserts — or, for a notCovered row, what a hostile
+	// server field could do at this surface today. Every row must say something;
+	// an empty why is a row nobody thought about.
+	why string
+}
+
+// notCovered is a FIRST-CLASS LEDGER VALUE, not a hole in the table.
+//
+// Writing it down is the whole mechanism. The alternative — leaving a function
+// out until someone writes its test — makes "unmeasured" and "covered"
+// indistinguishable, which is the state #399 found the repo in.
+const notCovered = ""
+
+// 🔴 EVERY ROW'S VERDICT WAS MEASURED, NOT READ OFF THE TESTS.
+//
+// Method, so it can be repeated: for each function below, every `safeTerm(x)`
+// inside it was rewritten to `x` by byte splice (nothing else in the file
+// moved), then `go test ./internal/cmd/ -count=1` was run against a tree frozen
+// at cf5e4a8. A named test is one that went red; notCovered means the suite
+// stayed green. Controls on that sweep: the unmutated tree was green first, the
+// mutated tree was diffed to prove the mutant was actually on disk, and
+// neutering safeTerm itself reddened 20 tests — so a SURVIVED verdict is not a
+// harness that cannot see red.
+//
+// The baseline that produced, at cf5e4a8 and BEFORE this change: 23 of the 59
+// functions were killed by some test, 36 SURVIVED losing every safeTerm call
+// they had. That is #399's headline, re-measured at the level of functions
+// rather than of sampled sites. The rows below were then re-measured against
+// the tree this commit ships, which is what they describe.
+//
+// 🔴 TWO ROWS NAME AN INCIDENTAL KILLER AND SAY SO. Deleting the safeTerm in
+// emitPreDownloadNotes or parseGraphInput reddens
+// TestSafeTermIsNeverAppliedToUserTypedInput — but only because its
+// bareIdentArgs ledger notices a classified NAME has stopped appearing. That is
+// bookkeeping noticing a deletion, not an assertion that the class stays off
+// the screen, and writing it down as ordinary coverage would overstate what
+// those two surfaces have.
+var safeTermCoveredBy = map[string]safeTermCoverage{
+	// --- read path: models / versions -------------------------------------
+	"printModelList": {"TestModelsSearchSanitizesControlChars",
+		"`models search` rows: an uploader's model name, type and creator username"},
+	"printModelDetail": {"TestModelsGetSanitizesControlChars",
+		"`models get`: name, type, creator, and each version's name and base model"},
+	"printModelVersionDetail": {"TestModelVersionsGetSanitizesControlChars",
+		"`model-versions get`: version name, parent model, AIR, download URL, file names"},
+	"joinTags": {"TestModelsGetSanitizesControlChars",
+		"the shared tag / trained-word list — trigger words are uploader free text"},
+	"nonModelFileMarker": {"TestReadRenderersStripTheInvisibleClass",
+		"the [Archive] / [Training Data] marker: `files[].type` INTERPOLATED INTO A HEADER LINE. " +
+			"It was raw until #399 — the same field is safeTerm'd in the files table below it"},
+
+	// --- read path: users / tags / creators --------------------------------
+	"printUser": {"TestUsersGetSanitizesControlChars",
+		"`users get`: the username and avatar URL"},
+	"printTagList": {"TestReadRenderersStripTheInvisibleClass",
+		"`tags search` rows: tag name and link"},
+	"printCreatorList": {"TestReadRenderersStripTheInvisibleClass",
+		"`creators search` rows: username and link"},
+
+	// --- read path: collections / articles ---------------------------------
+	"printCollectionList": {"TestReadRenderersStripTheInvisibleClass",
+		"`collections search` rows: name, type and owner username"},
+	"printCollectionDetail": {"TestReadRenderersStripTheInvisibleClass",
+		"`collections get`: name, type, read scope, description and owner"},
+	"joinCollectionTags": {"TestReadRenderersStripTheInvisibleClass",
+		"a collection's tag list"},
+	"printArticleList": {"TestReadRenderersStripTheInvisibleClass",
+		"`articles search` rows: title and author username"},
+	"printArticleDetail": {"TestArticlesGetSanitizesControlChars",
+		"`articles get`: title, author and tags"},
+	"joinArticleTags": {"TestArticlesGetSanitizesControlChars",
+		"an article's tag list"},
+	"htmlToText": {"TestHTMLToTextStripsControlChars",
+		"`articles get --content`: the article BODY, the largest free-text surface the CLI prints"},
+
+	// --- read path: apps ----------------------------------------------------
+	"printAppList": {"TestReadRenderersStripTheInvisibleClass",
+		"`app list` rows: name, slug, kind, category and author"},
+	"printAppDetail": {"TestReadRenderersStripTheInvisibleClass",
+		"`app view`: name, slug, tagline, category, content rating, description, and BOTH arms " +
+			"of the kind switch (onsite live URL; offsite subKind / external URL / client id)"},
+	"appCardAuthor": {"TestReadRenderersStripTheInvisibleClass",
+		"the creator chip shared by the app list and detail"},
+	"appViewOwnedAdvice": {"TestReadRenderersStripTheInvisibleClass",
+		"the 404-but-owned advice, which quotes the submission's server-supplied status"},
+	"offsiteRegisteredAt": {"TestOffsiteRefusalSanitizesControlChars",
+		"the registration date quoted in an offsite app's refusal"},
+
+	// --- read path: images --------------------------------------------------
+	"printImageList": {"TestImagesSearchBaseModelSanitized",
+		"`images search` rows: uploader, base model, rating and URL"},
+	"printImageMetaBlock": {"TestImagesSearchMetaHumanOutput",
+		"`images search --meta`: the generation prompt — attacker-controlled free text by design"},
+	"printImageResources": {"TestImagesSearchMetaResourceSanitized",
+		"the meta.resources recipe: resource type, name, weight and hash"},
+
+	// --- download path ------------------------------------------------------
+	"printDownloadPlan": {"TestDownloadPlanSanitizesControlChars",
+		"the plan a user reads before fetching: file name, sha256, target and notes. An escape here " +
+			"can overwrite the `SHA256 verified` line the plan is there to establish"},
+	"reportBaseModel": {"TestDownloadPlanSanitizesControlChars",
+		"the base-model line and the mismatch warnings above the plan"},
+	"formatFileList": {"TestReadRenderersStripTheInvisibleClass",
+		"the ambiguity list naming each candidate file by server-supplied name and type"},
+	"emitPreDownloadNotes": {"TestSafeTermIsNeverAppliedToUserTypedInput",
+		"INCIDENTAL, NOT BEHAVIOURAL: the published file name in the `no SHA256 published` warning. " +
+			"The red comes from bareIdentArgs noticing `name` stopped being passed, not from any " +
+			"assertion about what reaches the terminal"},
+
+	// --- generate path ------------------------------------------------------
+	"describeVersion": {"TestGenerate_SanitisesServerStrings",
+		"the resolved checkpoint/LoRA name and type on the PRE-SPEND quote screen"},
+	"serverReasonSuffix": {"TestGenerate_ServerReasonIsSanitizedForTheTerminal",
+		"the orchestrator's failure reason appended to a generate error"},
+	"printWorkflow": {"TestWorkflowsGet_ReasonBlockIsSanitized",
+		"`workflows get`: id, status, timestamps, the failure-reason block and each output"},
+	"printWorkflowList": {"TestWorkflowsList_ReasonCannotCarryTerminalControlBytes",
+		"`workflows list`: each row's id/status/date, the wrapped reason lines and the next cursor"},
+	"reportExcludedOutputs": {"TestReportExcludedOutputs_ReasonIsSanitized",
+		"the excluded-output line: output id and the server's exclusion reason"},
+	"reportModelSubstitutions": {"TestReportModelSubstitutions_SanitizesTheServerReason",
+		"the server's reason for swapping the model the user asked to spend on"},
+	"reportWorkflowSettlement": {"TestReportWorkflowSettlement_SanitisesTheServerType",
+		"the settlement table's transaction TYPE, printed next to a Buzz amount"},
+	"parseGraphInput": {"TestSafeTermIsNeverAppliedToUserTypedInput",
+		"INCIDENTAL, NOT BEHAVIOURAL: the `workflow` value out of the user's own --input FILE — " +
+			"saferune's documented file-content exception. The red comes from bareIdentArgs noticing " +
+			"`workflow` stopped being passed"},
+
+	// --- NOT COVERED --------------------------------------------------------
+	// Each of these lost every safeTerm call it had and the whole suite stayed
+	// green (measured at cf5e4a8). They are still pinned against WHOLESALE
+	// removal by the SHRANK check above; what is missing is an assertion that
+	// the class does not reach the screen.
+	"ambiguousYesNote": {notCovered,
+		"the --yes ambiguity note quotes the server's model and parent name"},
+	"ambiguousStopError": {notCovered,
+		"the same two names in the refusal that stops an ambiguous download"},
+	"warnMixedTypes": {notCovered,
+		"the mixed-file-type warnings above a download"},
+	"downloadSelected": {notCovered,
+		"the per-file routing note built from the server's file name"},
+	"downloadOne": {notCovered,
+		"the `Saved <target>` line — the one line that says where bytes landed"},
+	"presentTargetSatisfies": {notCovered,
+		"the `already present (SHA256 verified)` lines, which assert an integrity result"},
+	"pickleArchiveNote": {notCovered,
+		"the pickle/archive EXECUTION WARNING, whose text embeds the server's file name"},
+	"printOutputURLs": {notCovered,
+		"the generated output URLs printed for piping"},
+	"printSubmitted": {notCovered,
+		"the submitted-workflow id and its civitai.com link"},
+	"printReattach": {notCovered,
+		"the re-attach block: workflow id and last status"},
+	"printSubmitResult": {notCovered,
+		"the submit result's id and status"},
+	"printCostMap": {notCovered,
+		"the cost-map KEYS on the quote screen — server-named factors beside Buzz amounts"},
+	"classifyGenerateError": {notCovered,
+		"the server's own error message, shown verbatim when generation is refused"},
+	"buildGenerateGraph": {notCovered,
+		"the uploaded image URL echoed back into the img2img disclosure"},
+	"waitAndCollect": {notCovered,
+		"the terminal-status and dead-end lines naming the workflow and its status"},
+	"substitutionRefusal": {notCovered,
+		"the server's reason inside the refusal that ABORTS a spend"},
+	"joinQuoted": {notCovered,
+		"the quoted key list in an --input parse error"},
+	"downloadBlobTo": {notCovered,
+		"the `Saved <target>` line on the generate output path"},
+	"downloadOutputs": {notCovered,
+		"the multi-output progress line and the no-URL error, both naming server ids"},
+	"printAppMetrics": {notCovered,
+		"the scope and endpoint tokens — kept RAW on purpose (AGENTS.md item 8), which makes the " +
+			"strip the ONLY thing between an uploader-shaped token and the terminal"},
+	"newUsersGetCmd": {notCovered,
+		"the `closest matches` usernames printed when a user lookup misses"},
+	"(*quietPollReporter).tick": {notCovered,
+		"the server status echoed on every poll of a running generation"},
+	"(*quietPollReporter).finish": {notCovered,
+		"the final status line of a quiet poll"},
+	"(*ttyPollReporter).tick": {notCovered,
+		"the same status inside a \\r-rewritten spinner line, where a cursor escape is worth most"},
+	"(*ttyPollReporter).finish": {notCovered,
+		"the spinner's final status line"},
+}
+
+const (
+	// minSafeTermFuncsScanned is the POSITIVE CONTROL on the attribution. A walk
+	// that attributed nothing would find no unledgered function and report a
+	// serene pass; 60 functions hold a call today.
+	minSafeTermFuncsScanned = 40
+
+	// minTestDeclsScanned is the POSITIVE CONTROL on the name resolver. An empty
+	// declaration set would report every named test as a ghost — the same red for
+	// the opposite cause. There are ~1580 today.
+	minTestDeclsScanned = 500
+
+	// maxUncoveredSafeTermFuncs is the RATCHET: it is set to the exact count
+	// today, so there is no headroom to spend and the number cannot go UP.
+	// Lower it when you cover a row.
+	//
+	// Say what it does NOT do, because "ratchet" oversells it: it constrains the
+	// COUNT, so a commit that covers one row and uncovers another nets out and
+	// passes. GREW is what makes a new surface impossible to add SILENTLY — it
+	// must get a row, and whether that row is honest is then a review question
+	// with the evidence written next to it. That is the split #399 asked for:
+	// the count is mechanical, the content is reviewed.
+	maxUncoveredSafeTermFuncs = 25
+)
+
+// TestSafeTermCallSitesAreCoveredByANamedTest is civitai/cli#399.
+//
+// Four independent assertions, each with its own message, so a failure says
+// which thing went wrong rather than that "the ledger is out of date":
+//
+//	GREW    — a function now calls safeTerm and no row covers it.
+//	SHRANK  — a row names a function that no longer calls safeTerm.
+//	GHOST   — a row names a test that does not exist.
+//	RATCHET — the notCovered count went up.
+func TestSafeTermCallSitesAreCoveredByANamedTest(t *testing.T) {
+	sites := scanSafeTermCallSites(t)
+
+	calls := map[string]int{}
+	firstPos := map[string]string{}
+	for _, s := range sites {
+		calls[s.enclosing]++
+		if _, seen := firstPos[s.enclosing]; !seen {
+			firstPos[s.enclosing] = s.pos
+		}
+	}
+	if len(calls) < minSafeTermFuncsScanned {
+		t.Fatalf("CONTROL failure, not a finding: %d safeTerm call(s) attributed to only %d function(s), "+
+			"want >= %d. The enclosing-function attribution is broken, and every verdict below would be "+
+			"about nothing.", len(sites), len(calls), minSafeTermFuncsScanned)
+	}
+
+	// --- GREW ---------------------------------------------------------------
+	var unledgered []string
+	for fn, n := range calls {
+		if _, ok := safeTermCoveredBy[fn]; !ok {
+			unledgered = append(unledgered, fmt.Sprintf("%s — %d call(s), first at %s", fn, n, firstPos[fn]))
+		}
+	}
+	sort.Strings(unledgered)
+	if len(unledgered) > 0 {
+		t.Errorf("%d function(s) put SERVER text through safeTerm with no row in safeTermCoveredBy:\n  %s\n\n"+
+			"Add a row. Either name the test that goes RED when you delete the safeTerm call there — delete it "+
+			"and watch, do not read the test and believe it — or write notCovered and say in `why` what a "+
+			"hostile field could do at that surface. notCovered is an honest row, but it counts against "+
+			"maxUncoveredSafeTermFuncs (%d), which does not go up (civitai/cli#399).",
+			len(unledgered), strings.Join(unledgered, "\n  "), maxUncoveredSafeTermFuncs)
+	}
+
+	// --- SHRANK -------------------------------------------------------------
+	var stale []string
+	for fn, cov := range safeTermCoveredBy {
+		if calls[fn] == 0 {
+			stale = append(stale, fmt.Sprintf("%s (recorded as %s)", fn, describeCoverage(cov)))
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("%d ledger row(s) name a function that no longer calls safeTerm:\n  %s\n\n"+
+			"RENAMED or MOVED: move the row with it, in the same commit. DELETED: delete the row. "+
+			"CALL REMOVED: that is the #399 defect happening — a server-text surface lost its only gate, and "+
+			"a stale row would have gone on reading as coverage.", len(stale), strings.Join(stale, "\n  "))
+	}
+
+	// --- GHOST --------------------------------------------------------------
+	checkCoveringTestsResolve(t)
+
+	// --- RATCHET ------------------------------------------------------------
+	covered, uncovered := 0, 0
+	var missing []string
+	for fn, cov := range safeTermCoveredBy {
+		if cov.why == "" {
+			t.Errorf("safeTermCoveredBy[%q] has an empty `why`. A row with no reason is a row nobody thought "+
+				"about; say what the test asserts, or what a hostile field could do there.", fn)
+		}
+		if cov.test == notCovered {
+			uncovered++
+			missing = append(missing, fn)
+			continue
+		}
+		covered++
+	}
+	sort.Strings(missing)
+	if uncovered > maxUncoveredSafeTermFuncs {
+		t.Errorf("%d function(s) are ledgered notCovered, and the cap is %d:\n  %s\n\n"+
+			"This number only goes down. Cover one by adding a case to TestReadRenderersStripTheInvisibleClass "+
+			"— drive the renderer with hostileField and assert the paired predicate it uses (the class is gone "+
+			"AND every named field arrived) — then lower maxUncoveredSafeTermFuncs to match.",
+			uncovered, maxUncoveredSafeTermFuncs, strings.Join(missing, "\n  "))
+	}
+
+	t.Logf("%d safeTerm call site(s) in %d function(s): %d function(s) COVERED by a named test, "+
+		"%d NOT COVERED (cap %d)", len(sites), len(calls), covered, uncovered, maxUncoveredSafeTermFuncs)
+	if len(missing) > 0 {
+		t.Logf("NOT COVERED: %s", strings.Join(missing, ", "))
+	}
+}
+
+// describeCoverage renders a row for a failure message.
+func describeCoverage(c safeTermCoverage) string {
+	if c.test == notCovered {
+		return "notCovered"
+	}
+	return "covered by " + c.test
+}
+
+// checkCoveringTestsResolve requires every named covering test to be a test
+// function DECLARED in this package.
+//
+// 🔴 THIS IS WHAT SEPARATES A LEDGER FROM A LIST OF WORDS, and the pattern is
+// lifted from the module root's saferune_callers_ledger_test.go, where the
+// same check had to be added after a rename left two prose statements naming a
+// function that no longer existed while the suite stayed green.
+//
+// It resolves top-level funcs named Test… taking one parameter, which is what
+// every covering test is. A row naming a SUBTEST (`TestX/sub`) does not resolve
+// and is meant not to: a subtest name is not a declaration, and `-run` filters
+// are not a contract.
+func checkCoveringTestsResolve(t *testing.T) {
+	t.Helper()
+	decls := packageTestDecls(t)
+	if len(decls) < minTestDeclsScanned {
+		t.Fatalf("CONTROL failure, not a finding: resolved only %d test declaration(s) in this package, "+
+			"want >= %d. The resolver is not reading the tests, and it would report every named test as "+
+			"a ghost.", len(decls), minTestDeclsScanned)
+	}
+	var ghosts []string
+	for fn, cov := range safeTermCoveredBy {
+		if cov.test == notCovered || decls[cov.test] {
+			continue
+		}
+		ghosts = append(ghosts, fmt.Sprintf("%s -> %s", fn, cov.test))
+	}
+	sort.Strings(ghosts)
+	if len(ghosts) > 0 {
+		t.Errorf("%d ledger row(s) name a test that this package does not declare:\n  %s\n\n"+
+			"RENAMED: move the new name here in the same commit. DELETED: the surface lost its only pin — "+
+			"either restore it or change the row to notCovered and lower nothing. A row naming a test that "+
+			"does not exist reads as coverage and stops anyone looking, which is worse than no row at all.",
+			len(ghosts), strings.Join(ghosts, "\n  "))
+	}
+}
+
+// packageTestDecls returns the set of top-level `func TestXxx(t *testing.T)`
+// names declared in this package's _test.go files.
+func packageTestDecls(t *testing.T) map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	out := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("CONTROL failure, not a finding: cannot parse %s: %v", name, perr)
+		}
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv != nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+				continue
+			}
+			if fd.Type.Params == nil || len(fd.Type.Params.List) != 1 {
+				continue
+			}
+			out[fd.Name.Name] = true
+		}
+	}
+	return out
+}

--- a/internal/cmd/safeterm_coverage_test.go
+++ b/internal/cmd/safeterm_coverage_test.go
@@ -53,7 +53,7 @@ import (
 //
 // So a notCovered row is not "unguarded"; it is "guarded against wholesale
 // removal, not against a per-field regression". Do not read the covered count
-// as a coverage percentage of the 151 call sites — it is a count of FUNCTIONS
+// as a coverage percentage of the 152 call sites — it is a count of FUNCTIONS
 // whose output a test actually inspects.
 //
 // The walk is scanSafeTermCallSites in safeterm_userinput_test.go — the same
@@ -270,16 +270,27 @@ const (
 	// the opposite cause. There are ~1580 today.
 	minTestDeclsScanned = 500
 
-	// maxUncoveredSafeTermFuncs is the RATCHET: it is set to the exact count
-	// today, so there is no headroom to spend and the number cannot go UP.
-	// Lower it when you cover a row.
+	// maxUncoveredSafeTermFuncs is the RATCHET, and it is asserted as an
+	// EQUALITY, not as a ceiling.
 	//
-	// Say what it does NOT do, because "ratchet" oversells it: it constrains the
-	// COUNT, so a commit that covers one row and uncovers another nets out and
-	// passes. GREW is what makes a new surface impossible to add SILENTLY — it
-	// must get a row, and whether that row is honest is then a review question
-	// with the evidence written next to it. That is the split #399 asked for:
-	// the count is mechanical, the content is reviewed.
+	// 🔴 A CEILING SILENTLY ACQUIRES HEADROOM, WHICH IS THE ONE FAILURE A
+	// RATCHET EXISTS TO PREVENT. `uncovered > max` alone is satisfied by
+	// covering a row and leaving the constant where it was; the next commit may
+	// then add a brand-new safeTerm-calling surface with a notCovered row and
+	// stay green, spending headroom nobody knew was there. Measured on this
+	// file: cover one row at cap 25 -> green at 24, then add a new uncovered
+	// function -> green at 25, and a new unguarded server-text surface has
+	// landed with no signal. So BOTH directions are checked below: too many is
+	// the ratchet slipping, too few is unbanked progress that must be spent by
+	// lowering this constant in the same commit.
+	//
+	// Say what it still does NOT do, because "ratchet" would otherwise
+	// oversell it: it constrains the COUNT, so a commit that covers one row and
+	// uncovers another nets out and passes. GREW is what makes a new surface
+	// impossible to add SILENTLY — it must get a row, and whether that row is
+	// honest is then a review question with the evidence written next to it.
+	// That is the split #399 asked for: the count is mechanical, the content is
+	// reviewed.
 	maxUncoveredSafeTermFuncs = 25
 )
 
@@ -291,7 +302,9 @@ const (
 //	GREW    — a function now calls safeTerm and no row covers it.
 //	SHRANK  — a row names a function that no longer calls safeTerm.
 //	GHOST   — a row names a test that does not exist.
-//	RATCHET — the notCovered count went up.
+//	RATCHET — the notCovered count is not EXACTLY maxUncoveredSafeTermFuncs:
+//	          above it the ratchet slipped, below it there is unbanked headroom
+//	          a later commit could spend in silence.
 func TestSafeTermCallSitesAreCoveredByANamedTest(t *testing.T) {
 	sites := scanSafeTermCallSites(t)
 
@@ -360,12 +373,20 @@ func TestSafeTermCallSitesAreCoveredByANamedTest(t *testing.T) {
 		covered++
 	}
 	sort.Strings(missing)
-	if uncovered > maxUncoveredSafeTermFuncs {
+	switch {
+	case uncovered > maxUncoveredSafeTermFuncs:
 		t.Errorf("%d function(s) are ledgered notCovered, and the cap is %d:\n  %s\n\n"+
 			"This number only goes down. Cover one by adding a case to TestReadRenderersStripTheInvisibleClass "+
 			"— drive the renderer with hostileField and assert the paired predicate it uses (the class is gone "+
 			"AND every named field arrived) — then lower maxUncoveredSafeTermFuncs to match.",
 			uncovered, maxUncoveredSafeTermFuncs, strings.Join(missing, "\n  "))
+	case uncovered < maxUncoveredSafeTermFuncs:
+		t.Errorf("RATCHET HEADROOM: %d function(s) are ledgered notCovered but maxUncoveredSafeTermFuncs is %d. "+
+			"Lower it to %d in this commit.\n\nThis is not a nit. A cap above the real count is headroom a LATER "+
+			"commit can spend in silence: it adds a new safeTerm-calling surface, writes it a notCovered row, and "+
+			"the count climbs back to the stale cap while the suite stays green — a new unguarded server-text "+
+			"surface with no signal. The ratchet is an EQUALITY so progress is banked the moment it is made.",
+			uncovered, maxUncoveredSafeTermFuncs, uncovered)
 	}
 
 	t.Logf("%d safeTerm call site(s) in %d function(s): %d function(s) COVERED by a named test, "+

--- a/internal/cmd/safeterm_renderers_test.go
+++ b/internal/cmd/safeterm_renderers_test.go
@@ -34,12 +34,27 @@ import (
 // string instead of the class, fails on that field by name — a single shared
 // "FIXTURE arrived" control cannot see either.
 
-// classProbe is one rune from each half of the hazard, which is why there are
-// three: U+200B is INVISIBLE (a separator no wrapper splits on), U+202E
-// REORDERS what is displayed, and U+2800 is the blank-but-graphic residue the
-// `Cf` category cut missed (#382). Putting all three inside one field means a
-// renderer cannot pass by handling only the famous one.
-const classProbe = "\u200b\u202e\u2800"
+// classProbe is one rune from each half of the hazard: U+200B is INVISIBLE (a
+// separator no wrapper splits on), U+202E REORDERS what is displayed, U+2800 is
+// the blank-but-graphic residue the `Cf` category cut missed (#382), and
+// U+001B is the ESC that starts every cursor move and line-clear. Putting all
+// four inside one field means a renderer cannot pass by handling only the
+// famous one.
+//
+// 🔴 THE ESC IS CAUGHT BY THE ADJACENCY HALF, NOT THE CLASS HALF, AND THAT IS
+// DELIBERATE. invisibleOrBidiRunes is `unicode.Cf` plus U+2800 — U+001B is
+// `Cc`, so it is invisible to that predicate. What catches it is wantStripped:
+// safeTerm removes the ESC, so the two visible halves become adjacent, and a
+// renderer that let the ESC through fails the per-field assertion by name. The
+// class half alone could not see `\x1b[1A\x1b[2K` — the escape that overwrites
+// the CLI's own `SHA256 verified` line — reaching the terminal, which is the
+// concrete attack safeTerm's doc comment names.
+//
+// It is a BARE ESC on purpose: safeTerm strips the ESC and KEEPS the rest of a
+// sequence (`a\x1b[2Kb` -> `a[2Kb`, pinned in safeterm_invisible_test.go), so a
+// probe carrying `\x1b[2K` would leave `[2K` between the halves and break
+// wantStripped even where the gate is working.
+const classProbe = "\u200b\u202e\u2800\x1b"
 
 // hostileField is a server-supplied value carrying the class BETWEEN two
 // visible halves, so "the class is gone" and "the words arrived" are the same
@@ -306,10 +321,19 @@ func TestReadRenderersStripTheInvisibleClass(t *testing.T) {
 			},
 		},
 		{
+			// 🔴 BOTH COLUMNS, BECAUSE THE LEDGER ROW CLAIMS BOTH. The row for
+			// formatFileList says "name and type", and a fixture leaving Type
+			// unset makes the type half VACUOUS: dashIfEmpty turns an empty Type
+			// into "-", so deleting `safeTerm(dashIfEmpty(f.Type))` left the whole
+			// internal/cmd suite green (measured). A second, distinct marker is
+			// what makes the row's sentence and the assertion the same claim.
 			surface: "the download plan's file list (formatFileList)",
-			fields:  []string{"ffl"},
+			fields:  []string{"ffl", "ffltype"},
 			render: func() string {
-				return formatFileList([]civitai.ModelVersionFile{{Name: hostileField("ffl")}})
+				return formatFileList([]civitai.ModelVersionFile{{
+					Name: hostileField("ffl"),
+					Type: hostileField("ffltype"),
+				}})
 			},
 		},
 		{
@@ -363,6 +387,15 @@ func TestHostileFieldCarriesTheClass(t *testing.T) {
 	if len(bad) != 3 {
 		t.Fatalf("CONTROL failure, not a finding: the fixture carries %d rune(s) of the class (%v), want 3 — "+
 			"the renderer cases assert on what safeTerm removes from it: %q", len(bad), bad, in)
+	}
+	// The ESC is the FOURTH probe rune and it is deliberately NOT one of the
+	// three above: U+001B is `Cc`, so invisibleOrBidiRunes cannot see it and the
+	// count stays 3. It is checked separately because nothing else would notice
+	// it falling out of classProbe, and without it the adjacency half of every
+	// case stops being able to see a renderer that lets `\x1b[1A\x1b[2K` through.
+	if !strings.ContainsRune(in, 0x1b) {
+		t.Fatalf("CONTROL failure, not a finding: the fixture carries no U+001B, so every case's per-field "+
+			"assertion has stopped covering cursor-move and line-clear escapes: %q", in)
 	}
 	if got := safeTerm(in); got != wantStripped("probe") {
 		t.Fatalf("CONTROL failure, not a finding: safeTerm(%q) = %q, want %q — the cases assert the halves "+

--- a/internal/cmd/safeterm_renderers_test.go
+++ b/internal/cmd/safeterm_renderers_test.go
@@ -1,0 +1,378 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/civitai/cli/internal/appapi"
+	civitai "github.com/civitai/cli/pkg/civitai"
+)
+
+// civitai/cli#399 — THE READ-PATH RENDERERS, DRIVEN WITH A HOSTILE FIXTURE.
+//
+// #399's measurement: deleting `safeTerm(...)` at 20 of 25 sampled sites left
+// the whole suite green. Every one of those surfaces prints text a stranger
+// uploaded — a model name, a tag, a username, an app tagline — and safeTerm is
+// the only thing between it and the terminal. Its doc comment says what that
+// buys: cursor moves and line-clears that overwrite the CLI's own
+// `SHA256 verified` line, an OSC-52 clipboard set, a bidi control that makes
+// the displayed order differ from the bytes.
+//
+// #399 asked for exactly this shape rather than 150 tests: "one table-driven
+// test per renderer family that feeds a hostile string through the real
+// renderer and asserts the paired predicate the reason-path tests already use".
+//
+// 🔴 THE PREDICATE IS PAIRED AND PER-FIELD, WHICH IS STRONGER THAN THE
+// REASON-PATH TESTS IT COPIES. invisibleOrBidiRunes (safeterm_invisible_test.go)
+// is the independently-built class check — `unicode.Cf` plus the measured U+2800
+// counterexample, NOT saferune.Stripped, so it can disagree with the code under
+// test. On its own it is satisfied by a renderer that prints nothing, so every
+// case also names the fields it must show, and each field carries its OWN
+// visible marker. A renderer that drops one column, or that strips the whole
+// string instead of the class, fails on that field by name — a single shared
+// "FIXTURE arrived" control cannot see either.
+
+// classProbe is one rune from each half of the hazard, which is why there are
+// three: U+200B is INVISIBLE (a separator no wrapper splits on), U+202E
+// REORDERS what is displayed, and U+2800 is the blank-but-graphic residue the
+// `Cf` category cut missed (#382). Putting all three inside one field means a
+// renderer cannot pass by handling only the famous one.
+const classProbe = "\u200b\u202e\u2800"
+
+// hostileField is a server-supplied value carrying the class BETWEEN two
+// visible halves, so "the class is gone" and "the words arrived" are the same
+// assertion: the halves are only adjacent if the runes between them were
+// removed rather than the whole value dropped.
+func hostileField(label string) string { return "FIXTURE-" + label + classProbe + "-tail" }
+
+// wantStripped is what hostileField(label) must look like on screen.
+func wantStripped(label string) string { return "FIXTURE-" + label + "-tail" }
+
+func TestReadRenderersStripTheInvisibleClass(t *testing.T) {
+	// cmdOut renders through a cobra command with a captured stdout, which is
+	// how the `cmd *cobra.Command` renderers are reached.
+	cmdOut := func(render func(c *cobra.Command)) string {
+		c, out, _ := genCmd("")
+		render(c)
+		return out.String()
+	}
+
+	for _, tc := range []struct {
+		// surface names the renderer, for the failure message.
+		surface string
+		// fields are the labels this renderer must put on screen. They are
+		// pairwise distinct so a failure names the column that went missing.
+		fields []string
+		render func() string
+	}{
+		{
+			surface: "`models search` table (printModelList)",
+			fields:  []string{"mlname", "mltype", "mlcreator"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printModelList(c, []civitai.ModelListItem{{
+						ID:      7,
+						Name:    hostileField("mlname"),
+						Type:    hostileField("mltype"),
+						Creator: &civitai.Creator{Username: civitai.FlexString(hostileField("mlcreator"))},
+					}})
+				})
+			},
+		},
+		{
+			surface: "`models get` detail (printModelDetail, joinTags)",
+			fields:  []string{"mdname", "mdtype", "mdcreator", "mdtag", "mdver", "mdbase"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printModelDetail(c, &civitai.ModelDetail{
+						ID:      7,
+						Name:    hostileField("mdname"),
+						Type:    hostileField("mdtype"),
+						Creator: &civitai.Creator{Username: civitai.FlexString(hostileField("mdcreator"))},
+						Tags:    []string{hostileField("mdtag")},
+						ModelVersions: []civitai.ModelVersionSummary{{
+							ID:        9,
+							Name:      hostileField("mdver"),
+							BaseModel: hostileField("mdbase"),
+						}},
+					})
+				})
+			},
+		},
+		{
+			surface: "`model-versions get` detail (printModelVersionDetail)",
+			fields: []string{"mvname", "mvmodel", "mvmtype", "mvbase", "mvair",
+				"mvtrigger", "mvurl", "mvfile", "mvftype"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printModelVersionDetail(c, &civitai.ModelVersionDetail{
+						ID:           9,
+						ModelID:      7,
+						Name:         hostileField("mvname"),
+						BaseModel:    hostileField("mvbase"),
+						AIR:          hostileField("mvair"),
+						DownloadURL:  hostileField("mvurl"),
+						TrainedWords: []string{hostileField("mvtrigger")},
+						Model: &civitai.ModelVersionModel{
+							Name: hostileField("mvmodel"),
+							Type: hostileField("mvmtype"),
+						},
+						Files: []civitai.ModelVersionFile{{
+							Name: hostileField("mvfile"),
+							Type: hostileField("mvftype"),
+						}},
+					})
+				})
+			},
+		},
+		{
+			surface: "`users get` (printUser)",
+			fields:  []string{"uname", "uimage"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printUser(c, civitai.UserItem{
+						ID:       3,
+						Username: civitai.FlexString(hostileField("uname")),
+						Image:    hostileField("uimage"),
+					})
+				})
+			},
+		},
+		{
+			surface: "`tags search` table (printTagList)",
+			fields:  []string{"tname", "tlink"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printTagList(c, []civitai.TagItem{{
+						Name: hostileField("tname"),
+						Link: hostileField("tlink"),
+					}})
+				})
+			},
+		},
+		{
+			surface: "`creators search` table (printCreatorList)",
+			fields:  []string{"cname", "clink"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printCreatorList(c, []civitai.CreatorItem{{
+						Username: civitai.FlexString(hostileField("cname")),
+						Link:     hostileField("clink"),
+					}})
+				})
+			},
+		},
+		{
+			surface: "`collections search` table (printCollectionList)",
+			fields:  []string{"clsname", "clstype", "clsowner"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printCollectionList(c, []civitai.CollectionListItem{{
+						ID:   5,
+						Name: hostileField("clsname"),
+						Type: hostileField("clstype"),
+						User: &civitai.CollectionUser{Username: civitai.FlexString(hostileField("clsowner"))},
+					}})
+				})
+			},
+		},
+		{
+			surface: "`collections get` detail (printCollectionDetail, joinCollectionTags)",
+			fields:  []string{"cdname", "cdtype", "cdread", "cdabout", "cdowner", "cdtag"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printCollectionDetail(c, &civitai.CollectionDetail{
+						ID:          5,
+						Name:        hostileField("cdname"),
+						Type:        hostileField("cdtype"),
+						Read:        hostileField("cdread"),
+						Description: hostileField("cdabout"),
+						User:        &civitai.CollectionUser{Username: civitai.FlexString(hostileField("cdowner"))},
+						Tags:        []civitai.CollectionTag{{Name: hostileField("cdtag")}},
+					})
+				})
+			},
+		},
+		{
+			surface: "`articles search` table (printArticleList)",
+			fields:  []string{"altitle", "alauthor"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printArticleList(c, []civitai.ArticleListItem{{
+						ID:          4,
+						Title:       hostileField("altitle"),
+						PublishedAt: "2026-08-05T12:00:00Z",
+						User:        &civitai.ArticleUser{Username: civitai.FlexString(hostileField("alauthor"))},
+					}})
+				})
+			},
+		},
+		{
+			surface: "`articles get` detail (printArticleDetail, joinArticleTags)",
+			fields:  []string{"adtitle", "adauthor", "adtag"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printArticleDetail(c, &civitai.ArticleDetail{
+						ID:          4,
+						Title:       hostileField("adtitle"),
+						PublishedAt: "2026-08-05T12:00:00Z",
+						User:        &civitai.ArticleUser{Username: civitai.FlexString(hostileField("adauthor"))},
+						Tags:        []civitai.ArticleTag{{Name: hostileField("adtag")}},
+					})
+				})
+			},
+		},
+		{
+			surface: "`app list` table (printAppList, appCardAuthor)",
+			fields:  []string{"alname", "alslug", "alkind", "alcat", "alauth"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printAppList(c, []civitai.AppCard{{
+						Name:     hostileField("alname"),
+						Slug:     hostileField("alslug"),
+						Kind:     hostileField("alkind"),
+						Category: hostileField("alcat"),
+						Creator:  &civitai.ListingCreatorChip{Username: civitai.FlexString(hostileField("alauth"))},
+					}})
+				})
+			},
+		},
+		{
+			surface: "`app view` detail, offsite (printAppDetail)",
+			fields: []string{"avname", "avslug", "avtag", "avkind", "avcat", "avrating",
+				"avauth", "avsub", "avurl", "avclient", "avdesc"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printAppDetail(c, &civitai.AppDetail{
+						Name:          hostileField("avname"),
+						Slug:          hostileField("avslug"),
+						Tagline:       hostileField("avtag"),
+						Kind:          hostileField("avkind"),
+						Category:      hostileField("avcat"),
+						ContentRating: hostileField("avrating"),
+						Description:   hostileField("avdesc"),
+						Creator:       &civitai.ListingCreatorChip{Username: civitai.FlexString(hostileField("avauth"))},
+						KindData: civitai.AppDetailKindData{
+							Kind:            "offsite",
+							SubKind:         hostileField("avsub"),
+							ExternalURL:     hostileField("avurl"),
+							ConnectClientID: hostileField("avclient"),
+						},
+					})
+				})
+			},
+		},
+		{
+			// The onsite branch is a DIFFERENT arm of printAppDetail's switch, so
+			// the offsite case above cannot see a missing safeTerm on liveUrl.
+			surface: "`app view` detail, onsite live URL (printAppDetail)",
+			fields:  []string{"onname", "onlive"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printAppDetail(c, &civitai.AppDetail{
+						Name: hostileField("onname"),
+						KindData: civitai.AppDetailKindData{
+							Kind:    "onsite",
+							LiveURL: hostileField("onlive"),
+						},
+					})
+				})
+			},
+		},
+		{
+			surface: "the `app view` 404-but-owned advice (appViewOwnedAdvice)",
+			fields:  []string{"avostatus"},
+			render: func() string {
+				return appViewOwnedAdvice("my-app", &appapi.Submission{
+					Status: hostileField("avostatus"),
+				})
+			},
+		},
+		{
+			surface: "`images search` table (printImageList)",
+			fields:  []string{"ilname", "ilbase", "ilnsfw", "ilurl"},
+			render: func() string {
+				return cmdOut(func(c *cobra.Command) {
+					printImageList(c, []civitai.ImageItem{{
+						ID:        11,
+						Username:  civitai.FlexString(hostileField("ilname")),
+						BaseModel: hostileField("ilbase"),
+						NSFWLevel: hostileField("ilnsfw"),
+						URL:       hostileField("ilurl"),
+					}})
+				})
+			},
+		},
+		{
+			surface: "the download plan's file list (formatFileList)",
+			fields:  []string{"ffl"},
+			render: func() string {
+				return formatFileList([]civitai.ModelVersionFile{{Name: hostileField("ffl")}})
+			},
+		},
+		{
+			// 🔴 THIS CASE IS WHY THE TEST EXISTS RATHER THAN A REVIEW. It is the
+			// one surface in this table that was NOT already sanitised: the marker
+			// interpolated the uploader's `files[].type` into a HEADER LINE raw,
+			// while the identical field two lines below it in the same renderer
+			// went through safeTerm. Nothing could see the difference until the
+			// function was driven with a hostile value (civitai/cli#399).
+			surface: "the non-weights primary-file marker (nonModelFileMarker)",
+			fields:  []string{"nmfm"},
+			render: func() string {
+				return nonModelFileMarker([]civitai.ModelVersionFile{{
+					Primary: true,
+					Type:    hostileField("nmfm"),
+				}})
+			},
+		},
+	} {
+		t.Run(tc.surface, func(t *testing.T) {
+			got := tc.render()
+			if bad := invisibleOrBidiRunes(got); len(bad) > 0 {
+				t.Errorf("%s put %s on the terminal. safeTerm is the ONE gate on server-supplied text "+
+					"reaching a terminal: an invisible rune is a separator no wrapper splits on, and a bidi "+
+					"control changes the order the line is DISPLAYED in, so what the user reads is not what "+
+					"the bytes say (civitai/cli#399, #393):\n%q", tc.surface, strings.Join(bad, ", "), got)
+			}
+			for _, f := range tc.fields {
+				if strings.Contains(got, wantStripped(f)) {
+					continue
+				}
+				t.Errorf("%s did not render %q as %q. Either the field stopped being printed — in which "+
+					"case the class check above is VACUOUS for it — or the whole value was dropped instead "+
+					"of just the class, which loses what the user asked to see:\n%q",
+					tc.surface, f, wantStripped(f), got)
+			}
+		})
+	}
+}
+
+// TestHostileFieldCarriesTheClass is the control ON THE FIXTURE.
+//
+// 🔴 EVERY ASSERTION ABOVE IS ABOUT BYTES THAT MUST BE PRESENT BEFORE THE
+// RENDERER RUNS. If hostileField ever stopped carrying the class — a rune
+// dropped from classProbe, an escape written where a literal was meant — every
+// case would report "no invisible rune reached the terminal" and be measuring
+// nothing. This is the one place that checks the input side.
+func TestHostileFieldCarriesTheClass(t *testing.T) {
+	in := hostileField("probe")
+	bad := invisibleOrBidiRunes(in)
+	if len(bad) != 3 {
+		t.Fatalf("CONTROL failure, not a finding: the fixture carries %d rune(s) of the class (%v), want 3 — "+
+			"the renderer cases assert on what safeTerm removes from it: %q", len(bad), bad, in)
+	}
+	if got := safeTerm(in); got != wantStripped("probe") {
+		t.Fatalf("CONTROL failure, not a finding: safeTerm(%q) = %q, want %q — the cases assert the halves "+
+			"end up adjacent, so this is what they are asserting against", in, got, wantStripped("probe"))
+	}
+	// The label must be DISTINGUISHING, not just present: two fields sharing a
+	// marker would let one satisfy the other's assertion, and the whole point of
+	// per-field markers is that a dropped column is named.
+	if hostileField("probe") == hostileField("other") {
+		t.Fatal("CONTROL failure, not a finding: hostileField ignores its label, so every case's per-field " +
+			"assertions collapse into one")
+	}
+}

--- a/internal/cmd/safeterm_userinput_test.go
+++ b/internal/cmd/safeterm_userinput_test.go
@@ -81,15 +81,52 @@ var bareIdentArgs = map[string]string{
 	"name":       "SERVER: a published file name",
 	"h":          "SERVER: a hash out of image metadata",
 	"baseModel":  "SERVER: a base-model label",
+	"typ":        "SERVER: the primary file's published `type`, defaulted to \"Other\" when blank (nonModelFileMarker)",
 }
 
 // minSafeTermCallsScanned is the POSITIVE CONTROL. A parser that has stopped
 // finding calls — a moved package, a renamed helper, the wrong directory —
-// scans nothing, finds no violation and reports a serene pass. There are 150
+// scans nothing, finds no violation and reports a serene pass. There are 152
 // calls today.
 const minSafeTermCallsScanned = 100
 
-func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
+// safeTermSite is one safeTerm(...) call, ATTRIBUTED TO THE FUNCTION THAT
+// ENCLOSES IT.
+type safeTermSite struct {
+	// pos is file:line:col, for a failure message a reader can jump to.
+	pos string
+	// enclosing is the ledger key: the bare name for a top-level func, or
+	// `(*T).name` for a method, so two methods of different types that share a
+	// name stay distinguishable.
+	enclosing string
+	// arg is the rendered argument expression, and bareIdent says whether it was
+	// spelled as a bare local.
+	arg       string
+	bareIdent bool
+}
+
+// scanSafeTermCallSites parses this package's own non-test sources and returns
+// every one-argument safeTerm(...) call with its enclosing function.
+//
+// 🔴 IT WALKS file.Decls AND RECURSES INTO EACH *ast.FuncDecl, AND THAT ONE
+// STRUCTURAL DIFFERENCE IS WHAT #399 TURNED ON. The original walk here was a
+// flat `ast.Inspect(file, …)`: it saw every call and knew where NONE of them
+// lived, so the only thing it could count was a total. Deleting a safeTerm call
+// moved that total from ~151 to ~150 — nowhere near the floor below — and the
+// suite stayed green, which is exactly the defect #399 reports (20 of 25 sampled
+// sites survived deletion). Attribution is what lets a ledger be keyed by
+// SOMETHING THAT SHRINKS TO ZERO when a function's last call is removed.
+//
+// Two controls run here rather than in either caller, so both get them:
+//
+//  1. the file and call counts, against the floors above;
+//  2. 🔴 TOTALITY — a flat count of the same calls must equal the attributed
+//     count. A call in a package-level var initialiser, or in a func literal
+//     assigned outside any FuncDecl, is invisible to a Decls walk; without this
+//     it would silently be attributed to nothing and be covered by no row,
+//     which reads exactly like "no such site exists".
+func scanSafeTermCallSites(t *testing.T) []safeTermSite {
+	t.Helper()
 	// parser.ParseFile over an explicit file list rather than parser.ParseDir,
 	// which Go 1.25 deprecated. The list is the package's own non-test sources;
 	// a read that returns none of them trips the control below.
@@ -98,9 +135,8 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 		t.Fatalf("CONTROL failure, not a finding: cannot read the package directory: %v", err)
 	}
 	fset := token.NewFileSet()
-	scanned, files := 0, 0
-	var bad, unclassified []string
-	seenBare := map[string]bool{}
+	files, flat := 0, 0
+	var sites []safeTermSite
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
@@ -112,35 +148,87 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 		}
 		files++
 		ast.Inspect(file, func(n ast.Node) bool {
-			ce, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			id, ok := ce.Fun.(*ast.Ident)
-			if !ok || id.Name != "safeTerm" || len(ce.Args) != 1 {
-				return true
-			}
-			scanned++
-			arg := renderExpr(ce.Args[0])
-			if why, forbidden := userTypedArgs[arg]; forbidden {
-				bad = append(bad, fmt.Sprintf("%s: safeTerm(%s) — %s", fset.Position(ce.Lparen), arg, why))
-			}
-			if _, bare := ce.Args[0].(*ast.Ident); bare {
-				if _, known := bareIdentArgs[arg]; !known {
-					unclassified = append(unclassified, fmt.Sprintf("%s: safeTerm(%s)", fset.Position(ce.Lparen), arg))
-				}
-				seenBare[arg] = true
+			if isSafeTermCall(n) != nil {
+				flat++
 			}
 			return true
 		})
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			key := safeTermFuncKey(fd)
+			ast.Inspect(fd, func(n ast.Node) bool {
+				ce := isSafeTermCall(n)
+				if ce == nil {
+					return true
+				}
+				_, bare := ce.Args[0].(*ast.Ident)
+				sites = append(sites, safeTermSite{
+					pos:       fset.Position(ce.Lparen).String(),
+					enclosing: key,
+					arg:       renderExpr(ce.Args[0]),
+					bareIdent: bare,
+				})
+				return true
+			})
+		}
 	}
 	if files < 20 {
 		t.Fatalf("CONTROL failure, not a finding: only %d source file(s) parsed in this package", files)
 	}
-
-	if scanned < minSafeTermCallsScanned {
+	if len(sites) < minSafeTermCallsScanned {
 		t.Fatalf("CONTROL failure, not a finding: only %d safeTerm call(s) found, want >= %d. The scan is "+
-			"broken, and a clean result from it means nothing.", scanned, minSafeTermCallsScanned)
+			"broken, and a clean result from it means nothing.", len(sites), minSafeTermCallsScanned)
+	}
+	if flat != len(sites) {
+		t.Fatalf("CONTROL failure, not a finding: %d safeTerm call(s) exist but only %d sit inside a func "+
+			"declaration. The missing one is in a package-level initialiser or a func literal outside any "+
+			"FuncDecl, so no enclosing function owns it and no ledger row can cover it. Widen this walk "+
+			"before trusting either test that reads it.", flat, len(sites))
+	}
+	return sites
+}
+
+// isSafeTermCall returns the call when n is a one-argument safeTerm(...), and
+// nil otherwise. ONE spelling of the match, used by both halves of the totality
+// control above — two copies of it could disagree and the disagreement would
+// read as a finding.
+func isSafeTermCall(n ast.Node) *ast.CallExpr {
+	ce, ok := n.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	id, ok := ce.Fun.(*ast.Ident)
+	if !ok || id.Name != "safeTerm" || len(ce.Args) != 1 {
+		return nil
+	}
+	return ce
+}
+
+// safeTermFuncKey is the ledger key for a function declaration.
+func safeTermFuncKey(fd *ast.FuncDecl) string {
+	if fd.Recv != nil && len(fd.Recv.List) > 0 {
+		return "(" + renderExpr(fd.Recv.List[0].Type) + ")." + fd.Name.Name
+	}
+	return fd.Name.Name
+}
+
+func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
+	sites := scanSafeTermCallSites(t)
+	var bad, unclassified []string
+	seenBare := map[string]bool{}
+	for _, s := range sites {
+		if why, forbidden := userTypedArgs[s.arg]; forbidden {
+			bad = append(bad, fmt.Sprintf("%s: safeTerm(%s) — %s", s.pos, s.arg, why))
+		}
+		if s.bareIdent {
+			if _, known := bareIdentArgs[s.arg]; !known {
+				unclassified = append(unclassified, fmt.Sprintf("%s: safeTerm(%s)", s.pos, s.arg))
+			}
+			seenBare[s.arg] = true
+		}
 	}
 	if len(bad) > 0 {
 		t.Errorf("%d call site(s) sanitise input the USER typed:\n  %s\n\n"+
@@ -160,8 +248,8 @@ func TestSafeTermIsNeverAppliedToUserTypedInput(t *testing.T) {
 				"note reads as coverage; delete it or fix the name.", name)
 		}
 	}
-	t.Logf("scanned %d safeTerm call site(s) across %d file(s); %d forbidden shapes and %d bare-identifier "+
-		"origins are pinned", scanned, files, len(userTypedArgs), len(bareIdentArgs))
+	t.Logf("scanned %d safeTerm call site(s); %d forbidden shapes and %d bare-identifier origins are pinned",
+		len(sites), len(userTypedArgs), len(bareIdentArgs))
 }
 
 // renderExpr prints the small set of expression shapes safeTerm arguments take.


### PR DESCRIPTION
Addresses cli#399. Leaving the issue open for a human to close — it has been
auto-closed twice already by parsers reading the number out of prose, so this
body deliberately contains no keyword that would do it a third time.

## The defect

`safeTerm` is the CLI's one gate on server-supplied text reaching a terminal.
#399 measured that deleting `safeTerm(...)` at **20 of 25 sampled sites left the
whole suite green**. Nothing could say which sites were pinned, so nobody could
tell a refactor that dropped one from a refactor that did not.

Re-measured here at the level of **functions**, against a tree frozen at
`cf5e4a8` (`origin/main`): of the **59 functions** holding the 151 calls,
**36 survived losing every `safeTerm` call they had**. 23 were killed by some
test.

Method, so it can be repeated: each function's `safeTerm(x)` calls were
rewritten to `x` by **byte splice** — delete `safeTerm(` and its matching `)`,
nothing else in the file moves — then `go test ./internal/cmd/ -count=1` was run
on a frozen copy. Controls: the unmutated copy was green first; the mutated tree
was diffed to prove the mutant was on disk (a `SURVIVED` from an unmutated tree
is the whole failure mode); and neutering `safeTerm` itself reddened 20 tests,
so `SURVIVED` is not a harness that cannot see red.

## What this adds

**1. Enclosing-function attribution on the walk that already existed.**
`internal/cmd/safeterm_userinput_test.go` flat-`ast.Inspect`ed each file, so it
saw every call and knew where none of them lived — deleting one moved its count
from 151 to 150, nowhere near its floor of 100, and it stayed green. It now
walks `file.Decls` and recurses into each `*ast.FuncDecl`. One shared
`scanSafeTermCallSites` feeds both tests, with a **totality control**: a flat
count of the same calls must equal the attributed count, so a call in a
package-level initialiser (invisible to a `Decls` walk, and therefore owned by
no row) is a loud failure rather than a silent gap.

**2. A coverage ledger keyed by enclosing function**
(`internal/cmd/safeterm_coverage_test.go`), 60 rows, every verdict measured.
Keyed by function, not by argument name, because #398's `bareIdentArgs` is
keyed by name and its own comment concedes why that is weak ("the same name
holds a server-returned id at other call sites").

Four independent assertions, each with its own message:

| check | fires when |
|---|---|
| `GREW` | a function calls `safeTerm` and has no row |
| `SHRANK` | a row names a function that no longer calls `safeTerm` |
| `GHOST` | a row names a test this package does not declare |
| `RATCHET` | the `notCovered` count went up |

`notCovered` is a **first-class value**, not a hole. 25 rows say it, each with
what a hostile field could do at that surface. The count is logged and capped at
exactly today's number, so it can only shrink.

A named test is **resolved to a declaration** before it is believed — the
pattern from the module root's `saferune_callers_ledger_test.go`, which had to
add exactly this after a rename left two prose statements naming a function that
no longer existed while the suite stayed green.

**3. `TestReadRenderersStripTheInvisibleClass`** — #399's own "cheap version": a
table-driven test per renderer family, driving the real renderer with a hostile
fixture. The predicate is **paired and per-field**: no rune of the class on the
terminal, AND every named field arrives with its two visible halves adjacent.
Each field carries its own marker, so a renderer that drops one column fails on
that column by name — a single shared "the fixture arrived" control cannot see
that. The class check is `invisibleOrBidiRunes`, the independently-built
predicate (`unicode.Cf` plus the measured U+2800 counterexample), not
`saferune.Stripped` — a guard that asks the implementation what it strips is
satisfied by an implementation that strips nothing.

## A real hole this found

`nonModelFileMarker` (`internal/cmd/read.go`) returned the uploader's
`files[].type` **raw**, interpolated into a header line — the first line of
`model-versions get` and a row of `models get`'s version table. The identical
field is `safeTerm`'d in the files table a few lines below. It was found by
driving the function with a hostile value, not by reading it, and it is fixed
here (one line + the ledger row + the `bareIdentArgs` origin note the existing
guard immediately demanded). Both callers are human renderers; no `--json` path
reaches it, so `internal/ui/CONVENTION.md` rule 1 is untouched.

## The #399 closing condition, demonstrated

Site: `printCollectionDetail` (5 calls) — `SURVIVED` on the frozen baseline.

**Before**, on frozen `cf5e4a8`, all 5 calls spliced out:

```
ok  	github.com/civitai/cli/internal/cmd	40.436s
```

**After**, the same deletion on this branch:

```
--- FAIL: TestReadRenderersStripTheInvisibleClass/`collections_get`_detail_(printCollectionDetail,_joinCollectionTags)
    safeterm_renderers_test.go:336: `collections get` detail … put U+200B, U+202E, U+2800, … on the terminal.
        safeTerm is the ONE gate on server-supplied text reaching a terminal: an invisible rune is a
        separator no wrapper splits on, and a bidi control changes the order the line is DISPLAYED in,
        so what the user reads is not what the bytes say (civitai/cli#399, #393)
    safeterm_renderers_test.go:345: … did not render "cdname" as "FIXTURE-cdname-tail". Either the field
        stopped being printed — in which case the class check above is VACUOUS for it — or the whole value
        was dropped instead of just the class
--- FAIL: TestSafeTermCallSitesAreCoveredByANamedTest
```

11 further functions moved `SURVIVED` → `KILLED` the same way (`appCardAuthor`,
`appViewOwnedAdvice`, `formatFileList`, `joinCollectionTags`, `printAppDetail`,
`printAppList`, `printArticleList`, `printCollectionList`, `printCreatorList`,
`printTagList`, and the new `nonModelFileMarker`), each verified by deletion.

## The headline number

Re-running the full 60-function sweep against **this** branch: every function's
mutant is killed. `SHRANK` catches wholesale removal for all 60 rows,
`notCovered` ones included.

| | `origin/main` (cf5e4a8) | this branch |
|---|---|---|
| functions whose `safeTerm` calls can all be deleted with the suite green | **36 / 59** | **0 / 60** |
| functions whose OUTPUT a test inspects | 23 | 35 |

Those are different claims and the ledger's doc comment says so at length: the
ledger pins that a function still calls `safeTerm` **at all**; a named test pins
that the class does not reach the **screen**, which is the only thing that
catches deleting one of a function's twelve calls. Do not read 35/60 as a
percentage of the 152 call sites.

## Mutation matrix on the guard itself

Each mutant run against a copy of this branch; the control (unmutated copy
green) ran first.

| mutant | result |
|---|---|
| new function calling `safeTerm(v.Name)`, no row | KILLED — `no row in safeTermCoveredBy` |
| a row names `TestThisNameWasNeverDeclared` | KILLED — `name a test that this package does not declare` |
| a row for `printFinding`, which calls no `safeTerm` | KILLED — `no longer calls safeTerm` |
| a covered row flipped to `notCovered` | KILLED — `are ledgered notCovered, and the cap is 25` |
| a row with an empty `why` | KILLED — `has an empty why` |
| `safeTerm` call in a package-level var | KILLED — `sit inside a func declaration` |

Each died by **its own** message, not another guard's error and not a compile
failure; the mutant in row 1 passes a selector rather than a bare identifier so
`bareIdentArgs` cannot fire first and mask it.

## Verification

- `make ci` — green (see below).
- `make lint` — `0 issues`, and the instrument was validated: replacing the
  escapes in `classProbe` with raw bytes makes it report
  `ST1018: string literal contains Unicode format characters`, the exact class
  AGENTS.md records biting this repo. Run under nixpkgs golangci-lint 2.13.2;
  CI pins 2.12.2.

## Not done, deliberately

- **No AGENTS.md item.** `AGENTS.md` is 47 bytes under its own ceiling, so a new
  item means evicting an existing one — a separate exercise. The obligation
  ("add a row or say `notCovered`") is stated in the guard's failure message,
  which is where a reader meets it.
- **No README change.** The published contract already says invisible and
  direction-reversing characters are removed from server text before it reaches
  the terminal; the `nonModelFileMarker` fix makes that sentence *more* true
  rather than changing it.
- **Scope held to `internal/cmd`.** Two `saferune` callers live outside it —
  `pkg/civitai`'s `snippet` (`read.go`) and `internal/genapi`'s
  `hasPrintableContent` (`status.go`). Neither is in this ledger, and extending
  it there is a separate decision, not a bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzVihMt3EZDbJNxSN35DUR
